### PR TITLE
fix(rpc/trace): include block rewards in trace_filter rpc

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -853,8 +853,8 @@ impl ChainSpec {
         self.fork(Hardfork::Homestead).active_at_block(block_number)
     }
 
-    /// The Paris hardfork (merge) is activated via ttd. If we have knowledge of the block, this
-    /// function will return true if the block number is greater than or equal to the Paris
+    /// The Paris hardfork (merge) is activated via block number. If we have knowledge of the block,
+    /// this function will return true if the block number is greater than or equal to the Paris
     /// (merge) block.
     pub fn is_paris_active_at_block(&self, block_number: u64) -> Option<bool> {
         self.paris_block_and_final_difficulty.map(|(paris_block, _)| block_number >= paris_block)

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -319,17 +319,17 @@ where
             .flat_map(|traces| traces.into_iter().flatten().flat_map(|traces| traces.into_iter()))
             .collect::<Vec<_>>();
 
-        let mut is_paris_actived = None;
+        let mut is_paris_activated = None;
         for block in &blocks {
-            // check if the Paris hardfork is actived or not, no need to recheck if it's
+            // check if the Paris hardfork is activated or not, no need to recheck if it's
             // activation is known
-            if is_paris_actived.is_none() {
-                is_paris_actived =
+            if is_paris_activated.is_none() {
+                is_paris_activated =
                     self.provider().chain_spec().is_paris_active_at_block(block.number);
             }
 
             if let Some(base_block_reward) =
-                self.calculate_base_block_reward(block, is_paris_actived)?
+                self.calculate_base_block_reward(block, is_paris_activated)?
             {
                 all_traces.extend(self.extract_reward_traces(block, base_block_reward));
             }
@@ -487,14 +487,14 @@ where
     fn calculate_base_block_reward(
         &self,
         block: &SealedBlock,
-        is_paris_actived: Option<bool>,
+        is_paris_activated: Option<bool>,
     ) -> EthResult<Option<u128>> {
         let chain_spec = self.provider().chain_spec();
 
-        // 1. if Paris hardfork is actived, no block rewards are given
-        // 2. if Paris hardfork is not actived, calculate block rewards with block number only
+        // 1. if Paris hardfork is activated, no block rewards are given
+        // 2. if Paris hardfork is not activated, calculate block rewards with block number only
         // 3. if Paris hardfork is unknown, calculate block rewards with block number and ttd
-        Ok(match is_paris_actived {
+        Ok(match is_paris_activated {
             Some(true) => None,
             Some(false) => {
                 Some(base_block_reward_pre_merge(chain_spec.as_ref(), block.header.number))

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -314,42 +314,41 @@ where
             .flat_map(|traces| traces.into_iter().flatten().flat_map(|traces| traces.into_iter()))
             .collect::<Vec<_>>();
 
+        // add reward traces
         let mut reward_blocks = Vec::with_capacity(blocks.len());
         for block_id in &blocks {
             reward_blocks.push(self.inner.eth_api.block_by_id(block_id.number.into()));
         }
 
-        for maybe_reward_block in futures::future::try_join_all(reward_blocks).await? {
-            if let Some(block) = maybe_reward_block {
-                if let Some(header_td) = self.provider().header_td(&block.header.hash())? {
-                    if let Some(base_block_reward) = base_block_reward(
-                        self.provider().chain_spec().as_ref(),
-                        block.header.number,
-                        block.header.difficulty,
-                        header_td,
-                    ) {
-                        let block_reward = block_reward(base_block_reward, block.ommers.len());
+        for block in (futures::future::try_join_all(reward_blocks).await?).into_iter().flatten() {
+            if let Some(header_td) = self.provider().header_td(&block.header.hash())? {
+                if let Some(base_block_reward) = base_block_reward(
+                    self.provider().chain_spec().as_ref(),
+                    block.header.number,
+                    block.header.difficulty,
+                    header_td,
+                ) {
+                    let block_reward = block_reward(base_block_reward, block.ommers.len());
+                    all_traces.push(reward_trace(
+                        &block.header,
+                        RewardAction {
+                            author: block.header.beneficiary,
+                            reward_type: RewardType::Block,
+                            value: U256::from(block_reward),
+                        },
+                    ));
+
+                    for uncle in &block.ommers {
+                        let uncle_reward =
+                            ommer_reward(base_block_reward, block.header.number, uncle.number);
                         all_traces.push(reward_trace(
                             &block.header,
                             RewardAction {
-                                author: block.header.beneficiary,
-                                reward_type: RewardType::Block,
-                                value: U256::from(block_reward),
+                                author: uncle.beneficiary,
+                                reward_type: RewardType::Uncle,
+                                value: U256::from(uncle_reward),
                             },
                         ));
-
-                        for uncle in &block.ommers {
-                            let uncle_reward =
-                                ommer_reward(base_block_reward, block.header.number, uncle.number);
-                            all_traces.push(reward_trace(
-                                &block.header,
-                                RewardAction {
-                                    author: uncle.beneficiary,
-                                    reward_type: RewardType::Uncle,
-                                    value: U256::from(uncle_reward),
-                                },
-                            ));
-                        }
                     }
                 }
             }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -278,32 +278,35 @@ where
                     highest_matching_index = idx;
                 }
             }
-            if !transaction_indices.is_empty() {
-                target_blocks.push((block.number, transaction_indices, highest_matching_index));
-            }
+            target_blocks.push((block.number, transaction_indices, highest_matching_index));
         }
 
         // trace all relevant blocks
         let mut block_traces = Vec::with_capacity(target_blocks.len());
         for (num, indices, highest_idx) in target_blocks {
-            let traces = self.inner.eth_api.trace_block_until(
-                num.into(),
-                Some(highest_idx),
-                TracingInspectorConfig::default_parity(),
-                move |tx_info, inspector, res, _, _| {
-                    if let Some(idx) = tx_info.index {
-                        if !indices.contains(&idx) {
-                            // only record traces for relevant transactions
-                            return Ok(None)
+            let mut traces = if !indices.is_empty() {
+                self.inner.eth_api.trace_block_until(
+                    num.into(),
+                    Some(highest_idx),
+                    TracingInspectorConfig::default_parity(),
+                    move |tx_info, inspector, res, _, _| {
+                        if let Some(idx) = tx_info.index {
+                            if !indices.contains(&idx) {
+                                // only record traces for relevant transactions
+                                return Ok(None)
+                            }
                         }
-                    }
-                    let traces = inspector
-                        .with_transaction_gas_used(res.gas_used())
-                        .into_parity_builder()
-                        .into_localized_transaction_traces(tx_info);
-                    Ok(Some(traces))
-                },
-            );
+                        let traces = inspector
+                            .with_transaction_gas_used(res.gas_used())
+                            .into_parity_builder()
+                            .into_localized_transaction_traces(tx_info);
+                        Ok(Some(traces))
+                    },
+                )
+            } else {
+                Box::pin(futures::future::ready(Ok(None)))
+            };
+
             block_traces.push(traces);
         }
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -316,13 +316,14 @@ where
             .flat_map(|traces| traces.into_iter().flatten().flat_map(|traces| traces.into_iter()))
             .collect::<Vec<_>>();
 
-        let mut is_paris_activated = None;
         for block in &blocks {
-            // check if the Paris hardfork is activated or not, no need to recheck if it's
-            // activation status is already known
-            if is_paris_activated.is_none() {
-                is_paris_activated =
-                    self.provider().chain_spec().is_paris_active_at_block(block.number);
+            let is_paris_activated =
+                self.provider().chain_spec().is_paris_active_at_block(block.number);
+
+            // if the Paris hardfork is activated on current block, no need to check the later
+            // blocks
+            if is_paris_activated.is_some_and(|activated| activated) {
+                break
             }
 
             if let Some(base_block_reward) =

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -316,7 +316,7 @@ where
             .flat_map(|traces| traces.into_iter().flatten().flat_map(|traces| traces.into_iter()))
             .collect::<Vec<_>>();
 
-        // add reward traces
+        // include all the block reward traces
         let reward_blocks =
             blocks.iter().map(|block| self.inner.eth_api.block_by_id(block.number.into()));
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -382,10 +382,10 @@ where
             maybe_traces.map(|traces| traces.into_iter().flatten().collect::<Vec<_>>());
 
         if let (Some(block), Some(traces)) = (maybe_block, maybe_traces.as_mut()) {
-            let is_paris_actived =
+            let is_paris_activated =
                 self.provider().chain_spec().is_paris_active_at_block(block.number);
             if let Some(base_block_reward) =
-                self.calculate_base_block_reward(&block, is_paris_actived)?
+                self.calculate_base_block_reward(&block, is_paris_activated)?
             {
                 traces.extend(self.extract_reward_traces(&block, base_block_reward));
             }


### PR DESCRIPTION
the block rewards were missed in the result of `trace_filter`, which will affect the blocks before the merge, so add them into the result if some.

btw: if we know one block of the block-range is passed ttd, then no need to extract the following blocks anymore, but the results were handled in an async way, how can we break it? pseudo code as below:


```
for block in blocks:
    if block.is_passed_ttd():
        break
    reward_traces.extend(extract_block_reward_traces(block))

```