### PR TITLE
chore(trie): return nibbles from `TrieCursor::current`

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -299,7 +299,9 @@ where
                         };
 
                         trie_updates.extend(
-                            walker_deleted_keys.into_iter().map(|key| (key, TrieOp::Delete)),
+                            walker_deleted_keys
+                                .into_iter()
+                                .map(|nibbles| (TrieKey::AccountNode(nibbles), TrieOp::Delete)),
                         );
                         trie_updates.extend_with_account_updates(hash_builder_updates);
 

--- a/crates/trie/trie/src/trie_cursor/database_cursors.rs
+++ b/crates/trie/trie/src/trie_cursor/database_cursors.rs
@@ -1,5 +1,5 @@
 use super::{TrieCursor, TrieCursorFactory};
-use crate::{updates::TrieKey, BranchNodeCompact, Nibbles, StoredNibbles, StoredNibblesSubKey};
+use crate::{BranchNodeCompact, Nibbles, StoredNibbles, StoredNibblesSubKey};
 use reth_db::{tables, DatabaseError};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
@@ -60,8 +60,8 @@ where
     }
 
     /// Retrieves the current key in the cursor.
-    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
-        Ok(self.0.current()?.map(|(k, _)| TrieKey::AccountNode(k.0)))
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+        Ok(self.0.current()?.map(|(k, _)| k.0))
     }
 }
 
@@ -109,8 +109,8 @@ where
     }
 
     /// Retrieves the current value in the storage trie cursor.
-    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
-        Ok(self.cursor.current()?.map(|(k, v)| TrieKey::StorageNode(k, v.nibbles.0)))
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+        Ok(self.cursor.current()?.map(|(_, v)| v.nibbles.0))
     }
 }
 

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -1,4 +1,4 @@
-use crate::{updates::TrieKey, BranchNodeCompact, Nibbles};
+use crate::{BranchNodeCompact, Nibbles};
 use reth_db::DatabaseError;
 use reth_primitives::B256;
 
@@ -51,5 +51,5 @@ pub trait TrieCursor: Send + Sync {
         -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
 
     /// Get the current entry.
-    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError>;
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError>;
 }

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -1,5 +1,5 @@
 use super::{TrieCursor, TrieCursorFactory};
-use crate::{updates::TrieKey, BranchNodeCompact, Nibbles};
+use crate::{BranchNodeCompact, Nibbles};
 use reth_db::DatabaseError;
 use reth_primitives::B256;
 

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -49,7 +49,7 @@ impl TrieCursor for NoopAccountTrieCursor {
     }
 
     /// Retrieves the current cursor position within the account trie.
-    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
         Ok(None)
     }
 }
@@ -77,7 +77,7 @@ impl TrieCursor for NoopStorageTrieCursor {
     }
 
     /// Retrieves the current cursor position within storage tries.
-    fn current(&mut self) -> Result<Option<TrieKey>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
         Ok(None)
     }
 }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -1,7 +1,6 @@
 use crate::{
     prefix_set::PrefixSet,
     trie_cursor::{CursorSubNode, TrieCursor},
-    updates::TrieKey,
     BranchNodeCompact, Nibbles,
 };
 use reth_db::DatabaseError;
@@ -24,7 +23,7 @@ pub struct TrieWalker<C> {
     /// A `PrefixSet` representing the changes to be applied to the trie.
     pub changes: PrefixSet,
     /// The retained trie node keys that need to be deleted.
-    deleted_keys: Option<HashSet<TrieKey>>,
+    deleted_keys: Option<HashSet<Nibbles>>,
 }
 
 impl<C> TrieWalker<C> {
@@ -45,7 +44,7 @@ impl<C> TrieWalker<C> {
     }
 
     /// Split the walker into stack and trie updates.
-    pub fn split(mut self) -> (Vec<CursorSubNode>, HashSet<TrieKey>) {
+    pub fn split(mut self) -> (Vec<CursorSubNode>, HashSet<Nibbles>) {
         let keys = self.deleted_keys.take();
         (self.stack, keys.unwrap_or_default())
     }


### PR DESCRIPTION
## Description

`TrieCursor` should only ever operate on nibbles. `TrieKey` is soon to be obsolete type that should not be surfaced there.