### PR TITLE
chore(trie): `TrieOp::as_update`

### DIFF
--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -38,6 +38,15 @@ impl TrieOp {
     pub const fn is_update(&self) -> bool {
         matches!(self, Self::Update(..))
     }
+
+    /// Returns reference to updated branch node if operation is [`Self::Update`].
+    pub const fn as_update(&self) -> Option<&BranchNodeCompact> {
+        if let Self::Update(node) = &self {
+            Some(node)
+        } else {
+            None
+        }
+    }
 }
 
 /// The aggregation of trie updates.


### PR DESCRIPTION
## Description

Add helper to return updated node if `TrieOp` is an update. Ref #8199