### PR TITLE
chore: remove `tx_env_with_recovered` from rpc crates

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -111,7 +111,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
     /// Returns a [`TxEnv`] from a [`TransactionSignedEcRecovered`].
     fn tx_env(&self, transaction: &TransactionSignedEcRecovered) -> TxEnv {
         let mut tx_env = TxEnv::default();
-        fill_tx_env(&mut tx_env, transaction.deref(), transaction.signer());
+        self.fill_tx_env(&mut tx_env, transaction.deref(), transaction.signer());
         tx_env
     }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -12,10 +12,12 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+use core::ops::Deref;
+
 use reth_chainspec::ChainSpec;
 use reth_primitives::{
     revm::env::{fill_block_env, fill_tx_env},
-    Address, Header, TransactionSigned, U256,
+    Address, Header, TransactionSigned, TransactionSignedEcRecovered, U256,
 };
 use revm::{inspector_handle_register, Database, Evm, EvmBuilder, GetInspector};
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, SpecId, TxEnv};
@@ -106,6 +108,13 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
 /// Default trait method  implementation is done w.r.t. L1.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
+    /// Returns a [`TxEnv`] from a [`TransactionSignedEcRecovered`].
+    fn tx_env(&self, transaction: &TransactionSignedEcRecovered) -> TxEnv {
+        let mut tx_env = TxEnv::default();
+        fill_tx_env(&mut tx_env, transaction.deref(), transaction.signer());
+        tx_env
+    }
+
     /// Fill transaction environment from a [`TransactionSigned`] and the given sender address.
     fn fill_tx_env(&self, tx_env: &mut TxEnv, transaction: &TransactionSigned, sender: Address) {
         fill_tx_env(tx_env, transaction, sender)

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -4,7 +4,6 @@
 use futures::Future;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
-    revm::env::tx_env_with_recovered,
     revm_primitives::{
         BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ExecutionResult, HaltReason,
         ResultAndState, TransactTo,
@@ -30,6 +29,7 @@ use reth_rpc_types::{
 };
 use revm::{Database, DatabaseCommit};
 use revm_inspectors::access_list::AccessListInspector;
+use revm_primitives::TxEnv;
 use tracing::trace;
 
 use super::{LoadBlock, LoadPendingBlock, LoadState, LoadTransaction, SpawnBlocking, Trace};
@@ -119,9 +119,14 @@ pub trait EthCall: Call + LoadPendingBlock {
                     // to be replayed
                     let transactions = block.into_transactions_ecrecovered().take(num_txs);
                     for tx in transactions {
-                        let tx = tx_env_with_recovered(&tx);
-                        let env =
-                            EnvWithHandlerCfg::new_with_cfg_env(cfg.clone(), block_env.clone(), tx);
+                        let mut tx_env = TxEnv::default();
+                        let signer = tx.signer();
+                        Call::evm_config(&this).fill_tx_env(&mut tx_env, &tx.into_signed(), signer);
+                        let env = EnvWithHandlerCfg::new_with_cfg_env(
+                            cfg.clone(),
+                            block_env.clone(),
+                            tx_env,
+                        );
                         let (res, _) = this.transact(&mut db, env)?;
                         db.commit(res.state);
                     }
@@ -422,8 +427,11 @@ pub trait Call: LoadState + SpawnBlocking {
                     tx.hash,
                 )?;
 
-                let env =
-                    EnvWithHandlerCfg::new_with_cfg_env(cfg, block_env, tx_env_with_recovered(&tx));
+                let mut tx_env = TxEnv::default();
+                let signer = tx.signer();
+                Call::evm_config(&this).fill_tx_env(&mut tx_env, &tx.into_signed(), signer);
+
+                let env = EnvWithHandlerCfg::new_with_cfg_env(cfg, block_env, tx_env);
 
                 let (res, _) = this.transact(&mut db, env)?;
                 f(tx_info, res, db)

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -293,7 +293,7 @@ pub trait LoadPendingBlock {
 
             let mut tx_env = TxEnv::default();
             let signer = tx.signer();
-            Self::evm_config(&self).fill_tx_env(&mut tx_env, &tx.clone().into_signed(), signer);
+            Self::evm_config(self).fill_tx_env(&mut tx_env, &tx.clone().into_signed(), signer);
 
             // Configure the environment for the block.
             let env = Env::boxed(cfg.cfg_env.clone(), block_env.clone(), tx_env);

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -30,7 +30,6 @@ use reth_rpc_eth_types::{
 };
 use reth_transaction_pool::{BestTransactionsAttributes, TransactionPool};
 use revm::{db::states::bundle_state::BundleRetention, DatabaseCommit, State};
-use revm_primitives::TxEnv;
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -291,12 +290,12 @@ pub trait LoadPendingBlock {
                 }
             }
 
-            let mut tx_env = TxEnv::default();
-            let signer = tx.signer();
-            Self::evm_config(self).fill_tx_env(&mut tx_env, &tx.clone().into_signed(), signer);
-
             // Configure the environment for the block.
-            let env = Env::boxed(cfg.cfg_env.clone(), block_env.clone(), tx_env);
+            let env = Env::boxed(
+                cfg.cfg_env.clone(),
+                block_env.clone(),
+                Self::evm_config(self).tx_env(&tx),
+            );
 
             let mut evm = revm::Evm::builder().with_env(env).with_db(&mut db).build();
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -6,11 +6,12 @@ use reth_chainspec::EthereumHardforks;
 use reth_consensus_common::calc::{
     base_block_reward, base_block_reward_pre_merge, block_reward, ommer_reward,
 };
-use reth_primitives::{revm::env::tx_env_with_recovered, BlockId, Bytes, Header, B256, U256};
+use reth_evm::ConfigureEvmEnv;
+use reth_primitives::{BlockId, Bytes, Header, B256, U256};
 use reth_provider::{BlockReader, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::TraceApiServer;
-use reth_rpc_eth_api::helpers::TraceExt;
+use reth_rpc_eth_api::helpers::{Call, TraceExt};
 use reth_rpc_eth_types::{
     error::{EthApiError, EthResult},
     revm_utils::prepare_call_env,
@@ -35,6 +36,7 @@ use revm_inspectors::{
     opcode::OpcodeGasInspector,
     tracing::{parity::populate_state_diff, TracingInspector, TracingInspectorConfig},
 };
+use revm_primitives::TxEnv;
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 
 /// `trace` API implementation.
@@ -113,8 +115,16 @@ where
         let tx = recover_raw_transaction(tx)?;
 
         let (cfg, block, at) = self.inner.eth_api.evm_env_at(block_id.unwrap_or_default()).await?;
-        let tx = tx_env_with_recovered(&tx.into_ecrecovered_transaction());
-        let env = EnvWithHandlerCfg::new_with_cfg_env(cfg, block, tx);
+
+        let mut tx_env = TxEnv::default();
+        let signer = tx.signer();
+        Call::evm_config(self.eth_api()).fill_tx_env(
+            &mut tx_env,
+            &tx.into_ecrecovered_transaction().into_signed(),
+            signer,
+        );
+
+        let env = EnvWithHandlerCfg::new_with_cfg_env(cfg, block, tx_env);
 
         let config = TracingInspectorConfig::from_parity_config(&trace_types);
 


### PR DESCRIPTION
Follow-up should delete it entirely