### PR TITLE
chore: use `DatabaseProviderRW` instead of `TX` on `*State*::write_to_db` 

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -85,7 +85,7 @@ impl<DB: Database> Persistence<DB> {
             {
                 let trie_updates = block.trie_updates().clone();
                 let hashed_state = block.hashed_state();
-                HashedStateChanges(hashed_state.clone()).write_to_db(provider_rw.tx_ref())?;
+                HashedStateChanges(hashed_state.clone()).write_to_db(&provider_rw)?;
                 trie_updates.write_to_database(provider_rw.tx_ref())?;
             }
 

--- a/crates/storage/provider/src/bundle_state/execution_outcome.rs
+++ b/crates/storage/provider/src/bundle_state/execution_outcome.rs
@@ -25,7 +25,7 @@ impl StateWriter for ExecutionOutcome {
         let tx = provider_rw.tx_ref();
         let (plain_state, reverts) = self.bundle.into_plain_state_and_reverts(is_value_known);
 
-        StateReverts(reverts).write_to_db(tx, self.first_block)?;
+        StateReverts(reverts).write_to_db(provider_rw, self.first_block)?;
 
         // write receipts
         let mut bodies_cursor = tx.cursor_read::<tables::BlockBodyIndices>()?;
@@ -63,7 +63,7 @@ impl StateWriter for ExecutionOutcome {
             }
         }
 
-        StateChanges(plain_state).write_to_db(tx)?;
+        StateChanges(plain_state).write_to_db(provider_rw)?;
 
         Ok(())
     }
@@ -143,13 +143,11 @@ mod tests {
         assert!(plain_state.storage.is_empty());
         assert!(plain_state.contracts.is_empty());
         StateChanges(plain_state)
-            .write_to_db(provider.tx_ref())
+            .write_to_db(&provider)
             .expect("Could not write plain state to DB");
 
         assert_eq!(reverts.storage, [[]]);
-        StateReverts(reverts)
-            .write_to_db(provider.tx_ref(), 1)
-            .expect("Could not write reverts to DB");
+        StateReverts(reverts).write_to_db(&provider, 1).expect("Could not write reverts to DB");
 
         let reth_account_a = account_a.into();
         let reth_account_b = account_b.into();
@@ -209,16 +207,14 @@ mod tests {
         );
         assert!(plain_state.contracts.is_empty());
         StateChanges(plain_state)
-            .write_to_db(provider.tx_ref())
+            .write_to_db(&provider)
             .expect("Could not write plain state to DB");
 
         assert_eq!(
             reverts.storage,
             [[PlainStorageRevert { address: address_b, wiped: true, storage_revert: vec![] }]]
         );
-        StateReverts(reverts)
-            .write_to_db(provider.tx_ref(), 2)
-            .expect("Could not write reverts to DB");
+        StateReverts(reverts).write_to_db(&provider, 2).expect("Could not write reverts to DB");
 
         // Check new plain state for account B
         assert_eq!(

--- a/crates/storage/provider/src/bundle_state/state_reverts.rs
+++ b/crates/storage/provider/src/bundle_state/state_reverts.rs
@@ -1,9 +1,10 @@
+use crate::DatabaseProviderRW;
 use rayon::slice::ParallelSliceMut;
-use reth_db::tables;
+use reth_db::{tables, Database};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO, DbDupCursorRW},
     models::{AccountBeforeTx, BlockNumberAddress},
-    transaction::{DbTx, DbTxMut},
+    transaction::DbTxMut,
 };
 use reth_primitives::{BlockNumber, StorageEntry, B256, U256};
 use reth_storage_errors::db::DatabaseError;
@@ -24,15 +25,20 @@ impl StateReverts {
     /// Write reverts to database.
     ///
     /// `Note::` Reverts will delete all wiped storage from plain state.
-    pub fn write_to_db<TX: DbTxMut + DbTx>(
+    pub fn write_to_db<DB>(
         self,
-        tx: &TX,
+        provider: &DatabaseProviderRW<DB>,
         first_block: BlockNumber,
-    ) -> Result<(), DatabaseError> {
+    ) -> Result<(), DatabaseError>
+    where
+        DB: Database,
+    {
         // Write storage changes
         tracing::trace!(target: "provider::reverts", "Writing storage changes");
-        let mut storages_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
-        let mut storage_changeset_cursor = tx.cursor_dup_write::<tables::StorageChangeSets>()?;
+        let mut storages_cursor =
+            provider.tx_ref().cursor_dup_write::<tables::PlainStorageState>()?;
+        let mut storage_changeset_cursor =
+            provider.tx_ref().cursor_dup_write::<tables::StorageChangeSets>()?;
         for (block_index, mut storage_changes) in self.0.storage.into_iter().enumerate() {
             let block_number = first_block + block_index as BlockNumber;
 
@@ -72,7 +78,8 @@ impl StateReverts {
 
         // Write account changes
         tracing::trace!(target: "provider::reverts", "Writing account changes");
-        let mut account_changeset_cursor = tx.cursor_dup_write::<tables::AccountChangeSets>()?;
+        let mut account_changeset_cursor =
+            provider.tx_ref().cursor_dup_write::<tables::AccountChangeSets>()?;
 
         for (block_index, mut account_block_reverts) in self.0.accounts.into_iter().enumerate() {
             let block_number = first_block + block_index as BlockNumber;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3270,7 +3270,7 @@ impl<DB: Database> BlockWriter for DatabaseProviderRW<DB> {
 
         // insert hashes and intermediate merkle nodes
         {
-            HashedStateChanges(hashed_state).write_to_db(&self.tx)?;
+            HashedStateChanges(hashed_state).write_to_db(self)?;
             trie_updates.write_to_database(&self.tx)?;
         }
         durations_recorder.record_relative(metrics::Action::InsertHashes);

--- a/crates/trie/parallel/benches/root.rs
+++ b/crates/trie/parallel/benches/root.rs
@@ -27,7 +27,7 @@ pub fn calculate_state_root(c: &mut Criterion) {
         let provider_factory = create_test_provider_factory();
         {
             let provider_rw = provider_factory.provider_rw().unwrap();
-            HashedStateChanges(db_state).write_to_db(provider_rw.tx_ref()).unwrap();
+            HashedStateChanges(db_state).write_to_db(&provider_rw).unwrap();
             let (_, updates) =
                 StateRoot::from_tx(provider_rw.tx_ref()).root_with_updates().unwrap();
             updates.write_to_database(provider_rw.tx_ref()).unwrap();


### PR DESCRIPTION
I'm guessing these structs can eventually be moved to provider traits like other `Writers`