### PR TITLE
feat: configurable middleware and metrics 

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1141,7 +1141,6 @@ pub struct RpcServerConfig<RpcMiddleware = Identity> {
     /// JWT secret for authentication
     jwt_secret: Option<JwtSecret>,
     /// Configurable RPC middleware
-    #[allow(dead_code)]
     rpc_middleware: RpcServiceBuilder<RpcMiddleware>,
 }
 
@@ -1337,8 +1336,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
     /// Returns the [`RpcServerHandle`] with the handle to the started servers.
     pub async fn start(self, modules: &TransportRpcModules) -> Result<RpcServerHandle, RpcError>
     where
-        RpcMiddleware: for<'a> Layer<RpcService, Service: RpcServiceT<'a>> + Clone + Send + 'static,
-        <RpcMiddleware as Layer<RpcService>>::Service: Send + std::marker::Sync,
+        RpcMiddleware: tower::Layer<RpcService> + Clone + Send + 'static,
+        <RpcMiddleware as Layer<RpcService>>::Service: std::marker::Sync + Send,
+        for<'a> <RpcMiddleware as tower::Layer<RpcService>>::Service: RpcServiceT<'a>,
     {
         let mut http_handle = None;
         let mut ws_handle = None;
@@ -1396,7 +1396,7 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                             .option_layer(Self::maybe_jwt_layer(self.jwt_secret)),
                     )
                     .set_rpc_middleware(
-                        RpcServiceBuilder::new().layer(
+                        self.rpc_middleware.clone().layer(
                             modules
                                 .http
                                 .as_ref()
@@ -1444,7 +1444,8 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                         .option_layer(Self::maybe_jwt_layer(self.jwt_secret)),
                 )
                 .set_rpc_middleware(
-                    RpcServiceBuilder::new()
+                    self.rpc_middleware
+                        .clone()
                         .layer(modules.ws.as_ref().map(RpcRequestMetrics::ws).unwrap_or_default()),
                 )
                 .build(ws_socket_addr)
@@ -1468,7 +1469,7 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                         .option_layer(Self::maybe_jwt_layer(self.jwt_secret)),
                 )
                 .set_rpc_middleware(
-                    RpcServiceBuilder::new().layer(
+                    self.rpc_middleware.clone().layer(
                         modules.http.as_ref().map(RpcRequestMetrics::http).unwrap_or_default(),
                     ),
                 )

--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -61,11 +61,22 @@ impl RpcRequestMetrics {
     }
 }
 
-impl<S> Layer<S> for RpcRequestMetrics {
-    type Service = RpcRequestMetricsService<S>;
+// impl<S> Layer<S> for RpcRequestMetrics {
+//     type Service = RpcRequestMetricsService<S>;
+
+//     fn layer(&self, inner: S) -> Self::Service {
+//         RpcRequestMetricsService::new(inner, self.clone())
+//     }
+// }
+
+impl<S> Layer<S> for RpcRequestMetrics
+where
+    S: std::marker::Send + std::marker::Sync,
+{
+    type Service = S;
 
     fn layer(&self, inner: S) -> Self::Service {
-        RpcRequestMetricsService::new(inner, self.clone())
+        inner
     }
 }
 
@@ -82,11 +93,13 @@ struct RpcServerMetricsInner {
 ///
 /// This is created per connection and captures metrics for each request.
 #[derive(Clone)]
+#[allow(dead_code)]
 pub(crate) struct RpcRequestMetricsService<S> {
     metrics: RpcRequestMetrics,
     inner: S,
 }
 
+#[allow(dead_code)]
 impl<S> RpcRequestMetricsService<S> {
     pub(crate) fn new(service: S, metrics: RpcRequestMetrics) -> Self {
         // this instance is kept alive for the duration of the connection


### PR DESCRIPTION
this code here passes all the tests, but i don't think it's the right solution, there are parts of it that i think are right though. 

if use this adapted code here

```rust
impl<S> Layer<S> for RpcRequestMetrics 
where
    S: std::marker::Send + std::marker::Sync,
{
    type Service = RpcRequestMetricsService<S>;

    fn layer(&self, inner: S) -> Self::Service {
        RpcRequestMetricsService::new(inner, self.clone())
    }
}
```

i get an error that the trait bound

`RpcMiddleware: Layer<RpcRequestMetricsService<RpcService>>`

is unsatisfied, i check it with another type of middleware, i.e. 

```rust
use jsonrpsee::server::middleware::rpc::RpcLoggerLayer;
let rpc_middleware_0x = RpcLoggerLayer::new(1024);
...
.set_rpc_middleware(
    self.rpc_middleware
        .clone()
        .layer(modules.ws.as_ref().map(RpcRequestMetrics::ws).unwrap_or_default())
        .layer(rpc_middleware_0x),
```

and that gave me the error that 

`RpcMiddleware: Layer<RpcLogger<RpcService>>`

is unsatisfied

so i think it's probably right that the trait bound structure should be

`RpcMiddleware: Layer<SOMETHING<RpcService>>`

but i'm not yet sure how to enforce that

