### PR TITLE
fix: manually override certain chainconfig fields for adminNodeInfo

### DIFF
--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_network_api::{NetworkInfo, PeerKind, Peers};
 use reth_network_peers::AnyNode;
-use reth_primitives::{ChainSpec, NodeRecord};
+use reth_primitives::{ChainConfig, ChainSpec, NodeRecord};
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_types::{
     admin::{EthProtocolInfo, NodeInfo, Ports, ProtocolInfo},
@@ -94,7 +94,14 @@ where
     async fn node_info(&self) -> RpcResult<NodeInfo> {
         let enode = self.network.local_node_record();
         let status = self.network.network_status().await.to_rpc_result()?;
-        let config = self.chain_spec.genesis().config.clone();
+        let config = ChainConfig {
+            chain_id: self.chain_spec.chain.id(),
+            terminal_total_difficulty_passed: self
+                .chain_spec
+                .get_final_paris_total_difficulty()
+                .is_some(),
+            ..self.chain_spec.genesis().config.clone()
+        };
 
         let node_info = NodeInfo {
             id: B256::from_slice(&enode.id.as_slice()[..32]),


### PR DESCRIPTION
adminNodeInfo should return the genesis' chainconfig object which is usually missing but has a few fields that are emitted, 
this ensures we include the proper chain id and ttd info, but ideally this should be solved for the constants as well like modifying the genesis jsons we use for parsing:


https://github.com/paradigmxyz/reth/blob/60ef0c4b38cdbd81b4e397545064f4c18b3d5dfe/crates/primitives/src/chain/spec.rs#L177-L178

