### PR TITLE
chore(ci): exclude examples from docs

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -78,7 +78,7 @@ jobs:
         run: mdbook build
 
       - name: Build docs
-        run: cargo docs
+        run: cargo docs --exclude "example-*"
         env:
           # Keep in sync with ./ci.yml:jobs.docs
           RUSTDOCFLAGS:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cargo nextest run \
             --locked --features "asm-keccak ${{ matrix.network }}" \
-            --workspace --exclude examples --exclude ef-tests \
+            --workspace --exclude ef-tests \
             -E "kind(test)"
       - if: matrix.network == 'optimism'
         name: Run tests

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           cargo nextest run \
             --locked --features "asm-keccak ${{ matrix.network }}" \
-            --workspace --exclude examples --exclude ef-tests \
+            --workspace --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/2 \
             -E "!kind(test)"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,36 +1146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "beacon-api-sidecar-fetcher"
-version = "0.1.0"
-dependencies = [
- "alloy-rpc-types-beacon",
- "clap",
- "eyre",
- "futures-util",
- "reqwest",
- "reth",
- "reth-node-ethereum",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "beacon-api-sse"
-version = "0.0.0"
-dependencies = [
- "alloy-rpc-types-beacon",
- "clap",
- "futures-util",
- "mev-share-sse",
- "reth",
- "reth-node-ethereum",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,22 +1471,6 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.8",
  "tinyvec",
-]
-
-[[package]]
-name = "bsc-p2p"
-version = "0.0.0"
-dependencies = [
- "reth-chainspec",
- "reth-discv4",
- "reth-network",
- "reth-network-api",
- "reth-primitives",
- "reth-tracing",
- "secp256k1",
- "serde_json",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -2254,96 +2208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "custom-dev-node"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures-util",
- "reth",
- "reth-chainspec",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-primitives",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "custom-engine-types"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth",
- "reth-basic-payload-builder",
- "reth-chainspec",
- "reth-ethereum-payload-builder",
- "reth-node-api",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-payload-builder",
- "reth-primitives",
- "reth-rpc-types",
- "reth-tracing",
- "serde",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "custom-evm"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth",
- "reth-chainspec",
- "reth-node-api",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-primitives",
- "reth-tracing",
- "tokio",
-]
-
-[[package]]
-name = "custom-inspector"
-version = "0.0.0"
-dependencies = [
- "clap",
- "futures-util",
- "reth",
- "reth-node-ethereum",
- "reth-rpc-types",
-]
-
-[[package]]
-name = "custom-node-components"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth",
- "reth-node-ethereum",
- "reth-tracing",
- "reth-transaction-pool",
-]
-
-[[package]]
-name = "custom-payload-builder"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures-util",
- "reth",
- "reth-basic-payload-builder",
- "reth-chainspec",
- "reth-ethereum-payload-builder",
- "reth-node-api",
- "reth-node-ethereum",
- "reth-payload-builder",
- "reth-primitives",
- "tracing",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,18 +2279,6 @@ checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "db-access"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth-chainspec",
- "reth-db",
- "reth-primitives",
- "reth-provider",
- "reth-rpc-types",
 ]
 
 [[package]]
@@ -2873,7 +2725,155 @@ dependencies = [
 ]
 
 [[package]]
