### PR TITLE
chore: use create_test_provider_factory in more places

### DIFF
--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -361,22 +361,13 @@ impl<DB: Database> Pruner<DB, ProviderFactory<DB>> {
 
 #[cfg(test)]
 mod tests {
-
     use crate::Pruner;
-    use reth_chainspec::MAINNET;
-    use reth_db::test_utils::{create_test_rw_db, create_test_static_files_dir};
     use reth_exex_types::FinishedExExHeight;
-    use reth_provider::{providers::StaticFileProvider, ProviderFactory};
+    use reth_provider::{test_utils::create_test_provider_factory, ProviderFactory};
 
     #[test]
     fn is_pruning_needed() {
-        let db = create_test_rw_db();
-        let (_static_dir, static_dir_path) = create_test_static_files_dir();
-        let provider_factory = ProviderFactory::new(
-            db,
-            MAINNET.clone(),
-            StaticFileProvider::read_write(static_dir_path).unwrap(),
-        );
+        let provider_factory = create_test_provider_factory();
 
         let (finished_exex_height_tx, finished_exex_height_rx) =
             tokio::sync::watch::channel(FinishedExExHeight::NoExExs);

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -6,11 +6,10 @@ use crate::{
 };
 use alloy_rlp::Decodable;
 use rayon::iter::{ParallelBridge, ParallelIterator};
-use reth_db::test_utils::{create_test_rw_db, create_test_static_files_dir};
 use reth_primitives::{BlockBody, SealedBlock, StaticFileSegment};
 use reth_provider::{
-    providers::{StaticFileProvider, StaticFileWriter},
-    HashingWriter, ProviderFactory,
+    providers::StaticFileWriter, test_utils::create_test_provider_factory_with_chain_spec,
+    HashingWriter,
 };
 use reth_stages::{stages::ExecutionStage, ExecInput, Stage};
 use std::{collections::BTreeMap, fs, path::Path, sync::Arc};
@@ -84,13 +83,9 @@ impl Case for BlockchainTestCase {
             .par_bridge()
             .try_for_each(|case| {
                 // Create a new test database and initialize a provider for the test case.
-                let db = create_test_rw_db();
-                let (_static_files_dir, static_files_dir_path) = create_test_static_files_dir();
-                let provider = ProviderFactory::new(
-                    db.as_ref(),
-                    Arc::new(case.network.clone().into()),
-                    StaticFileProvider::read_write(static_files_dir_path).unwrap(),
-                )
+                let provider = create_test_provider_factory_with_chain_spec(Arc::new(
+                    case.network.clone().into(),
+                ))
                 .provider_rw()
                 .unwrap();
 


### PR DESCRIPTION
Was using this in a test and realized there were a few other places that could use it as well.