### PR TITLE
chore: rm redundant is_optimism checks

### DIFF
--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -198,11 +198,7 @@ impl Consensus for EthBeaconConsensus {
                 })
             }
 
-            // Early OP exception:
-            //  * If the network is pre-Bedrock OP, ignore the extradata check.
-            if !self.chain_spec.is_optimism() {
-                validate_header_extradata(header)?;
-            }
+            validate_header_extradata(header)?;
         }
 
         Ok(())

--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -246,8 +246,7 @@ where
     // If the canyon hardfork is active at the current timestamp, and it was not active at the
     // previous block timestamp (heuristically, block time is not perfectly constant at 2s), and the
     // chain is an optimism chain, then we need to force-deploy the create2 deployer contract.
-    if chain_spec.is_optimism() &&
-        chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, timestamp) &&
+    if chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, timestamp) &&
         !chain_spec
             .is_fork_active_at_timestamp(OptimismHardfork::Canyon, timestamp.saturating_sub(2))
     {

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -150,7 +150,7 @@ impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
         {
             cfg_with_handler_cfg = CfgEnvWithHandlerCfg {
                 cfg_env: cfg,
-                handler_cfg: HandlerCfg { spec_id, is_optimism: chain_spec.is_optimism() },
+                handler_cfg: HandlerCfg { spec_id, is_optimism: true },
             };
         }
 

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -147,7 +147,7 @@ impl PayloadAttributes for OptimismPayloadAttributes {
     ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(chain_spec, version, self.into())?;
 
-        if self.gas_limit.is_none() && chain_spec.is_optimism() {
+        if self.gas_limit.is_none() {
             return Err(EngineObjectValidationError::InvalidParams(
                 "MissingGasLimitInPayloadAttributes".to_string().into(),
             ))


### PR DESCRIPTION
now that the impls are separated, these calls can be removed