### PR TITLE
chore(trie): return mutable prefix sets from `HashedPostState::construct_prefix_sets`

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1866,7 +1866,7 @@ mod tests {
         );
 
         let provider = tree.externals.provider_factory.provider().unwrap();
-        let prefix_sets = exec5.hash_state_slow().construct_prefix_sets();
+        let prefix_sets = exec5.hash_state_slow().construct_prefix_sets().freeze();
         let state_root =
             StateRoot::from_tx(provider.tx_ref()).with_prefix_sets(prefix_sets).root().unwrap();
         assert_eq!(state_root, block5.state_root);

--- a/crates/trie/parallel/benches/root.rs
+++ b/crates/trie/parallel/benches/root.rs
@@ -41,7 +41,7 @@ pub fn calculate_state_root(c: &mut Criterion) {
             b.to_async(&runtime).iter_with_setup(
                 || {
                     let sorted_state = updated_state.clone().into_sorted();
-                    let prefix_sets = updated_state.construct_prefix_sets();
+                    let prefix_sets = updated_state.construct_prefix_sets().freeze();
                     let provider = provider_factory.provider().unwrap();
                     (provider, sorted_state, prefix_sets)
                 },

--- a/crates/trie/parallel/src/async_root.rs
+++ b/crates/trie/parallel/src/async_root.rs
@@ -86,7 +86,7 @@ where
         retain_updates: bool,
     ) -> Result<(B256, TrieUpdates), AsyncStateRootError> {
         let mut tracker = ParallelTrieTracker::default();
-        let prefix_sets = self.hashed_state.construct_prefix_sets();
+        let prefix_sets = self.hashed_state.construct_prefix_sets().freeze();
         let storage_root_targets = StorageRootTargets::new(
             self.hashed_state.accounts.keys().copied(),
             prefix_sets.storage_prefix_sets,

--- a/crates/trie/parallel/src/parallel_root.rs
+++ b/crates/trie/parallel/src/parallel_root.rs
@@ -77,7 +77,7 @@ where
         retain_updates: bool,
     ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
         let mut tracker = ParallelTrieTracker::default();
-        let prefix_sets = self.hashed_state.construct_prefix_sets();
+        let prefix_sets = self.hashed_state.construct_prefix_sets().freeze();
         let storage_root_targets = StorageRootTargets::new(
             self.hashed_state.accounts.keys().copied(),
             prefix_sets.storage_prefix_sets,

--- a/crates/trie/trie/src/prefix_set/mod.rs
+++ b/crates/trie/trie/src/prefix_set/mod.rs
@@ -8,6 +8,35 @@ use std::{
 mod loader;
 pub use loader::PrefixSetLoader;
 
+/// Collection of mutable prefix sets.
+#[derive(Default, Debug)]
+pub struct TriePrefixSetsMut {
+    /// A set of account prefixes that have changed.
+    pub account_prefix_set: PrefixSetMut,
+    /// A map containing storage changes with the hashed address as key and a set of storage key
+    /// prefixes as the value.
+    pub storage_prefix_sets: HashMap<B256, PrefixSetMut>,
+    /// A set of hashed addresses of destroyed accounts.
+    pub destroyed_accounts: HashSet<B256>,
+}
+
+impl TriePrefixSetsMut {
+    /// Returns a `TriePrefixSets` with the same elements as these sets.
+    ///
+    /// If not yet sorted, the elements will be sorted and deduplicated.
+    pub fn freeze(self) -> TriePrefixSets {
+        TriePrefixSets {
+            account_prefix_set: self.account_prefix_set.freeze(),
+            storage_prefix_sets: self
+                .storage_prefix_sets
+                .into_iter()
+                .map(|(hashed_address, prefix_set)| (hashed_address, prefix_set.freeze()))
+                .collect(),
+            destroyed_accounts: self.destroyed_accounts,
+        }
+    }
+}
+
 /// Collection of trie prefix sets.
 #[derive(Default, Debug)]
 pub struct TriePrefixSets {

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     hashed_cursor::HashedPostStateCursorFactory,
-    prefix_set::{PrefixSetMut, TriePrefixSets, TriePrefixSetsMut},
+    prefix_set::{PrefixSetMut, TriePrefixSetsMut},
     updates::TrieUpdates,
     Nibbles, StateRoot,
 };


### PR DESCRIPTION
## Motivation

To enable proof generation from given `HashedPostState` we need to have the ability to modify constructed prefix sets.