### PR TITLE
fix(op): configure discv5 properly in op builder

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -131,7 +131,7 @@ impl ConfigBuilder {
     }
 
     /// Adds boot nodes in the form a list of [`NodeRecord`]s, parsed enodes.
-    pub fn add_unsigned_boot_nodes(mut self, enodes: impl Iterator<Item = NodeRecord>) -> Self {
+    pub fn add_unsigned_boot_nodes(mut self, enodes: impl IntoIterator<Item = NodeRecord>) -> Self {
         for node in enodes {
             if let Ok(node) = BootNode::from_unsigned(node) {
                 self.bootstrap_nodes.insert(node);

--- a/crates/node-core/src/args/network.rs
+++ b/crates/node-core/src/args/network.rs
@@ -185,7 +185,7 @@ impl NetworkArgs {
                 } = self.discovery;
 
                 builder
-                    .add_unsigned_boot_nodes(chain_bootnodes.into_iter())
+                    .add_unsigned_boot_nodes(chain_bootnodes)
                     .lookup_interval(discv5_lookup_interval)
                     .bootstrap_lookup_interval(discv5_bootstrap_lookup_interval)
                     .bootstrap_lookup_countdown(discv5_bootstrap_lookup_countdown)

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -292,6 +292,18 @@ where
                 }
 
                 builder
+            })
+            // ensure we configure discv5
+            .map_discv5_config_builder(|builder| {
+                builder
+                    .add_unsigned_boot_nodes(ctx.chain_spec().bootnodes().unwrap_or_default())
+                    .lookup_interval(ctx.config().network.discovery.discv5_lookup_interval)
+                    .bootstrap_lookup_interval(
+                        ctx.config().network.discovery.discv5_bootstrap_lookup_interval,
+                    )
+                    .bootstrap_lookup_countdown(
+                        ctx.config().network.discovery.discv5_bootstrap_lookup_countdown,
+                    )
             });
 
         let mut network_config = ctx.build_network_config(network_builder);


### PR DESCRIPTION
closes #9052 #9053

the discv5 settings we apply by default were overwritten because we always enable discv5 for OP.

fx: apply discv5 settings in op network builder

the `map_discv5_config_builder` is a bit confusing and we should remove this

note: peering on op networks is still very bad and can take a while