### PR TITLE
chore: use alloy-genesis imports for Genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
 name = "example-custom-engine-types"
 version = "0.0.0"
 dependencies = [
+ "alloy-genesis",
  "eyre",
  "reth",
  "reth-basic-payload-builder",
@@ -2810,6 +2811,7 @@ dependencies = [
 name = "example-custom-evm"
 version = "0.0.0"
 dependencies = [
+ "alloy-genesis",
  "eyre",
  "reth",
  "reth-chainspec",
@@ -2931,6 +2933,7 @@ name = "example-exex-rollup"
 version = "0.0.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-genesis",
  "alloy-rlp",
  "alloy-sol-types",
  "eyre",
@@ -3049,6 +3052,7 @@ dependencies = [
 name = "example-stateful-precompile"
 version = "0.0.0"
 dependencies = [
+ "alloy-genesis",
  "eyre",
  "parking_lot 0.12.3",
  "reth",
@@ -6422,6 +6426,7 @@ dependencies = [
 name = "reth-beacon-consensus"
 version = "1.0.0-rc.2"
 dependencies = [
+ "alloy-genesis",
  "assert_matches",
  "futures",
  "itertools 0.12.1",
@@ -6513,6 +6518,7 @@ dependencies = [
 name = "reth-blockchain-tree"
 version = "1.0.0-rc.2"
 dependencies = [
+ "alloy-genesis",
  "aquamarine",
  "assert_matches",
  "linked_hash_set",
@@ -6744,6 +6750,7 @@ dependencies = [
 name = "reth-db-common"
 version = "1.0.0-rc.2"
 dependencies = [
+ "alloy-genesis",
  "eyre",
  "reth-chainspec",
  "reth-codecs",
@@ -6997,6 +7004,7 @@ dependencies = [
 name = "reth-eth-wire-types"
 version = "1.0.0-rc.2"
 dependencies = [
+ "alloy-genesis",
  "alloy-rlp",
  "arbitrary",
  "async-stream",
@@ -7523,6 +7531,7 @@ dependencies = [
 name = "reth-node-core"
 version = "1.0.0-rc.2"
 dependencies = [
+ "alloy-genesis",
  "alloy-rpc-types-engine",
  "clap",
  "const-str",
@@ -7641,6 +7650,7 @@ dependencies = [
 name = "reth-node-optimism"
 version = "1.0.0-rc.2"
 dependencies = [
+ "alloy-genesis",
  "alloy-primitives",
  "async-trait",
  "clap",
@@ -7949,6 +7959,7 @@ name = "reth-rpc"
 version = "1.0.0-rc.2"
 dependencies = [
  "alloy-dyn-abi",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -54,6 +54,7 @@ reth-revm.workspace = true
 reth-evm-ethereum.workspace = true
 parking_lot.workspace = true
 assert_matches.workspace = true
+alloy-genesis.workspace = true
 
 [features]
 test-utils = []

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1367,6 +1367,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_genesis::{Genesis, GenesisAccount};
     use assert_matches::assert_matches;
     use linked_hash_set::LinkedHashSet;
     use reth_chainspec::{ChainSpecBuilder, MAINNET};
@@ -1384,8 +1385,8 @@ mod tests {
         keccak256,
         proofs::calculate_transaction_root,
         revm_primitives::AccountInfo,
-        Account, Address, Genesis, GenesisAccount, Header, Signature, Transaction,
-        TransactionSigned, TransactionSignedEcRecovered, TxEip1559, Withdrawals, B256,
+        Account, Address, Header, Signature, Transaction, TransactionSigned,
+        TransactionSignedEcRecovered, TxEip1559, Withdrawals, B256,
     };
     use reth_provider::{
         test_utils::{blocks::BlockchainTestData, create_test_provider_factory_with_chain_spec},

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -69,6 +69,7 @@ reth-config.workspace = true
 reth-testing-utils.workspace = true
 reth-exex-types.workspace = true
 reth-prune-types.workspace = true
+alloy-genesis.workspace = true
 
 assert_matches.workspace = true
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2490,8 +2490,9 @@ mod tests {
 
     mod new_payload {
         use super::*;
+        use alloy_genesis::Genesis;
         use reth_db::test_utils::create_test_static_files_dir;
-        use reth_primitives::{genesis::Genesis, Hardfork, U256};
+        use reth_primitives::{Hardfork, U256};
         use reth_provider::{
             providers::StaticFileProvider, test_utils::blocks::BlockchainTestData,
         };

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -17,6 +17,7 @@ reth-chainspec.workspace = true
 reth-codecs-derive.workspace = true
 reth-primitives.workspace = true
 alloy-rlp = { workspace = true, features = ["derive"] }
+alloy-genesis.workspace = true
 
 bytes.workspace = true
 derive_more.workspace = true

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -1,8 +1,9 @@
 use crate::EthVersion;
+use alloy_genesis::Genesis;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use reth_chainspec::{Chain, ChainSpec, NamedChain, MAINNET};
 use reth_codecs_derive::derive_arbitrary;
-use reth_primitives::{hex, ForkId, Genesis, Hardfork, Head, B256, U256};
+use reth_primitives::{hex, ForkId, Hardfork, Head, B256, U256};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
@@ -228,10 +229,11 @@ impl StatusBuilder {
 #[cfg(test)]
 mod tests {
     use crate::{EthVersion, Status};
+    use alloy_genesis::Genesis;
     use alloy_rlp::{Decodable, Encodable};
     use rand::Rng;
     use reth_chainspec::{Chain, ChainSpec, ForkCondition, NamedChain};
-    use reth_primitives::{hex, ForkHash, ForkId, Genesis, Hardfork, Head, B256, U256};
+    use reth_primitives::{hex, ForkHash, ForkId, Hardfork, Head, B256, U256};
     use std::str::FromStr;
 
     #[test]

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -98,6 +98,7 @@ procfs = "0.16.0"
 [dev-dependencies]
 # test vectors generation
 proptest.workspace = true
+alloy-genesis.workspace = true
 
 [features]
 optimism = [

--- a/crates/node-core/src/args/utils.rs
+++ b/crates/node-core/src/args/utils.rs
@@ -168,9 +168,10 @@ pub fn parse_socket_address(value: &str) -> eyre::Result<SocketAddr, SocketAddre
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_genesis::{ChainConfig, Genesis, GenesisAccount};
     use proptest::prelude::Rng;
     use reth_chainspec::ChainSpecBuilder;
-    use reth_primitives::{hex, Address, ChainConfig, Genesis, GenesisAccount, U256};
+    use reth_primitives::{hex, Address, U256};
     use secp256k1::rand::thread_rng;
     use std::collections::HashMap;
 

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -57,6 +57,7 @@ reth-revm = { workspace = true, features = ["test-utils"] }
 reth-e2e-test-utils.workspace = true
 tokio.workspace = true
 alloy-primitives.workspace = true
+alloy-genesis.workspace = true
 
 [features]
 optimism = [

--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -1,9 +1,10 @@
+use alloy_genesis::Genesis;
 use reth::{rpc::types::engine::PayloadAttributes, tasks::TaskManager};
 use reth_chainspec::{ChainSpecBuilder, BASE_MAINNET};
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
 use reth_node_optimism::{OptimismBuiltPayload, OptimismNode, OptimismPayloadBuilderAttributes};
 use reth_payload_builder::EthPayloadBuilderAttributes;
-use reth_primitives::{Address, Genesis, B256};
+use reth_primitives::{Address, B256};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -135,10 +135,8 @@ pub fn calculate_ommers_root(ommers: &[Header]) -> B256 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        bloom, constants::EMPTY_ROOT_HASH, hex_literal::hex, Block, GenesisAccount, Log, TxType,
-        U256,
-    };
+    use crate::{bloom, constants::EMPTY_ROOT_HASH, hex_literal::hex, Block, Log, TxType, U256};
+    use alloy_genesis::GenesisAccount;
     use alloy_primitives::{b256, Address, LogData};
     use alloy_rlp::Decodable;
     use reth_chainspec::{GOERLI, HOLESKY, MAINNET, SEPOLIA};

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -39,6 +39,7 @@ alloy-rlp.workspace = true
 alloy-dyn-abi = { workspace = true, features = ["eip712"] }
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
+alloy-genesis.workspace = true
 revm = { workspace = true, features = [
     "optional_block_gas_limit",
     "optional_eip3607",

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -1,11 +1,11 @@
 use crate::result::ToRpcResult;
+use alloy_genesis::ChainConfig;
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::ChainSpec;
 use reth_network_api::{NetworkInfo, PeerKind, Peers};
 use reth_network_peers::{AnyNode, NodeRecord};
-use reth_primitives::ChainConfig;
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_types::{
     admin::{EthProtocolInfo, NodeInfo, Ports, ProtocolInfo},

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -20,6 +20,9 @@ reth-etl.workspace = true
 reth-codecs.workspace = true
 reth-stages-types.workspace = true
 
+# eth
+alloy-genesis.workspace = true
+
 # misc
 eyre.workspace = true
 thiserror.workspace = true

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -1,5 +1,6 @@
 //! Reth genesis initialization utility functions.
 
+use alloy_genesis::GenesisAccount;
 use reth_chainspec::ChainSpec;
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
@@ -7,8 +8,7 @@ use reth_db::tables;
 use reth_db_api::{database::Database, transaction::DbTxMut, DatabaseError};
 use reth_etl::Collector;
 use reth_primitives::{
-    Account, Address, Bytecode, GenesisAccount, Receipts, StaticFileSegment, StorageEntry, B256,
-    U256,
+    Account, Address, Bytecode, Receipts, StaticFileSegment, StorageEntry, B256, U256,
 };
 use reth_provider::{
     bundle_state::{BundleStateInit, RevertsInit},
@@ -525,6 +525,7 @@ struct GenesisAccountWithAddress {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_genesis::Genesis;
     use reth_chainspec::{Chain, GOERLI, MAINNET, SEPOLIA};
     use reth_db::DatabaseEnv;
     use reth_db_api::{
@@ -533,9 +534,7 @@ mod tests {
         table::{Table, TableRow},
         transaction::DbTx,
     };
-    use reth_primitives::{
-        Genesis, GOERLI_GENESIS_HASH, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH,
-    };
+    use reth_primitives::{GOERLI_GENESIS_HASH, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH};
     use reth_primitives_traits::IntegerList;
     use reth_provider::test_utils::create_test_provider_factory_with_chain_spec;
 

--- a/examples/custom-engine-types/Cargo.toml
+++ b/examples/custom-engine-types/Cargo.toml
@@ -17,6 +17,7 @@ reth-basic-payload-builder.workspace = true
 reth-ethereum-payload-builder.workspace = true
 reth-node-ethereum.workspace = true
 reth-tracing.workspace = true
+alloy-genesis.workspace = true
 
 eyre.workspace = true
 tokio.workspace = true

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -22,6 +22,7 @@ use std::convert::Infallible;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use alloy_genesis::Genesis;
 use reth::{
     api::PayloadTypes,
     builder::{
@@ -51,7 +52,7 @@ use reth_payload_builder::{
     error::PayloadBuilderError, EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderHandle,
     PayloadBuilderService,
 };
-use reth_primitives::{Address, Genesis, Header, Withdrawals, B256};
+use reth_primitives::{Address, Header, Withdrawals, B256};
 use reth_rpc_types::{
     engine::{
         ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,

--- a/examples/custom-evm/Cargo.toml
+++ b/examples/custom-evm/Cargo.toml
@@ -13,6 +13,7 @@ reth-node-core.workspace = true
 reth-primitives.workspace = true
 reth-node-ethereum.workspace = true
 reth-tracing.workspace = true
+alloy-genesis.workspace = true
 
 eyre.workspace = true
 tokio.workspace = true

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+use alloy_genesis::Genesis;
 use reth::{
     builder::{components::ExecutorBuilder, BuilderContext, NodeBuilder},
     primitives::{
@@ -21,7 +22,7 @@ use reth_chainspec::{Chain, ChainSpec};
 use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider, EthereumNode};
-use reth_primitives::{Genesis, Header, TransactionSigned};
+use reth_primitives::{Header, TransactionSigned};
 use reth_tracing::{RethTracer, Tracer};
 use std::sync::Arc;
 

--- a/examples/exex/rollup/Cargo.toml
+++ b/examples/exex/rollup/Cargo.toml
@@ -24,6 +24,7 @@ tokio.workspace = true
 
 # misc
 alloy-consensus = { workspace = true, features = ["kzg"] }
+alloy-genesis.workspace = true
 alloy-rlp.workspace = true
 alloy-sol-types = { workspace = true, features = ["json"] }
 eyre.workspace = true

--- a/examples/exex/rollup/src/main.rs
+++ b/examples/exex/rollup/src/main.rs
@@ -4,6 +4,7 @@
 //! The rollup contract accepts blocks of transactions and deposits of ETH and is deployed on
 //! Holesky at [ROLLUP_CONTRACT_ADDRESS], see <https://github.com/init4tech/zenith/blob/e0481e930947513166881a83e276b316c2f38502/src/Zenith.sol>.
 
+use alloy_genesis::Genesis;
 use alloy_sol_types::{sol, SolEventInterface, SolInterface};
 use db::Database;
 use execution::execute_block;
@@ -13,7 +14,7 @@ use reth_execution_types::Chain;
 use reth_exex::{ExExContext, ExExEvent};
 use reth_node_api::FullNodeComponents;
 use reth_node_ethereum::EthereumNode;
-use reth_primitives::{address, Address, Genesis, SealedBlockWithSenders, TransactionSigned, U256};
+use reth_primitives::{address, Address, SealedBlockWithSenders, TransactionSigned, U256};
 use reth_tracing::tracing::{error, info};
 use rusqlite::Connection;
 use std::sync::Arc;

--- a/examples/stateful-precompile/Cargo.toml
+++ b/examples/stateful-precompile/Cargo.toml
@@ -13,6 +13,7 @@ reth-node-core.workspace = true
 reth-primitives.workspace = true
 reth-node-ethereum.workspace = true
 reth-tracing.workspace = true
+alloy-genesis.workspace = true
 
 eyre.workspace = true
 parking_lot.workspace = true

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+use alloy_genesis::Genesis;
 use parking_lot::RwLock;
 use reth::{
     builder::{components::ExecutorBuilder, BuilderContext, NodeBuilder},
@@ -23,7 +24,7 @@ use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider, EthereumNode};
 use reth_primitives::{
     revm_primitives::{SpecId, StatefulPrecompileMut},
-    Genesis, Header, TransactionSigned,
+    Header, TransactionSigned,
 };
 use reth_tracing::{RethTracer, Tracer};
 use schnellru::{ByLength, LruMap};


### PR DESCRIPTION
removes `reth-primitives::Genesis` imports, using `alloy-genesis` instead