### PR TITLE
fix(commands): prevents potential arithmetic underflow in debug commands

### DIFF
--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -167,7 +167,9 @@ impl Command {
                 OriginalValuesKnown::Yes,
             )?;
 
-            let checkpoint = Some(StageCheckpoint::new(block_number - 1));
+            let checkpoint = Some(StageCheckpoint::new(
+                block_number.checked_sub(1).ok_or(eyre::eyre!("GenesisBlockHasNoParent"))?,
+            ));
 
             let mut account_hashing_done = false;
             while !account_hashing_done {


### PR DESCRIPTION
Since we don't need to generate checkout point for genesis block, adding additional overflow check to avoid it. This is also a previously overlooked check in https://github.com/paradigmxyz/reth/commit/72e5122e73ef981a1cd95d97aac1f1cf7de1f691.