### PR TITLE
fix(rpc/admin): missing enode/enr in admin_peers endpoint

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -195,8 +195,10 @@ pub struct PeerInfo {
     pub remote_id: PeerId,
     /// The client's name and version
     pub client_version: Arc<str>,
-    /// The peer's address we're connected to
-    pub remote_addr: SocketAddr,
+    /// The peer's TCP address we're connected to
+    pub tcp_addr: SocketAddr,
+    /// The peer's UDP address used as discovery
+    pub udp_addr: SocketAddr,
     /// The local address of the connection
     pub local_addr: Option<SocketAddr>,
     /// The direction of the session

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -211,6 +211,8 @@ pub struct PeerInfo {
     pub status: Arc<Status>,
     /// The timestamp when the session to that peer has been established.
     pub session_established: Instant,
+    /// The peer's connection kind
+    pub kind: PeerKind,
 }
 
 /// The direction of the connection.

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -195,10 +195,12 @@ pub struct PeerInfo {
     pub remote_id: PeerId,
     /// The client's name and version
     pub client_version: Arc<str>,
-    /// The peer's TCP address we're connected to
-    pub tcp_addr: SocketAddr,
-    /// The peer's UDP address used as discovery
-    pub udp_addr: SocketAddr,
+    /// The peer's enode
+    pub enode: String,
+    /// The peer's enr
+    pub enr: Option<String>,
+    /// The peer's address we're connected to
+    pub remote_addr: SocketAddr,
     /// The local address of the connection
     pub local_addr: Option<SocketAddr>,
     /// The direction of the session

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -881,18 +881,13 @@ where
     ///
     /// Returns `None` if there's no active session to the peer.
     fn get_peer_info_by_id(&self, peer_id: PeerId) -> Option<PeerInfo> {
-        self.swarm
-            .sessions()
-            .active_sessions()
-            .get(&peer_id)
-            .map(|session| {
-                self.swarm
-                    .state()
-                    .peers()
-                    .peer_by_id(peer_id)
-                    .map(|(record, kind)| session.peer_info(&record, kind))
-            })
-            .flatten()
+        self.swarm.sessions().active_sessions().get(&peer_id).and_then(|session| {
+            self.swarm
+                .state()
+                .peers()
+                .peer_by_id(peer_id)
+                .map(|(record, kind)| session.peer_info(&record, kind))
+        })
     }
 
     /// Returns [`PeerInfo`] for a given peers.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -870,8 +870,8 @@ where
         let peer_manager = self.swarm.state().peers();
         let mut peers = Vec::with_capacity(peer_manager.num_known_peers());
         for (peer_id, session) in self.swarm.sessions().active_sessions() {
-            if let Some(record) = peer_manager.peer_by_id(*peer_id) {
-                peers.push(session.peer_info(&record));
+            if let Some((record, kind)) = peer_manager.peer_by_id(*peer_id) {
+                peers.push(session.peer_info(&record, kind));
             }
         }
         peers
@@ -882,7 +882,11 @@ where
     /// Returns `None` if there's no active session to the peer.
     fn get_peer_info_by_id(&self, peer_id: PeerId) -> Option<PeerInfo> {
         if let Some(session) = self.swarm.sessions().active_sessions().get(&peer_id) {
-            self.swarm.state().peers().peer_by_id(peer_id).map(|record| session.peer_info(&record))
+            self.swarm
+                .state()
+                .peers()
+                .peer_by_id(peer_id)
+                .map(|(record, kind)| session.peer_info(&record, kind))
         } else {
             None
         }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -870,7 +870,7 @@ where
         self.swarm
             .sessions()
             .active_sessions()
-            .into_iter()
+            .iter()
             .filter_map(|(&peer_id, session)| {
                 self.swarm
                     .state()

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -881,15 +881,18 @@ where
     ///
     /// Returns `None` if there's no active session to the peer.
     fn get_peer_info_by_id(&self, peer_id: PeerId) -> Option<PeerInfo> {
-        if let Some(session) = self.swarm.sessions().active_sessions().get(&peer_id) {
-            self.swarm
-                .state()
-                .peers()
-                .peer_by_id(peer_id)
-                .map(|(record, kind)| session.peer_info(&record, kind))
-        } else {
-            None
-        }
+        self.swarm
+            .sessions()
+            .active_sessions()
+            .get(&peer_id)
+            .map(|session| {
+                self.swarm
+                    .state()
+                    .peers()
+                    .peer_by_id(peer_id)
+                    .map(|(record, kind)| session.peer_info(&record, kind))
+            })
+            .flatten()
     }
 
     /// Returns [`PeerInfo`] for a given peers.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -42,7 +42,7 @@ use reth_eth_wire::{
     DisconnectReason, EthVersion, Status,
 };
 use reth_metrics::common::mpsc::UnboundedMeteredSender;
-use reth_network_api::{EthProtocolInfo, NetworkStatus, ReputationChangeKind};
+use reth_network_api::{EthProtocolInfo, NetworkStatus, PeerInfo, ReputationChangeKind};
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_primitives::ForkId;
 use reth_provider::{BlockNumReader, BlockReader};
@@ -604,17 +604,17 @@ where
                 }
             }
             NetworkHandleMessage::GetPeerInfos(tx) => {
-                let _ = tx.send(self.swarm.sessions_mut().get_peer_info());
+                let _ = tx.send(self.get_peer_infos());
             }
             NetworkHandleMessage::GetPeerInfoById(peer_id, tx) => {
-                let _ = tx.send(self.swarm.sessions_mut().get_peer_info_by_id(peer_id));
+                let _ = tx.send(self.get_peer_info_by_id(peer_id));
             }
             NetworkHandleMessage::GetPeerInfosByIds(peer_ids, tx) => {
-                let _ = tx.send(self.swarm.sessions().get_peer_infos_by_ids(peer_ids));
+                let _ = tx.send(self.get_peer_infos_by_ids(peer_ids));
             }
             NetworkHandleMessage::GetPeerInfosByPeerKind(kind, tx) => {
-                let peers = self.swarm.state().peers().peers_by_kind(kind);
-                let _ = tx.send(self.swarm.sessions().get_peer_infos_by_ids(peers));
+                let peer_ids = self.swarm.state().peers().peers_by_kind(kind);
+                let _ = tx.send(self.get_peer_infos_by_ids(peer_ids));
             }
             NetworkHandleMessage::AddRlpxSubProtocol(proto) => self.add_rlpx_sub_protocol(proto),
             NetworkHandleMessage::GetTransactionsHandle(tx) => {
@@ -863,6 +863,42 @@ where
                     .apply_reputation_change(&peer_id, ReputationChangeKind::BadProtocol);
             }
         }
+    }
+
+    /// Returns [`PeerInfo`] for all connected peers
+    fn get_peer_infos(&self) -> Vec<PeerInfo> {
+        let peer_manager = self.swarm.state().peers();
+        let mut peers = Vec::with_capacity(peer_manager.num_known_peers());
+        for (peer_id, session) in self.swarm.sessions().active_sessions() {
+            if let Some(_nr) = peer_manager.peer_by_id(*peer_id) {
+                peers.push(session.peer_info());
+            }
+        }
+        peers
+    }
+
+    /// Returns [`PeerInfo`] for a given peer.
+    ///
+    /// Returns `None` if there's no active session to the peer.
+    fn get_peer_info_by_id(&self, peer_id: PeerId) -> Option<PeerInfo> {
+        if let Some(session) = self.swarm.sessions().active_sessions().get(&peer_id) {
+            self.swarm.state().peers().peer_by_id(peer_id).map(|_nr| session.peer_info())
+        } else {
+            None
+        }
+    }
+
+    /// Returns [`PeerInfo`] for a given peers.
+    ///
+    /// Ignore the non-active peer.
+    fn get_peer_infos_by_ids(&self, peer_ids: impl IntoIterator<Item = PeerId>) -> Vec<PeerInfo> {
+        let mut infos = Vec::new();
+        for peer_id in peer_ids {
+            if let Some(info) = self.get_peer_info_by_id(peer_id) {
+                infos.push(info)
+            }
+        }
+        infos
     }
 
     /// Updates the metrics for active,established connections

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -870,8 +870,8 @@ where
         let peer_manager = self.swarm.state().peers();
         let mut peers = Vec::with_capacity(peer_manager.num_known_peers());
         for (peer_id, session) in self.swarm.sessions().active_sessions() {
-            if let Some(_nr) = peer_manager.peer_by_id(*peer_id) {
-                peers.push(session.peer_info());
+            if let Some(record) = peer_manager.peer_by_id(*peer_id) {
+                peers.push(session.peer_info(&record));
             }
         }
         peers
@@ -882,7 +882,7 @@ where
     /// Returns `None` if there's no active session to the peer.
     fn get_peer_info_by_id(&self, peer_id: PeerId) -> Option<PeerInfo> {
         if let Some(session) = self.swarm.sessions().active_sessions().get(&peer_id) {
-            self.swarm.state().peers().peer_by_id(peer_id).map(|_nr| session.peer_info())
+            self.swarm.state().peers().peer_by_id(peer_id).map(|record| session.peer_info(&record))
         } else {
             None
         }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -894,13 +894,7 @@ where
     ///
     /// Ignore the non-active peer.
     fn get_peer_infos_by_ids(&self, peer_ids: impl IntoIterator<Item = PeerId>) -> Vec<PeerInfo> {
-        let mut infos = Vec::new();
-        for peer_id in peer_ids {
-            if let Some(info) = self.get_peer_info_by_id(peer_id) {
-                infos.push(info)
-            }
-        }
-        infos
+        peer_ids.into_iter().filter_map(|peer_id| self.get_peer_info_by_id(peer_id)).collect()
     }
 
     /// Updates the metrics for active,established connections

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -867,14 +867,18 @@ where
 
     /// Returns [`PeerInfo`] for all connected peers
     fn get_peer_infos(&self) -> Vec<PeerInfo> {
-        let peer_manager = self.swarm.state().peers();
-        let mut peers = Vec::with_capacity(peer_manager.num_known_peers());
-        for (peer_id, session) in self.swarm.sessions().active_sessions() {
-            if let Some((record, kind)) = peer_manager.peer_by_id(*peer_id) {
-                peers.push(session.peer_info(&record, kind));
-            }
-        }
-        peers
+        self.swarm
+            .sessions()
+            .active_sessions()
+            .into_iter()
+            .filter_map(|(&peer_id, session)| {
+                self.swarm
+                    .state()
+                    .peers()
+                    .peer_by_id(peer_id)
+                    .map(|(record, kind)| session.peer_info(&record, kind))
+            })
+            .collect()
     }
 
     /// Returns [`PeerInfo`] for a given peer.

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -213,8 +213,7 @@ impl PeersManager {
     }
 
     /// Returns the [`NodeRecord`] for the given peer id
-    #[allow(dead_code)]
-    fn peer_by_id(&self, peer_id: PeerId) -> Option<NodeRecord> {
+    pub(crate) fn peer_by_id(&self, peer_id: PeerId) -> Option<NodeRecord> {
         self.peers.get(&peer_id).map(|v| {
             NodeRecord::new_with_ports(
                 v.addr.tcp.ip(),

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -212,14 +212,17 @@ impl PeersManager {
         })
     }
 
-    /// Returns the [`NodeRecord`] for the given peer id
-    pub(crate) fn peer_by_id(&self, peer_id: PeerId) -> Option<NodeRecord> {
+    /// Returns the `NodeRecord` and `PeerKind` for the given peer id
+    pub(crate) fn peer_by_id(&self, peer_id: PeerId) -> Option<(NodeRecord, PeerKind)> {
         self.peers.get(&peer_id).map(|v| {
-            NodeRecord::new_with_ports(
-                v.addr.tcp.ip(),
-                v.addr.tcp.port(),
-                v.addr.udp.map(|addr| addr.port()),
-                peer_id,
+            (
+                NodeRecord::new_with_ports(
+                    v.addr.tcp.ip(),
+                    v.addr.tcp.port(),
+                    v.addr.udp.map(|addr| addr.port()),
+                    peer_id,
+                ),
+                v.kind,
             )
         })
     }
@@ -1377,7 +1380,7 @@ mod tests {
             _ => unreachable!(),
         }
 
-        let record = peers.peer_by_id(peer).unwrap();
+        let (record, _) = peers.peer_by_id(peer).unwrap();
         assert_eq!(record.tcp_addr(), socket_addr);
         assert_eq!(record.udp_addr(), socket_addr);
     }
@@ -1404,7 +1407,7 @@ mod tests {
             _ => unreachable!(),
         }
 
-        let record = peers.peer_by_id(peer).unwrap();
+        let (record, _) = peers.peer_by_id(peer).unwrap();
         assert_eq!(record.tcp_addr(), tcp_addr);
         assert_eq!(record.udp_addr(), udp_addr);
     }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -140,8 +140,9 @@ impl ActiveSessionHandle {
         PeerInfo {
             remote_id: self.remote_id,
             direction: self.direction,
-            tcp_addr: record.tcp_addr(),
-            udp_addr: record.udp_addr(),
+            enode: record.to_string(),
+            enr: None,
+            remote_addr: self.remote_addr,
             local_addr: self.local_addr,
             capabilities: self.capabilities.clone(),
             client_version: self.client_version.clone(),

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -11,7 +11,7 @@ use reth_eth_wire::{
     errors::EthStreamError,
     DisconnectReason, EthVersion, Status,
 };
-use reth_network_api::PeerInfo;
+use reth_network_api::{PeerInfo, PeerKind};
 use reth_network_peers::{NodeRecord, PeerId};
 use std::{io, net::SocketAddr, sync::Arc, time::Instant};
 use tokio::sync::{
@@ -136,7 +136,7 @@ impl ActiveSessionHandle {
     }
 
     /// Extracts the [`PeerInfo`] from the session handle.
-    pub(crate) fn peer_info(&self, record: &NodeRecord) -> PeerInfo {
+    pub(crate) fn peer_info(&self, record: &NodeRecord, kind: PeerKind) -> PeerInfo {
         PeerInfo {
             remote_id: self.remote_id,
             direction: self.direction,
@@ -149,6 +149,7 @@ impl ActiveSessionHandle {
             eth_version: self.version,
             status: self.status.clone(),
             session_established: self.established,
+            kind,
         }
     }
 }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -12,7 +12,7 @@ use reth_eth_wire::{
     DisconnectReason, EthVersion, Status,
 };
 use reth_network_api::PeerInfo;
-use reth_network_peers::PeerId;
+use reth_network_peers::{NodeRecord, PeerId};
 use std::{io, net::SocketAddr, sync::Arc, time::Instant};
 use tokio::sync::{
     mpsc::{self, error::SendError},
@@ -136,11 +136,12 @@ impl ActiveSessionHandle {
     }
 
     /// Extracts the [`PeerInfo`] from the session handle.
-    pub(crate) fn peer_info(&self) -> PeerInfo {
+    pub(crate) fn peer_info(&self, record: &NodeRecord) -> PeerInfo {
         PeerInfo {
             remote_id: self.remote_id,
             direction: self.direction,
-            remote_addr: self.remote_addr,
+            tcp_addr: record.tcp_addr(),
+            udp_addr: record.udp_addr(),
             local_addr: self.local_addr,
             capabilities: self.capabilities.clone(),
             client_version: self.client_version.clone(),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -170,6 +170,11 @@ impl SessionManager {
         self.secret_key
     }
 
+    /// Returns a borrowed reference to the active sessions.
+    pub const fn active_sessions(&self) -> &HashMap<PeerId, ActiveSessionHandle> {
+        &self.active_sessions
+    }
+
     /// Returns the session hello message.
     pub fn hello_message(&self) -> HelloMessageWithProtocols {
         self.hello_message.clone()
@@ -586,35 +591,6 @@ impl SessionManager {
                 }
             }
         }
-    }
-
-    /// Returns [`PeerInfo`] for all connected peers
-    pub(crate) fn get_peer_info(&self) -> Vec<PeerInfo> {
-        self.active_sessions.values().map(ActiveSessionHandle::peer_info).collect()
-    }
-
-    /// Returns [`PeerInfo`] for a given peer.
-    ///
-    /// Returns `None` if there's no active session to the peer.
-    pub(crate) fn get_peer_info_by_id(&self, peer_id: PeerId) -> Option<PeerInfo> {
-        self.active_sessions.get(&peer_id).map(ActiveSessionHandle::peer_info)
-    }
-    /// Returns [`PeerInfo`] for a given peer.
-    ///
-    /// Returns `None` if there's no active session to the peer.
-    pub(crate) fn get_peer_infos_by_ids(
-        &self,
-        peer_ids: impl IntoIterator<Item = PeerId>,
-    ) -> Vec<PeerInfo> {
-        let mut infos = Vec::new();
-        for peer_id in peer_ids {
-            if let Some(info) =
-                self.active_sessions.get(&peer_id).map(ActiveSessionHandle::peer_info)
-            {
-                infos.push(info);
-            }
-        }
-        infos
     }
 }
 

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -1,6 +1,6 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_network_peers::{AnyNode, NodeRecord};
-use reth_rpc_types::{admin::NodeInfo, PeerInfo};
+use reth_rpc_types::admin::{NodeInfo, PeerInfo};
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "admin"))]

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -68,7 +68,7 @@ where
         let peers = self.network.get_all_peers().await.to_rpc_result()?;
         let mut infos = Vec::with_capacity(peers.len());
 
-        for peer in peers.into_iter() {
+        for peer in peers {
             if let Ok(pk) = id2pk(peer.remote_id) {
                 infos.push(PeerInfo {
                     id: pk.to_string(),

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -6,12 +6,12 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::ChainSpec;
 use reth_network_api::{NetworkInfo, PeerKind, Peers};
-use reth_network_peers::{AnyNode, NodeRecord};
+use reth_network_peers::{id2pk, AnyNode, NodeRecord};
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_server_types::ToRpcResult;
-use reth_rpc_types::{
-    admin::{EthProtocolInfo, NodeInfo, Ports, ProtocolInfo},
-    PeerEthProtocolInfo, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo,
+use reth_rpc_types::admin::{
+    EthInfo, EthPeerInfo, EthProtocolInfo, NodeInfo, PeerInfo, PeerNetworkInfo, PeerProtocolInfo,
+    Ports, ProtocolInfo,
 };
 
 /// `admin` API implementation.
@@ -63,33 +63,43 @@ where
         Ok(true)
     }
 
+    /// Handler for `admin_peers`
     async fn peers(&self) -> RpcResult<Vec<PeerInfo>> {
         let peers = self.network.get_all_peers().await.to_rpc_result()?;
-        let peers = peers
-            .into_iter()
-            .map(|peer| PeerInfo {
-                id: Some(peer.remote_id.to_string()),
-                name: peer.client_version.to_string(),
-                caps: peer.capabilities.capabilities().iter().map(|cap| cap.to_string()).collect(),
-                network: PeerNetworkInfo {
-                    remote_address: peer.remote_addr.to_string(),
-                    local_address: peer
-                        .local_addr
-                        .unwrap_or_else(|| self.network.local_addr())
-                        .to_string(),
-                },
-                protocols: PeerProtocolsInfo {
-                    eth: Some(PeerEthProtocolInfo {
-                        difficulty: Some(peer.status.total_difficulty),
-                        head: peer.status.blockhash.to_string(),
-                        version: peer.status.version as u32,
-                    }),
-                    pip: None,
-                },
-            })
-            .collect();
+        let mut infos = Vec::with_capacity(peers.len());
 
-        Ok(peers)
+        for peer in peers.into_iter() {
+            if let Ok(pk) = id2pk(peer.remote_id) {
+                infos.push(PeerInfo {
+                    id: pk.to_string(),
+                    name: peer.client_version.to_string(),
+                    enode: peer.enode,
+                    enr: peer.enr,
+                    caps: peer
+                        .capabilities
+                        .capabilities()
+                        .iter()
+                        .map(|cap| cap.to_string())
+                        .collect(),
+                    network: PeerNetworkInfo {
+                        remote_address: peer.remote_addr,
+                        local_address: peer.local_addr.unwrap_or_else(|| self.network.local_addr()),
+                        inbound: peer.direction.is_incoming(),
+                        trusted: false,     // TODO: check
+                        static_node: false, // TODO: check
+                    },
+                    protocols: PeerProtocolInfo {
+                        eth: Some(EthPeerInfo::Info(EthInfo {
+                            version: peer.status.version as u64,
+                        })),
+                        snap: None,
+                        other: Default::default(),
+                    },
+                })
+            }
+        }
+
+        Ok(infos)
     }
 
     /// Handler for `admin_nodeInfo`

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -85,8 +85,8 @@ where
                         remote_address: peer.remote_addr,
                         local_address: peer.local_addr.unwrap_or_else(|| self.network.local_addr()),
                         inbound: peer.direction.is_incoming(),
-                        trusted: false,     // TODO: check
-                        static_node: false, // TODO: check
+                        trusted: peer.kind.is_trusted(),
+                        static_node: false, // TODO: add static kind
                     },
                     protocols: PeerProtocolInfo {
                         eth: Some(EthPeerInfo::Info(EthInfo {

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -86,7 +86,7 @@ where
                         local_address: peer.local_addr.unwrap_or_else(|| self.network.local_addr()),
                         inbound: peer.direction.is_incoming(),
                         trusted: peer.kind.is_trusted(),
-                        static_node: false, // TODO: add static kind
+                        static_node: peer.kind.is_static(),
                     },
                     protocols: PeerProtocolInfo {
                         eth: Some(EthPeerInfo::Info(EthInfo {


### PR DESCRIPTION
currently, we're returning the peer information in the net/session module, which misses the peer's discovery port, so can't recover the enode info, and in this PR I combine the peer-info both of the session and underearth socket info.