### PR TITLE
refactor: clean-up discv5 configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7430,7 +7430,6 @@ dependencies = [
  "aquamarine",
  "backon",
  "confy",
- "discv5",
  "eyre",
  "fdlimit",
  "futures",

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -34,7 +34,7 @@ use reth_stages::{
 };
 use reth_static_file::StaticFileProducer;
 use reth_tasks::TaskExecutor;
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use tokio::sync::watch;
 use tracing::*;
 
@@ -128,13 +128,14 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
+            .network_config(
+                config,
+                provider_factory.chain_spec(),
+                secret_key,
+                default_peers_path,
+                None,
+            )
             .with_task_executor(Box::new(task_executor))
-            .listener_addr(SocketAddr::new(self.network.addr, self.network.port))
-            .discovery_addr(SocketAddr::new(
-                self.network.discovery.addr,
-                self.network.discovery.port,
-            ))
             .build(provider_factory)
             .start_network()
             .await?;

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -128,13 +128,7 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(
-                config,
-                provider_factory.chain_spec(),
-                secret_key,
-                default_peers_path,
-                None,
-            )
+            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
             .with_task_executor(Box::new(task_executor))
             .build(provider_factory)
             .start_network()

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -62,13 +62,7 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(
-                config,
-                provider_factory.chain_spec(),
-                secret_key,
-                default_peers_path,
-                None,
-            )
+            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
             .with_task_executor(Box::new(task_executor))
             .build(provider_factory)
             .start_network()

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -26,7 +26,7 @@ use reth_revm::database::StateProviderDatabase;
 use reth_stages::StageId;
 use reth_tasks::TaskExecutor;
 use reth_trie::{updates::TrieKey, StateRoot};
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use tracing::*;
 
 /// `reth debug in-memory-merkle` command
@@ -62,13 +62,14 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
+            .network_config(
+                config,
+                provider_factory.chain_spec(),
+                secret_key,
+                default_peers_path,
+                None,
+            )
             .with_task_executor(Box::new(task_executor))
-            .listener_addr(SocketAddr::new(self.network.addr, self.network.port))
-            .discovery_addr(SocketAddr::new(
-                self.network.discovery.addr,
-                self.network.discovery.port,
-            ))
             .build(provider_factory)
             .start_network()
             .await?;

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -67,13 +67,7 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(
-                config,
-                provider_factory.chain_spec(),
-                secret_key,
-                default_peers_path,
-                None,
-            )
+            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
             .with_task_executor(Box::new(task_executor))
             .build(provider_factory)
             .start_network()

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -30,7 +30,7 @@ use reth_stages::{
     ExecInput, Stage, StageCheckpoint,
 };
 use reth_tasks::TaskExecutor;
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use tracing::*;
 
 /// `reth debug merkle` command
@@ -67,13 +67,14 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
+            .network_config(
+                config,
+                provider_factory.chain_spec(),
+                secret_key,
+                default_peers_path,
+                None,
+            )
             .with_task_executor(Box::new(task_executor))
-            .listener_addr(SocketAddr::new(self.network.addr, self.network.port))
-            .discovery_addr(SocketAddr::new(
-                self.network.discovery.addr,
-                self.network.discovery.port,
-            ))
             .build(provider_factory)
             .start_network()
             .await?;

--- a/bin/reth/src/commands/debug_cmd/replay_engine.rs
+++ b/bin/reth/src/commands/debug_cmd/replay_engine.rs
@@ -27,7 +27,7 @@ use reth_stages::Pipeline;
 use reth_static_file::StaticFileProducer;
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::noop::NoopTransactionPool;
-use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::sync::oneshot;
 use tracing::*;
 
@@ -63,13 +63,14 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
+            .network_config(
+                config,
+                provider_factory.chain_spec(),
+                secret_key,
+                default_peers_path,
+                None,
+            )
             .with_task_executor(Box::new(task_executor))
-            .listener_addr(SocketAddr::new(self.network.addr, self.network.port))
-            .discovery_addr(SocketAddr::new(
-                self.network.discovery.addr,
-                self.network.discovery.port,
-            ))
             .build(provider_factory)
             .start_network()
             .await?;

--- a/bin/reth/src/commands/debug_cmd/replay_engine.rs
+++ b/bin/reth/src/commands/debug_cmd/replay_engine.rs
@@ -63,13 +63,7 @@ impl Command {
         let secret_key = get_secret_key(&network_secret_path)?;
         let network = self
             .network
-            .network_config(
-                config,
-                provider_factory.chain_spec(),
-                secret_key,
-                default_peers_path,
-                None,
-            )
+            .network_config(config, provider_factory.chain_spec(), secret_key, default_peers_path)
             .with_task_executor(Box::new(task_executor))
             .build(provider_factory)
             .start_network()

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -4,13 +4,12 @@ use crate::{
     args::{
         get_secret_key,
         utils::{chain_help, chain_value_parser, hash_or_num_value_parser, SUPPORTED_CHAINS},
-        DatabaseArgs, DiscoveryArgs, NetworkArgs,
+        DatabaseArgs, NetworkArgs,
     },
     utils::get_single_header,
 };
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
-use discv5::ListenConfig;
 use reth_chainspec::ChainSpec;
 use reth_config::Config;
 use reth_db::create_db;
@@ -19,11 +18,7 @@ use reth_network_p2p::bodies::client::BodiesClient;
 use reth_node_core::args::DatadirArgs;
 use reth_primitives::BlockHashOrNumber;
 use reth_provider::{providers::StaticFileProvider, ProviderFactory};
-use std::{
-    net::{IpAddr, SocketAddrV4, SocketAddrV6},
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 
 /// `reth p2p` command
 #[derive(Debug, Parser)]
@@ -113,47 +108,7 @@ impl Command {
             .disable_discv4_discovery_if(self.chain.chain.is_optimism())
             .boot_nodes(boot_nodes.clone())
             .apply(|builder| {
-                self.network
-                    .discovery
-                    .apply_to_builder(builder, rlpx_socket)
-                    .map_discv5_config_builder(|builder| {
-                        let DiscoveryArgs {
-                            discv5_addr,
-                            discv5_addr_ipv6,
-                            discv5_port,
-                            discv5_port_ipv6,
-                            discv5_lookup_interval,
-                            discv5_bootstrap_lookup_interval,
-                            discv5_bootstrap_lookup_countdown,
-                            ..
-                        } = self.network.discovery;
-
-                        // Use rlpx address if none given
-                        let discv5_addr_ipv4 = discv5_addr.or(match self.network.addr {
-                            IpAddr::V4(ip) => Some(ip),
-                            IpAddr::V6(_) => None,
-                        });
-                        let discv5_addr_ipv6 = discv5_addr_ipv6.or(match self.network.addr {
-                            IpAddr::V4(_) => None,
-                            IpAddr::V6(ip) => Some(ip),
-                        });
-
-                        builder
-                            .discv5_config(
-                                discv5::ConfigBuilder::new(ListenConfig::from_two_sockets(
-                                    discv5_addr_ipv4
-                                        .map(|addr| SocketAddrV4::new(addr, discv5_port)),
-                                    discv5_addr_ipv6.map(|addr| {
-                                        SocketAddrV6::new(addr, discv5_port_ipv6, 0, 0)
-                                    }),
-                                ))
-                                .build(),
-                            )
-                            .add_unsigned_boot_nodes(boot_nodes.into_iter())
-                            .lookup_interval(discv5_lookup_interval)
-                            .bootstrap_lookup_interval(discv5_bootstrap_lookup_interval)
-                            .bootstrap_lookup_countdown(discv5_bootstrap_lookup_countdown)
-                    })
+                self.network.discovery.apply_to_builder(builder, rlpx_socket, boot_nodes, 1)
             })
             .build(Arc::new(ProviderFactory::new(
                 noop_db,

--- a/bin/reth/src/commands/p2p/mod.rs
+++ b/bin/reth/src/commands/p2p/mod.rs
@@ -108,7 +108,7 @@ impl Command {
             .disable_discv4_discovery_if(self.chain.chain.is_optimism())
             .boot_nodes(boot_nodes.clone())
             .apply(|builder| {
-                self.network.discovery.apply_to_builder(builder, rlpx_socket, boot_nodes, 1)
+                self.network.discovery.apply_to_builder(builder, rlpx_socket, boot_nodes)
             })
             .build(Arc::new(ProviderFactory::new(
                 noop_db,

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -141,6 +141,7 @@ impl Command {
                             provider_factory.chain_spec(),
                             p2p_secret_key,
                             default_peers_path,
+                            None,
                         )
                         .build(provider_factory.clone())
                         .start_network()

--- a/bin/reth/src/commands/stage/run.rs
+++ b/bin/reth/src/commands/stage/run.rs
@@ -141,7 +141,6 @@ impl Command {
                             provider_factory.chain_spec(),
                             p2p_secret_key,
                             default_peers_path,
-                            None,
                         )
                         .build(provider_factory.clone())
                         .start_network()

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -411,36 +411,6 @@ impl NetworkConfigBuilder {
         }
     }
 
-    /// Calls a closure on [`reth_discv5::ConfigBuilder`], if discv5 discovery is enabled and the
-    /// builder has been set.
-    /// ```
-    /// use reth_chainspec::MAINNET;
-    /// use reth_network::NetworkConfigBuilder;
-    /// use reth_provider::test_utils::NoopProvider;
-    /// use secp256k1::{rand::thread_rng, SecretKey};
-    ///
-    /// let sk = SecretKey::new(&mut thread_rng());
-    /// let fork_id = MAINNET.latest_fork_id();
-    /// let network_config = NetworkConfigBuilder::new(sk)
-    ///     .map_discv5_config_builder(|builder| builder.fork(b"eth", fork_id))
-    ///     .build(NoopProvider::default());
-    /// ```
-    pub fn map_discv5_config_builder(
-        mut self,
-        f: impl FnOnce(reth_discv5::ConfigBuilder) -> reth_discv5::ConfigBuilder,
-    ) -> Self {
-        if let Some(mut builder) = self.discovery_v5_builder {
-            if let Some(network_stack_id) = NetworkStackId::id(&self.chain_spec) {
-                let fork_id = self.chain_spec.latest_fork_id();
-                builder = builder.fork(network_stack_id, fork_id);
-            }
-
-            self.discovery_v5_builder = Some(f(builder));
-        }
-
-        self
-    }
-
     /// Adds a new additional protocol to the `RLPx` sub-protocol list.
     pub fn add_rlpx_sub_protocol(mut self, protocol: impl IntoRlpxSubProtocol) -> Self {
         self.extra_protocols.push(protocol);
@@ -480,7 +450,7 @@ impl NetworkConfigBuilder {
             secret_key,
             mut dns_discovery_config,
             discovery_v4_builder,
-            discovery_v5_builder,
+            mut discovery_v5_builder,
             boot_nodes,
             discovery_addr,
             listener_addr,
@@ -496,6 +466,15 @@ impl NetworkConfigBuilder {
             block_import,
             transactions_manager_config,
         } = self;
+
+        discovery_v5_builder = discovery_v5_builder.map(|mut builder| {
+            if let Some(network_stack_id) = NetworkStackId::id(&chain_spec) {
+                let fork_id = chain_spec.latest_fork_id();
+                builder = builder.fork(network_stack_id, fork_id)
+            }
+
+            builder
+        });
 
         let listener_addr = listener_addr.unwrap_or(DEFAULT_DISCOVERY_ADDRESS);
 

--- a/crates/node-core/src/node_config.rs
+++ b/crates/node-core/src/node_config.rs
@@ -390,6 +390,7 @@ impl NodeConfig {
     /// [`RpcServerArgs::adjust_instance_ports`] method.
     pub fn adjust_instance_ports(&mut self) {
         self.rpc.adjust_instance_ports(self.instance);
+        self.network.adjust_instance_ports(self.instance);
     }
 
     /// Sets networking and RPC ports to zero, causing the OS to choose random unused ports when

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -56,9 +56,6 @@ tokio = { workspace = true, features = [
 ] }
 tokio-stream.workspace = true
 
-## ethereum
-discv5.workspace = true
-
 ## crypto
 secp256k1 = { workspace = true, features = [
     "global-context",

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -534,7 +534,6 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
                 self.config().chain.clone(),
                 secret_key,
                 default_peers_path,
-                None,
             )
             .with_task_executor(Box::new(self.executor.clone()))
             .set_head(self.head);

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -251,7 +251,7 @@ impl<R> LaunchContextWith<Attached<WithConfigs, R>> {
     /// - Making sure the ETL dir is set to the datadir
     /// - RPC settings are adjusted to the correct port
     pub fn with_adjusted_configs(self) -> Self {
-        self.ensure_etl_datadir().with_adjusted_rpc_instance_ports()
+        self.ensure_etl_datadir().with_adjusted_instance_ports()
     }
 
     /// Make sure ETL doesn't default to /tmp/, but to whatever datadir is set to
@@ -265,7 +265,7 @@ impl<R> LaunchContextWith<Attached<WithConfigs, R>> {
     }
 
     /// Change rpc port numbers based on the instance number.
-    pub fn with_adjusted_rpc_instance_ports(mut self) -> Self {
+    pub fn with_adjusted_instance_ports(mut self) -> Self {
         self.node_config_mut().adjust_instance_ports();
         self
     }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -290,7 +290,6 @@ where
                     builder = builder.discovery_v5(args.discovery.discovery_v5_builder(
                         rlpx_socket,
                         ctx.chain_spec().bootnodes().unwrap_or_default(),
-                        ctx.config().instance,
                     ));
                 }
 

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -283,27 +283,18 @@ where
             // purposefully disable discv4
             .disable_discv4_discovery()
             // apply discovery settings
-            .apply(|builder| {
+            .apply(|mut builder| {
                 let rlpx_socket = (args.addr, args.port).into();
-                let mut builder = args.discovery.apply_to_builder(builder, rlpx_socket);
 
                 if !args.discovery.disable_discovery {
-                    builder = builder.discovery_v5(reth_discv5::Config::builder(rlpx_socket));
+                    builder = builder.discovery_v5(args.discovery.discovery_v5_builder(
+                        rlpx_socket,
+                        ctx.chain_spec().bootnodes().unwrap_or_default(),
+                        ctx.config().instance,
+                    ));
                 }
 
                 builder
-            })
-            // ensure we configure discv5
-            .map_discv5_config_builder(|builder| {
-                builder
-                    .add_unsigned_boot_nodes(ctx.chain_spec().bootnodes().unwrap_or_default())
-                    .lookup_interval(ctx.config().network.discovery.discv5_lookup_interval)
-                    .bootstrap_lookup_interval(
-                        ctx.config().network.discovery.discv5_bootstrap_lookup_interval,
-                    )
-                    .bootstrap_lookup_countdown(
-                        ctx.config().network.discovery.discv5_bootstrap_lookup_countdown,
-                    )
             });
 
         let mut network_config = ctx.build_network_config(network_builder);


### PR DESCRIPTION
Closes #9060 

`NetworkArgs` keeps most of the `NetworkConfig` parameters, so I've moved some duplicating code into `NetworkArgs::network_config` which now produces default `NetworkConfigBuilder` for both standalone commands and `BuilderContext`

Also, discv5 configuration is moved into `DiscoveryArgs::discovery_v5_builder` which now accepts optional `instance` and adjusts ports accordingly. This was the only usecase for `map_discv5_builder_config`, so this fn is now removed.