### PR TITLE
fix: commit receipts in write_execution_data

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -183,7 +183,7 @@ impl PersistenceHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::get_executed_block_with_number;
+    use crate::test_utils::{get_executed_block_with_number, get_executed_blocks};
     use reth_exex_types::FinishedExExHeight;
     use reth_primitives::B256;
     use reth_provider::{test_utils::create_test_provider_factory, ProviderFactory};
@@ -223,7 +223,7 @@ mod tests {
     #[tokio::test]
     async fn test_save_blocks_single_block() {
         let persistence_handle = default_persistence_handle();
-        let block_number = 5;
+        let block_number = 0;
         let executed = get_executed_block_with_number(block_number);
         let block_hash = executed.block().hash();
 
@@ -234,5 +234,19 @@ mod tests {
 
         let actual_hash = rx.await.unwrap();
         assert_eq!(block_hash, actual_hash);
+    }
+
+    #[tokio::test]
+    async fn test_save_blocks_multiple_blocks() {
+        let persistence_handle = default_persistence_handle();
+
+        let blocks = get_executed_blocks(0..5).collect::<Vec<_>>();
+        let last_hash = blocks.last().unwrap().block().hash();
+        let (tx, rx) = oneshot::channel();
+
+        persistence_handle.save_blocks(blocks, tx);
+
+        let actual_hash = rx.await.unwrap();
+        assert_eq!(last_hash, actual_hash);
     }
 }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -249,4 +249,21 @@ mod tests {
         let actual_hash = rx.await.unwrap();
         assert_eq!(last_hash, actual_hash);
     }
+
+    #[tokio::test]
+    async fn test_save_blocks_multiple_calls() {
+        let persistence_handle = default_persistence_handle();
+
+        let ranges = [0..1, 1..2, 2..4, 4..5];
+        for range in ranges {
+            let blocks = get_executed_blocks(range).collect::<Vec<_>>();
+            let last_hash = blocks.last().unwrap().block().hash();
+            let (tx, rx) = oneshot::channel();
+
+            persistence_handle.save_blocks(blocks, tx);
+
+            let actual_hash = rx.await.unwrap();
+            assert_eq!(last_hash, actual_hash);
+        }
+    }
 }

--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -75,13 +75,12 @@ where
             tx_number += 1;
         }
 
-        // increment block for both segments
-        header_writer.increment_block(StaticFileSegment::Headers, block.number)?;
+        // increment block for transactions
         transactions_writer.increment_block(StaticFileSegment::Transactions, block.number)?;
 
         // finally commit
-        header_writer.commit()?;
         transactions_writer.commit()?;
+        header_writer.commit()?;
 
         // TODO: do we care about the mpsc error here?
         // send a command to the db service to update the checkpoints for headers / bodies
@@ -123,6 +122,10 @@ where
                 receipts_writer.append_receipt(num, receipt.clone())?;
             }
         }
+
+        // finally increment block and commit
+        receipts_writer.increment_block(StaticFileSegment::Receipts, last_block.number)?;
+        receipts_writer.commit()?;
 
         // TODO: do we care about the mpsc error here?
         // send a command to the db service to update the checkpoints for execution etc.

--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -109,6 +109,10 @@ where
         let first_block = blocks.first().unwrap().block();
         let last_block = blocks.last().unwrap().block();
 
+        // get highest tx, if it returns none, use zero (this is the first static file write)
+        let highest_tx =
+            provider.get_highest_static_file_tx(StaticFileSegment::Receipts).unwrap_or_default();
+
         let mut receipts_writer =
             provider.get_writer(first_block.number, StaticFileSegment::Receipts)?;
         for (num, receipts) in blocks

--- a/crates/engine/tree/src/test_utils.rs
+++ b/crates/engine/tree/src/test_utils.rs
@@ -108,6 +108,6 @@ pub(crate) fn get_executed_block_with_number(block_number: BlockNumber) -> Execu
     )
 }
 
-pub(crate) fn get_executed_blocks(number: u64) -> Vec<ExecutedBlock> {
-    (1..=number).map(get_executed_block_with_number).collect()
+pub(crate) fn get_executed_blocks(range: Range<u64>) -> impl Iterator<Item = ExecutedBlock> {
+    range.map(get_executed_block_with_number)
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -44,7 +44,7 @@ use tracing::*;
 mod memory_overlay;
 pub use memory_overlay::MemoryOverlayStateProvider;
 
-/// Maximum number of blocks to be kept in memory without triggering persistence.
+/// Maximum number of blocks to be kept only in memory without triggering persistence.
 const PERSISTENCE_THRESHOLD: u64 = 256;
 
 /// Represents an executed block stored in-memory.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -393,17 +393,18 @@ where
     }
 
     /// Returns true if the canonical chain length minus the last persisted
-    /// block is more than the persistence threshold.
+    /// block is greater than or equal to the persistence threshold.
     fn should_persist(&self) -> bool {
         self.state.tree_state.max_block_number() -
-            self.persistence_state.last_persisted_block_number >
+            self.persistence_state.last_persisted_block_number >=
             PERSISTENCE_THRESHOLD
     }
 
     fn get_blocks_to_persist(&self) -> Vec<ExecutedBlock> {
-        let start = self.persistence_state.last_persisted_block_number + 1;
+        let start = self.persistence_state.last_persisted_block_number;
         let end = start + PERSISTENCE_THRESHOLD;
 
+        // NOTE: this is an exclusive range, to try to include exactly PERSISTENCE_THRESHOLD blocks
         self.state
             .tree_state
             .blocks_by_number
@@ -939,7 +940,7 @@ mod tests {
     async fn test_tree_persist_blocks() {
         // we need more than PERSISTENCE_THRESHOLD blocks to trigger the
         // persistence task.
-        let mut blocks = get_executed_blocks(PERSISTENCE_THRESHOLD + 1);
+        let mut blocks = get_executed_blocks(0..PERSISTENCE_THRESHOLD + 1).collect::<Vec<_>>();
 
         let mut blocks_by_hash = HashMap::new();
         let mut blocks_by_number = BTreeMap::new();
@@ -966,8 +967,8 @@ mod tests {
         if let StaticFileAction::WriteExecutionData((saved_blocks, _)) = received_action {
             // only PERSISTENCE_THRESHOLD will be persisted
             blocks.pop();
-            assert_eq!(saved_blocks, blocks);
             assert_eq!(saved_blocks.len() as u64, PERSISTENCE_THRESHOLD);
+            assert_eq!(saved_blocks, blocks);
         } else {
             panic!("unexpected action received {received_action:?}");
         }


### PR DESCRIPTION
The receipts were not actually committed, `increment_block` was not called, and there was a redundant `increment_block` included when writing headers.