### PR TITLE
chore(tracing): export tracing-appender crate

### DIFF
--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -45,12 +45,12 @@
 
 // Re-export tracing crates
 pub use tracing;
+pub use tracing_appender;
 pub use tracing_subscriber;
 
-// Re-export LogFormat
+// Re-export our types
 pub use formatter::LogFormat;
 pub use layers::{FileInfo, FileWorkerGuard};
-
 pub use test_tracer::TestTracer;
 
 mod formatter;


### PR DESCRIPTION
Otherwise the return type is unreachable without an additional dependency https://github.com/paradigmxyz/reth/blob/1b5845d40a2a64bcc098b8c7d591c66968b4e195/crates/tracing/src/lib.rs#L179