### PR TITLE
fix: division by zero when reading from nippy jar archive

### DIFF
--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -42,6 +42,11 @@ pub enum NippyJarError {
         /// The read offset size in number of bytes.
         offset_size: u8,
     },
+    #[error("the size of an offset must be at least 1 bytes, got {offset_size}")]
+    OffsetSizeTooSmall {
+        /// The read offset size in number of bytes.
+        offset_size: u8,
+    },
     #[error("attempted to read an out of bounds offset: {index}")]
     OffsetOutOfBounds {
         /// The index of the offset that was being read.

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -42,7 +42,7 @@ pub enum NippyJarError {
         /// The read offset size in number of bytes.
         offset_size: u8,
     },
-    #[error("the size of an offset must be at least 1 bytes, got {offset_size}")]
+    #[error("the size of an offset must be at least 1 byte, got {offset_size}")]
     OffsetSizeTooSmall {
         /// The read offset size in number of bytes.
         offset_size: u8,

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -514,6 +514,8 @@ impl DataReader {
         // Ensure that the size of an offset is at most 8 bytes.
         if offset_size > 8 {
             return Err(NippyJarError::OffsetSizeTooBig { offset_size })
+        } else if offset_size == 0 {
+            return Err(NippyJarError::OffsetSizeTooSmall { offset_size })
         }
 
         Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
@@ -551,7 +553,7 @@ impl DataReader {
     fn offset_at(&self, index: usize) -> Result<u64, NippyJarError> {
         let mut buffer: [u8; 8] = [0; 8];
 
-        let offset_end = index + self.offset_size as usize;
+        let offset_end = index.saturating_add(self.offset_size as usize);
         if offset_end > self.offset_mmap.len() {
             return Err(NippyJarError::OffsetOutOfBounds { index })
         }


### PR DESCRIPTION
This PR fixes:

1. Currently there's no check when `offset_size` (read from the file) is zero, which is invalid and will cause division by zero in `offsets_count` function.
2. Currently the index addition can overflow the size and cause the out-of-bound memory access in the `offset_at`. By adding an offset check, we can prevent the further invalid memory read.