### PR TITLE
feat: initial cli abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6706,6 +6706,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-cli"
+version = "1.0.0"
+
+[[package]]
 name = "reth-cli-commands"
 version = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/blockchain-tree/",
     "crates/blockchain-tree-api/",
     "crates/chainspec/",
+    "crates/cli/cli/",
     "crates/cli/commands/",
     "crates/cli/runner/",
     "crates/config/",
@@ -258,6 +259,7 @@ reth-beacon-consensus = { path = "crates/consensus/beacon" }
 reth-blockchain-tree = { path = "crates/blockchain-tree" }
 reth-blockchain-tree-api = { path = "crates/blockchain-tree-api" }
 reth-chainspec = { path = "crates/chainspec" }
+reth-cli = { path = "crates/cli/cli" }
 reth-cli-commands = { path = "crates/cli/commands" }
 reth-cli-runner = { path = "crates/cli/runner" }
 reth-codecs = { path = "crates/storage/codecs" }

--- a/crates/cli/cli/Cargo.toml
+++ b/crates/cli/cli/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "reth-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]

--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -1,0 +1,25 @@
+//! Cli abstraction for reth based nodes.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+use std::borrow::Cow;
+
+/// Reth based node cli.
+///
+/// This trait is supposed to be implemented by the main struct of the CLI.
+///
+/// It provides commonly used functionality for running commands and information about the CL, such
+/// as the name and version.
+pub trait RethCli: Sized {
+    /// The name of the implementation, eg. `reth`, `op-reth`, etc.
+    fn name(&self) -> Cow<'static, str>;
+
+    /// The version of the node, such as `reth/v1.0.0`
+    fn version(&self) -> Cow<'static, str>;
+}


### PR DESCRIPTION
towards #7576

defines the trait for a reth based cli.

this is required so that we can provide commonly used setups for running commands, display version etc...

this will allow us to move away from build scripts in node-core.


needs a ton of incremental followups, tracking in #7576