### PR TITLE
chore: use direct link to threshold docs

### DIFF
--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -107,7 +107,7 @@ impl<E> ExecutionStage<E> {
 
     /// Create an execution stage with the provided executor.
     ///
-    /// The commit threshold will be set to `10_000`.
+    /// The commit threshold will be set to [`MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD`].
     pub fn new_with_executor(executor_provider: E) -> Self {
         Self::new(
             executor_provider,


### PR DESCRIPTION
This is now `5000`, instead of correcting the number in the comment, I just changed it to link to the const directly