### PR TITLE
chore: tweak profiles, rename debug-fast to profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,20 +224,24 @@ opt-level = 3
 lto = "thin"
 
 [profile.release]
+opt-level = 3
 lto = "thin"
-strip = "debuginfo"
+debug = "line-tables-only"
+strip = true
+panic = "unwind"
+codegen-units = 16
 
-# Like release, but with full debug symbols. Useful for e.g. `perf`.
-[profile.debug-fast]
+# Use the `--profile profiling` flag to show symbols in release mode.
+# e.g. `cargo build --profile profiling`
+[profile.profiling]
 inherits = "release"
-strip = "none"
-debug = true
+debug = 1
+strip = false
 
 [profile.maxperf]
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-incremental = false
 
 [workspace.dependencies]
 # reth

--- a/bin/reth-bench/README.md
+++ b/bin/reth-bench/README.md
@@ -23,8 +23,7 @@ As long as the data is representative of real-world load, or closer to worst-cas
 
 ## Prerequisites
 
-If you will be collecting CPU profiles, make sure `reth` is compiled with the `debug-fast` profile.
-For collecting memory profiles, make sure `reth` is also compiled with the `--features profiling` flag.
+If you will be collecting CPU profiles, make sure `reth` is compiled with the `profiling` profile.
 Otherwise, running `make maxperf` at the root of the repo should be sufficient for collecting accurate performance metrics.
 
 ## Command Usage

--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -41,12 +41,12 @@ cargo build --features jemalloc-prof
 ```
 
 When performing a longer-running or performance-sensitive task with reth, such as a sync test or load benchmark, it's usually recommended to use the `maxperf` profile. However, the `maxperf`
-profile does not enable debug symbols, which are required for tools like `perf` and `jemalloc` to produce results that a human can interpret. Reth includes a performance profile with debug symbols called `debug-fast`. To compile reth with debug symbols, jemalloc, profiling, and a performance profile:
+profile does not enable debug symbols, which are required for tools like `perf` and `jemalloc` to produce results that a human can interpret. Reth includes a performance profile with debug symbols called `profiling`. To compile reth with debug symbols, jemalloc, profiling, and a performance profile:
 ```
-cargo build --features jemalloc-prof --profile debug-fast
+cargo build --features jemalloc-prof --profile profiling
 
 # May improve performance even more
-RUSTFLAGS="-C target-cpu=native" cargo build --features jemalloc-prof --profile debug-fast
+RUSTFLAGS="-C target-cpu=native" cargo build --features jemalloc-prof --profile profiling
 ```
 
 ### Monitoring memory usage

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2162,7 +2162,7 @@ mod tests {
                         b.clone().try_seal_with_senders().expect("invalid tx signature in block"),
                         None,
                     )
-                    .map(|_| ())
+                    .map(drop)
             })
             .expect("failed to insert");
         provider.commit().unwrap();

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1537,7 +1537,7 @@ impl Discv4Service {
     ///  - timestamp is expired (lower than current local UNIX timestamp)
     fn ensure_not_expired(&self, timestamp: u64) -> Result<(), ()> {
         // ensure the timestamp is a valid UNIX timestamp
-        let _ = i64::try_from(timestamp).map_err(|_| ())?;
+        let _ = i64::try_from(timestamp).map_err(drop)?;
 
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
         if self.config.enforce_expiration_timestamps && timestamp < now {

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -168,7 +168,7 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
                         .gas
                         .try_into()
                         .map_err(|_| ConversionError::Eip2718Error(RlpError::Overflow.into()))?,
-                    placeholder: tx.to.map(|_| ()),
+                    placeholder: tx.to.map(drop),
                     to: tx.to.unwrap_or_default(),
                     value: tx.value,
                     access_list: tx.access_list.ok_or(ConversionError::MissingAccessList)?,

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -741,7 +741,7 @@ mod tests {
                             let transaction = random_signed_tx(&mut rng);
                             static_file_producer
                                 .append_transaction(tx_num, transaction.into())
-                                .map(|_| ())
+                                .map(drop)
                         })?;
 
                         if body.tx_count != 0 {

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -464,7 +464,7 @@ impl TaskExecutor {
                 error!("{task_error}");
                 let _ = panicked_tasks_tx.send(task_error);
             })
-            .map(|_| ())
+            .map(drop)
             .in_current_span();
 
         self.handle.spawn(task)
@@ -513,7 +513,7 @@ impl TaskExecutor {
                 error!("{task_error}");
                 let _ = panicked_tasks_tx.send(task_error);
             })
-            .map(|_| ())
+            .map(drop)
             .in_current_span();
 
         self.handle.spawn(task)


### PR DESCRIPTION
We're generally profiling with this, not "debugging fast", which also aligns with what other projects name this "release with debug info" profile, and what [samply recommends](https://github.com/mstange/samply?tab=readme-ov-file#turn-on-debug-info-for-full-stacks) as a global profile (`~/.cargo/config.toml`).

Adds `strip = true` to release which strips symbols, making dist binary go from ~85MiB to ~62MiB. If you want symbols, build with `--profile profiling`, as it should've been.

Manually specify `panic = "unwind"` as it looks like we're using `catch_unwind` in a few places.