### PR TITLE
feat(pruner, stages): logs for Prune stage

### DIFF
--- a/crates/engine/tree/src/database.rs
+++ b/crates/engine/tree/src/database.rs
@@ -8,7 +8,7 @@ use reth_provider::{
     bundle_state::HashedStateChanges, BlockWriter, HistoryWriter, OriginalValuesKnown,
     ProviderFactory, StageCheckpointWriter, StateWriter,
 };
-use reth_prune::{PruneProgress, Pruner};
+use reth_prune::{Pruner, PrunerOutput};
 use reth_stages_types::{StageCheckpoint, StageId};
 use std::sync::mpsc::{Receiver, SendError, Sender};
 use tokio::sync::oneshot;
@@ -117,7 +117,7 @@ impl<DB: Database> DatabaseService<DB> {
 
     /// Prunes block data before the given block hash according to the configured prune
     /// configuration.
-    fn prune_before(&mut self, block_num: u64) -> PruneProgress {
+    fn prune_before(&mut self, block_num: u64) -> PrunerOutput {
         // TODO: doing this properly depends on pruner segment changes
         self.pruner.run(block_num).expect("todo: handle errors")
     }
@@ -200,7 +200,7 @@ pub enum DatabaseAction {
 
     /// Prune associated block data before the given block number, according to already-configured
     /// prune modes.
-    PruneBefore((u64, oneshot::Sender<PruneProgress>)),
+    PruneBefore((u64, oneshot::Sender<PrunerOutput>)),
 }
 
 /// A handle to the database service
@@ -245,7 +245,7 @@ impl DatabaseServiceHandle {
 
     /// Tells the database service to remove block data before the given hash, according to the
     /// configured prune config.
-    pub async fn prune_before(&self, block_num: u64) -> PruneProgress {
+    pub async fn prune_before(&self, block_num: u64) -> PrunerOutput {
         let (tx, rx) = oneshot::channel();
         self.sender
             .send(DatabaseAction::PruneBefore((block_num, tx)))

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -8,7 +8,7 @@ use crate::{
 use reth_db::Database;
 use reth_primitives::{SealedBlock, B256, U256};
 use reth_provider::ProviderFactory;
-use reth_prune::{PruneProgress, Pruner};
+use reth_prune::{Pruner, PrunerOutput};
 use std::sync::{
     mpsc::{SendError, Sender},
     Arc,
@@ -36,7 +36,7 @@ pub enum PersistenceAction {
 
     /// Prune associated block data before the given block number, according to already-configured
     /// prune modes.
-    PruneBefore((u64, oneshot::Sender<PruneProgress>)),
+    PruneBefore((u64, oneshot::Sender<PrunerOutput>)),
 }
 
 /// An error type for when there is a [`SendError`] while sending an action to one of the services.
@@ -172,7 +172,7 @@ impl PersistenceHandle {
 
     /// Tells the persistence service to remove block data before the given hash, according to the
     /// configured prune config.
-    pub async fn prune_before(&self, block_num: u64) -> PruneProgress {
+    pub async fn prune_before(&self, block_num: u64) -> PrunerOutput {
         let (tx, rx) = oneshot::channel();
         self.send_action(PersistenceAction::PruneBefore((block_num, tx)))
             .expect("should be able to send");

--- a/crates/prune/prune/src/segments/static_file/receipts.rs
+++ b/crates/prune/prune/src/segments/static_file/receipts.rs
@@ -1,12 +1,12 @@
 use crate::{
-    segments::{PruneInput, PruneOutput, Segment},
+    segments::{PruneInput, Segment},
     PrunerError,
 };
 use reth_db_api::database::Database;
 use reth_provider::{
     errors::provider::ProviderResult, providers::StaticFileProvider, DatabaseProviderRW,
 };
-use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
+use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 use reth_static_file_types::StaticFileSegment;
 
 #[derive(Debug)]
@@ -39,7 +39,7 @@ impl<DB: Database> Segment<DB> for Receipts {
         &self,
         provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
-    ) -> Result<PruneOutput, PrunerError> {
+    ) -> Result<SegmentOutput, PrunerError> {
         crate::segments::receipts::prune(provider, input)
     }
 

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -66,7 +66,7 @@ impl<DB: Database> Segment<DB> for AccountHistory {
         if limiter.is_limit_reached() {
             return Ok(SegmentOutput::not_done(
                 PruneInterruptReason::new(&limiter),
-                input.previous_checkpoint.map(|checkpoint| checkpoint.into()),
+                input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
             ))
         }
 

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -1,8 +1,5 @@
 use crate::{
-    segments::{
-        user::history::prune_history_indices, PruneInput, PruneOutput, PruneOutputCheckpoint,
-        Segment,
-    },
+    segments::{user::history::prune_history_indices, PruneInput, Segment},
     PrunerError,
 };
 use itertools::Itertools;
@@ -10,7 +7,8 @@ use reth_db::tables;
 use reth_db_api::{database::Database, models::ShardedKey};
 use reth_provider::DatabaseProviderRW;
 use reth_prune_types::{
-    PruneInterruptReason, PruneMode, PruneProgress, PrunePurpose, PruneSegment,
+    PruneInterruptReason, PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput,
+    SegmentOutputCheckpoint,
 };
 use rustc_hash::FxHashMap;
 use tracing::{instrument, trace};
@@ -50,12 +48,12 @@ impl<DB: Database> Segment<DB> for AccountHistory {
         &self,
         provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
-    ) -> Result<PruneOutput, PrunerError> {
+    ) -> Result<SegmentOutput, PrunerError> {
         let range = match input.get_next_block_range() {
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No account history to prune");
-                return Ok(PruneOutput::done())
+                return Ok(SegmentOutput::done())
             }
         };
         let range_end = *range.end();
@@ -66,7 +64,7 @@ impl<DB: Database> Segment<DB> for AccountHistory {
             input.limiter
         };
         if limiter.is_limit_reached() {
-            return Ok(PruneOutput::not_done(
+            return Ok(SegmentOutput::not_done(
                 PruneInterruptReason::new(&limiter),
                 input.previous_checkpoint.map(|checkpoint| checkpoint.into()),
             ))
@@ -117,10 +115,10 @@ impl<DB: Database> Segment<DB> for AccountHistory {
 
         let progress = PruneProgress::new(done, &limiter);
 
-        Ok(PruneOutput {
+        Ok(SegmentOutput {
             progress,
             pruned: pruned_changesets + outcomes.deleted,
-            checkpoint: Some(PruneOutputCheckpoint {
+            checkpoint: Some(SegmentOutputCheckpoint {
                 block_number: Some(last_changeset_pruned_block),
                 tx_number: None,
             }),
@@ -132,7 +130,7 @@ impl<DB: Database> Segment<DB> for AccountHistory {
 mod tests {
     use crate::segments::{
         user::account_history::ACCOUNT_HISTORY_TABLES_TO_PRUNE, AccountHistory, PruneInput,
-        PruneOutput, Segment,
+        Segment, SegmentOutput,
     };
     use alloy_primitives::{BlockNumber, B256};
     use assert_matches::assert_matches;
@@ -208,7 +206,7 @@ mod tests {
 
                 assert_matches!(
                     result,
-                    PruneOutput {progress, pruned, checkpoint: Some(_)}
+                    SegmentOutput {progress, pruned, checkpoint: Some(_)}
                         if (progress, pruned) == expected_result
                 );
 

--- a/crates/prune/prune/src/segments/user/receipts.rs
+++ b/crates/prune/prune/src/segments/user/receipts.rs
@@ -1,10 +1,10 @@
 use crate::{
-    segments::{PruneInput, PruneOutput, Segment},
+    segments::{PruneInput, Segment},
     PrunerError,
 };
 use reth_db_api::database::Database;
 use reth_provider::{errors::provider::ProviderResult, DatabaseProviderRW};
-use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
+use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 use tracing::instrument;
 
 #[derive(Debug)]
@@ -36,7 +36,7 @@ impl<DB: Database> Segment<DB> for Receipts {
         &self,
         provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
-    ) -> Result<PruneOutput, PrunerError> {
+    ) -> Result<SegmentOutput, PrunerError> {
         crate::segments::receipts::prune(provider, input)
     }
 

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -1,5 +1,5 @@
 use crate::{
-    segments::{PruneInput, PruneOutput, Segment},
+    segments::{PruneInput, Segment},
     PrunerError,
 };
 use reth_db::tables;
@@ -7,7 +7,7 @@ use reth_db_api::database::Database;
 use reth_provider::{BlockReader, DatabaseProviderRW, PruneCheckpointWriter, TransactionsProvider};
 use reth_prune_types::{
     PruneCheckpoint, PruneMode, PruneProgress, PrunePurpose, PruneSegment, ReceiptsLogPruneConfig,
-    MINIMUM_PRUNING_DISTANCE,
+    SegmentOutput, MINIMUM_PRUNING_DISTANCE,
 };
 use tracing::{instrument, trace};
 
@@ -40,7 +40,7 @@ impl<DB: Database> Segment<DB> for ReceiptsByLogs {
         &self,
         provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
-    ) -> Result<PruneOutput, PrunerError> {
+    ) -> Result<SegmentOutput, PrunerError> {
         // Contract log filtering removes every receipt possible except the ones in the list. So,
         // for the other receipts it's as if they had a `PruneMode::Distance()` of
         // `MINIMUM_PRUNING_DISTANCE`.
@@ -213,7 +213,7 @@ impl<DB: Database> Segment<DB> for ReceiptsByLogs {
 
         let progress = PruneProgress::new(done, &limiter);
 
-        Ok(PruneOutput { progress, pruned, checkpoint: None })
+        Ok(SegmentOutput { progress, pruned, checkpoint: None })
     }
 }
 

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -69,7 +69,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
         if limiter.is_limit_reached() {
             return Ok(SegmentOutput::not_done(
                 PruneInterruptReason::new(&limiter),
-                input.previous_checkpoint.map(|checkpoint| checkpoint.into()),
+                input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
             ))
         }
 

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -1,8 +1,5 @@
 use crate::{
-    segments::{
-        user::history::prune_history_indices, PruneInput, PruneOutput, PruneOutputCheckpoint,
-        Segment,
-    },
+    segments::{user::history::prune_history_indices, PruneInput, Segment, SegmentOutput},
     PrunerError,
 };
 use itertools::Itertools;
@@ -14,6 +11,7 @@ use reth_db_api::{
 use reth_provider::DatabaseProviderRW;
 use reth_prune_types::{
     PruneInterruptReason, PruneMode, PruneProgress, PrunePurpose, PruneSegment,
+    SegmentOutputCheckpoint,
 };
 use rustc_hash::FxHashMap;
 use tracing::{instrument, trace};
@@ -53,12 +51,12 @@ impl<DB: Database> Segment<DB> for StorageHistory {
         &self,
         provider: &DatabaseProviderRW<DB>,
         input: PruneInput,
-    ) -> Result<PruneOutput, PrunerError> {
+    ) -> Result<SegmentOutput, PrunerError> {
         let range = match input.get_next_block_range() {
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No storage history to prune");
-                return Ok(PruneOutput::done())
+                return Ok(SegmentOutput::done())
             }
         };
         let range_end = *range.end();
@@ -69,7 +67,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
             input.limiter
         };
         if limiter.is_limit_reached() {
-            return Ok(PruneOutput::not_done(
+            return Ok(SegmentOutput::not_done(
                 PruneInterruptReason::new(&limiter),
                 input.previous_checkpoint.map(|checkpoint| checkpoint.into()),
             ))
@@ -125,10 +123,10 @@ impl<DB: Database> Segment<DB> for StorageHistory {
 
         let progress = PruneProgress::new(done, &limiter);
 
-        Ok(PruneOutput {
+        Ok(SegmentOutput {
             progress,
             pruned: pruned_changesets + outcomes.deleted,
-            checkpoint: Some(PruneOutputCheckpoint {
+            checkpoint: Some(SegmentOutputCheckpoint {
                 block_number: Some(last_changeset_pruned_block),
                 tx_number: None,
             }),
@@ -139,7 +137,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
 #[cfg(test)]
 mod tests {
     use crate::segments::{
-        user::storage_history::STORAGE_HISTORY_TABLES_TO_PRUNE, PruneInput, PruneOutput, Segment,
+        user::storage_history::STORAGE_HISTORY_TABLES_TO_PRUNE, PruneInput, Segment, SegmentOutput,
         StorageHistory,
     };
     use alloy_primitives::{BlockNumber, B256};
@@ -215,7 +213,7 @@ mod tests {
 
             assert_matches!(
                 result,
-                PruneOutput {progress, pruned, checkpoint: Some(_)}
+                SegmentOutput {progress, pruned, checkpoint: Some(_)}
                     if (progress, pruned) == expected_result
             );
 

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -11,12 +11,16 @@
 mod checkpoint;
 mod limiter;
 mod mode;
+mod pruner;
 mod segment;
 mod target;
 
 pub use checkpoint::PruneCheckpoint;
 pub use limiter::PruneLimiter;
 pub use mode::PruneMode;
+pub use pruner::{
+    PruneInterruptReason, PruneProgress, PrunerOutput, SegmentOutput, SegmentOutputCheckpoint,
+};
 pub use segment::{PrunePurpose, PruneSegment, PruneSegmentError};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -97,68 +101,5 @@ impl ReceiptsLogPruneConfig {
         }
 
         Ok(lowest.map(|lowest| lowest.max(pruned_block)))
-    }
-}
-
-/// Progress of pruning.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum PruneProgress {
-    /// There is more data to prune.
-    HasMoreData(PruneInterruptReason),
-    /// Pruning has been finished.
-    Finished,
-}
-
-/// Reason for interrupting a prune run.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum PruneInterruptReason {
-    /// Prune run timed out.
-    Timeout,
-    /// Limit on the number of deleted entries (rows in the database) per prune run was reached.
-    DeletedEntriesLimitReached,
-    /// Unknown reason for stopping prune run.
-    Unknown,
-}
-
-impl PruneInterruptReason {
-    /// Creates new [`PruneInterruptReason`] based on the [`PruneLimiter`].
-    pub fn new(limiter: &PruneLimiter) -> Self {
-        if limiter.is_time_limit_reached() {
-            Self::Timeout
-        } else if limiter.is_deleted_entries_limit_reached() {
-            Self::DeletedEntriesLimitReached
-        } else {
-            Self::Unknown
-        }
-    }
-
-    /// Returns `true` if the reason is timeout.
-    pub const fn is_timeout(&self) -> bool {
-        matches!(self, Self::Timeout)
-    }
-
-    /// Returns `true` if the reason is reaching the limit on deleted entries.
-    pub const fn is_entries_limit_reached(&self) -> bool {
-        matches!(self, Self::DeletedEntriesLimitReached)
-    }
-}
-
-impl PruneProgress {
-    /// Creates new [`PruneProgress`].
-    ///
-    /// If `done == true`, returns [`PruneProgress::Finished`], otherwise
-    /// [`PruneProgress::HasMoreData`] is returned with [`PruneInterruptReason`] according to the
-    /// passed limiter.
-    pub fn new(done: bool, limiter: &PruneLimiter) -> Self {
-        if done {
-            Self::Finished
-        } else {
-            Self::HasMoreData(PruneInterruptReason::new(limiter))
-        }
-    }
-
-    /// Returns `true` if prune run is finished.
-    pub const fn is_finished(&self) -> bool {
-        matches!(self, Self::Finished)
     }
 }

--- a/crates/prune/types/src/pruner.rs
+++ b/crates/prune/types/src/pruner.rs
@@ -2,9 +2,12 @@ use alloy_primitives::{BlockNumber, TxNumber};
 
 use crate::{PruneCheckpoint, PruneLimiter, PruneMode, PruneSegment};
 
+/// Pruner run output.
 #[derive(Debug)]
 pub struct PrunerOutput {
+    /// Pruning progress.
     pub progress: PruneProgress,
+    /// Pruning output for each segment.
     pub segments: Vec<(PruneSegment, SegmentOutput)>,
 }
 
@@ -14,9 +17,10 @@ impl From<PruneProgress> for PrunerOutput {
     }
 }
 
-/// Segment pruning output, see [`Segment::prune`].
+/// Segment pruning output.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct SegmentOutput {
+    /// Segment pruning progress.
     pub progress: PruneProgress,
     /// Number of entries pruned, i.e. deleted from the database.
     pub pruned: usize,
@@ -41,6 +45,7 @@ impl SegmentOutput {
     }
 }
 
+/// Segment pruning checkpoint.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub struct SegmentOutputCheckpoint {
     /// Highest pruned block number. If it's [None], the pruning for block `0` is not finished yet.

--- a/crates/prune/types/src/pruner.rs
+++ b/crates/prune/types/src/pruner.rs
@@ -1,0 +1,126 @@
+use alloy_primitives::{BlockNumber, TxNumber};
+
+use crate::{PruneCheckpoint, PruneLimiter, PruneMode, PruneSegment};
+
+#[derive(Debug)]
+pub struct PrunerOutput {
+    pub progress: PruneProgress,
+    pub segments: Vec<(PruneSegment, SegmentOutput)>,
+}
+
+impl From<PruneProgress> for PrunerOutput {
+    fn from(progress: PruneProgress) -> Self {
+        Self { progress, segments: Vec::new() }
+    }
+}
+
+/// Segment pruning output, see [`Segment::prune`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct SegmentOutput {
+    pub progress: PruneProgress,
+    /// Number of entries pruned, i.e. deleted from the database.
+    pub pruned: usize,
+    /// Pruning checkpoint to save to database, if any.
+    pub checkpoint: Option<SegmentOutputCheckpoint>,
+}
+
+impl SegmentOutput {
+    /// Returns a [`SegmentOutput`] with `done = true`, `pruned = 0` and `checkpoint = None`.
+    /// Use when no pruning is needed.
+    pub const fn done() -> Self {
+        Self { progress: PruneProgress::Finished, pruned: 0, checkpoint: None }
+    }
+
+    /// Returns a [`SegmentOutput`] with `done = false`, `pruned = 0` and `checkpoint = None`.
+    /// Use when pruning is needed but cannot be done.
+    pub const fn not_done(
+        reason: PruneInterruptReason,
+        checkpoint: Option<SegmentOutputCheckpoint>,
+    ) -> Self {
+        Self { progress: PruneProgress::HasMoreData(reason), pruned: 0, checkpoint }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct SegmentOutputCheckpoint {
+    /// Highest pruned block number. If it's [None], the pruning for block `0` is not finished yet.
+    pub block_number: Option<BlockNumber>,
+    /// Highest pruned transaction number, if applicable.
+    pub tx_number: Option<TxNumber>,
+}
+
+impl SegmentOutputCheckpoint {
+    /// Converts [`SegmentOutputCheckpoint`] to [`PruneCheckpoint`] with the provided [`PruneMode`]
+    pub const fn as_prune_checkpoint(&self, prune_mode: PruneMode) -> PruneCheckpoint {
+        PruneCheckpoint { block_number: self.block_number, tx_number: self.tx_number, prune_mode }
+    }
+}
+
+impl From<PruneCheckpoint> for SegmentOutputCheckpoint {
+    fn from(checkpoint: PruneCheckpoint) -> Self {
+        Self { block_number: checkpoint.block_number, tx_number: checkpoint.tx_number }
+    }
+}
+
+/// Progress of pruning.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum PruneProgress {
+    /// There is more data to prune.
+    HasMoreData(PruneInterruptReason),
+    /// Pruning has been finished.
+    Finished,
+}
+
+/// Reason for interrupting a prune run.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum PruneInterruptReason {
+    /// Prune run timed out.
+    Timeout,
+    /// Limit on the number of deleted entries (rows in the database) per prune run was reached.
+    DeletedEntriesLimitReached,
+    /// Unknown reason for stopping prune run.
+    Unknown,
+}
+
+impl PruneInterruptReason {
+    /// Creates new [`PruneInterruptReason`] based on the [`PruneLimiter`].
+    pub fn new(limiter: &PruneLimiter) -> Self {
+        if limiter.is_time_limit_reached() {
+            Self::Timeout
+        } else if limiter.is_deleted_entries_limit_reached() {
+            Self::DeletedEntriesLimitReached
+        } else {
+            Self::Unknown
+        }
+    }
+
+    /// Returns `true` if the reason is timeout.
+    pub const fn is_timeout(&self) -> bool {
+        matches!(self, Self::Timeout)
+    }
+
+    /// Returns `true` if the reason is reaching the limit on deleted entries.
+    pub const fn is_entries_limit_reached(&self) -> bool {
+        matches!(self, Self::DeletedEntriesLimitReached)
+    }
+}
+
+impl PruneProgress {
+    /// Creates new [`PruneProgress`].
+    ///
+    /// If `done == true`, returns [`PruneProgress::Finished`], otherwise
+    /// [`PruneProgress::HasMoreData`] is returned with [`PruneInterruptReason`] according to the
+    /// passed limiter.
+    pub fn new(done: bool, limiter: &PruneLimiter) -> Self {
+        if done {
+            Self::Finished
+        } else {
+            Self::HasMoreData(PruneInterruptReason::new(limiter))
+        }
+    }
+
+    /// Returns `true` if prune run is finished.
+    pub const fn is_finished(&self) -> bool {
+        matches!(self, Self::Finished)
+    }
+}

--- a/crates/prune/types/src/pruner.rs
+++ b/crates/prune/types/src/pruner.rs
@@ -55,15 +55,14 @@ pub struct SegmentOutputCheckpoint {
 }
 
 impl SegmentOutputCheckpoint {
+    /// Converts [`PruneCheckpoint`] to [`SegmentOutputCheckpoint`].
+    pub const fn from_prune_checkpoint(checkpoint: PruneCheckpoint) -> Self {
+        Self { block_number: checkpoint.block_number, tx_number: checkpoint.tx_number }
+    }
+
     /// Converts [`SegmentOutputCheckpoint`] to [`PruneCheckpoint`] with the provided [`PruneMode`]
     pub const fn as_prune_checkpoint(&self, prune_mode: PruneMode) -> PruneCheckpoint {
         PruneCheckpoint { block_number: self.block_number, tx_number: self.tx_number, prune_mode }
-    }
-}
-
-impl From<PruneCheckpoint> for SegmentOutputCheckpoint {
-    fn from(checkpoint: PruneCheckpoint) -> Self {
-        Self { block_number: checkpoint.block_number, tx_number: checkpoint.tx_number }
     }
 }
 

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -46,9 +46,10 @@ impl<DB: Database> Stage<DB> for PruneStage {
             .build(provider.static_file_provider().clone());
 
         let result = pruner.run(provider, input.target())?;
-        if result.is_finished() {
+        if result.progress.is_finished() {
             Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
         } else {
+            info!(target: "sync::stages::prune::exec", segments = ?result.segments, "Pruner has more data to prune");
             // We cannot set the checkpoint yet, because prune segments may have different highest
             // pruned block numbers
             Ok(ExecOutput { checkpoint: input.checkpoint(), done: false })


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/9515

The change itself is just this line https://github.com/paradigmxyz/reth/blob/2dc3677fcd078e63d2677cb56da388eb66ccb3d8/crates/stages/stages/src/stages/prune.rs#L52

But I also needed to introduce a better output for the `Pruner::run`, which required juggling the pruner types around two crates.