### PR TITLE
chore(ecies): expose ECIESCodec for fuzzing

### DIFF
--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -1,3 +1,5 @@
+//! This contains the main codec for `RLPx` ECIES messages
+
 use crate::{algorithm::ECIES, ECIESError, EgressECIESValue, IngressECIESValue};
 use alloy_primitives::{bytes::BytesMut, B512 as PeerId};
 use secp256k1::SecretKey;
@@ -7,14 +9,14 @@ use tracing::{instrument, trace};
 
 /// Tokio codec for ECIES
 #[derive(Debug)]
-pub(crate) struct ECIESCodec {
+pub struct ECIESCodec {
     ecies: ECIES,
     state: ECIESState,
 }
 
 /// Current ECIES state of a connection
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ECIESState {
+pub enum ECIESState {
     /// The first stage of the ECIES handshake, where each side of the connection sends an auth
     /// message containing the ephemeral public key, signature of the public key, nonce, and other
     /// metadata.
@@ -23,7 +25,12 @@ enum ECIESState {
     /// The second stage of the ECIES handshake, where each side of the connection sends an ack
     /// message containing the nonce and other metadata.
     Ack,
+
+    /// The third stage of the ECIES handshake, where header is parsed, message integrity checks
+    /// performed, and message is decrypted.
     Header,
+
+    /// The final stage, where the ECIES message is actually read and returned by the ECIES codec.
     Body,
 }
 

--- a/crates/net/ecies/src/lib.rs
+++ b/crates/net/ecies/src/lib.rs
@@ -16,7 +16,7 @@ pub mod util;
 mod error;
 pub use error::ECIESError;
 
-mod codec;
+pub mod codec;
 
 use alloy_primitives::{
     bytes::{Bytes, BytesMut},


### PR DESCRIPTION
This needs to be exposed for external fuzz testing. Also includes docs for the rest of the `ECIESState` variants.