### PR TITLE
feat: make unwind_table_by_walker take RangeBounds

### DIFF
--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -317,7 +317,7 @@ where
         // First unwind the db tables, until the unwind_to block number. use the walker to unwind
         // HeaderNumbers based on the index in CanonicalHeaders
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
-            input.unwind_to,
+            input.unwind_to..,
         )?;
         provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
         provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to)?;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1078,13 +1078,16 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     }
 
     /// Unwind a table forward by a [`Walker`][reth_db_api::cursor::Walker] on another table
-    pub fn unwind_table_by_walker<T1, T2>(&self, start_at: T1::Key) -> Result<(), DatabaseError>
+    pub fn unwind_table_by_walker<T1, T2>(
+        &self,
+        range: impl RangeBounds<T1::Key>,
+    ) -> Result<(), DatabaseError>
     where
         T1: Table,
         T2: Table<Key = T1::Value>,
     {
         let mut cursor = self.tx.cursor_write::<T1>()?;
-        let mut walker = cursor.walk(Some(start_at))?;
+        let mut walker = cursor.walk_range(range)?;
         while let Some((_, value)) = walker.next().transpose()? {
             self.tx.delete::<T2>(value, None)?;
         }


### PR DESCRIPTION
This allows for the use of ranges in `unwind_table_by_walker`, which is required for this method to be used in other methods which take a type that impls `RangeBounds` as input.

ref https://github.com/paradigmxyz/reth/issues/9400