### PR TITLE
chore: disable reth-primitives default features in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ reth-optimism-primitives = { path = "crates/optimism/primitives" }
 reth-payload-builder = { path = "crates/payload/builder" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
-reth-primitives = { path = "crates/primitives" }
+reth-primitives = { path = "crates/primitives" , default-features = false }
 reth-primitives-traits = { path = "crates/primitives-traits" }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-eth-wire-types.workspace = true
-reth-primitives.workspace = true
+reth-primitives = { workspace = true, features = ["c-kzg"] }
 reth-fs-util.workspace = true
 reth-provider.workspace = true
 reth-tasks.workspace = true


### PR DESCRIPTION
Motivation:

closes: #8793 

Description:

Disable default features for reth-prims in workspace and renable specific features in crates where necessary.