### PR TITLE
fix: set finalized & safe block information on startup

### DIFF
--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -399,9 +399,15 @@ where
             )
             .expect("failed to create tree"),
         ));
-        let latest = self.base_config.chain_spec.genesis_header().seal_slow();
-        let blockchain_provider =
-            BlockchainProvider::with_latest(provider_factory.clone(), tree, latest);
+        let genesis_block = self.base_config.chain_spec.genesis_header().seal_slow();
+        let finalized_block = genesis_block.clone();
+
+        let blockchain_provider = BlockchainProvider::with_block_information(
+            provider_factory.clone(),
+            tree,
+            genesis_block,
+            finalized_block,
+        );
 
         let pruner = Pruner::<_, ProviderFactory<_>>::new(
             provider_factory.clone(),

--- a/crates/storage/provider/src/providers/chain_info.rs
+++ b/crates/storage/provider/src/providers/chain_info.rs
@@ -18,9 +18,10 @@ pub struct ChainInfoTracker {
 
 impl ChainInfoTracker {
     /// Create a new chain info container for the given canonical head.
-    pub fn new(head: SealedHeader) -> Self {
-        let (finalized_block, _) = watch::channel(None);
+    pub fn new(head: SealedHeader, finalized: SealedHeader) -> Self {
+        let (finalized_block, _) = watch::channel(Some(finalized));
         let (safe_block, _) = watch::channel(None);
+
         Self {
             inner: Arc::new(ChainInfoInner {
                 last_forkchoice_update: RwLock::new(None),

--- a/crates/storage/provider/src/providers/chain_info.rs
+++ b/crates/storage/provider/src/providers/chain_info.rs
@@ -19,8 +19,8 @@ pub struct ChainInfoTracker {
 impl ChainInfoTracker {
     /// Create a new chain info container for the given canonical head.
     pub fn new(head: SealedHeader, finalized: SealedHeader) -> Self {
-        let (finalized_block, _) = watch::channel(Some(finalized));
-        let (safe_block, _) = watch::channel(None);
+        let (finalized_block, _) = watch::channel(Some(finalized.clone()));
+        let (safe_block, _) = watch::channel(Some(finalized));
 
         Self {
             inner: Arc::new(ChainInfoInner {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -129,19 +129,19 @@ where
         let best: ChainInfo = provider.chain_info()?;
         let latest_header = provider
             .header_by_number(best.best_number)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(best.best_number.into()))?;
+            .ok_or(ProviderError::HeaderNotFound(best.best_number.into()))?;
 
         let finalized_block_number = provider.last_finalized_block_number()?;
         let finalized_header = provider
-            .header_by_number(finalized_block_number)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(finalized_block_number.into()))?;
+            .sealed_header(finalized_block_number)?
+            .ok_or(ProviderError::HeaderNotFound(finalized_block_number.into()))?;
 
         drop(provider);
         Ok(Self::with_block_information(
             database,
             tree,
             latest_header.seal(best.best_hash),
-            finalized_header.seal_slow(),
+            finalized_header,
         ))
     }
 }


### PR DESCRIPTION
### Description
Currently when you restart Reth, fetching blocks by `finalized` or `safe` block returns "block not found". This causes an issue when running op-reth via consensus layer sync, as it'll cause op-node to walk the chain back to genesis.

This PR loads the finalized block number from the database and initializes it on startup. It'll also set the safe block equal to the finalized value -- as the finalized block is also safe.

You can repro this bug on main with the following steps:

```
# set safe/finalized head via forkchoice update

# Fetch the finalized block
curl localhost:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getBlockByNumber","params":["finalized",false],"id":1,"jsonrpc":"2.0"}' | jq
{... block info}

# restart reth

# Fetch the finalized block
curl localhost:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getBlockByNumber","params":["finalized",false],"id":1,"jsonrpc":"2.0"}' | jq

{
  "jsonrpc": "2.0",
  "error": {
    "code": -39001,
    "message": "unknown block"
  },
  "id": 1
}
```