### PR TITLE
chore: use each prune segment method on `remove_blocks_above`

### DIFF
--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -189,6 +189,8 @@ where
         transactions_writer.prune_transactions(total_txs, block_num)?;
         header_writer.prune_headers(highest_static_file_block.saturating_sub(block_num))?;
 
+        sf_provider.commit()?;
+
         Ok(())
     }
 }

--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -185,17 +185,9 @@ where
         let mut receipts_writer = sf_provider.get_writer(block_num, StaticFileSegment::Receipts)?;
 
         // finally actually truncate, these internally commit
-        receipts_writer.truncate(StaticFileSegment::Receipts, total_txs, Some(block_num))?;
-        transactions_writer.truncate(
-            StaticFileSegment::Transactions,
-            total_txs,
-            Some(block_num),
-        )?;
-        header_writer.truncate(
-            StaticFileSegment::Headers,
-            highest_static_file_block.saturating_sub(block_num),
-            None,
-        )?;
+        receipts_writer.prune_receipts(total_txs, block_num)?;
+        transactions_writer.prune_transactions(total_txs, block_num)?;
+        header_writer.prune_headers(highest_static_file_block.saturating_sub(block_num))?;
 
         Ok(())
     }

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -338,7 +338,7 @@ impl StaticFileProviderRW {
     ///
     /// # Note
     /// Commits to the configuration file at the end.
-    pub fn truncate(
+    fn truncate(
         &mut self,
         segment: StaticFileSegment,
         num_rows: u64,


### PR DESCRIPTION
re https://github.com/paradigmxyz/reth/pull/9553

there are a couple reasons to use the prune methods instead of truncate (and why its a private method):
* cleaner
* debug_asserts
* it queues the pruning, doesn't actually delete anything until commit is called (truncate deletes on the spot)
