### PR TITLE
feat: disable default features in workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,7 +346,7 @@ reth-primitives-traits = { path = "crates/primitives-traits" }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types" }
-reth-revm = { path = "crates/revm", default-features = false, features = ["std"] }
+reth-revm = { path = "crates/revm", default-features = false, features = ["std", "c-kzg"] }
 reth-rpc = { path = "crates/rpc/rpc" }
 reth-rpc-api = { path = "crates/rpc/rpc-api" }
 reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ reth-evm = { path = "crates/evm" }
 reth-evm-ethereum = { path = "crates/ethereum/evm" }
 reth-evm-optimism = { path = "crates/optimism/evm" }
 reth-execution-errors = { path = "crates/evm/execution-errors" }
-reth-execution-types = { path = "crates/evm/execution-types" }
+reth-execution-types = { path = "crates/evm/execution-types", default-features = false }
 reth-exex = { path = "crates/exex/exex" }
 reth-exex-test-utils = { path = "crates/exex/test-utils" }
 reth-exex-types = { path = "crates/exex/types" }
@@ -341,12 +341,12 @@ reth-optimism-rpc = { path = "crates/optimism/rpc" }
 reth-payload-builder = { path = "crates/payload/builder" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
-reth-primitives = { path = "crates/primitives" }
+reth-primitives = { path = "crates/primitives", default-features = false, features = ["std"] }
 reth-primitives-traits = { path = "crates/primitives-traits" }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types" }
-reth-revm = { path = "crates/revm" }
+reth-revm = { path = "crates/revm", default-features = false, features = ["std"] }
 reth-rpc = { path = "crates/rpc/rpc" }
 reth-rpc-api = { path = "crates/rpc/rpc-api" }
 reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }
@@ -363,14 +363,14 @@ reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types" }
 reth-static-file = { path = "crates/static-file/static-file" }
 reth-static-file-types = { path = "crates/static-file/types" }
-reth-storage-api = { path = "crates/storage/storage-api" }
+reth-storage-api = { path = "crates/storage/storage-api", default-features = false }
 reth-storage-errors = { path = "crates/storage/errors" }
 reth-tasks = { path = "crates/tasks" }
 reth-testing-utils = { path = "testing/testing-utils" }
 reth-tokio-util = { path = "crates/tokio-util" }
 reth-tracing = { path = "crates/tracing" }
 reth-transaction-pool = { path = "crates/transaction-pool" }
-reth-trie = { path = "crates/trie/trie" }
+reth-trie = { path = "crates/trie/trie", default-features = false }
 reth-trie-common = { path = "crates/trie/common" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # reth
 reth-chainspec.workspace = true
 reth-eth-wire-types.workspace = true
-reth-primitives.workspace = true
+reth-primitives = { workspace = true, features = ["std", "c-kzg"] }
 reth-execution-types.workspace = true
 reth-fs-util.workspace = true
 reth-provider.workspace = true


### PR DESCRIPTION
Disables default features in the workspace dependencies. 

This is done so that features that do not compile in `wasm32-wasi` are not automatically enabled. This change was originally in #9430 but was seperated at the request of @mattsse.