### PR TITLE
fix: prevent block number underflow

### DIFF
--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -167,7 +167,9 @@ impl Command {
                 OriginalValuesKnown::Yes,
             )?;
 
-            let checkpoint = Some(StageCheckpoint::new(block_number - 1));
+            let checkpoint = Some(StageCheckpoint::new(
+                block_number.checked_sub(1).ok_or(eyre::eyre!("GenesisBlockHasNoParent"))?
+            ));
 
             let mut account_hashing_done = false;
             while !account_hashing_done {

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -42,6 +42,11 @@ pub enum NippyJarError {
         /// The read offset size in number of bytes.
         offset_size: u8,
     },
+    #[error("the size of an offset must be at least 1 bytes, got {offset_size}")]
+    OffsetSizeTooSmall {
+        /// The read offset size in number of bytes.
+        offset_size: u8,
+    },
     #[error("attempted to read an out of bounds offset: {index}")]
     OffsetOutOfBounds {
         /// The index of the offset that was being read.

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -514,6 +514,8 @@ impl DataReader {
         // Ensure that the size of an offset is at most 8 bytes.
         if offset_size > 8 {
             return Err(NippyJarError::OffsetSizeTooBig { offset_size })
+        } else if offset_size == 0 {
+            return Err(NippyJarError::OffsetSizeTooSmall { offset_size })
         }
 
         Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
@@ -551,7 +553,7 @@ impl DataReader {
     fn offset_at(&self, index: usize) -> Result<u64, NippyJarError> {
         let mut buffer: [u8; 8] = [0; 8];
 
-        let offset_end = index + self.offset_size as usize;
+        let offset_end = index.saturating_add(self.offset_size as usize);
         if offset_end > self.offset_mmap.len() {
             return Err(NippyJarError::OffsetOutOfBounds { index })
         }


### PR DESCRIPTION
Since we don't need to generate checkout point for genesis block, adding additional overflow check to avoid it. This is also a previously overlooked check in https://github.com/paradigmxyz/reth/commit/72e5122e73ef981a1cd95d97aac1f1cf7de1f691. 