### PR TITLE
feat: OP: keep encoded txs in payload attributes

### DIFF
--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -66,7 +66,6 @@ pub(crate) fn optimism_payload_attributes(timestamp: u64) -> OptimismPayloadBuil
     OptimismPayloadBuilderAttributes {
         payload_attributes: EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
         transactions: vec![],
-        encoded_transactions: vec![],
         no_tx_pool: false,
         gas_limit: Some(30_000_000),
     }

--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -66,6 +66,7 @@ pub(crate) fn optimism_payload_attributes(timestamp: u64) -> OptimismPayloadBuil
     OptimismPayloadBuilderAttributes {
         payload_attributes: EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
         transactions: vec![],
+        encoded_transactions: vec![],
         no_tx_pool: false,
         gas_limit: Some(30_000_000),
     }

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -318,7 +318,7 @@ where
         }
 
         // A sequencer's block should never contain blob transactions.
-        if sequencer_tx.is_eip4844() {
+        if sequencer_tx.data().is_eip4844() {
             return Err(PayloadBuilderError::other(
                 OptimismPayloadBuilderError::BlobTransactionRejected,
             ))
@@ -328,7 +328,7 @@ where
         // purely for the purposes of utilizing the `evm_config.tx_env`` function.
         // Deposit transactions do not have signatures, so if the tx is a deposit, this
         // will just pull in its `from` address.
-        let sequencer_tx = sequencer_tx.clone().try_into_ecrecovered().map_err(|_| {
+        let sequencer_tx = sequencer_tx.data().clone().try_into_ecrecovered().map_err(|_| {
             PayloadBuilderError::other(OptimismPayloadBuilderError::TransactionEcRecoverFailed)
         })?;
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -318,7 +318,7 @@ where
         }
 
         // A sequencer's block should never contain blob transactions.
-        if sequencer_tx.data().is_eip4844() {
+        if sequencer_tx.value().is_eip4844() {
             return Err(PayloadBuilderError::other(
                 OptimismPayloadBuilderError::BlobTransactionRejected,
             ))
@@ -328,7 +328,7 @@ where
         // purely for the purposes of utilizing the `evm_config.tx_env`` function.
         // Deposit transactions do not have signatures, so if the tx is a deposit, this
         // will just pull in its `from` address.
-        let sequencer_tx = sequencer_tx.data().clone().try_into_ecrecovered().map_err(|_| {
+        let sequencer_tx = sequencer_tx.value().clone().try_into_ecrecovered().map_err(|_| {
             PayloadBuilderError::other(OptimismPayloadBuilderError::TransactionEcRecoverFailed)
         })?;
 

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -2,6 +2,7 @@
 
 //! Optimism builder support
 
+use reth_primitives::Bytes;
 use alloy_rlp::Encodable;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_evm_optimism::revm_spec_by_timestamp_after_bedrock;
@@ -33,10 +34,21 @@ pub struct OptimismPayloadBuilderAttributes {
     pub payload_attributes: EthPayloadBuilderAttributes,
     /// `NoTxPool` option for the generated payload
     pub no_tx_pool: bool,
-    /// Transactions for the generated payload
+    /// Decoded Transactions for the generated payload
     pub transactions: Vec<TransactionSigned>,
+    /// Encoded Transactions for the generated payload
+    pub encoded_transactions: Vec<Bytes>,
     /// The gas limit for the generated payload
     pub gas_limit: Option<u64>,
+}
+
+/// Optimism Payload Builder Attributes Helper
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptimismPayloadBuilderAttributesHelper {
+    /// An decoded signed transaction
+    pub decoded_transaction: TransactionSigned,
+    /// An encoded signed transaction
+    pub encoded_transaction: Bytes, 
 }
 
 impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
@@ -58,6 +70,9 @@ impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
             (payload_id_optimism(&parent, &attributes, &transactions), transactions)
         };
 
+        // save the encoded transactions
+        let encoded_transactions = attributes.transactions.unwrap_or_default();
+
         let payload_attributes = EthPayloadBuilderAttributes {
             id,
             parent,
@@ -72,6 +87,7 @@ impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
             payload_attributes,
             no_tx_pool: attributes.no_tx_pool.unwrap_or_default(),
             transactions,
+            encoded_transactions,
             gas_limit: attributes.gas_limit,
         })
     }

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -2,7 +2,6 @@
 
 //! Optimism builder support
 
-use reth_primitives::transaction::WithEncoded;
 use alloy_rlp::Encodable;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_evm_optimism::revm_spec_by_timestamp_after_bedrock;
@@ -10,6 +9,7 @@ use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
 use reth_primitives::{
     revm_primitives::{BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId},
+    transaction::WithEncoded,
     Address, BlobTransactionSidecar, Header, SealedBlock, TransactionSigned, Withdrawals, B256,
     U256,
 };
@@ -34,7 +34,8 @@ pub struct OptimismPayloadBuilderAttributes {
     pub payload_attributes: EthPayloadBuilderAttributes,
     /// `NoTxPool` option for the generated payload
     pub no_tx_pool: bool,
-    /// Transactions for the generated payload
+    /// Decoded transactions and the original EIP-2718 encoded bytes as received in the payload
+    /// attributes.
     pub transactions: Vec<WithEncoded<TransactionSigned>>,
     /// The gas limit for the generated payload
     pub gas_limit: Option<u64>,
@@ -48,16 +49,17 @@ impl PayloadBuilderAttributes for OptimismPayloadBuilderAttributes {
     ///
     /// Derives the unique [`PayloadId`] for the given parent and attributes
     fn try_new(parent: B256, attributes: OptimismPayloadAttributes) -> Result<Self, Self::Error> {
-        let (id, transactions) = {
-            let transactions: Vec<_> = attributes
-                .transactions
-                .as_deref()
-                .unwrap_or(&[])
-                .iter()
-                .map(|tx| WithEncoded::new(tx.clone(), TransactionSigned::decode_enveloped(&mut tx.as_ref()).unwrap()))
-                .collect();
-            (payload_id_optimism(&parent, &attributes, &transactions), transactions)
-        };
+        let id = payload_id_optimism(&parent, &attributes);
+
+        let transactions = attributes
+            .transactions
+            .unwrap_or_default()
+            .into_iter()
+            .map(|data| {
+                TransactionSigned::decode_enveloped(&mut data.as_ref())
+                    .map(|tx| WithEncoded::new(data, tx))
+            })
+            .collect::<Result<_, _>>()?;
 
         let payload_attributes = EthPayloadBuilderAttributes {
             id,
@@ -309,7 +311,6 @@ impl From<OptimismBuiltPayload> for OptimismExecutionPayloadEnvelopeV4 {
 pub(crate) fn payload_id_optimism(
     parent: &B256,
     attributes: &OptimismPayloadAttributes,
-    txs: &[WithEncoded<TransactionSigned>],
 ) -> PayloadId {
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();
@@ -328,10 +329,9 @@ pub(crate) fn payload_id_optimism(
     }
 
     let no_tx_pool = attributes.no_tx_pool.unwrap_or_default();
-    if no_tx_pool || !txs.is_empty() {
-        hasher.update([no_tx_pool as u8]);
-        hasher.update(txs.len().to_be_bytes());
-        txs.iter().for_each(|tx| hasher.update(tx.data().hash()));
+    hasher.update([no_tx_pool as u8]);
+    if let Some(txs) = &attributes.transactions {
+        txs.iter().for_each(|tx| hasher.update(tx));
     }
 
     if let Some(gas_limit) = attributes.gas_limit {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1693,7 +1693,7 @@ impl IntoRecoveredTransaction for TransactionSignedEcRecovered {
     }
 }
 
-/// Generic wrapper with encoded Bytes
+/// Generic wrapper with encoded Bytes, such as transaction data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WithEncoded<T>(Bytes, pub T);
 
@@ -1714,22 +1714,22 @@ impl<T> WithEncoded<T> {
         self.0.clone()
     }
 
-    /// Get the underlying data
-    pub const fn data(&self) -> &T {
+    /// Get the underlying value
+    pub const fn value(&self) -> &T {
         &self.1
     }
 
-    /// Returns ownership of the underlying data.
-    pub fn into_data(self) -> T {
+    /// Returns ownership of the underlying value.
+    pub fn into_value(self) -> T {
         self.1
     }
 
-    /// Transform the data
+    /// Transform the value
     pub fn transform<F: From<T>>(self) -> WithEncoded<F> {
         WithEncoded(self.0, self.1.into())
     }
 
-    /// Split the wrapper into [`Bytes`] and data tuple
+    /// Split the wrapper into [`Bytes`] and value tuple
     pub fn split(self) -> (Bytes, T) {
         (self.0, self.1)
     }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1710,7 +1710,7 @@ impl<T> WithEncoded<T> {
     }
 
     /// Get the encoded bytes
-    pub fn bytes(&self) -> Bytes {
+    pub fn encoded_bytes(&self) -> Bytes {
         self.0.clone()
     }
 
@@ -1741,7 +1741,7 @@ impl<T> WithEncoded<T> {
 }
 
 impl<T> WithEncoded<Option<T>> {
-    /// returns `None` if the inner value is `None`, otherwise returns `Some(WithPeerId<T>)`.
+    /// returns `None` if the inner value is `None`, otherwise returns `Some(WithEncoded<T>)`.
     pub fn transpose(self) -> Option<WithEncoded<T>> {
         self.1.map(|v| WithEncoded(self.0, v))
     }


### PR DESCRIPTION
This PR has the following changes

I think the issue just wanted helper type added
- Added OptimismPayloadBuilderAttributesHelper type

Not sure if I'm jumping the gun with the following changes
- Added encoded-transactions to OptimismPayloadBuilderAttributes
- Updated try_new to store the encoded transactions
- Updated a test that relies on this

Let me know if you want the last changes or if I'm doing something bad

closes #9422 