### PR TITLE
test: disable dns discovery

### DIFF
--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -91,6 +91,7 @@ async fn test_tcp_port_node_record_discovery() {
     let config = NetworkConfigBuilder::new(secret_key)
         .listener_port(0)
         .discovery_port(0)
+        .disable_dns_discovery()
         .build_with_noop_provider();
     let network = NetworkManager::new(config).await.unwrap();
 


### PR DESCRIPTION
ref #9001

couldn't reproduce locally, but perhaps this has something to do with this, in any case we can opt out of DNS discovery here