### PR TITLE
perf(pruner): senders not written to db in full node

### DIFF
--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -124,7 +124,8 @@ where
                     exex_manager_handle,
                 )
                 .with_metrics_tx(metrics_tx),
-            ),
+            )
+            .disable_if(reth_stages::StageId::SenderRecovery, || prune_modes.receipts.is_some()),
         )
         .build(provider_factory, static_file_producer);
 

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -101,6 +101,8 @@ where
 
     let prune_modes = prune_config.map(|prune| prune.segments).unwrap_or_default();
 
+    let is_full_node = prune_modes.receipts.is_some();
+
     let pipeline = builder
         .with_tip_sender(tip_tx)
         .with_metrics_tx(metrics_tx.clone())
@@ -125,7 +127,7 @@ where
                 )
                 .with_metrics_tx(metrics_tx),
             )
-            .disable_if(reth_stages::StageId::SenderRecovery, || prune_modes.receipts.is_some()),
+            .disable_if(reth_stages::StageId::SenderRecovery, || is_full_node),
         )
         .build(provider_factory, static_file_producer);
 


### PR DESCRIPTION
Skips sender recovery stage for a full node. Instead, senders are recovered on demand in execution stage.

Execution with sender recovery on demand takes just under 3 hours on high end hw. Saves 158 GiB disk space. Comparing to [public node](https://reth.paradigm.xyz/d/2k8BXz24x/reth?orgId=1&refresh=30s&var-instance=localhost:5006&var-blockchain_tree_action=&var-database_action=).

<img width="1474" alt="Screenshot 2024-07-08 at 16 20 06" src="https://github.com/paradigmxyz/reth/assets/58548332/a0942eac-6937-4105-9fbf-c7103b449dad">
<img width="851" alt="Screenshot 2024-07-09 at 16 21 49" src="https://github.com/paradigmxyz/reth/assets/58548332/c5c4fbda-78e9-45f1-8f80-77e8f8369bd6">
<img width="855" alt="Screenshot 2024-07-09 at 16 22 04" src="https://github.com/paradigmxyz/reth/assets/58548332/5b99db91-325b-47ab-8e63-85b190413828">
