### PR TITLE
test: add EngineApiTreeHandlerImpl integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7057,6 +7057,7 @@ version = "1.0.1"
 dependencies = [
  "aquamarine",
  "assert_matches",
+ "async-trait",
  "futures",
  "metrics",
  "parking_lot 0.12.3",
@@ -7070,6 +7071,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-consensus",
+ "reth-ethereum-engine-primitives",
  "reth-evm",
  "reth-exex-types",
  "reth-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7057,7 +7057,6 @@ version = "1.0.1"
 dependencies = [
  "aquamarine",
  "assert_matches",
- "async-trait",
  "futures",
  "metrics",
  "parking_lot 0.12.3",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -42,6 +42,7 @@ reth-trie.workspace = true
 revm.workspace = true
 
 # common
+async-trait.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["macros", "sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }
@@ -63,6 +64,8 @@ reth-tracing = { workspace = true, optional = true }
 [dev-dependencies]
 # reth
 reth-db = { workspace = true, features = ["test-utils"] }
+reth-ethereum-engine-primitives.workspace = true
+reth-evm = { workspace = true, features = ["test-utils"] }
 reth-exex-types.workspace = true
 reth-network-p2p = { workspace = true, features = ["test-utils"] }
 reth-prune.workspace = true

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -42,7 +42,6 @@ reth-trie.workspace = true
 revm.workspace = true
 
 # common
-async-trait.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["macros", "sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -236,6 +236,7 @@ impl PersistenceHandle {
     pub const fn new(sender: Sender<PersistenceAction>) -> Self {
         Self { sender }
     }
+
     /// Sends a specific [`PersistenceAction`] in the contained channel. The caller is responsible
     /// for creating any channels for the given action.
     pub fn send_action(

--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -23,12 +23,11 @@ use crate::{
 ///
 /// This should be spawned in its own thread with [`std::thread::spawn`], since this performs
 /// blocking file operations in an endless loop.
-#[derive(Debug)]
 pub struct StaticFileService<DB> {
     /// The db / static file provider to use
     provider: ProviderFactory<DB>,
     /// Handle for the database service
-    database_handle: PersistenceHandle,
+    database_handle: Arc<dyn PersistenceHandle>,
     /// Incoming requests to write static files
     incoming: Receiver<StaticFileAction>,
     /// The pruning configuration

--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -27,7 +27,7 @@ pub struct StaticFileService<DB> {
     /// The db / static file provider to use
     provider: ProviderFactory<DB>,
     /// Handle for the database service
-    database_handle: Arc<dyn PersistenceHandle>,
+    database_handle: PersistenceHandle,
     /// Incoming requests to write static files
     incoming: Receiver<StaticFileAction>,
     /// The pruning configuration

--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -23,6 +23,7 @@ use crate::{
 ///
 /// This should be spawned in its own thread with [`std::thread::spawn`], since this performs
 /// blocking file operations in an endless loop.
+#[derive(Debug)]
 pub struct StaticFileService<DB> {
     /// The db / static file provider to use
     provider: ProviderFactory<DB>,

--- a/crates/engine/tree/src/test_utils.rs
+++ b/crates/engine/tree/src/test_utils.rs
@@ -1,12 +1,18 @@
+use crate::tree::ExecutedBlock;
 use reth_chainspec::ChainSpec;
 use reth_db::{mdbx::DatabaseEnv, test_utils::TempDatabase};
 use reth_network_p2p::test_utils::TestFullBlockClient;
-use reth_primitives::{BlockBody, SealedHeader, B256};
+use reth_primitives::{
+    Address, Block, BlockBody, BlockNumber, Receipts, Requests, SealedBlockWithSenders,
+    SealedHeader, TransactionSigned, B256,
+};
 use reth_provider::{test_utils::create_test_provider_factory_with_chain_spec, ExecutionOutcome};
 use reth_prune_types::PruneModes;
 use reth_stages::{test_utils::TestStages, ExecOutput, StageError};
 use reth_stages_api::Pipeline;
 use reth_static_file::StaticFileProducer;
+use reth_trie::{updates::TrieUpdates, HashedPostState};
+use revm::db::BundleState;
 use std::{collections::VecDeque, ops::Range, sync::Arc};
 use tokio::sync::watch;
 
@@ -74,4 +80,34 @@ pub(crate) fn insert_headers_into_client(
         sealed_header = header.seal_slow();
         client.insert(sealed_header.clone(), body.clone());
     }
+}
+
+pub(crate) fn get_executed_block_with_number(block_number: BlockNumber) -> ExecutedBlock {
+    let mut block = Block::default();
+    let mut header = block.header.clone();
+    header.number = block_number;
+    block.header = header;
+
+    let sender = Address::random();
+    let tx = TransactionSigned::default();
+    block.body.push(tx);
+    let sealed = block.seal_slow();
+    let sealed_with_senders = SealedBlockWithSenders::new(sealed.clone(), vec![sender]).unwrap();
+
+    ExecutedBlock::new(
+        Arc::new(sealed),
+        Arc::new(sealed_with_senders.senders),
+        Arc::new(ExecutionOutcome::new(
+            BundleState::default(),
+            Receipts { receipt_vec: vec![] },
+            block_number,
+            vec![Requests::default()],
+        )),
+        Arc::new(HashedPostState::default()),
+        Arc::new(TrieUpdates::default()),
+    )
+}
+
+pub(crate) fn get_executed_blocks(number: u64) -> Vec<ExecutedBlock> {
+    (1..=number).map(get_executed_block_with_number).collect()
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -252,6 +252,7 @@ pub enum TreeAction {
     MakeCanonical(B256),
 }
 
+#[derive(Debug)]
 pub struct EngineApiTreeHandlerImpl<P, E, T: EngineTypes> {
     provider: P,
     executor_provider: E,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -916,12 +916,13 @@ mod tests {
         }
 
         fn save_blocks(&self, blocks: Vec<ExecutedBlock>, tx: oneshot::Sender<B256>) {
+            let last_hash = blocks.last().unwrap().block().hash();
+
             if let Some(sender) = self.blocks_sender.lock().unwrap().take() {
                 let _ = sender.send(blocks);
             }
 
-            // Mock implementation: send a dummy B256 value
-            let _ = tx.send(B256::default());
+            let _ = tx.send(last_hash);
         }
 
         async fn remove_blocks_above(&self, block_num: u64) -> B256 {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -888,6 +888,7 @@ mod tests {
     use std::sync::mpsc::{channel, Sender};
     use tokio::sync::mpsc::unbounded_channel;
 
+    #[allow(clippy::type_complexity)]
     fn get_default_tree(
         persistence_handle: PersistenceHandle,
         tree_state: TreeState,


### PR DESCRIPTION
Follow up of #9365 I've added a `PersistenceHandler` trait to be able to insert a Mock in the tree and do some assertions after persisting blocks.  