### PR TITLE
chore(hive): enable discv5 hive tests

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -74,6 +74,8 @@ jobs:
         sim: [smoke/genesis, smoke/network]
         include:
           - sim: devp2p
+            limit: discv5
+          - sim: devp2p
             limit: discv4
           - sim: devp2p
             limit: eth


### PR DESCRIPTION
Enables discv5 hive tests, ref https://github.com/ethereum/hive/pull/1128#event-13279472446