### PR TITLE
feat: use a binary for sync tests

### DIFF
--- a/.github/workflows/eth-sync.yml
+++ b/.github/workflows/eth-sync.yml
@@ -32,19 +32,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Build reth
+        run: |
+          cargo install --features asm-keccak,jemalloc --path bin/reth
       - name: Run sync
         run: |
-          cargo run --release --features asm-keccak,jemalloc,min-error-logs --bin reth \
-            -- node \
+          reth node \
             --debug.tip 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4 \
             --debug.max-block 100000 \
             --debug.terminate
       - name: Verify the target block hash
         run: |
-          cargo run --release --bin reth \
-            -- db get static-file headers 100000 \
+          reth db get static-file headers 100000 \
             | grep 0x91c90676cab257a59cd956d7cb0bceb9b1a71d79755c23c7277a0697ccfaf8c4
       - name: Run stage unwind for 100 blocks
         run: |
-          cargo run --release --bin reth \
-            -- stage unwind num-blocks 100
+          reth stage unwind num-blocks 100

--- a/.github/workflows/op-sync.yml
+++ b/.github/workflows/op-sync.yml
@@ -32,21 +32,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Build op-reth
+        run: |
+          cargo install --features asm-keccak,jemalloc,optimism --bin op-reth --path bin/reth
       - name: Run sync
         # https://basescan.org/block/10000
         run: |
-          cargo run --release --features asm-keccak,jemalloc,min-error-logs,optimism --bin op-reth \
-            -- node \
+          op-reth node \
             --chain base \
             --debug.tip 0xbb9b85352c7ebca6ba8efc63bd66cecd038c92ec8ebd02e153a3e0b197e672b7 \
             --debug.max-block 10000 \
             --debug.terminate
       - name: Verify the target block hash
         run: |
-          cargo run --release --bin reth \
-            -- db get static-file headers 10000 \
+          op-reth db --chain base get static-file headers 100000 \
             | grep 0xbb9b85352c7ebca6ba8efc63bd66cecd038c92ec8ebd02e153a3e0b197e672b7
       - name: Run stage unwind for 100 blocks
         run: |
-          cargo run --release --bin reth \
-            -- stage unwind num-blocks 100
+          op-reth stage --chain base unwind num-blocks 100


### PR DESCRIPTION
Currently we have slightly different features for the `db get` part of these tests, and the actual sync. This means it spends some time rebuilding. Instead of using `cargo run`, we should just compile a binary and use that.

This also fixes an issue where `--chain base` was not specified in the op sync test