### PR TITLE
chore(deps): rm reth-rpc-types dep from reth-network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7274,7 +7274,6 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives",
  "reth-provider",
- "reth-rpc-types",
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
@@ -7298,10 +7297,10 @@ name = "reth-network-api"
 version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-admin",
  "enr",
  "reth-eth-wire",
  "reth-network-peers",
- "reth-rpc-types",
  "serde",
  "thiserror",
  "tokio",

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-eth-wire.workspace = true
-reth-rpc-types.workspace = true
+alloy-rpc-types-admin.workspace = true
 reth-network-peers.workspace = true
 
 # ethereum

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -13,13 +13,13 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use reth_eth_wire::{capability::Capabilities, DisconnectReason, EthVersion, Status};
-use reth_rpc_types::NetworkStatus;
-use std::{future::Future, net::SocketAddr, sync::Arc, time::Instant};
-
+pub use alloy_rpc_types_admin::EthProtocolInfo;
 pub use error::NetworkError;
 pub use reputation::{Reputation, ReputationChangeKind};
+use reth_eth_wire::{capability::Capabilities, DisconnectReason, EthVersion, Status};
 use reth_network_peers::NodeRecord;
+use serde::{Deserialize, Serialize};
+use std::{future::Future, net::SocketAddr, sync::Arc, time::Instant};
 
 /// The `PeerId` type.
 pub type PeerId = alloy_primitives::B512;
@@ -214,4 +214,15 @@ impl std::fmt::Display for Direction {
             Self::Outgoing(_) => write!(f, "outgoing"),
         }
     }
+}
+
+/// The status of the network being ran by the local node.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NetworkStatus {
+    /// The local node client version.
+    pub client_version: String,
+    /// The current ethereum protocol version
+    pub protocol_version: u64,
+    /// Information about the Ethereum Wire Protocol.
+    pub eth_protocol_info: EthProtocolInfo,
 }

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -4,13 +4,13 @@
 //! generic over it.
 
 use crate::{
-    NetworkError, NetworkInfo, PeerId, PeerInfo, PeerKind, Peers, PeersInfo, Reputation,
-    ReputationChangeKind,
+    NetworkError, NetworkInfo, NetworkStatus, PeerId, PeerInfo, PeerKind, Peers, PeersInfo,
+    Reputation, ReputationChangeKind,
 };
+use alloy_rpc_types_admin::EthProtocolInfo;
 use enr::{secp256k1::SecretKey, Enr};
 use reth_eth_wire::{DisconnectReason, ProtocolVersion};
 use reth_network_peers::NodeRecord;
-use reth_rpc_types::{admin::EthProtocolInfo, NetworkStatus};
 use std::net::{IpAddr, SocketAddr};
 
 /// A type that implements all network trait that does nothing.

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -26,7 +26,6 @@ reth-ecies.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
 reth-provider.workspace = true
-reth-rpc-types.workspace = true
 reth-tokio-util.workspace = true
 reth-consensus.workspace = true
 reth-network-peers.workspace = true

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -42,11 +42,10 @@ use reth_eth_wire::{
     DisconnectReason, EthVersion, Status,
 };
 use reth_metrics::common::mpsc::UnboundedMeteredSender;
-use reth_network_api::ReputationChangeKind;
+use reth_network_api::{EthProtocolInfo, NetworkStatus, ReputationChangeKind};
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_primitives::ForkId;
 use reth_provider::{BlockNumReader, BlockReader};
-use reth_rpc_types::{admin::EthProtocolInfo, NetworkStatus};
 use reth_tasks::shutdown::GracefulShutdown;
 use reth_tokio_util::EventSender;
 use secp256k1::SecretKey;

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -8,13 +8,12 @@ use parking_lot::Mutex;
 use reth_discv4::Discv4;
 use reth_eth_wire::{DisconnectReason, NewBlock, NewPooledTransactionHashes, SharedTransactions};
 use reth_network_api::{
-    NetworkError, NetworkInfo, PeerInfo, PeerKind, Peers, PeersInfo, Reputation,
+    NetworkError, NetworkInfo, NetworkStatus, PeerInfo, PeerKind, Peers, PeersInfo, Reputation,
     ReputationChangeKind,
 };
 use reth_network_p2p::sync::{NetworkSyncUpdater, SyncState, SyncStateProvider};
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_primitives::{Head, TransactionSigned, B256};
-use reth_rpc_types::NetworkStatus;
 use reth_tokio_util::{EventSender, EventStream};
 use secp256k1::SecretKey;
 use std::{

--- a/crates/net/network/src/protocol.rs
+++ b/crates/net/network/src/protocol.rs
@@ -6,9 +6,8 @@ use futures::Stream;
 use reth_eth_wire::{
     capability::SharedCapabilities, multiplex::ProtocolConnection, protocol::Protocol,
 };
-use reth_network_api::Direction;
+use reth_network_api::{Direction, PeerId};
 use reth_primitives::BytesMut;
-use reth_rpc_types::PeerId;
 use std::{
     fmt,
     net::SocketAddr,

--- a/crates/net/network/tests/it/multiplex.rs
+++ b/crates/net/network/tests/it/multiplex.rs
@@ -10,10 +10,9 @@ use reth_network::{
     protocol::{ConnectionHandler, OnNotSupported, ProtocolHandler},
     test_utils::Testnet,
 };
-use reth_network_api::Direction;
+use reth_network_api::{Direction, PeerId};
 use reth_primitives::BytesMut;
 use reth_provider::test_utils::MockEthProvider;
-use reth_rpc_types::PeerId;
 use std::{
     net::SocketAddr,
     pin::Pin,

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -12,7 +12,6 @@
 #[allow(hidden_glob_reexports)]
 mod eth;
 mod mev;
-mod net;
 mod peer;
 mod rpc;
 
@@ -53,6 +52,5 @@ pub use eth::{
 };
 
 pub use mev::*;
-pub use net::*;
 pub use peer::*;
 pub use rpc::*;


### PR DESCRIPTION
get rid of reth-rpc-types dep in reth-network by moving the reth internal helper type to network-api and import the only required type from the admin namespace crate