### PR TITLE
refactor(evm): more granular executor methods

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -271,8 +271,10 @@ impl Command {
                 let db = StateProviderDatabase::new(blockchain_db.latest()?);
                 let mut executor = block_executor!(provider_factory.chain_spec()).executor(db);
 
-                let BlockExecutionOutput { state, receipts, requests, .. } =
-                    executor.execute((&block_with_senders.clone().unseal(), U256::MAX).into())?;
+                let BlockExecutionOutput { state, receipts, requests, .. } = executor
+                    .execute_transactions(
+                        (&block_with_senders.clone().unseal(), U256::MAX).into(),
+                    )?;
                 let execution_outcome = ExecutionOutcome::new(
                     state,
                     receipts.into(),

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -269,7 +269,7 @@ impl Command {
                     SealedBlockWithSenders::new(block.clone(), senders).unwrap();
 
                 let db = StateProviderDatabase::new(blockchain_db.latest()?);
-                let executor = block_executor!(provider_factory.chain_spec()).executor(db);
+                let mut executor = block_executor!(provider_factory.chain_spec()).executor(db);
 
                 let BlockExecutionOutput { state, receipts, requests, .. } =
                     executor.execute((&block_with_senders.clone().unseal(), U256::MAX).into())?;

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -133,17 +133,18 @@ impl Command {
 
         let merkle_block_td =
             provider.header_td_by_number(merkle_block_number)?.unwrap_or_default();
-        let BlockExecutionOutput { state, receipts, requests, .. } = executor.execute(
-            (
-                &block
-                    .clone()
-                    .unseal()
-                    .with_recovered_senders()
-                    .ok_or(BlockValidationError::SenderRecoveryError)?,
-                merkle_block_td + block.difficulty,
-            )
-                .into(),
-        )?;
+        let BlockExecutionOutput { state, receipts, requests, .. } = executor
+            .execute_transactions(
+                (
+                    &block
+                        .clone()
+                        .unseal()
+                        .with_recovered_senders()
+                        .ok_or(BlockValidationError::SenderRecoveryError)?,
+                    merkle_block_td + block.difficulty,
+                )
+                    .into(),
+            )?;
         let execution_outcome =
             ExecutionOutcome::new(state, receipts.into(), block.number, vec![requests.into()]);
 

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -129,7 +129,7 @@ impl Command {
             provider_factory.static_file_provider(),
         ));
 
-        let executor = block_executor!(provider_factory.chain_spec()).executor(db);
+        let mut executor = block_executor!(provider_factory.chain_spec()).executor(db);
 
         let merkle_block_td =
             provider.header_td_by_number(merkle_block_number)?.unwrap_or_default();

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -209,7 +209,7 @@ impl AppendableChain {
         let block_hash = block.hash();
         let block = block.unseal();
 
-        let state = executor.execute((&block, U256::MAX).into())?;
+        let state = executor.execute_transactions((&block, U256::MAX).into())?;
         let BlockExecutionOutput { state, receipts, requests, .. } = state;
         externals
             .consensus

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -205,7 +205,7 @@ impl AppendableChain {
         let provider = BundleStateProvider::new(state_provider, bundle_state_data_provider);
 
         let db = StateProviderDatabase::new(&provider);
-        let executor = externals.executor_factory.executor(db);
+        let mut executor = externals.executor_factory.executor(db);
         let block_hash = block.hash();
         let block = block.unseal();
 

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -387,7 +387,7 @@ impl StorageInner {
             requests: block_execution_requests,
             gas_used,
             ..
-        } = executor.executor(&mut db).execute((&block, U256::ZERO).into())?;
+        } = executor.executor(&mut db).execute_transactions((&block, U256::ZERO).into())?;
         let execution_outcome = ExecutionOutcome::new(
             state,
             receipts.into(),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -671,7 +671,8 @@ where
         self.validate_block(&block)?;
 
         let state_provider = self.state_provider(block.parent_hash).unwrap();
-        let executor = self.executor_provider.executor(StateProviderDatabase::new(&state_provider));
+        let mut executor =
+            self.executor_provider.executor(StateProviderDatabase::new(&state_provider));
 
         let block_number = block.number;
         let block_hash = block.hash();

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -677,7 +677,7 @@ where
         let block_number = block.number;
         let block_hash = block.hash();
         let block = block.unseal();
-        let output = executor.execute((&block, U256::MAX).into()).unwrap();
+        let output = executor.execute_transactions((&block, U256::MAX).into()).unwrap();
         self.consensus.validate_block_post_execution(
             &block,
             PostExecutionInput::new(&output.receipts, &output.requests),

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -394,7 +394,10 @@ where
         Ok(())
     }
 
-    fn execute(&mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute_transactions(
+        &mut self,
+        input: Self::Input<'_>,
+    ) -> Result<Self::Output, Self::Error> {
         let BlockExecutionInput { block, total_difficulty } = input;
         let EthExecuteOutput { receipts, requests, gas_used } =
             self.execute_without_verification(block, total_difficulty)?;
@@ -622,7 +625,7 @@ mod tests {
         // attempt to execute a block without parent beacon block root, expect err
         let err = provider
             .executor(StateProviderDatabase::new(&db))
-            .execute(
+            .execute_transactions(
                 (
                     &BlockWithSenders {
                         block: Block {
@@ -1367,7 +1370,7 @@ mod tests {
         let mut executor = provider.executor(StateProviderDatabase::new(&db));
 
         let BlockExecutionOutput { receipts, requests, .. } = executor
-            .execute(
+            .execute_transactions(
                 (
                     &Block {
                         header,
@@ -1455,7 +1458,7 @@ mod tests {
         let mut executor = executor_provider(chain_spec).executor(StateProviderDatabase::new(&db));
 
         // Execute the block and capture the result
-        let exec_result = executor.execute(
+        let exec_result = executor.execute_transactions(
             (
                 &Block {
                     header,

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -67,10 +67,13 @@ where
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
-    fn execute(&mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute_transactions(
+        &mut self,
+        input: Self::Input<'_>,
+    ) -> Result<Self::Output, Self::Error> {
         match self {
-            Self::Left(a) => a.execute(input),
-            Self::Right(b) => b.execute(input),
+            Self::Left(a) => a.execute_transactions(input),
+            Self::Right(b) => b.execute_transactions(input),
         }
     }
 }

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -67,7 +67,7 @@ where
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
-    fn execute(self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute(&mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
         match self {
             Self::Left(a) => a.execute(input),
             Self::Right(b) => b.execute(input),

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -34,7 +34,7 @@ pub trait Executor<DB> {
         Ok(())
     }
 
-    /// Executes the block.
+    /// Executes the transactions in the block.
     ///
     /// # Note
     /// Execution happens without any validation of the output. To validate the output, use the
@@ -166,8 +166,8 @@ pub trait BlockExecutorProvider: Send + Sync + Clone + Unpin + 'static {
     ///
     /// # Verification
     ///
-    /// The on [`Executor::execute`] the executor is expected to validate the execution output of
-    /// the input, this includes:
+    /// On [`Executor::execute_transactions`] the executor is expected to validate the execution
+    /// output of the input, this includes:
     /// - Cumulative gas used must match the input's gas used.
     /// - Receipts must match the input's receipts root.
     ///

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -42,7 +42,8 @@ pub trait Executor<DB> {
     ///
     /// # Returns
     /// The output of the block execution.
-    fn execute(&mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error>;
+    fn execute_transactions(&mut self, input: Self::Input<'_>)
+        -> Result<Self::Output, Self::Error>;
 
     /// Executes the state changes after the block has been executed.
     ///
@@ -239,7 +240,10 @@ mod tests {
         type Output = BlockExecutionOutput<Receipt>;
         type Error = BlockExecutionError;
 
-        fn execute(&mut self, _input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+        fn execute_transactions(
+            &mut self,
+            _input: Self::Input<'_>,
+        ) -> Result<Self::Output, Self::Error> {
             Err(BlockExecutionError::msg("execution unavailable for tests"))
         }
     }
@@ -283,6 +287,6 @@ mod tests {
             requests: None,
         };
         let block = BlockWithSenders::new(block, Default::default()).unwrap();
-        let _ = executor.execute(BlockExecutionInput::new(&block, U256::ZERO));
+        let _ = executor.execute_transactions(BlockExecutionInput::new(&block, U256::ZERO));
     }
 }

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -45,7 +45,7 @@ impl<DB> Executor<DB> for NoopBlockExecutorProvider {
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
-    fn execute(self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute(&mut self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
         Err(BlockExecutionError::msg(UNAVAILABLE_FOR_NOOP))
     }
 }

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -45,7 +45,7 @@ impl<DB> Executor<DB> for NoopBlockExecutorProvider {
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
-    fn execute(&mut self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute_transactions(&mut self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
         Err(BlockExecutionError::msg(UNAVAILABLE_FOR_NOOP))
     }
 }

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -50,7 +50,7 @@ impl<DB> Executor<DB> for MockExecutorProvider {
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
-    fn execute(self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute(&mut self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
         let ExecutionOutcome { bundle, receipts, requests, first_block: _ } =
             self.exec_results.lock().pop().unwrap();
         Ok(BlockExecutionOutput {

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -50,7 +50,7 @@ impl<DB> Executor<DB> for MockExecutorProvider {
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
-    fn execute(&mut self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute_transactions(&mut self, _: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
         let ExecutionOutcome { bundle, receipts, requests, first_block: _ } =
             self.exec_results.lock().pop().unwrap();
         Ok(BlockExecutionOutput {

--- a/crates/exex/exex/src/backfill.rs
+++ b/crates/exex/exex/src/backfill.rs
@@ -256,7 +256,8 @@ where
 
         trace!(target: "exex::backfill", number = block_number, txs = block_with_senders.block.body.len(), "Executing block");
 
-        let block_execution_output = executor.execute((&block_with_senders, td).into())?;
+        let block_execution_output =
+            executor.execute_transactions((&block_with_senders, td).into())?;
 
         Ok((block_with_senders, block_execution_output))
     }
@@ -334,7 +335,7 @@ mod tests {
                 provider.tx_ref(),
                 provider.static_file_provider().clone(),
             )))
-            .execute(BlockExecutionInput { block, total_difficulty: U256::ZERO })?;
+            .execute_transactions(BlockExecutionInput { block, total_difficulty: U256::ZERO })?;
         block_execution_output.state.reverts.sort();
 
         // Convert the block execution output to an execution outcome for committing to the database

--- a/crates/exex/exex/src/backfill.rs
+++ b/crates/exex/exex/src/backfill.rs
@@ -250,7 +250,7 @@ where
             .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;
 
         // Configure the executor to use the previous block's state.
-        let executor = self.executor.executor(StateProviderDatabase::new(
+        let mut executor = self.executor.executor(StateProviderDatabase::new(
             self.provider.history_by_block_number(block_number.saturating_sub(1))?,
         ));
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -370,7 +370,10 @@ where
         Ok(())
     }
 
-    fn execute(&mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute_transactions(
+        &mut self,
+        input: Self::Input<'_>,
+    ) -> Result<Self::Output, Self::Error> {
         let BlockExecutionInput { block, total_difficulty } = input;
         let (receipts, gas_used) = self.execute_without_verification(block, total_difficulty)?;
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -351,7 +351,7 @@ where
     /// Returns an error if the block could not be executed or failed verification.
     ///
     /// State changes are committed to the database.
-    fn execute(mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
+    fn execute(&mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
         let BlockExecutionInput { block, total_difficulty } = input;
         let (receipts, gas_used) = self.execute_without_verification(block, total_difficulty)?;
 


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/8764

This PR is a prerequisite for placing hooks from https://github.com/paradigmxyz/reth/pull/9544 in between different parts of EVM execution.

Currently, nothing changed and the functionality is duplicated between the old `execute` and the new `execute_state_changes_pre`/`execute_state_changes_post` methods. We will remove the duplicate code from `execute` when we actually call new trait methods.