### PR TITLE
feat: scaffolding to support arbitrary rpc middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,6 +3039,7 @@ dependencies = [
  "reth-db",
  "reth-db-api",
  "reth-node-ethereum",
+ "reth-rpc-builder",
  "tokio",
 ]
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1131,7 +1131,7 @@ pub struct RpcServerConfig<RpcMiddleware = Identity> {
     ipc_endpoint: Option<String>,
     /// JWT secret for authentication
     jwt_secret: Option<JwtSecret>,
-    /// solala
+    /// Configurable middleware layer.
     rpc_middleware: Option<RpcServiceBuilder<RpcMiddleware>>,
 }
 

--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -21,12 +21,22 @@ use tower::Layer;
 /// - Request metrics: metrics for each RPC method (e.g. number of calls started, time taken to
 ///   process a call)
 #[derive(Default, Debug, Clone)]
-pub(crate) struct RpcRequestMetrics {
+#[allow(unreachable_pub)]
+pub struct RpcRequestMetrics {
     inner: Arc<RpcServerMetricsInner>,
 }
 
+#[allow(dead_code)]
 impl RpcRequestMetrics {
-    pub(crate) fn new(module: &RpcModule<()>, transport: RpcTransport) -> Self {
+    /// Creates a new `RpcRequestMetrics`.
+    ///
+    /// # Parameters
+    /// - `module`: The RPC module.
+    /// - `transport`: The transport protocol.
+    ///
+    /// # Returns
+    /// A new `RpcRequestMetrics` instance.
+    pub fn new(module: &RpcModule<()>, transport: RpcTransport) -> Self {
         Self {
             inner: Arc::new(RpcServerMetricsInner {
                 connection_metrics: transport.connection_metrics(),
@@ -38,25 +48,25 @@ impl RpcRequestMetrics {
     }
 
     /// Creates a new instance of the metrics layer for HTTP.
-    pub(crate) fn http(module: &RpcModule<()>) -> Self {
+    pub fn http(module: &RpcModule<()>) -> Self {
         Self::new(module, RpcTransport::Http)
     }
 
     /// Creates a new instance of the metrics layer for same port.
     ///
     /// Note: currently it's not possible to track transport specific metrics for a server that runs http and ws on the same port: <https://github.com/paritytech/jsonrpsee/issues/1345> until we have this feature we will use the http metrics for this case.
-    pub(crate) fn same_port(module: &RpcModule<()>) -> Self {
+    pub fn same_port(module: &RpcModule<()>) -> Self {
         Self::http(module)
     }
 
     /// Creates a new instance of the metrics layer for Ws.
-    pub(crate) fn ws(module: &RpcModule<()>) -> Self {
+    pub fn ws(module: &RpcModule<()>) -> Self {
         Self::new(module, RpcTransport::WebSocket)
     }
 
     /// Creates a new instance of the metrics layer for Ws.
     #[allow(unused)]
-    pub(crate) fn ipc(module: &RpcModule<()>) -> Self {
+    pub fn ipc(module: &RpcModule<()>) -> Self {
         Self::new(module, RpcTransport::Ipc)
     }
 }
@@ -81,8 +91,8 @@ struct RpcServerMetricsInner {
 /// A [`RpcServiceT`] middleware that captures RPC metrics for the server.
 ///
 /// This is created per connection and captures metrics for each request.
-#[derive(Clone)]
-pub(crate) struct RpcRequestMetricsService<S> {
+#[derive(Clone, Debug)]
+pub struct RpcRequestMetricsService<S> {
     metrics: RpcRequestMetrics,
     inner: S,
 }
@@ -125,7 +135,8 @@ impl<S> Drop for RpcRequestMetricsService<S> {
 
 /// Response future to update the metrics for a single request/response pair.
 #[pin_project::pin_project]
-pub(crate) struct MeteredRequestFuture<F> {
+#[allow(unreachable_pub)]
+pub struct MeteredRequestFuture<F> {
     #[pin]
     fut: F,
     /// time when the request started
@@ -174,7 +185,7 @@ impl<F: Future<Output = MethodResponse>> Future for MeteredRequestFuture<F> {
 
 /// The transport protocol used for the RPC connection.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub(crate) enum RpcTransport {
+pub enum RpcTransport {
     Http,
     WebSocket,
     #[allow(unused)]

--- a/examples/rpc-db/Cargo.toml
+++ b/examples/rpc-db/Cargo.toml
@@ -15,3 +15,4 @@ reth-db-api.workspace = true
 reth-node-ethereum.workspace = true
 tokio = { workspace = true, features = ["full"] }
 eyre.workspace = true
+reth-rpc-builder.workspace = true


### PR DESCRIPTION
the issue is fundamentally, that we need these trait bounds on a type that the server is able to start

```rust
RpcMiddleware: tower::Layer<RpcService> + Clone + Send + Sync + 'static,
for<'a> <RpcMiddleware as tower::Layer<RpcService>>::Service: Send + Sync + RpcServiceT<'a>,
```

but that the middleware implementations from tower are of this type (for example):

```rust
let middleware: RpcServiceBuilder<tower::layer::util::Stack<jsonrpsee::server::middleware::rpc::RpcLoggerLayer, Identity>> = RpcServiceBuilder::new().rpc_logger(1024); 
```

which doesn't support those trait bounds. 

<img width="1230" alt="Screenshot 2024-06-26 at 12 59 58 PM" src="https://github.com/paradigmxyz/reth/assets/9053984/c425a2fd-9000-4386-afb9-4edfa8826644">



---

In `examples/rpc-db/src/main.rs` I've tried to create a concrete implementation of a specific middleware, by extracting `RpcRequestMetrics` which is currently applied to all servers by default. It would look like this:

```rust
// Create the RpcServiceBuilder with RpcRequestMetrics
let middleware: RpcServiceBuilder<RpcRequestMetrics> = RpcServiceBuilder::new().layer(RpcRequestMetrics::default());

    // Start the server & keep it alive
    let server_args: RpcServerConfig<RpcRequestMetrics> =
        RpcServerConfig::http(Default::default())
        .with_http_address("0.0.0.0:8545".parse()?)
        .set_rpc_middleware(middleware);
    let _handle = server_args.start(server).await?;
    futures::future::pending::<()>().await;
```

This works if works if we don't enforce trait bounds on `RpcServerConfig`. 

---

In jsonrpsee there's a `TowerServiceBuilder` which has a [`set_rpc_middleware`](https://github.com/paritytech/jsonrpsee/blob/master/server/src/server.rs#L522-L529)  method which [doesn't enforce any trait bounds](https://github.com/paritytech/jsonrpsee/blob/master/server/src/server.rs#L232-L243) on the `RpcMiddleware` type. 

So they're able to call it [like this](https://github.com/paritytech/jsonrpsee/blob/master/examples/examples/jsonrpsee_as_service.rs#L212) in `examples/examples/jsonrpsee_as_service.rs`:

```rust
let mut svc = svc_builder.set_rpc_middleware(rpc_middleware).build(methods, stop_handle);
```
with a middleware parameter that's based on a `Stack`

```rust
let rpc_middleware: RpcServiceBuilder<tower::layer::util::Stack<jsonrpsee::server::middleware::rpc::RpcLoggerLayer, tower::layer::util::Identity>> = RpcServiceBuilder::new().rpc_logger(1024);
```

when we apply a trait bound to `RpcServerConfig` or the associated `start` methods, which we need in order to get them to compile, the compiler rejects code like this

```rust
// Create the RpcServiceBuilder with RpcRequestMetrics
let middleware: RpcServiceBuilder<RpcRequestMetrics> = RpcServiceBuilder::new().layer(RpcRequestMetrics::default());

    // Start the server & keep it alive
    let server_args: RpcServerConfig<RpcRequestMetrics> =
        RpcServerConfig::http(Default::default())
        .with_http_address("0.0.0.0:8545".parse()?)
        .set_rpc_middleware(middleware);
    let _handle = server_args.start(server).await?;
    futures::future::pending::<()>().await;
```

because the stack doesn't support the required trait bounds for a server to start

---

One idea I had to solve this was to create a function to convert `rpc_middleware: Option<RpcServiceBuilder<RpcMiddleware>>` into a type with the required trait bounds, something like this

```rust
fn ensure_layers<L, M>(builder: RpcServiceBuilder<L>, layer: M) -> RpcServiceBuilder<Stack<M, L>>
where
    M: tower::Layer<RpcService> + Clone + Send + Sync + 'static,
    for<'a> <M as tower::Layer<RpcService>>::Service: Send + Sync + RpcServiceT<'a>,
{
    builder.layer(layer)
}
```

but I'm not sure if that's a good idea or not.