### PR TITLE
configurable middleware and metrics & http middleware

### DIFF
--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -81,8 +81,8 @@ struct RpcServerMetricsInner {
 /// A [`RpcServiceT`] middleware that captures RPC metrics for the server.
 ///
 /// This is created per connection and captures metrics for each request.
-#[derive(Clone)]
-pub(crate) struct RpcRequestMetricsService<S> {
+#[derive(Clone, Debug)]
+pub struct RpcRequestMetricsService<S> {
     metrics: RpcRequestMetrics,
     inner: S,
 }
@@ -125,7 +125,7 @@ impl<S> Drop for RpcRequestMetricsService<S> {
 
 /// Response future to update the metrics for a single request/response pair.
 #[pin_project::pin_project]
-pub(crate) struct MeteredRequestFuture<F> {
+pub struct MeteredRequestFuture<F> {
     #[pin]
     fut: F,
     /// time when the request started


### PR DESCRIPTION
note: this compiles, but i don't think it would achieve the goal of allowing a builder to pass arbitrary middleware, as you can see [here](https://github.com/paradigmxyz/reth/compare/main...smatthewenglish:reth:x-middleware#diff-1eba6c2d8cbe34dba743f5be8ecebc22fb2521593a4bca308381696c4f9d0a58R85-R86)

another thing i tried was splitting the building of the server and the starting of the server into two distinct steps, but the trait bounds started to get very complicated and ultimately i wasn't able to get it working

---

this trait bound will get the server to start correctly
```rust
RpcMiddleware: Layer<RpcRequestMetricsService<RpcService>> + Send + 'static,
```
but i wish that it was more dynamic, i tried something like this 
```rust
RpcMiddleware: Layer<Box<dyn RpcServiceT<RpcService>>> + Send + 'static,
```

but that didnt work. 

---

i adjusted the visibility of `RpcRequestMetricsService` to avoid this error
```rust
type `RpcRequestMetricsService<RpcService>` is more private than the item `RpcServerConfig::<HttpMiddleware, RpcMiddleware>::start`
`#[warn(private_bounds)]` on by default
```
'cause it seems like a better solution than using `#[warn(private_bounds)]`