### PR TITLE
feat: add EIP-7702 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6c2674230e94ea98767550b02853bf7024b46f784827be95acfc5f5f1a445f"
+checksum = "03fd095a9d70f4b1c5c102c84a4c782867a5c6416dbf6dcd42a63e7c7a89d3c8"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -133,12 +133,11 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-serde 0.1.0",
  "c-kzg",
  "serde",
 ]
@@ -146,14 +145,12 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#af25c53f99a4549ece47625b7d65f088c3487864"
+source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
  "c-kzg",
- "serde",
 ]
 
 [[package]]
@@ -177,11 +174,10 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-serde 0.1.0",
  "arbitrary",
  "c-kzg",
  "derive_more",
@@ -195,37 +191,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#af25c53f99a4549ece47625b7d65f088c3487864"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
- "c-kzg",
- "once_cell",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-genesis"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#af25c53f99a4549ece47625b7d65f088c3487864"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-serde 0.1.0",
  "serde",
  "serde_json",
 ]
@@ -260,10 +230,10 @@ version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -276,7 +246,7 @@ name = "alloy-node-bindings"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-genesis",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -318,12 +288,12 @@ name = "alloy-provider"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-rpc-types-trace",
  "alloy-transport",
  "alloy-transport-http",
@@ -386,38 +356,19 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-consensus 0.1.0",
+ "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-serde 0.1.0",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.12.1",
  "jsonrpsee-types",
  "proptest",
  "proptest-derive",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "alloy-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#af25c53f99a4549ece47625b7d65f088c3487864"
-dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
- "alloy-sol-types",
- "itertools 0.12.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -438,7 +389,7 @@ name = "alloy-rpc-types-beacon"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "serde",
@@ -451,10 +402,10 @@ version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -471,8 +422,17 @@ version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=dd7a999#dd7a999d9efe259c47a34dde046952de795a8f6a"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
  "serde",
  "serde_json",
 ]
@@ -3137,9 +3097,9 @@ version = "0.1.0"
 source = "git+https://github.com/foundry-rs/block-explorers#adcb750e8d8e57f7decafca433118bf7836ffd55"
 dependencies = [
  "alloy-chains",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-rpc-types",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
  "chrono",
  "reqwest 0.12.4",
@@ -6578,8 +6538,8 @@ dependencies = [
 name = "reth-codecs"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -6787,7 +6747,7 @@ version = "0.2.0-beta.7"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
  "alloy-network",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-signer",
  "alloy-signer-wallet",
  "eyre",
@@ -6991,7 +6951,7 @@ dependencies = [
 name = "reth-evm-ethereum"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
  "reth-evm",
  "reth-interfaces",
  "reth-primitives",
@@ -7552,11 +7512,11 @@ name = "reth-primitives"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-chains",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-trie",
  "arbitrary",
  "assert_matches",
@@ -7656,7 +7616,7 @@ dependencies = [
 name = "reth-revm"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-eips",
  "reth-consensus-common",
  "reth-interfaces",
  "reth-primitives",
@@ -7842,7 +7802,7 @@ name = "reth-rpc-types"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
@@ -7867,7 +7827,7 @@ name = "reth-rpc-types-compat"
 version = "0.2.0-beta.7"
 dependencies = [
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "reth-primitives",
  "reth-rpc-types",
  "serde_json",
@@ -7974,7 +7934,7 @@ dependencies = [
 name = "reth-testing-utils"
 version = "0.2.0-beta.7"
 dependencies = [
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-genesis",
  "reth-primitives",
  "secp256k1 0.28.2",
 ]
@@ -8094,8 +8054,6 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c336f9921588e50871c00024feb51a521eca50ce6d01494bb9c50f837c8ed"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -8112,7 +8070,7 @@ version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=21a2db5#21a2db5a3a828a35e82b116e5d046a9efaca1449"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=dd7a999)",
+ "alloy-rpc-types",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
@@ -8127,8 +8085,6 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58182c7454179826f9dad2ca577661963092ce9d0fd0c9d682c1e9215a72e70"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -8137,8 +8093,6 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8af9aa737eef0509a50d9f3cc1a631557a00ef2e70a3aa8a75d9ee0ed275bb"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -8154,10 +8108,9 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bf5d465e64b697da6a111cb19e798b5b2ebb18e5faf2ad48e9e8d47c64add2"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "auto_impl",
  "bitflags 2.5.0",
  "bitvec",
@@ -8168,6 +8121,7 @@ dependencies = [
  "enumn",
  "hashbrown 0.14.5",
  "hex",
+ "k256",
  "once_cell",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,7 +291,7 @@ revm-primitives = { version = "4.0.0", features = [
 revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "21a2db5" }
 
 # eth
-alloy-chains = "0.1.15"
+alloy-chains = "0.1.18"
 alloy-primitives = "0.7.2"
 alloy-dyn-abi = "0.7.2"
 alloy-sol-types = "0.7.2"

--- a/crates/ethereum-forks/src/hardfork.rs
+++ b/crates/ethereum-forks/src/hardfork.rs
@@ -144,6 +144,7 @@ impl Hardfork {
             Hardfork::Paris => Some(15537394),
             Hardfork::Shanghai => Some(17034870),
             Hardfork::Cancun => Some(19426587),
+            Hardfork::Prague => Some(0), // TODO(eip7702): fix me
 
             _ => None,
         }
@@ -356,6 +357,7 @@ impl Hardfork {
             Hardfork::Paris => Some(1663224162),
             Hardfork::Shanghai => Some(1681338455),
             Hardfork::Cancun => Some(1710338135),
+            Hardfork::Prague => Some(0), // TODO(eip7702): fix me
 
             // upcoming hardforks
             _ => None,

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -332,6 +332,9 @@ pub struct AnnouncedTxTypesMetrics {
 
     /// Histogram for tracking frequency of EIP-4844 transaction type
     pub(crate) eip4844: Histogram,
+
+    /// Histogram for tracking frequency of EIP-7702 transaction type
+    pub(crate) eip7702: Histogram,
 }
 
 #[derive(Debug, Default)]
@@ -340,6 +343,7 @@ pub struct TxTypesCounter {
     pub(crate) eip2930: usize,
     pub(crate) eip1559: usize,
     pub(crate) eip4844: usize,
+    pub(crate) eip7702: usize,
 }
 
 impl TxTypesCounter {
@@ -358,6 +362,9 @@ impl TxTypesCounter {
             TxType::Eip4844 => {
                 self.eip4844 += 1;
             }
+            TxType::Eip7702 => {
+                self.eip7702 += 1;
+            }
             _ => {}
         }
     }
@@ -371,5 +378,6 @@ impl AnnouncedTxTypesMetrics {
         self.eip2930.record(tx_types_counter.eip2930 as f64);
         self.eip1559.record(tx_types_counter.eip1559 as f64);
         self.eip4844.record(tx_types_counter.eip4844 as f64);
+        self.eip7702.record(tx_types_counter.eip7702 as f64);
     }
 }

--- a/crates/net/network/src/transactions/validation.rs
+++ b/crates/net/network/src/transactions/validation.rs
@@ -331,6 +331,7 @@ impl FilterAnnouncement for EthMessageFilter {
     }
 }
 
+// TODO(eip7702): update tests as needed
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -194,6 +194,30 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
                         .ok_or(ConversionError::MissingMaxFeePerBlobGas)?,
                 }))
             }
+            Some(TxType::Eip7702) => {
+                // EIP-7702
+                Ok(Transaction::Eip7702(TxEip7702 {
+                    chain_id: tx.chain_id.ok_or(ConversionError::MissingChainId)?,
+                    nonce: tx.nonce,
+                    max_priority_fee_per_gas: tx
+                        .max_priority_fee_per_gas
+                        .ok_or(ConversionError::MissingMaxPriorityFeePerGas)?,
+                    max_fee_per_gas: tx
+                        .max_fee_per_gas
+                        .ok_or(ConversionError::MissingMaxFeePerGas)?,
+                    gas_limit: tx
+                        .gas
+                        .try_into()
+                        .map_err(|_| ConversionError::Eip2718Error(RlpError::Overflow.into()))?,
+                    to: tx.to.map_or(TxKind::Create, TxKind::Call),
+                    value: tx.value,
+                    access_list: tx.access_list.ok_or(ConversionError::MissingAccessList)?,
+                    authorization_list: tx
+                        .authorization_list
+                        .ok_or(ConversionError::MissingAuthorizationList)?,
+                    input: tx.input,
+                }))
+            }
             #[cfg(feature = "optimism")]
             Some(TxType::Deposit) => todo!(),
         }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -65,6 +65,7 @@ pub static MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             ),
             (Hardfork::Shanghai, ForkCondition::Timestamp(1681338455)),
             (Hardfork::Cancun, ForkCondition::Timestamp(1710338135)),
