### PR TITLE
fix: edge case divide by zero

### DIFF
--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -153,8 +153,7 @@ where
             }
 
             for header in &headers {
-                let mut ratio = header.gas_used as f64 / header.gas_limit as f64;
-                if ratio.is_infinite() { ratio = 1.0 };
+                let ratio = if header.gas_limit > 0 {header.gas_used as f64 / header.gas_limit as f64} else {1.0};
 
                 base_fee_per_gas.push(header.base_fee_per_gas.unwrap_or_default() as u128);
                 gas_used_ratio.push(ratio);

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -153,8 +153,11 @@ where
             }
 
             for header in &headers {
+                let mut ratio = header.gas_used as f64 / header.gas_limit as f64;
+                if ratio.is_infinite() { ratio = 1.0 };
+
                 base_fee_per_gas.push(header.base_fee_per_gas.unwrap_or_default() as u128);
-                gas_used_ratio.push(header.gas_used as f64 / header.gas_limit as f64);
+                gas_used_ratio.push(ratio);
                 base_fee_per_blob_gas.push(header.blob_fee().unwrap_or_default());
                 blob_gas_used_ratio.push(
                     header.blob_gas_used.unwrap_or_default() as f64 /


### PR DESCRIPTION
Fixes an edge case in fee history endpoint that results in invalid serialization. 

- if gaslimit is 0, there's a divide-by-zero in the fee history endpoint
- IEEE754 specifies division by 0.0 to yield infinity (or -infinity for -0.0)
- `serde_json` serializes infinity as `null`
- `serde_json` cannot deserialize `null` to infinity
- in this weird edge case, reth can produce serialized `FeeHistory` structs that cannot be deserialized

It may seem like this would never occur as blocks cannot have a 0 limit in real life, but genesis files sometimes use 0 placeholders for gas limit, so this would be triggered on fresh nodes using such a genesis

Fix is to check for infinite values and set ratio to `1.0`
NaN values are ruled out by casting from an integer