-name = "exex-in-memory-state"
+name = "example-beacon-api-sidecar-fetcher"
+version = "0.1.0"
+dependencies = [
+ "alloy-rpc-types-beacon",
+ "clap",
+ "eyre",
+ "futures-util",
+ "reqwest",
+ "reth",
+ "reth-node-ethereum",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "example-beacon-api-sse"
+version = "0.0.0"
+dependencies = [
+ "alloy-rpc-types-beacon",
+ "clap",
+ "futures-util",
+ "mev-share-sse",
+ "reth",
+ "reth-node-ethereum",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "example-bsc-p2p"
+version = "0.0.0"
+dependencies = [
+ "reth-chainspec",
+ "reth-discv4",
+ "reth-network",
+ "reth-network-api",
+ "reth-primitives",
+ "reth-tracing",
+ "secp256k1",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "example-custom-dev-node"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "futures-util",
+ "reth",
+ "reth-chainspec",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-primitives",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "example-custom-engine-types"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "reth",
+ "reth-basic-payload-builder",
+ "reth-chainspec",
+ "reth-ethereum-payload-builder",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-tracing",
+ "serde",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "example-custom-evm"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "reth",
+ "reth-chainspec",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-primitives",
+ "reth-tracing",
+ "tokio",
+]
+
+[[package]]
+name = "example-custom-inspector"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "futures-util",
+ "reth",
+ "reth-node-ethereum",
+ "reth-rpc-types",
+]
+
+[[package]]
+name = "example-custom-node-components"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "reth",
+ "reth-node-ethereum",
+ "reth-tracing",
+ "reth-transaction-pool",
+]
+
+[[package]]
+name = "example-custom-payload-builder"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "futures-util",
+ "reth",
+ "reth-basic-payload-builder",
+ "reth-chainspec",
+ "reth-ethereum-payload-builder",
+ "reth-node-api",
+ "reth-node-ethereum",
+ "reth-payload-builder",
+ "reth-primitives",
+ "tracing",
+]
+
+[[package]]
+name = "example-db-access"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "reth-chainspec",
+ "reth-db",
+ "reth-primitives",
+ "reth-provider",
+ "reth-rpc-types",
+]
+
+[[package]]
+name = "example-exex-in-memory-state"
 version = "0.0.0"
 dependencies = [
  "eyre",
@@ -2888,7 +2888,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "exex-minimal"
+name = "example-exex-minimal"
 version = "0.0.0"
 dependencies = [
  "eyre",
@@ -2903,7 +2903,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "exex-op-bridge"
+name = "example-exex-op-bridge"
 version = "0.0.0"
 dependencies = [
  "alloy-sol-types",
@@ -2925,7 +2925,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "exex-rollup"
+name = "example-exex-rollup"
 version = "0.0.0"
 dependencies = [
  "alloy-consensus",
@@ -2949,6 +2949,124 @@ dependencies = [
  "secp256k1",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "example-manual-p2p"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "futures",
+ "once_cell",
+ "reth-chainspec",
+ "reth-discv4",
+ "reth-ecies",
+ "reth-eth-wire",
+ "reth-network",
+ "reth-network-peers",
+ "reth-primitives",
+ "secp256k1",
+ "tokio",
+]
+
+[[package]]
+name = "example-network"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "futures",
+ "reth-network",
+ "reth-provider",
+ "tokio",
+]
+
+[[package]]
+name = "example-network-txpool"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "reth-network",
+ "reth-provider",
+ "reth-transaction-pool",
+ "tokio",
+]
+
+[[package]]
+name = "example-node-custom-rpc"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "jsonrpsee",
+ "reth",
+ "reth-node-ethereum",
+ "reth-transaction-pool",
+ "tokio",
+]
+
+[[package]]
+name = "example-node-event-hooks"
+version = "0.0.0"
+dependencies = [
+ "reth",
+ "reth-node-ethereum",
+]
+
+[[package]]
+name = "example-polygon-p2p"
+version = "0.0.0"
+dependencies = [
+ "reth-chainspec",
+ "reth-discv4",
+ "reth-network",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tracing",
+ "secp256k1",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "example-rpc-db"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "futures",
+ "jsonrpsee",
+ "reth",
+ "reth-chainspec",
+ "reth-db",
+ "reth-db-api",
+ "reth-node-ethereum",
+ "tokio",
+]
+
+[[package]]
+name = "example-stateful-precompile"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "parking_lot 0.12.3",
+ "reth",
+ "reth-chainspec",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-primitives",
+ "reth-tracing",
+ "schnellru",
+ "tokio",
+]
+
+[[package]]
+name = "example-txpool-tracing"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "futures-util",
+ "reth",
+ "reth-node-ethereum",
 ]
 
 [[package]]
@@ -4731,24 +4849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manual-p2p"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures",
- "once_cell",
- "reth-chainspec",
- "reth-discv4",
- "reth-ecies",
- "reth-eth-wire",
- "reth-network",
- "reth-network-peers",
- "reth-primitives",
- "secp256k1",
- "tokio",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5026,28 +5126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "network"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures",
- "reth-network",
- "reth-provider",
- "tokio",
-]
-
-[[package]]
-name = "network-txpool"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth-network",
- "reth-provider",
- "reth-transaction-pool",
- "tokio",
-]
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5065,26 +5143,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "node-custom-rpc"
-version = "0.0.0"
-dependencies = [
- "clap",
- "jsonrpsee",
- "reth",
- "reth-node-ethereum",
- "reth-transaction-pool",
- "tokio",
-]
-
-[[package]]
-name = "node-event-hooks"
-version = "0.0.0"
-dependencies = [
- "reth",
- "reth-node-ethereum",
 ]
 
 [[package]]
@@ -5627,22 +5685,6 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
-[[package]]
-name = "polygon-p2p"
-version = "0.0.0"
-dependencies = [
- "reth-chainspec",
- "reth-discv4",
- "reth-network",
- "reth-primitives",
- "reth-provider",
- "reth-tracing",
- "secp256k1",
- "serde_json",
- "tokio",
- "tokio-stream",
-]
 
 [[package]]
 name = "polyval"
