### PR TITLE
chore: rename PipelineHandler -> BackfillSync

### DIFF
--- a/crates/engine/tree/src/backfill.rs
+++ b/crates/engine/tree/src/backfill.rs
@@ -1,6 +1,6 @@
 //! It is expected that the node has two sync modes:
 //!
-//!  - Pipeline sync: Sync to a certain block height in stages, e.g. download data from p2p then
+//!  - Backfill sync: Sync to a certain block height in stages, e.g. download data from p2p then
 //!    execute that range.
 //!  - Live sync: In this mode the nodes is keeping up with the latest tip and listens for new
 //!    requests from the consensus client.
@@ -10,27 +10,27 @@
 use reth_stages_api::{ControlFlow, PipelineError, PipelineTarget};
 use std::task::{Context, Poll};
 
-/// A handler for the pipeline.
-pub trait PipelineHandler: Send + Sync {
-    /// Performs an action on the pipeline.
-    fn on_action(&mut self, event: PipelineAction);
+/// Backfill sync mode functionality.
+pub trait BackfillSync: Send + Sync {
+    /// Performs a backfill action.
+    fn on_action(&mut self, event: BackfillAction);
 
     /// Polls the pipeline for completion.
-    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<PipelineEvent>;
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<BackfillEvent>;
 }
 
-/// The actions that can be performed on the pipeline.
+/// The backfill actions that can be performed.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PipelineAction {
-    /// Start the pipeline with the given target.
+pub enum BackfillAction {
+    /// Start backfilling with the given target.
     Start(PipelineTarget),
 }
 
-/// The events that can be emitted by the pipeline.
+/// The events that can be emitted on backfill sync.
 #[derive(Debug)]
-pub enum PipelineEvent {
+pub enum BackfillEvent {
     Idle,
-    /// Pipeline started syncing
+    /// Backfill sync started.
     Started(PipelineTarget),
     /// Pipeline finished
     ///

--- a/crates/engine/tree/src/lib.rs
+++ b/crates/engine/tree/src/lib.rs
@@ -12,6 +12,8 @@
 /// Re-export of the blockchain tree API.
 pub use reth_blockchain_tree_api::*;
 
+/// Support for backfill sync mode.
+pub mod backfill;
 /// The type that drives the chain forward.
 pub mod chain;
 /// Support for downloading blocks on demand for live sync.
@@ -20,7 +22,5 @@ pub mod download;
 pub mod engine;
 /// The background writer task for batch db writes.
 pub mod persistence;
-/// Support for managing the pipeline.
-pub mod pipeline;
 /// Support for interacting with the blockchain tree.
 pub mod tree;

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1,4 +1,4 @@
-use crate::{engine::DownloadRequest, pipeline::PipelineAction};
+use crate::{backfill::BackfillAction, engine::DownloadRequest};
 use reth_beacon_consensus::{ForkchoiceStateTracker, InvalidHeaderCache, OnForkChoiceUpdated};
 use reth_blockchain_tree::{BlockBuffer, BlockStatus};
 use reth_blockchain_tree_api::{error::InsertBlockError, InsertPayloadOk};
@@ -175,8 +175,8 @@ impl<T> TreeOutcome<T> {
 /// Events that can be emitted by the [`EngineApiTreeHandler`].
 #[derive(Debug)]
 pub enum TreeEvent {
-    /// Pipeline action is needed.
-    PipelineAction(PipelineAction),
+    /// Backfill action is needed.
+    BackfillAction(BackfillAction),
     /// Block download is needed.
     Download(DownloadRequest),
 }


### PR DESCRIPTION
Closes #9008 

Renamed `PipelineHandler`, `PipelineEvent`, `PipelineAction` and `pipeline` module to their `Backfill` counterparts.

Still keeping `PipelineError` and `PipelineTarget` from `reth_stages_api` in `BackfillEvent`, @mattsse let me know wdyt