### PR TITLE
Add custom beacon withdrawals example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2395336745358cc47207442127c47c63801a7065ecc0aa928da844f8bb5576"
+checksum = "b0900b83f4ee1f45c640ceee596afbc118051921b9438fdb5a3175c1a7e05f8b"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed5047c9a241df94327879c2b0729155b58b941eae7805a7ada2e19436e6b39"
+checksum = "a41b1e78dde06b5e12e6702fa8c1d30621bf07728ba75b801fb801c9c6a0ba10"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dee02a81f529c415082235129f0df8b8e60aa1601b9c9298ffe54d75f57210b"
+checksum = "91dc311a561a306664393407b88d3e53ae58581624128afd8a15faa5de3627dc"
 dependencies = [
  "const-hex",
  "dunce",
@@ -2781,6 +2781,23 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "example-custom-beacon-withdrawals"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-sol-macro",
+ "alloy-sol-types",
+ "eyre",
+ "reth",
+ "reth-chainspec",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-node-ethereum",
+ "reth-primitives",
 ]
 
 [[package]]
@@ -10355,9 +10372,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfc1bfd06acc78f16d8fd3ef846bc222ee7002468d10a7dce8d703d6eab89a3"
+checksum = "9d5e0c2ea8db64b2898b62ea2fbd60204ca95e0b2c6bdf53ff768bbe916fbe4d"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ members = [
     "examples/rpc-db/",
     "examples/stateful-precompile/",
     "examples/txpool-tracing/",
+    "examples/custom-beacon-withdrawals",
     "testing/ef-tests/",
     "testing/testing-utils",
 ]

--- a/examples/custom-beacon-withdrawals/Cargo.toml
+++ b/examples/custom-beacon-withdrawals/Cargo.toml
@@ -5,20 +5,17 @@ publish = false
 edition.workspace = true
 license.workspace = true
 
-
 [dependencies]
 reth.workspace = true
 reth-node-ethereum.workspace = true
-reth-transaction-pool.workspace = true
-reth-tracing.workspace = true
 reth-evm-ethereum.workspace = true
 reth-chainspec.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
-reth-prune-types.workspace = true
-reth-ethereum-consensus.workspace = true
-alloy-sol-macro = "0.7.6"
-alloy-sol-types = "0.7.6"
 
+alloy-sol-macro = "0.8.9"
+alloy-sol-types.workspace = true
+alloy-eips.workspace = true
+alloy-consensus.workspace = true
 
 eyre.workspace = true

--- a/examples/custom-beacon-withdrawals/Cargo.toml
+++ b/examples/custom-beacon-withdrawals/Cargo.toml
@@ -19,3 +19,6 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 
 eyre.workspace = true
+
+[features]
+optimism = []

--- a/examples/custom-beacon-withdrawals/Cargo.toml
+++ b/examples/custom-beacon-withdrawals/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "example-custom-beacon-withdrawals"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+
+
+[dependencies]
+reth.workspace = true
+reth-node-ethereum.workspace = true
+reth-transaction-pool.workspace = true
+reth-tracing.workspace = true
+reth-evm-ethereum.workspace = true
+reth-chainspec.workspace = true
+reth-evm.workspace = true
+reth-primitives.workspace = true
+reth-prune-types.workspace = true
+reth-ethereum-consensus.workspace = true
+alloy-sol-macro = "0.7.6"
+alloy-sol-types = "0.7.6"
+
+
+eyre.workspace = true

--- a/examples/custom-beacon-withdrawals/Cargo.toml
+++ b/examples/custom-beacon-withdrawals/Cargo.toml
@@ -21,4 +21,6 @@ alloy-consensus.workspace = true
 eyre.workspace = true
 
 [features]
