### PR TITLE
fix: Use correct base fee params for Base mainnet after canyon hardfork

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -218,7 +218,7 @@ pub static BASE_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![
                 (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),
-                (OptimismHardfork::Canyon.boxed(), BaseFeeParams::optimism()),
+                (OptimismHardfork::Canyon.boxed(), BaseFeeParams::optimism_canyon()),
             ]
             .into(),
         ),


### PR DESCRIPTION
Fixes the base fee calculation for Base Mainnet after the Canyon hardfork is activated, by using the `optimism_canyon` `BaseFeeParams` instead of the pre-canyon `optimism` params.

See the following reference data in the superchain registry: https://github.com/ethereum-optimism/superchain-registry/blob/c01722001e88a8d21a6450f89bb7bb42311c9609/bindings/rust-primitives/src/rollup_config.rs#L386