### PR TITLE
chore(op): make mint in deposit tx non optional

### DIFF
--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -193,7 +193,7 @@ impl TryFrom<alloy_rpc_types::Transaction> for Transaction {
                         .ok_or_else(|| ConversionError::Custom("MissingSourceHash".to_string()))?,
                     from: tx.from,
                     to: TxKind::from(tx.to),
-                    mint: fields.mint.map(|n| n.to::<u128>()).filter(|n| *n != 0),
+                    mint: fields.mint.map(|n| n.to::<u128>()).unwrap_or_default(),
                     value: tx.value,
                     gas_limit: tx
                         .gas
@@ -317,7 +317,7 @@ mod tests {
                 deposit_tx.to,
                 TxKind::from(address!("4200000000000000000000000000000000000007"))
             );
-            assert_eq!(deposit_tx.mint, None);
+            assert_eq!(deposit_tx.mint, 0);
             assert_eq!(deposit_tx.value, U256::ZERO);
             assert_eq!(deposit_tx.gas_limit, 796584);
             assert!(!deposit_tx.is_system_transaction);
@@ -368,7 +368,7 @@ mod tests {
                 deposit_tx.to,
                 TxKind::from(address!("4200000000000000000000000000000000000007"))
             );
-            assert_eq!(deposit_tx.mint, Some(656890000000000000000));
+            assert_eq!(deposit_tx.mint, 656890000000000000000);
             assert_eq!(deposit_tx.value, U256::from(0x239c2e16a5ca590000_u128));
             assert_eq!(deposit_tx.gas_limit, 491822);
             assert!(!deposit_tx.is_system_transaction);

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -352,7 +352,7 @@ pub fn fill_op_tx_env<T: AsRef<Transaction>>(
         Transaction::Deposit(tx) => {
             tx_env.optimism = OptimismFields {
                 source_hash: Some(tx.source_hash),
-                mint: tx.mint,
+                mint: Some(tx.mint).filter(|m| *m != 0),
                 is_system_transaction: Some(tx.is_system_transaction),
                 enveloped_tx: Some(envelope),
             };

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -429,7 +429,7 @@ impl Transaction {
     #[cfg(feature = "optimism")]
     pub const fn mint(&self) -> Option<u128> {
         match self {
-            Self::Deposit(TxDeposit { mint, .. }) => *mint,
+            Self::Deposit(TxDeposit { mint, .. }) => Some(*mint),
             _ => None,
         }
     }


### PR DESCRIPTION
## Description

Make mint value in deposit tx type non-optional. Keeping it an option is ambiguous as there is not practical difference between `Some(0)` and `None`.