### PR TITLE
chore: rename `TrieCursorFactory::storage_tries_cursor` to `TrieCursorFactory::storage_trie_cursor`

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -491,7 +491,7 @@ where
         }
 
         let mut tracker = TrieTracker::default();
-        let trie_cursor = self.trie_cursor_factory.storage_tries_cursor(self.hashed_address)?;
+        let trie_cursor = self.trie_cursor_factory.storage_trie_cursor(self.hashed_address)?;
         let walker = TrieWalker::new(trie_cursor, self.prefix_set).with_updates(retain_updates);
 
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);

--- a/crates/trie/trie/src/trie_cursor/database_cursors.rs
+++ b/crates/trie/trie/src/trie_cursor/database_cursors.rs
@@ -13,7 +13,7 @@ impl<'a, TX: DbTx> TrieCursorFactory for &'a TX {
         Ok(Box::new(DatabaseAccountTrieCursor::new(self.cursor_read::<tables::AccountsTrie>()?)))
     }
 
-    fn storage_tries_cursor(
+    fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Box<dyn TrieCursor + '_>, DatabaseError> {

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -18,7 +18,7 @@ pub trait TrieCursorFactory {
     fn account_trie_cursor(&self) -> Result<Box<dyn TrieCursor + '_>, DatabaseError>;
 
     /// Create a storage tries cursor.
-    fn storage_tries_cursor(
+    fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Box<dyn TrieCursor + '_>, DatabaseError>;

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -1,6 +1,7 @@
 use super::{TrieCursor, TrieCursorFactory};
 use crate::{updates::TrieKey, BranchNodeCompact, Nibbles};
 use reth_db::DatabaseError;
+use reth_primitives::B256;
 
 /// Noop trie cursor factory.
 #[derive(Default, Debug)]
@@ -14,9 +15,9 @@ impl TrieCursorFactory for NoopTrieCursorFactory {
     }
 
     /// Generates a Noop storage trie cursor.
-    fn storage_tries_cursor(
+    fn storage_trie_cursor(
         &self,
-        _hashed_address: reth_primitives::B256,
+        _hashed_address: B256,
     ) -> Result<Box<dyn TrieCursor + '_>, DatabaseError> {
         Ok(Box::<NoopStorageTrieCursor>::default())
     }


### PR DESCRIPTION
## Description

Rename storage trie cursor creation method as it creates a cursor over a single storage trie for the specified hashed address.