### PR TITLE
fix: do not drop sub protocol messages during EthStream Handshake

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1006,10 +1006,7 @@ async fn authenticate_stream(
         (eth_stream.into(), their_status)
     } else {
         // Multiplex the stream with the extra protocols
-        let (mut multiplex_stream, their_status) = RlpxProtocolMultiplexer::new(p2p_stream)
-            .into_eth_satellite_stream(status, fork_filter)
-            .await
-            .unwrap();
+        let mut multiplex_stream = RlpxProtocolMultiplexer::new(p2p_stream);
 
         // install additional handlers
         for handler in extra_handlers.into_iter() {
@@ -1021,6 +1018,9 @@ async fn authenticate_stream(
                 })
                 .ok();
         }
+
+        let (multiplex_stream, their_status) =
+            multiplex_stream.into_eth_satellite_stream(status, fork_filter).await.unwrap();
 
         (multiplex_stream.into(), their_status)
     };

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1020,7 +1020,17 @@ async fn authenticate_stream(
         }
 
         let (multiplex_stream, their_status) =
-            multiplex_stream.into_eth_satellite_stream(status, fork_filter).await.unwrap();
+            match multiplex_stream.into_eth_satellite_stream(status, fork_filter).await {
+                Ok((multiplex_stream, their_status)) => (multiplex_stream, their_status),
+                Err(err) => {
+                    return PendingSessionEvent::Disconnected {
+                        remote_addr,
+                        session_id,
+                        direction,
+                        error: Some(PendingSessionHandshakeError::Eth(err)),
+                    }
+                }
+            };
 
         (multiplex_stream.into(), their_status)
     };


### PR DESCRIPTION
The handshake occurs in `into_eth_satellite_stream() `. During this procedure, any messages not related to the primary protocol are delegated to the associated sub protocol via `delegate_message()`  here https://github.com/paradigmxyz/reth/blob/main/crates/net/eth-wire/src/multiplex.rs#L242-L250

However, `delegate_message()` will not yet contain any items in `self.protocols` since `install_protocol()` has not been called.

The changes in this PR install the sub protocols before the handshake happens.