### PR TITLE
chore: resolve new clippy error w/ suggested fix part 2

### DIFF
--- a/crates/primitives/src/transaction/compat.rs
+++ b/crates/primitives/src/transaction/compat.rs
@@ -79,7 +79,7 @@ impl FillTxEnv for TransactionSigned {
                 tx_env.data = tx.input.clone();
                 tx_env.chain_id = Some(tx.chain_id);
                 tx_env.nonce = Some(tx.nonce);
-                tx_env.access_list = tx.access_list.0.clone();
+                tx_env.access_list.clone_from(&tx.access_list.0);
                 tx_env.blob_hashes.clear();
                 tx_env.max_fee_per_blob_gas.take();
                 tx_env.authorization_list =


### PR DESCRIPTION
This commit from 9 hours ago broke clippy/`make pr` in the same way that it was broken yesterday. applying the same fix as in #9427

<img width="1348" alt="Screenshot 2024-07-11 at 11 01 04 AM" src="https://github.com/paradigmxyz/reth/assets/9053984/848b800d-f3b3-48ae-8548-8efc4788c979">
