### PR TITLE
chore: switch from `zstd-codec` to `no-zstd`

### DIFF
--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -16,7 +16,7 @@ reth-payload-builder.workspace = true
 reth-ethereum-engine-primitives.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-ethereum-payload-builder.workspace = true
-reth-node-builder.workspace = true
+reth-node-builder = { workspace = true, features = ["zstd"] } 
 reth-tracing.workspace = true
 reth-provider.workspace = true
 reth-transaction-pool.workspace = true

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -82,4 +82,5 @@ tempfile.workspace = true
 [features]
 default = []
 zstd = ["reth-primitives/zstd"]
+no-zstd = ["reth-primitives/no-zstd"]
 test-utils = ["reth-db/test-utils"]

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -81,4 +81,5 @@ tempfile.workspace = true
 
 [features]
 default = []
+zstd = ["reth-primitives/zstd"]
 test-utils = ["reth-db/test-utils"]

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -23,7 +23,7 @@ reth-rpc-types.workspace = true
 reth-rpc.workspace = true
 reth-rpc-types-compat.workspace = true
 reth-node-api.workspace = true
-reth-node-builder.workspace = true
+reth-node-builder = { workspace = true, features = ["zstd"] } 
 reth-tracing.workspace = true
 reth-provider.workspace = true
 reth-transaction-pool.workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -84,7 +84,7 @@ pprof = { workspace = true, features = [
 secp256k1.workspace = true
 
 [features]
-default = ["c-kzg", "alloy-compat", "std", "zstd"]
+default = ["c-kzg",  "zstd", "alloy-compat", "std"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "reth-primitives-traits/arbitrary",
@@ -96,6 +96,7 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "dep:arbitrary",
     "dep:proptest",
+    "zstd"
 ]
 c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg"]
 zstd = ["dep:zstd"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -84,7 +84,7 @@ pprof = { workspace = true, features = [
 secp256k1.workspace = true
 
 [features]
-default = ["c-kzg", "zstd-codec", "alloy-compat", "std"]
+default = ["c-kzg", "alloy-compat", "std", "zstd"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "reth-primitives-traits/arbitrary",
@@ -96,10 +96,10 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "dep:arbitrary",
     "dep:proptest",
-    "zstd-codec",
 ]
 c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg"]
-zstd-codec = ["dep:zstd"]
+zstd = ["dep:zstd"]
+no-zstd = []
 optimism = [
     "reth-chainspec/optimism",
     "reth-codecs/optimism",

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -24,7 +24,7 @@ extern crate alloc;
 mod alloy_compat;
 pub mod basefee;
 mod block;
-#[cfg(feature = "zstd-codec")]
+#[cfg(not(feature = "no-zstd"))]
 mod compression;
 pub mod constants;
 pub mod eip4844;
@@ -39,7 +39,7 @@ pub use block::{
     Block, BlockBody, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, BlockWithSenders,
     ForkBlock, RpcBlockHash, SealedBlock, SealedBlockWithSenders,
 };
-#[cfg(feature = "zstd-codec")]
+#[cfg(not(feature = "no-zstd"))]
 pub use compression::*;
 pub use constants::{
     DEV_GENESIS_HASH, EMPTY_OMMER_ROOT_HASH, HOLESKY_GENESIS_HASH, KECCAK_EMPTY,

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "zstd-codec")]
+#[cfg(not(feature = "no-zstd"))]
 use crate::compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR};
 use crate::{logs_bloom, Bloom, Bytes, TxType, B256};
 use alloy_primitives::Log;
@@ -6,7 +6,7 @@ use alloy_rlp::{length_of_length, Decodable, Encodable, RlpDecodable, RlpEncodab
 use bytes::{Buf, BufMut};
 use core::{cmp::Ordering, ops::Deref};
 use derive_more::{Deref, DerefMut, From, IntoIterator};
-#[cfg(feature = "zstd-codec")]
+#[cfg(not(feature = "no-zstd"))]
 use reth_codecs::CompactZstd;
 use reth_codecs::{add_arbitrary_tests, main_codec, Compact};
 use serde::{Deserialize, Serialize};
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use alloc::{vec, vec::Vec};
 
 /// Receipt containing result of transaction execution.
-#[cfg_attr(feature = "zstd-codec", main_codec(no_arbitrary, zstd))]
-#[cfg_attr(not(feature = "zstd-codec"), main_codec(no_arbitrary))]
+#[cfg_attr(not(feature = "no-zstd"), main_codec(no_arbitrary, zstd))]
+#[cfg_attr(feature = "no-zstd", main_codec(no_arbitrary))]
 #[add_arbitrary_tests]
 #[derive(Clone, Debug, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
 #[rlp(trailing)]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,6 +1,6 @@
 //! Transaction types.
 
-#[cfg(any(feature = "arbitrary", feature = "zstd-codec"))]
+#[cfg(any(feature = "arbitrary", not(feature = "no-zstd")))]
 use crate::compression::{TRANSACTION_COMPRESSOR, TRANSACTION_DECOMPRESSOR};
 use crate::{keccak256, Address, BlockHashOrNumber, Bytes, TxHash, TxKind, B256, U256};
 
@@ -907,7 +907,7 @@ impl TransactionSignedNoHash {
     }
 }
 
-#[cfg(feature = "zstd-codec")]
+#[cfg(not(feature = "no-zstd"))]
 impl Compact for TransactionSignedNoHash {
     fn to_compact<B>(self, buf: &mut B) -> usize
     where
@@ -971,7 +971,7 @@ impl Compact for TransactionSignedNoHash {
     }
 }
 
-#[cfg(not(feature = "zstd-codec"))]
+#[cfg(feature = "no-zstd")]
 impl Compact for TransactionSignedNoHash {
     fn to_compact<B>(self, buf: &mut B) -> usize
     where
@@ -1019,7 +1019,7 @@ fn from_compact_zstd_unaware(mut buf: &[u8], _len: usize) -> (TransactionSignedN
     let zstd_bit = bitflags >> 3;
     assert_eq!(
         zstd_bit, 0,
-        "zstd-codec feature is not enabled, cannot decode `TransactionSignedNoHash` with zstd flag"
+        "no-zstd feature is enabled, cannot decode `TransactionSignedNoHash` with zstd flag"
     );
 
     let transaction_type = bitflags >> 1;
@@ -2105,7 +2105,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "zstd-codec feature is not enabled, cannot decode `TransactionSignedNoHash` with zstd flag"
+        expected = "no-zstd feature is enabled, cannot decode `TransactionSignedNoHash` with zstd flag"
     )]
     fn transaction_signed_zstd_encoded_no_zstd_decode() {
         let signature = Signature {


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/8889
ref https://github.com/paradigmxyz/reth/pull/9456

I don't know what's the best approach, tbh

This PR still has `zstd` as default. However, if default features are turned off it will fail compilatio, unless the developer chooses either `no-zstd` or `zstd` through `reth-node-builder`