### PR TITLE
feat: backfill job single block iterator

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -363,13 +363,11 @@ where
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
-    /// Executes the block and commits the state changes.
+    /// Executes the block and commits the changes to the internal state.
     ///
     /// Returns the receipts of the transactions in the block.
     ///
     /// Returns an error if the block could not be executed or failed verification.
-    ///
-    /// State changes are committed to the database.
     fn execute(mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
         let BlockExecutionInput { block, total_difficulty } = input;
         let EthExecuteOutput { receipts, requests, gas_used } =

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -101,7 +101,7 @@ pub trait BatchExecutor<DB> {
 /// Contains the state changes, transaction receipts, and total gas used in the block.
 ///
 /// TODO(mattsse): combine with `ExecutionOutcome`
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct BlockExecutionOutput<T> {
     /// The changed state of the block after execution.
     pub state: BundleState,

--- a/crates/exex/exex/src/backfill.rs
+++ b/crates/exex/exex/src/backfill.rs
@@ -197,6 +197,13 @@ where
     }
 }
 
+impl<E, DB, P> BackfillJob<E, DB, P> {
+    /// Converts the backfill job into a single block backfill job.
+    pub fn into_single_blocks(self) -> SingleBlockBackfillJob<E, DB, P> {
+        self.into()
+    }
+}
+
 impl<E, DB, P> From<BackfillJob<E, DB, P>> for SingleBlockBackfillJob<E, DB, P> {
     fn from(value: BackfillJob<E, DB, P>) -> Self {
         Self {
@@ -269,7 +276,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{BackfillJobFactory, SingleBlockBackfillJob};
+    use crate::BackfillJobFactory;
     use eyre::OptionExt;
     use reth_blockchain_tree::noop::NoopBlockchainTree;
     use reth_chainspec::{ChainSpec, ChainSpecBuilder, EthereumHardfork, MAINNET};
@@ -501,7 +508,7 @@ mod tests {
         // Backfill the first block
         let factory = BackfillJobFactory::new(executor, blockchain_db);
         let job = factory.backfill(1..=1);
-        let single_job: SingleBlockBackfillJob<_, _, _> = job.into();
+        let single_job = job.into_single_blocks();
         let block_execution_it = single_job.into_iter();
 
         // Assert that the backfill job only produces a single block

--- a/crates/exex/exex/src/backfill.rs
+++ b/crates/exex/exex/src/backfill.rs
@@ -280,7 +280,7 @@ mod tests {
     {
         let provider = provider_factory.provider()?;
 
-        // Execute both blocks on top of the genesis state
+        // Execute the block to produce a block execution output
         let block_execution_output = EthExecutorProvider::ethereum(chain_spec)
             .executor(StateProviderDatabase::new(LatestStateProviderRef::new(
                 provider.tx_ref(),
@@ -297,7 +297,7 @@ mod tests {
         };
         execution_outcome.bundle.reverts.sort();
 
-        // Commit the block to the database
+        // Commit the block's execution outcome to the database
         let provider_rw = provider_factory.provider_rw()?;
         let block = block.clone().seal_slow();
         provider_rw.append_blocks_with_state(
@@ -349,7 +349,7 @@ mod tests {
         .with_recovered_senders()
         .ok_or_eyre("failed to recover senders")?;
 
-        // Second block has resend the same transaction with increased nonce
+        // Second block resends the same transaction with increased nonce
         let block2 = Block {
             header: Header {
                 parent_hash: block1.header.hash_slow(),
@@ -458,7 +458,7 @@ mod tests {
         let blocks_and_outcomes = block_execution_it.collect::<Vec<_>>();
         assert_eq!(blocks_and_outcomes.len(), 1);
 
-        // Assert that the backfill job single block iterator produces the same output for each
+        // Assert that the backfill job single block iterator produces the expected output for each
         // block
         for (i, res) in blocks_and_outcomes.into_iter().enumerate() {
             let (block, mut outcome) = res?;


### PR DESCRIPTION
Resolves #9172 

Adds a `into_single_blocks` function to `BackfillJob` in order to produce an iterator which yields single block execution outcomes.