### PR TITLE
feat(net/peer): set rpc added peer as static

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -68,12 +68,12 @@ pub trait PeersInfo: Send + Sync {
 pub trait Peers: PeersInfo {
     /// Adds a peer to the peer set with UDP `SocketAddr`.
     fn add_peer(&self, peer: PeerId, tcp_addr: SocketAddr) {
-        self.add_peer_kind(peer, PeerKind::Basic, tcp_addr, None);
+        self.add_peer_kind(peer, PeerKind::Static, tcp_addr, None);
     }
 
     /// Adds a peer to the peer set with TCP and UDP `SocketAddr`.
     fn add_peer_with_udp(&self, peer: PeerId, tcp_addr: SocketAddr, udp_addr: SocketAddr) {
-        self.add_peer_kind(peer, PeerKind::Basic, tcp_addr, Some(udp_addr));
+        self.add_peer_kind(peer, PeerKind::Static, tcp_addr, Some(udp_addr));
     }
 
     /// Adds a trusted [`PeerId`] to the peer set.
@@ -163,6 +163,8 @@ pub enum PeerKind {
     /// Basic peer kind.
     #[default]
     Basic,
+    /// Static peer, added via JSON-RPC.
+    Static,
     /// Trusted peer.
     Trusted,
 }
@@ -171,6 +173,11 @@ impl PeerKind {
     /// Returns `true` if the peer is trusted.
     pub const fn is_trusted(&self) -> bool {
         matches!(self, Self::Trusted)
+    }
+
+    /// Returns `true` if the peer is static.
+    pub const fn is_static(&self) -> bool {
+        matches!(self, Self::Static)
     }
 
     /// Returns `true` if the peer is basic.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -562,7 +562,7 @@ where
                 }
             }
             NetworkHandleMessage::RemovePeer(peer_id, kind) => {
-                self.swarm.state_mut().remove_peer(peer_id, kind);
+                self.swarm.state_mut().remove_peer_kind(peer_id, kind);
             }
             NetworkHandleMessage::DisconnectPeer(peer_id, reason) => {
                 self.swarm.sessions_mut().disconnect(peer_id, reason);

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -278,7 +278,8 @@ where
         self.peers_manager.add_peer_kind(peer_id, kind, addr, None)
     }
 
-    pub(crate) fn remove_peer(&mut self, peer_id: PeerId, kind: PeerKind) {
+    /// Removes a peer and its address with the given kind from the peerset.
+    pub(crate) fn remove_peer_kind(&mut self, peer_id: PeerId, kind: PeerKind) {
         match kind {
             PeerKind::Basic | PeerKind::Static => self.peers_manager.remove_peer(peer_id),
             PeerKind::Trusted => self.peers_manager.remove_peer_from_trusted_set(peer_id),

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -280,7 +280,7 @@ where
 
     pub(crate) fn remove_peer(&mut self, peer_id: PeerId, kind: PeerKind) {
         match kind {
-            PeerKind::Basic => self.peers_manager.remove_peer(peer_id),
+            PeerKind::Basic | PeerKind::Static => self.peers_manager.remove_peer(peer_id),
             PeerKind::Trusted => self.peers_manager.remove_peer_from_trusted_set(peer_id),
         }
     }


### PR DESCRIPTION
indent with geth, which will mark the jsonrpc added peer as static:

```go
// AddPeer adds the given node to the static node set. When there is room in the peer set,
// the server will connect to the node. If the connection fails for any reason, the server
// will attempt to reconnect the peer.
func (srv *Server) AddPeer(node *enode.Node) {
	srv.dialsched.addStatic(node)
}
```

https://github.com/ethereum/go-ethereum/blob/7cfff30ba3a67de767a9b2a7405b91f120873d10/p2p/server.go#L334-L339

this will affect the fields in response of `admin_peers`, eg:

```json
{
    "caps": ["eth/68"],
    "enode": "enode://e8be860040494291648a18182adbfd5dacd303ea881e2f1e702356dcca7dfee5b45fe4d83e2256f0d718baf12a50d6123e8989628ee05@1.1.1.1:30000",
    "enr": "enr:-J24QBgSMApOgEhV8PMLVLvQan2tLpQvqYu-DzSpum4z...-5YN0Y3CCdTCDdWRwgnUw",
    "id": "2fed6060ef025a0951e7705451bff6ef4ad0073fb2...",
    "name": "Geth/v1.13.14-stable-2ecaf439/linux-amd64/go1.22.2",
    "network": {
        "inbound": false,
        "localAddress": "172.20.0.3:56918",
        "remoteAddress": "1.1.1.1:30000",
        "static": true,
        "trusted": true
    },
    "protocols": {
        "eth": "handshake"
    }
}
```
