### PR TITLE
feat: add entrypoint and main loop to EngineApiTreeHandlerImpl

### DIFF
--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -23,7 +23,8 @@ pub struct InvalidHeaderCache {
 }
 
 impl InvalidHeaderCache {
-    pub(crate) fn new(max_length: u32) -> Self {
+    /// Invalid header cache constructor.
+    pub fn new(max_length: u32) -> Self {
         Self { headers: LruMap::new(ByLength::new(max_length)), metrics: Default::default() }
     }
 

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -3,6 +3,7 @@
 use crate::{
     chain::{ChainHandler, FromOrchestrator, HandlerEvent},
     download::{BlockDownloader, DownloadAction, DownloadOutcome},
+    tree::TreeEvent,
 };
 use futures::{Stream, StreamExt};
 use reth_beacon_consensus::BeaconEngineMessage;
@@ -150,7 +151,6 @@ pub struct EngineApiRequestHandler<T: EngineTypes> {
     to_tree: Sender<FromEngine<BeaconEngineMessage<T>>>,
     /// channel to receive messages from the tree.
     from_tree: UnboundedReceiver<EngineApiEvent>,
-    // TODO add db controller
 }
 
 impl<T> EngineApiRequestHandler<T>
@@ -178,13 +178,16 @@ where
     }
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<RequestHandlerEvent<Self::Event>> {
-        todo!("poll tree and handle db")
+        todo!("poll from_tree")
     }
 }
 
 /// Events emitted by the engine API handler.
 #[derive(Debug)]
-pub enum EngineApiEvent {}
+pub enum EngineApiEvent {
+    /// Bubled from tree.
+    FromTree(TreeEvent),
+}
 
 #[derive(Debug)]
 pub enum FromEngine<Req> {

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -178,14 +178,14 @@ where
     }
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<RequestHandlerEvent<Self::Event>> {
-        todo!("poll from_tree")
+        todo!("poll tree")
     }
 }
 
 /// Events emitted by the engine API handler.
 #[derive(Debug)]
 pub enum EngineApiEvent {
-    /// Bubled from tree.
+    /// Bubbled from tree.
     FromTree(TreeEvent),
 }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -259,8 +259,7 @@ where
         payload_validator: ExecutionPayloadValidator,
         incoming: Receiver<FromEngine<BeaconEngineMessage<T>>>,
         outgoing: UnboundedSender<EngineApiEvent>,
-        block_buffer_limit: u32,
-        max_invalid_header_cache_length: u32,
+        state: EngineApiTreeState,
     ) -> Self {
         Self {
             provider,
@@ -270,7 +269,7 @@ where
             incoming,
             outgoing,
             is_pipeline_active: false,
-            state: EngineApiTreeState::new(block_buffer_limit, max_invalid_header_cache_length),
+            state,
             _marker: PhantomData,
         }
     }
@@ -282,8 +281,7 @@ where
         consensus: Arc<dyn Consensus>,
         payload_validator: ExecutionPayloadValidator,
         incoming: Receiver<FromEngine<BeaconEngineMessage<T>>>,
-        block_buffer_limit: u32,
-        max_invalid_header_cache_length: u32,
+        state: EngineApiTreeState,
     ) -> UnboundedSender<EngineApiEvent> {
         let (outgoing, rx) = tokio::sync::mpsc::unbounded_channel();
         let task = Self::new(
@@ -293,8 +291,7 @@ where
             payload_validator,
             incoming,
             outgoing.clone(),
-            block_buffer_limit,
-            max_invalid_header_cache_length,
+            state,
         );
         std::thread::Builder::new().name("Tree Task".to_string()).spawn(|| task.run()).unwrap();
         outgoing

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -329,7 +329,9 @@ where
                                 error!("Failed to send event: {err:?}");
                             }
                         }
-                        BeaconEngineMessage::TransitionConfigurationExchanged => {}
+                        BeaconEngineMessage::TransitionConfigurationExchanged => {
+                            todo!()
+                        }
                     },
                     FromEngine::DownloadedBlocks(blocks) => {
                         if let Some(event) = self.on_downloaded(blocks) {


### PR DESCRIPTION
Towards #9235

Changes to spawn ``EngineApiTreeHandlerImpl in a separate thread running an infinite loop to handle incoming messages, this will be used later to hook other actions. 

I've added initial handling for the incoming messages, not sure what to do with `FromEngine::Event`, left it as todo!.  I've also added code to bubble up the `TreeEvent` result of `self.on_downloaded` in a response of `FromEngine::DownloadedBlocks`, let me know if this is needed.