### PR TITLE
chore: remove cursed comments from broken proptest impl

### DIFF
--- a/crates/primitives-traits/src/header/mod.rs
+++ b/crates/primitives-traits/src/header/mod.rs
@@ -380,26 +380,22 @@ impl Encodable for Header {
         self.mix_hash.encode(out); // Encode mix hash.
         B64::new(self.nonce.to_be_bytes()).encode(out); // Encode nonce.
 
-        // Encode base fee. Put empty list if base fee is missing,
-        // but withdrawals root is present.
+        // Encode base fee.
         if let Some(ref base_fee) = self.base_fee_per_gas {
             U256::from(*base_fee).encode(out);
         }
 
-        // Encode withdrawals root. Put empty string if withdrawals root is missing,
-        // but blob gas used is present.
+        // Encode withdrawals root.
         if let Some(ref root) = self.withdrawals_root {
             root.encode(out);
         }
 
-        // Encode blob gas used. Put empty list if blob gas used is missing,
-        // but excess blob gas is present.
+        // Encode blob gas used.
         if let Some(ref blob_gas_used) = self.blob_gas_used {
             U256::from(*blob_gas_used).encode(out);
         }
 
-        // Encode excess blob gas. Put empty list if excess blob gas is missing,
-        // but parent beacon block root is present.
+        // Encode excess blob gas.
         if let Some(ref excess_blob_gas) = self.excess_blob_gas {
             U256::from(*excess_blob_gas).encode(out);
         }
@@ -410,14 +406,6 @@ impl Encodable for Header {
         }
 
         // Encode EIP-7685 requests root
-        //
-        // If new fields are added, the above pattern will need to
-        // be repeated and placeholders added. Otherwise, it's impossible to tell _which_
-        // fields are missing. This is mainly relevant for contrived cases where a header is
-        // created at random, for example:
-        //  * A header is created with a withdrawals root, but no base fee. Shanghai blocks are
-        //    post-London, so this is technically not valid. However, a tool like proptest would
-        //    generate a block like this.
         if let Some(ref requests_root) = self.requests_root {
             requests_root.encode(out);
         }
@@ -485,14 +473,6 @@ impl Decodable for Header {
         }
 
         // Decode requests root.
-        //
-        // If new fields are added, the above pattern will need to
-        // be repeated and placeholders decoded. Otherwise, it's impossible to tell _which_
-        // fields are missing. This is mainly relevant for contrived cases where a header is
-        // created at random, for example:
-        //  * A header is created with a withdrawals root, but no base fee. Shanghai blocks are
-        //    post-London, so this is technically not valid. However, a tool like proptest would
-        //    generate a block like this.
         if started_len - buf.len() < rlp_head.payload_length {
             this.requests_root = Some(B256::decode(buf)?);
         }


### PR DESCRIPTION
We had to do this stuff before because of a weird proptest / arbitrary impl, that is no longer broken. Removes comments mentioning the old behavior