### PR TITLE
feat: add non feature gated noop block reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7485,6 +7485,7 @@ dependencies = [
  "reth-network-types",
  "reth-primitives",
  "reth-provider",
+ "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -25,7 +25,8 @@ reth-eth-wire.workspace = true
 reth-ecies.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
-reth-provider.workspace = true
+reth-storage-api.workspace = true
+reth-provider = { workspace = true, optional = true }
 reth-tokio-util.workspace = true
 reth-consensus.workspace = true
 reth-network-peers.workspace = true
@@ -98,7 +99,7 @@ criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 default = ["serde"]
 geth-tests = []
 serde = ["dep:serde", "dep:humantime-serde", "secp256k1/serde", "enr/serde", "dep:serde_json", "reth-network-types/serde"]
-test-utils = ["reth-provider/test-utils", "dep:tempfile", "reth-transaction-pool/test-utils", "reth-network-types/test-utils"]
+test-utils = ["dep:reth-provider", "reth-provider?/test-utils", "dep:tempfile", "reth-transaction-pool/test-utils", "reth-network-types/test-utils"]
 
 [[bench]]
 name = "bench"

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -14,7 +14,7 @@ use reth_eth_wire::{HelloMessage, HelloMessageWithProtocols, Status};
 use reth_network_peers::{mainnet_nodes, pk2id, sepolia_nodes, PeerId, TrustedPeer};
 use reth_network_types::{PeersConfig, SessionsConfig};
 use reth_primitives::{ForkFilter, Head};
-use reth_provider::{BlockReader, HeaderProvider};
+use reth_storage_api::{BlockReader, HeaderProvider};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use secp256k1::SECP256K1;
 use std::{collections::HashSet, net::SocketAddr, sync::Arc};
@@ -443,11 +443,10 @@ impl NetworkConfigBuilder {
 
     /// Convenience function for creating a [`NetworkConfig`] with a noop provider that does
     /// nothing.
-    #[cfg(any(test, feature = "test-utils"))]
     pub fn build_with_noop_provider(
         self,
-    ) -> NetworkConfig<reth_provider::test_utils::NoopProvider> {
-        self.build(reth_provider::test_utils::NoopProvider::default())
+    ) -> NetworkConfig<reth_storage_api::noop::NoopBlockReader> {
+        self.build(Default::default())
     }
 
     /// Consumes the type and creates the actual [`NetworkConfig`]

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -13,7 +13,7 @@ use reth_eth_wire::{
 use reth_network_p2p::error::RequestResult;
 use reth_network_peers::PeerId;
 use reth_primitives::{BlockBody, BlockHashOrNumber, Header, HeadersDirection};
-use reth_provider::{BlockReader, HeaderProvider, ReceiptProvider};
+use reth_storage_api::{BlockReader, HeaderProvider, ReceiptProvider};
 use std::{
     future::Future,
     pin::Pin,

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -45,7 +45,7 @@ use reth_metrics::common::mpsc::UnboundedMeteredSender;
 use reth_network_api::{EthProtocolInfo, NetworkStatus, PeerInfo, ReputationChangeKind};
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_primitives::ForkId;
-use reth_provider::{BlockNumReader, BlockReader};
+use reth_storage_api::BlockNumReader;
 use reth_tasks::shutdown::GracefulShutdown;
 use reth_tokio_util::EventSender;
 use secp256k1::SecretKey;
@@ -926,7 +926,7 @@ where
 
 impl<C> NetworkManager<C>
 where
-    C: BlockReader + Unpin,
+    C: BlockNumReader + Unpin,
 {
     /// Drives the [`NetworkManager`] future until a [`GracefulShutdown`] signal is received.
     ///
@@ -955,7 +955,7 @@ where
 
 impl<C> Future for NetworkManager<C>
 where
-    C: BlockReader + Unpin,
+    C: BlockNumReader + Unpin,
 {
     type Output = ();
 

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -20,7 +20,7 @@ use reth_eth_wire::{
 use reth_network_api::PeerKind;
 use reth_network_peers::PeerId;
 use reth_primitives::{ForkId, B256};
-use reth_provider::BlockNumReader;
+use reth_storage_api::BlockNumReader;
 use std::{
     collections::{HashMap, VecDeque},
     net::{IpAddr, SocketAddr},

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -13,7 +13,7 @@ use reth_eth_wire::{
     EthVersion, Status,
 };
 use reth_network_peers::PeerId;
-use reth_provider::{BlockNumReader, BlockReader};
+use reth_storage_api::BlockNumReader;
 use std::{
     io,
     net::SocketAddr,
@@ -287,7 +287,7 @@ where
 
 impl<C> Stream for Swarm<C>
 where
-    C: BlockReader + Unpin,
+    C: BlockNumReader + Unpin,
 {
     type Item = SwarmEvent;
 

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -16,9 +16,8 @@ use reth_chainspec::MAINNET;
 use reth_eth_wire::{protocol::Protocol, DisconnectReason, HelloMessageWithProtocols};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::PeerId;
-use reth_provider::{
-    test_utils::NoopProvider, BlockReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory,
-};
+use reth_provider::test_utils::NoopProvider;
+use reth_storage_api::{BlockReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory};
 use reth_tasks::TokioTaskExecutor;
 use reth_tokio_util::EventStream;
 use reth_transaction_pool::{

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -51,3 +51,5 @@ pub use trie::*;
 
 mod withdrawals;
 pub use withdrawals::*;
+
+pub mod noop;

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -1,0 +1,44 @@
+//! Various noop implementations for traits.
+
+use crate::{BlockHashReader, BlockNumReader};
+use reth_chainspec::ChainInfo;
+use reth_primitives::{BlockNumber, B256};
+use reth_storage_errors::provider::ProviderResult;
+
+/// Supports various api interfaces for testing purposes.
+#[derive(Debug, Clone, Default, Copy)]
+#[non_exhaustive]
+pub struct NoopBlockReader;
+
+/// Noop implementation for testing purposes
+impl BlockHashReader for NoopBlockReader {
+    fn block_hash(&self, _number: u64) -> ProviderResult<Option<B256>> {
+        Ok(None)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        _start: BlockNumber,
+        _end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        Ok(vec![])
+    }
+}
+
+impl BlockNumReader for NoopBlockReader {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        Ok(ChainInfo::default())
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        Ok(0)
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        Ok(0)
+    }
+
+    fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
adds a non feature gated NoopBlockReader type that can be easily consumed, so we can use it in reth-network without pulling in heavy provider impls via test-utils etc...