### PR TITLE
feat: log throughput in execution stage

### DIFF
--- a/crates/primitives-traits/src/constants/gas_units.rs
+++ b/crates/primitives-traits/src/constants/gas_units.rs
@@ -18,11 +18,11 @@ pub const GIGAGAS: u64 = MEGAGAS * 1_000;
 pub fn format_gas_throughput(gas: u64, execution_duration: Duration) -> String {
     let gas_per_second = gas as f64 / execution_duration.as_secs_f64();
     if gas_per_second < MEGAGAS as f64 {
-        format!("{:.} Kgas/second", gas_per_second / KILOGAS as f64)
+        format!("{:.2} Kgas/second", gas_per_second / KILOGAS as f64)
     } else if gas_per_second < GIGAGAS as f64 {
-        format!("{:.} Mgas/second", gas_per_second / MEGAGAS as f64)
+        format!("{:.2} Mgas/second", gas_per_second / MEGAGAS as f64)
     } else {
-        format!("{:.} Ggas/second", gas_per_second / GIGAGAS as f64)
+        format!("{:.2} Ggas/second", gas_per_second / GIGAGAS as f64)
     }
 }
 

--- a/crates/primitives-traits/src/constants/gas_units.rs
+++ b/crates/primitives-traits/src/constants/gas_units.rs
@@ -67,14 +67,14 @@ mod tests {
         let duration = Duration::from_secs(1);
         let gas = 100_000;
         let throughput = format_gas_throughput(gas, duration);
-        assert_eq!(throughput, "100 Kgas/second");
+        assert_eq!(throughput, "100.00 Kgas/second");
 
         let gas = 100_000_000;
         let throughput = format_gas_throughput(gas, duration);
-        assert_eq!(throughput, "100 Mgas/second");
+        assert_eq!(throughput, "100.00 Mgas/second");
 
         let gas = 100_000_000_000;
         let throughput = format_gas_throughput(gas, duration);
-        assert_eq!(throughput, "100 Ggas/second");
+        assert_eq!(throughput, "100.00 Ggas/second");
     }
 }

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -276,7 +276,7 @@ where
             })?;
             execution_duration += execute_start.elapsed();
 
-            // Log execution speed
+            // Log execution throughput
             if execution_duration - last_duration >= log_speed_duration {
                 info!(
                     target: "sync::stages::execution",

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -236,6 +236,7 @@ where
         let mut last_block = start_block;
         let mut last_execution_duration = Duration::default();
         let mut last_cumulative_gas = 0;
+        let mut last_log_instant = Instant::now();
         let log_duration = Duration::from_secs(10);
 
         debug!(target: "sync::stages::execution", start = start_block, end = max_block, "Executing range");
@@ -277,7 +278,7 @@ where
             execution_duration += execute_start.elapsed();
 
             // Log execution throughput
-            if execution_duration - last_execution_duration >= log_duration {
+            if last_log_instant.elapsed() >= log_duration {
                 info!(
                     target: "sync::stages::execution",
                     start = last_block,
@@ -289,6 +290,7 @@ where
                 last_block = block_number + 1;
                 last_execution_duration = execution_duration;
                 last_cumulative_gas = cumulative_gas;
+                last_log_instant = Instant::now();
             }
 
             // Gas metrics

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -284,7 +284,7 @@ where
                     start = last_block,
                     end = block_number,
                     throughput = format_gas_throughput(cumulative_gas - last_cumulative_gas, execution_duration - last_execution_duration),
-                    "Finished executing block range"
+                    "Executed block range"
                 );
 
                 last_block = block_number + 1;

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -234,9 +234,9 @@ where
         let mut execution_duration = Duration::default();
 
         let mut last_block = start_block;
-        let mut last_duration = Duration::default();
+        let mut last_execution_duration = Duration::default();
         let mut last_cumulative_gas = 0;
-        let log_speed_duration = Duration::from_secs(10);
+        let log_duration = Duration::from_secs(10);
 
         debug!(target: "sync::stages::execution", start = start_block, end = max_block, "Executing range");
 
@@ -277,17 +277,17 @@ where
             execution_duration += execute_start.elapsed();
 
             // Log execution throughput
-            if execution_duration - last_duration >= log_speed_duration {
+            if execution_duration - last_execution_duration >= log_duration {
                 info!(
                     target: "sync::stages::execution",
                     start = last_block,
                     end = block_number,
-                    throughput = format_gas_throughput(cumulative_gas - last_cumulative_gas, execution_duration - last_duration),
+                    throughput = format_gas_throughput(cumulative_gas - last_cumulative_gas, execution_duration - last_execution_duration),
                     "Finished executing block range"
                 );
 
                 last_block = block_number + 1;
-                last_duration = execution_duration;
+                last_execution_duration = execution_duration;
                 last_cumulative_gas = cumulative_gas;
             }
 


### PR DESCRIPTION
This PR logs throughput in execution stage in every 10 second. Change `format_gas_throughput` to show 2 decimal places to make it more readable.

![execution_speed](https://github.com/paradigmxyz/reth/assets/161195644/15272abf-f97b-4ae9-9a17-337c2543b9c1)


Will close #6741 