### PR TITLE
fix: remove useless arbitrary feature

### DIFF
--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 reth-codecs-derive = { path = "./derive", default-features = false }
 
 # eth
-alloy-consensus = { workspace = true, optional = true, features = ["arbitrary"] }
+alloy-consensus = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
 alloy-genesis = { workspace = true, optional = true }
 alloy-primitives.workspace = true


### PR DESCRIPTION
Using [SP1 zkVM](https://github.com/succinctlabs/sp1), I need `reth-chainspec`, but adding the dep lead to the following error:

```
error[E0433]: failed to resolve: use of undeclared crate or module `imp`
  --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/wait-timeout-0.2.0/src/lib.rs:66:9
   |
66 |         imp::wait_timeout(self, dur)
   |         ^^^ use of undeclared crate or module `imp`
```
I have the following tree:

```
├── reth-chainspec v1.0.0 (https://github.com/paradigmxyz/reth?tag=v1.0.0#83d412da)
│   ├── alloy-eips v0.1.3
│   │   ├── alloy-primitives v0.7.6
│   │   │   ├── proptest v1.5.0
│   │   │   │   ├── rusty-fork v0.3.0
│   │   │   │   │   └── wait-timeout v0.2.0
```

And after digging it appears the optional dep `proptest` is added because of the `arbitrary` feature on `alloy-consensus` in `reth-codecs`.