### PR TITLE
fix: ambiguous deposit mint value in arbitrary

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1478,10 +1478,10 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
                 if tx_eip_4844.to != Address::default() { Some(()) } else { None };
         }
 
+        #[cfg(feature = "optimism")]
         /// Both `Some(0)` and `None` values are encoded as empty string byte. This introduces
         /// ambiguity in roundtrip tests. Patch the mint value of deposit transaction here, so that
         /// it's `None` if zero.
-        #[cfg(feature = "optimism")]
         if let Transaction::Deposit(ref mut tx_deposit) = transaction {
             if tx_deposit.mint == Some(0) {
                 tx_deposit.mint = None;

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1478,6 +1478,16 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
                 if tx_eip_4844.to != Address::default() { Some(()) } else { None };
         }
 
+        /// Both `Some(0)` and `None` values are encoded as empty string byte. This introduces
+        /// ambiguity in roundtrip tests. Patch the mint value of deposit transaction here, so that
+        /// it's `None` if zero.
+        #[cfg(feature = "optimism")]
+        if let Transaction::Deposit(ref mut tx_deposit) = transaction {
+            if tx_deposit.mint == Some(0) {
+                tx_deposit.mint = None;
+            }
+        }
+
         let signature = Signature::arbitrary(u)?;
 
         #[cfg(feature = "optimism")]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1479,9 +1479,9 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
         }
 
         #[cfg(feature = "optimism")]
-        /// Both `Some(0)` and `None` values are encoded as empty string byte. This introduces
-        /// ambiguity in roundtrip tests. Patch the mint value of deposit transaction here, so that
-        /// it's `None` if zero.
+        // Both `Some(0)` and `None` values are encoded as empty string byte. This introduces
+        // ambiguity in roundtrip tests. Patch the mint value of deposit transaction here, so that
+        // it's `None` if zero.
         if let Transaction::Deposit(ref mut tx_deposit) = transaction {
             if tx_deposit.mint == Some(0) {
                 tx_deposit.mint = None;


### PR DESCRIPTION
## Description 

Patch the deposit mint value to `None` if it's `Some(0)`. Ref failure:  https://github.com/paradigmxyz/reth/actions/runs/9734634145/job/26862907179 
