### PR TITLE
fix: Added CI back for `check_no_std` with compilation to `wasm32`

### DIFF
--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -3,7 +3,9 @@ set -eo pipefail
 
 # TODO
 no_std_packages=(
-#   reth-codecs
+  reth-codecs
+  reth-primitives-traits
+#   reth-primitives
 #   reth-consensus
 #   reth-db
 #   reth-errors
@@ -11,13 +13,11 @@ no_std_packages=(
 #   reth-evm
 #   reth-evm-ethereum
 #   reth-network-peers
-#   reth-primitives
-#   reth-primitives-traits
 #   reth-revm
 )
 
 for package in "${no_std_packages[@]}"; do
-  cmd="cargo +stable build -p $package --target riscv32imac-unknown-none-elf --no-default-features"
+  cmd="cargo +stable build -p $package --target wasm32-wasi --no-default-features"
 
   if [ -n "$CI" ]; then
     echo "::group::$cmd"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: riscv32imac-unknown-none-elf
+          target: wasm32-wasi
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8044,6 +8044,7 @@ dependencies = [
  "c-kzg",
  "criterion",
  "derive_more",
+ "k256",
  "modular-bitfield",
  "nybbles",
  "once_cell",

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -27,7 +27,7 @@ revm-primitives = { workspace = true, features = ["serde"] }
 # misc
 thiserror-no-std = { workspace = true, default-features = false }
 roaring = "0.10.2"
-byteorder = "1"
+byteorder = { version = "1", default-features = false }
 
 # required by reth-codecs
 modular-bitfield.workspace = true

--- a/crates/primitives-traits/src/constants/gas_units.rs
+++ b/crates/primitives-traits/src/constants/gas_units.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String};
+
+use core::time::Duration;
 
 /// Represents one Kilogas, or `1_000` gas.
 pub const KILOGAS: u64 = 1_000;

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -9,6 +9,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[cfg(feature = "alloy-compat")]
 mod alloy_compat;
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -33,7 +33,8 @@ secp256k1 = { workspace = true, features = [
     "global-context",
     "recovery",
     "rand",
-] }
+], optional = true }
+k256 = { version = "0.13.3", default-features = false, features = ["ecdsa"] }
 # for eip-4844
 c-kzg = { workspace = true, features = ["serde"], optional = true }
 
@@ -83,8 +84,9 @@ pprof = { workspace = true, features = [
 ] }
 secp256k1.workspace = true
 
+
 [features]
-default = ["c-kzg", "zstd-codec", "alloy-compat", "std"]
+default = ["c-kzg", "zstd-codec", "alloy-compat", "std", "secp256k1"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "reth-primitives-traits/arbitrary",
@@ -98,6 +100,7 @@ arbitrary = [
     "dep:proptest",
     "zstd-codec",
 ]
+secp256k1 = ["dep:secp256k1"]
 c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg"]
 zstd-codec = ["dep:zstd"]
 optimism = [

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -64,13 +64,20 @@ pub use transaction::{
 pub use transaction::BlobTransactionValidationError;
 
 pub use transaction::{
-    util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
     AccessList, AccessListItem, IntoRecoveredTransaction, InvalidTransactionError, Signature,
     Transaction, TransactionMeta, TransactionSigned, TransactionSignedEcRecovered,
     TransactionSignedNoHash, TryFromRecoveredTransaction, TxEip1559, TxEip2930, TxEip4844,
     TxHashOrNumber, TxLegacy, TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
     LEGACY_TX_TYPE_ID,
 };
+
+#[cfg(feature = "secp256k1")]
+pub use transaction::util::secp256k1::{
+    public_key_to_address, recover_signer_unchecked, sign_message,
+};
+
+#[cfg(not(feature = "secp256k1"))]
+pub use transaction::util::secp256k1::recover_signer_unchecked;
 
 // Re-exports
 pub use self::ruint::UintTryTo;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -79,6 +79,8 @@ pub use transaction::util::secp256k1::{
 #[cfg(not(feature = "secp256k1"))]
 pub use transaction::util::secp256k1::recover_signer_unchecked;
 
+use k256 as _;
+
 // Re-exports
 pub use self::ruint::UintTryTo;
 pub use alloy_primitives::{

--- a/crates/primitives/src/transaction/eip1559.rs
+++ b/crates/primitives/src/transaction/eip1559.rs
@@ -2,6 +2,10 @@ use super::access_list::AccessList;
 use crate::{keccak256, Bytes, ChainId, Signature, TxKind, TxType, B256, U256};
 use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use core::mem;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use reth_codecs::{main_codec, Compact};
 
 /// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)).

--- a/crates/primitives/src/transaction/eip2930.rs
+++ b/crates/primitives/src/transaction/eip2930.rs
@@ -4,6 +4,9 @@ use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use core::mem;
 use reth_codecs::{main_codec, Compact};
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]

--- a/crates/primitives/src/transaction/legacy.rs
+++ b/crates/primitives/src/transaction/legacy.rs
@@ -3,6 +3,9 @@ use alloy_rlp::{length_of_length, Encodable, Header};
 use core::mem;
 use reth_codecs::{main_codec, Compact};
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Legacy transaction.
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -19,6 +19,12 @@
 
 pub use reth_codecs_derive::*;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U256};
 use bytes::Buf;
 


### PR DESCRIPTION
Previously the CI check for `check_no_std` was commented out, as the `riscv32imac-unknown-none-elf` target doesn't come with `std` and there are many dependencies in `reth` that don't support `no_std`, making it difficult to compile to this target.

However, there are several embedded environments (namely zkVMs like SP1) that *do* support `std`, but do not (easily) support crates with embedded C++ dependencies (like secp256k1, or blst or z-std) and also do not support networking crates like socket. The zkVM embedded environment is therefore similar to a target like `wasm32-wasi` which comes with `std`, but also does not support crates like secp256k1, blst and does not support networking crates. 

This PR adds back the `no_std` CI check but with the `wasm32-wasi` target, which should be significantly easier to support within Reth and also will ensure that all relevant packages that might be used in a zkVM context can compile. 

With this PR, `reth-codecs` and `reth-primitives-traits` compiles with `no-default-features` to `wasm32-wasi`. `reth-primitives` _almost_ compiles with `no-default-features`, but I'm running into this weird error that I was hoping @JackG-eth could help with since I saw he did the replacement of `thiserror_no_std::Error` everywhere.

```
Compiling reth-primitives v1.0.0 (/Users/umaroy/Documents/reth/crates/primitives)
error[E0433]: failed to resolve: use of undeclared crate or module `std`
 --> crates/primitives/src/transaction/error.rs:6:1
  |
6 | pub enum InvalidTransactionError {
  | ^^^ use of undeclared crate or module `std`
  |
help: consider importing this module
  |
1 + use core::error;

error[E0433]: failed to resolve: use of undeclared crate or module `std`
  --> crates/primitives/src/transaction/error.rs:59:1
   |
59 | pub enum TransactionConversionError {
   | ^^^ use of undeclared crate or module `std`
   |
help: consider importing this module
   |
1  + use core::error;
   |

error[E0433]: failed to resolve: use of undeclared crate or module `std`
  --> crates/primitives/src/transaction/error.rs:70:1
   |
70 | pub enum TryFromRecoveredTransactionError {
   | ^^^ use of undeclared crate or module `std`
   |
help: consider importing this module
   |
1  + use core::error;
```

