### PR TITLE
chore: remove node-core from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,6 @@ crates/metrics/             @onbjerg
 crates/net/                 @emhane @mattsse @Rjected
 crates/net/downloaders/     @onbjerg @rkrasiuk @emhane
 crates/node/                @mattsse @Rjected @onbjerg
-crates/node-core/           @mattsse @Rjected @onbjerg
 crates/optimism/            @mattsse @Rjected @fgimenez
 crates/payload/             @mattsse @Rjected
 crates/primitives/          @DaniPopes @Rjected


### PR DESCRIPTION
node-core is now in `crates/node/core`, which has the same CODEOWNERS, so it is removed