### PR TITLE
feat: add temporary docker tag action

### DIFF
--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -1,0 +1,52 @@
+# Tags the given docker image as latest
+
+name: docker-tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Whether or not to perform a dry run'
+        required: true
+        default: 'warning'
+        type: boolean
+      tag:
+        description: 'The tag to push as latest'
+        required: true
+        default: 'warning'
+        type: string
+
+env:
+  REPO_NAME: ${{ github.repository_owner }}/reth
+  IMAGE_NAME: ${{ github.repository_owner }}/reth
+  OP_IMAGE_NAME: ${{ github.repository_owner }}/op-reth
+  CARGO_TERM_COLOR: always
+  DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reth
+  OP_DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/op-reth
+  DOCKER_USERNAME: ${{ github.actor }}
+
+jobs:
+  build:
+    name: build and push
+    runs-on: ubuntu-20.04
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to Docker
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
+      - name: Tag reth image as "latest"
+        run: |
+          docker pull ghcr.io/paradigmxyz/reth:${{ github.events.inputs.tag }}
+          docker tag ghcr.io/paradigmxyz/reth:${{ github.event.inputs.tag }} ghcr.io/paradigmxyz/reth:latest
+      - name: Tag op-reth image as "latest"
+        run: |
+          docker pull ghcr.io/paradigmxyz/op-reth:${{ github.events.inputs.tag }}
+          docker tag ghcr.io/paradigmxyz/op-reth:${{ github.event.inputs.tag }} ghcr.io/paradigmxyz/op-reth:latest
+      - name: Push all tags
+        if: ${{ github.event.inputs.dryRun }}
+        run: |
+          docker image push --all-tags ghcr.io/paradigmxyz/op-reth
+          docker image push --all-tags ghcr.io/paradigmxyz/reth

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -8,12 +8,11 @@ on:
       dryRun:
         description: 'Whether or not to perform a dry run'
         required: true
-        default: 'warning'
+        default: 'true'
         type: boolean
       tag:
         description: 'The tag to push as latest'
         required: true
-        default: 'warning'
         type: string
 
 env:
@@ -46,7 +45,7 @@ jobs:
           docker pull ghcr.io/paradigmxyz/op-reth:${{ github.events.inputs.tag }}
           docker tag ghcr.io/paradigmxyz/op-reth:${{ github.event.inputs.tag }} ghcr.io/paradigmxyz/op-reth:latest
       - name: Push all tags
-        if: ${{ github.event.inputs.dryRun }}
+        if: ${{ !github.event.inputs.dryRun }}
         run: |
           docker image push --all-tags ghcr.io/paradigmxyz/op-reth
           docker image push --all-tags ghcr.io/paradigmxyz/reth

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -38,14 +38,14 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
       - name: Tag reth image as "latest"
         run: |
-          docker pull ghcr.io/paradigmxyz/reth:${{ github.events.inputs.tag }}
-          docker tag ghcr.io/paradigmxyz/reth:${{ github.event.inputs.tag }} ghcr.io/paradigmxyz/reth:latest
+          docker pull ghcr.io/paradigmxyz/reth:${{ inputs.tag }}
+          docker tag ghcr.io/paradigmxyz/reth:${{ inputs.tag }} ghcr.io/paradigmxyz/reth:latest
       - name: Tag op-reth image as "latest"
         run: |
-          docker pull ghcr.io/paradigmxyz/op-reth:${{ github.events.inputs.tag }}
-          docker tag ghcr.io/paradigmxyz/op-reth:${{ github.event.inputs.tag }} ghcr.io/paradigmxyz/op-reth:latest
+          docker pull ghcr.io/paradigmxyz/op-reth:${{ inputs.tag }}
+          docker tag ghcr.io/paradigmxyz/op-reth:${{ inputs.tag }} ghcr.io/paradigmxyz/op-reth:latest
       - name: Push all tags
-        if: ${{ !github.event.inputs.dryRun }}
+        if: ${{ !inputs.dryRun }}
         run: |
           docker image push --all-tags ghcr.io/paradigmxyz/op-reth
           docker image push --all-tags ghcr.io/paradigmxyz/reth


### PR DESCRIPTION
Provides a github action that will tag a specific docker image as latest, with the option to do a dry run, which will tag the image but not push the tag.