### PR TITLE
chore(net): enable rust.unnameable-types = "warn" lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ rust.unreachable_pub = "warn"
 rust.unused_must_use = "deny"
 rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rustdoc.all = "warn"
-rust.unnameable-types = "warn"
+# rust.unnameable-types = "warn"
 
 [workspace.lints.clippy]
 # These are some of clippy's nursery (i.e., experimental) lints that we like.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ rust.unreachable_pub = "warn"
 rust.unused_must_use = "deny"
 rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rustdoc.all = "warn"
+rust.unnameable-types = "warn"
 
 [workspace.lints.clippy]
 # These are some of clippy's nursery (i.e., experimental) lints that we like.

--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 pub use config::DnsDiscoveryConfig;
 use enr::Enr;
-use error::ParseDnsEntryError;
+pub use error::ParseDnsEntryError;
 use reth_ethereum_forks::{EnrForkIdEntry, ForkId};
 use reth_network_peers::{pk2id, NodeRecord};
 use schnellru::{ByLength, LruMap};

--- a/crates/net/ecies/src/error.rs
+++ b/crates/net/ecies/src/error.rs
@@ -81,7 +81,7 @@ pub enum ECIESErrorImpl {
     /// decode a message from the (partially filled) buffer.
     #[error("stream closed due to not being readable")]
     UnreadableStream,
-    // Error when data is not received from peer for a prolonged period.
+    /// Error when data is not received from peer for a prolonged period.
     #[error("never received data from remote peer")]
     StreamTimeout,
 }

--- a/crates/net/ecies/src/lib.rs
+++ b/crates/net/ecies/src/lib.rs
@@ -14,7 +14,7 @@ pub mod stream;
 pub mod util;
 
 mod error;
-pub use error::ECIESError;
+pub use error::{ECIESError, ECIESErrorImpl};
 
 pub mod codec;
 

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -45,3 +45,5 @@ pub use crate::{
 // Re-export wire types
 #[doc(inline)]
 pub use reth_eth_wire_types::*;
+
+pub use disconnect::UnknownDisconnectReason;

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -151,5 +151,10 @@ pub use session::{
 
 pub use transactions::{FilterAnnouncement, MessageFilter, ValidateTx68};
 
+pub use flattened_response::FlattenedResponse;
+pub use manager::DiscoveredEvent;
+pub use metrics::TxTypesCounter;
 pub use reth_eth_wire::{DisconnectReason, HelloMessageWithProtocols};
 pub use reth_network_types::{PeersConfig, SessionsConfig};
+pub use session::EthRlpxConnection;
+pub use swarm::NetworkConnectionState;

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -1077,9 +1077,29 @@ pub enum NetworkEvent {
     PeerRemoved(PeerId),
 }
 
+/// Represents events related to peer discovery in the network.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscoveredEvent {
-    EventQueued { peer_id: PeerId, addr: PeerAddr, fork_id: Option<ForkId> },
+    /// Indicates that a new peer has been discovered and queued for potential connection.
+    ///
+    /// This event is generated when the system becomes aware of a new peer
+    /// but hasn't yet established a connection.
+    ///
+    /// # Fields
+    ///
+    /// * `peer_id` - The unique identifier of the discovered peer.
+    /// * `addr` - The network address of the discovered peer.
+    /// * `fork_id` - An optional identifier for the fork that this peer is associated with. `None`
+    ///   if the peer is not associated with a specific fork.
+    EventQueued {
+        /// The unique identifier of the discovered peer.
+        peer_id: PeerId,
+        /// The network address of the discovered peer.
+        addr: PeerAddr,
+        /// An optional identifier for the fork that this peer is associated with.
+        /// `None` if the peer is not associated with a specific fork.
+        fork_id: Option<ForkId>,
+    },
 }
 
 #[derive(Debug, Default)]

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -347,12 +347,25 @@ pub struct AnnouncedTxTypesMetrics {
     pub(crate) eip7702: Histogram,
 }
 
+/// Counts the number of transactions by their type in a block or collection.
+///
+/// This struct keeps track of the count of different transaction types
+/// as defined by various Ethereum Improvement Proposals (EIPs).
 #[derive(Debug, Default)]
 pub struct TxTypesCounter {
+    /// Count of legacy transactions (pre-EIP-2718).
     pub(crate) legacy: usize,
+
+    /// Count of transactions conforming to EIP-2930 (Optional access lists).
     pub(crate) eip2930: usize,
+
+    /// Count of transactions conforming to EIP-1559 (Fee market change).
     pub(crate) eip1559: usize,
+
+    /// Count of transactions conforming to EIP-4844 (Shard Blob Transactions).
     pub(crate) eip4844: usize,
+
+    /// Count of transactions conforming to EIP-7702 (Restricted Storage Windows).
     pub(crate) eip7702: usize,
 }
 

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -23,12 +23,14 @@ pub type EthSatelliteConnection =
 
 /// Connection types that support the ETH protocol.
 ///
-/// Either a [`EthPeerConnection`] or an [`EthSatelliteConnection`].
+/// This can be either:
+/// - A connection that only supports the ETH protocol
+/// - A connection that supports the ETH protocol and at least one other `RLPx` protocol
 // This type is boxed because the underlying stream is ~6KB,
 // mostly coming from `P2PStream`'s `snap::Encoder` (2072), and `ECIESStream` (3600).
 #[derive(Debug)]
 pub enum EthRlpxConnection {
-    /// A That only supports the ETH protocol.
+    /// A connection that only supports the ETH protocol.
     EthOnly(Box<EthPeerConnection>),
     /// A connection that supports the ETH protocol and __at least one other__ `RLPx` protocol.
     Satellite(Box<EthSatelliteConnection>),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -40,13 +40,13 @@ mod counter;
 mod handle;
 pub use crate::message::PeerRequestSender;
 use crate::protocol::{IntoRlpxSubProtocol, RlpxSubProtocolHandlers, RlpxSubProtocols};
+pub use conn::EthRlpxConnection;
 pub use handle::{
     ActiveSessionHandle, ActiveSessionMessage, PendingSessionEvent, PendingSessionHandle,
     SessionCommand,
 };
 use reth_eth_wire::multiplex::RlpxProtocolMultiplexer;
 pub use reth_network_api::{Direction, PeerInfo};
-
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
 pub struct SessionId(usize);

--- a/crates/net/network/src/test_utils/mod.rs
+++ b/crates/net/network/src/test_utils/mod.rs
@@ -7,4 +7,4 @@ pub use init::{
     enr_to_peer_id, unused_port, unused_tcp_addr, unused_tcp_and_udp_port, unused_tcp_udp,
     unused_udp_addr, unused_udp_port, GETH_TIMEOUT,
 };
-pub use testnet::{NetworkEventStream, Peer, PeerConfig, PeerHandle, Testnet};
+pub use testnet::{NetworkEventStream, Peer, PeerConfig, PeerHandle, Testnet, TestnetHandle};


### PR DESCRIPTION
## Description

Partially addresses #9401 

Fix `unnameable-types` warnings on `net` crate