### PR TITLE
chore(makefile): remove cfg-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,11 +466,7 @@ test:
 	make test-doc && \
 	make test-other-targets
 
-cfg-check:
-	cargo +nightly -Zcheck-cfg c
-
 pr:
-	make cfg-check && \
 	make lint && \
 	make update-book-cli && \
 	make test


### PR DESCRIPTION
This is enabled by default on nightly, and is ran as part of other commands.
