### PR TITLE
docs: remove random pub from transaction docs

### DIFF
--- a/crates/primitives/src/transaction/eip1559.rs
+++ b/crates/primitives/src/transaction/eip1559.rs
@@ -8,16 +8,19 @@ use reth_codecs::{main_codec, Compact};
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TxEip1559 {
-    /// Added as EIP-pub 155: Simple replay attack protection
+    /// Added as EIP-155: Simple replay attack protection
     pub chain_id: ChainId,
+
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
     pub nonce: u64,
+
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
     pub gas_limit: u64,
+
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
@@ -30,6 +33,7 @@ pub struct TxEip1559 {
     ///
     /// This is also known as `GasFeeCap`
     pub max_fee_per_gas: u128,
+
     /// Max Priority fee that transaction is paying
     ///
     /// As ethereum circulation is around 120mil eth as of 2022 that is around
@@ -38,24 +42,31 @@ pub struct TxEip1559 {
     ///
     /// This is also known as `GasTipCap`
     pub max_priority_fee_per_gas: u128,
+
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
     pub to: TxKind,
+
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment
     /// to the newly created account; formally Tv.
     pub value: U256,
+
     /// The accessList specifies a list of addresses and storage keys;
     /// these addresses and storage keys are added into the `accessed_addresses`
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
     pub access_list: AccessList,
-    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
-    /// Some). pub init: An unlimited size byte array specifying the
-    /// EVM-code for the account initialisation procedure CREATE,
-    /// data: An unlimited size byte array specifying the
+
+    /// Input has two uses depending if the transaction `to` field is [`TxKind::Create`] or
+    /// [`TxKind::Call`].
+    ///
+    /// Input as init code, or if `to` is [`TxKind::Create`]: An unlimited size byte array
+    /// specifying the EVM-code for the account initialisation procedure `CREATE`
+    ///
+    /// Input as data, or if `to` is [`TxKind::Call`]: An unlimited size byte array specifying the
     /// input data of the message call, formally Td.
     pub input: Bytes,
 }

--- a/crates/primitives/src/transaction/eip2930.rs
+++ b/crates/primitives/src/transaction/eip2930.rs
@@ -8,10 +8,12 @@ use reth_codecs::{main_codec, Compact};
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TxEip2930 {
-    /// Added as EIP-pub 155: Simple replay attack protection
+    /// Added as EIP-155: Simple replay attack protection
     pub chain_id: ChainId,
+
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
     pub nonce: u64,
+
     /// A scalar value equal to the number of
     /// Wei to be paid per unit of gas for all computation
     /// costs incurred as a result of the execution of this transaction; formally Tp.
@@ -20,30 +22,38 @@ pub struct TxEip2930 {
     /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
     /// 340282366920938463463374607431768211455
     pub gas_price: u128,
+
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
     pub gas_limit: u64,
+
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
     pub to: TxKind,
+
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment
     /// to the newly created account; formally Tv.
     pub value: U256,
+
     /// The accessList specifies a list of addresses and storage keys;
     /// these addresses and storage keys are added into the `accessed_addresses`
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
     pub access_list: AccessList,
-    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
-    /// Some). pub init: An unlimited size byte array specifying the
-    /// EVM-code for the account initialisation procedure CREATE,
-    /// data: An unlimited size byte array specifying the
+
+    /// Input has two uses depending if the transaction `to` field is [`TxKind::Create`] or
+    /// [`TxKind::Call`].
+    ///
+    /// Input as init code, or if `to` is [`TxKind::Create`]: An unlimited size byte array
+    /// specifying the EVM-code for the account initialisation procedure `CREATE`
+    ///
+    /// Input as data, or if `to` is [`TxKind::Call`]: An unlimited size byte array specifying the
     /// input data of the message call, formally Td.
     pub input: Bytes,
 }

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -84,8 +84,9 @@ pub struct TxEip4844 {
     pub max_fee_per_blob_gas: u128,
 
     /// Unlike other transaction types, where the `input` field has two uses depending on whether
-    /// or not the `to` field is [`TxKind::Create`] or [`TxKind::Call`], EIP-4844 transactions
-    /// cannot be [`TxKind::Create`] transactions.
+    /// or not the `to` field is [`Create`](crate::TxKind::Create) or
+    /// [`Call`](crate::TxKind::Call), EIP-4844 transactions cannot be
+    /// [`Create`](crate::TxKind::Create) transactions.
     ///
     /// This means the `input` field has a single use, as data: An unlimited size byte array
     /// specifying the input data of the message call, formally Td.

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -19,16 +19,19 @@ use alloc::vec::Vec;
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TxEip4844 {
-    /// Added as EIP-pub 155: Simple replay attack protection
+    /// Added as EIP-155: Simple replay attack protection
     pub chain_id: ChainId,
+
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
     pub nonce: u64,
+
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
     pub gas_limit: u64,
+
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
@@ -41,6 +44,7 @@ pub struct TxEip4844 {
     ///
     /// This is also known as `GasFeeCap`
     pub max_fee_per_gas: u128,
+
     /// Max Priority fee that transaction is paying
     ///
     /// As ethereum circulation is around 120mil eth as of 2022 that is around
@@ -49,17 +53,21 @@ pub struct TxEip4844 {
     ///
     /// This is also known as `GasTipCap`
     pub max_priority_fee_per_gas: u128,
+
     /// TODO(debt): this should be removed if we break the DB.
     /// Makes sure that the Compact bitflag struct has one bit after the above field:
     /// <https://github.com/paradigmxyz/reth/pull/8291#issuecomment-2117545016>
     pub placeholder: Option<CompactPlaceholder>,
+
     /// The 160-bit address of the message call’s recipient.
     pub to: Address,
+
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
     /// in the case of contract creation, as an endowment
     /// to the newly created account; formally Tv.
     pub value: U256,
+
     /// The accessList specifies a list of addresses and storage keys;
     /// these addresses and storage keys are added into the `accessed_addresses`
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
@@ -75,11 +83,12 @@ pub struct TxEip4844 {
     /// aka BlobFeeCap or blobGasFeeCap
     pub max_fee_per_blob_gas: u128,
 
-    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
-    /// Some). pub init: An unlimited size byte array specifying the
-    /// EVM-code for the account initialisation procedure CREATE,
-    /// data: An unlimited size byte array specifying the
-    /// input data of the message call, formally Td.
+    /// Unlike other transaction types, where the `input` field has two uses depending on whether
+    /// or not the `to` field is [`TxKind::Create`] or [`TxKind::Call`], EIP-4844 transactions
+    /// cannot be [`TxKind::Create`] transactions.
+    ///
+    /// This means the `input` field has a single use, as data: An unlimited size byte array
+    /// specifying the input data of the message call, formally Td.
     pub input: Bytes,
 }
 


### PR DESCRIPTION
The `input` field docs are updated to make more sense given the current use of `TxKind` in transaction types.

This also updates the EIP-4844 transaction docs to explain that EIP-4844 transactions cannot be create transactions.