### PR TITLE
fix: use 8 byte SHA in getClientVersionV1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,10 +1865,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-str"
-version = "0.5.7"
+name = "const_format"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -4499,6 +4514,21 @@ dependencies = [
  "digest 0.10.7",
  "sha3-asm",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -7525,7 +7555,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
  "clap",
- "const-str",
+ "const_format",
  "derive_more",
  "dirs-next",
  "eyre",
@@ -10343,6 +10373,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,6 +412,7 @@ aquamarine = "0.5"
 bytes = "1.5"
 bitflags = "2.4"
 clap = "4"
+const_format = { version = "0.2.32", features = ["rust_1_64"] }
 dashmap = "5.5"
 derive_more = "0.99.17"
 fdlimit = "0.3.0"

--- a/crates/node-core/Cargo.toml
+++ b/crates/node-core/Cargo.toml
@@ -58,7 +58,7 @@ eyre.workspace = true
 clap = { workspace = true, features = ["derive"] }
 humantime.workspace = true
 thiserror.workspace = true
-const-str = "0.5.6"
+const_format.workspace = true
 rand.workspace = true
 derive_more.workspace = true
 once_cell.workspace = true

--- a/crates/node-core/build.rs
+++ b/crates/node-core/build.rs
@@ -8,19 +8,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     EmitBuilder::builder()
         .git_describe(false, true, None)
         .git_dirty(true)
-        .git_sha(true)
+        .git_sha(false)
         .build_timestamp()
         .cargo_features()
         .cargo_target_triple()
         .emit_and_set()?;
 
     let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
 
     let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
     // > git describe --always --tags
     // if not on a tag: v0.2.0-beta.3-82-g1939939b
     // if on a tag: v0.2.0-beta.3
-    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha}"));
+    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
     let is_dev = is_dirty || not_on_tag;
     println!("cargo:rustc-env=RETH_VERSION_SUFFIX={}", if is_dev { "-dev" } else { "" });
     Ok(())

--- a/crates/node-core/src/metrics/version_metrics.rs
+++ b/crates/node-core/src/metrics/version_metrics.rs
@@ -1,13 +1,13 @@
 //! This exposes reth's version information over prometheus.
 
-use crate::version::build_profile_name;
+use crate::version::{build_profile_name, VERGEN_GIT_SHA};
 use metrics::gauge;
 
 const LABELS: [(&str, &str); 6] = [
     ("version", env!("CARGO_PKG_VERSION")),
     ("build_timestamp", env!("VERGEN_BUILD_TIMESTAMP")),
     ("cargo_features", env!("VERGEN_CARGO_FEATURES")),
-    ("git_sha", env!("VERGEN_GIT_SHA")),
+    ("git_sha", VERGEN_GIT_SHA),
     ("target_triple", env!("VERGEN_CARGO_TARGET_TRIPLE")),
     ("build_profile", build_profile_name()),
 ];

--- a/crates/node-core/src/version.rs
+++ b/crates/node-core/src/version.rs
@@ -14,11 +14,8 @@ pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The full SHA of the latest commit.
 pub const VERGEN_GIT_SHA_LONG: &str = env!("VERGEN_GIT_SHA");
 
-/// The 7 character short SHA of the latest commit.
-pub const VERGEN_GIT_SHA: &str = const_format::str_index!(VERGEN_GIT_SHA_LONG, ..7);
-
 /// The 8 character short SHA of the latest commit.
-pub const VERGEN_GIT_SHA_8_CHARS: &str = const_format::str_index!(VERGEN_GIT_SHA_LONG, ..8);
+pub const VERGEN_GIT_SHA: &str = const_format::str_index!(VERGEN_GIT_SHA_LONG, ..8);
 
 /// The build timestamp.
 pub const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
