### PR TITLE
chore(op): add link to op labs bedrock datadir download

### DIFF
--- a/book/run/sync-op-mainnet.md
+++ b/book/run/sync-op-mainnet.md
@@ -12,9 +12,14 @@ Importing OP mainnet Bedrock datadir requires exported data:
 
 ## Manual Export Steps
 
-See <https://github.com/testinprod-io/op-geth/pull/1>.
+The `op-geth` Bedrock datadir can be downloaded from <https://datadirs.optimism.io/mainnet-bedrock.tar.zst>.
 
-Output from running the command to export state, can also be downloaded from <https://datadirs.testinprod.io/world_trie_state_op_mainnet_b2c2b6e7edb919a0b856b9fd9aa02b11ead5305e63cdb33386babd82b9bc4cfe.jsonl.zst>.
+To export the OVM chain from `op-geth`, clone the `testinprod-io/op-geth` repo and checkout
+<https://github.com/testinprod-io/op-geth/pull/1>. Commands to export blocks, receipts and state dump can be
+found in `op-geth/migrate.sh`.
+
+Output from running the command to export state, can also be downloaded from
+<https://datadirs.testinprod.io/world_trie_state_op_mainnet_b2c2b6e7edb919a0b856b9fd9aa02b11ead5305e63cdb33386babd82b9bc4cfe.jsonl.zst>.
 
 ## Manual Import Steps
 


### PR DESCRIPTION
- Adds link to `op-geth` Bedrock datadir to Bedrock export docs
- Makes re-direction to `testinprod` for export, more verbose

cc @pcw109550