### PR TITLE
feat(rpc): enable historical proofs

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -313,6 +313,11 @@ RPC:
 
           [default: 50000000]
 
+      --rpc.eth-proof-window <RPC_ETH_PROOF_WINDOW>
+          The maximum proof window for historical proof generation. This value allows for generating historical proofs up to configured number of blocks from current tip (up to `tip - window`)
+
+          [default: 0]
+
 RPC State Cache:
       --rpc-cache.max-blocks <MAX_BLOCKS>
           Max number of blocks in cache

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -156,9 +156,11 @@ pub struct RpcServerArgs {
     )]
     pub rpc_gas_cap: u64,
 
-    /// The maximum proof lookback for historical proof generation.
-    #[arg(long = "rpc.max-proof-lookback", default_value_t = 0)]
-    pub rpc_max_proof_lookback: u64,
+    /// The maximum proof window for historical proof generation.
+    /// This value allows for generating historical proofs up to
+    /// configured number of blocks from current tip (up to `tip - window`).
+    #[arg(long = "rpc.eth-proof-window", default_value_t = constants::DEFAULT_ETH_PROOF_WINDOW)]
+    pub rpc_eth_proof_window: u64,
 
     /// State cache configuration.
     #[command(flatten)]
@@ -290,7 +292,7 @@ impl Default for RpcServerArgs {
             rpc_max_blocks_per_filter: constants::DEFAULT_MAX_BLOCKS_PER_FILTER.into(),
             rpc_max_logs_per_response: (constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64).into(),
             rpc_gas_cap: constants::gas_oracle::RPC_DEFAULT_GAS_CAP,
-            rpc_max_proof_lookback: 0,
+            rpc_eth_proof_window: constants::DEFAULT_ETH_PROOF_WINDOW,
             gas_price_oracle: GasPriceOracleArgs::default(),
             rpc_state_cache: RpcStateCacheArgs::default(),
         }

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -159,7 +159,11 @@ pub struct RpcServerArgs {
     /// The maximum proof window for historical proof generation.
     /// This value allows for generating historical proofs up to
     /// configured number of blocks from current tip (up to `tip - window`).
-    #[arg(long = "rpc.eth-proof-window", default_value_t = constants::DEFAULT_ETH_PROOF_WINDOW)]
+    #[arg(
+        long = "rpc.eth-proof-window",
+        default_value_t = constants::DEFAULT_ETH_PROOF_WINDOW,
+        value_parser = RangedU64ValueParser::<u64>::new().range(..=constants::MAX_ETH_PROOF_WINDOW)
+    )]
     pub rpc_eth_proof_window: u64,
 
     /// State cache configuration.

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -156,6 +156,10 @@ pub struct RpcServerArgs {
     )]
     pub rpc_gas_cap: u64,
 
+    /// The maximum proof lookback for historical proof generation.
+    #[arg(long = "rpc.max-proof-lookback", default_value_t = 0)]
+    pub rpc_max_proof_lookback: u64,
+
     /// State cache configuration.
     #[command(flatten)]
     pub rpc_state_cache: RpcStateCacheArgs,
