### PR TITLE
chore(trie): remove database-related types from trie keys

### DIFF
--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -196,7 +196,7 @@ impl Command {
                 (Some(in_mem), Some(incr)) => {
                     similar_asserts::assert_eq!(in_mem.0, incr.0, "Nibbles don't match");
                     if in_mem.1 != incr.1 &&
-                        matches!(in_mem.0, TrieKey::AccountNode(ref nibbles) if nibbles.0.len() > self.skip_node_depth.unwrap_or_default())
+                        matches!(in_mem.0, TrieKey::AccountNode(ref nibbles) if nibbles.len() > self.skip_node_depth.unwrap_or_default())
                     {
                         in_mem_mismatched.push(in_mem);
                         incremental_mismatched.push(incr);

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -1208,7 +1208,7 @@ mod tests {
             .iter()
             .filter_map(|entry| match entry {
                 (TrieKey::AccountNode(nibbles), TrieOp::Update(node)) => {
-                    Some((nibbles.0.clone(), node.clone()))
+                    Some((nibbles.clone(), node.clone()))
                 }
                 _ => None,
             })
@@ -1295,7 +1295,7 @@ mod tests {
             .iter()
             .filter_map(|entry| match entry {
                 (TrieKey::StorageNode(_, nibbles), TrieOp::Update(node)) => {
-                    Some((nibbles.0.clone(), node.clone()))
+                    Some((nibbles.clone(), node.clone()))
                 }
                 _ => None,
             })

--- a/crates/trie/trie/src/trie_cursor/database_cursors.rs
+++ b/crates/trie/trie/src/trie_cursor/database_cursors.rs
@@ -61,7 +61,7 @@ where
 
     /// Retrieves the current key in the cursor.
     fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
-        Ok(self.0.current()?.map(|(k, _)| TrieKey::AccountNode(k)))
+        Ok(self.0.current()?.map(|(k, _)| TrieKey::AccountNode(k.0)))
     }
 }
 
@@ -110,7 +110,7 @@ where
 
     /// Retrieves the current value in the storage trie cursor.
     fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
-        Ok(self.cursor.current()?.map(|(k, v)| TrieKey::StorageNode(k, v.nibbles)))
+        Ok(self.cursor.current()?.map(|(k, v)| TrieKey::StorageNode(k, v.nibbles.0)))
     }
 }
 

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -16,16 +16,16 @@ use std::collections::{hash_map::IntoIter, HashMap, HashSet};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TrieKey {
     /// A node in the account trie.
-    AccountNode(StoredNibbles),
+    AccountNode(Nibbles),
     /// A node in the storage trie.
-    StorageNode(B256, StoredNibblesSubKey),
+    StorageNode(B256, Nibbles),
     /// Storage trie of an account.
     StorageTrie(B256),
 }
 
 impl TrieKey {
     /// Returns reference to account node key if the key is for [`Self::AccountNode`].
-    pub const fn as_account_node_key(&self) -> Option<&StoredNibbles> {
+    pub const fn as_account_node_key(&self) -> Option<&Nibbles> {
         if let Self::AccountNode(nibbles) = &self {
             Some(nibbles)
         } else {
@@ -34,7 +34,7 @@ impl TrieKey {
     }
 
     /// Returns reference to storage node key if the key is for [`Self::StorageNode`].
-    pub const fn as_storage_node_key(&self) -> Option<(&B256, &StoredNibblesSubKey)> {
+    pub const fn as_storage_node_key(&self) -> Option<(&B256, &Nibbles)> {
         if let Self::StorageNode(key, subkey) = &self {
             Some((key, subkey))
         } else {
@@ -179,18 +179,21 @@ impl TrieUpdates {
         trie_operations.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         for (key, operation) in trie_operations {
             match key {
-                TrieKey::AccountNode(nibbles) => match operation {
-                    TrieOp::Delete => {
-                        if account_trie_cursor.seek_exact(nibbles)?.is_some() {
-                            account_trie_cursor.delete_current()?;
+                TrieKey::AccountNode(nibbles) => {
+                    let nibbles = StoredNibbles(nibbles);
+                    match operation {
+                        TrieOp::Delete => {
+                            if account_trie_cursor.seek_exact(nibbles)?.is_some() {
+                                account_trie_cursor.delete_current()?;
+                            }
+                        }
+                        TrieOp::Update(node) => {
+                            if !nibbles.0.is_empty() {
+                                account_trie_cursor.upsert(nibbles, StoredBranchNode(node))?;
+                            }
                         }
                     }
-                    TrieOp::Update(node) => {
-                        if !nibbles.0.is_empty() {
-                            account_trie_cursor.upsert(nibbles, StoredBranchNode(node))?;
-                        }
-                    }
-                },
+                }
                 TrieKey::StorageTrie(hashed_address) => match operation {
                     TrieOp::Delete => {
                         if storage_trie_cursor.seek_exact(hashed_address)?.is_some() {
@@ -201,6 +204,7 @@ impl TrieUpdates {
                 },
                 TrieKey::StorageNode(hashed_address, nibbles) => {
                     if !nibbles.is_empty() {
+                        let nibbles = StoredNibblesSubKey(nibbles);
                         // Delete the old entry if it exists.
                         if storage_trie_cursor
                             .seek_by_key_subkey(hashed_address, nibbles.clone())?
@@ -250,7 +254,7 @@ impl TrieUpdatesSorted {
     pub fn find_account_node(&self, key: &Nibbles) -> Option<(TrieKey, TrieOp)> {
         self.trie_operations
             .iter()
-            .find(|(k, _)| matches!(k, TrieKey::AccountNode(nibbles) if &nibbles.0 == key))
+            .find(|(k, _)| matches!(k, TrieKey::AccountNode(nibbles) if nibbles == key))
             .cloned()
     }
 
@@ -261,7 +265,7 @@ impl TrieUpdatesSorted {
         key: &Nibbles,
     ) -> Option<(TrieKey, TrieOp)> {
         self.trie_operations.iter().find(|(k, _)| {
-            matches!(k, TrieKey::StorageNode(address, nibbles) if address == hashed_address && &nibbles.0 == key)
+            matches!(k, TrieKey::StorageNode(address, nibbles) if address == hashed_address && nibbles == key)
         }).cloned()
     }
 }

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -121,9 +121,9 @@ impl TrieUpdates {
     /// Extend the updates with account trie updates.
     pub fn extend_with_account_updates(&mut self, updates: HashMap<Nibbles, BranchNodeCompact>) {
         self.extend(
-            updates.into_iter().map(|(nibbles, node)| {
-                (TrieKey::AccountNode(nibbles.into()), TrieOp::Update(node))
-            }),
+            updates
+                .into_iter()
+                .map(|(nibbles, node)| (TrieKey::AccountNode(nibbles), TrieOp::Update(node))),
         );
     }
 
@@ -162,7 +162,7 @@ impl TrieUpdates {
         // Add storage node updates from hash builder.
         let (_, hash_builder_updates) = hash_builder.split();
         self.extend(hash_builder_updates.into_iter().map(|(nibbles, node)| {
-            (TrieKey::StorageNode(hashed_address, nibbles.into()), TrieOp::Update(node))
+            (TrieKey::StorageNode(hashed_address, nibbles), TrieOp::Update(node))
         }));
     }
 


### PR DESCRIPTION
## Description

Remove database-related types from `TrieKey` enum given that now it's also used for storing and searching trie nodes in-memory.