-optimism = []
+optimism = [
+  "reth-primitives/optimism"
+]

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -1,0 +1,444 @@
+//! Example for how to modify a block post-execution step. It credits beacon withdrawals with a
+//! custom mechanism instead of minting native tokens
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+use alloy_sol_macro::sol;
+use alloy_sol_types::SolCall;
+use reth::{
+    api::ConfigureEvm,
+    builder::{components::ExecutorBuilder, BuilderContext, FullNodeTypes},
+    cli::Cli,
+    primitives::{address, Address, Bytes},
+    providers::{ExecutionOutcome, ProviderError},
+    revm::{
+        batch::{BlockBatchRecord, BlockExecutorStats},
+        db::states::bundle_state::BundleRetention,
+        interpreter::Host,
+        primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, TransactTo, TxEnv},
+        Database, DatabaseCommit, Evm, State,
+    },
+};
+use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_ethereum_consensus::validate_block_post_execution;
+use reth_evm::execute::{
+    BatchExecutor, BlockExecutionError, BlockExecutionInput, BlockExecutionOutput,
+    BlockExecutorProvider, Executor,
+};
+use reth_evm_ethereum::{
+    execute::{EthEvmExecutor, EthExecuteOutput},
+    EthEvmConfig,
+};
+use reth_node_ethereum::EthereumNode;
+use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt, Receipts, Withdrawal, U256};
+use reth_prune_types::PruneModes;
+use std::fmt::Display;
+use std::sync::Arc;
+
+pub const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
+pub const WITHDRAWALS_ADDRESS: Address = address!("4200000000000000000000000000000000000000");
+
+fn main() {
+    Cli::parse_args()
+        .run(|builder, _| async move {
+            let handle = builder
+                // use the default ethereum node types
+                .with_types::<EthereumNode>()
+                // Configure the components of the node
+                // use default ethereum components but use our custom pool
+                .with_components(
+                    EthereumNode::components().executor(CustomExecutorBuilder::default()),
+                )
+                .launch()
+                .await?;
+
+            handle.wait_for_node_exit().await
+        })
+        .unwrap();
+}
+
+/// A custom executor builder
+#[derive(Debug, Default, Clone, Copy)]
+#[non_exhaustive]
+pub struct CustomExecutorBuilder;
+
+impl<Node> ExecutorBuilder<Node> for CustomExecutorBuilder
+where
+    Node: FullNodeTypes,
+{
+    type EVM = EthEvmConfig;
+    type Executor = CustomExecutorProvider<Self::EVM>;
+
+    async fn build_evm(
+        self,
+        ctx: &BuilderContext<Node>,
+    ) -> eyre::Result<(Self::EVM, Self::Executor)> {
+        let chain_spec = ctx.chain_spec();
+
+        let evm_config = EthEvmConfig::default();
+        let executor = CustomExecutorProvider::new(chain_spec, evm_config);
+
+        Ok((evm_config, executor))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CustomExecutorProvider<EvmConfig: Clone> {
+    chain_spec: Arc<ChainSpec>,
+    evm_config: EvmConfig,
+}
+
+impl<EvmConfig: Clone> CustomExecutorProvider<EvmConfig> {
+    /// Creates a new executor provider.
+    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
+        Self { chain_spec, evm_config }
+    }
+}
+
+impl<EvmConfig: Clone> CustomExecutorProvider<EvmConfig>
+where
+    EvmConfig: ConfigureEvm,
+{
+    fn custom_executor<DB>(&self, db: DB) -> CustomBlockExecutor<EvmConfig, DB>
+    where
+        DB: Database<Error: Into<ProviderError> + Display>,
+    {
+        CustomBlockExecutor::new(
+            self.chain_spec.clone(),
+            self.evm_config.clone(),
+            State::builder().with_database(db).with_bundle_update().without_state_clear().build(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct CustomBlockExecutor<EvmConfig, DB> {
+    /// Chain specific evm config that's used to execute a block.
+    executor: EthEvmExecutor<EvmConfig>,
+    /// The state to use for execution
+    state: State<DB>,
+}
+
+impl<EvmConfig, DB> CustomBlockExecutor<EvmConfig, DB> {
+    /// Creates a new Custom block executor.
+    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
+        Self { executor: EthEvmExecutor { chain_spec, evm_config }, state }
+    }
+
+    #[inline]
+    fn chain_spec(&self) -> &ChainSpec {
+        &self.executor.chain_spec
+    }
+
+    /// Returns mutable reference to the state that wraps the underlying database.
+    #[allow(unused)]
+    fn state_mut(&mut self) -> &mut State<DB> {
+        &mut self.state
+    }
+}
+
+// Trait required by ExecutorBuilder
+// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthExecutorProvider
+impl<EvmConfig: Clone> BlockExecutorProvider for CustomExecutorProvider<EvmConfig>
+where
+    EvmConfig: ConfigureEvm,
+{
+    type Executor<DB: Database<Error: Into<ProviderError> + Display>> =
+        CustomBlockExecutor<EvmConfig, DB>;
+    type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> =
+        CustomBatchExecutor<EvmConfig, DB>;
+
+    fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
+    where
+        DB: Database<Error: Into<ProviderError> + Display>,
+    {
+        self.custom_executor(db)
+    }
+
+    fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
+    where
+        DB: Database<Error: Into<ProviderError> + Display>,
+    {
+        let executor = self.custom_executor(db);
+        CustomBatchExecutor {
+            executor,
+            batch_record: BlockBatchRecord::default(),
+            stats: BlockExecutorStats::default(),
+        }
+    }
+}
+
+impl<EvmConfig, DB> CustomBlockExecutor<EvmConfig, DB>
+where
+    EvmConfig: ConfigureEvm,
+    DB: Database<Error: Into<ProviderError> + Display>,
+{
+    /// Configures a new evm configuration and block environment for the given block.
+    ///
+    /// # Caution
+    ///
+    /// This does not initialize the tx environment.
+    fn evm_env_for_block(&self, header: &Header, total_difficulty: U256) -> EnvWithHandlerCfg {
+        let mut cfg = CfgEnvWithHandlerCfg::new(Default::default(), Default::default());
+        let mut block_env = BlockEnv::default();
+        self.executor.evm_config.fill_cfg_and_block_env(
+            &mut cfg,
+            &mut block_env,
+            self.chain_spec(),
+            header,
+            total_difficulty,
+        );
+
+        EnvWithHandlerCfg::new_with_cfg_env(cfg, block_env, Default::default())
+    }
+
+    /// Execute a single block and apply the state changes to the internal state.
+    ///
+    /// Returns the receipts of the transactions in the block, the total gas used and the list of
+    /// EIP-7685 [requests](Request).
+    ///
+    /// Returns an error if execution fails.
+    fn execute_without_verification(
+        &mut self,
+        block: &BlockWithSenders,
+        total_difficulty: U256,
+    ) -> Result<EthExecuteOutput, BlockExecutionError> {
+        // 1. prepare state on new block
+        self.on_new_block(&block.header);
+
+        // 2. configure the evm and execute
+        let env = self.evm_env_for_block(&block.header, total_difficulty);
+        let output = {
+            let evm = self.executor.evm_config.evm_with_env(&mut self.state, env);
+            self.executor.execute_state_transitions(block, evm)
+        }?;
+
+        // 3. apply post execution changes
+        self.post_execution(block, total_difficulty)?;
+
+        Ok(output)
+    }
+
+    /// Apply settings before a new block is executed.
+    pub(crate) fn on_new_block(&mut self, header: &Header) {
+        // Set state clear flag if the block is after the Spurious Dragon hardfork.
+        let state_clear_flag = self.chain_spec().is_spurious_dragon_active_at_block(header.number);
+        self.state.set_state_clear_flag(state_clear_flag);
+    }
+
+    /// Apply post execution state changes that do not require an [EVM](Evm), such as: block
+    /// rewards, withdrawals, and irregular DAO hardfork state change
+    pub fn post_execution(
+        &mut self,
+        block: &BlockWithSenders,
+        total_difficulty: U256,
+    ) -> Result<(), BlockExecutionError> {
+        let env = self.evm_env_for_block(&block.header, total_difficulty);
+        let mut evm = self.executor.evm_config.evm_with_env(&mut self.state, env);
+
+        if let Some(withdrawals) = block.withdrawals.as_ref() {
+            apply_withdrawals_contract_call(withdrawals, &mut evm)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<EvmConfig, DB> Executor<DB> for CustomBlockExecutor<EvmConfig, DB>
+where
+    EvmConfig: ConfigureEvm,
+    DB: Database<Error: Into<ProviderError> + Display>,
+{
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Output = BlockExecutionOutput<Receipt>;
+    type Error = BlockExecutionError;
+
+    fn execute(mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+        let BlockExecutionInput { block, total_difficulty } = input;
+        let EthExecuteOutput { receipts, requests, gas_used } =
+            self.execute_without_verification(block, total_difficulty)?;
+
+        // NOTE: we need to merge keep the reverts for the bundle retention
+        self.state.merge_transitions(BundleRetention::Reverts);
+
+        Ok(BlockExecutionOutput { state: self.state.take_bundle(), receipts, requests, gas_used })
+    }
+}
+
+/// An executor for a batch of blocks.
+///
+/// State changes are tracked until the executor is finalized.
+#[derive(Debug)]
+// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+pub struct CustomBatchExecutor<EvmConfig, DB> {
+    /// The executor used to execute blocks.
+    executor: CustomBlockExecutor<EvmConfig, DB>,
+    /// Keeps track of the batch and record receipts based on the configured prune mode
+    batch_record: BlockBatchRecord,
+    stats: BlockExecutorStats,
+}
+
+// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+impl<EvmConfig, DB> CustomBatchExecutor<EvmConfig, DB> {
+    /// Returns the receipts of the executed blocks.
+    pub const fn receipts(&self) -> &Receipts {
+        self.batch_record.receipts()
+    }
+
+    /// Returns mutable reference to the state that wraps the underlying database.
+    #[allow(unused)]
+    fn state_mut(&mut self) -> &mut State<DB> {
+        self.executor.state_mut()
+    }
+}
+
+// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+impl<EvmConfig, DB> BatchExecutor<DB> for CustomBatchExecutor<EvmConfig, DB>
+where
+    EvmConfig: ConfigureEvm,
+    DB: Database<Error: Into<ProviderError> + Display>,
+{
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Output = ExecutionOutcome;
+    type Error = BlockExecutionError;
+
+    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+    fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
+        let BlockExecutionInput { block, total_difficulty } = input;
+        let EthExecuteOutput { receipts, requests, gas_used: _ } =
+            self.executor.execute_without_verification(block, total_difficulty)?;
+
+        validate_block_post_execution(block, self.executor.chain_spec(), &receipts, &requests)?;
+
+        // prepare the state according to the prune mode
+        let retention = self.batch_record.bundle_retention(block.number);
+        self.executor.state.merge_transitions(retention);
+
+        // store receipts in the set
+        self.batch_record.save_receipts(receipts)?;
+
+        // store requests in the set
+        self.batch_record.save_requests(requests);
+
+        if self.batch_record.first_block().is_none() {
+            self.batch_record.set_first_block(block.number);
+        }
+
+        Ok(())
+    }
+
+    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+    fn finalize(mut self) -> Self::Output {
+        self.stats.log_debug();
+
+        ExecutionOutcome::new(
+            self.executor.state.take_bundle(),
+            self.batch_record.take_receipts(),
+            self.batch_record.first_block().unwrap_or_default(),
+            self.batch_record.take_requests(),
+        )
+    }
+
+    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+    fn set_tip(&mut self, tip: BlockNumber) {
+        self.batch_record.set_tip(tip);
+    }
+
+    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+    fn set_prune_modes(&mut self, prune_modes: PruneModes) {
+        self.batch_record.set_prune_modes(prune_modes);
+    }
+
+    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.executor.state.bundle_state.size_hint())
+    }
+}
+
+sol!(
+    function withdrawals(
+        uint64[] calldata amounts,
+        address[] calldata addresses
+    );
+);
+
+/// Applies the post-block call to the withdrawal / deposit contract, using the given block,
+/// [`ChainSpec`], EVM.
+pub fn apply_withdrawals_contract_call<EXT, DB: Database + DatabaseCommit>(
+    withdrawals: &[Withdrawal],
+    evm: &mut Evm<'_, EXT, DB>,
+) -> Result<(), BlockExecutionError>
+where
+    DB::Error: std::fmt::Display,
+{
+    // get previous env
+    let previous_env = Box::new(evm.context.env().clone());
+
+    // modify env for pre block call
+    fill_tx_env_with_system_contract_call(
+        &mut evm.context.evm.env,
+        SYSTEM_ADDRESS,
+        WITHDRAWALS_ADDRESS,
+        withdrawalsCall {
+            amounts: withdrawals.iter().map(|w| w.amount).collect::<Vec<_>>(),
+            addresses: withdrawals.iter().map(|w| w.address).collect::<Vec<_>>(),
+        }
+        .abi_encode()
+        .into(),
+    );
+
+    let mut state = match evm.transact() {
+        Ok(res) => res.state,
+        Err(e) => {
+            evm.context.evm.env = previous_env;
+            return Err(BlockExecutionError::Other(
+                format!("withdrawal contract system call revert: {}", e).into(),
+            ));
+        }
+    };
+
+    // Clean-up post system tx context
+    state.remove(&SYSTEM_ADDRESS);
+    state.remove(&evm.block().coinbase);
+    evm.context.evm.db.commit(state);
+    // re-set the previous env
+    evm.context.evm.env = previous_env;
+
+    Ok(())
+}
+
+fn fill_tx_env_with_system_contract_call(
+    env: &mut Env,
+    caller: Address,
+    contract: Address,
+    data: Bytes,
+) {
+    env.tx = TxEnv {
+        caller,
+        transact_to: TransactTo::Call(contract),
+        // Explicitly set nonce to None so revm does not do any nonce checks
+        nonce: None,
+        gas_limit: 30_000_000,
+        value: U256::ZERO,
+        data,
+        // Setting the gas price to zero enforces that no value is transferred as part of the call,
+        // and that the call will not count against the block's gas limit
+        gas_price: U256::ZERO,
+        // The chain ID check is not relevant here and is disabled if set to None
+        chain_id: None,
+        // Setting the gas priority fee to None ensures the effective gas price is derived from the
+        // `gas_price` field, which we need to be zero
+        gas_priority_fee: None,
+        access_list: Vec::new(),
+        // blob fields can be None for this tx
+        blob_hashes: Vec::new(),
+        max_fee_per_blob_gas: None,
+        authorization_list: None,
+    };
+
+    // ensure the block gas limit is >= the tx
+    env.block.gas_limit = U256::from(env.tx.gas_limit);
+
+    // disable the base fee check for this call by setting the base fee to zero
+    env.block.basefee = U256::ZERO;
+}

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -6,6 +6,8 @@
 use alloy_eips::eip7685::Requests;
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
+#[cfg(feature = "optimism")]
+use reth::revm::primitives::OptimismFields;
 use reth::{
     api::{ConfigureEvm, ConfigureEvmEnv, NodeTypesWithEngine},
     builder::{components::ExecutorBuilder, BuilderContext, FullNodeTypes},
@@ -272,6 +274,8 @@ fn fill_tx_env_with_system_contract_call(
         blob_hashes: Vec::new(),
         max_fee_per_blob_gas: None,
         authorization_list: None,
+        #[cfg(feature = "optimism")]
+        optimism: OptimismFields::default(),
     };
 
     // ensure the block gas limit is >= the tx

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -3,37 +3,34 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+use alloy_eips::eip7685::Requests;
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 use reth::{
-    api::ConfigureEvm,
+    api::{ConfigureEvm, ConfigureEvmEnv, NodeTypesWithEngine},
     builder::{components::ExecutorBuilder, BuilderContext, FullNodeTypes},
     cli::Cli,
-    primitives::{address, Address, Bytes},
-    providers::{ExecutionOutcome, ProviderError},
+    providers::ProviderError,
     revm::{
-        batch::{BlockBatchRecord, BlockExecutorStats},
-        db::states::bundle_state::BundleRetention,
         interpreter::Host,
-        primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, TransactTo, TxEnv},
+        primitives::{Env, TransactTo, TxEnv},
         Database, DatabaseCommit, Evm, State,
     },
 };
 use reth_chainspec::{ChainSpec, EthereumHardforks};
-use reth_ethereum_consensus::validate_block_post_execution;
 use reth_evm::execute::{
-    BatchExecutor, BlockExecutionError, BlockExecutionInput, BlockExecutionOutput,
-    BlockExecutorProvider, Executor,
+    BlockExecutionError, BlockExecutionStrategy, BlockExecutionStrategyFactory, ExecuteOutput,
+    InternalBlockExecutionError,
 };
-use reth_evm_ethereum::{
-    execute::{EthEvmExecutor, EthExecuteOutput},
-    EthEvmConfig,
+use reth_evm_ethereum::EthEvmConfig;
+use reth_node_ethereum::{node::EthereumAddOns, BasicBlockExecutorProvider, EthereumNode};
+use reth_primitives::{
+    revm_primitives::{
+        address, Address, BlockEnv, Bytes, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, U256,
+    },
+    BlockWithSenders, Receipt, Withdrawal,
 };
-use reth_node_ethereum::EthereumNode;
-use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt, Receipts, Withdrawal, U256};
-use reth_prune_types::PruneModes;
-use std::fmt::Display;
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc};
 
 pub const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
 pub const WITHDRAWALS_ADDRESS: Address = address!("4200000000000000000000000000000000000000");
@@ -49,6 +46,7 @@ fn main() {
                 .with_components(
                     EthereumNode::components().executor(CustomExecutorBuilder::default()),
                 )
+                .with_add_ons(EthereumAddOns::default())
                 .launch()
                 .await?;
 
@@ -62,115 +60,67 @@ fn main() {
 #[non_exhaustive]
 pub struct CustomExecutorBuilder;
 
-impl<Node> ExecutorBuilder<Node> for CustomExecutorBuilder
+impl<Types, Node> ExecutorBuilder<Node> for CustomExecutorBuilder
 where
-    Node: FullNodeTypes,
+    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types = Types>,
 {
     type EVM = EthEvmConfig;
-    type Executor = CustomExecutorProvider<Self::EVM>;
+    type Executor = BasicBlockExecutorProvider<CustomExecutorStrategyFactory>;
 
     async fn build_evm(
         self,
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
         let chain_spec = ctx.chain_spec();
-
-        let evm_config = EthEvmConfig::default();
-        let executor = CustomExecutorProvider::new(chain_spec, evm_config);
+        let evm_config = EthEvmConfig::new(ctx.chain_spec());
+        let strategy_factory =
+            CustomExecutorStrategyFactory { chain_spec, evm_config: evm_config.clone() };
+        let executor = BasicBlockExecutorProvider::new(strategy_factory);
 
         Ok((evm_config, executor))
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct CustomExecutorProvider<EvmConfig: Clone> {
+#[derive(Clone)]
+pub struct CustomExecutorStrategyFactory {
+    /// The chainspec
     chain_spec: Arc<ChainSpec>,
-    evm_config: EvmConfig,
+    /// How to create an EVM.
+    evm_config: EthEvmConfig,
 }
 
-impl<EvmConfig: Clone> CustomExecutorProvider<EvmConfig> {
-    /// Creates a new executor provider.
-    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
-        Self { chain_spec, evm_config }
-    }
-}
+impl BlockExecutionStrategyFactory for CustomExecutorStrategyFactory {
+    type Strategy<DB: Database<Error: Into<ProviderError> + Display>> = CustomExecutorStrategy<DB>;
 
-impl<EvmConfig: Clone> CustomExecutorProvider<EvmConfig>
-where
-    EvmConfig: ConfigureEvm,
-{
-    fn custom_executor<DB>(&self, db: DB) -> CustomBlockExecutor<EvmConfig, DB>
+    fn create_strategy<DB>(&self, db: DB) -> Self::Strategy<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
     {
-        CustomBlockExecutor::new(
-            self.chain_spec.clone(),
-            self.evm_config.clone(),
-            State::builder().with_database(db).with_bundle_update().without_state_clear().build(),
-        )
-    }
-}
-
-#[derive(Debug)]
-pub struct CustomBlockExecutor<EvmConfig, DB> {
-    /// Chain specific evm config that's used to execute a block.
-    executor: EthEvmExecutor<EvmConfig>,
-    /// The state to use for execution
-    state: State<DB>,
-}
-
-impl<EvmConfig, DB> CustomBlockExecutor<EvmConfig, DB> {
-    /// Creates a new Custom block executor.
-    pub fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
-        Self { executor: EthEvmExecutor { chain_spec, evm_config }, state }
-    }
-
-    #[inline]
-    fn chain_spec(&self) -> &ChainSpec {
-        &self.executor.chain_spec
-    }
-
-    /// Returns mutable reference to the state that wraps the underlying database.
-    #[allow(unused)]
-    fn state_mut(&mut self) -> &mut State<DB> {
-        &mut self.state
-    }
-}
-
-// Trait required by ExecutorBuilder
-// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthExecutorProvider
-impl<EvmConfig: Clone> BlockExecutorProvider for CustomExecutorProvider<EvmConfig>
-where
-    EvmConfig: ConfigureEvm,
-{
-    type Executor<DB: Database<Error: Into<ProviderError> + Display>> =
-        CustomBlockExecutor<EvmConfig, DB>;
-    type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> =
-        CustomBatchExecutor<EvmConfig, DB>;
-
-    fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
-    where
-        DB: Database<Error: Into<ProviderError> + Display>,
-    {
-        self.custom_executor(db)
-    }
-
-    fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
-    where
-        DB: Database<Error: Into<ProviderError> + Display>,
-    {
-        let executor = self.custom_executor(db);
-        CustomBatchExecutor {
-            executor,
-            batch_record: BlockBatchRecord::default(),
-            stats: BlockExecutorStats::default(),
+        let state =
+            State::builder().with_database(db).with_bundle_update().without_state_clear().build();
+        CustomExecutorStrategy {
+            state,
+            chain_spec: self.chain_spec.clone(),
+            evm_config: self.evm_config.clone(),
         }
     }
 }
 
-impl<EvmConfig, DB> CustomBlockExecutor<EvmConfig, DB>
+pub struct CustomExecutorStrategy<DB>
 where
-    EvmConfig: ConfigureEvm,
+    DB: Database<Error: Into<ProviderError> + Display>,
+{
+    /// The chainspec
+    chain_spec: Arc<ChainSpec>,
+    /// How to create an EVM.
+    evm_config: EthEvmConfig,
+    /// Current state for block execution.
+    state: State<DB>,
+}
+
+impl<DB> CustomExecutorStrategy<DB>
+where
     DB: Database<Error: Into<ProviderError> + Display>,
 {
     /// Configures a new evm configuration and block environment for the given block.
@@ -178,180 +128,68 @@ where
     /// # Caution
     ///
     /// This does not initialize the tx environment.
-    fn evm_env_for_block(&self, header: &Header, total_difficulty: U256) -> EnvWithHandlerCfg {
+    fn evm_env_for_block(
+        &self,
+        header: &alloy_consensus::Header,
+        total_difficulty: U256,
+    ) -> EnvWithHandlerCfg {
         let mut cfg = CfgEnvWithHandlerCfg::new(Default::default(), Default::default());
         let mut block_env = BlockEnv::default();
-        self.executor.evm_config.fill_cfg_and_block_env(
-            &mut cfg,
-            &mut block_env,
-            self.chain_spec(),
-            header,
-            total_difficulty,
-        );
+        self.evm_config.fill_cfg_and_block_env(&mut cfg, &mut block_env, header, total_difficulty);
 
         EnvWithHandlerCfg::new_with_cfg_env(cfg, block_env, Default::default())
     }
+}
 
-    /// Execute a single block and apply the state changes to the internal state.
-    ///
-    /// Returns the receipts of the transactions in the block, the total gas used and the list of
-    /// EIP-7685 [requests](Request).
-    ///
-    /// Returns an error if execution fails.
-    fn execute_without_verification(
+impl<DB> BlockExecutionStrategy<DB> for CustomExecutorStrategy<DB>
+where
+    DB: Database<Error: Into<ProviderError> + Display>,
+{
+    type Error = BlockExecutionError;
+
+    fn apply_pre_execution_changes(
         &mut self,
         block: &BlockWithSenders,
-        total_difficulty: U256,
-    ) -> Result<EthExecuteOutput, BlockExecutionError> {
-        // 1. prepare state on new block
-        self.on_new_block(&block.header);
-
-        // 2. configure the evm and execute
-        let env = self.evm_env_for_block(&block.header, total_difficulty);
-        let output = {
-            let evm = self.executor.evm_config.evm_with_env(&mut self.state, env);
-            self.executor.execute_state_transitions(block, evm)
-        }?;
-
-        // 3. apply post execution changes
-        self.post_execution(block, total_difficulty)?;
-
-        Ok(output)
-    }
-
-    /// Apply settings before a new block is executed.
-    pub(crate) fn on_new_block(&mut self, header: &Header) {
+        _total_difficulty: U256,
+    ) -> Result<(), Self::Error> {
         // Set state clear flag if the block is after the Spurious Dragon hardfork.
-        let state_clear_flag = self.chain_spec().is_spurious_dragon_active_at_block(header.number);
+        let state_clear_flag =
+            (*self.chain_spec).is_spurious_dragon_active_at_block(block.header.number);
         self.state.set_state_clear_flag(state_clear_flag);
+
+        Ok(())
     }
 
-    /// Apply post execution state changes that do not require an [EVM](Evm), such as: block
-    /// rewards, withdrawals, and irregular DAO hardfork state change
-    pub fn post_execution(
+    fn execute_transactions(
+        &mut self,
+        _block: &BlockWithSenders,
+        _total_difficulty: U256,
+    ) -> Result<ExecuteOutput, Self::Error> {
+        Ok(ExecuteOutput { receipts: vec![], gas_used: 0 })
+    }
+
+    fn apply_post_execution_changes(
         &mut self,
         block: &BlockWithSenders,
         total_difficulty: U256,
-    ) -> Result<(), BlockExecutionError> {
+        _receipts: &[Receipt],
+    ) -> Result<Requests, Self::Error> {
         let env = self.evm_env_for_block(&block.header, total_difficulty);
-        let mut evm = self.executor.evm_config.evm_with_env(&mut self.state, env);
+        let mut evm = self.evm_config.evm_with_env(&mut self.state, env);
 
-        if let Some(withdrawals) = block.withdrawals.as_ref() {
+        if let Some(withdrawals) = block.body.withdrawals.as_ref() {
             apply_withdrawals_contract_call(withdrawals, &mut evm)?;
         }
 
-        Ok(())
-    }
-}
-
-impl<EvmConfig, DB> Executor<DB> for CustomBlockExecutor<EvmConfig, DB>
-where
-    EvmConfig: ConfigureEvm,
-    DB: Database<Error: Into<ProviderError> + Display>,
-{
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
-    type Output = BlockExecutionOutput<Receipt>;
-    type Error = BlockExecutionError;
-
-    fn execute(mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
-        let BlockExecutionInput { block, total_difficulty } = input;
-        let EthExecuteOutput { receipts, requests, gas_used } =
-            self.execute_without_verification(block, total_difficulty)?;
-
-        // NOTE: we need to merge keep the reverts for the bundle retention
-        self.state.merge_transitions(BundleRetention::Reverts);
-
-        Ok(BlockExecutionOutput { state: self.state.take_bundle(), receipts, requests, gas_used })
-    }
-}
-
-/// An executor for a batch of blocks.
-///
-/// State changes are tracked until the executor is finalized.
-#[derive(Debug)]
-// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-pub struct CustomBatchExecutor<EvmConfig, DB> {
-    /// The executor used to execute blocks.
-    executor: CustomBlockExecutor<EvmConfig, DB>,
-    /// Keeps track of the batch and record receipts based on the configured prune mode
-    batch_record: BlockBatchRecord,
-    stats: BlockExecutorStats,
-}
-
-// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-impl<EvmConfig, DB> CustomBatchExecutor<EvmConfig, DB> {
-    /// Returns the receipts of the executed blocks.
-    pub const fn receipts(&self) -> &Receipts {
-        self.batch_record.receipts()
+        Ok(Requests::default())
     }
 
-    /// Returns mutable reference to the state that wraps the underlying database.
-    #[allow(unused)]
+    fn state_ref(&self) -> &State<DB> {
+        &self.state
+    }
+
     fn state_mut(&mut self) -> &mut State<DB> {
-        self.executor.state_mut()
-    }
-}
-
-// [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-impl<EvmConfig, DB> BatchExecutor<DB> for CustomBatchExecutor<EvmConfig, DB>
-where
-    EvmConfig: ConfigureEvm,
-    DB: Database<Error: Into<ProviderError> + Display>,
-{
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
-    type Output = ExecutionOutcome;
-    type Error = BlockExecutionError;
-
-    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-    fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
-        let BlockExecutionInput { block, total_difficulty } = input;
-        let EthExecuteOutput { receipts, requests, gas_used: _ } =
-            self.executor.execute_without_verification(block, total_difficulty)?;
-
-        validate_block_post_execution(block, self.executor.chain_spec(), &receipts, &requests)?;
-
-        // prepare the state according to the prune mode
-        let retention = self.batch_record.bundle_retention(block.number);
-        self.executor.state.merge_transitions(retention);
-
-        // store receipts in the set
-        self.batch_record.save_receipts(receipts)?;
-
-        // store requests in the set
-        self.batch_record.save_requests(requests);
-
-        if self.batch_record.first_block().is_none() {
-            self.batch_record.set_first_block(block.number);
-        }
-
-        Ok(())
-    }
-
-    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-    fn finalize(mut self) -> Self::Output {
-        self.stats.log_debug();
-
-        ExecutionOutcome::new(
-            self.executor.state.take_bundle(),
-            self.batch_record.take_receipts(),
-            self.batch_record.first_block().unwrap_or_default(),
-            self.batch_record.take_requests(),
-        )
-    }
-
-    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-    fn set_tip(&mut self, tip: BlockNumber) {
-        self.batch_record.set_tip(tip);
-    }
-
-    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-    fn set_prune_modes(&mut self, prune_modes: PruneModes) {
-        self.batch_record.set_prune_modes(prune_modes);
-    }
-
-    // [Custom/fork] Copy paste code from crates/ethereum/evm/src/execute.rs::EthBatchExecutor
-    fn size_hint(&self) -> Option<usize> {
-        Some(self.executor.state.bundle_state.size_hint())
+        &mut self.state
     }
 }
 
@@ -391,9 +229,9 @@ where
         Ok(res) => res.state,
         Err(e) => {
             evm.context.evm.env = previous_env;
-            return Err(BlockExecutionError::Other(
+            return Err(BlockExecutionError::Internal(InternalBlockExecutionError::Other(
                 format!("withdrawal contract system call revert: {}", e).into(),
-            ));
+            )))
         }
     };
 


### PR DESCRIPTION
Adds an example of modifying a post-block execution step. Specifically, it modifies the beacon withdrawal processing logic: do a system call instead of minting native tokens.

I have made some structs and fns pub to reduce diff. Please let me know if there are more opportunities to minimize the diff. There's duplicated code between this custom executor, the op executor and the eth executor.