### PR TITLE
feat: re-export test types

### DIFF
--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -136,13 +136,18 @@ where
     }
 }
 
-type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
-type Adapter = NodeAdapter<
+/// A shared [`TempDatabase`] used for testing
+pub type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
+/// The [`NodeAdapter`] for the [`TestExExContext`]. Contains type necessary to
+/// boot the testing environment
+pub type Adapter = NodeAdapter<
     RethFullAdapter<TmpDB, TestNode>,
     <<TestNode as Node<FullNodeTypesAdapter<TestNode, TmpDB, BlockchainProvider<TmpDB>>>>::ComponentsBuilder as NodeComponentsBuilder<
         RethFullAdapter<TmpDB, TestNode>,
     >>::Components,
 >;
+/// An ExExContext using the [`Adapter`] type.
+pub type TestExExContext = ExExContext<Adapter>;
 
 /// A helper type for testing Execution Extensions.
 #[derive(Debug)]

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -146,7 +146,7 @@ pub type Adapter = NodeAdapter<
         RethFullAdapter<TmpDB, TestNode>,
     >>::Components,
 >;
-/// An ExExContext using the [`Adapter`] type.
+/// An [`ExExContext`] using the [`Adapter`] type.
 pub type TestExExContext = ExExContext<Adapter>;
 
 /// A helper type for testing Execution Extensions.


### PR DESCRIPTION
Re-exports some exex test utils types for easier downstream use