### PR TITLE
feat(rpc): `debug_executionWitness`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8278,6 +8278,7 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "revm-primitives",

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256};
 use reth_rpc_types::{
@@ -131,6 +133,18 @@ pub trait DebugApi {
         state_context: Option<StateContext>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<Vec<GethTrace>>>;
+
+    /// The `debug_executionWitness` method allows for re-execution of a block with the purpose of
+    /// generating an execution witness. The witness comprises of a map of all hashed trie nodes
+    /// to their preimages that were required during the execution of the block, including during
+    /// state root recomputation.
+    ///
+    /// The first and only argument is the block number or block hash.
+    #[method(name = "executionWitness")]
+    async fn debug_execution_witness(
+        &self,
+        block: BlockNumberOrTag,
+    ) -> RpcResult<HashMap<B256, Bytes>>;
 
     /// Sets the logging backtrace location. When a backtrace location is set and a log message is
     /// emitted at that location, the stack of the goroutine executing the log statement will

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256};
 use reth_rpc_types::{
@@ -9,6 +7,7 @@ use reth_rpc_types::{
     },
     Bundle, RichBlock, StateContext, TransactionRequest,
 };
+use std::collections::HashMap;
 
 /// Debug rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -34,6 +34,7 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-node-api.workspace = true
 reth-network-types.workspace = true
+reth-trie.workspace = true
 
 # eth
 alloy-dyn-abi.workspace = true

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -629,7 +629,9 @@ where
                 // Generate an execution witness for the aggregated state of accessed accounts.
                 // Destruct the cache database to retrieve the state provider.
                 let state_provider = db.database.into_inner();
-                let witness = state_provider.witness(HashedPostState::default(), hashed_state)?;
+                let witness = state_provider
+                    .witness(HashedPostState::default(), hashed_state)
+                    .map_err(Into::into)?;
                 Ok(witness)
             })
             .await

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -564,7 +564,7 @@ where
             self.inner.eth_api.evm_env_at(block_id.into()),
             self.inner.eth_api.block_with_senders(block_id.into()),
         )?;
-        let block = maybe_block.ok_or(EthApiError::UnknownBlockNumber.into())?;
+        let block = maybe_block.ok_or(EthApiError::UnknownBlockNumber)?;
 
         let this = self.clone();
 


### PR DESCRIPTION
## Overview

Adds a new endpoint to the `debug` namespace for generating historical execution witnesses.

### Rationale

For ZK and Optimistic proving systems, generating execution witnesses for stateless execution can be tough. Before [peter's recent cross-client validation proposal](https://gist.github.com/karalabe/47c906f0ab4fdc5b8b791b74f084e5f9), there were fairly limited proposals for this feature pre-verkle. All existing options involve expensive-to-run nodes with large storage requirements, i.e. `gcmode=archive` + `state.scheme=hash` geth.

Hash scheme geth does the trick, but in an abusive way towards their `debug_dbGet` endpoint, which just-so-happens to key all RLP-encoded trie nodes by their hash (`H(rlp(trie_node))` -> `rlp(trie_node)`).

### How does it work?

1. The block is re-executed on top if its parent's state.
2. All _referenced_ accounts & their storage slots (both referenced and modified) are pulled from the wrapping `CacheDB`.
3. For each of these accounts, an `AccountProof` is generated, utilizing the `HistoricalStateProvider::proof` method.
5. All RLP encoded trie nodes are hashed, and placed into a map of `H(rlp(trie_node))` -> `rlp(trie_node)`.

### DoS concerns

Due to reth's database format only storing merkle diffs, this process can become very expensive for the same reason that state root generation in historical execution within reth can be very expensive. Each diff is layered, which means the further back we reach, the more expensive the operation becomes (approaching upper bound, potentially unable to even fit in memory due to the sheer volume of layers.)

Because of this, this endpoint has been placed in the `debug_*` namespace, which is not often exposed to the open internet by node operators. Exposing this endpoint can pose major DoS concerns for node operators as it stands.

#### Future historical `eth_getProof` support

Historical `eth_getProof` support was already possible in `reth` before this PR, but was never implemented due to the above DoS concerns (per @rkrasiuk). This PR [does not remove the requirement for being at tip to use `eth_getProof`](https://github.com/paradigmxyz/reth/blob/cl%2Fwitness-producer/crates/rpc/rpc-eth-api/src/helpers/state.rs#L103-L106), but this could be supported in a future PR, by adding a sane default for allowed `eth_getProof` depth, configurable via the CLI. A max chain depth for `eth_getProof` would effectively cap the number of in-memory layers that must be applied to the trie.

### TODO

In order to complete this feature, we'll need to be able to also include branch sibling nodes that must be referenced in order to delete leaves in the MPT. This endpoint currently gives the entirety of the witness data required for execution, but not to re-produce the block header for the processed block. The crux of this is that we cannot know which nodes we need to reveal until we're performing the deletion, meaning we also have to compute the state root in this endpoint and collect them, as these nodes are not included within the account proofs we already generate.

To outline the problem, let's say we start with this small trie, where the root node is a branch containing 2 children (both leaf nodes):

<img width="1756" alt="Untitled (21)" src="https://github.com/paradigmxyz/reth/assets/8406232/a5c1c27d-1b02-44ad-af99-3bd81bc407ff">

If we want to delete the node in the `3` bucket, the branch node would be left with only one child - this is an invalid state. To complete the deletion, we must reveal `A` (which is hashed), and collapse the branch node into `A`. 

In order of operation:
1. Replace `3` with `rlp(empty) = 0x80`
2. Reveal the preimage of `H(node_at(A))`, and prepend the branch nibble (`A`) to its path.
3. Replace the branch node with the truncated leaf.


<img width="1756" alt="Untitled (19)" src="https://github.com/paradigmxyz/reth/assets/8406232/45f00cd2-043e-44dd-ad03-4a89eb202899">

<br />

<img width="1852" alt="Untitled (23)" src="https://github.com/paradigmxyz/reth/assets/8406232/e9528709-19d6-4379-82e9-ac936c6088dc">