### PR TITLE
chore(pruner): remove redundant code

### DIFF
--- a/crates/prune/prune/src/segments/history.rs
+++ b/crates/prune/prune/src/segments/history.rs
@@ -42,7 +42,7 @@ where
         // Get the highest block number that needs to be deleted for this sharded key
         let to_block = sharded_key.as_ref().highest_block_number;
 
-        loop {
+        'shard: loop {
             let Some((key, block_nums)) =
                 shard.map(|(k, v)| Result::<_, DatabaseError>::Ok((k.key()?, v))).transpose()?
             else {
@@ -57,7 +57,7 @@ where
                 }
             } else {
                 // If such shard doesn't exist, skip to the next sharded key
-                break
+                break 'shard
             }
 
             shard = cursor.next()?;

--- a/crates/prune/prune/src/segments/history.rs
+++ b/crates/prune/prune/src/segments/history.rs
@@ -37,42 +37,30 @@ where
     for sharded_key in highest_sharded_keys {
         // Seek to the shard that has the key >= the given sharded key
         // TODO: optimize
-        let result = cursor
-            .seek(RawKey::new(sharded_key.clone()))?
-            .map(|(key, value)| Result::<_, DatabaseError>::Ok((key.key()?, value)))
-            .transpose()?;
-
-        // If such shard doesn't exist, skip to the next sharded key
-        if result.as_ref().map_or(true, |(key, _)| !key_matches(key, &sharded_key)) {
-            continue
-        }
-
-        // At this point, we're sure that the shard with the given sharded key exists
-        let (key, raw_blocks): (T::Key, RawValue<BlockNumberList>) = result.unwrap();
+        let mut shard = cursor.seek(RawKey::new(sharded_key.clone()))?;
 
         // Get the highest block number that needs to be deleted for this sharded key
         let to_block = sharded_key.as_ref().highest_block_number;
 
-        match prune_shard(&mut cursor, key, raw_blocks, to_block, &key_matches)? {
-            PruneShardOutcome::Deleted => deleted += 1,
-            PruneShardOutcome::Updated => updated += 1,
-            PruneShardOutcome::Unchanged => unchanged += 1,
-        }
+        loop {
+            let Some((key, block_nums)) =
+                shard.map(|(k, v)| Result::<_, DatabaseError>::Ok((k.key()?, v))).transpose()?
+            else {
+                break
+            };
 
-        while let Some((key, value)) = cursor
-            .next()?
-            .map(|(k, v)| Result::<_, DatabaseError>::Ok((k.key()?, v)))
-            .transpose()?
-        {
             if key_matches(&key, &sharded_key) {
-                match prune_shard(&mut cursor, key, value, to_block, &key_matches)? {
+                match prune_shard(&mut cursor, key, block_nums, to_block, &key_matches)? {
                     PruneShardOutcome::Deleted => deleted += 1,
                     PruneShardOutcome::Updated => updated += 1,
                     PruneShardOutcome::Unchanged => unchanged += 1,
                 }
             } else {
+                // If such shard doesn't exist, skip to the next sharded key
                 break
             }
+
+            shard = cursor.next()?;
         }
     }
 


### PR DESCRIPTION
Removes redundant code. This improves readability and reduces time spent reviewing `pruner_history_indices` in future.