### PR TITLE
chore(evm): turn associated `ConfigureEvm` fns into methods

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -145,7 +145,8 @@ where
         DB::Error: Into<ProviderError> + std::fmt::Display,
     {
         // apply pre execution changes
-        apply_beacon_root_contract_call::<EvmConfig, _, _>(
+        apply_beacon_root_contract_call(
+            &self.evm_config,
             &self.chain_spec,
             block.timestamp,
             block.number,
@@ -220,7 +221,7 @@ where
 
             // Collect all EIP-7685 requests
             let withdrawal_requests =
-                apply_withdrawal_requests_contract_call::<EvmConfig, _, _>(&mut evm)?;
+                apply_withdrawal_requests_contract_call(&self.evm_config, &mut evm)?;
 
             [deposit_requests, withdrawal_requests].concat()
         } else {
@@ -275,7 +276,7 @@ where
     fn evm_env_for_block(&self, header: &Header, total_difficulty: U256) -> EnvWithHandlerCfg {
         let mut cfg = CfgEnvWithHandlerCfg::new(Default::default(), Default::default());
         let mut block_env = BlockEnv::default();
-        EvmConfig::fill_cfg_and_block_env(
+        self.executor.evm_config.fill_cfg_and_block_env(
             &mut cfg,
             &mut block_env,
             self.chain_spec(),

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -36,6 +36,7 @@ pub struct EthEvmConfig;
 
 impl ConfigureEvmEnv for EthEvmConfig {
     fn fill_cfg_env(
+        &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
         chain_spec: &ChainSpec,
         header: &Header,
@@ -63,6 +64,7 @@ impl ConfigureEvmEnv for EthEvmConfig {
     }
 
     fn fill_tx_env_system_contract_call(
+        &self,
         env: &mut Env,
         caller: Address,
         contract: Address,
@@ -132,7 +134,7 @@ mod tests {
         let chain_spec = ChainSpec::default();
         let total_difficulty = U256::ZERO;
 
-        EthEvmConfig::fill_cfg_and_block_env(
+        EthEvmConfig::default().fill_cfg_and_block_env(
             &mut cfg_env,
             &mut block_env,
             &chain_spec,

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -118,7 +118,7 @@ where
         // apply eip-4788 pre block contract call
         pre_block_beacon_root_contract_call(
             &mut db,
-            self.evm_config.clone(),
+            &self.evm_config,
             &chain_spec,
             &initialized_cfg,
             &initialized_block_env,
@@ -201,6 +201,7 @@ where
             // We do not calculate the EIP-6110 deposit requests because there are no
             // transactions in an empty payload.
             let withdrawal_requests = post_block_withdrawal_requests_contract_call::<EvmConfig, _>(
+                &self.evm_config,
                 &mut db,
                 &initialized_cfg,
                 &initialized_block_env,
@@ -296,7 +297,7 @@ where
     // apply eip-4788 pre block contract call
     pre_block_beacon_root_contract_call(
         &mut db,
-        evm_config.clone(),
+        &evm_config,
         &chain_spec,
         &initialized_cfg,
         &initialized_block_env,
@@ -443,7 +444,8 @@ where
     {
         let deposit_requests = parse_deposits_from_receipts(&chain_spec, receipts.iter().flatten())
             .map_err(|err| PayloadBuilderError::Internal(RethError::Execution(err.into())))?;
-        let withdrawal_requests = post_block_withdrawal_requests_contract_call::<EvmConfig, _>(
+        let withdrawal_requests = post_block_withdrawal_requests_contract_call(
+            &evm_config,
             &mut db,
             &initialized_cfg,
             &initialized_block_env,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -122,6 +122,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
 
     /// Fill transaction environment with a system contract call.
     fn fill_tx_env_system_contract_call(
+        &self,
         env: &mut Env,
         caller: Address,
         contract: Address,
@@ -130,6 +131,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
 
     /// Fill [`CfgEnvWithHandlerCfg`] fields according to the chain spec and given header
     fn fill_cfg_env(
+        &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
         chain_spec: &ChainSpec,
         header: &Header,
@@ -145,11 +147,12 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
         after_merge: bool,
     ) {
         let coinbase = block_coinbase(chain_spec, header, after_merge);
-        Self::fill_block_env_with_coinbase(block_env, header, after_merge, coinbase);
+        self.fill_block_env_with_coinbase(block_env, header, after_merge, coinbase);
     }
 
     /// Fill block environment with coinbase.
     fn fill_block_env_with_coinbase(
+        &self,
         block_env: &mut BlockEnv,
         header: &Header,
         after_merge: bool,
@@ -177,15 +180,16 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
     /// Convenience function to call both [`fill_cfg_env`](ConfigureEvmEnv::fill_cfg_env) and
     /// [`ConfigureEvmEnv::fill_block_env`].
     fn fill_cfg_and_block_env(
+        &self,
         cfg: &mut CfgEnvWithHandlerCfg,
         block_env: &mut BlockEnv,
         chain_spec: &ChainSpec,
         header: &Header,
         total_difficulty: U256,
     ) {
-        Self::fill_cfg_env(cfg, chain_spec, header, total_difficulty);
+        self.fill_cfg_env(cfg, chain_spec, header, total_difficulty);
         let after_merge = cfg.handler_cfg.spec_id >= SpecId::MERGE;
-        Self::fill_block_env_with_coinbase(
+        self.fill_block_env_with_coinbase(
             block_env,
             header,
             after_merge,

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -122,7 +122,8 @@ where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
         // apply pre execution changes
-        apply_beacon_root_contract_call::<EvmConfig, _, _>(
+        apply_beacon_root_contract_call(
+            &self.evm_config,
             &self.chain_spec,
             block.timestamp,
             block.number,
@@ -271,7 +272,7 @@ where
     fn evm_env_for_block(&self, header: &Header, total_difficulty: U256) -> EnvWithHandlerCfg {
         let mut cfg = CfgEnvWithHandlerCfg::new(Default::default(), Default::default());
         let mut block_env = BlockEnv::default();
-        EvmConfig::fill_cfg_and_block_env(
+        self.executor.evm_config.fill_cfg_and_block_env(
             &mut cfg,
             &mut block_env,
             self.chain_spec(),

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -40,6 +40,7 @@ impl ConfigureEvmEnv for OptimismEvmConfig {
     }
 
     fn fill_tx_env_system_contract_call(
+        &self,
         env: &mut Env,
         caller: Address,
         contract: Address,
@@ -83,6 +84,7 @@ impl ConfigureEvmEnv for OptimismEvmConfig {
     }
 
     fn fill_cfg_env(
+        &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
         chain_spec: &ChainSpec,
         header: &Header,
@@ -143,7 +145,7 @@ mod tests {
         let chain_spec = ChainSpec::default();
         let total_difficulty = U256::ZERO;
 
-        OptimismEvmConfig::fill_cfg_and_block_env(
+        OptimismEvmConfig::default().fill_cfg_and_block_env(
             &mut cfg_env,
             &mut block_env,
             &chain_spec,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -125,7 +125,7 @@ where
         // apply eip-4788 pre block contract call
         pre_block_beacon_root_contract_call(
             &mut db,
-            self.evm_config.clone(),
+            &self.evm_config,
             &chain_spec,
             &initialized_cfg,
             &initialized_block_env,
@@ -288,7 +288,7 @@ where
     // apply eip-4788 pre block contract call
     pre_block_beacon_root_contract_call(
         &mut db,
-        evm_config.clone(),
+        &evm_config,
         &chain_spec,
         &initialized_cfg,
         &initialized_block_env,

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -235,7 +235,7 @@ pub trait LoadPendingBlock {
             // parent beacon block root
             pre_block_beacon_root_contract_call(
                 &mut db,
-                self.evm_config().clone(),
+                self.evm_config(),
                 chain_spec.as_ref(),
                 &cfg,
                 &block_env,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2040,7 +2040,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         cfg: &mut CfgEnvWithHandlerCfg,
         block_env: &mut BlockEnv,
         header: &Header,
-        _evm_config: EvmConfig,
+        evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
         EvmConfig: ConfigureEvmEnv,
@@ -2048,7 +2048,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
-        EvmConfig::fill_cfg_and_block_env(
+        evm_config.fill_cfg_and_block_env(
             cfg,
             block_env,
             &self.chain_spec,
@@ -2076,7 +2076,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         &self,
         cfg: &mut CfgEnvWithHandlerCfg,
         header: &Header,
-        _evm_config: EvmConfig,
+        evm_config: EvmConfig,
     ) -> ProviderResult<()>
     where
         EvmConfig: ConfigureEvmEnv,
@@ -2084,7 +2084,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
-        EvmConfig::fill_cfg_env(cfg, &self.chain_spec, header, total_difficulty);
+        evm_config.fill_cfg_env(cfg, &self.chain_spec, header, total_difficulty);
         Ok(())
     }
 }

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -102,7 +102,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
         contract: Address,
         data: Bytes,
     ) {
-        self.fill_tx_env_system_contract_call(env, caller, contract, data)
+        EthEvmConfig::default().fill_tx_env_system_contract_call(env, caller, contract, data)
     }
 }
 

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -68,6 +68,7 @@ impl MyEvmConfig {
 
 impl ConfigureEvmEnv for MyEvmConfig {
     fn fill_cfg_env(
+        &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
         chain_spec: &ChainSpec,
         header: &Header,
@@ -95,12 +96,13 @@ impl ConfigureEvmEnv for MyEvmConfig {
     }
 
     fn fill_tx_env_system_contract_call(
+        &self,
         env: &mut Env,
         caller: Address,
         contract: Address,
         data: Bytes,
     ) {
-        EthEvmConfig::fill_tx_env_system_contract_call(env, caller, contract, data)
+        self.fill_tx_env_system_contract_call(env, caller, contract, data)
     }
 }
 

--- a/examples/exex/rollup/src/execution.rs
+++ b/examples/exex/rollup/src/execution.rs
@@ -107,13 +107,7 @@ fn configure_evm<'a>(
     );
 
     let mut cfg = CfgEnvWithHandlerCfg::new_with_spec_id(evm.cfg().clone(), evm.spec_id());
-    EthEvmConfig::fill_cfg_and_block_env(
-        &mut cfg,
-        evm.block_mut(),
-        &CHAIN_SPEC,
-        header,
-        U256::ZERO,
-    );
+    config.fill_cfg_and_block_env(&mut cfg, evm.block_mut(), &CHAIN_SPEC, header, U256::ZERO);
     *evm.cfg_mut() = cfg.cfg_env;
 
     evm

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -143,6 +143,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
     }
 
     fn fill_cfg_env(
+        &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
         chain_spec: &ChainSpec,
         header: &Header,
@@ -152,6 +153,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
     }
 
     fn fill_tx_env_system_contract_call(
+        &self,
         env: &mut Env,
         caller: Address,
         contract: Address,

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -148,7 +148,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
         header: &Header,
         total_difficulty: U256,
     ) {
-        EthEvmConfig::fill_cfg_env(cfg_env, chain_spec, header, total_difficulty)
+        EthEvmConfig::default().fill_cfg_env(cfg_env, chain_spec, header, total_difficulty)
     }
 
     fn fill_tx_env_system_contract_call(
@@ -157,7 +157,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
         contract: Address,
         data: Bytes,
     ) {
-        EthEvmConfig::fill_tx_env_system_contract_call(env, caller, contract, data)
+        EthEvmConfig::default().fill_tx_env_system_contract_call(env, caller, contract, data)
     }
 }
 


### PR DESCRIPTION
## Description

Currently, there is a discrepancy in `ConfigureEvm` interface where some fns are associated and some are methods. Fix this by turning remaining associated functions into methods. cc @mattsse 