### PR TITLE
fix: encode block as is in debug_getRawBlock

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -234,7 +234,7 @@ where
     let block_id = BlockId::Number(BlockNumberOrTag::default());
 
     DebugApiClient::raw_header(client, block_id).await.unwrap();
-    DebugApiClient::raw_block(client, block_id).await.unwrap();
+    DebugApiClient::raw_block(client, block_id).await.unwrap_err();
     DebugApiClient::raw_transaction(client, B256::default()).await.unwrap();
     DebugApiClient::raw_receipts(client, block_id).await.unwrap();
     assert!(is_unimplemented(DebugApiClient::bad_blocks(client).await.err().unwrap()));

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -6,8 +6,7 @@ use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthereumHardforks;
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
-    Address, Block, BlockId, BlockNumberOrTag, Bytes, TransactionSignedEcRecovered, Withdrawals,
-    B256, U256,
+    Address, Block, BlockId, BlockNumberOrTag, Bytes, TransactionSignedEcRecovered, B256, U256,
 };
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, HeaderProvider, StateProviderFactory,
@@ -674,17 +673,14 @@ where
 
     /// Handler for `debug_getRawBlock`
     async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes> {
-        let block = self.inner.provider.block_by_id(block_id).to_rpc_result()?;
-
+        let block = self
+            .inner
+            .provider
+            .block_by_id(block_id)
+            .to_rpc_result()?
+            .ok_or_else(|| EthApiError::UnknownBlockNumber)?;
         let mut res = Vec::new();
-        if let Some(mut block) = block {
-            // In RPC withdrawals are always present
-            if block.withdrawals.is_none() {
-                block.withdrawals = Some(Withdrawals::default());
-            }
-            block.encode(&mut res);
-        }
-
+        block.encode(&mut res);
         Ok(res.into())
     }
 


### PR DESCRIPTION
closes #9348
removes bad withdrawals check, unclear where this originated from, but this now mirrors geth:

https://github.com/ethereum/go-ethereum/blob/473ee8fc07a3f89cf3978e164a6fad218de9a6b5/core/types/block.go#L215-L215

and also returns an error, like geth:

https://github.com/ethereum/go-ethereum/blob/473ee8fc07a3f89cf3978e164a6fad218de9a6b5/internal/ethapi/api.go#L2048-L2048