### PR TITLE
chore(trie): add helpers to return trie keys as variants

### DIFF
--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -24,8 +24,8 @@ pub enum TrieKey {
 }
 
 impl TrieKey {
-    /// Returns reference to account node key if the key is for [Self::AccountNode].
-    pub fn as_account_node_key(&self) -> Option<&StoredNibbles> {
+    /// Returns reference to account node key if the key is for [`Self::AccountNode`].
+    pub const fn as_account_node_key(&self) -> Option<&StoredNibbles> {
         if let Self::AccountNode(nibbles) = &self {
             Some(nibbles)
         } else {
@@ -33,8 +33,8 @@ impl TrieKey {
         }
     }
 
-    /// Returns reference to storage node key if the key is for [Self::StorageNode].
-    pub fn as_storage_node_key(&self) -> Option<(&B256, &StoredNibblesSubKey)> {
+    /// Returns reference to storage node key if the key is for [`Self::StorageNode`].
+    pub const fn as_storage_node_key(&self) -> Option<(&B256, &StoredNibblesSubKey)> {
         if let Self::StorageNode(key, subkey) = &self {
             Some((key, subkey))
         } else {
@@ -42,8 +42,8 @@ impl TrieKey {
         }
     }
 
-    /// Returns reference to storage trie key if the key is for [Self::StorageTrie].
-    pub fn as_storage_trie_key(&self) -> Option<&B256> {
+    /// Returns reference to storage trie key if the key is for [`Self::StorageTrie`].
+    pub const fn as_storage_trie_key(&self) -> Option<&B256> {
         if let Self::StorageTrie(key) = &self {
             Some(key)
         } else {

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -23,6 +23,35 @@ pub enum TrieKey {
     StorageTrie(B256),
 }
 
+impl TrieKey {
+    /// Returns reference to account node key if the key is for [Self::AccountNode].
+    pub fn as_account_node_key(&self) -> Option<&StoredNibbles> {
+        if let Self::AccountNode(nibbles) = &self {
+            Some(nibbles)
+        } else {
+            None
+        }
+    }
+
+    /// Returns reference to storage node key if the key is for [Self::StorageNode].
+    pub fn as_storage_node_key(&self) -> Option<(&B256, &StoredNibblesSubKey)> {
+        if let Self::StorageNode(key, subkey) = &self {
+            Some((key, subkey))
+        } else {
+            None
+        }
+    }
+
+    /// Returns reference to storage trie key if the key is for [Self::StorageTrie].
+    pub fn as_storage_trie_key(&self) -> Option<&B256> {
+        if let Self::StorageTrie(key) = &self {
+            Some(key)
+        } else {
+            None
+        }
+    }
+}
+
 /// The operation to perform on the trie.
 #[derive(PartialEq, Eq, Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Description

Add helper methods to return trie keys as respective variants. Ref https://github.com/paradigmxyz/reth/pull/8199