### PR TITLE
trie: revamp trie updates

### DIFF
--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -188,9 +188,9 @@ impl Command {
         // Compare updates
         let mut in_mem_mismatched = Vec::new();
         let mut incremental_mismatched = Vec::new();
-        let mut in_mem_updates_iter = in_memory_updates.account_nodes_ref().into_iter().peekable();
+        let mut in_mem_updates_iter = in_memory_updates.account_nodes_ref().iter().peekable();
         let mut incremental_updates_iter =
-            incremental_trie_updates.account_nodes_ref().into_iter().peekable();
+            incremental_trie_updates.account_nodes_ref().iter().peekable();
 
         while in_mem_updates_iter.peek().is_some() || incremental_updates_iter.peek().is_some() {
             match (in_mem_updates_iter.next(), incremental_updates_iter.next()) {

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -25,7 +25,7 @@ use reth_provider::{
 use reth_revm::database::StateProviderDatabase;
 use reth_stages::StageId;
 use reth_tasks::TaskExecutor;
-use reth_trie::{updates::TrieKey, StateRoot};
+use reth_trie::StateRoot;
 use std::{path::PathBuf, sync::Arc};
 use tracing::*;
 
@@ -188,15 +188,16 @@ impl Command {
         // Compare updates
         let mut in_mem_mismatched = Vec::new();
         let mut incremental_mismatched = Vec::new();
-        let mut in_mem_updates_iter = in_memory_updates.into_iter().peekable();
-        let mut incremental_updates_iter = incremental_trie_updates.into_iter().peekable();
+        let mut in_mem_updates_iter = in_memory_updates.account_nodes_ref().into_iter().peekable();
+        let mut incremental_updates_iter =
+            incremental_trie_updates.account_nodes_ref().into_iter().peekable();
 
         while in_mem_updates_iter.peek().is_some() || incremental_updates_iter.peek().is_some() {
             match (in_mem_updates_iter.next(), incremental_updates_iter.next()) {
                 (Some(in_mem), Some(incr)) => {
                     similar_asserts::assert_eq!(in_mem.0, incr.0, "Nibbles don't match");
                     if in_mem.1 != incr.1 &&
-                        matches!(in_mem.0, TrieKey::AccountNode(ref nibbles) if nibbles.len() > self.skip_node_depth.unwrap_or_default())
+                        in_mem.0.len() > self.skip_node_depth.unwrap_or_default()
                     {
                         in_mem_mismatched.push(in_mem);
                         incremental_mismatched.push(incr);

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -86,7 +86,7 @@ impl<DB: Database> Persistence<DB> {
                 let trie_updates = block.trie_updates().clone();
                 let hashed_state = block.hashed_state();
                 HashedStateChanges(hashed_state.clone()).write_to_db(provider_rw.tx_ref())?;
-                trie_updates.flush(provider_rw.tx_ref())?;
+                trie_updates.write_to_database(provider_rw.tx_ref())?;
             }
 
             // update history indices

--- a/crates/stages/stages/benches/setup/mod.rs
+++ b/crates/stages/stages/benches/setup/mod.rs
@@ -139,7 +139,11 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> TestStageDB {
         let offset = transitions.len() as u64;
 
         db.insert_changesets(transitions, None).unwrap();
-        db.commit(|tx| Ok(updates.flush(tx)?)).unwrap();
+        db.commit(|tx| {
+            updates.write_to_database(tx)?;
+            Ok(())
+        })
+        .unwrap();
 
         let (transitions, final_state) = random_changeset_range(
             &mut rng,

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -217,7 +217,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                 })?;
             match progress {
                 StateRootProgress::Progress(state, hashed_entries_walked, updates) => {
-                    updates.flush(tx)?;
+                    updates.write_to_database(tx)?;
 
                     let checkpoint = MerkleCheckpoint::new(
                         to_block,
@@ -237,7 +237,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                     })
                 }
                 StateRootProgress::Complete(root, hashed_entries_walked, updates) => {
-                    updates.flush(tx)?;
+                    updates.write_to_database(tx)?;
 
                     entities_checkpoint.processed += hashed_entries_walked as u64;
 
@@ -252,7 +252,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
                         error!(target: "sync::stages::merkle", %e, ?current_block_number, ?to_block, "Incremental state root failed! {INVALID_STATE_ROOT_ERROR_MESSAGE}");
                         StageError::Fatal(Box::new(e))
                     })?;
-            updates.flush(provider.tx_ref())?;
+            updates.write_to_database(provider.tx_ref())?;
 
             let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
                 provider.count_entries::<tables::HashedStorages>()?)
@@ -325,7 +325,7 @@ impl<DB: Database> Stage<DB> for MerkleStage {
             validate_state_root(block_root, target.seal_slow(), input.unwind_to)?;
 
             // Validation passed, apply unwind changes to the database.
-            updates.flush(provider.tx_ref())?;
+            updates.write_to_database(provider.tx_ref())?;
 
             // TODO(alexey): update entities checkpoint
         } else {

--- a/crates/storage/provider/src/bundle_state/execution_outcome.rs
+++ b/crates/storage/provider/src/bundle_state/execution_outcome.rs
@@ -892,7 +892,7 @@ mod tests {
             }
 
             let (_, updates) = StateRoot::from_tx(tx).root_with_updates().unwrap();
-            updates.flush(tx).unwrap();
+            updates.write_to_database(tx).unwrap();
         })
         .unwrap();
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2396,7 +2396,7 @@ impl<TX: DbTxMut + DbTx> HashingWriter for DatabaseProvider<TX> {
                     block_hash: end_block_hash,
                 })))
             }
-            trie_updates.flush(&self.tx)?;
+            trie_updates.write_to_database(&self.tx)?;
         }
         durations_recorder.record_relative(metrics::Action::InsertMerkleTree);
 
@@ -2592,7 +2592,7 @@ impl<TX: DbTxMut + DbTx> BlockExecutionWriter for DatabaseProvider<TX> {
                     block_hash: parent_hash,
                 })))
             }
