### PR TITLE
feat: add stage unwind to sync 100k CI flow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,6 +77,10 @@ jobs:
           cargo run --release --bin reth \
             -- db get static-file headers 100000 \
             | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
+      - name: Run stage unwind for 100 blocks
+        run: |
+          cargo run --release --bin reth \
+            -- stage unwind num-blocks 100
 
   integration-success:
     name: integration success


### PR DESCRIPTION
We can start testing more CLI commands automatically by running them in the sync job in CI. This starts by running `stage unwind` for 100 blocks