### PR TITLE
perf(pruner): pass `ProviderFactory` to segments

### DIFF
--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -9,7 +9,7 @@ use alloy_primitives::BlockNumber;
 use reth_db_api::database::Database;
 use reth_exex_types::FinishedExExHeight;
 use reth_provider::{
-    DatabaseProviderRW, ProviderFactory, PruneCheckpointReader, StaticFileProviderFactory,
+    DatabaseProviderFactory, ProviderFactory, PruneCheckpointReader, StaticFileProviderFactory,
 };
 use reth_prune_types::{PruneLimiter, PruneMode, PruneProgress, PrunePurpose, PruneSegment};
 use reth_static_file_types::StaticFileSegment;
@@ -127,10 +127,8 @@ impl<DB: Database> Pruner<DB> {
             limiter = limiter.set_time_limit(timeout);
         };
 
-        let provider = self.provider_factory.provider_rw()?;
         let (stats, deleted_entries, progress) =
-            self.prune_segments(&provider, tip_block_number, &mut limiter)?;
-        provider.commit()?;
+            self.prune_segments(tip_block_number, &mut limiter)?;
 
         self.previous_tip_block_number = Some(tip_block_number);
 
@@ -165,7 +163,6 @@ impl<DB: Database> Pruner<DB> {
     /// Returns [`PrunerStats`], total number of entries pruned, and [`PruneProgress`].
     fn prune_segments(
         &mut self,
-        provider: &DatabaseProviderRW<DB>,
         tip_block_number: BlockNumber,
         limiter: &mut PruneLimiter,
     ) -> Result<(PrunerStats, usize, PruneProgress), PrunerError> {
@@ -200,15 +197,15 @@ impl<DB: Database> Pruner<DB> {
                 );
 
                 let segment_start = Instant::now();
-                let previous_checkpoint = provider.get_prune_checkpoint(segment.segment())?;
+                let previous_checkpoint = self
+                    .provider_factory
+                    .database_provider_ro()?
+                    .get_prune_checkpoint(segment.segment())?;
                 let output = segment.prune(
-                    provider,
+                    &self.provider_factory,
                     PruneInput { previous_checkpoint, to_block, limiter: limiter.clone() },
                 )?;
-                if let Some(checkpoint) = output.checkpoint {
-                    segment
-                        .save_checkpoint(provider, checkpoint.as_prune_checkpoint(prune_mode))?;
-                }
+
                 self.metrics
                     .get_prune_segment_metrics(segment.segment())
                     .duration_seconds


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/9183

Incrementally implementing https://github.com/paradigmxyz/reth/issues/9181, next step will possibly be to change `prune_history_indices` to take `ProviderFactory` instead of `DatabaseProviderRW`, so the write lock on db can be taken in that scope when needed instead. 

commit time is less than on main, so is rw tx open time. no noticeable difference in pruning behaviour.
<img width="1720" alt="Screenshot 2024-07-03 at 17 01 13" src="https://github.com/paradigmxyz/reth/assets/58548332/58c615ee-2fa5-41bd-89a4-050721c876bd">
<img width="1725" alt="Screenshot 2024-07-03 at 17 05 57" src="https://github.com/paradigmxyz/reth/assets/58548332/e6742286-6071-4a70-b0b5-9ff155c18636">
main full node on commit 063c08f56

<img width="1718" alt="Screenshot 2024-07-03 at 17 02 54" src="https://github.com/paradigmxyz/reth/assets/58548332/13439ea4-6610-4a3f-97b9-e383731c75af">
<img width="1721" alt="Screenshot 2024-07-03 at 17 07 29" src="https://github.com/paradigmxyz/reth/assets/58548332/14e2ff94-529b-4d6e-b3a8-b0fc4d9e34bd">
this branch full node on commit 93a31f31