-            trie_updates.flush(&self.tx)?;
+            trie_updates.write_to_database(&self.tx)?;
         }
 
         // get blocks
@@ -2793,7 +2793,7 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
         // insert hashes and intermediate merkle nodes
         {
             HashedStateChanges(hashed_state).write_to_db(&self.tx)?;
-            trie_updates.flush(&self.tx)?;
+            trie_updates.write_to_database(&self.tx)?;
         }
         durations_recorder.record_relative(metrics::Action::InsertHashes);
 

--- a/crates/trie/parallel/benches/root.rs
+++ b/crates/trie/parallel/benches/root.rs
@@ -30,7 +30,7 @@ pub fn calculate_state_root(c: &mut Criterion) {
             HashedStateChanges(db_state).write_to_db(provider_rw.tx_ref()).unwrap();
             let (_, updates) =
                 StateRoot::from_tx(provider_rw.tx_ref()).root_with_updates().unwrap();
-            updates.flush(provider_rw.tx_ref()).unwrap();
+            updates.write_to_database(provider_rw.tx_ref()).unwrap();
             provider_rw.commit().unwrap();
         }
 

--- a/crates/trie/parallel/src/async_root.rs
+++ b/crates/trie/parallel/src/async_root.rs
@@ -166,7 +166,7 @@ where
                     };
 
                     if retain_updates {
-                        trie_updates.extend(updates.into_iter());
+                        trie_updates.insert_storage_updates(hashed_address, updates);
                     }
 
                     account_rlp.clear();
@@ -179,7 +179,7 @@ where
 
         let root = hash_builder.root();
 
