### PR TITLE
Fix: fix the issue of not being able to specify bootnode through command parameters

### DIFF
--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -8,13 +8,12 @@ use std::{
     str::FromStr,
 };
 
-use crate::{PeerId, TrustedPeer};
+use crate::PeerId;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 #[cfg(feature = "secp256k1")]
 use enr::Enr;
-use url::Host;
 
 /// Represents a ENR in discovery.
 ///
@@ -194,26 +193,6 @@ impl FromStr for NodeRecord {
             .map_err(|e| NodeRecordParseError::InvalidId(e.to_string()))?;
 
         Ok(Self { address, id, tcp_port: port, udp_port })
-    }
-}
-
-impl From<TrustedPeer> for NodeRecord {
-    fn from(trust: TrustedPeer) -> Self {
-        use std::net::{SocketAddr, ToSocketAddrs};
-        let lookup_host = |host: &str| -> Option<SocketAddr> {
-            let mut addrs = host.to_socket_addrs().expect("No IP found");
-            addrs.next()
-        };
-
-        let address = match trust.host {
-            Host::Ipv4(ip) => IpAddr::V4(ip),
-            Host::Ipv6(ip) => IpAddr::V6(ip),
-            Host::Domain(domain) => {
-                let ip = lookup_host(&format!("{domain}:0")).expect("No IP found");
-                ip.ip()
-            }
-        };
-        Self { address, tcp_port: trust.tcp_port, udp_port: trust.udp_port, id: trust.id }
     }
 }
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -137,9 +137,15 @@ impl NetworkArgs {
                 bootnodes
                     .into_iter()
                     .filter_map(|trusted_peer| trusted_peer.resolve_blocking().ok())
-                    .collect()
+                    .collect::<Vec<NodeRecord>>()
             })
-            .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
+            .unwrap_or_default()
+            .into_iter()
+            .chain(chain_spec.bootnodes().unwrap_or_default())
+            .collect::<Vec<NodeRecord>>();
+        let chain_bootnodes =
+            if chain_bootnodes.is_empty() { mainnet_nodes() } else { chain_bootnodes };
+
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 
         // Configure peer connections

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -130,10 +130,15 @@ impl NetworkArgs {
         secret_key: SecretKey,
         default_peers_file: PathBuf,
     ) -> NetworkConfigBuilder {
-        let chain_bootnodes: Vec<NodeRecord> = self
+        let chain_bootnodes = self
             .bootnodes
             .clone()
-            .map(|bootnodes| bootnodes.into_iter().map(Into::into).collect())
+            .map(|bootnodes| {
+                bootnodes
+                    .into_iter()
+                    .filter_map(|trusted_peer| trusted_peer.resolve_blocking().ok())
+                    .collect()
+            })
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -50,7 +50,7 @@ pub struct NetworkArgs {
     ///
     /// Will fall back to a network-specific default if not specified.
     #[arg(long, value_delimiter = ',')]
-    pub bootnodes: Option<Vec<NodeRecord>>,
+    pub bootnodes: Option<Vec<TrustedPeer>>,
 
     /// Amount of DNS resolution requests retries to perform when peering.
     #[arg(long, default_value_t = 0)]
@@ -130,9 +130,10 @@ impl NetworkArgs {
         secret_key: SecretKey,
         default_peers_file: PathBuf,
     ) -> NetworkConfigBuilder {
-        let chain_bootnodes = self
+        let chain_bootnodes: Vec<NodeRecord> = self
             .bootnodes
             .clone()
+            .map(|bootnodes| bootnodes.into_iter().map(Into::into).collect())
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -50,7 +50,7 @@ pub struct NetworkArgs {
     ///
     /// Will fall back to a network-specific default if not specified.
     #[arg(long, value_delimiter = ',')]
-    pub bootnodes: Option<Vec<TrustedPeer>>,
+    pub bootnodes: Option<Vec<NodeRecord>>,
 
     /// Amount of DNS resolution requests retries to perform when peering.
     #[arg(long, default_value_t = 0)]
@@ -130,7 +130,10 @@ impl NetworkArgs {
         secret_key: SecretKey,
         default_peers_file: PathBuf,
     ) -> NetworkConfigBuilder {
-        let chain_bootnodes = chain_spec.bootnodes().unwrap_or_else(mainnet_nodes);
+        let chain_bootnodes = self
+            .bootnodes
+            .clone()
+            .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 
         // Configure peer connections


### PR DESCRIPTION
When I specify the bootnode of a node using the following command, it does not take effect:
```
reth node -vvv --datadir=$DATA_PATH --chain=$PATH/genesis.json --http --http.port=$SYNC_HTTP_PORT 
--authrpc.port=$SYNC_AUTH_RPC_PORT --discovery.port=$SYNC_PORT --port=$SYNC_PORT 
--debug.tip $TIP --bootnodes=$reth1_node --debug.terminate
```

I found that the[ code here](https://github.com/paradigmxyz/reth/blob/6eca557dbe6cd51e0956e110ae928856b3022773/crates/node/core/src/args/network.rs#L133) only allows bootnode to read from chainspec and does not allow parameter configuration.

