### PR TITLE
fix(net): batch `P2PStream` sends

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -613,7 +613,7 @@ where
     /// Returns `Poll::Ready(Ok(()))` when no buffered items remain.
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let mut this = self.project();
-        let res = loop {
+        let poll_res = loop {
             // P2PStream wraps `reth_ecies::stream::ECIESStream` in node. `ECIESStream`
             // internally wraps the network connection in `tokio_util::codec::Framed`.
             //
@@ -621,15 +621,23 @@ where
             // reached. `Framed::poll_ready`, only returns `Poll::Pending` or `Poll::Ready(Err(e))`
             // if it had to call flush - no need to explicitly flush the batch again before
             // propagating pending or error.
-            ready!(this.inner.as_mut().poll_ready(cx))?;
-            let Some(message) = this.outgoing_messages.pop_front() else { break Ok(()) };
-            if let Err(err) = this.inner.as_mut().start_send(message) {
-                break Err(err.into())
+            match this.inner.as_mut().poll_ready(cx) {
+                Poll::Pending => break Poll::Pending,
+                Poll::Ready(Err(err)) => break Poll::Ready(Err(err.into())),
+                Poll::Ready(Ok(())) => {
+                    let Some(message) = this.outgoing_messages.pop_front() else {
+                        break Poll::Ready(Ok(()))
+                    };
+                    if let Err(err) = this.inner.as_mut().start_send(message) {
+                        break Poll::Ready(Err(err.into()))
+                    }
+                }
             }
         };
 
         ready!(this.inner.as_mut().poll_flush(cx))?;
-        Poll::Ready(res)
+
+        poll_res
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -614,13 +614,6 @@ where
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let mut this = self.project();
         let poll_res = loop {
-            // P2PStream wraps `reth_ecies::stream::ECIESStream` in node. `ECIESStream`
-            // internally wraps the network connection in `tokio_util::codec::Framed`.
-            //
-            // Call to `Framed::poll_ready` will flush internally, if limit for buffered messages
-            // reached. `Framed::poll_ready`, only returns `Poll::Pending` or `Poll::Ready(Err(e))`
-            // if it had to call flush - no need to explicitly flush the batch again before
-            // propagating pending or error.
             match this.inner.as_mut().poll_ready(cx) {
                 Poll::Pending => break Poll::Pending,
                 Poll::Ready(Err(err)) => break Poll::Ready(Err(err.into())),


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/8399

Fixes `Sink` impl. Calls `poll_ready` before `start_send`, instead of `poll_flush` before each call to `start_send` - the latter defeats the purpose of using `Framed` to batch sends. 

This fix ensures we don't do more syscalls than intended by `tokio_util::codec::Framed` frame size.