### PR TITLE
feat: add base mainnet 10k block sync test to CI

### DIFF
--- a/.github/workflows/eth-sync.yml
+++ b/.github/workflows/eth-sync.yml
@@ -1,0 +1,50 @@
+# Runs an ethereum mainnet sync test.
+
+name: eth-sync-test
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: sync / 100k blocks
+    # Only run sync tests in merge groups
+    if: github.event_name == 'merge_group'
+    runs-on:
+      group: Reth
+    env:
+      RUST_LOG: info,sync=error
+      RUST_BACKTRACE: 1
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run sync
+        run: |
+          cargo run --release --features asm-keccak,jemalloc,min-error-logs --bin reth \
+            -- node \
+            --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
+            --debug.max-block 100000 \
+            --debug.terminate
+      - name: Verify the target block hash
+        run: |
+          cargo run --release --bin reth \
+            -- db get static-file headers 100000 \
+            | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
+      - name: Run stage unwind for 100 blocks
+        run: |
+          cargo run --release --bin reth \
+            -- stage unwind num-blocks 100

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,39 +49,6 @@ jobs:
           cargo nextest run \
             --locked -p reth-node-optimism --features "optimism"
 
-  sync:
-    name: sync / 100k blocks
-    # Only run sync tests in merge groups
-    if: github.event_name == 'merge_group'
-    runs-on:
-      group: Reth
-    env:
-      RUST_LOG: info,sync=error
-      RUST_BACKTRACE: 1
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: Run sync
-        run: |
-          cargo run --release --features asm-keccak,jemalloc,min-error-logs --bin reth \
-            -- node \
-            --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
-            --debug.max-block 100000 \
-            --debug.terminate
-      - name: Verify the target block hash
-        run: |
-          cargo run --release --bin reth \
-            -- db get static-file headers 100000 \
-            | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
-      - name: Run stage unwind for 100 blocks
-        run: |
-          cargo run --release --bin reth \
-            -- stage unwind num-blocks 100
-
   integration-success:
     name: integration success
     runs-on: ubuntu-latest

--- a/.github/workflows/op-sync.yml
+++ b/.github/workflows/op-sync.yml
@@ -1,0 +1,51 @@
+# Runs a base mainnet sync test.
+
+name: op-sync-test
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: op sync / 100k blocks
+    # Only run sync tests in merge groups
+    if: github.event_name == 'merge_group'
+    runs-on:
+      group: Reth
+    env:
+      RUST_LOG: info,sync=error
+      RUST_BACKTRACE: 1
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run sync
+        run: |
+          cargo run --release --features asm-keccak,jemalloc,min-error-logs,optimism --bin op-reth \
+            -- node \
+            --chain base \
+            --debug.tip 0xbb9b85352c7ebca6ba8efc63bd66cecd038c92ec8ebd02e153a3e0b197e672b7 \ # https://basescan.org/block/10000
+            --debug.max-block 10000 \
+            --debug.terminate
+      - name: Verify the target block hash
+        run: |
+          cargo run --release --bin reth \
+            -- db get static-file headers 10000 \
+            | grep 0xbb9b85352c7ebca6ba8efc63bd66cecd038c92ec8ebd02e153a3e0b197e672b7
+      - name: Run stage unwind for 100 blocks
+        run: |
+          cargo run --release --bin reth \
+            -- stage unwind num-blocks 100


### PR DESCRIPTION
This uses base mainnet and syncs 10k blocks instead of 100k, closes https://github.com/paradigmxyz/reth/issues/9057

depends on https://github.com/paradigmxyz/reth/pull/9061