### PR TITLE
chore(meta): remove security link from issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: GitHub Discussions
     url: https://github.com/foundry-rs/reth/discussions
     about: Please ask and answer questions here to keep the issue tracker clean.
-  - name: Security
-    url: mailto:georgios@paradigm.xyz
-    about: Please report security vulnerabilities here.


### PR DESCRIPTION
1. It's not displayed anywhere because it only accepts `https?://`
2. It's already linked based on repo security config
![image](https://github.com/paradigmxyz/reth/assets/57450786/b0020d5e-556a-48ed-a6ca-b0f55a7d63d8)