-        trie_updates.finalize_state_updates(
+        trie_updates.finalize(
             account_node_iter.walker,
             hash_builder,
             prefix_sets.destroyed_accounts,

--- a/crates/trie/parallel/src/parallel_root.rs
+++ b/crates/trie/parallel/src/parallel_root.rs
@@ -148,7 +148,7 @@ where
                     };
 
                     if retain_updates {
-                        trie_updates.extend(updates.into_iter());
+                        trie_updates.insert_storage_updates(hashed_address, updates);
                     }
 
                     account_rlp.clear();
@@ -161,7 +161,7 @@ where
 
         let root = hash_builder.root();
 
-        trie_updates.finalize_state_updates(
+        trie_updates.finalize(
             account_node_iter.walker,
             hash_builder,
             prefix_sets.destroyed_accounts,

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -12,6 +12,7 @@ use reth_db_api::transaction::DbTx;
 use reth_execution_errors::{StateRootError, StorageRootError};
 use reth_primitives::{constants::EMPTY_ROOT_HASH, keccak256, Address, B256};
 use reth_trie_common::{proof::ProofRetainer, AccountProof, StorageProof, TrieAccount};
+
 /// A struct for generating merkle proofs.
 ///
 /// Proof generator adds the target address and slots to the prefix set, enables the proof retainer

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -226,7 +226,7 @@ mod tests {
         let (root, updates) = StateRoot::from_tx(provider.tx_ref())
             .root_with_updates()
             .map_err(Into::<reth_db::DatabaseError>::into)?;
-        updates.flush(provider.tx_mut())?;
+        updates.write_to_database(provider.tx_mut())?;
 
         provider.commit()?;
 

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -995,8 +995,10 @@ mod tests {
         assert_eq!(node2a.hashes.len(), 1);
 
         // Check storage trie
-        assert_eq!(trie_updates.storage_tries.len(), 1);
-        let (_, storage_trie_updates) = trie_updates.storage_tries.iter().next().unwrap();
+        let mut updated_storage_trie =
+            trie_updates.storage_tries.iter().filter(|(_, u)| !u.storage_nodes.is_empty());
+        assert_eq!(updated_storage_trie.clone().count(), 1);
+        let (_, storage_trie_updates) = updated_storage_trie.next().unwrap();
         assert_eq!(storage_trie_updates.storage_nodes.len(), 1);
 
         let (nibbles3, node3) = storage_trie_updates.storage_nodes.iter().next().unwrap();
@@ -1080,8 +1082,7 @@ mod tests {
                 .root_with_updates()
                 .unwrap();
             assert_eq!(root, computed_expected_root);
-            assert_eq!(trie_updates.account_nodes.len() + trie_updates.removed_nodes.len(), 7);
-            assert_eq!(trie_updates.storage_tries.len(), 1);
+            assert_eq!(trie_updates.account_nodes.len() + trie_updates.removed_nodes.len(), 1);
 
             assert_eq!(trie_updates.account_nodes.len(), 1);
 
@@ -1132,8 +1133,12 @@ mod tests {
                 .root_with_updates()
                 .unwrap();
             assert_eq!(root, computed_expected_root);
-            assert_eq!(trie_updates.account_nodes.len() + trie_updates.removed_nodes.len(), 6);
-            assert!(trie_updates.storage_tries.is_empty()); // no storage root update
+            assert_eq!(trie_updates.account_nodes.len() + trie_updates.removed_nodes.len(), 1);
+            assert!(trie_updates
+                .storage_tries
+                .iter()
+                .find(|(_, u)| !u.storage_nodes.is_empty() || !u.removed_nodes.is_empty())
+                .is_none()); // no storage root update
 
             assert_eq!(trie_updates.account_nodes.len(), 1);
 

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -1266,8 +1266,7 @@ mod tests {
 
         let root = hb.root();
         let (_, updates) = hb.split();
-        let mut trie_updates = StorageTrieUpdates::default();
-        trie_updates.storage_nodes = updates;
+        let trie_updates = StorageTrieUpdates { storage_nodes: updates, ..Default::default() };
         (root, trie_updates)
     }
 

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -1137,8 +1137,7 @@ mod tests {
             assert!(trie_updates
                 .storage_tries
                 .iter()
-                .find(|(_, u)| !u.storage_nodes.is_empty() || !u.removed_nodes.is_empty())
-                .is_none()); // no storage root update
+                .any(|(_, u)| !u.storage_nodes.is_empty() || !u.removed_nodes.is_empty())); // no storage root update
 
             assert_eq!(trie_updates.account_nodes.len(), 1);
 

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -1134,7 +1134,7 @@ mod tests {
                 .unwrap();
             assert_eq!(root, computed_expected_root);
             assert_eq!(trie_updates.account_nodes.len() + trie_updates.removed_nodes.len(), 1);
-            assert!(trie_updates
+            assert!(!trie_updates
                 .storage_tries
                 .iter()
                 .any(|(_, u)| !u.storage_nodes.is_empty() || !u.removed_nodes.is_empty())); // no storage root update

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -1,5 +1,5 @@
 use super::{TrieCursor, TrieCursorFactory};
-use crate::updates::{TrieKey, TrieUpdatesSorted};
+use crate::updates::TrieUpdatesSorted;
 use reth_db::DatabaseError;
 use reth_primitives::B256;
 use reth_trie_common::{BranchNodeCompact, Nibbles};
@@ -39,6 +39,7 @@ impl<'a, CF: TrieCursorFactory> TrieCursorFactory for InMemoryTrieCursorFactory<
 /// The cursor to iterate over account trie updates and corresponding database entries.
 /// It will always give precedence to the data from the trie updates.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct InMemoryAccountTrieCursor<'a, C> {
     cursor: C,
     trie_updates: &'a TrieUpdatesSorted,
@@ -54,57 +55,27 @@ impl<'a, C> InMemoryAccountTrieCursor<'a, C> {
 impl<'a, C: TrieCursor> TrieCursor for InMemoryAccountTrieCursor<'a, C> {
     fn seek_exact(
         &mut self,
-        key: Nibbles,
+        _key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        if let Some((nibbles, trie_op)) = self.trie_updates.find_account_node(&key) {
-            self.last_key = Some(nibbles);
-            Ok(trie_op.into_update().map(|node| (key, node)))
-        } else {
-            let result = self.cursor.seek_exact(key)?;
-            self.last_key = result.as_ref().map(|(key, _)| key.clone());
-            Ok(result)
-        }
+        unimplemented!()
     }
 
     fn seek(
         &mut self,
-        key: Nibbles,
+        _key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        let trie_update_entry = self
-            .trie_updates
-            .trie_operations
-            .iter()
-            .find(|(k, _)| matches!(k, TrieKey::AccountNode(nibbles) if nibbles <= &key))
-            .cloned();
-
-        if let Some((trie_key, trie_op)) = trie_update_entry {
-            let nibbles = match trie_key {
-                TrieKey::AccountNode(nibbles) => {
-                    self.last_key = Some(nibbles.clone());
-                    nibbles
-                }
-                _ => panic!("Invalid trie key"),
-            };
-            return Ok(trie_op.into_update().map(|node| (nibbles, node)))
-        }
-
-        let result = self.cursor.seek(key)?;
-        self.last_key = result.as_ref().map(|(key, _)| key.clone());
-        Ok(result)
+        unimplemented!()
     }
 
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-        if self.last_key.is_some() {
-            Ok(self.last_key.clone())
-        } else {
-            self.cursor.current()
-        }
+        unimplemented!()
     }
 }
 
 /// The cursor to iterate over storage trie updates and corresponding database entries.
 /// It will always give precedence to the data from the trie updates.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct InMemoryStorageTrieCursor<'a, C> {
     cursor: C,
     trie_update_index: usize,
@@ -122,55 +93,19 @@ impl<'a, C> InMemoryStorageTrieCursor<'a, C> {
 impl<'a, C: TrieCursor> TrieCursor for InMemoryStorageTrieCursor<'a, C> {
     fn seek_exact(
         &mut self,
-        key: Nibbles,
+        _key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        if let Some((trie_key, trie_op)) =
-            self.trie_updates.find_storage_node(&self.hashed_address, &key)
-        {
-            self.last_key = Some(trie_key);
-            Ok(trie_op.into_update().map(|node| (key, node)))
-        } else {
-            let result = self.cursor.seek_exact(key)?;
-            self.last_key = result.as_ref().map(|(key, _)| key.clone());
-            Ok(result)
-        }
+        unimplemented!()
     }
 
     fn seek(
         &mut self,
-        key: Nibbles,
+        _key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        let mut trie_update_entry = self.trie_updates.trie_operations.get(self.trie_update_index);
-        while trie_update_entry
-            .filter(|(k, _)| matches!(k, TrieKey::StorageNode(address, nibbles) if address == &self.hashed_address && nibbles < &key)).is_some()
-        {
-            self.trie_update_index += 1;
-            trie_update_entry = self.trie_updates.trie_operations.get(self.trie_update_index);
-        }
-
-        if let Some((trie_key, trie_op)) =
-            trie_update_entry.filter(|(k, _)| matches!(k, TrieKey::StorageNode(_, _)))
-        {
-            let nibbles = match trie_key {
-                TrieKey::StorageNode(_, nibbles) => {
-                    self.last_key = Some(nibbles.clone());
-                    nibbles.clone()
-                }
-                _ => panic!("this should not happen!"),
-            };
-            return Ok(trie_op.as_update().map(|node| (nibbles, node.clone())))
-        }
-
-        let result = self.cursor.seek(key)?;
-        self.last_key = result.as_ref().map(|(key, _)| key.clone());
-        Ok(result)
+        unimplemented!()
     }
 
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-        if self.last_key.is_some() {
-            Ok(self.last_key.clone())
-        } else {
-            self.cursor.current()
-        }
+        unimplemented!()
     }
 }

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -21,7 +21,7 @@ pub struct TrieUpdates {
 
 impl TrieUpdates {
     /// Returns reference to updated account nodes.
-    pub fn account_nodes_ref(&self) -> &HashMap<Nibbles, BranchNodeCompact> {
+    pub const fn account_nodes_ref(&self) -> &HashMap<Nibbles, BranchNodeCompact> {
         &self.account_nodes
     }
 

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -2,276 +2,258 @@ use crate::{
     walker::TrieWalker, BranchNodeCompact, HashBuilder, Nibbles, StorageTrieEntry,
     StoredBranchNode, StoredNibbles, StoredNibblesSubKey,
 };
-use derive_more::Deref;
 use reth_db::tables;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     transaction::{DbTx, DbTxMut},
 };
 use reth_primitives::B256;
-use std::collections::{hash_map::IntoIter, HashMap, HashSet};
-
-/// The key of a trie node.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum TrieKey {
-    /// A node in the account trie.
-    AccountNode(Nibbles),
-    /// A node in the storage trie.
-    StorageNode(B256, Nibbles),
-    /// Storage trie of an account.
-    StorageTrie(B256),
-}
-
-impl TrieKey {
-    /// Returns reference to account node key if the key is for [`Self::AccountNode`].
-    pub const fn as_account_node_key(&self) -> Option<&Nibbles> {
-        if let Self::AccountNode(nibbles) = &self {
-            Some(nibbles)
-        } else {
-            None
-        }
-    }
-
-    /// Returns reference to storage node key if the key is for [`Self::StorageNode`].
-    pub const fn as_storage_node_key(&self) -> Option<(&B256, &Nibbles)> {
-        if let Self::StorageNode(key, subkey) = &self {
-            Some((key, subkey))
-        } else {
-            None
-        }
-    }
-
-    /// Returns reference to storage trie key if the key is for [`Self::StorageTrie`].
-    pub const fn as_storage_trie_key(&self) -> Option<&B256> {
-        if let Self::StorageTrie(key) = &self {
-            Some(key)
-        } else {
-            None
-        }
-    }
-}
-
-/// The operation to perform on the trie.
-#[derive(PartialEq, Eq, Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum TrieOp {
-    /// Delete the node entry.
-    Delete,
-    /// Update the node entry with the provided value.
-    Update(BranchNodeCompact),
-}
-
-impl TrieOp {
-    /// Returns `true` if the operation is an update.
-    pub const fn is_update(&self) -> bool {
-        matches!(self, Self::Update(..))
-    }
-
-    /// Returns reference to updated branch node if operation is [`Self::Update`].
-    pub const fn as_update(&self) -> Option<&BranchNodeCompact> {
-        if let Self::Update(node) = &self {
-            Some(node)
-        } else {
-            None
-        }
-    }
-
-    /// Returns owned updated branch node if operation is [`Self::Update`].
-    pub fn into_update(self) -> Option<BranchNodeCompact> {
-        if let Self::Update(node) = self {
-            Some(node)
-        } else {
-            None
-        }
-    }
-}
+use std::collections::{HashMap, HashSet};
 
 /// The aggregation of trie updates.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deref)]
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrieUpdates {
-    trie_operations: HashMap<TrieKey, TrieOp>,
-}
-
-impl<const N: usize> From<[(TrieKey, TrieOp); N]> for TrieUpdates {
-    fn from(value: [(TrieKey, TrieOp); N]) -> Self {
-        Self { trie_operations: HashMap::from(value) }
-    }
-}
-
-impl IntoIterator for TrieUpdates {
-    type Item = (TrieKey, TrieOp);
-    type IntoIter = IntoIter<TrieKey, TrieOp>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.trie_operations.into_iter()
-    }
+    pub(crate) account_nodes: HashMap<Nibbles, BranchNodeCompact>,
+    pub(crate) removed_nodes: HashSet<Nibbles>,
+    pub(crate) storage_tries: HashMap<B256, StorageTrieUpdates>,
 }
 
 impl TrieUpdates {
-    /// Extend the updates with trie updates.
-    pub fn extend(&mut self, updates: impl IntoIterator<Item = (TrieKey, TrieOp)>) {
-        self.trie_operations.extend(updates);
+    /// Returns reference to updated account nodes.
+    pub fn account_nodes_ref(&self) -> &HashMap<Nibbles, BranchNodeCompact> {
+        &self.account_nodes
     }
 
-    /// Extend the updates with account trie updates.
-    pub fn extend_with_account_updates(&mut self, updates: HashMap<Nibbles, BranchNodeCompact>) {
-        self.extend(
-            updates
-                .into_iter()
-                .map(|(nibbles, node)| (TrieKey::AccountNode(nibbles), TrieOp::Update(node))),
-        );
+    /// Insert storage updates for a given hashed address.
+    pub fn insert_storage_updates(
+        &mut self,
+        hashed_address: B256,
+        storage_updates: StorageTrieUpdates,
+    ) {
+        let existing = self.storage_tries.insert(hashed_address, storage_updates);
+        debug_assert!(existing.is_none());
     }
 
     /// Finalize state trie updates.
-    pub fn finalize_state_updates<C>(
+    pub fn finalize<C>(
         &mut self,
         walker: TrieWalker<C>,
         hash_builder: HashBuilder,
         destroyed_accounts: HashSet<B256>,
     ) {
-        // Add updates from trie walker.
-        let (_, deleted_keys) = walker.split();
-        self.extend(
-            deleted_keys.into_iter().map(|nibbles| (TrieKey::AccountNode(nibbles), TrieOp::Delete)),
-        );
+        // Retrieve deleted keys from trie walker.
+        let (_, removed_node_keys) = walker.split();
+        self.removed_nodes.extend(removed_node_keys);
 
-        // Add account node updates from hash builder.
-        let (_, hash_builder_updates) = hash_builder.split();
-        self.extend_with_account_updates(hash_builder_updates);
+        // Retrieve updated nodes from hash builder.
+        let (_, updated_nodes) = hash_builder.split();
+        self.account_nodes.extend(updated_nodes);
 
         // Add deleted storage tries for destroyed accounts.
-        self.extend(
-            destroyed_accounts.into_iter().map(|key| (TrieKey::StorageTrie(key), TrieOp::Delete)),
-        );
+        for destroyed in destroyed_accounts {
+            self.storage_tries.entry(destroyed).or_default().set_deleted(true);
+        }
     }
 
-    /// Finalize storage trie updates for a given address.
-    pub fn finalize_storage_updates<C>(
-        &mut self,
-        hashed_address: B256,
-        walker: TrieWalker<C>,
-        hash_builder: HashBuilder,
-    ) {
-        // Add updates from trie walker.
-        let (_, deleted_keys) = walker.split();
-        self.extend(
-            deleted_keys
+    /// Converts trie updates into [`TrieUpdatesSorted`].
+    pub fn into_sorted(self) -> TrieUpdatesSorted {
+        let mut account_nodes = Vec::from_iter(self.account_nodes);
+        account_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut storage_tries = Vec::from_iter(
+            self.storage_tries
                 .into_iter()
-                .map(|nibbles| (TrieKey::StorageNode(hashed_address, nibbles), TrieOp::Delete)),
+                .map(|(hashed_address, updates)| (hashed_address, updates.into_sorted())),
         );
-
-        // Add storage node updates from hash builder.
-        let (_, hash_builder_updates) = hash_builder.split();
-        self.extend(hash_builder_updates.into_iter().map(|(nibbles, node)| {
-            (TrieKey::StorageNode(hashed_address, nibbles), TrieOp::Update(node))
-        }));
+        storage_tries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        TrieUpdatesSorted { removed_nodes: self.removed_nodes, account_nodes, storage_tries }
     }
 
     /// Flush updates all aggregated updates to the database.
-    pub fn flush(self, tx: &(impl DbTx + DbTxMut)) -> Result<(), reth_db::DatabaseError> {
-        if self.trie_operations.is_empty() {
-            return Ok(())
+    ///
+    /// # Returns
+    ///
+    /// The number of storage trie entries updated in the database.
+    pub fn write_to_database(
+        self,
+        tx: &(impl DbTx + DbTxMut),
+    ) -> Result<usize, reth_db::DatabaseError> {
+        if self.account_nodes.is_empty() &&
+            self.removed_nodes.is_empty() &&
+            self.storage_tries.is_empty()
+        {
+            return Ok(0)
         }
 
+        let mut num_entries = 0;
+        let mut account_updates =
+            Vec::from_iter(self.removed_nodes.into_iter().map(|nibbles| (nibbles, None)).chain(
+                self.account_nodes.into_iter().map(|(nibbles, node)| (nibbles, Some(node))),
+            ));
+        account_updates.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         let mut account_trie_cursor = tx.cursor_write::<tables::AccountsTrie>()?;
-        let mut storage_trie_cursor = tx.cursor_dup_write::<tables::StoragesTrie>()?;
-
-        let mut trie_operations = Vec::from_iter(self.trie_operations);
-        trie_operations.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-        for (key, operation) in trie_operations {
-            match key {
-                TrieKey::AccountNode(nibbles) => {
-                    let nibbles = StoredNibbles(nibbles);
-                    match operation {
-                        TrieOp::Delete => {
-                            if account_trie_cursor.seek_exact(nibbles)?.is_some() {
-                                account_trie_cursor.delete_current()?;
-                            }
-                        }
-                        TrieOp::Update(node) => {
-                            if !nibbles.0.is_empty() {
-                                account_trie_cursor.upsert(nibbles, StoredBranchNode(node))?;
-                            }
-                        }
+        for (key, updated_node) in account_updates {
+            let nibbles = StoredNibbles(key);
+            match updated_node {
+                Some(node) => {
+                    if !nibbles.0.is_empty() {
+                        num_entries += 1;
+                        account_trie_cursor.upsert(nibbles, StoredBranchNode(node))?;
                     }
                 }
-                TrieKey::StorageTrie(hashed_address) => match operation {
-                    TrieOp::Delete => {
-                        if storage_trie_cursor.seek_exact(hashed_address)?.is_some() {
-                            storage_trie_cursor.delete_current_duplicates()?;
-                        }
-                    }
-                    TrieOp::Update(..) => unreachable!("Cannot update full storage trie."),
-                },
-                TrieKey::StorageNode(hashed_address, nibbles) => {
-                    if !nibbles.is_empty() {
-                        let nibbles = StoredNibblesSubKey(nibbles);
-                        // Delete the old entry if it exists.
-                        if storage_trie_cursor
-                            .seek_by_key_subkey(hashed_address, nibbles.clone())?
-                            .filter(|e| e.nibbles == nibbles)
-                            .is_some()
-                        {
-                            storage_trie_cursor.delete_current()?;
-                        }
-
-                        // The operation is an update, insert new entry.
-                        if let TrieOp::Update(node) = operation {
-                            storage_trie_cursor
-                                .upsert(hashed_address, StorageTrieEntry { nibbles, node })?;
-                        }
+                None => {
+                    num_entries += 1;
+                    if account_trie_cursor.seek_exact(nibbles)?.is_some() {
+                        account_trie_cursor.delete_current()?;
                     }
                 }
-            };
+            }
         }
 
-        Ok(())
-    }
+        let mut storage_tries = Vec::from_iter(self.storage_tries);
+        storage_tries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut storage_trie_cursor = tx.cursor_dup_write::<tables::StoragesTrie>()?;
+        for (hashed_address, storage_trie_updates) in storage_tries {
+            let updated_storage_entries =
+                storage_trie_updates.write_with_cursor(&mut storage_trie_cursor, hashed_address)?;
+            num_entries += updated_storage_entries;
+        }
 
-    /// creates [`TrieUpdatesSorted`] by sorting the `trie_operations`.
-    pub fn sorted(&self) -> TrieUpdatesSorted {
-        let mut trie_operations = Vec::from_iter(self.trie_operations.clone());
-        trie_operations.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-        TrieUpdatesSorted { trie_operations }
-    }
-
-    /// converts trie updates into [`TrieUpdatesSorted`].
-    pub fn into_sorted(self) -> TrieUpdatesSorted {
-        let mut trie_operations = Vec::from_iter(self.trie_operations);
-        trie_operations.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-        TrieUpdatesSorted { trie_operations }
+        Ok(num_entries)
     }
 }
 
-/// The aggregation of trie updates.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deref)]
+/// Trie updates for storage trie of a single account.
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
+pub struct StorageTrieUpdates {
+    /// Flag indicating whether the trie was deleted.
+    pub(crate) is_deleted: bool,
+    /// Collection of updated storage trie nodes.
+    pub(crate) storage_nodes: HashMap<Nibbles, BranchNodeCompact>,
+    /// Collection of removed storage trie nodes.
+    pub(crate) removed_nodes: HashSet<Nibbles>,
+}
+
+impl StorageTrieUpdates {
+    /// Returns empty storage trie updates with `deleted` set to `true`.
+    pub fn deleted() -> Self {
+        Self {
+            is_deleted: true,
+            storage_nodes: HashMap::default(),
+            removed_nodes: HashSet::default(),
+        }
+    }
+
+    /// Returns the length of updated nodes.
+    pub fn len(&self) -> usize {
+        self.storage_nodes.len() + self.removed_nodes.len()
+    }
+
+    /// Returns `true` if storage updates are empty.
+    pub fn is_empty(&self) -> bool {
+        self.storage_nodes.is_empty() && self.removed_nodes.is_empty()
+    }
+
+    /// Sets `deleted` flag on the storage trie.
+    pub fn set_deleted(&mut self, deleted: bool) {
+        self.is_deleted = deleted;
+    }
+
+    /// Finalize storage trie updates for by taking updates from walker and hash builder.
+    pub fn finalize<C>(&mut self, walker: TrieWalker<C>, hash_builder: HashBuilder) {
+        // Retrieve deleted keys from trie walker.
+        let (_, removed_keys) = walker.split();
+        self.removed_nodes.extend(removed_keys);
+
+        // Retrieve updated nodes from hash builder.
+        let (_, updated_nodes) = hash_builder.split();
+        self.storage_nodes.extend(updated_nodes);
+    }
+
+    /// Convert storage trie updates into [`StorageTrieUpdatesSorted`].
+    pub fn into_sorted(self) -> StorageTrieUpdatesSorted {
+        let mut storage_nodes = Vec::from_iter(self.storage_nodes);
+        storage_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        StorageTrieUpdatesSorted {
+            is_deleted: self.is_deleted,
+            removed_nodes: self.removed_nodes,
+            storage_nodes,
+        }
+    }
+
+    /// Initializes a storage trie cursor and writes updates to database.
+    pub fn write_to_database(
+        self,
+        tx: &(impl DbTx + DbTxMut),
+        hashed_address: B256,
+    ) -> Result<usize, reth_db::DatabaseError> {
+        let mut cursor = tx.cursor_dup_write::<tables::StoragesTrie>()?;
+        self.write_with_cursor(&mut cursor, hashed_address)
+    }
+
+    /// Writes updates to database.
+    ///
+    /// # Returns
+    ///
+    /// The number of storage trie entries updated in the database.
+    fn write_with_cursor<C>(
+        self,
+        cursor: &mut C,
+        hashed_address: B256,
+    ) -> Result<usize, reth_db::DatabaseError>
+    where
+        C: DbCursorRO<tables::StoragesTrie>
+            + DbCursorRW<tables::StoragesTrie>
+            + DbDupCursorRO<tables::StoragesTrie>
+            + DbDupCursorRW<tables::StoragesTrie>,
+    {
+        // The storage trie for this account has to be deleted.
+        if self.is_deleted && cursor.seek_exact(hashed_address)?.is_some() {
+            cursor.delete_current_duplicates()?;
+        }
+
+        let mut num_entries = 0;
+        let mut storage_updates =
+            Vec::from_iter(self.removed_nodes.into_iter().map(|nibbles| (nibbles, None)).chain(
+                self.storage_nodes.into_iter().map(|(nibbles, node)| (nibbles, Some(node))),
+            ));
+        storage_updates.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        for (nibbles, maybe_updated) in storage_updates {
+            if !nibbles.is_empty() {
+                num_entries += 1;
+                let nibbles = StoredNibblesSubKey(nibbles);
+                // Delete the old entry if it exists.
+                if cursor
+                    .seek_by_key_subkey(hashed_address, nibbles.clone())?
+                    .filter(|e| e.nibbles == nibbles)
+                    .is_some()
+                {
+                    cursor.delete_current()?;
+                }
+
+                // There is an updated version of this node, insert new entry.
+                if let Some(node) = maybe_updated {
+                    cursor.upsert(hashed_address, StorageTrieEntry { nibbles, node })?;
+                }
+            }
+        }
+
+        Ok(num_entries)
+    }
+}
+
+/// Sorted trie updates used for lookups and insertions.
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
 pub struct TrieUpdatesSorted {
-    /// Sorted collection of trie operations.
-    pub(crate) trie_operations: Vec<(TrieKey, TrieOp)>,
+    pub(crate) account_nodes: Vec<(Nibbles, BranchNodeCompact)>,
+    pub(crate) removed_nodes: HashSet<Nibbles>,
+    pub(crate) storage_tries: Vec<(B256, StorageTrieUpdatesSorted)>,
 }
 
-impl TrieUpdatesSorted {
-    /// Find the account node with the given nibbles.
-    pub fn find_account_node(&self, key: &Nibbles) -> Option<(Nibbles, TrieOp)> {
-        self.trie_operations.iter().find_map(|(k, op)| {
-            k.as_account_node_key()
-                .filter(|nibbles| nibbles == &key)
-                .map(|nibbles| (nibbles.clone(), op.clone()))
-        })
-    }
-
-    /// Find the storage node with the given hashed address and key.
-    pub fn find_storage_node(
-        &self,
-        hashed_address: &B256,
-        key: &Nibbles,
-    ) -> Option<(Nibbles, TrieOp)> {
-        self.trie_operations.iter().find_map(|(k, op)| {
-            k.as_storage_node_key()
-                .filter(|(address, nibbles)| address == &hashed_address && nibbles == &key)
-                .map(|(_, nibbles)| (nibbles.clone(), op.clone()))
-        })
-    }
+/// Sorted trie updates used for lookups and insertions.
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
+pub struct StorageTrieUpdatesSorted {
+    pub(crate) is_deleted: bool,
+    pub(crate) storage_nodes: Vec<(Nibbles, BranchNodeCompact)>,
+    pub(crate) removed_nodes: HashSet<Nibbles>,
 }

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -125,6 +125,7 @@ impl TrieUpdates {
 
 /// Trie updates for storage trie of a single account.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageTrieUpdates {
     /// Flag indicating whether the trie was deleted.
     pub(crate) is_deleted: bool,


### PR DESCRIPTION
## Description

Revamp trie updates internal storage. Store account trie and storage trie updates separately. Remove buggy implementation of in-memory trie nodes (will be addressed in the follow up).  