### PR TITLE
Book: fix bad usage of MD

### DIFF
--- a/book/cli/cli.md
+++ b/book/cli/cli.md
@@ -4,4 +4,4 @@ The Reth node is operated via the CLI by running the `reth node` command. To sto
 
 However, Reth has more commands:
 
-{{#include ./SUMMARY.md}}
+For more details, see [the additional commands summary](./SUMMARY.md).


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/efefbf4b-90fd-48dd-a8e4-98cbed255f67)
When I was looking through the book related, I noticed this unusual way of including. I looked up the documentation for Markdown and found out that it doesn't support directly including complex content management features. This kind of syntax might be used in tools like GitBook, so there might be a mistake in how it's being used here.