### PR TITLE
chore(trie): rename in-memory trie cursors

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -549,7 +549,7 @@ mod tests {
         hashed_cursor::HashedPostStateCursorFactory,
         prefix_set::PrefixSetMut,
         test_utils::{state_root, state_root_prehashed, storage_root, storage_root_prehashed},
-        trie_cursor::TrieUpdatesCursorFactory,
+        trie_cursor::InMemoryTrieCursorFactory,
         BranchNodeCompact, HashedPostState, HashedStorage, TrieMask,
     };
     use proptest::{prelude::ProptestConfig, proptest};
@@ -1488,7 +1488,7 @@ mod tests {
                 tx,
                 &post_state.clone().into_sorted(),
             ))
-            .with_trie_cursor_factory(TrieUpdatesCursorFactory::new(tx, &update.sorted()))
+            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(tx, &update.sorted()))
             .with_prefix_set(prefix_sets.storage_prefix_sets.remove(&keccak256(address)).unwrap())
             .root_with_updates()
             .unwrap();

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -1,17 +1,23 @@
 use crate::{updates::TrieKey, BranchNodeCompact, Nibbles};
 use reth_db::DatabaseError;
 use reth_primitives::B256;
+
+/// Database implementations of trie cursors.
 mod database_cursors;
+
+/// In-memory implementations of trie cursors.
+mod in_memory;
+
+/// Cursor for iterating over a subtrie.
 mod subnode;
-mod update;
 
 /// Noop trie cursor implementations.
 pub mod noop;
 
 pub use self::{
     database_cursors::{DatabaseAccountTrieCursor, DatabaseStorageTrieCursor},
+    in_memory::*,
     subnode::CursorSubNode,
-    update::*,
 };
 
 /// Factory for creating trie cursors.


### PR DESCRIPTION
## Description

Rename `TrieUpdates*` cursors & factory in to `InMemory*`.