@@ -286,6 +290,7 @@ impl Default for RpcServerArgs {
             rpc_max_blocks_per_filter: constants::DEFAULT_MAX_BLOCKS_PER_FILTER.into(),
             rpc_max_logs_per_response: (constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64).into(),
             rpc_gas_cap: constants::gas_oracle::RPC_DEFAULT_GAS_CAP,
+            rpc_max_proof_lookback: 0,
             gas_price_oracle: GasPriceOracleArgs::default(),
             rpc_state_cache: RpcStateCacheArgs::default(),
         }

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -91,6 +91,7 @@ impl RethRpcServerConfig for RpcServerArgs {
             .max_tracing_requests(self.rpc_max_tracing_requests)
             .max_blocks_per_filter(self.rpc_max_blocks_per_filter.unwrap_or_max())
             .max_logs_per_response(self.rpc_max_logs_per_response.unwrap_or_max() as usize)
+            .max_proof_lookback(self.rpc_max_proof_lookback)
             .rpc_gas_cap(self.rpc_gas_cap)
             .state_cache(self.state_cache_config())
             .gpo_config(self.gas_price_oracle_config())

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -91,7 +91,7 @@ impl RethRpcServerConfig for RpcServerArgs {
             .max_tracing_requests(self.rpc_max_tracing_requests)
             .max_blocks_per_filter(self.rpc_max_blocks_per_filter.unwrap_or_max())
             .max_logs_per_response(self.rpc_max_logs_per_response.unwrap_or_max() as usize)
-            .max_proof_lookback(self.rpc_max_proof_lookback)
+            .eth_proof_window(self.rpc_eth_proof_window)
             .rpc_gas_cap(self.rpc_gas_cap)
             .state_cache(self.state_cache_config())
             .gpo_config(self.gas_price_oracle_config())

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -141,6 +141,8 @@ pub struct EthConfig {
     pub cache: EthStateCacheConfig,
     /// Settings for the gas price oracle
     pub gas_oracle: GasPriceOracleConfig,
+    /// The maximum number of blocks into the past for generating state proofs.
+    pub max_proof_lookback: u64,
     /// The maximum number of tracing calls that can be executed in concurrently.
     pub max_tracing_requests: usize,
     /// Maximum number of blocks that could be scanned per filter request in `eth_getLogs` calls.
@@ -173,6 +175,7 @@ impl Default for EthConfig {
         Self {
             cache: EthStateCacheConfig::default(),
             gas_oracle: GasPriceOracleConfig::default(),
+            max_proof_lookback: 0,
             max_tracing_requests: default_max_tracing_requests(),
             max_blocks_per_filter: DEFAULT_MAX_BLOCKS_PER_FILTER,
             max_logs_per_response: DEFAULT_MAX_LOGS_PER_RESPONSE,
@@ -217,6 +220,12 @@ impl EthConfig {
     /// Configures the maximum gas limit for `eth_call` and call tracing RPC methods
     pub const fn rpc_gas_cap(mut self, rpc_gas_cap: u64) -> Self {
         self.rpc_gas_cap = rpc_gas_cap;
+        self
+    }
+
+    /// Configures the maximum proof lookback for historical proof generation.
+    pub const fn max_proof_lookback(mut self, max_lookback: u64) -> Self {
+        self.max_proof_lookback = max_lookback;
         self
     }
 }
@@ -269,6 +278,7 @@ impl EthApiBuild {
             ctx.cache.clone(),
             gas_oracle,
             ctx.config.rpc_gas_cap,
+            ctx.config.max_proof_lookback,
             Box::new(ctx.executor.clone()),
             BlockingTaskPool::build().expect("failed to build blocking task pool"),
             fee_history_cache,

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -4,7 +4,6 @@
 use alloy_dyn_abi::TypedData;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64};
-use reth_rpc_eth_types::EthApiError;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_rpc_types::{
     serde_helpers::JsonStorageKey,
@@ -715,13 +714,6 @@ where
         block_number: Option<BlockId>,
     ) -> RpcResult<EIP1186AccountProofResponse> {
         trace!(target: "rpc::eth", ?address, ?keys, ?block_number, "Serving eth_getProof");
-        let res = EthState::get_proof(self, address, keys, block_number)?.await;
-
-        Ok(res.map_err(|e| match e {
-            EthApiError::InvalidBlockRange => {
-                internal_rpc_err("eth_getProof is unimplemented for historical blocks")
-            }
-            _ => e.into(),
-        })?)
+        Ok(EthState::get_proof(self, address, keys, block_number)?.await?)
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -3,7 +3,7 @@
 
 use futures::Future;
 use reth_evm::ConfigureEvmEnv;
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, Header, B256, U256};
+use reth_primitives::{Address, BlockId, Bytes, Header, B256, U256};
 use reth_provider::{
     BlockIdReader, ChainSpecProvider, StateProvider, StateProviderBox, StateProviderFactory,
 };
@@ -19,6 +19,9 @@ use super::{EthApiSpec, LoadPendingBlock, SpawnBlocking};
 
 /// Helper methods for `eth_` methods relating to state (accounts).
 pub trait EthState: LoadState + SpawnBlocking {
+    /// Returns the maximum number of blocks into the past for generating state proofs.
+    fn maximum_proof_lookback(&self) -> u64;
+
     /// Returns the number of transactions sent from an address at the given block identifier.
     ///
     /// If this is [`BlockNumberOrTag::Pending`](reth_primitives::BlockNumberOrTag) then this will
@@ -90,19 +93,11 @@ pub trait EthState: LoadState + SpawnBlocking {
         let chain_info = self.chain_info()?;
         let block_id = block_id.unwrap_or_default();
 
-        // if we are trying to create a proof for the latest block, but have a BlockId as input
-        // that is not BlockNumberOrTag::Latest, then we need to figure out whether or not the
-        // BlockId corresponds to the latest block
-        let is_latest_block = match block_id {
-            BlockId::Number(BlockNumberOrTag::Number(num)) => num == chain_info.best_number,
-            BlockId::Hash(hash) => hash == chain_info.best_hash.into(),
-            BlockId::Number(BlockNumberOrTag::Latest) => true,
-            _ => false,
-        };
-
-        // TODO: remove when HistoricalStateProviderRef::proof is implemented
-        if !is_latest_block {
-            return Err(EthApiError::InvalidBlockRange)
+        // Check whether the distance to the block exceeds the maximum configured lookback.
+        let block_number = self.provider().block_number_for_id(block_id)?;
+        let max_lookback = self.maximum_proof_lookback();
+        if chain_info.best_number.saturating_sub(block_number.unwrap_or_default()) > max_lookback {
+            return Err(EthApiError::ExceedsMaxProofLookback)
         }
 
         Ok(self.spawn_tracing(move |this| {

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -54,6 +54,9 @@ pub enum EthApiError {
     /// When an invalid block range is provided
     #[error("invalid block range")]
     InvalidBlockRange,
+    /// Thrown when the target block for proof computation exceeds the maximum configured lookback.
+    #[error("distance to target block exceeds maximum proof lookback")]
+    ExceedsMaxProofLookback,
     /// An internal error where prevrandao is not set in the evm's environment
     #[error("prevrandao not in the EVM's environment after merge")]
     PrevrandaoNotSet,
@@ -143,6 +146,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidTransactionSignature |
             EthApiError::EmptyRawTransactionData |
             EthApiError::InvalidBlockRange |
+            EthApiError::ExceedsMaxProofLookback |
             EthApiError::ConflictingFeeFieldsInRequest |
             EthApiError::Signing(_) |
             EthApiError::BothStateAndStateDiffInOverride(_) |

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -54,9 +54,9 @@ pub enum EthApiError {
     /// When an invalid block range is provided
     #[error("invalid block range")]
     InvalidBlockRange,
-    /// Thrown when the target block for proof computation exceeds the maximum configured lookback.
-    #[error("distance to target block exceeds maximum proof lookback")]
-    ExceedsMaxProofLookback,
+    /// Thrown when the target block for proof computation exceeds the maximum configured window.
+    #[error("distance to target block exceeds maximum proof window")]
+    ExceedsMaxProofWindow,
     /// An internal error where prevrandao is not set in the evm's environment
     #[error("prevrandao not in the EVM's environment after merge")]
     PrevrandaoNotSet,
@@ -146,7 +146,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidTransactionSignature |
             EthApiError::EmptyRawTransactionData |
             EthApiError::InvalidBlockRange |
-            EthApiError::ExceedsMaxProofLookback |
+            EthApiError::ExceedsMaxProofWindow |
             EthApiError::ConflictingFeeFieldsInRequest |
             EthApiError::Signing(_) |
             EthApiError::BothStateAndStateDiffInOverride(_) |

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -42,6 +42,9 @@ pub const DEFAULT_ENGINE_API_IPC_ENDPOINT: &str = r"\\.\pipe\reth_engine_api.ipc
 #[cfg(not(windows))]
 pub const DEFAULT_ENGINE_API_IPC_ENDPOINT: &str = "/tmp/reth_engine_api.ipc";
 
+/// The default eth historical proof window.
+pub const DEFAULT_ETH_PROOF_WINDOW: u64 = 0;
+
 /// GPO specific constants
 pub mod gas_oracle {
     use alloy_primitives::U256;

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -45,6 +45,9 @@ pub const DEFAULT_ENGINE_API_IPC_ENDPOINT: &str = "/tmp/reth_engine_api.ipc";
 /// The default eth historical proof window.
 pub const DEFAULT_ETH_PROOF_WINDOW: u64 = 0;
 
+/// Maximum eth historical proof window. Equivalent to roughly one month of data.
+pub const MAX_ETH_PROOF_WINDOW: u64 = 216_000;
+
 /// GPO specific constants
 pub mod gas_oracle {
     use alloy_primitives::U256;

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use derive_more::Deref;
 use reth_primitives::{BlockNumberOrTag, U256};
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider};
+use reth_provider::BlockReaderIdExt;
 use reth_rpc_eth_api::{
     helpers::{transaction::UpdateRawTxForwarder, EthSigner, SpawnBlocking},
     RawTransactionForwarder,
@@ -31,18 +31,9 @@ pub struct EthApi<Provider, Pool, Network, EvmConfig> {
     pub(super) inner: Arc<EthApiInner<Provider, Pool, Network, EvmConfig>>,
 }
 
-impl<Provider, Pool, Network, EvmConfig> EthApi<Provider, Pool, Network, EvmConfig> {
-    /// Sets a forwarder for `eth_sendRawTransaction`
-    ///
-    /// Note: this might be removed in the future in favor of a more generic approach.
-    pub fn set_eth_raw_transaction_forwarder(&self, forwarder: Arc<dyn RawTransactionForwarder>) {
-        self.inner.raw_transaction_forwarder.write().replace(forwarder);
-    }
-}
-
 impl<Provider, Pool, Network, EvmConfig> EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Provider: BlockReaderIdExt + ChainSpecProvider,
+    Provider: BlockReaderIdExt,
 {
     /// Creates a new, shareable instance using the default tokio task spawner.
     #[allow(clippy::too_many_arguments)]
@@ -118,6 +109,15 @@ where
         };
 
         Self { inner: Arc::new(inner) }
+    }
+}
+
+impl<Provider, Pool, Network, EvmConfig> EthApi<Provider, Pool, Network, EvmConfig> {
+    /// Sets a forwarder for `eth_sendRawTransaction`
+    ///
+    /// Note: this might be removed in the future in favor of a more generic approach.
+    pub fn set_eth_raw_transaction_forwarder(&self, forwarder: Arc<dyn RawTransactionForwarder>) {
+        self.inner.raw_transaction_forwarder.write().replace(forwarder);
     }
 
     /// Returns the state cache frontend

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -53,7 +53,7 @@ where
         eth_cache: EthStateCache,
         gas_oracle: GasPriceOracle<Provider>,
         gas_cap: impl Into<GasCap>,
-        max_proof_lookback: u64,
+        eth_proof_window: u64,
         blocking_task_pool: BlockingTaskPool,
         fee_history_cache: FeeHistoryCache,
         evm_config: EvmConfig,
@@ -66,7 +66,7 @@ where
             eth_cache,
             gas_oracle,
             gas_cap.into().into(),
-            max_proof_lookback,
+            eth_proof_window,
             Box::<TokioTaskExecutor>::default(),
             blocking_task_pool,
             fee_history_cache,
@@ -84,7 +84,7 @@ where
         eth_cache: EthStateCache,
         gas_oracle: GasPriceOracle<Provider>,
         gas_cap: u64,
-        max_proof_lookback: u64,
+        eth_proof_window: u64,
         task_spawner: Box<dyn TaskSpawner>,
         blocking_task_pool: BlockingTaskPool,
         fee_history_cache: FeeHistoryCache,
@@ -107,7 +107,7 @@ where
             eth_cache,
             gas_oracle,
             gas_cap,
-            max_proof_lookback,
+            eth_proof_window,
             starting_block: U256::from(latest_block),
             task_spawner,
             pending_block: Default::default(),
@@ -136,8 +136,8 @@ where
     }
 
     /// The maximum number of blocks into the past for generating state proofs.
-    pub fn max_proof_lookback(&self) -> u64 {
-        self.inner.max_proof_lookback
+    pub fn eth_proof_window(&self) -> u64 {
+        self.inner.eth_proof_window
     }
 
     /// Returns the inner `Provider`
@@ -218,7 +218,7 @@ pub struct EthApiInner<Provider, Pool, Network, EvmConfig> {
     /// Maximum gas limit for `eth_call` and call tracing RPC methods.
     gas_cap: u64,
     /// The maximum number of blocks into the past for generating state proofs.
-    max_proof_lookback: u64,
+    eth_proof_window: u64,
     /// The block number at which the node started
     starting_block: U256,
     /// The type that can spawn tasks which would otherwise block.

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -341,6 +341,7 @@ mod tests {
     use reth_rpc_eth_types::{
         EthStateCache, FeeHistoryCache, FeeHistoryCacheConfig, GasPriceOracle,
     };
+    use reth_rpc_server_types::constants::DEFAULT_ETH_PROOF_WINDOW;
     use reth_rpc_types::FeeHistory;
     use reth_tasks::pool::BlockingTaskPool;
     use reth_testing_utils::{generators, generators::Rng};
@@ -372,7 +373,7 @@ mod tests {
             cache.clone(),
             GasPriceOracle::new(provider, Default::default(), cache),
             ETHEREUM_BLOCK_GAS_LIMIT,
-            0,
+            DEFAULT_ETH_PROOF_WINDOW,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
             fee_history_cache,
             evm_config,

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,6 +1,6 @@
 //! Contains RPC handler implementations specific to state.
 
-use reth_provider::StateProviderFactory;
+use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
 use reth_rpc_eth_api::helpers::{EthState, LoadState, SpawnBlocking};
@@ -8,9 +8,14 @@ use reth_rpc_eth_types::EthStateCache;
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthState for EthApi<Provider, Pool, Network, EvmConfig> where
-    Self: LoadState + SpawnBlocking
+impl<Provider, Pool, Network, EvmConfig> EthState for EthApi<Provider, Pool, Network, EvmConfig>
+where
+    Self: LoadState + SpawnBlocking,
+    Provider: BlockReaderIdExt + ChainSpecProvider,
 {
+    fn maximum_proof_lookback(&self) -> u64 {
+        self.max_proof_lookback()
+    }
 }
 
 impl<Provider, Pool, Network, EvmConfig> LoadState for EthApi<Provider, Pool, Network, EvmConfig>
@@ -66,6 +71,7 @@ mod tests {
             cache.clone(),
             GasPriceOracle::new(NoopProvider::default(), Default::default(), cache.clone()),
             ETHEREUM_BLOCK_GAS_LIMIT,
+            0,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
             FeeHistoryCache::new(cache, FeeHistoryCacheConfig::default()),
             evm_config,
@@ -91,6 +97,7 @@ mod tests {
             cache.clone(),
             GasPriceOracle::new(mock_provider, Default::default(), cache.clone()),
             ETHEREUM_BLOCK_GAS_LIMIT,
+            0,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
             FeeHistoryCache::new(cache, FeeHistoryCacheConfig::default()),
             evm_config,

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -13,8 +13,8 @@ where
     Self: LoadState + SpawnBlocking,
     Provider: BlockReaderIdExt + ChainSpecProvider,
 {
-    fn maximum_proof_lookback(&self) -> u64 {
-        self.max_proof_lookback()
+    fn max_proof_window(&self) -> u64 {
+        self.eth_proof_window()
     }
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -52,6 +52,7 @@ mod tests {
     use reth_rpc_eth_types::{
         EthStateCache, FeeHistoryCache, FeeHistoryCacheConfig, GasPriceOracle,
     };
+    use reth_rpc_server_types::constants::DEFAULT_ETH_PROOF_WINDOW;
     use reth_tasks::pool::BlockingTaskPool;
     use reth_transaction_pool::test_utils::testing_pool;
 
@@ -71,7 +72,7 @@ mod tests {
             cache.clone(),
             GasPriceOracle::new(NoopProvider::default(), Default::default(), cache.clone()),
             ETHEREUM_BLOCK_GAS_LIMIT,
-            0,
+            DEFAULT_ETH_PROOF_WINDOW,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
             FeeHistoryCache::new(cache, FeeHistoryCacheConfig::default()),
             evm_config,
@@ -97,7 +98,7 @@ mod tests {
             cache.clone(),
             GasPriceOracle::new(mock_provider, Default::default(), cache.clone()),
             ETHEREUM_BLOCK_GAS_LIMIT,
-            0,
+            DEFAULT_ETH_PROOF_WINDOW,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
             FeeHistoryCache::new(cache, FeeHistoryCacheConfig::default()),
             evm_config,

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,6 +1,6 @@
 //! Contains RPC handler implementations specific to state.
 
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
+use reth_provider::StateProviderFactory;
 use reth_transaction_pool::TransactionPool;
 
 use reth_rpc_eth_api::helpers::{EthState, LoadState, SpawnBlocking};
@@ -11,7 +11,6 @@ use crate::EthApi;
 impl<Provider, Pool, Network, EvmConfig> EthState for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: LoadState + SpawnBlocking,
-    Provider: BlockReaderIdExt + ChainSpecProvider,
 {
     fn max_proof_window(&self) -> u64 {
         self.eth_proof_window()

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -68,6 +68,7 @@ mod tests {
     use reth_rpc_eth_types::{
         EthStateCache, FeeHistoryCache, FeeHistoryCacheConfig, GasPriceOracle,
     };
+    use reth_rpc_server_types::constants::DEFAULT_ETH_PROOF_WINDOW;
     use reth_tasks::pool::BlockingTaskPool;
     use reth_transaction_pool::{test_utils::testing_pool, TransactionPool};
 
@@ -91,7 +92,7 @@ mod tests {
             cache.clone(),
             GasPriceOracle::new(noop_provider, Default::default(), cache.clone()),
             ETHEREUM_BLOCK_GAS_LIMIT,
-            0,
+            DEFAULT_ETH_PROOF_WINDOW,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
             fee_history_cache,
             evm_config,

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -91,6 +91,7 @@ mod tests {
             cache.clone(),
             GasPriceOracle::new(noop_provider, Default::default(), cache.clone()),
             ETHEREUM_BLOCK_GAS_LIMIT,
+            0,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
             fee_history_cache,
             evm_config,


### PR DESCRIPTION
## Description

Enable historical proofs with configurable lookback window. Set to `0` by default, meaning that proof generation is enabled only for latest block.