### PR TITLE
feat(net/peer): simple support rank higher with static peer

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -376,7 +376,8 @@ impl PeersManager {
         let mut ban_duration = self.ban_duration;
         if let Some(peer) = self.peers.get(&peer_id) {
             if peer.is_trusted() || peer.is_static() {
-                // For misbehaving trusted peers, we provide a bit more leeway when penalizing them.
+                // For misbehaving trusted or static peers, we provide a bit more leeway when
+                // penalizing them.
                 ban_duration = self.backoff_durations.medium;
             }
         }
@@ -447,7 +448,7 @@ impl PeersManager {
             } else {
                 let mut reputation_change = self.reputation_weights.change(rep).as_i32();
                 if peer.is_trusted() || peer.is_static() {
-                    // exempt trusted peers from reputation slashing for
+                    // exempt trusted and static peers from reputation slashing for
                     if matches!(
                         rep,
                         ReputationChangeKind::Dropped |

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -375,7 +375,7 @@ impl PeersManager {
     fn ban_peer(&mut self, peer_id: PeerId) {
         let mut ban_duration = self.ban_duration;
         if let Some(peer) = self.peers.get(&peer_id) {
-            if peer.is_trusted() {
+            if peer.is_trusted() || peer.is_static() {
                 // For misbehaving trusted peers, we provide a bit more leeway when penalizing them.
                 ban_duration = self.backoff_durations.medium;
             }
@@ -446,7 +446,7 @@ impl PeersManager {
                 peer.reset_reputation()
             } else {
                 let mut reputation_change = self.reputation_weights.change(rep).as_i32();
-                if peer.is_trusted() {
+                if peer.is_trusted() || peer.is_static() {
                     // exempt trusted peers from reputation slashing for
                     if matches!(
                         rep,
@@ -781,8 +781,8 @@ impl PeersManager {
 
     /// Returns the idle peer with the highest reputation.
     ///
-    /// Peers that are `trusted`, see [`PeerKind`], are prioritized as long as they're not currently
-    /// marked as banned or backed off.
+    /// Peers that are `trusted` or `static`, see [`PeerKind`], are prioritized as long as they're
+    /// not currently marked as banned or backed off.
     ///
     /// If `trusted_nodes_only` is enabled, see [`PeersConfig`], then this will only consider
     /// `trusted` peers.
@@ -799,13 +799,13 @@ impl PeersManager {
         // keep track of the best peer, if there's one
         let mut best_peer = unconnected.next()?;
 
-        if best_peer.1.is_trusted() {
+        if best_peer.1.is_trusted() || best_peer.1.is_static() {
             return Some((*best_peer.0, best_peer.1))
         }
 
         for maybe_better in unconnected {
-            // if the peer is trusted, return it immediately
-            if maybe_better.1.is_trusted() {
+            // if the peer is trusted or static, return it immediately
+            if maybe_better.1.is_trusted() || maybe_better.1.is_static() {
                 return Some((*maybe_better.0, maybe_better.1))
             }
 
@@ -1151,6 +1151,12 @@ impl Peer {
     #[inline]
     const fn is_trusted(&self) -> bool {
         matches!(self.kind, PeerKind::Trusted)
+    }
+
+    /// Returns whether this peer is static
+    #[inline]
+    const fn is_static(&self) -> bool {
+        matches!(self.kind, PeerKind::Static)
     }
 }
 


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/9213


@mattsse sorry for the long time delay, but currently I only add the `|| peer.is_static()` along with `peer.is_trusted()` as you mentioned in the task. 

I think this’s not enough for the original issue, at least we need to distinguish the differ of trusted and static, but can't get more ideas, could you please give more advice, thanks. 