### PR TITLE
chore: disable `test-utils` for `stages-api` on `stages`

### DIFF
--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -30,7 +30,7 @@ reth-execution-types.workspace = true
 reth-prune-types.workspace = true
 reth-storage-errors.workspace = true
 reth-revm.workspace = true
-reth-stages-api = { workspace = true, features = ["test-utils"] }
+reth-stages-api.workspace = true
 reth-trie = { workspace = true, features = ["metrics"] }
 
 reth-testing-utils = { workspace = true, optional = true }


### PR DESCRIPTION
test-utils should be a dev-dependency only