### PR TITLE
feat: blockchain provider tree state integration

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -936,7 +936,7 @@ pub struct State {
     block_number: BlockNumber,
     /// State root after applying the block.
     state_root: B256,
-    /// Transactions root after applying the the block.
+    /// Transactions root of the block.
     transactions_root: B256,
     /// Receipts root after applying the the block.
     receipts_root: B256,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -974,7 +974,7 @@ mod tests {
     }
 
     fn get_default_test_harness(number_of_blocks: u64) -> TestHarness {
-        let blocks = get_executed_blocks(number_of_blocks);
+        let blocks: Vec<_> = get_executed_blocks(0..number_of_blocks).collect();
 
         let mut blocks_by_hash = HashMap::new();
         let mut blocks_by_number = BTreeMap::new();

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -924,8 +924,8 @@ trait InMemoryState {
     fn in_memory_current_head(&self) -> Option<(BlockNumber, B256)>;
     /// Returns the pending block hash.
     fn in_memory_pending_block_hash(&self) -> Option<B256>;
-    /// Returns the pending state corresponding to the current head plus one, if
-    /// we have the payload.
+    /// Returns the pending state corresponding to the current head plus one,
+    /// from the payload received in newPayload that does not have a FCU yet.
     fn in_memory_pending_state(&self) -> Option<Arc<State>>;
 }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -101,11 +101,22 @@ pub struct TreeState {
     blocks_by_hash: HashMap<B256, ExecutedBlock>,
     /// Executed blocks grouped by their respective block number.
     blocks_by_number: BTreeMap<BlockNumber, Vec<ExecutedBlock>>,
+    /// Pending state not yet applied
+    pending: Option<Arc<State>>,
+    /// Block number and hash of the current head.
+    current_head: Option<(BlockNumber, B256)>,
 }
 
 impl TreeState {
     fn block_by_hash(&self, hash: B256) -> Option<Arc<SealedBlock>> {
         self.blocks_by_hash.get(&hash).map(|b| b.block.clone())
+    }
+
+    fn block_by_number(&self, number: BlockNumber) -> Option<Arc<SealedBlock>> {
+        self.blocks_by_number
+            .get(&number)
+            .and_then(|blocks| blocks.last())
+            .map(|executed_block| executed_block.block.clone())
     }
 
     /// Insert executed block into the state.
@@ -876,6 +887,78 @@ impl PersistenceState {
     }
 }
 
+/// Represents the tree state kept in memory.
+trait InMemoryState {
+    /// Returns the state for a given block hash.
+    fn in_memory_state_by_hash(&self, hash: B256) -> Option<Arc<State>>;
+    /// Returns the state for a given block number.
+    fn in_memory_state_by_number(&self, number: u64) -> Option<Arc<State>>;
+    /// Returns the current chain head.
+    fn in_memory_current_head(&self) -> Option<(BlockNumber, B256)>;
+    /// Returns the pending block hash.
+    fn in_memory_pending_block_hash(&self) -> Option<B256>;
+    /// Returns the pending state corresponding to the current head plus one, if
+    /// we have the payload.
+    fn in_memory_pending_state(&self) -> Option<Arc<State>>;
+}
+
+/// State composed of a block hash, and the receipts, state and transactions root
+/// after executing it.
+#[derive(Debug, PartialEq, Eq)]
+pub struct State {
+    /// Block hash defining the state.
+    block_hash: B256,
+    /// Block number defining the state.
+    block_number: BlockNumber,
+    /// State root after applying the block.
+    state_root: B256,
+    /// Transactions root after applying the the block.
+    transactions_root: B256,
+    /// Receipts root after applying the the block.
+    receipts_root: B256,
+}
+
+impl State {
+    fn new(sealed_block: Arc<SealedBlock>) -> Self {
+        Self {
+            block_hash: sealed_block.hash(),
+            block_number: sealed_block.number,
+            state_root: sealed_block.state_root,
+            transactions_root: sealed_block.transactions_root,
+            receipts_root: sealed_block.receipts_root,
+        }
+    }
+}
+
+impl<P, E, T> InMemoryState for EngineApiTreeHandlerImpl<P, E, T>
+where
+    P: BlockReader + StateProviderFactory + Clone + 'static,
+    E: BlockExecutorProvider,
+    T: EngineTypes + 'static,
+{
+    fn in_memory_state_by_hash(&self, hash: B256) -> Option<Arc<State>> {
+        let sealed_block = self.state.tree_state.block_by_hash(hash)?;
+        Some(Arc::new(State::new(sealed_block)))
+    }
+
+    fn in_memory_state_by_number(&self, number: u64) -> Option<Arc<State>> {
+        let sealed_block = self.state.tree_state.block_by_number(number)?;
+        Some(Arc::new(State::new(sealed_block)))
+    }
+
+    fn in_memory_current_head(&self) -> Option<(BlockNumber, B256)> {
+        self.state.tree_state.current_head
+    }
+
+    fn in_memory_pending_state(&self) -> Option<Arc<State>> {
+        self.state.tree_state.pending.clone()
+    }
+
+    fn in_memory_pending_block_hash(&self) -> Option<B256> {
+        self.state.tree_state.pending.as_ref().map(|state| state.block_hash)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -888,14 +971,31 @@ mod tests {
     use std::sync::mpsc::{channel, Sender};
     use tokio::sync::mpsc::unbounded_channel;
 
-    #[allow(clippy::type_complexity)]
-    fn get_default_tree(
-        persistence_handle: PersistenceHandle,
-        tree_state: TreeState,
-    ) -> (
-        EngineApiTreeHandlerImpl<MockEthProvider, MockExecutorProvider, EthEngineTypes>,
-        Sender<FromEngine<BeaconEngineMessage<EthEngineTypes>>>,
-    ) {
+    struct TestHarness {
+        tree: EngineApiTreeHandlerImpl<MockEthProvider, MockExecutorProvider, EthEngineTypes>,
+        to_tree_tx: Sender<FromEngine<BeaconEngineMessage<EthEngineTypes>>>,
+        blocks: Vec<ExecutedBlock>,
+        sf_action_rx: Receiver<StaticFileAction>,
+    }
+
+    fn get_default_tree(number_of_blocks: u64) -> TestHarness {
+        let blocks: Vec<_> = get_executed_blocks(0..number_of_blocks).collect();
+
+        let mut blocks_by_hash = HashMap::new();
+        let mut blocks_by_number = BTreeMap::new();
+        for block in &blocks {
+            blocks_by_hash.insert(block.block().hash(), block.clone());
+            blocks_by_number
+                .entry(block.block().number)
+                .or_insert_with(Vec::new)
+                .push(block.clone());
+        }
+        let tree_state = TreeState { blocks_by_hash, blocks_by_number, ..Default::default() };
+
+        let (action_tx, action_rx) = channel();
+        let (sf_action_tx, sf_action_rx) = channel();
+        let persistence_handle = PersistenceHandle::new(action_tx, sf_action_tx);
+
         let chain_spec = Arc::new(
             ChainSpecBuilder::default()
                 .chain(MAINNET.chain)
@@ -921,8 +1021,8 @@ mod tests {
             forkchoice_state_tracker: ForkchoiceStateTracker::default(),
         };
 
-        (
-            EngineApiTreeHandlerImpl::new(
+        TestHarness {
+            tree: EngineApiTreeHandlerImpl::new(
                 provider,
                 executor_factory,
                 consensus,
@@ -933,34 +1033,20 @@ mod tests {
                 persistence_handle,
             ),
             to_tree_tx,
-        )
+            blocks,
+            sf_action_rx,
+        }
     }
 
     #[tokio::test]
     async fn test_tree_persist_blocks() {
         // we need more than PERSISTENCE_THRESHOLD blocks to trigger the
         // persistence task.
-        let mut blocks = get_executed_blocks(0..PERSISTENCE_THRESHOLD + 1).collect::<Vec<_>>();
-
-        let mut blocks_by_hash = HashMap::new();
-        let mut blocks_by_number = BTreeMap::new();
-        for block in &blocks {
-            blocks_by_hash.insert(block.block().hash(), block.clone());
-            blocks_by_number
-                .entry(block.block().number)
-                .or_insert_with(Vec::new)
-                .push(block.clone());
-        }
-        let tree_state = TreeState { blocks_by_hash, blocks_by_number };
-
-        let (action_tx, action_rx) = channel();
-        let (sf_action_tx, sf_action_rx) = channel();
-        let persistence_handle = PersistenceHandle::new(action_tx, sf_action_tx);
-
-        let (tree, to_tree_tx) = get_default_tree(persistence_handle, tree_state);
+        let TestHarness { tree, to_tree_tx, sf_action_rx, mut blocks } =
+            get_default_tree(PERSISTENCE_THRESHOLD + 1);
         std::thread::Builder::new().name("Tree Task".to_string()).spawn(|| tree.run()).unwrap();
 
-        // send a message to the tree
+        // send a message to the tree to enter the main loop.
         to_tree_tx.send(FromEngine::DownloadedBlocks(vec![])).unwrap();
 
         let received_action = sf_action_rx.recv().expect("Failed to receive saved blocks");
@@ -972,5 +1058,21 @@ mod tests {
         } else {
             panic!("unexpected action received {received_action:?}");
         }
+    }
+
+    #[test]
+    fn test_in_memory_state_trait_impl() {
+        let TestHarness { tree, to_tree_tx, sf_action_rx, blocks } = get_default_tree(10);
+
+        let head_block = blocks.last().unwrap().block();
+
+        let expected_head_state = State::new(Arc::new(head_block.clone()));
+
+        let actual_head_state_by_hash = tree.in_memory_state_by_hash(head_block.hash()).unwrap();
+        assert_eq!(expected_head_state, *actual_head_state_by_hash);
+
+        let actual_head_state_by_number =
+            tree.in_memory_state_by_number(head_block.number).unwrap();
+        assert_eq!(expected_head_state, *actual_head_state_by_number);
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -938,7 +938,7 @@ pub struct State {
     state_root: B256,
     /// Transactions root of the block.
     transactions_root: B256,
-    /// Receipts root after applying the the block.
+    /// Receipts root after applying the block.
     receipts_root: B256,
 }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -932,9 +932,7 @@ impl State {
 
 impl<P, E, T> InMemoryState for EngineApiTreeHandlerImpl<P, E, T>
 where
-    P: BlockReader + StateProviderFactory + Clone + 'static,
-    E: BlockExecutorProvider,
-    T: EngineTypes + 'static,
+    T: EngineTypes,
 {
     fn in_memory_state_by_hash(&self, hash: B256) -> Option<Arc<State>> {
         let sealed_block = self.state.tree_state.block_by_hash(hash)?;

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -75,7 +75,7 @@ pub struct BlockchainProvider<DB> {
     /// Tracks the chain info wrt forkchoice updates
     chain_info: ChainInfoTracker,
     // TODO: In-memory state for recent blocks and pending state.
-    //in_memory_state: Arc<RwLock<dyn InMemoryState>>,
+    //in_memory_state: Arc<dyn InMemoryState>,
 }
 
 impl<DB> Clone for BlockchainProvider<DB> {
@@ -97,7 +97,7 @@ impl<DB> BlockchainProvider<DB> {
         database: ProviderFactory<DB>,
         tree: Arc<dyn TreeViewer>,
         // TODO: add in_memory_state
-        // in_memory_state: Arc<RwLock<dyn InMemoryState>>,
+        // in_memory_state: Arc<dyn InMemoryState>,
         latest: SealedHeader,
     ) -> Self {
         Self {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -74,6 +74,8 @@ pub struct BlockchainProvider<DB> {
     tree: Arc<dyn TreeViewer>,
     /// Tracks the chain info wrt forkchoice updates
     chain_info: ChainInfoTracker,
+    // TODO: In-memory state for recent blocks and pending state.
+    //in_memory_state: Arc<RwLock<dyn InMemoryState>>,
 }
 
 impl<DB> Clone for BlockchainProvider<DB> {
@@ -82,6 +84,8 @@ impl<DB> Clone for BlockchainProvider<DB> {
             database: self.database.clone(),
             tree: self.tree.clone(),
             chain_info: self.chain_info.clone(),
+            // TODO: add in_memory_state
+            // in_memory_state: self.in_memory_state.clone(),
         }
     }
 }
@@ -92,9 +96,17 @@ impl<DB> BlockchainProvider<DB> {
     pub fn with_latest(
         database: ProviderFactory<DB>,
         tree: Arc<dyn TreeViewer>,
+        // TODO: add in_memory_state
+        // in_memory_state: Arc<RwLock<dyn InMemoryState>>,
         latest: SealedHeader,
     ) -> Self {
-        Self { database, tree, chain_info: ChainInfoTracker::new(latest) }
+        Self {
+            database,
+            tree,
+            // TODO: add in_memory_state
+            // in_memory_state,
+            chain_info: ChainInfoTracker::new(latest),
+        }
     }
 
     /// Sets the treeviewer for the provider.


### PR DESCRIPTION
Towards #8747

Scaffolds `InMemoryState` trait and implements it for `EngineApiTreeHandlerImpl`.  `TreeState` is updated to include `pending` and `current_head` data. 

For now in `BlockchainProvider` there are only references to the field that will provide this state. 