### PR TITLE
chore(eip7702): nonce is no longer optional

### DIFF
--- a/crates/primitives/src/eip7702.rs
+++ b/crates/primitives/src/eip7702.rs
@@ -2,4 +2,4 @@
 
 /// Re-export from `alloy_eips`.
 #[doc(inline)]
-pub use alloy_eips::eip7702::{Authorization, OptionalNonce, SignedAuthorization};
+pub use alloy_eips::eip7702::{Authorization, SignedAuthorization};

--- a/crates/primitives/src/transaction/eip7702.rs
+++ b/crates/primitives/src/transaction/eip7702.rs
@@ -288,7 +288,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TxEip7702 {
                 alloy_eips::eip7702::Authorization {
                     chain_id: auth.chain_id,
                     address: auth.address,
-                    nonce: auth.nonce.into(),
+                    nonce: auth.nonce,
                 }
                 .into_signed(sig),
             );

--- a/crates/storage/codecs/src/alloy/authorization_list.rs
+++ b/crates/storage/codecs/src/alloy/authorization_list.rs
@@ -12,7 +12,7 @@ use reth_codecs_derive::main_codec;
 struct Authorization {
     chain_id: ChainId,
     address: Address,
-    nonce: Option<u64>,
+    nonce: u64,
 }
 
 impl Compact for AlloyAuthorization {
@@ -30,7 +30,7 @@ impl Compact for AlloyAuthorization {
         let alloy_authorization = Self {
             chain_id: authorization.chain_id,
             address: authorization.address,
-            nonce: authorization.nonce.into(),
+            nonce: authorization.nonce,
         };
         (alloy_authorization, buf)
     }
@@ -77,7 +77,7 @@ mod tests {
         let authorization = AlloyAuthorization {
             chain_id: 1,
             address: address!("dac17f958d2ee523a2206206994597c13d831ec7"),
-            nonce: None.into(),
+            nonce: 0,
         }
         .into_signed(
             alloy_primitives::Signature::from_rs_and_parity(


### PR DESCRIPTION
Nonce is no longer optional for authorizations in EIP7702.

Depends on https://github.com/alloy-rs/alloy/pull/1056 and an Alloy bump.

**Do not merge before devnet2**