### PR TITLE
chore: rm redundant optimism feature

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -102,7 +102,6 @@ c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg"]
 zstd-codec = ["dep:zstd"]
 optimism = [
     "reth-chainspec/optimism",
-    "reth-codecs/optimism",
     "reth-ethereum-forks/optimism",
     "revm-primitives/optimism",
 ]

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -49,4 +49,3 @@ alloy = [
     "dep:alloy-genesis",
     "dep:modular-bitfield",
 ]
-optimism = ["reth-codecs-derive/optimism"]

--- a/crates/storage/codecs/derive/Cargo.toml
+++ b/crates/storage/codecs/derive/Cargo.toml
@@ -23,6 +23,3 @@ syn.workspace = true
 [dev-dependencies]
 similar-asserts.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits"] }
-
-[features]
-optimism = []

--- a/crates/storage/codecs/src/alloy/withdrawal.rs
+++ b/crates/storage/codecs/src/alloy/withdrawal.rs
@@ -67,14 +67,6 @@ mod tests {
     // expand the flags field and break backwards compatibility
     #[test]
     fn test_ensure_backwards_compatibility() {
-        #[cfg(not(feature = "optimism"))]
-        {
-            assert_eq!(Withdrawal::bitflag_encoded_bytes(), 2);
-        }
-
-        #[cfg(feature = "optimism")]
-        {
-            assert_eq!(Withdrawal::bitflag_encoded_bytes(), 2);
-        }
+        assert_eq!(Withdrawal::bitflag_encoded_bytes(), 2);
     }
 }


### PR DESCRIPTION
this didn't do anything, the cfg and not(cfg) case was the same