### PR TITLE
chore: fix clippy warnings for needless_borrows_for_generic_args

### DIFF
--- a/crates/e2e-test-utils/src/wallet.rs
+++ b/crates/e2e-test-utils/src/wallet.rs
@@ -36,7 +36,7 @@ impl Wallet {
         let mut wallets = Vec::with_capacity(self.amount);
         for idx in 0..self.amount {
             let builder =
-                builder.clone().derivation_path(&format!("{derivation_path}{idx}")).unwrap();
+                builder.clone().derivation_path(format!("{derivation_path}{idx}")).unwrap();
             let wallet = builder.build().unwrap().with_chain_id(Some(self.chain_id));
             wallets.push(wallet)
         }

--- a/crates/rpc/rpc-layer/src/auth_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_layer.rs
@@ -232,7 +232,7 @@ mod tests {
 
         let body = r#"{"jsonrpc": "2.0", "method": "greet_melkor", "params": [], "id": 1}"#;
         let response = client
-            .post(&format!("http://{AUTH_ADDR}:{AUTH_PORT}"))
+            .post(format!("http://{AUTH_ADDR}:{AUTH_PORT}"))
             .bearer_auth(jwt.unwrap_or_default())
             .body(body)
             .header(header::CONTENT_TYPE, "application/json")


### PR DESCRIPTION
With latest nightly `35b658fb1 2024-07-08` we are getting:
```
warning: the borrowed expression implements the required traits
   --> crates/rpc/rpc-layer/src/auth_layer.rs:235:19
    |
235 |             .post(&format!("http://{AUTH_ADDR}:{AUTH_PORT}"))
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `format!("http://{AUTH_ADDR}:{AUTH_PORT}")`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default
```