### PR TITLE
chore: use `reth_chainspec` where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,6 +1541,7 @@ dependencies = [
 name = "bsc-p2p"
 version = "0.0.0"
 dependencies = [
+ "reth-chainspec",
  "reth-discv4",
  "reth-network",
  "reth-network-api",
@@ -2294,6 +2295,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "reth",
+ "reth-chainspec",
  "reth-node-core",
  "reth-node-ethereum",
  "reth-primitives",
@@ -2308,6 +2310,7 @@ dependencies = [
  "eyre",
  "reth",
  "reth-basic-payload-builder",
+ "reth-chainspec",
  "reth-ethereum-payload-builder",
  "reth-node-api",
  "reth-node-core",
@@ -2327,6 +2330,7 @@ version = "0.0.0"
 dependencies = [
  "eyre",
  "reth",
+ "reth-chainspec",
  "reth-node-api",
  "reth-node-core",
  "reth-node-ethereum",
@@ -2365,6 +2369,7 @@ dependencies = [
  "futures-util",
  "reth",
  "reth-basic-payload-builder",
+ "reth-chainspec",
  "reth-ethereum-payload-builder",
  "reth-node-api",
  "reth-node-ethereum",
@@ -2452,6 +2457,7 @@ name = "db-access"
 version = "0.0.0"
 dependencies = [
  "eyre",
+ "reth-chainspec",
  "reth-db",
  "reth-primitives",
  "reth-provider",
@@ -2727,6 +2733,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "alloy-rlp",
  "rayon",
+ "reth-chainspec",
  "reth-db",
  "reth-db-api",
  "reth-evm-ethereum",
@@ -2963,6 +2970,7 @@ dependencies = [
  "foundry-blob-explorers",
  "once_cell",
  "reth",
+ "reth-chainspec",
  "reth-execution-errors",
  "reth-exex",
  "reth-node-api",
@@ -4779,6 +4787,7 @@ dependencies = [
  "eyre",
  "futures",
  "once_cell",
+ "reth-chainspec",
  "reth-discv4",
  "reth-ecies",
  "reth-eth-wire",
@@ -5679,6 +5688,7 @@ checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 name = "polygon-p2p"
 version = "0.0.0"
 dependencies = [
+ "reth-chainspec",
  "reth-discv4",
  "reth-network",
  "reth-primitives",
@@ -6265,6 +6275,7 @@ dependencies = [
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
  "reth-blockchain-tree",
+ "reth-chainspec",
  "reth-cli-runner",
  "reth-config",
  "reth-consensus",
@@ -6327,6 +6338,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
+ "reth-chainspec",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-evm",
@@ -6353,6 +6365,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "metrics",
+ "reth-chainspec",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -6376,6 +6389,7 @@ dependencies = [
  "metrics",
  "reth-blockchain-tree",
  "reth-blockchain-tree-api",
+ "reth-chainspec",
  "reth-config",
  "reth-consensus",
  "reth-db",
@@ -6466,6 +6480,7 @@ dependencies = [
  "metrics",
  "parking_lot 0.12.3",
  "reth-blockchain-tree-api",
+ "reth-chainspec",
  "reth-consensus",
  "reth-db",
  "reth-db-api",
@@ -6588,6 +6603,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "mockall",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-consensus",
  "reth-primitives",
  "reth-storage-api",
@@ -6687,6 +6703,7 @@ name = "reth-db-common"
 version = "1.0.0-rc.1"
 dependencies = [
  "eyre",
+ "reth-chainspec",
  "reth-codecs",
  "reth-config",
  "reth-db",
@@ -6714,6 +6731,7 @@ dependencies = [
  "generic-array",
  "parking_lot 0.12.3",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-ethereum-forks",
  "reth-net-common",
  "reth-net-nat",
@@ -6743,6 +6761,7 @@ dependencies = [
  "metrics",
  "multiaddr",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-metrics",
  "reth-network-peers",
  "reth-primitives",
@@ -6765,10 +6784,10 @@ dependencies = [
  "linked_hash_set",
  "parking_lot 0.12.3",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-ethereum-forks",
  "reth-net-common",
  "reth-network-peers",
- "reth-primitives",
  "reth-tracing",
  "schnellru",
  "secp256k1",
@@ -6794,6 +6813,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "rayon",
+ "reth-chainspec",
  "reth-config",
  "reth-consensus",
  "reth-db",
@@ -6827,6 +6847,7 @@ dependencies = [
  "futures-util",
  "jsonrpsee",
  "reth",
+ "reth-chainspec",
  "reth-db",
  "reth-node-builder",
  "reth-payload-builder",
@@ -6877,8 +6898,8 @@ dependencies = [
 name = "reth-engine-primitives"
 version = "1.0.0-rc.1"
 dependencies = [
+ "reth-chainspec",
  "reth-payload-primitives",
- "reth-primitives",
  "serde",
 ]
 
@@ -6908,6 +6929,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-codecs",
  "reth-discv4",
  "reth-ecies",
@@ -6940,6 +6962,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-codecs-derive",
  "reth-net-common",
  "reth-primitives",
@@ -6954,6 +6977,7 @@ dependencies = [
 name = "reth-ethereum-consensus"
 version = "1.0.0-rc.1"
 dependencies = [
+ "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
  "reth-primitives",
@@ -6965,6 +6989,7 @@ name = "reth-ethereum-engine-primitives"
 version = "1.0.0-rc.1"
 dependencies = [
  "alloy-rlp",
+ "reth-chainspec",
  "reth-engine-primitives",
  "reth-payload-primitives",
  "reth-primitives",
@@ -7025,6 +7050,7 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "parking_lot 0.12.3",
+ "reth-chainspec",
  "reth-execution-errors",
  "reth-execution-types",
  "reth-primitives",
@@ -7040,6 +7066,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "alloy-eips 0.1.0",
  "alloy-sol-types",
+ "reth-chainspec",
  "reth-ethereum-consensus",
  "reth-evm",
  "reth-execution-types",
@@ -7056,6 +7083,7 @@ dependencies = [
 name = "reth-evm-optimism"
 version = "1.0.0-rc.1"
 dependencies = [
+ "reth-chainspec",
  "reth-consensus-common",
  "reth-evm",
  "reth-execution-errors",
@@ -7089,6 +7117,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "alloy-eips 0.1.0",
  "alloy-primitives",
+ "reth-chainspec",
  "reth-execution-errors",
  "reth-primitives",
  "reth-trie",
@@ -7124,6 +7153,7 @@ dependencies = [
  "futures-util",
  "rand 0.8.5",
  "reth-blockchain-tree",
+ "reth-chainspec",
  "reth-config",
  "reth-consensus",
  "reth-db",
@@ -7276,6 +7306,7 @@ dependencies = [
  "pin-project",
  "pprof",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
  "reth-discv5",
@@ -7408,6 +7439,7 @@ dependencies = [
  "reth-auto-seal-consensus",
  "reth-beacon-consensus",
  "reth-blockchain-tree",
+ "reth-chainspec",
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
@@ -7466,6 +7498,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "reth-beacon-consensus",
+ "reth-chainspec",
  "reth-config",
  "reth-consensus-common",
  "reth-db",
@@ -7516,6 +7549,7 @@ dependencies = [
  "reth-auto-seal-consensus",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
+ "reth-chainspec",
  "reth-consensus",
  "reth-db",
  "reth-e2e-test-utils",
@@ -7571,6 +7605,7 @@ dependencies = [
  "reth",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
+ "reth-chainspec",
  "reth-db",
  "reth-discv5",
  "reth-e2e-test-utils",
@@ -7602,6 +7637,7 @@ dependencies = [
 name = "reth-optimism-consensus"
 version = "1.0.0-rc.1"
 dependencies = [
+ "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
  "reth-primitives",
@@ -7614,6 +7650,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "alloy-rlp",
  "reth-basic-payload-builder",
+ "reth-chainspec",
  "reth-evm",
  "reth-evm-optimism",
  "reth-payload-builder",
@@ -7661,6 +7698,7 @@ dependencies = [
 name = "reth-payload-primitives"
 version = "1.0.0-rc.1"
 dependencies = [
+ "reth-chainspec",
  "reth-errors",
  "reth-primitives",
  "reth-rpc-types",
@@ -7674,6 +7712,7 @@ dependencies = [
 name = "reth-payload-validator"
 version = "1.0.0-rc.1"
 dependencies = [
+ "reth-chainspec",
  "reth-primitives",
  "reth-rpc-types",
  "reth-rpc-types-compat",
@@ -7765,6 +7804,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "reth-blockchain-tree-api",
+ "reth-chainspec",
  "reth-codecs",
  "reth-db",
  "reth-db-api",
@@ -7799,6 +7839,7 @@ dependencies = [
  "itertools 0.12.1",
  "metrics",
  "rayon",
+ "reth-chainspec",
  "reth-config",
  "reth-db",
  "reth-db-api",
@@ -7843,6 +7884,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "alloy-eips 0.1.0",
  "alloy-rlp",
+ "reth-chainspec",
  "reth-consensus-common",
  "reth-execution-errors",
  "reth-primitives",
@@ -7876,6 +7918,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-consensus-common",
  "reth-errors",
  "reth-evm",
@@ -7949,6 +7992,7 @@ dependencies = [
  "metrics",
  "pin-project",
  "reth-beacon-consensus",
+ "reth-chainspec",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
  "reth-evm",
@@ -7991,6 +8035,7 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "reth-beacon-consensus",
+ "reth-chainspec",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
  "reth-evm",
@@ -8088,6 +8133,7 @@ dependencies = [
  "pprof",
  "rand 0.8.5",
  "rayon",
+ "reth-chainspec",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
@@ -8198,6 +8244,7 @@ name = "reth-storage-api"
 version = "1.0.0-rc.1"
 dependencies = [
  "auto_impl",
+ "reth-chainspec",
  "reth-db-api",
  "reth-execution-types",
  "reth-primitives",
@@ -8284,6 +8331,7 @@ dependencies = [
  "pprof",
  "proptest",
  "rand 0.8.5",
+ "reth-chainspec",
  "reth-eth-wire-types",
  "reth-fs-util",
  "reth-metrics",
@@ -8315,6 +8363,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "rayon",
+ "reth-chainspec",
  "reth-db",
  "reth-db-api",
  "reth-execution-errors",
@@ -8565,6 +8614,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "reth",
+ "reth-chainspec",
  "reth-db",
  "reth-db-api",
  "reth-node-ethereum",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-config.workspace = true
 reth-primitives.workspace = true
 reth-fs-util.workspace = true

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -13,10 +13,10 @@ use crate::{
     version::{LONG_VERSION, SHORT_VERSION},
 };
 use clap::{value_parser, Parser, Subcommand};
+use reth_chainspec::ChainSpec;
 use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
-use reth_primitives::ChainSpec;
 use reth_tracing::FileWorkerGuard;
 use std::{ffi::OsString, fmt, future::Future, sync::Arc};
 use tracing::info;

--- a/bin/reth/src/commands/common.rs
+++ b/bin/reth/src/commands/common.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use reth_beacon_consensus::EthBeaconConsensus;
+use reth_chainspec::ChainSpec;
 use reth_config::{config::EtlConfig, Config};
 use reth_db::{init_db, open_db_read_only, DatabaseEnv};
 use reth_db_common::init::init_genesis;
@@ -14,7 +15,7 @@ use reth_node_core::{
     },
     dirs::{ChainPath, DataDirPath},
 };
-use reth_primitives::{ChainSpec, B256};
+use reth_primitives::B256;
 use reth_provider::{providers::StaticFileProvider, ProviderFactory, StaticFileProviderFactory};
 use reth_stages::{sets::DefaultStages, Pipeline, PipelineTarget};
 use reth_static_file::StaticFileProducer;

--- a/bin/reth/src/commands/dump_genesis.rs
+++ b/bin/reth/src/commands/dump_genesis.rs
@@ -1,7 +1,7 @@
 //! Command that dumps genesis block JSON configuration to stdout
 use crate::args::utils::{chain_help, genesis_value_parser, SUPPORTED_CHAINS};
 use clap::Parser;
-use reth_primitives::ChainSpec;
+use reth_chainspec::ChainSpec;
 use std::sync::Arc;
 
 /// Dumps genesis block JSON configuration to stdout
@@ -39,7 +39,7 @@ mod tests {
                 DumpGenesisCommand::parse_from(["reth", "--chain", chain]);
             assert_eq!(
                 Ok(args.chain.chain),
-                chain.parse::<reth_primitives::Chain>(),
+                chain.parse::<reth_chainspec::Chain>(),
                 "failed to parse chain {chain}"
             );
         }

--- a/bin/reth/src/commands/import.rs
+++ b/bin/reth/src/commands/import.rs
@@ -237,7 +237,7 @@ mod tests {
             let args: ImportCommand = ImportCommand::parse_from(["reth", "--chain", chain, "."]);
             assert_eq!(
                 Ok(args.env.chain.chain),
-                chain.parse::<reth_primitives::Chain>(),
+                chain.parse::<reth_chainspec::Chain>(),
                 "failed to parse chain {chain}"
             );
         }

--- a/bin/reth/src/commands/node/mod.rs
+++ b/bin/reth/src/commands/node/mod.rs
@@ -6,11 +6,11 @@ use crate::args::{
     RpcServerArgs, TxPoolArgs,
 };
 use clap::{value_parser, Args, Parser};
+use reth_chainspec::ChainSpec;
 use reth_cli_runner::CliContext;
 use reth_db::{init_db, DatabaseEnv};
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_node_core::{node_config::NodeConfig, version};
-use reth_primitives::ChainSpec;
 use std::{ffi::OsString, fmt, future::Future, net::SocketAddr, path::PathBuf, sync::Arc};
 
 /// Start the node
@@ -213,7 +213,7 @@ mod tests {
     fn parse_common_node_command_chain_args() {
         for chain in SUPPORTED_CHAINS {
             let args: NodeCommand = NodeCommand::<NoArgs>::parse_from(["reth", "--chain", chain]);
-            assert_eq!(args.chain.chain, chain.parse::<reth_primitives::Chain>().unwrap());
+            assert_eq!(args.chain.chain, chain.parse::<reth_chainspec::Chain>().unwrap());
         }
     }
 
@@ -305,7 +305,7 @@ mod tests {
     #[cfg(not(feature = "optimism"))] // dev mode not yet supported in op-reth
     fn parse_dev() {
         let cmd = NodeCommand::<NoArgs>::parse_from(["reth", "--dev"]);
-        let chain = reth_primitives::DEV.clone();
+        let chain = reth_chainspec::DEV.clone();
         assert_eq!(cmd.chain.chain, chain.chain);
         assert_eq!(cmd.chain.genesis_hash, chain.genesis_hash);
         assert_eq!(

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -11,12 +11,13 @@ use crate::{
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
 use discv5::ListenConfig;
+use reth_chainspec::ChainSpec;
 use reth_config::Config;
 use reth_db::create_db;
 use reth_network::NetworkConfigBuilder;
 use reth_network_p2p::bodies::client::BodiesClient;
 use reth_node_core::args::DatadirArgs;
-use reth_primitives::{BlockHashOrNumber, ChainSpec};
+use reth_primitives::BlockHashOrNumber;
 use reth_provider::{providers::StaticFileProvider, ProviderFactory};
 use std::{
     net::{IpAddr, SocketAddrV4, SocketAddrV6},

--- a/bin/reth/src/utils.rs
+++ b/bin/reth/src/utils.rs
@@ -2,6 +2,7 @@
 
 use boyer_moore_magiclen::BMByte;
 use eyre::Result;
+use reth_chainspec::ChainSpec;
 use reth_db::{RawTable, TableRawRow};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
@@ -11,7 +12,6 @@ use reth_db_api::{
     DatabaseError,
 };
 use reth_fs_util as fs;
-use reth_primitives::ChainSpec;
 use reth_provider::{ChainSpecProvider, ProviderFactory};
 use std::{path::Path, rc::Rc, sync::Arc};
 use tracing::info;

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -42,6 +42,7 @@ aquamarine.workspace = true
 linked_hash_set.workspace = true
 
 [dev-dependencies]
+reth-chainspec.workspace = true
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-primitives = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1371,6 +1371,7 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use linked_hash_set::LinkedHashSet;
+    use reth_chainspec::{ChainSpecBuilder, MAINNET};
     use reth_consensus::test_utils::TestConsensus;
     use reth_db::{tables, test_utils::TempDatabase, DatabaseEnv};
     use reth_db_api::transaction::DbTxMut;
@@ -1385,9 +1386,8 @@ mod tests {
         keccak256,
         proofs::calculate_transaction_root,
         revm_primitives::AccountInfo,
-        Account, Address, ChainSpecBuilder, Genesis, GenesisAccount, Header, Signature,
-        Transaction, TransactionSigned, TransactionSignedEcRecovered, TxEip1559, Withdrawals, B256,
-        MAINNET,
+        Account, Address, Genesis, GenesisAccount, Header, Signature, Transaction,
+        TransactionSigned, TransactionSignedEcRecovered, TxEip1559, Withdrawals, B256,
     };
     use reth_provider::{
         test_utils::{blocks::BlockchainTestData, create_test_provider_factory_with_chain_spec},

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -32,6 +32,9 @@ mod spec;
 /// Chain specific constants
 pub(crate) mod constants;
 
+/// Re-export for convenience
+pub use reth_ethereum_forks::*;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/consensus/auto-seal/Cargo.toml
+++ b/crates/consensus/auto-seal/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-beacon-consensus.workspace = true
 reth-primitives.workspace = true
 reth-execution-errors.workspace = true

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -16,15 +16,15 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use reth_beacon_consensus::BeaconEngineMessage;
+use reth_chainspec::ChainSpec;
 use reth_consensus::{Consensus, ConsensusError, PostExecutionInput};
 use reth_engine_primitives::EngineTypes;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
     constants::{EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT},
     eip4844::calculate_excess_blob_gas,
-    proofs, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders,
-    ChainSpec, Header, Requests, SealedBlock, SealedHeader, TransactionSigned, Withdrawals, B256,
-    U256,
+    proofs, Block, BlockBody, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, Header,
+    Requests, SealedBlock, SealedHeader, TransactionSigned, Withdrawals, B256, U256,
 };
 use reth_provider::{BlockReaderIdExt, ExecutionOutcome, StateProviderFactory, StateRootProvider};
 use reth_revm::database::StateProviderDatabase;

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -1,9 +1,10 @@
 use crate::{mode::MiningMode, Storage};
 use futures_util::{future::BoxFuture, FutureExt};
 use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
+use reth_chainspec::ChainSpec;
 use reth_engine_primitives::EngineTypes;
 use reth_evm::execute::BlockExecutorProvider;
-use reth_primitives::{ChainSpec, IntoRecoveredTransaction};
+use reth_primitives::IntoRecoveredTransaction;
 use reth_provider::{CanonChainTracker, StateProviderFactory};
 use reth_rpc_types::engine::ForkchoiceState;
 use reth_stages_api::PipelineEvent;

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-blockchain-tree-api.workspace = true
 reth-primitives.workspace = true

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1975,7 +1975,7 @@ mod tests {
         BeaconForkChoiceUpdateError,
     };
     use assert_matches::assert_matches;
-    use reth_primitives::{ChainSpecBuilder, MAINNET};
+    use reth_chainspec::{ChainSpecBuilder, MAINNET};
     use reth_provider::{BlockWriter, ProviderFactory};
     use reth_rpc_types::engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
     use reth_rpc_types_compat::engine::payload::block_to_payload_v1;

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -5,13 +5,14 @@ use crate::{
     ConsensusEngineLiveSyncProgress, EthBeaconConsensus,
 };
 use futures::FutureExt;
+use reth_chainspec::ChainSpec;
 use reth_db_api::database::Database;
 use reth_network_p2p::{
     bodies::client::BodiesClient,
     full_block::{FetchFullBlockFuture, FetchFullBlockRangeFuture, FullBlockClient},
     headers::client::HeadersClient,
 };
-use reth_primitives::{BlockNumber, ChainSpec, SealedBlock, B256};
+use reth_primitives::{BlockNumber, SealedBlock, B256};
 use reth_stages_api::{ControlFlow, Pipeline, PipelineError, PipelineTarget, PipelineWithResult};
 use reth_tasks::TaskSpawner;
 use reth_tokio_util::EventSender;
@@ -413,12 +414,10 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use futures::poll;
+    use reth_chainspec::{ChainSpecBuilder, MAINNET};
     use reth_db::{mdbx::DatabaseEnv, test_utils::TempDatabase};
     use reth_network_p2p::{either::Either, test_utils::TestFullBlockClient};
-    use reth_primitives::{
-        constants::ETHEREUM_BLOCK_GAS_LIMIT, BlockBody, ChainSpecBuilder, Header, SealedHeader,
-        MAINNET,
-    };
+    use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, BlockBody, Header, SealedHeader};
     use reth_provider::{
         test_utils::create_test_provider_factory_with_chain_spec, ExecutionOutcome,
     };

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -6,6 +6,7 @@ use crate::{
 use reth_blockchain_tree::{
     config::BlockchainTreeConfig, externals::TreeExternals, BlockchainTree, ShareableBlockchainTree,
 };
+use reth_chainspec::ChainSpec;
 use reth_config::config::StageConfig;
 use reth_consensus::{test_utils::TestConsensus, Consensus};
 use reth_db::{test_utils::TempDatabase, DatabaseEnv as DE};
@@ -22,7 +23,7 @@ use reth_network_p2p::{
     test_utils::NoopFullBlockClient,
 };
 use reth_payload_builder::test_utils::spawn_test_payload_service;
-use reth_primitives::{BlockNumber, ChainSpec, B256};
+use reth_primitives::{BlockNumber, B256};
 use reth_provider::{
     providers::BlockchainProvider, test_utils::create_test_provider_factory_with_chain_spec,
     ExecutionOutcome,

--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-consensus.workspace = true
 

--- a/crates/consensus/common/src/calc.rs
+++ b/crates/consensus/common/src/calc.rs
@@ -46,9 +46,10 @@ pub fn base_block_reward(
 /// # Examples
 ///
 /// ```
+/// # use reth_chainspec::MAINNET;
 /// # use reth_consensus_common::calc::{base_block_reward, block_reward};
 /// # use reth_primitives::constants::ETH_TO_WEI;
-/// # use reth_primitives::{MAINNET, U256};
+/// # use reth_primitives::U256;
 /// #
 /// // This is block 126 on mainnet.
 /// let block_number = 126;

--- a/crates/consensus/common/src/calc.rs
+++ b/crates/consensus/common/src/calc.rs
@@ -1,4 +1,5 @@
-use reth_primitives::{constants::ETH_TO_WEI, BlockNumber, Chain, ChainSpec, Hardfork, U256};
+use reth_chainspec::{Chain, ChainSpec, Hardfork};
+use reth_primitives::{constants::ETH_TO_WEI, BlockNumber, U256};
 /// Calculates the base block reward.
 ///
 /// The base block reward is defined as:
@@ -102,7 +103,7 @@ pub const fn ommer_reward(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_primitives::MAINNET;
+    use reth_chainspec::MAINNET;
 
     #[test]
     fn calc_base_block_reward() {

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -1,5 +1,6 @@
 //! Collection of methods for block validation.
 
+use reth_chainspec::ChainSpec;
 use reth_consensus::ConsensusError;
 use reth_primitives::{
     constants::{
@@ -7,7 +8,7 @@ use reth_primitives::{
         MAXIMUM_EXTRA_DATA_SIZE,
     },
     eip4844::calculate_excess_blob_gas,
-    ChainSpec, GotExpected, Hardfork, Header, SealedBlock, SealedHeader,
+    GotExpected, Hardfork, Header, SealedBlock, SealedHeader,
 };
 
 /// Gas used needs to be less than gas limit. Gas used is going to be checked after execution.
@@ -270,10 +271,11 @@ mod tests {
     use super::*;
     use mockall::mock;
     use rand::Rng;
+    use reth_chainspec::ChainSpecBuilder;
     use reth_primitives::{
         hex_literal::hex, proofs, Account, Address, BlockBody, BlockHash, BlockHashOrNumber,
-        BlockNumber, Bytes, ChainSpecBuilder, Signature, Transaction, TransactionSigned, TxEip4844,
-        Withdrawal, Withdrawals, U256,
+        BlockNumber, Bytes, Signature, Transaction, TransactionSigned, TxEip4844, Withdrawal,
+        Withdrawals, U256,
     };
     use reth_storage_api::{
         errors::provider::ProviderResult, AccountReader, HeaderProvider, WithdrawalsProvider,

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-tracing.workspace = true
 reth-db.workspace = true

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -4,11 +4,11 @@ use reth::{
     builder::{NodeBuilder, NodeConfig, NodeHandle},
     tasks::TaskManager,
 };
+use reth_chainspec::ChainSpec;
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_node_builder::{
     components::NodeComponentsBuilder, FullNodeTypesAdapter, Node, NodeAdapter, RethFullAdapter,
 };
-use reth_primitives::ChainSpec;
 use reth_provider::providers::BlockchainProvider;
 use std::sync::Arc;
 use tracing::{span, Level};

--- a/crates/e2e-test-utils/src/network.rs
+++ b/crates/e2e-test-utils/src/network.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use reth::network::{NetworkEvent, NetworkEvents, NetworkHandle, PeersInfo};
-use reth_primitives::NodeRecord;
+use reth_chainspec::net::NodeRecord;
 use reth_tokio_util::EventStream;
 use reth_tracing::tracing::info;
 

--- a/crates/engine-primitives/Cargo.toml
+++ b/crates/engine-primitives/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives.workspace = true
+reth-chainspec.workspace = true
 reth-payload-primitives.workspace = true
 
 # misc

--- a/crates/engine-primitives/src/lib.rs
+++ b/crates/engine-primitives/src/lib.rs
@@ -8,11 +8,11 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use reth_chainspec::ChainSpec;
 pub use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, EngineObjectValidationError, PayloadOrAttributes,
     PayloadTypes,
 };
-use reth_primitives::ChainSpec;
 use serde::{de::DeserializeOwned, ser::Serialize};
 
 /// This type defines the versioned types of the engine API.

--- a/crates/ethereum/consensus/Cargo.toml
+++ b/crates/ethereum/consensus/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-consensus-common.workspace = true
 reth-primitives.workspace = true
 reth-consensus.workspace = true

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use reth_chainspec::{Chain, ChainSpec, Hardfork};
 use reth_consensus::{Consensus, ConsensusError, PostExecutionInput};
 use reth_consensus_common::validation::{
     validate_4844_header_standalone, validate_against_parent_4844,
@@ -16,8 +17,8 @@ use reth_consensus_common::validation::{
     validate_header_extradata, validate_header_gas,
 };
 use reth_primitives::{
-    constants::MINIMUM_GAS_LIMIT, BlockWithSenders, Chain, ChainSpec, Hardfork, Header,
-    SealedBlock, SealedHeader, EMPTY_OMMER_ROOT_HASH, U256,
+    constants::MINIMUM_GAS_LIMIT, BlockWithSenders, Header, SealedBlock, SealedHeader,
+    EMPTY_OMMER_ROOT_HASH, U256,
 };
 use std::{sync::Arc, time::SystemTime};
 
@@ -223,9 +224,9 @@ impl Consensus for EthBeaconConsensus {
 
 #[cfg(test)]
 mod tests {
-    use reth_primitives::{proofs, ChainSpecBuilder, B256};
-
     use super::*;
+    use reth_chainspec::ChainSpecBuilder;
+    use reth_primitives::{proofs, B256};
 
     fn header_with_gas_limit(gas_limit: u64) -> SealedHeader {
         let header = Header { gas_limit, ..Default::default() };

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -1,7 +1,7 @@
+use reth_chainspec::ChainSpec;
 use reth_consensus::ConsensusError;
 use reth_primitives::{
-    gas_spent_by_transactions, BlockWithSenders, Bloom, ChainSpec, GotExpected, Receipt, Request,
-    B256,
+    gas_spent_by_transactions, BlockWithSenders, Bloom, GotExpected, Receipt, Request, B256,
 };
 
 /// Validate a block with regard to execution results:

--- a/crates/ethereum/engine-primitives/Cargo.toml
+++ b/crates/ethereum/engine-primitives/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-engine-primitives.workspace = true
 reth-payload-primitives.workspace = true

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -11,12 +11,12 @@
 mod payload;
 pub use payload::{EthBuiltPayload, EthPayloadBuilderAttributes};
 
+use reth_chainspec::ChainSpec;
 use reth_engine_primitives::EngineTypes;
 use reth_payload_primitives::{
     validate_version_specific_fields, EngineApiMessageVersion, EngineObjectValidationError,
     PayloadOrAttributes, PayloadTypes,
 };
-use reth_primitives::ChainSpec;
 use reth_rpc_types::{
     engine::{
         ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -1,10 +1,11 @@
 //! Contains types required for building a payload.
 
 use alloy_rlp::Encodable;
+use reth_chainspec::ChainSpec;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
 use reth_primitives::{
     constants::EIP1559_INITIAL_BASE_FEE, revm::config::revm_spec_by_timestamp_after_merge, Address,
-    BlobTransactionSidecar, ChainSpec, Hardfork, Header, SealedBlock, Withdrawals, B256, U256,
+    BlobTransactionSidecar, Hardfork, Header, SealedBlock, Withdrawals, B256, U256,
 };
 use reth_rpc_types::engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # Reth
+reth-chainspec.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
 reth-revm.workspace = true

--- a/crates/ethereum/evm/src/eip6110.rs
+++ b/crates/ethereum/evm/src/eip6110.rs
@@ -1,8 +1,9 @@
 //! EIP-6110 deposit requests parsing
 use alloy_eips::eip6110::{DepositRequest, MAINNET_DEPOSIT_CONTRACT_ADDRESS};
 use alloy_sol_types::{sol, SolEvent};
+use reth_chainspec::ChainSpec;
 use reth_evm::execute::BlockValidationError;
-use reth_primitives::{ChainSpec, Receipt, Request};
+use reth_primitives::{Receipt, Request};
 use revm_primitives::Log;
 
 sol! {
@@ -85,7 +86,8 @@ fn parse_deposit_from_log(log: &Log<DepositEvent>) -> DepositRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_primitives::{TxType, MAINNET};
+    use reth_chainspec::MAINNET;
+    use reth_primitives::TxType;
 
     #[test]
     fn test_parse_deposit_from_log() {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -4,6 +4,7 @@ use crate::{
     dao_fork::{DAO_HARDFORK_BENEFICIARY, DAO_HARDKFORK_ACCOUNTS},
     EthEvmConfig,
 };
+use reth_chainspec::{ChainSpec, MAINNET};
 use reth_ethereum_consensus::validate_block_post_execution;
 use reth_evm::{
     execute::{
@@ -14,8 +15,7 @@ use reth_evm::{
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{
-    BlockNumber, BlockWithSenders, ChainSpec, Hardfork, Header, Receipt, Request, Withdrawals,
-    MAINNET, U256,
+    BlockNumber, BlockWithSenders, Hardfork, Header, Receipt, Request, Withdrawals, U256,
 };
 use reth_prune_types::PruneModes;
 use reth_revm::{
@@ -461,10 +461,10 @@ mod tests {
         eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE, SYSTEM_ADDRESS},
         eip7002::{WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_PREDEPLOY_CODE},
     };
+    use reth_chainspec::{ChainSpecBuilder, ForkCondition};
     use reth_primitives::{
         constants::{EMPTY_ROOT_HASH, ETH_TO_WEI},
-        keccak256, public_key_to_address, Account, Block, ChainSpecBuilder, ForkCondition,
-        Transaction, TxKind, TxLegacy, B256,
+        keccak256, public_key_to_address, Account, Block, Transaction, TxKind, TxLegacy, B256,
     };
     use reth_revm::{
         database::StateProviderDatabase, state_change::HISTORY_SERVE_WINDOW,

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -8,11 +8,12 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use reth_chainspec::ChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_tx_env},
     revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
-    Address, ChainSpec, Head, Header, TransactionSigned, U256,
+    Address, Head, Header, TransactionSigned, U256,
 };
 use reth_revm::{Database, EvmBuilder};
 

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -31,6 +31,7 @@ eyre.workspace = true
 
 [dev-dependencies]
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-db.workspace = true
 reth-exex.workspace = true
 reth-node-api.workspace = true

--- a/crates/ethereum/node/tests/e2e/blobs.rs
+++ b/crates/ethereum/node/tests/e2e/blobs.rs
@@ -6,11 +6,12 @@ use reth::{
     rpc::types::engine::PayloadStatusEnum,
     tasks::TaskManager,
 };
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{
     node::NodeTestContext, transaction::TransactionTestContext, wallet::Wallet,
 };
 use reth_node_ethereum::EthereumNode;
-use reth_primitives::{b256, ChainSpecBuilder, Genesis, MAINNET};
+use reth_primitives::{b256, Genesis};
 use reth_transaction_pool::TransactionPool;
 
 use crate::utils::eth_payload_attributes;

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -1,8 +1,9 @@
 use crate::utils::EthNode;
 use futures::StreamExt;
 use reth::rpc::eth::EthTransactions;
+use reth_chainspec::ChainSpec;
 use reth_e2e_test_utils::setup;
-use reth_primitives::{b256, hex, ChainSpec, Genesis};
+use reth_primitives::{b256, hex, Genesis};
 use reth_provider::CanonStateSubscriptions;
 use std::sync::Arc;
 

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -4,11 +4,12 @@ use reth::{
     builder::{NodeBuilder, NodeConfig, NodeHandle},
     tasks::TaskManager,
 };
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{
     node::NodeTestContext, setup, transaction::TransactionTestContext, wallet::Wallet,
 };
 use reth_node_ethereum::EthereumNode;
-use reth_primitives::{ChainSpecBuilder, Genesis, MAINNET};
+use reth_primitives::Genesis;
 use std::sync::Arc;
 
 #[tokio::test]

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -1,7 +1,7 @@
 use crate::utils::eth_payload_attributes;
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{setup, transaction::TransactionTestContext};
 use reth_node_ethereum::EthereumNode;
-use reth_primitives::{ChainSpecBuilder, MAINNET};
 use std::sync::Arc;
 
 #[tokio::test]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-execution-errors.workspace = true
 reth-primitives.workspace = true
 revm-primitives.workspace = true

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -24,4 +24,4 @@ alloy-primitives.workspace = true
 alloy-eips.workspace = true
 
 [features]
-optimism = ["reth-chainspec"]
+optimism = ["dep:reth-chainspec"]

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 reth-primitives.workspace = true
+reth-chainspec.workspace = true
 reth-execution-errors.workspace = true
 reth-trie.workspace = true
 

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 reth-primitives.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, optional = true }
 reth-execution-errors.workspace = true
 reth-trie.workspace = true
 
@@ -24,4 +24,4 @@ alloy-primitives.workspace = true
 alloy-eips.workspace = true
 
 [features]
-optimism = []
+optimism = ["reth-chainspec"]

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -190,7 +190,7 @@ impl ExecutionOutcome {
     pub fn optimism_receipts_root_slow(
         &self,
         block_number: BlockNumber,
-        chain_spec: &reth_primitives::ChainSpec,
+        chain_spec: &reth_chainspec::ChainSpec,
         timestamp: u64,
     ) -> Option<B256> {
         self.receipts.optimism_root_slow(

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -8,9 +8,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use reth_primitives::{
-    revm::env::fill_block_env, Address, ChainSpec, Header, TransactionSigned, U256,
-};
+use reth_chainspec::ChainSpec;
+use reth_primitives::{revm::env::fill_block_env, Address, Header, TransactionSigned, U256};
 use revm::{inspector_handle_register, Database, Evm, EvmBuilder, GetInspector};
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, SpecId, TxEnv};
 

--- a/crates/exex/test-utils/Cargo.toml
+++ b/crates/exex/test-utils/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 ## reth
+reth-chainspec.workspace = true
 reth-blockchain-tree.workspace = true
 reth-config.workspace = true
 reth-consensus = { workspace = true, features = ["test-utils"] }

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -10,6 +10,7 @@
 
 use futures_util::FutureExt;
 use reth_blockchain_tree::noop::NoopBlockchainTree;
+use reth_chainspec::{ChainSpec, MAINNET};
 use reth_consensus::test_utils::TestConsensus;
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_db_common::init::init_genesis;
@@ -30,7 +31,7 @@ use reth_node_ethereum::{
     EthEngineTypes, EthEvmConfig,
 };
 use reth_payload_builder::noop::NoopPayloadBuilderService;
-use reth_primitives::{ChainSpec, Head, SealedBlockWithSenders, MAINNET};
+use reth_primitives::{Head, SealedBlockWithSenders};
 use reth_provider::{
     providers::BlockchainProvider, test_utils::create_test_provider_factory_with_chain_spec,
     BlockReader, Chain, ProviderFactory,

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -44,6 +44,7 @@ generic-array.workspace = true
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 assert_matches.workspace = true
 rand.workspace = true

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -214,9 +214,9 @@ impl Discv4 {
     /// ```
     /// # use std::io;
     /// use rand::thread_rng;
+    /// use reth_chainspec::net::NodeRecord;
     /// use reth_discv4::{Discv4, Discv4Config};
     /// use reth_network_peers::{pk2id, PeerId};
-    /// use reth_primitives::NodeRecord;
     /// use secp256k1::SECP256K1;
     /// use std::{net::SocketAddr, str::FromStr};
     /// # async fn t() -> io::Result<()> {
@@ -2287,7 +2287,8 @@ mod tests {
     use crate::test_utils::{create_discv4, create_discv4_with_config, rng_endpoint, rng_record};
     use alloy_rlp::{Decodable, Encodable};
     use rand::{thread_rng, Rng};
-    use reth_primitives::{hex, mainnet_nodes, EnrForkIdEntry, ForkHash};
+    use reth_chainspec::net::mainnet_nodes;
+    use reth_primitives::{hex, EnrForkIdEntry, ForkHash};
     use std::future::poll_fn;
 
     #[tokio::test]

--- a/crates/net/discv5/Cargo.toml
+++ b/crates/net/discv5/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-metrics.workspace = true
 reth-network-peers = { workspace = true, features = ["secp256k1"] }

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -9,7 +9,8 @@ use std::{
 use derive_more::Display;
 use discv5::ListenConfig;
 use multiaddr::{Multiaddr, Protocol};
-use reth_primitives::{Bytes, EnrForkIdEntry, ForkId, NodeRecord};
+use reth_network_peers::NodeRecord;
+use reth_primitives::{Bytes, EnrForkIdEntry, ForkId};
 use tracing::warn;
 
 use crate::{enr::discv4_id_to_multiaddr_id, filter::MustNotIncludeKeys, NetworkStackId};

--- a/crates/net/discv5/src/enr.rs
+++ b/crates/net/discv5/src/enr.rs
@@ -58,7 +58,8 @@ mod tests {
     use super::*;
     use alloy_rlp::Encodable;
     use discv5::enr::{CombinedKey, EnrKey};
-    use reth_primitives::{Hardfork, NodeRecord, MAINNET};
+    use reth_chainspec::{Hardfork, MAINNET};
+    use reth_network_peers::NodeRecord;
 
     #[test]
     fn discv5_discv4_id_conversion() {

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -22,8 +22,8 @@ use enr::{discv4_id_to_discv5_id, EnrCombinedKeyWrapper};
 use futures::future::join_all;
 use itertools::Itertools;
 use rand::{Rng, RngCore};
-use reth_network_peers::PeerId;
-use reth_primitives::{bytes::Bytes, EnrForkIdEntry, ForkId, NodeRecord};
+use reth_network_peers::{NodeRecord, PeerId};
+use reth_primitives::{bytes::Bytes, EnrForkIdEntry, ForkId};
 use secp256k1::SecretKey;
 use tokio::{sync::mpsc, task};
 use tracing::{debug, error, trace};
@@ -652,7 +652,7 @@ pub async fn lookup(
 mod test {
     use super::*;
     use ::enr::{CombinedKey, EnrKey};
-    use reth_primitives::MAINNET;
+    use reth_chainspec::MAINNET;
     use secp256k1::rand::thread_rng;
     use tracing::trace;
 

--- a/crates/net/discv5/src/network_stack_id.rs
+++ b/crates/net/discv5/src/network_stack_id.rs
@@ -1,7 +1,7 @@
 //! Keys of ENR [`ForkId`](reth_primitives::ForkId) kv-pair. Identifies which network stack a node
 //! belongs to.
 
-use reth_primitives::ChainSpec;
+use reth_chainspec::ChainSpec;
 
 /// Identifies which Ethereum network stack a node belongs to, on the discovery network.
 #[derive(Debug)]

--- a/crates/net/dns/Cargo.toml
+++ b/crates/net/dns/Cargo.toml
@@ -40,7 +40,7 @@ serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 
 [dev-dependencies]
-reth-primitives.workspace = true
+reth-chainspec.workspace = true
 alloy-rlp.workspace = true
 alloy-chains.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread"] }

--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -414,8 +414,8 @@ mod tests {
     use alloy_chains::Chain;
     use alloy_rlp::{Decodable, Encodable};
     use enr::EnrKey;
+    use reth_chainspec::MAINNET;
     use reth_ethereum_forks::{ForkHash, Hardfork};
-    use reth_primitives::MAINNET;
     use secp256k1::rand::thread_rng;
     use std::{future::poll_fn, net::Ipv4Addr};
 

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -50,6 +50,7 @@ tempfile = { workspace = true, optional = true }
 itertools.workspace = true
 
 [dev-dependencies]
+reth-chainspec.workspace = true
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-db-api.workspace = true
 reth-consensus = { workspace = true, features = ["test-utils"] }

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -604,9 +604,10 @@ mod tests {
         test_utils::{generate_bodies, TestBodiesClient},
     };
     use assert_matches::assert_matches;
+    use reth_chainspec::MAINNET;
     use reth_consensus::test_utils::TestConsensus;
     use reth_db::test_utils::{create_test_rw_db, create_test_static_files_dir};
-    use reth_primitives::{BlockBody, B256, MAINNET};
+    use reth_primitives::{BlockBody, B256};
     use reth_provider::{providers::StaticFileProvider, ProviderFactory};
     use reth_testing_utils::{generators, generators::random_block_range};
     use std::collections::HashMap;

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-codecs-derive.workspace = true
 reth-primitives.workspace = true
 alloy-rlp = { workspace = true, features = ["derive"] }

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -1,9 +1,8 @@
 use crate::EthVersion;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
+use reth_chainspec::{Chain, ChainSpec, NamedChain, MAINNET};
 use reth_codecs_derive::derive_arbitrary;
-use reth_primitives::{
-    hex, Chain, ChainSpec, ForkId, Genesis, Hardfork, Head, NamedChain, B256, MAINNET, U256,
-};
+use reth_primitives::{hex, ForkId, Genesis, Hardfork, Head, B256, U256};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
@@ -152,8 +151,9 @@ impl Default for Status {
 ///
 /// # Example
 /// ```
+/// use reth_chainspec::{Chain, Hardfork, MAINNET};
 /// use reth_eth_wire_types::{EthVersion, Status};
-/// use reth_primitives::{Chain, Hardfork, B256, MAINNET, MAINNET_GENESIS_HASH, U256};
+/// use reth_primitives::{B256, MAINNET_GENESIS_HASH, U256};
 ///
 /// // this is just an example status message!
 /// let status = Status::builder()
@@ -230,10 +230,8 @@ mod tests {
     use crate::{EthVersion, Status};
     use alloy_rlp::{Decodable, Encodable};
     use rand::Rng;
-    use reth_primitives::{
-        hex, Chain, ChainSpec, ForkCondition, ForkHash, ForkId, Genesis, Hardfork, Head,
-        NamedChain, B256, U256,
-    };
+    use reth_chainspec::{Chain, ChainSpec, ForkCondition, NamedChain};
+    use reth_primitives::{hex, ForkHash, ForkId, Genesis, Hardfork, Head, B256, U256};
     use std::str::FromStr;
 
     #[test]

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-codecs.workspace = true
 reth-primitives.workspace = true
 reth-ecies.workspace = true

--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -3,7 +3,8 @@
 use crate::{
     errors::P2PStreamError, message::MessageError, version::ParseVersionError, DisconnectReason,
 };
-use reth_primitives::{Chain, GotExpected, GotExpectedBoxed, ValidationError, B256};
+use reth_chainspec::Chain;
+use reth_primitives::{GotExpected, GotExpectedBoxed, ValidationError, B256};
 use std::io;
 
 /// Errors when sending/receiving messages

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -352,10 +352,11 @@ mod tests {
         EthMessage, EthStream, EthVersion, HelloMessageWithProtocols, PassthroughCodec, Status,
     };
     use futures::{SinkExt, StreamExt};
+    use reth_chainspec::NamedChain;
     use reth_discv4::DEFAULT_DISCOVERY_PORT;
     use reth_ecies::stream::ECIESStream;
     use reth_network_peers::pk2id;
-    use reth_primitives::{ForkFilter, Head, NamedChain, B256, U256};
+    use reth_primitives::{ForkFilter, Head, B256, U256};
     use secp256k1::{SecretKey, SECP256K1};
     use std::time::Duration;
     use tokio::net::{TcpListener, TcpStream};

--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -3,9 +3,10 @@
 use crate::{
     EthVersion, HelloMessageWithProtocols, P2PStream, ProtocolVersion, Status, UnauthedP2PStream,
 };
+use reth_chainspec::Chain;
 use reth_discv4::DEFAULT_DISCOVERY_PORT;
 use reth_network_peers::pk2id;
-use reth_primitives::{Chain, ForkFilter, Head, B256, U256};
+use reth_primitives::{ForkFilter, Head, B256, U256};
 use secp256k1::{SecretKey, SECP256K1};
 use std::net::SocketAddr;
 use tokio::net::TcpStream;

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-net-common.workspace = true
 reth-network-api.workspace = true

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -8,14 +8,16 @@ use crate::{
     transactions::TransactionsManagerConfig,
     NetworkHandle, NetworkManager,
 };
+use reth_chainspec::{
+    net::{mainnet_nodes, sepolia_nodes, TrustedPeer},
+    ChainSpec, MAINNET,
+};
 use reth_discv4::{Discv4Config, Discv4ConfigBuilder, NatResolver, DEFAULT_DISCOVERY_ADDRESS};
 use reth_discv5::NetworkStackId;
 use reth_dns_discovery::DnsDiscoveryConfig;
 use reth_eth_wire::{HelloMessage, HelloMessageWithProtocols, Status};
 use reth_network_peers::{pk2id, PeerId};
-use reth_primitives::{
-    mainnet_nodes, sepolia_nodes, ChainSpec, ForkFilter, Head, TrustedPeer, MAINNET,
-};
+use reth_primitives::{ForkFilter, Head};
 use reth_provider::{BlockReader, HeaderProvider};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use secp256k1::SECP256K1;
@@ -417,8 +419,8 @@ impl NetworkConfigBuilder {
     /// Calls a closure on [`reth_discv5::ConfigBuilder`], if discv5 discovery is enabled and the
     /// builder has been set.
     /// ```
+    /// use reth_chainspec::MAINNET;
     /// use reth_network::NetworkConfigBuilder;
-    /// use reth_primitives::MAINNET;
     /// use reth_provider::test_utils::NoopProvider;
     /// use secp256k1::{rand::thread_rng, SecretKey};
     ///
@@ -584,8 +586,9 @@ impl NetworkMode {
 mod tests {
     use super::*;
     use rand::thread_rng;
+    use reth_chainspec::Chain;
     use reth_dns_discovery::tree::LinkEntry;
-    use reth_primitives::{Chain, ForkHash};
+    use reth_primitives::ForkHash;
     use reth_provider::test_utils::NoopProvider;
     use std::collections::BTreeMap;
 

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -12,8 +12,8 @@ use reth_discv5::{DiscoveredPeer, Discv5};
 use reth_dns_discovery::{
     DnsDiscoveryConfig, DnsDiscoveryHandle, DnsDiscoveryService, DnsNodeRecordUpdate, DnsResolver,
 };
-use reth_network_peers::PeerId;
-use reth_primitives::{EnrForkIdEntry, ForkId, NodeRecord};
+use reth_network_peers::{NodeRecord, PeerId};
+use reth_primitives::{EnrForkIdEntry, ForkId};
 use secp256k1::SecretKey;
 use std::{
     collections::VecDeque,

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -46,8 +46,8 @@
 //!
 //! ```
 //! # async fn launch() {
-//! use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
 //! use reth_chainspec::net::mainnet_nodes;
+//! use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
 //! use reth_provider::test_utils::NoopProvider;
 //!
 //! // This block provider implementation is used for testing purposes.
@@ -71,8 +71,8 @@
 //! ### Configure all components of the Network with the [`NetworkBuilder`]
 //!
 //! ```
+//! use reth_chainspec::net::mainnet_nodes;
 //! use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
-//! use reth_primitives::mainnet_nodes;
 //! use reth_provider::test_utils::NoopProvider;
 //! use reth_transaction_pool::TransactionPool;
 //! async fn launch<Pool: TransactionPool>(pool: Pool) {

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -47,7 +47,7 @@
 //! ```
 //! # async fn launch() {
 //! use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
-//! use reth_primitives::mainnet_nodes;
+//! use reth_chainspec::net::mainnet_nodes;
 //! use reth_provider::test_utils::NoopProvider;
 //!
 //! // This block provider implementation is used for testing purposes.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -281,8 +281,8 @@ where
     /// components of the network
     ///
     /// ```
+    /// use reth_chainspec::net::mainnet_nodes;
     /// use reth_network::{config::rng_secret_key, NetworkConfig, NetworkManager};
-    /// use reth_primitives::mainnet_nodes;
     /// use reth_provider::test_utils::NoopProvider;
     /// use reth_transaction_pool::TransactionPool;
     /// async fn launch<Pool: TransactionPool>(pool: Pool) {

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -43,8 +43,8 @@ use reth_eth_wire::{
 };
 use reth_metrics::common::mpsc::UnboundedMeteredSender;
 use reth_network_api::ReputationChangeKind;
-use reth_network_peers::PeerId;
-use reth_primitives::{ForkId, NodeRecord};
+use reth_network_peers::{NodeRecord, PeerId};
+use reth_primitives::ForkId;
 use reth_provider::{BlockNumReader, BlockReader};
 use reth_rpc_types::{admin::EthProtocolInfo, NetworkStatus};
 use reth_tasks::shutdown::GracefulShutdown;

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -12,8 +12,8 @@ use reth_network_api::{
     ReputationChangeKind,
 };
 use reth_network_p2p::sync::{NetworkSyncUpdater, SyncState, SyncStateProvider};
-use reth_network_peers::PeerId;
-use reth_primitives::{Head, NodeRecord, TransactionSigned, B256};
+use reth_network_peers::{NodeRecord, PeerId};
+use reth_primitives::{Head, TransactionSigned, B256};
 use reth_rpc_types::NetworkStatus;
 use reth_tokio_util::{EventSender, EventStream};
 use secp256k1::SecretKey;

--- a/crates/net/network/src/peers/manager.rs
+++ b/crates/net/network/src/peers/manager.rs
@@ -14,8 +14,8 @@ use futures::StreamExt;
 use reth_eth_wire::{errors::EthStreamError, DisconnectReason};
 use reth_net_common::ban_list::BanList;
 use reth_network_api::{PeerKind, ReputationChangeKind};
-use reth_network_peers::PeerId;
-use reth_primitives::{ForkId, NodeRecord};
+use reth_network_peers::{NodeRecord, PeerId};
+use reth_primitives::ForkId;
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
     fmt::Display,

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -763,13 +763,14 @@ mod tests {
         config::PROTOCOL_BREACH_REQUEST_TIMEOUT, handle::PendingSessionEvent,
         start_pending_incoming_session,
     };
+    use reth_chainspec::MAINNET;
     use reth_ecies::stream::ECIESStream;
     use reth_eth_wire::{
         EthStream, GetBlockBodies, HelloMessageWithProtocols, P2PStream, Status, StatusBuilder,
         UnauthedEthStream, UnauthedP2PStream,
     };
     use reth_network_peers::pk2id;
-    use reth_primitives::{ForkFilter, Hardfork, MAINNET};
+    use reth_primitives::{ForkFilter, Hardfork};
     use secp256k1::{SecretKey, SECP256K1};
     use tokio::{
         net::{TcpListener, TcpStream},

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -12,10 +12,10 @@ use crate::{
 };
 use futures::{FutureExt, StreamExt};
 use pin_project::pin_project;
+use reth_chainspec::MAINNET;
 use reth_eth_wire::{protocol::Protocol, DisconnectReason, HelloMessageWithProtocols};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::PeerId;
-use reth_primitives::MAINNET;
 use reth_provider::{
     test_utils::NoopProvider, BlockReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory,
 };

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -3,6 +3,7 @@
 use alloy_node_bindings::Geth;
 use alloy_provider::{ext::AdminApi, ProviderBuilder};
 use futures::StreamExt;
+use reth_chainspec::net::mainnet_nodes;
 use reth_discv4::Discv4Config;
 use reth_eth_wire::DisconnectReason;
 use reth_net_common::ban_list::BanList;
@@ -15,7 +16,8 @@ use reth_network_p2p::{
     headers::client::{HeadersClient, HeadersRequest},
     sync::{NetworkSyncUpdater, SyncState},
 };
-use reth_primitives::{mainnet_nodes, HeadersDirection, NodeRecord};
+use reth_network_peers::NodeRecord;
+use reth_primitives::HeadersDirection;
 use reth_provider::test_utils::NoopProvider;
 use reth_transaction_pool::test_utils::testing_pool;
 use secp256k1::SecretKey;

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-fs-util.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
@@ -31,6 +32,7 @@ reth-config.workspace = true
 reth-discv4.workspace = true
 reth-discv5.workspace = true
 reth-net-nat.workspace = true
+reth-network-peers.workspace = true
 reth-engine-primitives.workspace = true
 reth-tasks.workspace = true
 reth-consensus-common.workspace = true
@@ -96,7 +98,6 @@ procfs = "0.16.0"
 [dev-dependencies]
 # test vectors generation
 proptest.workspace = true
-reth-network-peers.workspace = true
 
 [features]
 optimism = [

--- a/crates/node-core/src/args/datadir_args.rs
+++ b/crates/node-core/src/args/datadir_args.rs
@@ -2,7 +2,7 @@
 
 use crate::dirs::{ChainPath, DataDirPath, MaybePlatformPath};
 use clap::Args;
-use reth_primitives::Chain;
+use reth_chainspec::Chain;
 use std::path::PathBuf;
 
 /// Parameters for datadir configuration

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -2,6 +2,7 @@
 
 use crate::version::P2P_CLIENT_VERSION;
 use clap::Args;
+use reth_chainspec::{net::mainnet_nodes, ChainSpec};
 use reth_config::Config;
 use reth_discv4::{DEFAULT_DISCOVERY_ADDR, DEFAULT_DISCOVERY_PORT};
 use reth_discv5::{
@@ -17,7 +18,7 @@ use reth_network::{
     },
     HelloMessageWithProtocols, NetworkConfigBuilder, SessionsConfig,
 };
-use reth_primitives::{mainnet_nodes, ChainSpec, TrustedPeer};
+use reth_network_peers::TrustedPeer;
 use secp256k1::SecretKey;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},

--- a/crates/node-core/src/args/pruning.rs
+++ b/crates/node-core/src/args/pruning.rs
@@ -1,8 +1,8 @@
 //! Pruning and full node arguments
 
 use clap::Args;
+use reth_chainspec::ChainSpec;
 use reth_config::config::PruneConfig;
-use reth_primitives::ChainSpec;
 use reth_prune_types::{PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_PRUNING_DISTANCE};
 
 /// Parameters for pruning and full node

--- a/crates/node-core/src/args/utils.rs
+++ b/crates/node-core/src/args/utils.rs
@@ -1,7 +1,8 @@
 //! Clap parser utilities
 
+use reth_chainspec::{AllGenesisFormats, ChainSpec};
 use reth_fs_util as fs;
-use reth_primitives::{AllGenesisFormats, BlockHashOrNumber, ChainSpec, B256};
+use reth_primitives::{BlockHashOrNumber, B256};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
     path::PathBuf,
@@ -10,13 +11,13 @@ use std::{
     time::Duration,
 };
 
-use reth_primitives::DEV;
+use reth_chainspec::DEV;
 
 #[cfg(feature = "optimism")]
-use reth_primitives::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA};
+use reth_chainspec::{BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA};
 
 #[cfg(not(feature = "optimism"))]
-use reth_primitives::{GOERLI, HOLESKY, MAINNET, SEPOLIA};
+use reth_chainspec::{GOERLI, HOLESKY, MAINNET, SEPOLIA};
 
 #[cfg(feature = "optimism")]
 /// Chains supported by op-reth. First value should be used as the default.
@@ -168,9 +169,8 @@ pub fn parse_socket_address(value: &str) -> eyre::Result<SocketAddr, SocketAddre
 mod tests {
     use super::*;
     use proptest::prelude::Rng;
-    use reth_primitives::{
-        hex, Address, ChainConfig, ChainSpecBuilder, Genesis, GenesisAccount, U256,
-    };
+    use reth_chainspec::ChainSpecBuilder;
+    use reth_primitives::{hex, Address, ChainConfig, Genesis, GenesisAccount, U256};
     use secp256k1::rand::thread_rng;
     use std::collections::HashMap;
 

--- a/crates/node-core/src/dirs.rs
+++ b/crates/node-core/src/dirs.rs
@@ -1,7 +1,7 @@
 //! reth data directories.
 
 use crate::{args::DatadirArgs, utils::parse_path};
-use reth_primitives::Chain;
+use reth_chainspec::Chain;
 use std::{
     env::VarError,
     fmt::{Debug, Display, Formatter},

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -11,12 +11,13 @@ use crate::{
 };
 use metrics_exporter_prometheus::PrometheusHandle;
 use once_cell::sync::Lazy;
+use reth_chainspec::{ChainSpec, MAINNET};
 use reth_config::config::PruneConfig;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
 use reth_network_p2p::headers::client::HeadersClient;
 use reth_primitives::{
     constants::eip4844::MAINNET_KZG_TRUSTED_SETUP, kzg::KzgSettings, BlockHashOrNumber,
-    BlockNumber, ChainSpec, Head, SealedHeader, B256, MAINNET,
+    BlockNumber, Head, SealedHeader, B256,
 };
 use reth_provider::{
     providers::StaticFileProvider, BlockHashReader, HeaderProvider, ProviderFactory,

--- a/crates/node-core/src/utils.rs
+++ b/crates/node-core/src/utils.rs
@@ -2,6 +2,7 @@
 //! blocks from the network.
 
 use eyre::Result;
+use reth_chainspec::ChainSpec;
 use reth_consensus_common::validation::validate_block_pre_execution;
 use reth_fs_util as fs;
 use reth_network::NetworkManager;
@@ -10,7 +11,7 @@ use reth_network_p2p::{
     headers::client::{HeadersClient, HeadersRequest},
     priority::Priority,
 };
-use reth_primitives::{BlockHashOrNumber, ChainSpec, HeadersDirection, SealedBlock, SealedHeader};
+use reth_primitives::{BlockHashOrNumber, HeadersDirection, SealedBlock, SealedHeader};
 use reth_provider::BlockReader;
 use reth_rpc_types::engine::{JwtError, JwtSecret};
 use std::{

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 ## reth
+reth-chainspec.workspace = true
 reth-auto-seal-consensus.workspace = true
 reth-beacon-consensus.workspace = true
 reth-blockchain-tree.workspace = true

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use discv5::ListenConfig;
 use futures::Future;
+use reth_chainspec::ChainSpec;
 use reth_db::{
     test_utils::{create_test_rw_db_with_path, tempdir_path, TempDatabase},
     DatabaseEnv,
@@ -32,7 +33,7 @@ use reth_node_core::{
     primitives::{kzg::KzgSettings, Head},
     utils::write_peers_to_file,
 };
-use reth_primitives::{constants::eip4844::MAINNET_KZG_TRUSTED_SETUP, ChainSpec};
+use reth_primitives::constants::eip4844::MAINNET_KZG_TRUSTED_SETUP;
 use reth_provider::{providers::BlockchainProvider, ChainSpecProvider};
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{PoolConfig, TransactionPool};

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -5,6 +5,7 @@ use eyre::Context;
 use rayon::ThreadPoolBuilder;
 use reth_auto_seal_consensus::MiningMode;
 use reth_beacon_consensus::EthBeaconConsensus;
+use reth_chainspec::{Chain, ChainSpec};
 use reth_config::{config::EtlConfig, PruneConfig};
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
 use reth_db_common::init::{init_genesis, InitDatabaseError};
@@ -15,7 +16,7 @@ use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     node_config::NodeConfig,
 };
-use reth_primitives::{BlockNumber, Chain, ChainSpec, Head, B256};
+use reth_primitives::{BlockNumber, Head, B256};
 use reth_provider::{providers::StaticFileProvider, ProviderFactory, StaticFileProviderFactory};
 use reth_prune::{PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -1,4 +1,5 @@
 use crate::rpc::{RethRpcServerHandles, RpcRegistry};
+use reth_chainspec::ChainSpec;
 use reth_network::NetworkHandle;
 use reth_node_api::FullNodeComponents;
 use reth_node_core::{
@@ -7,7 +8,6 @@ use reth_node_core::{
     rpc::api::EngineApiClient,
 };
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_primitives::ChainSpec;
 use reth_provider::ChainSpecProvider;
 use reth_rpc_builder::{auth::AuthServerHandle, RpcServerHandle};
 use reth_tasks::TaskExecutor;

--- a/crates/optimism/consensus/Cargo.toml
+++ b/crates/optimism/consensus/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-consensus-common.workspace = true
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-consensus.workspace = true
 

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -9,6 +9,7 @@
 // The `optimism` feature must be enabled to use this crate.
 #![cfg(feature = "optimism")]
 
+use reth_chainspec::ChainSpec;
 use reth_consensus::{Consensus, ConsensusError, PostExecutionInput};
 use reth_consensus_common::validation::{
     validate_against_parent_4844, validate_against_parent_eip1559_base_fee,
@@ -17,7 +18,7 @@ use reth_consensus_common::validation::{
     validate_header_gas,
 };
 use reth_primitives::{
-    BlockWithSenders, ChainSpec, Header, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT_HASH, U256,
+    BlockWithSenders, Header, SealedBlock, SealedHeader, EMPTY_OMMER_ROOT_HASH, U256,
 };
 use std::{sync::Arc, time::SystemTime};
 

--- a/crates/optimism/consensus/src/validation.rs
+++ b/crates/optimism/consensus/src/validation.rs
@@ -1,7 +1,8 @@
+use reth_chainspec::ChainSpec;
 use reth_consensus::ConsensusError;
 use reth_primitives::{
     gas_spent_by_transactions, proofs::calculate_receipt_root_optimism, BlockWithSenders, Bloom,
-    ChainSpec, GotExpected, Receipt, B256,
+    GotExpected, Receipt, B256,
 };
 
 /// Validate a block with regard to execution results:

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # Reth
+reth-chainspec.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
 reth-revm.workspace = true

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -1,6 +1,7 @@
 //! Optimism block executor.
 
 use crate::{l1::ensure_create2_deployer, OptimismBlockExecutionError, OptimismEvmConfig};
+use reth_chainspec::{ChainSpec, Hardfork};
 use reth_evm::{
     execute::{
         BatchExecutor, BlockExecutionError, BlockExecutionInput, BlockExecutionOutput,
@@ -10,8 +11,7 @@ use reth_evm::{
 };
 use reth_optimism_consensus::validate_block_post_execution;
 use reth_primitives::{
-    BlockNumber, BlockWithSenders, ChainSpec, Hardfork, Header, Receipt, Receipts, TxType,
-    Withdrawals, U256,
+    BlockNumber, BlockWithSenders, Header, Receipt, Receipts, TxType, Withdrawals, U256,
 };
 use reth_provider::ExecutionOutcome;
 use reth_prune_types::PruneModes;
@@ -444,9 +444,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_chainspec::ChainSpecBuilder;
     use reth_primitives::{
-        b256, Account, Address, Block, ChainSpecBuilder, Signature, StorageKey, StorageValue,
-        Transaction, TransactionSigned, TxEip1559, BASE_MAINNET,
+        b256, Account, Address, Block, Signature, StorageKey, StorageValue, Transaction,
+        TransactionSigned, TxEip1559, BASE_MAINNET,
     };
     use reth_revm::{
         database::StateProviderDatabase, test_utils::StateProviderTest, L1_BLOCK_CONTRACT,

--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -1,8 +1,9 @@
 //! Optimism-specific implementation and utilities for the executor
 
 use crate::OptimismBlockExecutionError;
+use reth_chainspec::{ChainSpec, Hardfork};
 use reth_execution_errors::BlockExecutionError;
-use reth_primitives::{address, b256, hex, Address, Block, Bytes, ChainSpec, Hardfork, B256, U256};
+use reth_primitives::{address, b256, hex, Address, Block, Bytes, B256, U256};
 use revm::{
     primitives::{Bytecode, HashMap, SpecId},
     DatabaseCommit, L1BlockInfo,

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -9,11 +9,12 @@
 // The `optimism` feature must be enabled to use this crate.
 #![cfg(feature = "optimism")]
 
+use reth_chainspec::ChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
     revm::{config::revm_spec, env::fill_op_tx_env},
     revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
-    Address, ChainSpec, Head, Header, TransactionSigned, U256,
+    Address, Head, Header, TransactionSigned, U256,
 };
 use reth_revm::{inspector_handle_register, Database, Evm, EvmBuilder, GetInspector};
 

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-payload-builder.workspace = true
 reth-basic-payload-builder.workspace = true
@@ -57,6 +58,7 @@ alloy-primitives.workspace = true
 
 [features]
 optimism = [
+    "reth-chainspec/optimism",
     "reth-primitives/optimism",
     "reth-provider/optimism",
     "reth-rpc-types-compat/optimism",

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -1,3 +1,4 @@
+use reth_chainspec::{ChainSpec, Hardfork};
 use reth_node_api::{
     payload::{
         validate_parent_beacon_block_root_presence, EngineApiMessageVersion,
@@ -7,7 +8,6 @@ use reth_node_api::{
     EngineTypes,
 };
 use reth_optimism_payload_builder::{OptimismBuiltPayload, OptimismPayloadBuilderAttributes};
-use reth_primitives::{ChainSpec, Hardfork};
 use reth_rpc_types::{
     engine::{
         ExecutionPayloadEnvelopeV2, OptimismExecutionPayloadEnvelopeV3,

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -1,7 +1,8 @@
 //! OP transaction pool types
 use parking_lot::RwLock;
+use reth_chainspec::ChainSpec;
 use reth_evm_optimism::RethL1BlockInfo;
-use reth_primitives::{Block, ChainSpec, GotExpected, InvalidTransactionError, SealedBlock};
+use reth_primitives::{Block, GotExpected, InvalidTransactionError, SealedBlock};
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use reth_revm::L1BlockInfo;
 use reth_transaction_pool::{
@@ -202,9 +203,10 @@ pub struct OpL1BlockInfo {
 #[cfg(test)]
 mod tests {
     use crate::txpool::OpTransactionValidator;
+    use reth_chainspec::MAINNET;
     use reth_primitives::{
         Signature, Transaction, TransactionSigned, TransactionSignedEcRecovered, TxDeposit, TxKind,
-        MAINNET, U256,
+        U256,
     };
     use reth_provider::test_utils::MockEthProvider;
     use reth_transaction_pool::{

--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -1,9 +1,9 @@
 use reth::{rpc::types::engine::PayloadAttributes, tasks::TaskManager};
-use reth_chainspec::ChainSpecBuilder;
+use reth_chainspec::{ChainSpecBuilder, BASE_MAINNET};
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
 use reth_node_optimism::{OptimismBuiltPayload, OptimismNode, OptimismPayloadBuilderAttributes};
 use reth_payload_builder::EthPayloadBuilderAttributes;
-use reth_primitives::{Address, Genesis, B256, BASE_MAINNET};
+use reth_primitives::{Address, Genesis, B256};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -1,8 +1,9 @@
 use reth::{rpc::types::engine::PayloadAttributes, tasks::TaskManager};
+use reth_chainspec::ChainSpecBuilder;
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
 use reth_node_optimism::{OptimismBuiltPayload, OptimismNode, OptimismPayloadBuilderAttributes};
 use reth_payload_builder::EthPayloadBuilderAttributes;
-use reth_primitives::{Address, ChainSpecBuilder, Genesis, B256, BASE_MAINNET};
+use reth_primitives::{Address, Genesis, B256, BASE_MAINNET};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-revm.workspace = true
 reth-transaction-pool.workspace = true
@@ -36,6 +37,7 @@ sha2.workspace = true
 
 [features]
 optimism = [
+    "reth-chainspec/optimism",
     "reth-primitives/optimism",
     "reth-provider/optimism",
     "reth-rpc-types-compat/optimism",

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -5,6 +5,7 @@ use crate::{
     payload::{OptimismBuiltPayload, OptimismPayloadBuilderAttributes},
 };
 use reth_basic_payload_builder::*;
+use reth_chainspec::ChainSpec;
 use reth_evm::ConfigureEvm;
 use reth_payload_builder::error::PayloadBuilderError;
 use reth_primitives::{
@@ -12,8 +13,8 @@ use reth_primitives::{
     eip4844::calculate_excess_blob_gas,
     proofs,
     revm::env::tx_env_with_recovered,
-    Block, ChainSpec, Hardfork, Header, IntoRecoveredTransaction, Receipt, TxType,
-    EMPTY_OMMER_ROOT_HASH, U256,
+    Block, Hardfork, Header, IntoRecoveredTransaction, Receipt, TxType, EMPTY_OMMER_ROOT_HASH,
+    U256,
 };
 use reth_provider::{ExecutionOutcome, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -3,13 +3,14 @@
 //! Optimism builder support
 
 use alloy_rlp::Encodable;
+use reth_chainspec::ChainSpec;
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
 use reth_primitives::{
     revm::config::revm_spec_by_timestamp_after_merge,
     revm_primitives::{BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId},
-    Address, BlobTransactionSidecar, ChainSpec, Header, SealedBlock, TransactionSigned,
-    Withdrawals, B256, U256,
+    Address, BlobTransactionSidecar, Header, SealedBlock, TransactionSigned, Withdrawals, B256,
+    U256,
 };
 use reth_rpc_types::engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadV1, OptimismExecutionPayloadEnvelopeV3,

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-revm.workspace = true
 reth-transaction-pool.workspace = true

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -11,6 +11,7 @@
 use crate::metrics::PayloadBuilderMetrics;
 use futures_core::ready;
 use futures_util::FutureExt;
+use reth_chainspec::ChainSpec;
 use reth_payload_builder::{
     database::CachedReads, error::PayloadBuilderError, KeepPayloadJobAlive, PayloadId, PayloadJob,
     PayloadJobGenerator,
@@ -18,7 +19,7 @@ use reth_payload_builder::{
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
 use reth_primitives::{
     constants::{EMPTY_WITHDRAWALS, RETH_CLIENT_VERSION, SLOT_DURATION},
-    proofs, BlockNumberOrTag, Bytes, ChainSpec, Request, SealedBlock, Withdrawals, B256, U256,
+    proofs, BlockNumberOrTag, Bytes, Request, SealedBlock, Withdrawals, B256, U256,
 };
 use reth_provider::{
     BlockReaderIdExt, BlockSource, CanonStateNotification, ProviderError, StateProviderFactory,

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-errors.workspace = true
 reth-primitives.workspace = true
 reth-transaction-pool.workspace = true

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -20,7 +20,7 @@ pub use traits::{BuiltPayload, PayloadAttributes, PayloadBuilderAttributes};
 mod payload;
 pub use payload::PayloadOrAttributes;
 
-use reth_primitives::ChainSpec;
+use reth_chainspec::ChainSpec;
 
 /// The types that are used by the engine API.
 pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone {

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -1,6 +1,7 @@
+use reth_chainspec::ChainSpec;
 use reth_primitives::{
     revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg},
-    Address, ChainSpec, Header, SealedBlock, Withdrawals, B256, U256,
+    Address, Header, SealedBlock, Withdrawals, B256, U256,
 };
 use reth_rpc_types::{
     engine::{OptimismPayloadAttributes, PayloadAttributes as EthPayloadAttributes, PayloadId},

--- a/crates/payload/validator/Cargo.toml
+++ b/crates/payload/validator/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-rpc-types.workspace = true
 reth-rpc-types-compat.workspace = true

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -8,7 +8,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use reth_primitives::{ChainSpec, SealedBlock};
+use reth_chainspec::ChainSpec;
+use reth_primitives::SealedBlock;
 use reth_rpc_types::{engine::MaybeCancunPayloadFields, ExecutionPayload, PayloadError};
 use reth_rpc_types_compat::engine::payload::try_into_block;
 use std::sync::Arc;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -67,16 +67,6 @@ pub use receipt::{
     gas_spent_by_transactions, Receipt, ReceiptWithBloom, ReceiptWithBloomRef, Receipts,
 };
 pub use request::Requests;
-pub use reth_chainspec::{
-    net::{
-        goerli_nodes, holesky_nodes, mainnet_nodes, parse_nodes, sepolia_nodes, NodeRecord,
-        NodeRecordParseError, TrustedPeer, GOERLI_BOOTNODES, HOLESKY_BOOTNODES, MAINNET_BOOTNODES,
-        SEPOLIA_BOOTNODES,
-    },
-    AllGenesisFormats, BaseFeeParams, BaseFeeParamsKind, Chain, ChainInfo, ChainKind, ChainSpec,
-    ChainSpecBuilder, DepositContract, DisplayHardforks, ForkBaseFeeParams, ForkCondition,
-    NamedChain, DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA,
-};
 pub use static_file::StaticFileSegment;
 pub use storage::StorageEntry;
 

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -42,7 +42,7 @@ pub fn calculate_requests_root(requests: &[Request]) -> B256 {
 #[cfg(feature = "optimism")]
 pub fn calculate_receipt_root_optimism(
     receipts: &[ReceiptWithBloom],
-    chain_spec: &crate::ChainSpec,
+    chain_spec: &reth_chainspec::ChainSpec,
     timestamp: u64,
 ) -> B256 {
     // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
@@ -50,8 +50,8 @@ pub fn calculate_receipt_root_optimism(
     // encoding. In the Regolith Hardfork, we must strip the deposit nonce from the
     // receipts before calculating the receipt root. This was corrected in the Canyon
     // hardfork.
-    if chain_spec.is_fork_active_at_timestamp(crate::Hardfork::Regolith, timestamp) &&
-        !chain_spec.is_fork_active_at_timestamp(crate::Hardfork::Canyon, timestamp)
+    if chain_spec.is_fork_active_at_timestamp(reth_chainspec::Hardfork::Regolith, timestamp) &&
+        !chain_spec.is_fork_active_at_timestamp(reth_chainspec::Hardfork::Canyon, timestamp)
     {
         let receipts = receipts
             .iter()
@@ -90,7 +90,7 @@ pub fn calculate_receipt_root_no_memo(receipts: &[&Receipt]) -> B256 {
 #[cfg(feature = "optimism")]
 pub fn calculate_receipt_root_no_memo_optimism(
     receipts: &[&Receipt],
-    chain_spec: &crate::ChainSpec,
+    chain_spec: &reth_chainspec::ChainSpec,
     timestamp: u64,
 ) -> B256 {
     // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
@@ -98,8 +98,8 @@ pub fn calculate_receipt_root_no_memo_optimism(
     // encoding. In the Regolith Hardfork, we must strip the deposit nonce from the
     // receipts before calculating the receipt root. This was corrected in the Canyon
     // hardfork.
-    if chain_spec.is_fork_active_at_timestamp(crate::Hardfork::Regolith, timestamp) &&
-        !chain_spec.is_fork_active_at_timestamp(crate::Hardfork::Canyon, timestamp)
+    if chain_spec.is_fork_active_at_timestamp(reth_chainspec::Hardfork::Regolith, timestamp) &&
+        !chain_spec.is_fork_active_at_timestamp(reth_chainspec::Hardfork::Canyon, timestamp)
     {
         let receipts = receipts
             .iter()
@@ -137,10 +137,11 @@ mod tests {
     use super::*;
     use crate::{
         bloom, constants::EMPTY_ROOT_HASH, hex_literal::hex, Block, GenesisAccount, Log, TxType,
-        GOERLI, HOLESKY, MAINNET, SEPOLIA, U256,
+        U256,
     };
     use alloy_primitives::{b256, Address, LogData};
     use alloy_rlp::Decodable;
+    use reth_chainspec::{GOERLI, HOLESKY, MAINNET, SEPOLIA};
     use reth_trie_common::root::{state_root_ref_unhashed, state_root_unhashed};
     use std::collections::HashMap;
 

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -100,7 +100,7 @@ impl Receipts {
     pub fn optimism_root_slow(
         &self,
         index: usize,
-        chain_spec: &crate::ChainSpec,
+        chain_spec: &reth_chainspec::ChainSpec,
         timestamp: u64,
     ) -> Option<B256> {
         Some(crate::proofs::calculate_receipt_root_no_memo_optimism(

--- a/crates/primitives/src/revm/config.rs
+++ b/crates/primitives/src/revm/config.rs
@@ -1,4 +1,5 @@
-use crate::{ChainSpec, Hardfork, Head};
+use reth_chainspec::ChainSpec;
+use reth_ethereum_forks::{Hardfork, Head};
 
 /// Returns the spec id at the given timestamp.
 ///
@@ -86,7 +87,8 @@ pub fn revm_spec(chain_spec: &ChainSpec, block: Head) -> revm_primitives::SpecId
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ChainSpecBuilder, MAINNET, U256};
+    use crate::U256;
+    use reth_chainspec::{ChainSpecBuilder, MAINNET};
 
     #[test]
     fn test_to_revm_spec() {
@@ -148,7 +150,7 @@ mod tests {
         {
             #[inline(always)]
             fn op_cs(f: impl FnOnce(ChainSpecBuilder) -> ChainSpecBuilder) -> ChainSpec {
-                let cs = ChainSpecBuilder::mainnet().chain(crate::Chain::from_id(10));
+                let cs = ChainSpecBuilder::mainnet().chain(reth_chainspec::Chain::from_id(10));
                 f(cs).build()
             }
             assert_eq!(

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -1,9 +1,9 @@
 use crate::{
     recover_signer_unchecked,
     revm_primitives::{BlockEnv, Env, TransactTo, TxEnv},
-    Address, Bytes, Chain, ChainSpec, Header, Transaction, TransactionSignedEcRecovered, TxKind,
-    B256, U256,
+    Address, Bytes, Header, Transaction, TransactionSignedEcRecovered, TxKind, B256, U256,
 };
+use reth_chainspec::{Chain, ChainSpec};
 
 use alloy_eips::{eip4788::BEACON_ROOTS_ADDRESS, eip7002::WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS};
 #[cfg(feature = "optimism")]
@@ -374,7 +374,7 @@ pub fn fill_op_tx_env<T: AsRef<Transaction>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::GOERLI;
+    use reth_chainspec::GOERLI;
 
     #[test]
     fn test_recover_genesis_goerli_signer() {

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-exex-types.workspace = true
 reth-primitives.workspace = true
 reth-db.workspace = true

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -1,8 +1,8 @@
 use crate::{segments::SegmentSet, Pruner};
+use reth_chainspec::MAINNET;
 use reth_config::PruneConfig;
 use reth_db_api::database::Database;
 use reth_exex_types::FinishedExExHeight;
-use reth_primitives::MAINNET;
 use reth_provider::ProviderFactory;
 use reth_prune_types::PruneModes;
 use std::time::Duration;

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -332,9 +332,9 @@ impl<DB: Database> Pruner<DB> {
 mod tests {
 
     use crate::Pruner;
+    use reth_chainspec::MAINNET;
     use reth_db::test_utils::{create_test_rw_db, create_test_static_files_dir};
     use reth_exex_types::FinishedExExHeight;
-    use reth_primitives::MAINNET;
     use reth_provider::{providers::StaticFileProvider, ProviderFactory};
 
     #[test]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-storage-errors.workspace = true
 reth-execution-errors.workspace = true

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -3,6 +3,7 @@ use alloy_eips::{
     eip7002::WithdrawalRequest,
 };
 use alloy_rlp::Buf;
+use reth_chainspec::ChainSpec;
 use reth_consensus_common::calc;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 use reth_primitives::{
@@ -10,7 +11,7 @@ use reth_primitives::{
         fill_tx_env_with_beacon_root_contract_call,
         fill_tx_env_with_withdrawal_requests_contract_call,
     },
-    Address, ChainSpec, Header, Request, Withdrawal, B256, U256,
+    Address, Header, Request, Withdrawal, B256, U256,
 };
 use reth_storage_errors::provider::ProviderError;
 use revm::{

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -1,6 +1,5 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_network_peers::AnyNode;
-use reth_primitives::NodeRecord;
+use reth_network_peers::{AnyNode, NodeRecord};
 use reth_rpc_types::{admin::NodeInfo, PeerInfo};
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -43,6 +43,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+reth-chainspec.workspace = true
 reth-beacon-consensus.workspace = true
 reth-network-api.workspace = true
 reth-evm-ethereum.workspace = true

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -11,9 +11,9 @@ use jsonrpsee::{
     rpc_params,
     types::error::ErrorCode,
 };
+use reth_chainspec::net::NodeRecord;
 use reth_primitives::{
-    hex_literal::hex, Address, BlockId, BlockNumberOrTag, Bytes, NodeRecord, TxHash, B256, B64,
-    U256, U64,
+    hex_literal::hex, Address, BlockId, BlockNumberOrTag, Bytes, TxHash, B256, B64, U256, U64,
 };
 use reth_rpc_api::{
     clients::{AdminApiClient, EthApiClient},

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -1,9 +1,9 @@
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
+use reth_chainspec::MAINNET;
 use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_network_api::noop::NoopNetwork;
 use reth_payload_builder::test_utils::spawn_test_payload_service;
-use reth_primitives::MAINNET;
 use reth_provider::test_utils::{NoopProvider, TestCanonStateSubscriptions};
 use reth_rpc_builder::{
     auth::{AuthRpcModule, AuthServerConfig, AuthServerHandle},

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-rpc-api.workspace = true
 reth-rpc-types.workspace = true

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -2,6 +2,7 @@ use crate::{metrics::EngineApiMetrics, EngineApiError, EngineApiResult};
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
+use reth_chainspec::ChainSpec;
 use reth_engine_primitives::EngineTypes;
 use reth_evm::provider::EvmEnvProvider;
 use reth_payload_builder::PayloadStore;
@@ -9,7 +10,7 @@ use reth_payload_primitives::{
     validate_payload_timestamp, EngineApiMessageVersion, PayloadAttributes,
     PayloadBuilderAttributes, PayloadOrAttributes,
 };
-use reth_primitives::{BlockHash, BlockHashOrNumber, BlockNumber, ChainSpec, Hardfork, B256, U64};
+use reth_primitives::{BlockHash, BlockHashOrNumber, BlockNumber, Hardfork, B256, U64};
 use reth_rpc_api::EngineApiServer;
 use reth_rpc_types::engine::{
     CancunPayloadFields, ClientVersionV1, ExecutionPayload, ExecutionPayloadBodiesV1,
@@ -842,8 +843,9 @@ mod tests {
     use reth_ethereum_engine_primitives::EthEngineTypes;
     use reth_testing_utils::generators::random_block;
 
+    use reth_chainspec::MAINNET;
     use reth_payload_builder::test_utils::spawn_test_payload_service;
-    use reth_primitives::{SealedBlock, B256, MAINNET};
+    use reth_primitives::{SealedBlock, B256};
     use reth_provider::test_utils::MockEthProvider;
     use reth_rpc_types::engine::{ClientCode, ClientVersionV1};
     use reth_rpc_types_compat::engine::payload::execution_payload_from_sealed_block;

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-rpc-api.workspace = true
 reth-rpc-server-types.workspace = true

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -2,9 +2,10 @@ use crate::result::ToRpcResult;
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
+use reth_chainspec::ChainSpec;
 use reth_network_api::{NetworkInfo, PeerKind, Peers};
-use reth_network_peers::AnyNode;
-use reth_primitives::{ChainConfig, ChainSpec, NodeRecord};
+use reth_network_peers::{AnyNode, NodeRecord};
+use reth_primitives::ChainConfig;
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_types::{
     admin::{EthProtocolInfo, NodeInfo, Ports, ProtocolInfo},

--- a/crates/rpc/rpc/src/eth/api/fee_history.rs
+++ b/crates/rpc/rpc/src/eth/api/fee_history.rs
@@ -6,10 +6,11 @@ use futures::{
     FutureExt, Stream, StreamExt,
 };
 use metrics::atomics::AtomicU64;
+use reth_chainspec::ChainSpec;
 use reth_primitives::{
     basefee::calc_next_block_base_fee,
     eip4844::{calc_blob_gasprice, calculate_excess_blob_gas},
-    ChainSpec, Receipt, SealedBlock, TransactionSigned, B256,
+    Receipt, SealedBlock, TransactionSigned, B256,
 };
 use reth_provider::{BlockReaderIdExt, CanonStateNotification, ChainSpecProvider};
 use reth_rpc_server_types::constants::gas_oracle::MAX_HEADER_HISTORY;

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -13,13 +13,13 @@ use crate::eth::{
     traits::RawTransactionForwarder,
 };
 use async_trait::async_trait;
+use reth_chainspec::ChainInfo;
 use reth_errors::{RethError, RethResult};
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{
     revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg},
-    Address, BlockId, BlockNumberOrTag, ChainInfo, SealedBlockWithSenders, SealedHeader, B256,
-    U256, U64,
+    Address, BlockId, BlockNumberOrTag, SealedBlockWithSenders, SealedHeader, B256, U256, U64,
 };
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderBox, StateProviderFactory,

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -1,6 +1,7 @@
 //! Support for building a pending block via local txpool.
 
 use crate::eth::error::{EthApiError, EthResult};
+use reth_chainspec::ChainSpec;
 use reth_errors::ProviderError;
 use reth_primitives::{
     constants::{eip4844::MAX_DATA_GAS_PER_BLOCK, BEACON_NONCE, EMPTY_ROOT_HASH},
@@ -9,8 +10,8 @@ use reth_primitives::{
     revm_primitives::{
         BlockEnv, CfgEnvWithHandlerCfg, EVMError, Env, InvalidTransaction, ResultAndState, SpecId,
     },
-    Block, BlockId, BlockNumberOrTag, ChainSpec, Header, IntoRecoveredTransaction, Receipt,
-    Requests, SealedBlockWithSenders, SealedHeader, B256, EMPTY_OMMER_ROOT_HASH, U256,
+    Block, BlockId, BlockNumberOrTag, Header, IntoRecoveredTransaction, Receipt, Requests,
+    SealedBlockWithSenders, SealedHeader, B256, EMPTY_OMMER_ROOT_HASH, U256,
 };
 use reth_provider::{ChainSpecProvider, ExecutionOutcome, StateProviderFactory};
 use reth_revm::{

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -433,11 +433,12 @@ mod tests {
         EthApi,
     };
     use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+    use reth_chainspec::BaseFeeParams;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{
-        constants::ETHEREUM_BLOCK_GAS_LIMIT, BaseFeeParams, Block, BlockNumberOrTag, Header,
-        TransactionSigned, B256, U64,
+        constants::ETHEREUM_BLOCK_GAS_LIMIT, Block, BlockNumberOrTag, Header, TransactionSigned,
+        B256, U64,
     };
     use reth_provider::{
         test_utils::{MockEthProvider, NoopProvider},

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -11,7 +11,8 @@ use core::fmt;
 
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
-use reth_primitives::{ChainInfo, IntoRecoveredTransaction, TxHash};
+use reth_chainspec::ChainInfo;
+use reth_primitives::{IntoRecoveredTransaction, TxHash};
 use reth_provider::{BlockIdReader, BlockReader, EvmEnvProvider, ProviderError};
 use reth_rpc_api::EthFilterApiServer;
 use reth_rpc_types::{

--- a/crates/rpc/rpc/src/eth/logs_utils.rs
+++ b/crates/rpc/rpc/src/eth/logs_utils.rs
@@ -1,6 +1,7 @@
 use super::filter::FilterError;
 use alloy_primitives::TxHash;
-use reth_primitives::{BlockNumHash, ChainInfo, Receipt};
+use reth_chainspec::ChainInfo;
+use reth_primitives::{BlockNumHash, Receipt};
 use reth_provider::{BlockReader, ProviderError};
 use reth_rpc_types::{FilteredParams, Log};
 

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, optional = true }
 reth-codecs.workspace = true
 reth-config.workspace = true
 reth-consensus.workspace = true
@@ -49,6 +49,7 @@ tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-db = { workspace = true, features = ["test-utils", "mdbx"] }
 reth-evm-ethereum.workspace = true
@@ -86,6 +87,7 @@ pprof = { workspace = true, features = [
 
 [features]
 test-utils = [
+    "dep:reth-chainspec",
     "reth-network-p2p/test-utils",
     "reth-db/test-utils",
     "reth-provider/test-utils",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-codecs.workspace = true
 reth-config.workspace = true
 reth-consensus.workspace = true

--- a/crates/stages/stages/src/lib.rs
+++ b/crates/stages/stages/src/lib.rs
@@ -17,7 +17,8 @@
 //! # use reth_downloaders::headers::reverse_headers::ReverseHeadersDownloaderBuilder;
 //! # use reth_network_p2p::test_utils::{TestBodiesClient, TestHeadersClient};
 //! # use reth_evm_ethereum::execute::EthExecutorProvider;
-//! # use reth_primitives::{MAINNET, B256};
+//! # use reth_primitives::B256;
+//! # use reth_chainspec::MAINNET;
 //! # use reth_prune_types::PruneModes;
 //! # use reth_network_peers::PeerId;
 //! # use reth_stages::Pipeline;

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -12,7 +12,7 @@
 //! ```no_run
 //! # use reth_stages::Pipeline;
 //! # use reth_stages::sets::{OfflineStages};
-//! # use reth_primitives::MAINNET;
+//! # use reth_chainspec::MAINNET;
 //! # use reth_prune_types::PruneModes;
 //! # use reth_evm_ethereum::EthEvmConfig;
 //! # use reth_provider::StaticFileProviderFactory;

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -707,12 +707,13 @@ mod tests {
     use crate::test_utils::TestStageDB;
     use alloy_rlp::Decodable;
     use assert_matches::assert_matches;
+    use reth_chainspec::ChainSpecBuilder;
     use reth_db_api::{models::AccountBeforeTx, transaction::DbTxMut};
     use reth_evm_ethereum::execute::EthExecutorProvider;
     use reth_execution_errors::BlockValidationError;
     use reth_primitives::{
-        address, hex_literal::hex, keccak256, Account, Address, Bytecode, ChainSpecBuilder,
-        SealedBlock, StorageEntry, B256, U256,
+        address, hex_literal::hex, keccak256, Account, Address, Bytecode, SealedBlock,
+        StorageEntry, B256, U256,
     };
     use reth_provider::{
         test_utils::create_test_provider_factory, AccountReader, ReceiptProvider,

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -42,6 +42,7 @@ mod tests {
     use super::*;
     use crate::test_utils::{StorageKind, TestStageDB};
     use alloy_rlp::Decodable;
+    use reth_chainspec::ChainSpecBuilder;
     use reth_db::{
         mdbx::{cursor::Cursor, RW},
         tables,
@@ -56,8 +57,8 @@ mod tests {
     use reth_evm_ethereum::execute::EthExecutorProvider;
     use reth_exex::ExExManagerHandle;
     use reth_primitives::{
-        address, hex_literal::hex, keccak256, Account, BlockNumber, Bytecode, ChainSpecBuilder,
-        SealedBlock, StaticFileSegment, B256, U256,
+        address, hex_literal::hex, keccak256, Account, BlockNumber, Bytecode, SealedBlock,
+        StaticFileSegment, B256, U256,
     };
     use reth_provider::{
         providers::StaticFileWriter, AccountExtReader, BlockReader, DatabaseProviderFactory,

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -1,3 +1,4 @@
+use reth_chainspec::MAINNET;
 use reth_db::{
     tables,
     test_utils::{
@@ -16,7 +17,7 @@ use reth_db_api::{
 };
 use reth_primitives::{
     keccak256, Account, Address, BlockNumber, Receipt, SealedBlock, SealedHeader,
-    StaticFileSegment, StorageEntry, TxHash, TxNumber, B256, MAINNET, U256,
+    StaticFileSegment, StorageEntry, TxHash, TxNumber, B256, U256,
 };
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileProviderRWRefMut, StaticFileWriter},

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -1,13 +1,14 @@
 //! Reth genesis initialization utility functions.
 
+use reth_chainspec::ChainSpec;
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
 use reth_db::tables;
 use reth_db_api::{database::Database, transaction::DbTxMut, DatabaseError};
 use reth_etl::Collector;
 use reth_primitives::{
-    Account, Address, Bytecode, ChainSpec, GenesisAccount, Receipts, StaticFileSegment,
-    StorageEntry, B256, U256,
+    Account, Address, Bytecode, GenesisAccount, Receipts, StaticFileSegment, StorageEntry, B256,
+    U256,
 };
 use reth_provider::{
     bundle_state::{BundleStateInit, RevertsInit},
@@ -524,6 +525,7 @@ struct GenesisAccountWithAddress {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_chainspec::{Chain, GOERLI, MAINNET, SEPOLIA};
     use reth_db::DatabaseEnv;
     use reth_db_api::{
         cursor::DbCursorRO,
@@ -532,8 +534,7 @@ mod tests {
         transaction::DbTx,
     };
     use reth_primitives::{
-        Chain, Genesis, IntegerList, GOERLI, GOERLI_GENESIS_HASH, MAINNET, MAINNET_GENESIS_HASH,
-        SEPOLIA, SEPOLIA_GENESIS_HASH,
+        Genesis, IntegerList, GOERLI_GENESIS_HASH, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH,
     };
     use reth_provider::test_utils::create_test_provider_factory_with_chain_spec;
 

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-blockchain-tree-api.workspace = true
 reth-execution-types.workspace = true
 reth-primitives.workspace = true

--- a/crates/storage/provider/src/providers/chain_info.rs
+++ b/crates/storage/provider/src/providers/chain_info.rs
@@ -1,5 +1,6 @@
 use parking_lot::RwLock;
-use reth_primitives::{BlockNumHash, BlockNumber, ChainInfo, SealedHeader};
+use reth_chainspec::ChainInfo;
+use reth_primitives::{BlockNumHash, BlockNumber, SealedHeader};
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -7,15 +7,16 @@ use crate::{
     PruneCheckpointReader, RequestsProvider, StageCheckpointReader, StateProviderBox,
     StaticFileProviderFactory, TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
+use reth_chainspec::{ChainInfo, ChainSpec};
 use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
-    Address, Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, ChainInfo,
-    ChainSpec, Header, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
-    StaticFileSegment, TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash,
-    TxNumber, Withdrawal, Withdrawals, B256, U256,
+    Address, Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, Header, Receipt,
+    SealedBlock, SealedBlockWithSenders, SealedHeader, StaticFileSegment, TransactionMeta,
+    TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256,
+    U256,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
@@ -597,14 +598,13 @@ mod tests {
     use alloy_rlp::Decodable;
     use assert_matches::assert_matches;
     use rand::Rng;
+    use reth_chainspec::ChainSpecBuilder;
     use reth_db::{
         mdbx::DatabaseArguments,
         tables,
         test_utils::{create_test_static_files_dir, ERROR_TEMPDIR},
     };
-    use reth_primitives::{
-        hex_literal::hex, ChainSpecBuilder, SealedBlock, StaticFileSegment, TxNumber, B256, U256,
-    };
+    use reth_primitives::{hex_literal::hex, SealedBlock, StaticFileSegment, TxNumber, B256, U256};
     use reth_prune_types::{PruneMode, PruneModes};
     use reth_storage_errors::provider::ProviderError;
     use reth_testing_utils::{

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -14,6 +14,7 @@ use crate::{
     WithdrawalsProvider,
 };
 use itertools::{izip, Itertools};
+use reth_chainspec::{ChainInfo, ChainSpec};
 use reth_db::{tables, BlockNumberList};
 use reth_db_api::{
     common::KeyValue,
@@ -33,10 +34,10 @@ use reth_primitives::{
     keccak256,
     revm::{config::revm_spec, env::fill_block_env},
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders,
-    ChainInfo, ChainSpec, GotExpected, Head, Header, Receipt, Requests, SealedBlock,
-    SealedBlockWithSenders, SealedHeader, StaticFileSegment, StorageEntry, TransactionMeta,
-    TransactionSigned, TransactionSignedEcRecovered, TransactionSignedNoHash, TxHash, TxNumber,
-    Withdrawal, Withdrawals, B256, U256,
+    GotExpected, Head, Header, Receipt, Requests, SealedBlock, SealedBlockWithSenders,
+    SealedHeader, StaticFileSegment, StorageEntry, TransactionMeta, TransactionSigned,
+    TransactionSignedEcRecovered, TransactionSignedNoHash, TxHash, TxNumber, Withdrawal,
+    Withdrawals, B256, U256,
 };
 use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -12,6 +12,7 @@ use reth_blockchain_tree_api::{
     BlockValidationKind, BlockchainTreeEngine, BlockchainTreeViewer, CanonicalOutcome,
     InsertPayloadOk,
 };
+use reth_chainspec::{ChainInfo, ChainSpec};
 use reth_db_api::{
     database::Database,
     models::{AccountBeforeTx, StoredBlockBodyIndices},
@@ -19,9 +20,9 @@ use reth_db_api::{
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumber,
-    BlockNumberOrTag, BlockWithSenders, ChainInfo, ChainSpec, Header, Receipt, SealedBlock,
-    SealedBlockWithSenders, SealedHeader, TransactionMeta, TransactionSigned,
-    TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256, U256,
+    BlockNumberOrTag, BlockWithSenders, Header, Receipt, SealedBlock, SealedBlockWithSenders,
+    SealedHeader, TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber,
+    Withdrawal, Withdrawals, B256, U256,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -6,10 +6,11 @@ use crate::{
     to_range, BlockHashReader, BlockNumReader, HeaderProvider, ReceiptProvider,
     TransactionsProvider,
 };
+use reth_chainspec::ChainInfo;
 use reth_db::static_file::{HeaderMask, ReceiptMask, StaticFileCursor, TransactionMask};
 use reth_db_api::models::CompactU256;
 use reth_primitives::{
-    Address, BlockHash, BlockHashOrNumber, BlockNumber, ChainInfo, Header, Receipt, SealedHeader,
+    Address, BlockHash, BlockHashOrNumber, BlockNumber, Header, Receipt, SealedHeader,
     TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, B256, U256,
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult};

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use dashmap::{mapref::entry::Entry as DashMapEntry, DashMap};
 use parking_lot::RwLock;
+use reth_chainspec::ChainInfo;
 use reth_db::{
     lockfile::StorageLock,
     static_file::{iter_static_files, HeaderMask, ReceiptMask, StaticFileCursor, TransactionMask},
@@ -24,8 +25,8 @@ use reth_nippy_jar::NippyJar;
 use reth_primitives::{
     keccak256,
     static_file::{find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive},
-    Address, Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, ChainInfo, Header,
-    Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader, StaticFileSegment, TransactionMeta,
+    Address, Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithSenders, Header, Receipt,
+    SealedBlock, SealedBlockWithSenders, SealedHeader, StaticFileSegment, TransactionMeta,
     TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256,
     U256,
 };

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -6,14 +6,14 @@ use crate::{
     StateRootProvider, TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
 use parking_lot::Mutex;
+use reth_chainspec::{ChainInfo, ChainSpec};
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber,
-    BlockWithSenders, Bytecode, Bytes, ChainInfo, ChainSpec, Header, Receipt, SealedBlock,
-    SealedBlockWithSenders, SealedHeader, StorageKey, StorageValue, TransactionMeta,
-    TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256,
-    U256,
+    BlockWithSenders, Bytecode, Bytes, Header, Receipt, SealedBlock, SealedBlockWithSenders,
+    SealedHeader, StorageKey, StorageValue, TransactionMeta, TransactionSigned,
+    TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256, U256,
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::{updates::TrieUpdates, AccountProof};
@@ -46,7 +46,7 @@ impl Default for MockEthProvider {
             blocks: Default::default(),
             headers: Default::default(),
             accounts: Default::default(),
-            chain_spec: Arc::new(reth_primitives::ChainSpecBuilder::mainnet().build()),
+            chain_spec: Arc::new(reth_chainspec::ChainSpecBuilder::mainnet().build()),
         }
     }
 }

--- a/crates/storage/provider/src/test_utils/mod.rs
+++ b/crates/storage/provider/src/test_utils/mod.rs
@@ -1,9 +1,9 @@
 use crate::{providers::StaticFileProvider, ProviderFactory};
+use reth_chainspec::{ChainSpec, MAINNET};
 use reth_db::{
     test_utils::{create_test_rw_db, create_test_static_files_dir, TempDatabase},
     DatabaseEnv,
 };
-use reth_primitives::{ChainSpec, MAINNET};
 use std::sync::Arc;
 
 pub mod blocks;

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -6,13 +6,14 @@ use crate::{
     StateProviderFactory, StateRootProvider, TransactionVariant, TransactionsProvider,
     WithdrawalsProvider,
 };
+use reth_chainspec::{ChainInfo, ChainSpec, MAINNET};
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, BlockWithSenders,
-    Bytecode, ChainInfo, ChainSpec, Header, Receipt, SealedBlock, SealedBlockWithSenders,
-    SealedHeader, StorageKey, StorageValue, TransactionMeta, TransactionSigned,
-    TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256, MAINNET, U256,
+    Bytecode, Header, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader, StorageKey,
+    StorageValue, TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber,
+    Withdrawal, Withdrawals, B256, U256,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};

--- a/crates/storage/provider/src/traits/spec.rs
+++ b/crates/storage/provider/src/traits/spec.rs
@@ -1,4 +1,4 @@
-use reth_primitives::ChainSpec;
+use reth_chainspec::ChainSpec;
 use std::sync::Arc;
 
 /// A trait for reading the current chainspec.

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-execution-types.workspace = true
 reth-db-api.workspace = true
 reth-primitives.workspace = true

--- a/crates/storage/storage-api/src/block_id.rs
+++ b/crates/storage/storage-api/src/block_id.rs
@@ -1,5 +1,6 @@
 use crate::BlockHashReader;
-use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag, ChainInfo, B256};
+use reth_chainspec::ChainInfo;
+use reth_primitives::{BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag, B256};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 
 /// Client trait for getting important block numbers (such as the latest block number), converting

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-eth-wire-types.workspace = true
 reth-primitives.workspace = true
 reth-fs-util.workspace = true

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -79,7 +79,7 @@
 //! Listen for new transactions and print them:
 //!
 //! ```
-//! use reth_primitives::MAINNET;
+//! use reth_chainspec::MAINNET;
 //! use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::{TransactionValidationTaskExecutor, Pool, TransactionPool};
@@ -107,7 +107,7 @@
 //!
 //! ```
 //! use futures_util::Stream;
-//! use reth_primitives::MAINNET;
+//! use reth_chainspec::MAINNET;
 //! use reth_provider::{BlockReaderIdExt, CanonStateNotification, ChainSpecProvider, StateProviderFactory};
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_tasks::TaskSpawner;
@@ -285,7 +285,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use reth_primitives::MAINNET;
+    /// use reth_chainspec::MAINNET;
     /// use reth_provider::{BlockReaderIdExt, StateProviderFactory};
     /// use reth_tasks::TokioTaskExecutor;
     /// use reth_transaction_pool::{

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -681,8 +681,9 @@ mod tests {
         blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
         CoinbaseTipOrdering, EthPooledTransaction, Pool, PoolTransaction, TransactionOrigin,
     };
+    use reth_chainspec::MAINNET;
     use reth_fs_util as fs;
-    use reth_primitives::{hex, PooledTransactionsElement, MAINNET, U256};
+    use reth_primitives::{hex, PooledTransactionsElement, U256};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_tasks::TaskManager;
 

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -1,9 +1,10 @@
 use crate::EthPooledTransaction;
 use rand::Rng;
+use reth_chainspec::MAINNET;
 use reth_primitives::{
     constants::MIN_PROTOCOL_BASE_FEE, sign_message, AccessList, Address, Bytes, Transaction,
     TransactionSigned, TryFromRecoveredTransaction, TxEip1559, TxEip4844, TxKind, TxLegacy, B256,
-    MAINNET, U256,
+    U256,
 };
 
 /// A generator for transactions for testing purposes.

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -9,6 +9,7 @@ use crate::{
     EthBlobTransactionSidecar, EthPoolTransaction, LocalTransactionConfig, PoolTransaction,
     TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
 };
+use reth_chainspec::ChainSpec;
 use reth_primitives::{
     constants::{
         eip4844::{MAINNET_KZG_TRUSTED_SETUP, MAX_BLOBS_PER_BLOCK},
@@ -16,8 +17,8 @@ use reth_primitives::{
     },
     kzg::KzgSettings,
     revm::compat::calculate_intrinsic_gas_after_merge,
-    ChainSpec, GotExpected, InvalidTransactionError, SealedBlock, EIP1559_TX_TYPE_ID,
-    EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
+    GotExpected, InvalidTransactionError, SealedBlock, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID,
+    EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
 };
 use reth_provider::{AccountReader, BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::TaskSpawner;
@@ -734,9 +735,8 @@ mod tests {
         blobstore::InMemoryBlobStore, error::PoolErrorKind, CoinbaseTipOrdering,
         EthPooledTransaction, Pool, TransactionPool,
     };
-    use reth_primitives::{
-        hex, FromRecoveredPooledTransaction, PooledTransactionsElement, MAINNET, U256,
-    };
+    use reth_chainspec::MAINNET;
+    use reth_primitives::{hex, FromRecoveredPooledTransaction, PooledTransactionsElement, U256};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 
     fn get_transaction() -> EthPooledTransaction {

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -7,7 +7,8 @@ use crate::{
     TransactionValidator,
 };
 use futures_util::{lock::Mutex, StreamExt};
-use reth_primitives::{ChainSpec, SealedBlock};
+use reth_chainspec::ChainSpec;
+use reth_primitives::SealedBlock;
 use reth_provider::BlockReaderIdExt;
 use reth_tasks::TaskSpawner;
 use std::{future::Future, pin::Pin, sync::Arc};

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -42,6 +42,7 @@ triehash = { version = "0.8", optional = true }
 
 [dev-dependencies]
 # reth
+reth-chainspec.workspace = true
 reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -164,8 +164,9 @@ mod tests {
     use super::*;
     use crate::StateRoot;
     use once_cell::sync::Lazy;
+    use reth_chainspec::{Chain, ChainSpec, HOLESKY, MAINNET};
     use reth_db_api::database::Database;
-    use reth_primitives::{Account, Bytes, Chain, ChainSpec, StorageEntry, HOLESKY, MAINNET, U256};
+    use reth_primitives::{Account, Bytes, StorageEntry, U256};
     use reth_provider::{test_utils::create_test_provider_factory, HashingWriter, ProviderFactory};
     use reth_storage_errors::provider::ProviderResult;
     use std::{str::FromStr, sync::Arc};

--- a/examples/bsc-p2p/Cargo.toml
+++ b/examples/bsc-p2p/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reth-chainspec.workspace = true
 reth-discv4 = { workspace = true, features = ["test-utils"] }
 reth-network = { workspace = true, features = ["test-utils"] }
 reth-network-api.workspace = true

--- a/examples/bsc-p2p/src/chainspec.rs
+++ b/examples/bsc-p2p/src/chainspec.rs
@@ -1,6 +1,5 @@
-use reth_primitives::{
-    b256, BaseFeeParams, Chain, ChainSpec, ForkCondition, Hardfork, NodeRecord, B256,
-};
+use reth_chainspec::{net::NodeRecord, BaseFeeParams, Chain, ChainSpec, ForkCondition, Hardfork};
+use reth_primitives::{b256, B256};
 
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -16,7 +15,7 @@ pub(crate) fn bsc_chain_spec() -> Arc<ChainSpec> {
         paris_block_and_final_difficulty: None,
         hardforks: BTreeMap::from([(Hardfork::Shanghai, ForkCondition::Timestamp(SHANGHAI_TIME))]),
         deposit_contract: None,
-        base_fee_params: reth_primitives::BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
+        base_fee_params: reth_chainspec::BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
         prune_delete_limit: 0,
     }
     .into()

--- a/examples/custom-dev-node/Cargo.toml
+++ b/examples/custom-dev-node/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-node-core.workspace = true
 reth-primitives.workspace = true
 reth-node-ethereum.workspace = true

--- a/examples/custom-dev-node/src/main.rs
+++ b/examples/custom-dev-node/src/main.rs
@@ -10,9 +10,10 @@ use reth::{
     rpc::eth::EthTransactions,
     tasks::TaskManager,
 };
+use reth_chainspec::ChainSpec;
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::EthereumNode;
-use reth_primitives::{b256, hex, ChainSpec, Genesis};
+use reth_primitives::{b256, hex, Genesis};
 use std::sync::Arc;
 
 #[tokio::main]

--- a/examples/custom-engine-types/Cargo.toml
+++ b/examples/custom-engine-types/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-rpc-types.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -38,6 +38,7 @@ use reth_basic_payload_builder::{
     BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig, BuildArguments, BuildOutcome,
     PayloadBuilder, PayloadConfig,
 };
+use reth_chainspec::{Chain, ChainSpec};
 use reth_node_api::{
     payload::{EngineApiMessageVersion, EngineObjectValidationError, PayloadOrAttributes},
     validate_version_specific_fields, EngineTypes, PayloadAttributes, PayloadBuilderAttributes,
@@ -50,7 +51,7 @@ use reth_payload_builder::{
     error::PayloadBuilderError, EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderHandle,
     PayloadBuilderService,
 };
-use reth_primitives::{Address, Chain, ChainSpec, Genesis, Header, Withdrawals, B256};
+use reth_primitives::{Address, Genesis, Header, Withdrawals, B256};
 use reth_rpc_types::{
     engine::{
         ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,

--- a/examples/custom-evm/Cargo.toml
+++ b/examples/custom-evm/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true
 reth-primitives.workspace = true

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -17,10 +17,11 @@ use reth::{
     },
     tasks::TaskManager,
 };
+use reth_chainspec::{Chain, ChainSpec};
 use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider, EthereumNode};
-use reth_primitives::{Chain, ChainSpec, Genesis, Header, TransactionSigned};
+use reth_primitives::{Genesis, Header, TransactionSigned};
 use reth_tracing::{RethTracer, Tracer};
 use std::sync::Arc;
 

--- a/examples/custom-payload-builder/Cargo.toml
+++ b/examples/custom-payload-builder/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-node-api.workspace = true
 reth-basic-payload-builder.workspace = true

--- a/examples/custom-payload-builder/src/generator.rs
+++ b/examples/custom-payload-builder/src/generator.rs
@@ -5,9 +5,10 @@ use reth::{
     transaction_pool::TransactionPool,
 };
 use reth_basic_payload_builder::{BasicPayloadJobGeneratorConfig, PayloadBuilder, PayloadConfig};
+use reth_chainspec::ChainSpec;
 use reth_node_api::PayloadBuilderAttributes;
 use reth_payload_builder::{error::PayloadBuilderError, PayloadJobGenerator};
-use reth_primitives::{BlockNumberOrTag, Bytes, ChainSpec};
+use reth_primitives::{BlockNumberOrTag, Bytes};
 use std::sync::Arc;
 
 /// The generator type that creates new jobs that builds empty blocks.

--- a/examples/db-access/Cargo.toml
+++ b/examples/db-access/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 
 [dependencies]
+reth-chainspec.workspace = true
 reth-db.workspace = true
 reth-primitives.workspace = true
 reth-provider.workspace = true

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -1,5 +1,6 @@
+use reth_chainspec::ChainSpecBuilder;
 use reth_db::open_db_read_only;
-use reth_primitives::{Address, ChainSpecBuilder, B256};
+use reth_primitives::{Address, B256};
 use reth_provider::{
     providers::StaticFileProvider, AccountReader, BlockReader, BlockSource, HeaderProvider,
     ProviderFactory, ReceiptProvider, StateProvider, TransactionsProvider,

--- a/examples/exex/rollup/Cargo.toml
+++ b/examples/exex/rollup/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 # reth
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-exex.workspace = true
 reth-node-api.workspace = true
 reth-node-ethereum.workspace = true

--- a/examples/exex/rollup/src/main.rs
+++ b/examples/exex/rollup/src/main.rs
@@ -8,13 +8,11 @@ use alloy_sol_types::{sol, SolEventInterface, SolInterface};
 use db::Database;
 use execution::execute_block;
 use once_cell::sync::Lazy;
+use reth_chainspec::{ChainSpec, ChainSpecBuilder};
 use reth_exex::{ExExContext, ExExEvent};
 use reth_node_api::FullNodeComponents;
 use reth_node_ethereum::EthereumNode;
-use reth_primitives::{
-    address, Address, ChainSpec, ChainSpecBuilder, Genesis, SealedBlockWithSenders,
-    TransactionSigned, U256,
-};
+use reth_primitives::{address, Address, Genesis, SealedBlockWithSenders, TransactionSigned, U256};
 use reth_provider::Chain;
 use reth_tracing::tracing::{error, info};
 use rusqlite::Connection;

--- a/examples/manual-p2p/Cargo.toml
+++ b/examples/manual-p2p/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-network.workspace = true
 reth-discv4.workspace = true

--- a/examples/manual-p2p/src/main.rs
+++ b/examples/manual-p2p/src/main.rs
@@ -10,16 +10,15 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use once_cell::sync::Lazy;
+use reth_chainspec::{net::mainnet_nodes, Chain, MAINNET};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4ConfigBuilder, DEFAULT_DISCOVERY_ADDRESS};
 use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
     EthMessage, EthStream, HelloMessage, P2PStream, Status, UnauthedEthStream, UnauthedP2PStream,
 };
 use reth_network::config::rng_secret_key;
-use reth_network_peers::pk2id;
-use reth_primitives::{
-    mainnet_nodes, Chain, Hardfork, Head, NodeRecord, MAINNET, MAINNET_GENESIS_HASH,
-};
+use reth_network_peers::{pk2id, NodeRecord};
+use reth_primitives::{Hardfork, Head, MAINNET_GENESIS_HASH};
 use secp256k1::{SecretKey, SECP256K1};
 use tokio::net::TcpStream;
 

--- a/examples/polygon-p2p/Cargo.toml
+++ b/examples/polygon-p2p/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "recovery"] }
 tokio.workspace = true
 reth-network.workspace = true
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 serde_json.workspace = true
 reth-tracing.workspace = true

--- a/examples/polygon-p2p/src/chain_cfg.rs
+++ b/examples/polygon-p2p/src/chain_cfg.rs
@@ -1,6 +1,6 @@
-use reth_primitives::{
-    b256, BaseFeeParams, Chain, ChainSpec, ForkCondition, Hardfork, Head, NodeRecord, B256,
-};
+use reth_chainspec::{BaseFeeParams, Chain, ChainSpec, ForkCondition, Hardfork};
+use reth_discv4::NodeRecord;
+use reth_primitives::{b256, Head, B256};
 
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -24,7 +24,7 @@ pub(crate) fn polygon_chain_spec() -> Arc<ChainSpec> {
             (Hardfork::Shanghai, ForkCondition::Block(SHANGAI_BLOCK)),
         ]),
         deposit_contract: None,
-        base_fee_params: reth_primitives::BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
+        base_fee_params: reth_chainspec::BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
         prune_delete_limit: 0,
     }
     .into()

--- a/examples/rpc-db/Cargo.toml
+++ b/examples/rpc-db/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 futures.workspace = true
 jsonrpsee.workspace = true
 reth.workspace = true
+reth-chainspec.workspace = true
 reth-db.workspace = true
 reth-db-api.workspace = true
 reth-node-ethereum.workspace = true

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -13,13 +13,13 @@
 //! ```
 
 use reth::{
-    primitives::ChainSpecBuilder,
     providers::{
         providers::{BlockchainProvider, StaticFileProvider},
         ProviderFactory,
     },
     utils::db::open_db_read_only,
 };
+use reth_chainspec::ChainSpecBuilder;
 use reth_db::mdbx::DatabaseArguments;
 use reth_db_api::models::ClientVersion;
 

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -16,6 +16,7 @@ ef-tests = []
 asm-keccak = ["reth-primitives/asm-keccak"]
 
 [dependencies]
+reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-db = { workspace = true, features = ["mdbx", "test-utils", "disable-lock"] }
 reth-db-api.workspace = true

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -1,15 +1,15 @@
 //! Shared models for <https://github.com/ethereum/tests>
 
 use crate::{assert::assert_equal, Error};
+use reth_chainspec::{ChainSpec, ChainSpecBuilder};
 use reth_db::tables;
 use reth_db_api::{
     cursor::DbDupCursorRO,
     transaction::{DbTx, DbTxMut},
 };
 use reth_primitives::{
-    keccak256, Account as RethAccount, Address, Bloom, Bytecode, Bytes, ChainSpec,
-    ChainSpecBuilder, Header as RethHeader, SealedHeader, StorageEntry, Withdrawals, B256, B64,
-    U256,
+    keccak256, Account as RethAccount, Address, Bloom, Bytecode, Bytes, Header as RethHeader,
+    SealedHeader, StorageEntry, Withdrawals, B256, B64, U256,
 };
 use serde::Deserialize;
 use std::{collections::BTreeMap, ops::Deref};


### PR DESCRIPTION
Remove re-export from `reth_primitives` and import `reth_chainspec` where necessary. Everywhere.