@@ -114,7 +111,7 @@ pub fn default_extradata() -> String {
 pub fn default_client_version() -> ClientVersion {
     ClientVersion {
         version: CARGO_PKG_VERSION.to_string(),
-        git_sha: VERGEN_GIT_SHA_8_CHARS.to_string(),
+        git_sha: VERGEN_GIT_SHA.to_string(),
         build_timestamp: VERGEN_BUILD_TIMESTAMP.to_string(),
     }
 }
@@ -125,7 +122,7 @@ pub(crate) const fn build_profile_name() -> &'static str {
     // `std::path::MAIN_SEPARATOR_STR`.
     const OUT_DIR: &str = env!("OUT_DIR");
     let unix_parts = const_format::str_split!(OUT_DIR, '/');
-    if unix_parts.len() > 0 {
+    if unix_parts.len() >= 4 {
         unix_parts[unix_parts.len() - 4]
     } else {
         let win_parts = const_format::str_split!(OUT_DIR, '\\');

--- a/crates/node-core/src/version.rs
+++ b/crates/node-core/src/version.rs
@@ -11,8 +11,14 @@ pub const NAME_CLIENT: &str = "Reth";
 /// The latest version from Cargo.toml.
 pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// The short SHA of the latest commit.
-pub const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA");
+/// The full SHA of the latest commit.
+pub const VERGEN_GIT_SHA_LONG: &str = env!("VERGEN_GIT_SHA");
+
+/// The 7 character short SHA of the latest commit.
+pub const VERGEN_GIT_SHA: &str = const_format::str_index!(VERGEN_GIT_SHA_LONG, ..7);
+
+/// The 8 character short SHA of the latest commit.
+pub const VERGEN_GIT_SHA_8_CHARS: &str = const_format::str_index!(VERGEN_GIT_SHA_LONG, ..8);
 
 /// The build timestamp.
 pub const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
@@ -27,11 +33,11 @@ pub const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
 /// ```text
 /// 0.1.0 (defa64b2)
 /// ```
-pub const SHORT_VERSION: &str = concat!(
+pub const SHORT_VERSION: &str = const_format::concatcp!(
     env!("CARGO_PKG_VERSION"),
     env!("RETH_VERSION_SUFFIX"),
     " (",
-    env!("VERGEN_GIT_SHA"),
+    VERGEN_GIT_SHA,
     ")"
 );
 
@@ -52,13 +58,13 @@ pub const SHORT_VERSION: &str = concat!(
 /// Build Features: jemalloc
 /// Build Profile: maxperf
 /// ```
-pub const LONG_VERSION: &str = const_str::concat!(
+pub const LONG_VERSION: &str = const_format::concatcp!(
     "Version: ",
     env!("CARGO_PKG_VERSION"),
     env!("RETH_VERSION_SUFFIX"),
     "\n",
     "Commit SHA: ",
-    env!("VERGEN_GIT_SHA"),
+    VERGEN_GIT_SHA_LONG,
     "\n",
     "Build Timestamp: ",
     env!("VERGEN_BUILD_TIMESTAMP"),
@@ -81,11 +87,11 @@ pub const LONG_VERSION: &str = const_str::concat!(
 /// reth/v{major}.{minor}.{patch}-{sha1}/{target}
 /// ```
 /// e.g.: `reth/v0.1.0-alpha.1-428a6dc2f/aarch64-apple-darwin`
-pub(crate) const P2P_CLIENT_VERSION: &str = concat!(
+pub(crate) const P2P_CLIENT_VERSION: &str = const_format::concatcp!(
     "reth/v",
     env!("CARGO_PKG_VERSION"),
     "-",
-    env!("VERGEN_GIT_SHA"),
+    VERGEN_GIT_SHA,
     "/",
     env!("VERGEN_CARGO_TARGET_TRIPLE")
 );
@@ -108,7 +114,7 @@ pub fn default_extradata() -> String {
 pub fn default_client_version() -> ClientVersion {
     ClientVersion {
         version: CARGO_PKG_VERSION.to_string(),
-        git_sha: VERGEN_GIT_SHA.to_string(),
+        git_sha: VERGEN_GIT_SHA_8_CHARS.to_string(),
         build_timestamp: VERGEN_BUILD_TIMESTAMP.to_string(),
     }
 }
@@ -118,9 +124,13 @@ pub(crate) const fn build_profile_name() -> &'static str {
     // We split on the path separator of the *host* machine, which may be different from
     // `std::path::MAIN_SEPARATOR_STR`.
     const OUT_DIR: &str = env!("OUT_DIR");
-    const SEP: char = if const_str::contains!(OUT_DIR, "/") { '/' } else { '\\' };
-    let parts = const_str::split!(OUT_DIR, SEP);
-    parts[parts.len() - 4]
+    let unix_parts = const_format::str_split!(OUT_DIR, '/');
+    if unix_parts.len() > 0 {
+        unix_parts[unix_parts.len() - 4]
+    } else {
+        let win_parts = const_format::str_split!(OUT_DIR, '\\');
+        win_parts[win_parts.len() - 4]
+    }
 }
 
 #[cfg(test)]

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -20,7 +20,7 @@ use reth_node_api::FullNodeTypes;
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
-    version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA_8_CHARS},
+    version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA},
 };
 use reth_node_events::{cl::ConsensusLayerHealthEvents, node};
 use reth_primitives::format_ether;
@@ -292,7 +292,7 @@ where
             code: CLIENT_CODE,
             name: NAME_CLIENT.to_string(),
             version: CARGO_PKG_VERSION.to_string(),
-            commit: VERGEN_GIT_SHA_8_CHARS.to_string(),
+            commit: VERGEN_GIT_SHA.to_string(),
         };
         let engine_api = EngineApi::new(
             ctx.blockchain_db().clone(),

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -20,7 +20,7 @@ use reth_node_api::FullNodeTypes;
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
-    version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA},
+    version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA_8_CHARS},
 };
 use reth_node_events::{cl::ConsensusLayerHealthEvents, node};
 use reth_primitives::format_ether;
@@ -292,7 +292,7 @@ where
             code: CLIENT_CODE,
             name: NAME_CLIENT.to_string(),
             version: CARGO_PKG_VERSION.to_string(),
-            commit: VERGEN_GIT_SHA.to_string(),
+            commit: VERGEN_GIT_SHA_8_CHARS.to_string(),
         };
         let engine_api = EngineApi::new(
             ctx.blockchain_db().clone(),

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,7 @@ allow = [
     "Unicode-DFS-2016",
     "Unlicense",
     "Unicode-3.0",
+    "Zlib",
     # https://github.com/briansmith/ring/issues/902
     "LicenseRef-ring",
     # https://github.com/rustls/webpki/blob/main/LICENSE ISC Style


### PR DESCRIPTION
Reth is currently returning a 7-byte commit hash in response to `engine_getClientVersionV1`. This causes Lighthouse to log a persistent warning:

> Jun 26 18:01:11.001 WARN Execution engine call failed            error: InvalidClientVersion("Input must be exactly 8 characters long (excluding any '0x' prefix)"), service: exec
Jun 26 18:01:11.001 WARN Failed to populate engine version cache, error: ApiError(InvalidClientVersion("Input must be exactly 8 characters long (excluding any '0x' prefix)")), service: beacon

I've fixed this by getting `vergen` to generate the long commit hash, and then using `const_format` macros to trim it to 7/8 bytes as appropriate. I'm assuming the 7-byte version hashes are desired for backwards-compatibility. If not, we could simplify things further by using 8-byte hashes everywhere.