### PR TITLE
ci(hive): build `reth` externally 

### DIFF
--- a/.github/assets/hive/Dockerfile
+++ b/.github/assets/hive/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 
-COPY artifacts/reth /usr/local/bin
+COPY dist/reth /usr/local/bin
 
 COPY LICENSE-* ./
 

--- a/.github/assets/hive/Dockerfile
+++ b/.github/assets/hive/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu AS runtime
 
-COPY ./target/hivetests/reth /usr/local/bin
+COPY artifacts/reth /usr/local/bin
 
 COPY LICENSE-* ./
 

--- a/.github/assets/hive/Dockerfile
+++ b/.github/assets/hive/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu AS runtime
+
+COPY ./target/hivetests/reth /usr/local/bin
+
+COPY LICENSE-* ./
+
+EXPOSE 30303 30303/udp 9001 8545 8546
+ENTRYPOINT ["/usr/local/bin/reth"]

--- a/.github/assets/hive/Dockerfile
+++ b/.github/assets/hive/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu AS runtime
+FROM ubuntu
 
 COPY artifacts/reth /usr/local/bin
 

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build reth
         run: |
           touch artifacts/reth

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -30,7 +30,7 @@ jobs:
           cache-on-failure: true
       - name: Build reth
         run: |
-          cargo build --features asm-keccak --profile hivetests --bin reth
+          cargo build --features asm-keccak --profile hivetests --bin reth --locked
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and export reth image

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Build reth
         run: |
           touch artifacts/reth
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Build and export reth image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -28,11 +28,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Build reth
         run: |
-          touch artifacts/reth
+          cargo build --features asm-keccak --profile hivetests --bin reth --locked
+          mkdir dist && cp ./target/hivetests/reth ./dist/reth
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and export reth image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -23,7 +23,14 @@ jobs:
       group: Reth
     steps:
       - uses: actions/checkout@v4
-      - run: mkdir artifacts
+      - run: mkdir artifacts 
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Build reth
+        run: |
+          cargo build --features asm-keccak --profile hivetests --bin reth
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and export reth image
@@ -31,9 +38,6 @@ jobs:
         with:
           context: .
           tags: ghcr.io/paradigmxyz/reth:latest
-          build-args: |
-            BUILD_PROFILE=hivetests
-            FEATURES=asm-keccak
           outputs: type=docker,dest=./artifacts/reth_image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: .github/assets/hive/Dockerfile
           tags: ghcr.io/paradigmxyz/reth:latest
           outputs: type=docker,dest=./artifacts/reth_image.tar
           cache-from: type=gha

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Build reth
         run: |
           cargo build --features asm-keccak --profile hivetests --bin reth --locked
+          cp ./target/hivetests/reth ./artifacts/reth
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and export reth image

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -30,8 +30,7 @@ jobs:
           cache-on-failure: true
       - name: Build reth
         run: |
-          cargo build --features asm-keccak --profile hivetests --bin reth --locked
-          cp ./target/hivetests/reth ./artifacts/reth
+          touch artifacts/reth
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and export reth image


### PR DESCRIPTION
Changes the `prepare` stage, so we build the binary outside of the docker environment and copy it later on to the docker image. This way we can leverage the rust caching gh action

from [~20min](https://github.com/paradigmxyz/reth/actions/runs/9769617610/job/26969394641) to [12min cached](https://github.com/paradigmxyz/reth/actions/runs/9783659606/job/27012758378) 