### PR TITLE
chore: rename pipeline references to backfill sync

### DIFF
--- a/crates/engine/tree/src/backfill.rs
+++ b/crates/engine/tree/src/backfill.rs
@@ -239,7 +239,7 @@ mod tests {
                     .build(),
             );
 
-            // force the pipeline to be "done" after 5 blocks
+            // force the pipeline to be "done" after `pipeline_done_after` blocks
             let pipeline = TestPipelineBuilder::new()
                 .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
                     checkpoint: StageCheckpoint::new(BlockNumber::from(pipeline_done_after)),

--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -20,7 +20,7 @@ use tracing::trace;
 /// A trait that can download blocks on demand.
 pub trait BlockDownloader: Send + Sync {
     /// Handle an action.
-    fn on_action(&mut self, event: DownloadAction);
+    fn on_action(&mut self, action: DownloadAction);
 
     /// Advance in progress requests if any
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<DownloadOutcome>;
@@ -65,7 +65,7 @@ where
     Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
 {
     /// Create a new instance
-    pub(crate) fn new(client: Client, consensus: Arc<dyn Consensus>) -> Self {
+    pub fn new(client: Client, consensus: Arc<dyn Consensus>) -> Self {
         Self {
             full_block_client: FullBlockClient::new(client, consensus),
             inflight_full_block_requests: Vec::new(),
@@ -154,8 +154,8 @@ where
     Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
 {
     /// Handles incoming download actions.
-    fn on_action(&mut self, event: DownloadAction) {
-        match event {
+    fn on_action(&mut self, action: DownloadAction) {
+        match action {
             DownloadAction::Clear => self.clear(),
             DownloadAction::Download(request) => self.download(request),
         }

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -72,10 +72,10 @@ where
                     RequestHandlerEvent::Idle => break,
                     RequestHandlerEvent::HandlerEvent(ev) => {
                         return match ev {
-                            HandlerEvent::Pipeline(target) => {
-                                // bubble up pipeline request
+                            HandlerEvent::BackfillSync(target) => {
+                                // bubble up backfill sync request request
                                 self.downloader.on_action(DownloadAction::Clear);
-                                Poll::Ready(HandlerEvent::Pipeline(target))
+                                Poll::Ready(HandlerEvent::BackfillSync(target))
                             }
                             HandlerEvent::Event(ev) => {
                                 // bubble up the event


### PR DESCRIPTION
Towards #8742

These are leftovers from #9059, besides the concrete `PipelineSync` implementation, the remaining variables and comments in `chain` submodule should refer to backfill sync instead of pipeline. 