### PR TITLE
chore(deps): remove igd-next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,7 +484,6 @@ tower-http = "0.5"
 
 # p2p
 discv5 = "0.6.0"
-igd-next = "0.14.3"
 
 # rpc
 jsonrpsee = "0.23"

--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,6 @@ exceptions = [
     { allow = ["CC0-1.0"], name = "aurora-engine-modexp" },
     # TODO: decide on MPL-2.0 handling
     # These dependencies are grandfathered in in https://github.com/paradigmxyz/reth/pull/6980
-    { allow = ["MPL-2.0"], name = "attohttpc" },
     { allow = ["MPL-2.0"], name = "option-ext" },
     { allow = ["MPL-2.0"], name = "webpki-roots" },
 ]


### PR DESCRIPTION
This will close #7890
`igd-next` is already removed with #8516 