### PR TITLE
chore: disable discovery for --dev

### DIFF
--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -58,15 +58,12 @@ where
     let mut nodes: Vec<NodeTestContext<_>> = Vec::with_capacity(num_nodes);
 
     for idx in 0..num_nodes {
-        let mut node_config = NodeConfig::test()
+        let node_config = NodeConfig::test()
             .with_chain(chain_spec.clone())
             .with_network(network_config.clone())
             .with_unused_ports()
-            .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
-
-        if is_dev {
-            node_config = node_config.dev();
-        }
+            .with_rpc(RpcServerArgs::default().with_unused_ports().with_http())
+            .set_dev(is_dev);
 
         let span = span!(Level::INFO, "node", idx);
         let _enter = span.enter();

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -155,10 +155,23 @@ impl NodeConfig {
             .with_unused_ports()
     }
 
-    /// Sets --dev mode for the node
+    /// Sets --dev mode for the node.
+    ///
+    /// In addition to setting the `--dev` flag, this also:
+    ///   - disables discovery in [`NetworkArgs`].
     pub const fn dev(mut self) -> Self {
         self.dev.dev = true;
+        self.network.discovery.disable_discovery = true;
         self
+    }
+
+    /// Sets --dev mode for the node [`NodeConfig::dev`], if `dev` is true.
+    pub const fn set_dev(self, dev: bool) -> Self {
+        if dev {
+            self.dev()
+        } else {
+            self
+        }
     }
 
     /// Set the data directory args for the node


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/blob/90ed154de7405dc59ec124a32449550577f44803/crates/node/core/src/args/network.rs#L248-L250

discovery is disabled if --dev is provided.
this also disables discovery if dev function is called