### PR TITLE
refactor(trie): add `From` implementations for `TrieKey` and `TrieOp`

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -5,7 +5,7 @@ use crate::{
     progress::{IntermediateStateRootState, StateRootProgress},
     stats::TrieTracker,
     trie_cursor::TrieCursorFactory,
-    updates::{TrieKey, TrieOp, TrieUpdates},
+    updates::{TrieOp, TrieUpdates},
     walker::TrieWalker,
     HashBuilder, Nibbles, TrieAccount,
 };
@@ -486,7 +486,7 @@ where
             return Ok((
                 EMPTY_ROOT_HASH,
                 0,
-                TrieUpdates::from([(TrieKey::StorageTrie(self.hashed_address), TrieOp::Delete)]),
+                TrieUpdates::from([(self.hashed_address.into(), TrieOp::Delete)]),
             ))
         }
 
@@ -548,6 +548,7 @@ mod tests {
     use crate::{
         prefix_set::PrefixSetMut,
         test_utils::{state_root, state_root_prehashed, storage_root, storage_root_prehashed},
+        updates::TrieKey,
         BranchNodeCompact, TrieMask,
     };
     use proptest::{prelude::ProptestConfig, proptest};

--- a/crates/trie/trie/src/trie_cursor/database_cursors.rs
+++ b/crates/trie/trie/src/trie_cursor/database_cursors.rs
@@ -57,7 +57,7 @@ where
 
     /// Retrieves the current key in the cursor.
     fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
-        Ok(self.0.current()?.map(|(k, _)| TrieKey::AccountNode(k)))
+        Ok(self.0.current()?.map(|(k, _)| k.into()))
     }
 }
 
@@ -106,7 +106,7 @@ where
 
     /// Retrieves the current value in the storage trie cursor.
     fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
-        Ok(self.cursor.current()?.map(|(k, v)| TrieKey::StorageNode(k, v.nibbles)))
+        Ok(self.cursor.current()?.map(|(k, v)| (k, v.nibbles).into()))
     }
 }
 


### PR DESCRIPTION
@mattsse let me know what you think about this, I had the impression that this simplification was missing, don't hesitate to close if you feel it's unneeded or unclear