### PR TITLE
fix(rpc/ots): set block_number as u64 instead of NumberOrTag

### DIFF
--- a/crates/rpc/rpc-api/src/otterscan.rs
+++ b/crates/rpc/rpc-api/src/otterscan.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, TxHash, B256};
+use reth_primitives::{Address, BlockId, Bytes, TxHash, B256};
 use reth_rpc_types::{
     trace::otterscan::{
         BlockDetails, ContractCreator, InternalOperation, OtsBlockTransactions, TraceEntry,
@@ -48,10 +48,7 @@ pub trait Otterscan {
     /// Tailor-made and expanded version of eth_getBlockByNumber for block details page in
     /// Otterscan.
     #[method(name = "getBlockDetails")]
-    async fn get_block_details(
-        &self,
-        block_number: BlockNumberOrTag,
-    ) -> RpcResult<Option<BlockDetails>>;
+    async fn get_block_details(&self, block_number: u64) -> RpcResult<Option<BlockDetails>>;
 
     /// Tailor-made and expanded version of eth_getBlockByHash for block details page in Otterscan.
     #[method(name = "getBlockDetailsByHash")]
@@ -61,7 +58,7 @@ pub trait Otterscan {
     #[method(name = "getBlockTransactions")]
     async fn get_block_transactions(
         &self,
-        block_number: BlockNumberOrTag,
+        block_number: u64,
         page_number: usize,
         page_size: usize,
     ) -> RpcResult<OtsBlockTransactions>;
@@ -71,7 +68,7 @@ pub trait Otterscan {
     async fn search_transactions_before(
         &self,
         address: Address,
-        block_number: BlockNumberOrTag,
+        block_number: u64,
         page_size: usize,
     ) -> RpcResult<TransactionsWithReceipts>;
 
@@ -80,7 +77,7 @@ pub trait Otterscan {
     async fn search_transactions_after(
         &self,
         address: Address,
-        block_number: BlockNumberOrTag,
+        block_number: u64,
         page_size: usize,
     ) -> RpcResult<TransactionsWithReceipts>;
 

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -295,13 +295,13 @@ where
     let address = Address::default();
     let sender = Address::default();
     let tx_hash = TxHash::default();
-    let block_number = BlockNumberOrTag::default();
+    let block_number = 1;
     let page_number = 1;
     let page_size = 10;
     let nonce = 1;
     let block_hash = B256::default();
 
-    OtterscanClient::get_header_by_number(client, 1).await.unwrap();
+    OtterscanClient::get_header_by_number(client, block_number).await.unwrap();
 
     OtterscanClient::has_code(client, address, None).await.unwrap();
 

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -99,11 +99,8 @@ where
     }
 
     /// Handler for `ots_getBlockDetails`
-    async fn get_block_details(
-        &self,
-        block_number: BlockNumberOrTag,
-    ) -> RpcResult<Option<BlockDetails>> {
-        let block = self.eth.block_by_number(block_number, true).await?;
+    async fn get_block_details(&self, block_number: u64) -> RpcResult<Option<BlockDetails>> {
+        let block = self.eth.block_by_number(BlockNumberOrTag::Number(block_number), true).await?;
         Ok(block.map(Into::into))
     }
 
@@ -116,11 +113,12 @@ where
     /// Handler for `getBlockTransactions`
     async fn get_block_transactions(
         &self,
-        block_number: BlockNumberOrTag,
+        block_number: u64,
         page_number: usize,
         page_size: usize,
     ) -> RpcResult<OtsBlockTransactions> {
         // retrieve full block and its receipts
+        let block_number = BlockNumberOrTag::Number(block_number);
         let block = self.eth.block_by_number(block_number, true);
         let receipts = self.eth.block_receipts(BlockId::Number(block_number));
         let (block, receipts) = futures::try_join!(block, receipts)?;
@@ -184,7 +182,7 @@ where
     async fn search_transactions_before(
         &self,
         _address: Address,
-        _block_number: BlockNumberOrTag,
+        _block_number: u64,
         _page_size: usize,
     ) -> RpcResult<TransactionsWithReceipts> {
         Err(internal_rpc_err("unimplemented"))
@@ -194,7 +192,7 @@ where
     async fn search_transactions_after(
         &self,
         _address: Address,
-        _block_number: BlockNumberOrTag,
+        _block_number: u64,
         _page_size: usize,
     ) -> RpcResult<TransactionsWithReceipts> {
         Err(internal_rpc_err("unimplemented"))


### PR DESCRIPTION
Ref  https://github.com/ledgerwatch/erigon/blob/2711926dc18560d4e2affebe8744dac17c85e21b/turbo/jsonrpc/otterscan_api.go#L56-L69 

the `block_number` in Erigon's `ots_` namespace are uint64, instead of blockNumberOrTag, we should also use u64 instead, and then otterscan can smoothy run with reth(including the other pending ots_ rpc + ots_searchRPC).