@@ -8607,21 +8649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
-name = "rpc-db"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures",
- "jsonrpsee",
- "reth",
- "reth-chainspec",
- "reth-db",
- "reth-db-api",
- "reth-node-ethereum",
- "tokio",
-]
-
-[[package]]
 name = "ruint"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9389,23 +9416,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "stateful-precompile"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "parking_lot 0.12.3",
- "reth",
- "reth-chainspec",
- "reth-node-api",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-primitives",
- "reth-tracing",
- "schnellru",
- "tokio",
-]
 
 [[package]]
 name = "static_assertions"
@@ -10235,16 +10245,6 @@ dependencies = [
  "sha1",
  "thiserror",
  "utf-8",
-]
-
-[[package]]
-name = "txpool-tracing"
-version = "0.0.0"
-dependencies = [
- "clap",
- "futures-util",
- "reth",
- "reth-node-ethereum",
 ]
 
 [[package]]

--- a/examples/beacon-api-sidecar-fetcher/Cargo.toml
+++ b/examples/beacon-api-sidecar-fetcher/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "beacon-api-sidecar-fetcher"
+name = "example-beacon-api-sidecar-fetcher"
 version = "0.1.0"
 publish = false
 edition.workspace = true

--- a/examples/beacon-api-sse/Cargo.toml
+++ b/examples/beacon-api-sse/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "beacon-api-sse"
+name = "example-beacon-api-sse"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/bsc-p2p/Cargo.toml
+++ b/examples/bsc-p2p/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bsc-p2p"
+name = "example-bsc-p2p"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/custom-dev-node/Cargo.toml
+++ b/examples/custom-dev-node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "custom-dev-node"
+name = "example-custom-dev-node"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/custom-engine-types/Cargo.toml
+++ b/examples/custom-engine-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "custom-engine-types"
+name = "example-custom-engine-types"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/custom-evm/Cargo.toml
+++ b/examples/custom-evm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "custom-evm"
+name = "example-custom-evm"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/custom-inspector/Cargo.toml
+++ b/examples/custom-inspector/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "custom-inspector"
+name = "example-custom-inspector"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/custom-node-components/Cargo.toml
+++ b/examples/custom-node-components/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "custom-node-components"
+name = "example-custom-node-components"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/custom-payload-builder/Cargo.toml
+++ b/examples/custom-payload-builder/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "custom-payload-builder"
+name = "example-custom-payload-builder"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/db-access/Cargo.toml
+++ b/examples/db-access/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "db-access"
+name = "example-db-access"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/exex/in-memory-state/Cargo.toml
+++ b/examples/exex/in-memory-state/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exex-in-memory-state"
+name = "example-exex-in-memory-state"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/exex/minimal/Cargo.toml
+++ b/examples/exex/minimal/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exex-minimal"
+name = "example-exex-minimal"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/exex/op-bridge/Cargo.toml
+++ b/examples/exex/op-bridge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exex-op-bridge"
+name = "example-exex-op-bridge"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/exex/rollup/Cargo.toml
+++ b/examples/exex/rollup/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exex-rollup"
+name = "example-exex-rollup"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/manual-p2p/Cargo.toml
+++ b/examples/manual-p2p/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "manual-p2p"
+name = "example-manual-p2p"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/network-txpool/Cargo.toml
+++ b/examples/network-txpool/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "network-txpool"
+name = "example-network-txpool"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/network/Cargo.toml
+++ b/examples/network/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "network"
+name = "example-network"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/node-custom-rpc/Cargo.toml
+++ b/examples/node-custom-rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "node-custom-rpc"
+name = "example-node-custom-rpc"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/node-event-hooks/Cargo.toml
+++ b/examples/node-event-hooks/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "node-event-hooks"
+name = "example-node-event-hooks"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/polygon-p2p/Cargo.toml
+++ b/examples/polygon-p2p/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "polygon-p2p"
+name = "example-polygon-p2p"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/rpc-db/Cargo.toml
+++ b/examples/rpc-db/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rpc-db"
+name = "example-rpc-db"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/stateful-precompile/Cargo.toml
+++ b/examples/stateful-precompile/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stateful-precompile"
+name = "example-stateful-precompile"
 version = "0.0.0"
 publish = false
 edition.workspace = true

--- a/examples/txpool-tracing/Cargo.toml
+++ b/examples/txpool-tracing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "txpool-tracing"
+name = "example-txpool-tracing"
 version = "0.0.0"
 publish = false
 edition.workspace = true


### PR DESCRIPTION
All our examples are published to https://reth.rs/docs, e.g. https://reth.rs/docs/custom_node_components/index.html. This PR removes the generation of docs with `cargo docs` for them. AFAIK cargo doesn't allow excluding packages from the directory, so I added an `example-*` prefix to all example packages.

Also, this PR enables running unit tests for examples.