### PR TITLE
feat: remove get or take usage

### DIFF
--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -410,7 +410,7 @@ where
         // Unwind account and storage changesets, as well as receipts.
         //
         // This also updates `PlainStorageState` and `PlainAccountState`.
-        let bundle_state_with_receipts = provider.unwind_or_peek_state::<true>(range.clone())?;
+        let bundle_state_with_receipts = provider.take_state(range.clone())?;
 
         // Prepare the input for post unwind commit hook, where an `ExExNotification` will be sent.
         if self.exex_manager_handle.has_exexs() {
@@ -444,7 +444,7 @@ where
             // files do not support filters.
             //
             // If we hit this case, the receipts have already been unwound by the call to
-            // `unwind_or_peek_state`.
+            // `take_state`.
         }
 
         // Update the checkpoint.

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -718,7 +718,7 @@ mod tests {
                 Ok(_)
             );
 
-            let senders = provider.get_or_take::<tables::TransactionSenders, true>(range.clone());
+            let senders = provider.take::<tables::TransactionSenders>(range.clone());
             assert_eq!(
                 senders,
                 Ok(range

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -703,7 +703,7 @@ mod tests {
     }
 
     #[test]
-    fn get_take_block_transaction_range_recover_senders() {
+    fn take_block_transaction_range_recover_senders() {
         let factory = create_test_provider_factory();
 
         let mut rng = generators::rng();
@@ -733,7 +733,7 @@ mod tests {
             let db_senders = provider.senders_by_tx_range(range);
             assert_eq!(db_senders, Ok(vec![]));
 
-            let result = provider.get_take_block_transaction_range::<true>(0..=0);
+            let result = provider.take_block_transaction_range(0..=0);
             assert_eq!(
                 result,
                 Ok(vec![(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1065,7 +1065,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     /// * [`TransactionSenders`](tables::TransactionSenders)
     /// * [`TransactionHashNumbers`](tables::TransactionHashNumbers)
     /// * [`TransactionBlocks`](tables::TransactionBlocks)
-    pub(crate) fn remove_block_transaction_range(
+    pub fn remove_block_transaction_range(
         &self,
         range: impl RangeBounds<BlockNumber> + Clone,
     ) -> ProviderResult<()> {
@@ -1120,7 +1120,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
     /// * [`TransactionSenders`](tables::TransactionSenders)
     /// * [`TransactionHashNumbers`](tables::TransactionHashNumbers)
     /// * [`TransactionBlocks`](tables::TransactionBlocks)
-    pub(crate) fn take_block_transaction_range(
+    pub fn take_block_transaction_range(
         &self,
         range: impl RangeBounds<BlockNumber> + Clone,
     ) -> ProviderResult<Vec<(BlockNumber, Vec<TransactionSignedEcRecovered>)>> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1498,18 +1498,6 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         Ok(blocks)
     }
 
-    /// Get or unwind the given range of blocks.
-    pub fn get_take_block_range<const TAKE: bool>(
-        &self,
-        range: impl RangeBounds<BlockNumber> + Clone,
-    ) -> ProviderResult<Vec<SealedBlockWithSenders>> {
-        if TAKE {
-            self.take_block_range(range)
-        } else {
-            self.get_block_range(range)
-        }
-    }
-
     /// Unwind table by some number key.
     /// Returns number of rows unwound.
     ///

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -620,7 +620,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         let start_block_number = *range.start();
 
         // We are not removing block meta as it is used to get block changesets.
-        let block_bodies = self.get_or_take::<tables::BlockBodyIndices, false>(range.clone())?;
+        let block_bodies = self.get::<tables::BlockBodyIndices>(range.clone())?;
 
         // get transaction receipts
         let from_transaction_num =
@@ -826,7 +826,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         range: impl RangeBounds<BlockNumber> + Clone,
     ) -> ProviderResult<Vec<(BlockNumber, Vec<TransactionSignedEcRecovered>)>> {
         // Raad range of block bodies to get all transactions id's of this range.
-        let block_bodies = self.get_or_take::<tables::BlockBodyIndices, false>(range)?;
+        let block_bodies = self.get::<tables::BlockBodyIndices>(range)?;
 
         if block_bodies.is_empty() {
             return Ok(Vec::new())

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -13,20 +13,10 @@ pub trait BlockExecutionWriter: BlockWriter + BlockReader + Send + Sync {
     fn get_block_and_execution_range(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Chain> {
-        self.get_or_take_block_and_execution_range::<false>(range)
-    }
+    ) -> ProviderResult<Chain>;
 
     /// Take range of blocks and its execution result
     fn take_block_and_execution_range(
-        &self,
-        range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Chain> {
-        self.get_or_take_block_and_execution_range::<true>(range)
-    }
-
-    /// Return range of blocks and its execution result
-    fn get_or_take_block_and_execution_range<const TAKE: bool>(
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Chain>;


### PR DESCRIPTION
Removes get_or_take everything from the codebase. This adds some code duplication. This also introduces direct `remove` methods, which do not return anything.

closes https://github.com/paradigmxyz/reth/issues/9400