### PR TITLE
feat(stages): unwind prune checkpoints

### DIFF
--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -1,5 +1,5 @@
 use reth_db_api::database::Database;
-use reth_provider::{DatabaseProviderRW, PruneCheckpointReader};
+use reth_provider::{DatabaseProviderRW, PruneCheckpointReader, PruneCheckpointWriter};
 use reth_prune::{PruneMode, PruneModes, PruneSegment, PrunerBuilder};
 use reth_stages_api::{
     ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
@@ -58,10 +58,16 @@ impl<DB: Database> Stage<DB> for PruneStage {
 
     fn unwind(
         &mut self,
-        _provider: &DatabaseProviderRW<DB>,
+        provider: &DatabaseProviderRW<DB>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        info!(target: "sync::stages::prune::unwind", "Stage is always skipped");
+        // We cannot recover the data that was pruned in `execute`, so we just update the
+        // checkpoints.
+        let prune_checkpoints = provider.get_prune_checkpoints()?;
+        for (segment, mut checkpoint) in prune_checkpoints {
+            checkpoint.block_number = Some(input.unwind_to);
+            provider.save_prune_checkpoint(segment, checkpoint)?;
+        }
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
     }
 }

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -49,7 +49,9 @@ impl<DB: Database> Stage<DB> for PruneStage {
         if result.progress.is_finished() {
             Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
         } else {
-            info!(target: "sync::stages::prune::exec", segments = ?result.segments, "Pruner has more data to prune");
+            if let Some(last_segment) = result.segments.last() {
+                info!(target: "sync::stages::prune::exec", ?last_segment, "Pruner has more data to prune");
+            }
             // We cannot set the checkpoint yet, because prune segments may have different highest
             // pruned block numbers
             Ok(ExecOutput { checkpoint: input.checkpoint(), done: false })

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -582,6 +582,10 @@ impl<DB: Database> PruneCheckpointReader for ProviderFactory<DB> {
     ) -> ProviderResult<Option<PruneCheckpoint>> {
         self.provider()?.get_prune_checkpoint(segment)
     }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        self.provider()?.get_prune_checkpoints()
+    }
 }
 
 impl<DB> Clone for ProviderFactory<DB> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3327,6 +3327,14 @@ impl<TX: DbTx> PruneCheckpointReader for DatabaseProvider<TX> {
     ) -> ProviderResult<Option<PruneCheckpoint>> {
         Ok(self.tx.get::<tables::PruneCheckpoints>(segment)?)
     }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        Ok(self
+            .tx
+            .cursor_read::<tables::PruneCheckpoints>()?
+            .walk(None)?
+            .collect::<Result<_, _>>()?)
+    }
 }
 
 impl<TX: DbTxMut> PruneCheckpointWriter for DatabaseProvider<TX> {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -581,6 +581,10 @@ where
     ) -> ProviderResult<Option<PruneCheckpoint>> {
         self.database.provider()?.get_prune_checkpoint(segment)
     }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        self.database.provider()?.get_prune_checkpoints()
+    }
 }
 
 impl<DB> ChainSpecProvider for BlockchainProvider<DB>

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -474,6 +474,10 @@ impl PruneCheckpointReader for NoopProvider {
     ) -> ProviderResult<Option<PruneCheckpoint>> {
         Ok(None)
     }
+
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>> {
+        Ok(Vec::new())
+    }
 }
 
 impl StaticFileProviderFactory for NoopProvider {

--- a/crates/storage/storage-api/src/prune_checkpoint.rs
+++ b/crates/storage/storage-api/src/prune_checkpoint.rs
@@ -4,13 +4,13 @@ use reth_storage_errors::provider::ProviderResult;
 /// The trait for fetching prune checkpoint related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait PruneCheckpointReader: Send + Sync {
-    /// Fetch the checkpoint for the given prune segment.
+    /// Fetch the prune checkpoint for the given segment.
     fn get_prune_checkpoint(
         &self,
         segment: PruneSegment,
     ) -> ProviderResult<Option<PruneCheckpoint>>;
 
-    /// Fetch all the checkpoints.
+    /// Fetch all the prune checkpoints.
     fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>>;
 }
 

--- a/crates/storage/storage-api/src/prune_checkpoint.rs
+++ b/crates/storage/storage-api/src/prune_checkpoint.rs
@@ -9,6 +9,9 @@ pub trait PruneCheckpointReader: Send + Sync {
         &self,
         segment: PruneSegment,
     ) -> ProviderResult<Option<PruneCheckpoint>>;
+
+    /// Fetch all the checkpoints.
+    fn get_prune_checkpoints(&self) -> ProviderResult<Vec<(PruneSegment, PruneCheckpoint)>>;
 }
 
 /// The trait for updating prune checkpoint related data.


### PR DESCRIPTION
This PR implements the unwind functionality of the Prune stage. It's quite simple and don't restore the pruned data, but instead just updates the prune checkpoints with the block that we unwound to.

Also, fixes the logs from https://github.com/paradigmxyz/reth/pull/9520 as a drive-by to make them less verbose.