### PR TITLE
refactor(trie): replace `DatabaseError` with associated error type

### DIFF
--- a/crates/trie/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/trie/src/hashed_cursor/mod.rs
@@ -1,4 +1,5 @@
 use reth_primitives::{Account, B256, U256};
+use std::fmt::Debug;
 
 /// Default implementation of the hashed state cursor traits.
 mod default;
@@ -10,36 +11,38 @@ pub use post_state::*;
 
 /// The factory trait for creating cursors over the hashed state.
 pub trait HashedCursorFactory {
+    /// The associated error that might occur on the cursor operation.
+    type Err: Debug;
     /// The hashed account cursor type.
     type AccountCursor: HashedCursor<Value = Account>;
     /// The hashed storage cursor type.
     type StorageCursor: HashedStorageCursor<Value = U256>;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, Self::Err>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
-    fn hashed_storage_cursor(
-        &self,
-        hashed_address: B256,
-    ) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
+    fn hashed_storage_cursor(&self, hashed_address: B256)
+        -> Result<Self::StorageCursor, Self::Err>;
 }
 
 /// The cursor for iterating over hashed entries.
 pub trait HashedCursor {
+    /// The associated error that might occur on the cursor operation.
+    type Err: Debug;
     /// Value returned by the cursor.
-    type Value: std::fmt::Debug;
+    type Value: Debug;
 
     /// Seek an entry greater or equal to the given key and position the cursor there.
     /// Returns the first entry with the key greater or equal to the sought key.
-    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, Self::Err>;
 
     /// Move the cursor to the next entry and return it.
-    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, Self::Err>;
 }
 
 /// The cursor for iterating over hashed storage entries.
 pub trait HashedStorageCursor: HashedCursor {
     /// Returns `true` if there are no entries for a given key.
-    fn is_storage_empty(&mut self) -> Result<bool, reth_db::DatabaseError>;
+    fn is_storage_empty(&mut self) -> Result<bool, Self::Err>;
 }

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -1,5 +1,4 @@
 use crate::{hashed_cursor::HashedCursor, trie_cursor::TrieCursor, walker::TrieWalker, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
 
 /// Represents a branch node in the trie.
@@ -70,6 +69,7 @@ impl<C, H> TrieNodeIter<C, H>
 where
     C: TrieCursor,
     H: HashedCursor,
+    C::Err: From<H::Err>,
 {
     /// Return the next trie node to be added to the hash builder.
     ///
@@ -82,9 +82,7 @@ where
     /// 5. Repeat.
     ///
     /// NOTE: The iteration will start from the key of the previous hashed entry if it was supplied.
-    pub fn try_next(
-        &mut self,
-    ) -> Result<Option<TrieElement<<H as HashedCursor>::Value>>, DatabaseError> {
+    pub fn try_next(&mut self) -> Result<Option<TrieElement<<H as HashedCursor>::Value>>, C::Err> {
         loop {
             // If the walker has a key...
             if let Some(key) = self.walker.key() {

--- a/crates/trie/trie/src/trie_cursor/database_cursors.rs
+++ b/crates/trie/trie/src/trie_cursor/database_cursors.rs
@@ -9,18 +9,19 @@ use reth_primitives::B256;
 
 /// Implementation of the trie cursor factory for a database transaction.
 impl<'a, TX: DbTx> TrieCursorFactory for &'a TX {
+    type Err = DatabaseError;
     type AccountTrieCursor = DatabaseAccountTrieCursor<<TX as DbTx>::Cursor<tables::AccountsTrie>>;
     type StorageTrieCursor =
         DatabaseStorageTrieCursor<<TX as DbTx>::DupCursor<tables::StoragesTrie>>;
 
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError> {
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, Self::Err> {
         Ok(DatabaseAccountTrieCursor::new(self.cursor_read::<tables::AccountsTrie>()?))
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError> {
+    ) -> Result<Self::StorageTrieCursor, Self::Err> {
         Ok(DatabaseStorageTrieCursor::new(
             self.cursor_dup_read::<tables::StoragesTrie>()?,
             hashed_address,
@@ -43,24 +44,23 @@ impl<C> TrieCursor for DatabaseAccountTrieCursor<C>
 where
     C: DbCursorRO<tables::AccountsTrie> + Send + Sync,
 {
+    type Err = DatabaseError;
+
     /// Seeks an exact match for the provided key in the account trie.
     fn seek_exact(
         &mut self,
         key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         Ok(self.0.seek_exact(StoredNibbles(key))?.map(|value| (value.0 .0, value.1 .0)))
     }
 
     /// Seeks a key in the account trie that matches or is greater than the provided key.
-    fn seek(
-        &mut self,
-        key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         Ok(self.0.seek(StoredNibbles(key))?.map(|value| (value.0 .0, value.1 .0)))
     }
 
     /// Retrieves the current key in the cursor.
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Err> {
         Ok(self.0.current()?.map(|(k, _)| k.0))
     }
 }
@@ -85,11 +85,13 @@ impl<C> TrieCursor for DatabaseStorageTrieCursor<C>
 where
     C: DbDupCursorRO<tables::StoragesTrie> + DbCursorRO<tables::StoragesTrie> + Send + Sync,
 {
+    type Err = DatabaseError;
+
     /// Seeks an exact match for the given key in the storage trie.
     fn seek_exact(
         &mut self,
         key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         Ok(self
             .cursor
             .seek_by_key_subkey(self.hashed_address, StoredNibblesSubKey(key.clone()))?
@@ -98,10 +100,7 @@ where
     }
 
     /// Seeks the given key in the storage trie.
-    fn seek(
-        &mut self,
-        key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         Ok(self
             .cursor
             .seek_by_key_subkey(self.hashed_address, StoredNibblesSubKey(key))?
@@ -109,7 +108,7 @@ where
     }
 
     /// Retrieves the current value in the storage trie cursor.
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Err> {
         Ok(self.cursor.current()?.map(|(_, v)| v.nibbles.0))
     }
 }

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -3,7 +3,6 @@ use crate::{
     forward_cursor::ForwardInMemoryCursor,
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
 };
-use reth_db::DatabaseError;
 use reth_primitives::B256;
 use reth_trie_common::{BranchNodeCompact, Nibbles};
 use std::collections::HashSet;
@@ -25,10 +24,11 @@ impl<'a, CF> InMemoryTrieCursorFactory<'a, CF> {
 }
 
 impl<'a, CF: TrieCursorFactory> TrieCursorFactory for InMemoryTrieCursorFactory<'a, CF> {
+    type Err = CF::Err;
     type AccountTrieCursor = InMemoryAccountTrieCursor<'a, CF::AccountTrieCursor>;
     type StorageTrieCursor = InMemoryStorageTrieCursor<'a, CF::StorageTrieCursor>;
 
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError> {
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, Self::Err> {
         let cursor = self.cursor_factory.account_trie_cursor()?;
         Ok(InMemoryAccountTrieCursor::new(cursor, self.trie_updates))
     }
@@ -36,7 +36,7 @@ impl<'a, CF: TrieCursorFactory> TrieCursorFactory for InMemoryTrieCursorFactory<
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError> {
+    ) -> Result<Self::StorageTrieCursor, Self::Err> {
         let cursor = self.cursor_factory.storage_trie_cursor(hashed_address)?;
         Ok(InMemoryStorageTrieCursor::new(
             hashed_address,
@@ -74,21 +74,20 @@ impl<'a, C> InMemoryAccountTrieCursor<'a, C> {
 }
 
 impl<'a, C: TrieCursor> TrieCursor for InMemoryAccountTrieCursor<'a, C> {
+    type Err = C::Err;
+
     fn seek_exact(
         &mut self,
         _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         unimplemented!()
     }
 
-    fn seek(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         unimplemented!()
     }
 
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Err> {
         unimplemented!()
     }
 }
@@ -129,21 +128,20 @@ impl<'a, C> InMemoryStorageTrieCursor<'a, C> {
 }
 
 impl<'a, C: TrieCursor> TrieCursor for InMemoryStorageTrieCursor<'a, C> {
+    type Err = C::Err;
+
     fn seek_exact(
         &mut self,
         _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         unimplemented!()
     }
 
-    fn seek(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err> {
         unimplemented!()
     }
 
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Err> {
         unimplemented!()
     }
 }

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -1,6 +1,6 @@
 use crate::{BranchNodeCompact, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
+use std::fmt::Debug;
 
 /// Database implementations of trie cursors.
 mod database_cursors;
@@ -22,34 +22,40 @@ pub use self::{
 
 /// Factory for creating trie cursors.
 pub trait TrieCursorFactory {
+    /// The associated error which can be returned from operations on the cursor.
+    type Err: Debug;
+
     /// The account trie cursor type.
     type AccountTrieCursor: TrieCursor;
+
     /// The storage trie cursor type.
     type StorageTrieCursor: TrieCursor;
 
     /// Create an account trie cursor.
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError>;
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, Self::Err>;
 
     /// Create a storage tries cursor.
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError>;
+    ) -> Result<Self::StorageTrieCursor, Self::Err>;
 }
 
 /// A cursor for navigating a trie that works with both Tables and DupSort tables.
 #[auto_impl::auto_impl(&mut, Box)]
 pub trait TrieCursor: Send + Sync {
+    /// The associated error which can be returned from operations on the cursor.
+    type Err: Debug;
+
     /// Move the cursor to the key and return if it is an exact match.
     fn seek_exact(
         &mut self,
         key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err>;
 
     /// Move the cursor to the key and return a value matching of greater than the key.
-    fn seek(&mut self, key: Nibbles)
-        -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
+    fn seek(&mut self, key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Err>;
 
     /// Get the current entry.
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError>;
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Err>;
 }

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -1,6 +1,5 @@
 use super::{TrieCursor, TrieCursorFactory};
 use crate::{BranchNodeCompact, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
 
 /// Noop trie cursor factory.
@@ -9,19 +8,17 @@ use reth_primitives::B256;
 pub struct NoopTrieCursorFactory;
 
 impl TrieCursorFactory for NoopTrieCursorFactory {
+    type Err = ();
     type AccountTrieCursor = NoopAccountTrieCursor;
     type StorageTrieCursor = NoopStorageTrieCursor;
 
     /// Generates a Noop account trie cursor.
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError> {
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, ()> {
         Ok(NoopAccountTrieCursor::default())
     }
 
     /// Generates a Noop storage trie cursor.
-    fn storage_trie_cursor(
-        &self,
-        _hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError> {
+    fn storage_trie_cursor(&self, _hashed_address: B256) -> Result<Self::StorageTrieCursor, ()> {
         Ok(NoopStorageTrieCursor::default())
     }
 }
@@ -32,24 +29,20 @@ impl TrieCursorFactory for NoopTrieCursorFactory {
 pub struct NoopAccountTrieCursor;
 
 impl TrieCursor for NoopAccountTrieCursor {
+    type Err = ();
+
     /// Seeks an exact match within the account trie.
-    fn seek_exact(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek_exact(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, ()> {
         Ok(None)
     }
 
     /// Seeks within the account trie.
-    fn seek(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, ()> {
         Ok(None)
     }
 
     /// Retrieves the current cursor position within the account trie.
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, ()> {
         Ok(None)
     }
 }
@@ -60,24 +53,20 @@ impl TrieCursor for NoopAccountTrieCursor {
 pub struct NoopStorageTrieCursor;
 
 impl TrieCursor for NoopStorageTrieCursor {
+    type Err = ();
+
     /// Seeks an exact match in storage tries.
-    fn seek_exact(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek_exact(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, ()> {
         Ok(None)
     }
 
     /// Seeks a key in storage tries.
-    fn seek(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, ()> {
         Ok(None)
     }
 
     /// Retrieves the current cursor position within storage tries.
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, ()> {
         Ok(None)
     }
 }

--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -1,6 +1,6 @@
 use crate::{
-    walker::TrieWalker, BranchNodeCompact, HashBuilder, Nibbles, StorageTrieEntry,
-    StoredBranchNode, StoredNibbles, StoredNibblesSubKey,
+    trie_cursor::TrieCursorFactory, walker::TrieWalker, BranchNodeCompact, HashBuilder, Nibbles,
+    StorageTrieEntry, StoredBranchNode, StoredNibbles, StoredNibblesSubKey,
 };
 use reth_db::tables;
 use reth_db_api::{
@@ -90,7 +90,7 @@ impl TrieUpdates {
     /// # Returns
     ///
     /// The number of storage trie entries updated in the database.
-    pub fn write_to_database<TX>(self, tx: &TX) -> Result<usize, reth_db::DatabaseError>
+    pub fn write_to_database<TX>(self, tx: &TX) -> Result<usize, <&TX as TrieCursorFactory>::Err>
     where
         TX: DbTx + DbTxMut,
     {
@@ -223,7 +223,7 @@ impl StorageTrieUpdates {
         self,
         tx: &TX,
         hashed_address: B256,
-    ) -> Result<usize, reth_db::DatabaseError>
+    ) -> Result<usize, <&TX as TrieCursorFactory>::Err>
     where
         TX: DbTx + DbTxMut,
     {

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -3,7 +3,6 @@ use crate::{
     trie_cursor::{CursorSubNode, TrieCursor},
     BranchNodeCompact, Nibbles,
 };
-use reth_db::DatabaseError;
 use reth_primitives::B256;
 use std::collections::HashSet;
 
@@ -130,7 +129,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     /// # Returns
     ///
     /// * `Result<Option<Nibbles>, Error>` - The next key in the trie or an error.
-    pub fn advance(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    pub fn advance(&mut self) -> Result<Option<Nibbles>, C::Err> {
         if let Some(last) = self.stack.last() {
             if !self.can_skip_current_node && self.children_are_in_trie() {
                 // If we can't skip the current node and the children are in the trie,
@@ -153,7 +152,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Retrieves the current root node from the DB, seeking either the exact node or the next one.
-    fn node(&mut self, exact: bool) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn node(&mut self, exact: bool) -> Result<Option<(Nibbles, BranchNodeCompact)>, C::Err> {
         let key = self.key().expect("key must exist").clone();
         let entry = if exact { self.cursor.seek_exact(key)? } else { self.cursor.seek(key)? };
 
@@ -165,7 +164,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Consumes the next node in the trie, updating the stack.
-    fn consume_node(&mut self) -> Result<(), DatabaseError> {
+    fn consume_node(&mut self) -> Result<(), C::Err> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
             self.stack.clear();
@@ -197,10 +196,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Moves to the next sibling node in the trie, updating the stack.
-    fn move_to_next_sibling(
-        &mut self,
-        allow_root_to_child_nibble: bool,
-    ) -> Result<(), DatabaseError> {
+    fn move_to_next_sibling(&mut self, allow_root_to_child_nibble: bool) -> Result<(), C::Err> {
         let Some(subnode) = self.stack.last_mut() else { return Ok(()) };
 
         // Check if the walker needs to backtrack to the previous level in the trie during its


### PR DESCRIPTION
See #9282 for more context.