### PR TITLE
fix(docs): `op-node` flags

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -83,9 +83,11 @@ op-node \
     --l2.jwt-secret=/path/to/jwt.hex \
     --rpc.addr=0.0.0.0 \
     --rpc.port=7000 \
-    --l1.trustrpc \
     --l1.beacon=<your-beacon-node-http-endpoint>
+    --syncmode=execution-layer
 ```
+
+Consider adding the `--l1.trustrpc` flag to improve performance, if the connection to l1 is over localhost.
 
 If you opted to build the `op-node` with the `rethdb` build tag, this feature can be enabled by appending one extra flag to the `op-node` invocation:
 


### PR DESCRIPTION
- Adds missing `op-node` flag `--syncmode=execution-layer`
- Security precaution, don't recommend  always running `op-node` with `--l1.trustrpc` flag