### PR TITLE
wip:feat: replace native op deposit with op-alloy deposit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5337,6 +5337,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "arbitrary",
  "serde",
 ]
 
@@ -6693,6 +6694,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
+ "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
  "proptest-derive 0.5.0",
@@ -8085,6 +8087,7 @@ dependencies = [
  "modular-bitfield",
  "nybbles",
  "once_cell",
+ "op-alloy-consensus",
  "pprof",
  "proptest",
  "proptest-arbitrary-interop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,6 +426,7 @@ alloy-rpc-client = { version = "0.1", default-features = false }
 
 # op
 op-alloy-rpc-types = "0.1"
+op-alloy-consensus = "0.1"
 
 # misc
 auto_impl = "1"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -28,6 +28,8 @@ alloy-rpc-types = { workspace = true, optional = true }
 alloy-genesis.workspace = true
 alloy-eips = { workspace = true, features = ["serde"] }
 
+op-alloy-consensus = { workspace = true, optional = true }
+
 # crypto
 secp256k1 = { workspace = true, features = [
     "global-context",
@@ -101,6 +103,7 @@ arbitrary = [
 c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg"]
 zstd-codec = ["dep:zstd"]
 optimism = [
+    "dep:op-alloy-consensus",
     "reth-chainspec/optimism",
     "reth-codecs/optimism",
     "reth-ethereum-forks/optimism",

--- a/crates/primitives/src/transaction/compat.rs
+++ b/crates/primitives/src/transaction/compat.rs
@@ -88,7 +88,7 @@ impl FillTxEnv for TransactionSigned {
             #[cfg(feature = "optimism")]
             Transaction::Deposit(tx) => {
                 tx_env.access_list.clear();
-                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_limit = tx.gas_limit as u64;
                 tx_env.gas_price = U256::ZERO;
                 tx_env.gas_priority_fee = None;
                 tx_env.transact_to = tx.to;

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -213,7 +213,7 @@ impl Transaction {
             Self::Eip4844(blob_tx) => blob_tx.tx_type(),
             Self::Eip7702(set_code_tx) => set_code_tx.tx_type(),
             #[cfg(feature = "optimism")]
-            Self::Deposit(deposit_tx) => deposit_tx.tx_type(),
+            Self::Deposit(_) => TxType::Deposit,
         }
     }
 
@@ -280,7 +280,7 @@ impl Transaction {
             Self::Eip4844(TxEip4844 { gas_limit, .. }) |
             Self::Eip7702(TxEip7702 { gas_limit, .. }) => *gas_limit,
             #[cfg(feature = "optimism")]
-            Self::Deposit(TxDeposit { gas_limit, .. }) => *gas_limit,
+            Self::Deposit(TxDeposit { gas_limit, .. }) => *gas_limit as u64,
         }
     }
 
@@ -521,7 +521,7 @@ impl Transaction {
             Self::Eip4844(tx) => tx.gas_limit = gas_limit,
             Self::Eip7702(tx) => tx.gas_limit = gas_limit,
             #[cfg(feature = "optimism")]
-            Self::Deposit(tx) => tx.gas_limit = gas_limit,
+            Self::Deposit(tx) => tx.gas_limit = gas_limit as u128,
         }
     }
 

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -6,6 +6,8 @@ use bytes::Buf;
 use reth_codecs::{main_codec, Compact};
 use std::mem;
 
+pub use op_alloy_consensus::TxDeposit;
+
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
 #[main_codec]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -16,6 +16,7 @@ reth-codecs-derive = { path = "./derive", default-features = false }
 
 # eth
 alloy-consensus = { workspace = true, optional = true }
+op-alloy-consensus = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
 alloy-genesis = { workspace = true, optional = true }
 alloy-primitives.workspace = true
@@ -32,6 +33,8 @@ alloy-eips = { workspace = true, default-features = false, features = [
 ] }
 alloy-primitives = { workspace = true, features = ["arbitrary", "serde"] }
 alloy-consensus = { workspace = true, features = ["arbitrary"] }
+op-alloy-consensus = { workspace = true, features = ["arbitrary"] }
+
 test-fuzz.workspace = true
 serde_json.workspace = true
 
@@ -45,6 +48,7 @@ default = ["std", "alloy"]
 std = ["alloy-primitives/std", "bytes/std"]
 alloy = [
     "dep:alloy-consensus",
+    "dep:op-alloy-consensus",
     "dep:alloy-eips",
     "dep:alloy-genesis",
     "dep:modular-bitfield",

--- a/crates/storage/codecs/src/alloy/mod.rs
+++ b/crates/storage/codecs/src/alloy/mod.rs
@@ -3,5 +3,6 @@ mod authorization_list;
 mod genesis_account;
 mod log;
 mod request;
+mod transaction;
 mod txkind;
 mod withdrawal;

--- a/crates/storage/codecs/src/alloy/transaction.rs
+++ b/crates/storage/codecs/src/alloy/transaction.rs
@@ -1,0 +1,62 @@
+use crate::Compact;
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+use op_alloy_consensus::TxDeposit as AlloyDeposit;
+use reth_codecs_derive::main_codec;
+
+/// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
+#[main_codec]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+struct Deposit {
+    /// Hash that uniquely identifies the source of the deposit.
+    source_hash: B256,
+    /// The address of the sender account.
+    from: Address,
+    /// The address of the recipient account, or the null (zero-length) address if the deposited
+    /// transaction is a contract creation.
+    to: TxKind,
+    /// The ETH value to mint on L2.
+    mint: Option<u128>,
+    ///  The ETH value to send to the recipient account.
+    value: U256,
+    /// The gas limit for the L2 transaction.
+    gas_limit: u64,
+    /// Field indicating if this transaction is exempt from the L2 gas limit.
+    is_system_transaction: bool,
+    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
+    /// Some).
+    input: Bytes,
+}
+
+impl Compact for AlloyDeposit {
+    fn to_compact<B>(self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let deposit = Deposit {
+            source_hash: self.source_hash,
+            from: self.from,
+            to: self.to,
+            mint: self.mint,
+            value: self.value,
+            gas_limit: self.gas_limit as u64,
+            is_system_transaction: self.is_system_transaction,
+            input: self.input,
+        };
+        deposit.to_compact(buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (deposit, _) = Deposit::from_compact(buf, len);
+        let alloy_withdrawal = Self {
+            source_hash: deposit.source_hash,
+            from: deposit.from,
+            to: deposit.to,
+            mint: deposit.mint,
+            value: deposit.value,
+            gas_limit: deposit.gas_limit as u128,
+            is_system_transaction: deposit.is_system_transaction,
+            input: deposit.input,
+        };
+        (alloy_withdrawal, buf)
+    }
+}


### PR DESCRIPTION
ref #9484 #8721

replaces the reth op deposit type with op-alloy's 

https://github.com/alloy-rs/op-alloy/blob/main/crates/consensus/src/transaction/deposit.rs

there are still some issues with rlp encoding functions (of course)....