### PR TITLE
feat: add ethereum engine chain orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7125,6 +7125,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ethereum-engine"
+version = "1.0.0"
+dependencies = [
+ "eyre",
+ "futures",
+ "pin-project",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-engine-tree",
+ "reth-ethereum-engine-primitives",
+ "reth-network-p2p",
+ "reth-primitives",
+ "reth-stages",
+ "reth-stages-api",
+ "reth-tasks",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7128,13 +7128,11 @@ dependencies = [
 name = "reth-ethereum-engine"
 version = "1.0.0"
 dependencies = [
- "eyre",
  "futures",
  "pin-project",
  "reth-beacon-consensus",
  "reth-chainspec",
  "reth-db-api",
- "reth-engine-primitives",
  "reth-engine-tree",
  "reth-ethereum-engine-primitives",
  "reth-network-p2p",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7138,8 +7138,6 @@ dependencies = [
  "reth-engine-tree",
  "reth-ethereum-engine-primitives",
  "reth-network-p2p",
- "reth-primitives",
- "reth-stages",
  "reth-stages-api",
  "reth-tasks",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/errors/",
     "crates/ethereum-forks/",
     "crates/ethereum/consensus/",
+    "crates/ethereum/engine/",
     "crates/ethereum/engine-primitives/",
     "crates/ethereum/evm",
     "crates/ethereum/node",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -30,6 +30,7 @@ reth-payload-validator.workspace = true
 reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-prune.workspace = true
+reth-prune-types.workspace = true
 reth-revm.workspace = true
 reth-rpc-types.workspace = true
 reth-stages-api.workspace = true
@@ -54,11 +55,24 @@ aquamarine.workspace = true
 parking_lot.workspace = true
 tracing.workspace = true
 
+# optional deps for test-utils
+reth-stages = { workspace = true, optional = true }
+reth-tracing = { workspace = true, optional = true }
+
 [dev-dependencies]
 # reth
+reth-db = { workspace = true, features = ["test-utils"] }
 reth-network-p2p = { workspace = true, features = ["test-utils"] }
 reth-prune-types.workspace = true
 reth-stages = { workspace = true, features = ["test-utils"] }
 reth-tracing.workspace = true
 
 assert_matches.workspace = true
+
+[features]
+test-utils = [
+  "reth-db/test-utils",
+  "reth-network-p2p/test-utils",
+  "reth-stages/test-utils",
+  "reth-tracing"
+]

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -10,9 +10,10 @@ use reth_engine_primitives::EngineTypes;
 use reth_primitives::{SealedBlockWithSenders, B256};
 use std::{
     collections::HashSet,
+    sync::mpsc::Sender,
     task::{Context, Poll},
 };
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 /// Advances the chain based on incoming requests.
 ///
@@ -146,9 +147,9 @@ pub trait EngineRequestHandler: Send + Sync {
 #[derive(Debug)]
 pub struct EngineApiRequestHandler<T: EngineTypes> {
     /// channel to send messages to the tree to execute the payload.
-    to_tree: mpsc::Sender<FromEngine<BeaconEngineMessage<T>>>,
+    to_tree: Sender<FromEngine<BeaconEngineMessage<T>>>,
     /// channel to receive messages from the tree.
-    from_tree: mpsc::UnboundedReceiver<EngineApiEvent>,
+    from_tree: UnboundedReceiver<EngineApiEvent>,
     // TODO add db controller
 }
 
@@ -157,8 +158,8 @@ where
     T: EngineTypes,
 {
     pub const fn new(
-        to_tree: mpsc::Sender<FromEngine<BeaconEngineMessage<T>>>,
-        from_tree: mpsc::UnboundedReceiver<EngineApiEvent>,
+        to_tree: Sender<FromEngine<BeaconEngineMessage<T>>>,
+        from_tree: UnboundedReceiver<EngineApiEvent>,
     ) -> Self {
         Self { to_tree, from_tree }
     }

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -172,9 +172,8 @@ where
     type Request = BeaconEngineMessage<T>;
 
     fn on_event(&mut self, event: FromEngine<Self::Request>) {
-        // delegate to the tree, given that we are not currently using it here
-        // we explicitly drop the future to prevent warnings
-        std::mem::drop(self.to_tree.send(event));
+        // delegate to the tree
+        let _ = self.to_tree.send(event);
     }
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<RequestHandlerEvent<Self::Event>> {

--- a/crates/engine/tree/src/lib.rs
+++ b/crates/engine/tree/src/lib.rs
@@ -1,4 +1,8 @@
 //! This crate includes the core components for advancing a reth chain.
+//!
+//! ## Feature Flags
+//!
+//! - `test-utils`: Export utilities for testing
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
@@ -27,5 +31,5 @@ pub mod persistence;
 /// Support for interacting with the blockchain tree.
 pub mod tree;
 
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;

--- a/crates/engine/tree/src/test_utils.rs
+++ b/crates/engine/tree/src/test_utils.rs
@@ -1,6 +1,62 @@
+use reth_chainspec::ChainSpec;
+use reth_db::{mdbx::DatabaseEnv, test_utils::TempDatabase};
 use reth_network_p2p::test_utils::TestFullBlockClient;
-use reth_primitives::{BlockBody, SealedHeader};
-use std::ops::Range;
+use reth_primitives::{BlockBody, SealedHeader, B256};
+use reth_provider::{test_utils::create_test_provider_factory_with_chain_spec, ExecutionOutcome};
+use reth_prune_types::PruneModes;
+use reth_stages::{test_utils::TestStages, ExecOutput, StageError};
+use reth_stages_api::Pipeline;
+use reth_static_file::StaticFileProducer;
+use std::{collections::VecDeque, ops::Range, sync::Arc};
+use tokio::sync::watch;
+
+/// Test pipeline builder.
+#[derive(Default)]
+pub struct TestPipelineBuilder {
+    pipeline_exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
+    executor_results: Vec<ExecutionOutcome>,
+}
+
+impl TestPipelineBuilder {
+    /// Create a new [`TestPipelineBuilder`].
+    pub const fn new() -> Self {
+        Self { pipeline_exec_outputs: VecDeque::new(), executor_results: Vec::new() }
+    }
+
+    /// Set the pipeline execution outputs to use for the test consensus engine.
+    pub fn with_pipeline_exec_outputs(
+        mut self,
+        pipeline_exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
+    ) -> Self {
+        self.pipeline_exec_outputs = pipeline_exec_outputs;
+        self
+    }
+
+    /// Set the executor results to use for the test consensus engine.
+    #[allow(dead_code)]
+    pub fn with_executor_results(mut self, executor_results: Vec<ExecutionOutcome>) -> Self {
+        self.executor_results = executor_results;
+        self
+    }
+
+    /// Builds the pipeline.
+    pub fn build(self, chain_spec: Arc<ChainSpec>) -> Pipeline<Arc<TempDatabase<DatabaseEnv>>> {
+        reth_tracing::init_test_tracing();
+
+        // Setup pipeline
+        let (tip_tx, _tip_rx) = watch::channel(B256::default());
+        let pipeline = Pipeline::builder()
+            .add_stages(TestStages::new(self.pipeline_exec_outputs, Default::default()))
+            .with_tip_sender(tip_tx);
+
+        let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec);
+
+        let static_file_producer =
+            StaticFileProducer::new(provider_factory.clone(), PruneModes::default());
+
+        pipeline.build(provider_factory, static_file_producer)
+    }
+}
 
 pub(crate) fn insert_headers_into_client(
     client: &TestFullBlockClient,

--- a/crates/ethereum/engine/Cargo.toml
+++ b/crates/ethereum/engine/Cargo.toml
@@ -33,5 +33,3 @@ eyre.workspace = true
 
 [dev-dependencies]
 reth-engine-tree = { workspace = true, features = ["test-utils"] }
-reth-primitives.workspace = true
-reth-stages.workspace = true

--- a/crates/ethereum/engine/Cargo.toml
+++ b/crates/ethereum/engine/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 reth-beacon-consensus.workspace = true
 reth-chainspec.workspace = true
 reth-db-api.workspace = true
-reth-engine-primitives.workspace = true
 reth-engine-tree.workspace = true
 reth-ethereum-engine-primitives.workspace = true
 reth-network-p2p.workspace = true
@@ -27,9 +26,6 @@ futures.workspace = true
 pin-project.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
-
-## misc
-eyre.workspace = true
 
 [dev-dependencies]
 reth-engine-tree = { workspace = true, features = ["test-utils"] }

--- a/crates/ethereum/engine/Cargo.toml
+++ b/crates/ethereum/engine/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "reth-ethereum-engine"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-beacon-consensus.workspace = true
+reth-chainspec.workspace = true
+reth-db-api.workspace = true
+reth-engine-primitives.workspace = true
+reth-engine-tree.workspace = true
+reth-ethereum-engine-primitives.workspace = true
+reth-network-p2p.workspace = true
+reth-stages-api.workspace = true
+reth-tasks.workspace = true
+
+# async
+futures.workspace = true
+pin-project.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream.workspace = true
+
+## misc
+eyre.workspace = true
+
+[dev-dependencies]
+reth-engine-tree = { workspace = true, features = ["test-utils"] }
+reth-primitives.workspace = true
+reth-stages.workspace = true

--- a/crates/ethereum/engine/src/lib.rs
+++ b/crates/ethereum/engine/src/lib.rs
@@ -1,0 +1,12 @@
+//! Ethereum engine implementation.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+/// Ethereum engine orchestrator.
+pub mod orchestrator;

--- a/crates/ethereum/engine/src/orchestrator.rs
+++ b/crates/ethereum/engine/src/orchestrator.rs
@@ -96,7 +96,7 @@ where
         self
     }
 
-    fn with_pipeline_container(
+    fn with_pipeline_and_spawner(
         mut self,
         pipeline: Pipeline<DB>,
         pipeline_task_spawner: Box<dyn TaskSpawner>,
@@ -226,7 +226,7 @@ mod tests {
             .with_client(client)
             .with_incoming_requests(incoming_requests)
             .with_tree_channels(to_tree_tx, from_tree_rx)
-            .with_pipeline_container(pipeline, pipeline_task_spawner)
+            .with_pipeline_and_spawner(pipeline, pipeline_task_spawner)
             .build()
             .unwrap();
     }

--- a/crates/ethereum/engine/src/orchestrator.rs
+++ b/crates/ethereum/engine/src/orchestrator.rs
@@ -188,11 +188,8 @@ mod tests {
     use reth_engine_tree::test_utils::TestPipelineBuilder;
     use reth_ethereum_engine_primitives::EthEngineTypes;
     use reth_network_p2p::test_utils::TestFullBlockClient;
-    use reth_primitives::BlockNumber;
-    use reth_stages::ExecOutput;
-    use reth_stages_api::StageCheckpoint;
     use reth_tasks::TokioTaskExecutor;
-    use std::{collections::VecDeque, sync::Arc};
+    use std::sync::Arc;
 
     #[test]
     fn eth_chain_orchestrator_build() {
@@ -209,13 +206,7 @@ mod tests {
         let (_tx, rx) = mpsc::unbounded_channel::<BeaconEngineMessage<EthEngineTypes>>();
         let incoming_requests = UnboundedReceiverStream::new(rx);
 
-        const PIPELINE_DONE_AFTER: u64 = 5;
-        let pipeline = TestPipelineBuilder::new()
-            .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
-                checkpoint: StageCheckpoint::new(BlockNumber::from(PIPELINE_DONE_AFTER)),
-                done: true,
-            })]))
-            .build(chain_spec.clone());
+        let pipeline = TestPipelineBuilder::new().build(chain_spec.clone());
         let pipeline_task_spawner = Box::<TokioTaskExecutor>::default();
 
         let (to_tree_tx, _to_tree_rx) = mpsc::channel(32);

--- a/crates/ethereum/engine/src/orchestrator.rs
+++ b/crates/ethereum/engine/src/orchestrator.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures::{ready, StreamExt};
 use pin_project::pin_project;
 use reth_beacon_consensus::{BeaconEngineMessage, EthBeaconConsensus};
 use reth_chainspec::ChainSpec;
@@ -79,10 +79,9 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // Call poll on the inner orchestrator.
-        match self.project().orchestrator.poll_next_unpin(cx) {
-            Poll::Ready(Some(_event)) => Poll::Ready(Ok(())),
-            Poll::Ready(None) => Poll::Ready(Ok(())),
-            Poll::Pending => Poll::Pending,
+        match ready!(self.project().orchestrator.poll_next_unpin(cx)) {
+            Some(_event) => Poll::Ready(Ok(())),
+            None => Poll::Ready(Ok(())),
         }
     }
 }

--- a/crates/ethereum/engine/src/orchestrator.rs
+++ b/crates/ethereum/engine/src/orchestrator.rs
@@ -79,9 +79,12 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // Call poll on the inner orchestrator.
-        match ready!(self.project().orchestrator.poll_next_unpin(cx)) {
-            Some(_event) => Poll::Ready(Ok(())),
-            None => Poll::Ready(Ok(())),
+        let mut orchestrator = self.project().orchestrator;
+        loop {
+            match ready!(StreamExt::poll_next_unpin(&mut orchestrator, cx)) {
+                Some(_event) => continue,
+                None => return Poll::Ready(Ok(())),
+            }
         }
     }
 }

--- a/crates/ethereum/engine/src/orchestrator.rs
+++ b/crates/ethereum/engine/src/orchestrator.rs
@@ -1,0 +1,233 @@
+use futures::StreamExt;
+use pin_project::pin_project;
+use reth_beacon_consensus::{BeaconEngineMessage, EthBeaconConsensus};
+use reth_chainspec::ChainSpec;
+use reth_db_api::database::Database;
+use reth_engine_primitives::EngineTypes;
+use reth_engine_tree::{
+    backfill::PipelineSync,
+    chain::ChainOrchestrator,
+    download::BasicBlockDownloader,
+    engine::{EngineApiEvent, EngineApiRequestHandler, EngineHandler, FromEngine},
+};
+use reth_ethereum_engine_primitives::EthEngineTypes;
+use reth_network_p2p::{bodies::client::BodiesClient, headers::client::HeadersClient};
+use reth_stages_api::Pipeline;
+use reth_tasks::TaskSpawner;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+/// Alias for Ethereum chain orchestrator.
+type EthChainOrchestratorType<DB, Client> = ChainOrchestrator<
+    EngineHandler<
+        EngineApiRequestHandler<EthEngineTypes>,
+        UnboundedReceiverStream<BeaconEngineMessage<EthEngineTypes>>,
+        BasicBlockDownloader<Client>,
+    >,
+    PipelineSync<DB>,
+>;
+
+/// Builder for `EthChainOrchestrator`.
+#[allow(missing_debug_implementations, dead_code)]
+pub struct EthChainOrchestratorBuilder<DB, Client>
+where
+    DB: Database + 'static,
+    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+{
+    chain_spec: Option<Arc<ChainSpec>>,
+    client: Option<Client>,
+    incoming_requests: Option<UnboundedReceiverStream<BeaconEngineMessage<EthEngineTypes>>>,
+    tree_channels: Option<TreeChannels<EthEngineTypes>>,
+    pipeline_container: Option<PipelineContainer<DB>>,
+}
+
+impl<DB, Client> Default for EthChainOrchestratorBuilder<DB, Client>
+where
+    DB: Database + 'static,
+    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+{
+    fn default() -> Self {
+        Self {
+            chain_spec: None,
+            client: None,
+            incoming_requests: None,
+            tree_channels: None,
+            pipeline_container: None,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl<DB, Client> EthChainOrchestratorBuilder<DB, Client>
+where
+    DB: Database + 'static,
+    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+{
+    fn with_chain_spec(mut self, chain_spec: Arc<ChainSpec>) -> Self {
+        self.chain_spec = Some(chain_spec);
+        self
+    }
+
+    fn with_client(mut self, client: Client) -> Self {
+        self.client = Some(client);
+        self
+    }
+
+    fn with_incoming_requests(
+        mut self,
+        incoming_requests: UnboundedReceiverStream<BeaconEngineMessage<EthEngineTypes>>,
+    ) -> Self {
+        self.incoming_requests = Some(incoming_requests);
+        self
+    }
+
+    fn with_tree_channels(
+        mut self,
+        to_tree: mpsc::Sender<FromEngine<BeaconEngineMessage<EthEngineTypes>>>,
+        from_tree: mpsc::UnboundedReceiver<EngineApiEvent>,
+    ) -> Self {
+        self.tree_channels = Some(TreeChannels { to_tree, from_tree });
+        self
+    }
+
+    fn with_pipeline_container(
+        mut self,
+        pipeline: Pipeline<DB>,
+        pipeline_task_spawner: Box<dyn TaskSpawner>,
+    ) -> Self {
+        self.pipeline_container = Some(PipelineContainer { pipeline, pipeline_task_spawner });
+        self
+    }
+
+    fn build(self) -> eyre::Result<EthChainOrchestrator<DB, Client>> {
+        let (
+            Some(chain_spec),
+            Some(client),
+            Some(incoming_requests),
+            Some(tree_channels),
+            Some(pipeline_container),
+        ) = (
+            self.chain_spec,
+            self.client,
+            self.incoming_requests,
+            self.tree_channels,
+            self.pipeline_container,
+        )
+        else {
+            eyre::bail!("not all required compoenents specified")
+        };
+
+        let consensus = Arc::new(EthBeaconConsensus::new(chain_spec));
+        let downloader = BasicBlockDownloader::new(client, consensus);
+
+        let TreeChannels { to_tree, from_tree } = tree_channels;
+        let engine_handler = EngineApiRequestHandler::new(to_tree, from_tree);
+        let handler = EngineHandler::new(engine_handler, downloader, incoming_requests);
+
+        let PipelineContainer { pipeline, pipeline_task_spawner } = pipeline_container;
+        let backfill_sync = PipelineSync::new(pipeline, pipeline_task_spawner);
+
+        Ok(EthChainOrchestrator { orchestrator: ChainOrchestrator::new(handler, backfill_sync) })
+    }
+}
+
+/// The type that drives the Ethereum chain forward and communicates progress.
+#[pin_project]
+#[allow(missing_debug_implementations)]
+pub struct EthChainOrchestrator<DB, Client>
+where
+    DB: Database + 'static,
+    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+{
+    orchestrator: EthChainOrchestratorType<DB, Client>,
+}
+
+impl<DB, Client> Future for EthChainOrchestrator<DB, Client>
+where
+    DB: Database + 'static,
+    Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
+{
+    type Output = Result<(), EthChainOrchestratorError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Call poll on the inner orchestrator.
+        match self.project().orchestrator.poll_next_unpin(cx) {
+            Poll::Ready(Some(_event)) => Poll::Ready(Ok(())),
+            Poll::Ready(None) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Potential error returned by `EthChainOrchestrator`.
+#[derive(Debug)]
+pub struct EthChainOrchestratorError {}
+
+/// Helper container for tree channels in `EthChainOrchestratorBuilder`.
+struct TreeChannels<T: EngineTypes> {
+    to_tree: mpsc::Sender<FromEngine<BeaconEngineMessage<T>>>,
+    from_tree: mpsc::UnboundedReceiver<EngineApiEvent>,
+}
+
+/// Helper container for pipeline related values in `EthChainOrchestratorBuilder`.
+struct PipelineContainer<DB: Database> {
+    pipeline: Pipeline<DB>,
+    pipeline_task_spawner: Box<dyn TaskSpawner>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_chainspec::{ChainSpecBuilder, MAINNET};
+    use reth_engine_tree::test_utils::TestPipelineBuilder;
+    use reth_ethereum_engine_primitives::EthEngineTypes;
+    use reth_network_p2p::test_utils::TestFullBlockClient;
+    use reth_primitives::BlockNumber;
+    use reth_stages::ExecOutput;
+    use reth_stages_api::StageCheckpoint;
+    use reth_tasks::TokioTaskExecutor;
+    use std::{collections::VecDeque, sync::Arc};
+
+    #[test]
+    fn eth_chain_orchestrator_build() {
+        let chain_spec = Arc::new(
+            ChainSpecBuilder::default()
+                .chain(MAINNET.chain)
+                .genesis(MAINNET.genesis.clone())
+                .paris_activated()
+                .build(),
+        );
+
+        let client = TestFullBlockClient::default();
+
+        let (_tx, rx) = mpsc::unbounded_channel::<BeaconEngineMessage<EthEngineTypes>>();
+        let incoming_requests = UnboundedReceiverStream::new(rx);
+
+        const PIPELINE_DONE_AFTER: u64 = 5;
+        let pipeline = TestPipelineBuilder::new()
+            .with_pipeline_exec_outputs(VecDeque::from([Ok(ExecOutput {
+                checkpoint: StageCheckpoint::new(BlockNumber::from(PIPELINE_DONE_AFTER)),
+                done: true,
+            })]))
+            .build(chain_spec.clone());
+        let pipeline_task_spawner = Box::<TokioTaskExecutor>::default();
+
+        let (to_tree_tx, _to_tree_rx) = mpsc::channel(32);
+        let (_from_tree_tx, from_tree_rx) = mpsc::unbounded_channel();
+
+        let _eth_chain_orchestrator = EthChainOrchestratorBuilder::default()
+            .with_chain_spec(chain_spec)
+            .with_client(client)
+            .with_incoming_requests(incoming_requests)
+            .with_tree_channels(to_tree_tx, from_tree_rx)
+            .with_pipeline_container(pipeline, pipeline_task_spawner)
+            .build()
+            .unwrap();
+    }
+}


### PR DESCRIPTION
Closes #9151

Adds new `reth-ethereum-engine` crate and `EthChainOrchestrator` type implementing `ChainOrchestrator`. It also includes a builder for this type that creates all the required components.

For now the communication with this component is expected to be done using incoming requests (`BeaconEngineMessage<EthEngineTypes>`) and the channels to communicate directly to/from the tree. `EthChainOrchestrator` wraps a `ChainOrchestrator` that uses these channels to setup all the required components.

There's a simple test that for now builds an orchestrator instance it reuses part of the test pipeline builder from `reth-engine-tree`, which has been made available through a `test-utils` feature. 