+            (Hardfork::Prague, ForkCondition::Timestamp(0)), // TODO(eip7702): fix me
         ]),
         // https://etherscan.io/tx/0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0
         deposit_contract: Some(DepositContract::new(
@@ -239,6 +240,7 @@ pub static DEV: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             ),
             (Hardfork::Shanghai, ForkCondition::Timestamp(0)),
             (Hardfork::Cancun, ForkCondition::Timestamp(0)),
+            (Hardfork::Prague, ForkCondition::Timestamp(0)),
             #[cfg(feature = "optimism")]
             (Hardfork::Regolith, ForkCondition::Timestamp(0)),
             #[cfg(feature = "optimism")]
@@ -1233,6 +1235,13 @@ impl ChainSpecBuilder {
     pub fn cancun_activated(mut self) -> Self {
         self = self.shanghai_activated();
         self.hardforks.insert(Hardfork::Cancun, ForkCondition::Timestamp(0));
+        self
+    }
+
+    /// Enable Prague at genesis.
+    pub fn prague_activated(mut self) -> Self {
+        self = self.cancun_activated();
+        self.hardforks.insert(Hardfork::Prague, ForkCondition::Timestamp(0));
         self
     }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -99,7 +99,7 @@ pub use transaction::{
     Transaction, TransactionMeta, TransactionSigned, TransactionSignedEcRecovered,
     TransactionSignedNoHash, TryFromRecoveredTransaction, TxEip1559, TxEip2930, TxEip4844,
     TxHashOrNumber, TxLegacy, TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
-    LEGACY_TX_TYPE_ID,
+    EIP7702_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
 };
 
 pub use withdrawal::{Withdrawal, Withdrawals};

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -402,6 +402,10 @@ impl Decodable for ReceiptWithBloom {
                         buf.advance(1);
                         Self::decode_receipt(buf, TxType::Eip4844)
                     }
+                    0x04 => {
+                        buf.advance(1);
+                        Self::decode_receipt(buf, TxType::Eip7702)
+                    }
                     #[cfg(feature = "optimism")]
                     0x7E => {
                         buf.advance(1);
@@ -533,6 +537,9 @@ impl<'a> ReceiptWithBloomEncoder<'a> {
             }
             TxType::Eip4844 => {
                 out.put_u8(0x03);
+            }
+            TxType::Eip7702 => {
+                out.put_u8(0x04);
             }
             #[cfg(feature = "optimism")]
             TxType::Deposit => {

--- a/crates/primitives/src/revm/config.rs
+++ b/crates/primitives/src/revm/config.rs
@@ -21,7 +21,9 @@ pub fn revm_spec_by_timestamp_after_merge(
         }
     }
 
-    if chain_spec.is_cancun_active_at_timestamp(timestamp) {
+    if chain_spec.is_prague_active_at_timestamp(timestamp) {
+        revm_primitives::PRAGUE
+    } else if chain_spec.is_cancun_active_at_timestamp(timestamp) {
         revm_primitives::CANCUN
     } else if chain_spec.is_shanghai_active_at_timestamp(timestamp) {
         revm_primitives::SHANGHAI
@@ -45,7 +47,9 @@ pub fn revm_spec(chain_spec: &ChainSpec, block: Head) -> revm_primitives::SpecId
         }
     }
 
-    if chain_spec.fork(Hardfork::Cancun).active_at_head(&block) {
+    if chain_spec.fork(Hardfork::Prague).active_at_head(&block) {
+        revm_primitives::PRAGUE
+    } else if chain_spec.fork(Hardfork::Cancun).active_at_head(&block) {
         revm_primitives::CANCUN
     } else if chain_spec.fork(Hardfork::Shanghai).active_at_head(&block) {
         revm_primitives::SHANGHAI

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -162,6 +162,7 @@ pub fn fill_tx_env_with_beacon_root_contract_call(env: &mut Env, parent_beacon_b
         // blob fields can be None for this tx
         blob_hashes: Vec::new(),
         max_fee_per_blob_gas: None,
+        authorization_list: Vec::new(),
         #[cfg(feature = "optimism")]
         optimism: OptimismFields {
             source_hash: None,
@@ -290,6 +291,42 @@ where
                 .collect();
             tx_env.blob_hashes.clone_from(&tx.blob_versioned_hashes);
             tx_env.max_fee_per_blob_gas = Some(U256::from(tx.max_fee_per_blob_gas));
+        }
+        Transaction::Eip7702(tx) => {
+            tx_env.gas_limit = tx.gas_limit;
+            tx_env.gas_price = U256::from(tx.max_fee_per_gas);
+            tx_env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
+            tx_env.transact_to = match tx.to {
+                TxKind::Call(to) => TransactTo::Call(to),
+                TxKind::Create => TransactTo::create(),
+            };
+            tx_env.value = U256::ZERO;
+            tx_env.data = tx.input.clone();
+            tx_env.chain_id = Some(tx.chain_id);
+            tx_env.nonce = Some(tx.nonce);
+            tx_env.access_list = tx
+                .access_list
+                .0
+                .iter()
+                .map(|l| {
+                    (l.address, l.storage_keys.iter().map(|k| U256::from_be_bytes(k.0)).collect())
+                })
+                .collect();
+            tx_env.authorization_list = tx
+                .authorization_list
+                .0
+                .iter()
+                .map(|a| revm_primitives::Authorization {
+                    chain_id: a.chain_id,
+                    address: a.address,
+                    nonce: a.nonce,
+                    y_parity: a.y_parity,
+                    r: a.r,
+                    s: a.s,
+                })
+                .collect();
+            tx_env.blob_hashes.clear();
+            tx_env.max_fee_per_blob_gas.take();
         }
         #[cfg(feature = "optimism")]
         Transaction::Deposit(tx) => {

--- a/crates/primitives/src/transaction/eip7702.rs
+++ b/crates/primitives/src/transaction/eip7702.rs
@@ -1,0 +1,300 @@
+use super::access_list::AccessList;
+use crate::{keccak256, Bytes, ChainId, Signature, TxKind, TxType, B256, U256};
+use alloy_eips::eip7702::AuthorizationList;
+use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
+use bytes::BytesMut;
+use reth_codecs::{main_codec, Compact};
+use std::mem;
+
+/// [EIP-7702 Set Code Transaction](https://eips.ethereum.org/EIPS/eip-7702)
+///
+/// Set EOA account code for one transaction
+#[main_codec]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct TxEip7702 {
+    /// Added as EIP-pub 155: Simple replay attack protection
+    pub chain_id: ChainId,
+    /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    pub nonce: u64,
+    /// A scalar value equal to the number of
+    /// Wei to be paid per unit of gas for all computation
+    /// costs incurred as a result of the execution of this transaction; formally Tp.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    pub gas_limit: u64,
+    /// A scalar value equal to the maximum
+    /// amount of gas that should be used in executing
+    /// this transaction. This is paid up-front, before any
+    /// computation is done and may not be increased
+    /// later; formally Tg.
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasFeeCap`
+    pub max_fee_per_gas: u128,
+    /// Max Priority fee that transaction is paying
+    ///
+    /// As ethereum circulation is around 120mil eth as of 2022 that is around
+    /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
+    /// 340282366920938463463374607431768211455
+    ///
+    /// This is also known as `GasTipCap`
+    pub max_priority_fee_per_gas: u128,
+    /// The 160-bit address of the message call’s recipient or, for a contract creation
+    /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    pub to: TxKind,
+    /// A scalar value equal to the number of Wei to
+    /// be transferred to the message call’s recipient or,
+    /// in the case of contract creation, as an endowment
+    /// to the newly created account; formally Tv.
+    pub value: U256,
+    /// The accessList specifies a list of addresses and storage keys;
+    /// these addresses and storage keys are added into the `accessed_addresses`
+    /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
+    /// A gas cost is charged, though at a discount relative to the cost of
+    /// accessing outside the list.
+    pub access_list: AccessList,
+    /// Authorizations are used to temporarily set the code of its signer to
+    /// the code referenced by `address`. These also include a `chain_id` (which
+    /// can be set to zero and not evaluated) as well as an optional `nonce`.
+    pub authorization_list: AuthorizationList,
+    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
+    /// Some). pub init: An unlimited size byte array specifying the
+    /// EVM-code for the account initialisation procedure CREATE,
+    /// data: An unlimited size byte array specifying the
+    /// input data of the message call, formally Td.
+    pub input: Bytes,
+}
+
+impl TxEip7702 {
+    /// Returns the effective gas price for the given `base_fee`.
+    pub fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        match base_fee {
+            None => self.max_fee_per_gas,
+            Some(base_fee) => {
+                // if the tip is greater than the max priority fee per gas, set it to the max
+                // priority fee per gas + base fee
+                let tip = self.max_fee_per_gas.saturating_sub(base_fee as u128);
+                if tip > self.max_priority_fee_per_gas {
+                    self.max_priority_fee_per_gas + base_fee as u128
+                } else {
+                    // otherwise return the max fee per gas
+                    self.max_fee_per_gas
+                }
+            }
+        }
+    }
+
+    /// Calculates a heuristic for the in-memory size of the [TxEip7702] transaction.
+    #[inline]
+    pub fn size(&self) -> usize {
+        mem::size_of::<ChainId>() + // chain_id
+        mem::size_of::<u64>() + // nonce
+        mem::size_of::<u128>() + // gas_price
+        mem::size_of::<u64>() + // gas_limit
+        self.to.size() + // to
+        mem::size_of::<U256>() + // value
+        self.access_list.size() + // access_list
+        self.authorization_list.size() + // authorization_list
+        self.input.len() // input
+    }
+
+    /// Decodes the inner [TxEip7702] fields from RLP bytes.
+    ///
+    /// NOTE: This assumes a RLP header has already been decoded, and _just_ decodes the following
+    /// RLP fields in the following order:
+    ///
+    /// - `chain_id`
+    /// - `nonce`
+    /// - `gas_price`
+    /// - `gas_limit`
+    /// - `to`
+    /// - `value`
+    /// - `data` (`input`)
+    /// - `access_list`
+    /// - `authorization_list`
+    pub(crate) fn decode_inner(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            chain_id: Decodable::decode(buf)?,
+            nonce: Decodable::decode(buf)?,
+            max_priority_fee_per_gas: Decodable::decode(buf)?,
+            max_fee_per_gas: Decodable::decode(buf)?,
+            gas_limit: Decodable::decode(buf)?,
+            to: Decodable::decode(buf)?,
+            value: Decodable::decode(buf)?,
+            input: Decodable::decode(buf)?,
+            access_list: Decodable::decode(buf)?,
+            authorization_list: Decodable::decode(buf)?,
+        })
+    }
+
+    /// Outputs the length of the transaction's fields, without a RLP header.
+    pub(crate) fn fields_len(&self) -> usize {
+        self.chain_id.length() +
+            self.nonce.length() +
+            self.max_priority_fee_per_gas.length() +
+            self.max_fee_per_gas.length() +
+            self.gas_limit.length() +
+            self.to.length() +
+            self.value.length() +
+            self.input.0.length() +
+            self.access_list.length() +
+            self.authorization_list.length()
+    }
+
+    /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
+    pub(crate) fn encode_fields(&self, out: &mut dyn bytes::BufMut) {
+        self.chain_id.encode(out);
+        self.nonce.encode(out);
+        self.max_priority_fee_per_gas.encode(out);
+        self.max_fee_per_gas.encode(out);
+        self.gas_limit.encode(out);
+        self.to.encode(out);
+        self.value.encode(out);
+        self.input.0.encode(out);
+        self.access_list.encode(out);
+        self.authorization_list.encode(out);
+    }
+
+    /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
+    /// hash that for eip2718 does not require rlp header
+    ///
+    /// This encodes the transaction as:
+    /// `rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination,
+    /// value, data, access_list, authorization_list, signature_y_parity, signature_r,
+    /// signature_s])`
+    pub(crate) fn encode_with_signature(
+        &self,
+        signature: &Signature,
+        out: &mut dyn bytes::BufMut,
+        with_header: bool,
+    ) {
+        let payload_length = self.fields_len() + signature.payload_len();
+        if with_header {
+            Header {
+                list: false,
+                payload_length: 1 + length_of_length(payload_length) + payload_length,
+            }
+            .encode(out);
+        }
+        out.put_u8(self.tx_type() as u8);
+        let header = Header { list: true, payload_length };
+        header.encode(out);
+        self.encode_fields(out);
+        signature.encode(out);
+    }
+
+    /// Output the length of the RLP signed transaction encoding, _without_ a RLP string header.
+    pub(crate) fn payload_len_with_signature_without_header(&self, signature: &Signature) -> usize {
+        let payload_length = self.fields_len() + signature.payload_len();
+        // 'transaction type byte length' + 'header length' + 'payload length'
+        1 + length_of_length(payload_length) + payload_length
+    }
+
+    /// Output the length of the RLP signed transaction encoding. This encodes with a RLP header.
+    pub(crate) fn payload_len_with_signature(&self, signature: &Signature) -> usize {
+        let len = self.payload_len_with_signature_without_header(signature);
+        length_of_length(len) + len
+    }
+
+    /// Get transaction type
+    pub(crate) fn tx_type(&self) -> TxType {
+        TxType::Eip7702
+    }
+
+    /// Encodes the EIP-7702 transaction in RLP for signing.
+    ///
+    /// This encodes the transaction as:
+    /// `tx_type || rlp(chain_id, nonce, gas_price, gas_limit, to, value, input, access_list,
+    /// authorization_list)`
+    ///
+    /// Note that there is no rlp header before the transaction type byte.
+    pub(crate) fn encode_for_signing(&self, out: &mut dyn bytes::BufMut) {
+        out.put_u8(self.tx_type() as u8);
+        Header { list: true, payload_length: self.fields_len() }.encode(out);
+        self.encode_fields(out);
+    }
+
+    /// Outputs the length of the signature RLP encoding for the transaction.
+    pub(crate) fn payload_len_for_signature(&self) -> usize {
+        let payload_length = self.fields_len();
+        // 'transaction type byte length' + 'header length' + 'payload length'
+        1 + length_of_length(payload_length) + payload_length
+    }
+
+    /// Outputs the signature hash of the transaction by first encoding without a signature, then
+    /// hashing.
+    pub(crate) fn signature_hash(&self) -> B256 {
+        let mut buf = BytesMut::with_capacity(self.payload_len_for_signature());
+        self.encode_for_signing(&mut buf);
+        keccak256(&buf)
+    }
+}
+
+// TODO(eip7702): fix these tests
+#[cfg(test)]
+mod tests {
+    use super::TxEip7702;
+    use crate::{
+        transaction::{signature::Signature, TxKind},
+        Address, Bytes, Transaction, TransactionSigned, U256,
+    };
+    use alloy_rlp::{Decodable, Encodable};
+
+    #[test]
+    fn test_decode_create() {
+        // tests that a contract creation tx encodes and decodes properly
+        let request = Transaction::Eip7702(TxEip7702 {
+            chain_id: 1u64,
+            nonce: 0,
+            max_fee_per_gas: 0x4a817c800,
+            max_priority_fee_per_gas: 0x3b9aca00,
+            gas_limit: 2,
+            to: TxKind::Create, // TODO(eip7702): fix
+            value: U256::ZERO,
+            input: Bytes::from(vec![1, 2]),
+            access_list: Default::default(),
+            authorization_list: Default::default(),
+        });
+        let signature = Signature { odd_y_parity: true, r: U256::default(), s: U256::default() };
+        let tx = TransactionSigned::from_transaction_and_signature(request, signature);
+
+        let mut encoded = Vec::new();
+        tx.encode(&mut encoded);
+        assert_eq!(encoded.len(), tx.length());
+
+        let decoded = TransactionSigned::decode(&mut &*encoded).unwrap();
+        assert_eq!(decoded, tx);
+    }
+
+    #[test]
+    fn test_decode_call() {
+        let request = Transaction::Eip7702(TxEip7702 {
+            chain_id: 1u64,
+            nonce: 0,
+            max_fee_per_gas: 0x4a817c800,
+            max_priority_fee_per_gas: 0x3b9aca00,
+            gas_limit: 2,
+            to: Address::default().into(),
+            value: U256::ZERO,
+            input: Bytes::from(vec![1, 2]),
+            access_list: Default::default(),
+            authorization_list: Default::default(),
+        });
+
+        let signature = Signature { odd_y_parity: true, r: U256::default(), s: U256::default() };
+
+        let tx = TransactionSigned::from_transaction_and_signature(request, signature);
+
+        let mut encoded = Vec::new();
+        tx.encode(&mut encoded);
+        assert_eq!(encoded.len(), tx.length());
+
+        let decoded = TransactionSigned::decode(&mut &*encoded).unwrap();
+        assert_eq!(decoded, tx);
+    }
+}

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -29,6 +29,9 @@ pub enum InvalidTransactionError {
     /// The transaction requires EIP-4844 which is not enabled currently.
     #[error("EIP-4844 transactions are disabled")]
     Eip4844Disabled,
+    /// The transaction requires EIP-7702 which is not enabled currently.
+    #[error("EIP-7702 transactions are disabled")]
+    Eip7702Disabled,
     /// Thrown if a transaction is not supported in the current network configuration.
     #[error("transaction type not supported")]
     TxTypeNotSupported,

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -1,7 +1,7 @@
 //! Defines the types for blob transactions, legacy, and other EIP-2718 transactions included in a
 //! response to `GetPooledTransactions`.
 
-use super::error::TransactionConversionError;
+use super::{error::TransactionConversionError, TxEip7702};
 use crate::{
     Address, BlobTransaction, BlobTransactionSidecar, Bytes, Signature, Transaction,
     TransactionSigned, TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844, TxHash,
@@ -45,6 +45,15 @@ pub enum PooledTransactionsElement {
         /// The hash of the transaction
         hash: TxHash,
     },
+    /// An EIP-7702 typed transaction
+    Eip7702 {
+        /// The inner transaction
+        transaction: TxEip7702,
+        /// The signature
+        signature: Signature,
+        /// The hash of the transaction
+        hash: TxHash,
+    },
     /// A blob transaction, which includes the transaction, blob data, commitments, and proofs.
     BlobTransaction(BlobTransaction),
 }
@@ -65,6 +74,9 @@ impl PooledTransactionsElement {
             }
             TransactionSigned { transaction: Transaction::Eip1559(tx), signature, hash } => {
                 Ok(PooledTransactionsElement::Eip1559 { transaction: tx, signature, hash })
+            }
+            TransactionSigned { transaction: Transaction::Eip7702(tx), signature, hash } => {
+                Ok(PooledTransactionsElement::Eip7702 { transaction: tx, signature, hash })
             }
             // Not supported because missing blob sidecar
             tx @ TransactionSigned { transaction: Transaction::Eip4844(_), .. } => Err(tx),
@@ -107,6 +119,7 @@ impl PooledTransactionsElement {
             Self::Legacy { transaction, .. } => transaction.signature_hash(),
             Self::Eip2930 { transaction, .. } => transaction.signature_hash(),
             Self::Eip1559 { transaction, .. } => transaction.signature_hash(),
+            Self::Eip7702 { transaction, .. } => transaction.signature_hash(),
             Self::BlobTransaction(blob_tx) => blob_tx.transaction.signature_hash(),
         }
     }
@@ -116,7 +129,8 @@ impl PooledTransactionsElement {
         match self {
             PooledTransactionsElement::Legacy { hash, .. } |
             PooledTransactionsElement::Eip2930 { hash, .. } |
-            PooledTransactionsElement::Eip1559 { hash, .. } => hash,
+            PooledTransactionsElement::Eip1559 { hash, .. } |
+            PooledTransactionsElement::Eip7702 { hash, .. } => hash,
             PooledTransactionsElement::BlobTransaction(tx) => &tx.hash,
         }
     }
@@ -126,7 +140,8 @@ impl PooledTransactionsElement {
         match self {
             Self::Legacy { signature, .. } |
             Self::Eip2930 { signature, .. } |
-            Self::Eip1559 { signature, .. } => signature,
+            Self::Eip1559 { signature, .. } |
+            Self::Eip7702 { signature, .. } => signature,
             Self::BlobTransaction(blob_tx) => &blob_tx.signature,
         }
     }
@@ -137,6 +152,7 @@ impl PooledTransactionsElement {
             Self::Legacy { transaction, .. } => transaction.nonce,
             Self::Eip2930 { transaction, .. } => transaction.nonce,
             Self::Eip1559 { transaction, .. } => transaction.nonce,
+            Self::Eip7702 { transaction, .. } => transaction.nonce,
             Self::BlobTransaction(blob_tx) => blob_tx.transaction.nonce,
         }
     }
@@ -240,6 +256,11 @@ impl PooledTransactionsElement {
                         signature: typed_tx.signature,
                         hash: typed_tx.hash,
                     }),
+                    Transaction::Eip7702(tx) => {Ok(PooledTransactionsElement::Eip7702 {
+                        transaction: tx,
+                        signature: typed_tx.signature,
+                        hash: typed_tx.hash,
+                    })},
                     #[cfg(feature = "optimism")]
                     Transaction::Deposit(_) => Err(RlpError::Custom("Optimism deposit transaction cannot be decoded to PooledTransactionsElement"))
                 }
@@ -269,6 +290,11 @@ impl PooledTransactionsElement {
                 signature,
                 hash,
             },
+            Self::Eip7702 { transaction, signature, hash } => TransactionSigned {
+                transaction: Transaction::Eip7702(transaction),
+                signature,
+                hash,
+            },
             Self::BlobTransaction(blob_tx) => blob_tx.into_parts().0,
         }
     }
@@ -285,6 +311,10 @@ impl PooledTransactionsElement {
                 transaction.payload_len_with_signature_without_header(signature)
             }
             Self::Eip1559 { transaction, signature, .. } => {
+                // method computes the payload len without a RLP header
+                transaction.payload_len_with_signature_without_header(signature)
+            }
+            Self::Eip7702 { transaction, signature, .. } => {
                 // method computes the payload len without a RLP header
                 transaction.payload_len_with_signature_without_header(signature)
             }
@@ -318,6 +348,7 @@ impl PooledTransactionsElement {
         // - EIP-2930: TxEip2930::encode_with_signature
         // - EIP-1559: TxEip1559::encode_with_signature
         // - EIP-4844: BlobTransaction::encode_with_type_inner
+        // - EIP-7702: TxEip7702::encode_with_signature
         match self {
             Self::Legacy { transaction, signature, .. } => {
                 transaction.encode_with_signature(signature, out)
@@ -326,6 +357,9 @@ impl PooledTransactionsElement {
                 transaction.encode_with_signature(signature, out, false)
             }
             Self::Eip1559 { transaction, signature, .. } => {
+                transaction.encode_with_signature(signature, out, false)
+            }
+            Self::Eip7702 { transaction, signature, .. } => {
                 transaction.encode_with_signature(signature, out, false)
             }
             Self::BlobTransaction(blob_tx) => {
@@ -375,6 +409,14 @@ impl PooledTransactionsElement {
         }
     }
 
+    /// Returns the [TxEip7702] variant if the transaction is an EIP-7702 transaction.
+    pub fn as_eip7702(&self) -> Option<&TxEip7702> {
+        match self {
+            Self::Eip7702 { transaction, .. } => Some(transaction),
+            _ => None,
+        }
+    }
+
     /// Returns the blob gas used for all blobs of the EIP-4844 transaction if it is an EIP-4844
     /// transaction.
     ///
@@ -404,6 +446,7 @@ impl PooledTransactionsElement {
         match self {
             Self::Legacy { .. } | Self::Eip2930 { .. } => None,
             Self::Eip1559 { transaction, .. } => Some(transaction.max_priority_fee_per_gas),
+            Self::Eip7702 { transaction, .. } => Some(transaction.max_priority_fee_per_gas),
             Self::BlobTransaction(tx) => Some(tx.transaction.max_priority_fee_per_gas),
         }
     }
@@ -416,6 +459,7 @@ impl PooledTransactionsElement {
             Self::Legacy { transaction, .. } => transaction.gas_price,
             Self::Eip2930 { transaction, .. } => transaction.gas_price,
             Self::Eip1559 { transaction, .. } => transaction.max_fee_per_gas,
+            Self::Eip7702 { transaction, .. } => transaction.max_fee_per_gas,
             Self::BlobTransaction(tx) => tx.transaction.max_fee_per_gas,
         }
     }
@@ -435,6 +479,7 @@ impl Encodable for PooledTransactionsElement {
         // - EIP-2930: TxEip2930::encode_with_signature
         // - EIP-1559: TxEip1559::encode_with_signature
         // - EIP-4844: BlobTransaction::encode_with_type_inner
+        // - EIP-7702: TxEip7702::encode_with_signature
         match self {
             Self::Legacy { transaction, signature, .. } => {
                 transaction.encode_with_signature(signature, out)
@@ -444,6 +489,10 @@ impl Encodable for PooledTransactionsElement {
                 transaction.encode_with_signature(signature, out, true)
             }
             Self::Eip1559 { transaction, signature, .. } => {
+                // encodes with string header
+                transaction.encode_with_signature(signature, out, true)
+            }
+            Self::Eip7702 { transaction, signature, .. } => {
                 // encodes with string header
                 transaction.encode_with_signature(signature, out, true)
             }
@@ -467,6 +516,10 @@ impl Encodable for PooledTransactionsElement {
                 transaction.payload_len_with_signature(signature)
             }
             Self::Eip1559 { transaction, signature, .. } => {
+                // method computes the payload len with a RLP header
+                transaction.payload_len_with_signature(signature)
+            }
+            Self::Eip7702 { transaction, signature, .. } => {
                 // method computes the payload len with a RLP header
                 transaction.payload_len_with_signature(signature)
             }
@@ -571,6 +624,11 @@ impl Decodable for PooledTransactionsElement {
                         hash: typed_tx.hash,
                     }),
                     Transaction::Eip1559(tx) => Ok(PooledTransactionsElement::Eip1559 {
+                        transaction: tx,
+                        signature: typed_tx.signature,
+                        hash: typed_tx.hash,
+                    }),
+                    Transaction::Eip7702(tx) => Ok(PooledTransactionsElement::Eip7702 {
                         transaction: tx,
                         signature: typed_tx.signature,
                         hash: typed_tx.hash,

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -17,6 +17,9 @@ pub const EIP1559_TX_TYPE_ID: u8 = 2;
 /// Identifier for [TxEip4844](crate::TxEip4844) transaction.
 pub const EIP4844_TX_TYPE_ID: u8 = 3;
 
+/// Identifier for [TxEip7702](crate::TxEip7702) transaction.
+pub const EIP7702_TX_TYPE_ID: u8 = 4;
+
 /// Identifier for [TxDeposit](crate::TxDeposit) transaction.
 #[cfg(feature = "optimism")]
 pub const DEPOSIT_TX_TYPE_ID: u8 = 126;
@@ -42,6 +45,8 @@ pub enum TxType {
     Eip1559 = 2_isize,
     /// Shard Blob Transactions - EIP-4844
     Eip4844 = 3_isize,
+    /// EOA Contract Code Transactions - EIP-7702
+    Eip7702 = 4_isize,
     /// Optimism Deposit transaction.
     #[cfg(feature = "optimism")]
     Deposit = 126_isize,
@@ -49,13 +54,13 @@ pub enum TxType {
 
 impl TxType {
     /// The max type reserved by an EIP.
-    pub const MAX_RESERVED_EIP: TxType = Self::Eip4844;
+    pub const MAX_RESERVED_EIP: TxType = Self::Eip7702;
 
     /// Check if the transaction type has an access list.
     pub const fn has_access_list(&self) -> bool {
         match self {
             TxType::Legacy => false,
-            TxType::Eip2930 | TxType::Eip1559 | TxType::Eip4844 => true,
+            TxType::Eip2930 | TxType::Eip1559 | TxType::Eip4844 | TxType::Eip7702 => true,
             #[cfg(feature = "optimism")]
             TxType::Deposit => false,
         }
@@ -69,6 +74,7 @@ impl From<TxType> for u8 {
             TxType::Eip2930 => EIP2930_TX_TYPE_ID,
             TxType::Eip1559 => EIP1559_TX_TYPE_ID,
             TxType::Eip4844 => EIP4844_TX_TYPE_ID,
+            TxType::Eip7702 => EIP7702_TX_TYPE_ID,
             #[cfg(feature = "optimism")]
             TxType::Deposit => DEPOSIT_TX_TYPE_ID,
         }
@@ -98,6 +104,8 @@ impl TryFrom<u8> for TxType {
             return Ok(TxType::Eip1559)
         } else if value == TxType::Eip4844 {
             return Ok(TxType::Eip4844)
+        } else if value == TxType::Eip7702 {
+            return Ok(TxType::Eip7702)
         }
 
         Err("invalid tx type")
@@ -137,6 +145,10 @@ impl Compact for TxType {
                 buf.put_u8(self as u8);
                 3
             }
+            TxType::Eip7702 => {
+                buf.put_u8(self as u8);
+                3
+            }
             #[cfg(feature = "optimism")]
             TxType::Deposit => {
                 buf.put_u8(self as u8);
@@ -158,6 +170,7 @@ impl Compact for TxType {
                     let extended_identifier = buf.get_u8();
                     match extended_identifier {
                         EIP4844_TX_TYPE_ID => TxType::Eip4844,
+                        EIP7702_TX_TYPE_ID => TxType::Eip7702,
                         #[cfg(feature = "optimism")]
                         DEPOSIT_TX_TYPE_ID => TxType::Deposit,
                         _ => panic!("Unsupported TxType identifier: {extended_identifier}"),
@@ -200,6 +213,7 @@ impl Decodable for TxType {
     }
 }
 
+// TODO(eip7702): check these tests
 #[cfg(test)]
 mod tests {
     use rand::Rng;
@@ -222,6 +236,9 @@ mod tests {
         // Test for EIP4844 transaction
         assert_eq!(TxType::try_from(U64::from(3)).unwrap(), TxType::Eip4844);
 
+        // Test for EIP7702 transaction
+        assert_eq!(TxType::try_from(U64::from(4)).unwrap(), TxType::Eip7702);
+
         // Test for Deposit transaction
         #[cfg(feature = "optimism")]
         assert_eq!(TxType::try_from(U64::from(126)).unwrap(), TxType::Deposit);
@@ -237,6 +254,7 @@ mod tests {
             (TxType::Eip2930, 1, vec![]),
             (TxType::Eip1559, 2, vec![]),
             (TxType::Eip4844, 3, vec![EIP4844_TX_TYPE_ID]),
+            (TxType::Eip7702, 3, vec![EIP7702_TX_TYPE_ID]),
             #[cfg(feature = "optimism")]
             (TxType::Deposit, 3, vec![DEPOSIT_TX_TYPE_ID]),
         ];
@@ -259,6 +277,7 @@ mod tests {
             (TxType::Eip2930, 1, vec![]),
             (TxType::Eip1559, 2, vec![]),
             (TxType::Eip4844, 3, vec![EIP4844_TX_TYPE_ID]),
+            (TxType::Eip7702, 3, vec![EIP7702_TX_TYPE_ID]),
             #[cfg(feature = "optimism")]
             (TxType::Deposit, 3, vec![DEPOSIT_TX_TYPE_ID]),
         ];
@@ -290,6 +309,10 @@ mod tests {
         // Test for EIP4844 transaction
         let tx_type = TxType::decode(&mut &[3u8][..]).unwrap();
         assert_eq!(tx_type, TxType::Eip4844);
+
+        // Test for EIP7702 transaction
+        let tx_type = TxType::decode(&mut &[4u8][..]).unwrap();
+        assert_eq!(tx_type, TxType::Eip7702);
 
         // Test random byte not in range
         let buf = [rand::thread_rng().gen_range(4..=u8::MAX)];

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -74,6 +74,7 @@ fn fill(
     let chain_id = signed_tx.chain_id();
     let blob_versioned_hashes = signed_tx.blob_versioned_hashes();
     let access_list = signed_tx.access_list().cloned();
+    let authorization_list = signed_tx.authorization_list().cloned();
 
     let signature =
         from_primitive_signature(*signed_tx.signature(), signed_tx.tx_type(), signed_tx.chain_id());
@@ -92,6 +93,7 @@ fn fill(
         input: signed_tx.input().clone(),
         chain_id,
         access_list,
+        authorization_list,
         transaction_type: Some(signed_tx.tx_type() as u8),
 
         // These fields are set to None because they are not stored as part of the transaction
@@ -125,6 +127,7 @@ pub fn transaction_to_call_request(tx: TransactionSignedEcRecovered) -> Transact
     let chain_id = tx.transaction.chain_id();
     let access_list = tx.transaction.access_list().cloned();
     let max_fee_per_blob_gas = tx.transaction.max_fee_per_blob_gas();
+    let authorization_list = tx.transaction.authorization_list().cloned();
     let blob_versioned_hashes = tx.transaction.blob_versioned_hashes();
     let tx_type = tx.transaction.tx_type();
 
@@ -150,6 +153,7 @@ pub fn transaction_to_call_request(tx: TransactionSignedEcRecovered) -> Transact
         access_list,
         max_fee_per_blob_gas,
         blob_versioned_hashes,
+        authorization_list,
         transaction_type: Some(tx_type.into()),
         sidecar: None,
     }

--- a/crates/rpc/rpc/src/eth/error.rs
+++ b/crates/rpc/rpc/src/eth/error.rs
@@ -512,7 +512,8 @@ impl From<reth_primitives::InvalidTransactionError> for RpcInvalidTransactionErr
             InvalidTransactionError::ChainIdMismatch => RpcInvalidTransactionError::InvalidChainId,
             InvalidTransactionError::Eip2930Disabled |
             InvalidTransactionError::Eip1559Disabled |
-            InvalidTransactionError::Eip4844Disabled => {
+            InvalidTransactionError::Eip4844Disabled |
+            InvalidTransactionError::Eip7702Disabled => {
                 RpcInvalidTransactionError::TxTypeNotSupported
             }
             InvalidTransactionError::TxTypeNotSupported => {

--- a/crates/rpc/rpc/src/eth/revm_utils.rs
+++ b/crates/rpc/rpc/src/eth/revm_utils.rs
@@ -235,6 +235,7 @@ pub(crate) fn create_txn_env(
         chain_id,
         blob_versioned_hashes,
         max_fee_per_blob_gas,
+        authorization_list,
         ..
     } = request;
 
@@ -270,6 +271,22 @@ pub(crate) fn create_txn_env(
         // EIP-4844 fields
         blob_hashes: blob_versioned_hashes.unwrap_or_default(),
         max_fee_per_blob_gas,
+        // EIP-7702 fields
+        authorization_list: authorization_list
+            .map(|list| {
+                list.0
+                    .into_iter()
+                    .map(|a| revm_primitives::Authorization {
+                        chain_id: a.chain_id,
+                        address: a.address,
+                        nonce: a.nonce,
+                        y_parity: a.y_parity,
+                        r: a.r,
+                        s: a.s,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
         #[cfg(feature = "optimism")]
         optimism: OptimismFields { enveloped_tx: Some(Bytes::new()), ..Default::default() },
         // TODO(EOF)

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -59,7 +59,13 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident, is_zstd: bool) -> To
     // it's hard to figure out with derive_macro which types have Bytes fields.
     //
     // This removes the requirement of the field to be placed last in the struct.
-    known_types.extend_from_slice(&["TxKind", "AccessList", "Signature", "CheckpointBlockRange"]);
+    known_types.extend_from_slice(&[
+        "TxKind",
+        "AccessList",
+        "AuthorizationList",
+        "Signature",
+        "CheckpointBlockRange",
+    ]);
 
     // let mut handle = FieldListHandler::new(fields);
     let is_enum = fields.iter().any(|field| matches!(field, FieldTypes::EnumVariant(_)));

--- a/crates/storage/codecs/src/alloy/authorization_list.rs
+++ b/crates/storage/codecs/src/alloy/authorization_list.rs
@@ -1,0 +1,109 @@
+use crate::Compact;
+use alloy_eips::eip7702::{Authorization, AuthorizationList};
+use alloy_primitives::{Address, U256};
+use bytes::{Buf, BufMut};
+
+impl Compact for Authorization {
+    // TODO(eip7702): actually compact this
+    fn to_compact<B>(self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let mut buffer = bytes::BytesMut::new();
+        buffer.put_u64(self.chain_id);
+        buffer.put_slice(&self.address.0.as_slice());
+        if self.nonce.is_some() {
+            buffer.put_u8(1);
+            buffer.put_u64(self.nonce.unwrap());
+        } else {
+            buffer.put_u8(0);
+        }
+        buffer.put_u8(self.y_parity as u8);
+        buffer.put_slice(&self.r.as_le_slice());
+        buffer.put_slice(&self.s.as_le_slice());
+        let total_length = buffer.len();
+        buf.put(buffer);
+        total_length
+    }
+
+    fn from_compact(mut buf: &[u8], _: usize) -> (Self, &[u8]) {
+        let chain_id = bytes::Buf::get_u64(&mut buf);
+        let address = Address::from_slice(&buf[0..20]);
+        buf.advance(20);
+        let has_nonce = bytes::Buf::get_u8(&mut buf);
+        let nonce = if has_nonce == 1 {
+            let nonce = bytes::Buf::get_u64(&mut buf);
+            Some(nonce)
+        } else {
+            None
+        };
+        let y_parity = bytes::Buf::get_u8(&mut buf) == 1;
+        let r = U256::from_le_slice(&buf[0..32]);
+        buf.advance(32);
+        let s = U256::from_le_slice(&buf[0..32]);
+        buf.advance(32);
+        let authorization = Authorization { chain_id, address, nonce, y_parity, r, s };
+        (authorization, buf)
+    }
+}
+
+impl Compact for AuthorizationList {
+    fn to_compact<B>(self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let mut buffer = bytes::BytesMut::new();
+        self.0.to_compact(&mut buffer);
+        let total_length = buffer.len();
+        buf.put(buffer);
+        total_length
+    }
+
+    fn from_compact(mut buf: &[u8], _: usize) -> (Self, &[u8]) {
+        let (access_list_items, new_buf) = Vec::from_compact(buf, buf.len());
+        buf = new_buf;
+        let access_list = AuthorizationList(access_list_items);
+        (access_list, buf)
+    }
+}
+
+// TODO(eip7702): complete these tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, b256};
+
+    #[test]
+    fn test_roundtrip_compact_authorization_list_item() {
+        let authorization = Authorization {
+            chain_id: 1,
+            address: address!("dac17f958d2ee523a2206206994597c13d831ec7"),
+            nonce: None,
+            y_parity: false,
+            r: b256!("1fd474b1f9404c0c5df43b7620119ffbc3a1c3f942c73b6e14e9f55255ed9b1d").into(),
+            s: b256!("29aca24813279a901ec13b5f7bb53385fa1fc627b946592221417ff74a49600d").into(),
+        };
+        let mut compacted_authorization = Vec::<u8>::new();
+        let len = authorization.clone().to_compact(&mut compacted_authorization);
+        let (decoded_authorization, _) = Authorization::from_compact(&compacted_authorization, len);
+        assert_eq!(authorization, decoded_authorization);
+    }
+
+    #[test]
+    fn test_roundtrip_compact_authorization_list() {
+        let authorization = Authorization {
+            chain_id: 1,
+            address: address!("dac17f958d2ee523a2206206994597c13d831ec7"),
+            nonce: None,
+            y_parity: false,
+            r: b256!("1fd474b1f9404c0c5df43b7620119ffbc3a1c3f942c73b6e14e9f55255ed9b1d").into(),
+            s: b256!("29aca24813279a901ec13b5f7bb53385fa1fc627b946592221417ff74a49600d").into(),
+        };
+        let authorization_list = AuthorizationList(vec![authorization.clone(), authorization]);
+        let mut compacted_authorization_list = Vec::<u8>::new();
+        let len = authorization_list.clone().to_compact(&mut compacted_authorization_list);
+        let (decoded_authorization_list, _) =
+            AuthorizationList::from_compact(&compacted_authorization_list, len);
+        assert_eq!(authorization_list, decoded_authorization_list);
+    }
+}

--- a/crates/storage/codecs/src/alloy/mod.rs
+++ b/crates/storage/codecs/src/alloy/mod.rs
@@ -1,4 +1,5 @@
 mod access_list;
+mod authorization_list;
 mod genesis_account;
 mod log;
 mod txkind;

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -239,7 +239,8 @@ impl InvalidPoolTransactionError {
                     }
                     InvalidTransactionError::Eip2930Disabled |
                     InvalidTransactionError::Eip1559Disabled |
-                    InvalidTransactionError::Eip4844Disabled => {
+                    InvalidTransactionError::Eip4844Disabled |
+                    InvalidTransactionError::Eip7702Disabled => {
                         // settings
                         false
                     }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -936,6 +936,9 @@ impl EthPooledTransaction {
                 blob_sidecar = EthBlobTransactionSidecar::Missing;
                 U256::from(t.max_fee_per_gas).saturating_mul(U256::from(t.gas_limit))
             }
+            Transaction::Eip7702(t) => {
+                U256::from(t.max_fee_per_gas).saturating_mul(U256::from(t.gas_limit))
+            }
             _ => U256::ZERO,
         };
         let mut cost = transaction.value();
@@ -1022,6 +1025,7 @@ impl PoolTransaction for EthPooledTransaction {
             Transaction::Eip2930(tx) => tx.gas_price,
             Transaction::Eip1559(tx) => tx.max_fee_per_gas,
             Transaction::Eip4844(tx) => tx.max_fee_per_gas,
+            Transaction::Eip7702(tx) => tx.max_fee_per_gas,
             _ => 0,
         }
     }
@@ -1039,6 +1043,7 @@ impl PoolTransaction for EthPooledTransaction {
             Transaction::Legacy(_) | Transaction::Eip2930(_) => None,
             Transaction::Eip1559(tx) => Some(tx.max_priority_fee_per_gas),
             Transaction::Eip4844(tx) => Some(tx.max_priority_fee_per_gas),
+            Transaction::Eip7702(tx) => Some(tx.max_priority_fee_per_gas),
             _ => None,
         }
     }
@@ -1123,6 +1128,7 @@ impl EthPoolTransaction for EthPooledTransaction {
 impl TryFromRecoveredTransaction for EthPooledTransaction {
     type Error = TryFromRecoveredTransactionError;
 
+    // TODO(eip7702): fix this
     fn try_from_recovered_transaction(
         tx: TransactionSignedEcRecovered,
     ) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Sharing our work for adding EIP-7702 transaction support to reth / revm / alloy

Current state:

- 7702 transaction support has been added to reth and alloy
- EOA code loading has been added to revm but full 7702 execution has not been tested yet
- The teardown of 7702 transactions in revm has not been added yet
- Gas calculations have not been updated and are not correct
- Compact encoding of added types in reth is currently byte-for-byte
- Overall correctness needs to be checked
- Not all tests have been added or updated

Incomplete items and points of discussion are marked with `TODO(eip7702)` 

If you have any questions about any of this work let us know

The three related PRs:

https://github.com/paradigmxyz/reth/pull/8895
https://github.com/bluealloy/revm/pull/1541
https://github.com/alloy-rs/alloy/pull/928
