### PR TITLE
github-workflows: delete the direction of dead(deleted) code

### DIFF
--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -4,7 +4,6 @@ The CI runs a couple of workflows:
 
 ### Code
 
-- **[ci]**: A catch-all for small jobs. Currently only runs lints (rustfmt, clippy etc.)
 - **[unit]**: Runs unit tests (tests in `src/`) and doc tests
 - **[integration]**: Runs integration tests (tests in `tests/` and sync tests)
 - **[bench]**: Runs benchmarks
@@ -16,14 +15,11 @@ The CI runs a couple of workflows:
 ### Meta
 
 - **[deny]**: Runs `cargo deny` to check for license conflicts and security advisories in our dependencies
-- **[sanity]**: Runs a couple of sanity checks on the code every night, such as checking for unused dependencies
 - **[release]**: Runs the release workflow
 
-[ci]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/ci.yml
 [unit]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/unit.yml
 [integration]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/integration.yml
 [bench]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/bench.yml
 [book]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/book.yml
 [deny]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/deny.yml
-[sanity]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/sanity.yml
 [release]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/release.yml


### PR DESCRIPTION
Upon this [PR](https://github.com/paradigmxyz/reth/pull/6889/files#diff-7020d160ab8b155fea4e4c525a39b73a8fa74c20e06c48b6c4d4c9c4fcbd1a7a)
The `sanity.yml ` already been deleted. Same in `ci.yml`