### PR TITLE
chore: use `BLOCKHASH_SERVE_WINDOW` from revm

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -467,11 +467,10 @@ mod tests {
         keccak256, public_key_to_address, Account, Block, Transaction, TxKind, TxLegacy, B256,
     };
     use reth_revm::{
-        database::StateProviderDatabase, state_change::HISTORY_SERVE_WINDOW,
-        test_utils::StateProviderTest, TransitionState,
+        database::StateProviderDatabase, test_utils::StateProviderTest, TransitionState,
     };
     use reth_testing_utils::generators::{self, sign_tx_with_key_pair};
-    use revm_primitives::{b256, fixed_bytes, Bytes};
+    use revm_primitives::{b256, fixed_bytes, Bytes, BLOCKHASH_SERVE_WINDOW};
     use secp256k1::{Keypair, Secp256k1};
     use std::collections::HashMap;
 
@@ -976,7 +975,7 @@ mod tests {
 
     #[test]
     fn eip_2935_fork_activation_within_window_bounds() {
-        let fork_activation_block = HISTORY_SERVE_WINDOW - 10;
+        let fork_activation_block = (BLOCKHASH_SERVE_WINDOW - 10) as u64;
         let db = create_state_provider_with_block_hashes(fork_activation_block);
 
         let chain_spec = Arc::new(
@@ -1039,7 +1038,7 @@ mod tests {
 
     #[test]
     fn eip_2935_fork_activation_outside_window_bounds() {
-        let fork_activation_block = HISTORY_SERVE_WINDOW + 256;
+        let fork_activation_block = (BLOCKHASH_SERVE_WINDOW + 256) as u64;
         let db = create_state_provider_with_block_hashes(fork_activation_block);
 
         let chain_spec = Arc::new(
@@ -1090,7 +1089,7 @@ mod tests {
                 .state_mut()
                 .storage(
                     HISTORY_STORAGE_ADDRESS,
-                    U256::from(fork_activation_block % HISTORY_SERVE_WINDOW - 1)
+                    U256::from(fork_activation_block % (BLOCKHASH_SERVE_WINDOW - 1) as u64)
                 )
                 .unwrap(),
             U256::ZERO

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -1089,7 +1089,7 @@ mod tests {
                 .state_mut()
                 .storage(
                     HISTORY_STORAGE_ADDRESS,
-                    U256::from(fork_activation_block % (BLOCKHASH_SERVE_WINDOW - 1) as u64)
+                    U256::from(fork_activation_block % BLOCKHASH_SERVE_WINDOW as u64 - 1)
                 )
                 .unwrap(),
             U256::ZERO

--- a/crates/revm/src/state_change.rs
+++ b/crates/revm/src/state_change.rs
@@ -17,7 +17,8 @@ use reth_storage_errors::provider::ProviderError;
 use revm::{
     interpreter::Host,
     primitives::{
-        Account, AccountInfo, Bytecode, EvmStorageSlot, ExecutionResult, FixedBytes, ResultAndState,
+        Account, AccountInfo, Bytecode, EvmStorageSlot, ExecutionResult, FixedBytes,
+        ResultAndState, BLOCKHASH_SERVE_WINDOW,
     },
     Database, DatabaseCommit, Evm,
 };
@@ -66,9 +67,6 @@ pub fn post_block_balance_increments(
 
     balance_increments
 }
-
-/// todo: temporary move over of constants from revm until we've migrated to the latest version
-pub const HISTORY_SERVE_WINDOW: u64 = 8192;
 
 /// Applies the pre-block state change outlined in [EIP-2935] to store historical blockhashes in a
 /// system contract.
@@ -131,7 +129,7 @@ fn eip2935_block_hash_slot<DB: Database<Error = ProviderError>>(
     block_number: u64,
     block_hash: B256,
 ) -> Result<(U256, EvmStorageSlot), BlockValidationError> {
-    let slot = U256::from(block_number % HISTORY_SERVE_WINDOW);
+    let slot = U256::from(block_number % BLOCKHASH_SERVE_WINDOW as u64);
     let current_hash = db
         .storage(HISTORY_STORAGE_ADDRESS, slot)
         .map_err(BlockValidationError::BlockHashAccountLoadingFailed)?;


### PR DESCRIPTION
dedupe eip-2935 constant with revm