### PR TITLE
fix(ci): inherit profiling in bench profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,8 +235,12 @@ codegen-units = 16
 # e.g. `cargo build --profile profiling`
 [profile.profiling]
 inherits = "release"
-debug = 1
+debug = 2
 strip = false
+
+# Make sure debug symbols are in the bench profile
+[profile.bench]
+inherits = "profiling"
 
 [profile.maxperf]
 inherits = "release"


### PR DESCRIPTION
When benchmarking, I am usually also profiling. If not, maxperf should be used instead. This should also fix the recent CI failures on main.