### PR TITLE
chore(evm): move execute input/output to `execution-types` crate

### DIFF
--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,0 +1,41 @@
+use reth_primitives::{Request, U256};
+use revm::db::BundleState;
+
+/// A helper type for ethereum block inputs that consists of a block and the total difficulty.
+#[derive(Debug)]
+pub struct BlockExecutionInput<'a, Block> {
+    /// The block to execute.
+    pub block: &'a Block,
+    /// The total difficulty of the block.
+    pub total_difficulty: U256,
+}
+
+impl<'a, Block> BlockExecutionInput<'a, Block> {
+    /// Creates a new input.
+    pub const fn new(block: &'a Block, total_difficulty: U256) -> Self {
+        Self { block, total_difficulty }
+    }
+}
+
+impl<'a, Block> From<(&'a Block, U256)> for BlockExecutionInput<'a, Block> {
+    fn from((block, total_difficulty): (&'a Block, U256)) -> Self {
+        Self::new(block, total_difficulty)
+    }
+}
+
+/// The output of an ethereum block.
+///
+/// Contains the state changes, transaction receipts, and total gas used in the block.
+///
+/// TODO(mattsse): combine with `ExecutionOutcome`
+#[derive(Debug, PartialEq, Eq)]
+pub struct BlockExecutionOutput<T> {
+    /// The changed state of the block after execution.
+    pub state: BundleState,
+    /// All the receipts of the transactions in the block.
+    pub receipts: Vec<T>,
+    /// All the EIP-7685 requests of the transactions in the block.
+    pub requests: Vec<Request>,
+    /// The total gas used by the block.
+    pub gas_used: u64,
+}

--- a/crates/evm/execution-types/src/lib.rs
+++ b/crates/evm/execution-types/src/lib.rs
@@ -8,8 +8,11 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-mod execution_outcome;
-pub use execution_outcome::*;
-
 mod chain;
 pub use chain::*;
+
+mod execute;
+pub use execute::*;
+
+mod execution_outcome;
+pub use execution_outcome::*;

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -2,11 +2,9 @@
 
 use std::fmt::Display;
 
-use crate::execute::{
-    BatchExecutor, BlockExecutionInput, BlockExecutionOutput, BlockExecutorProvider, Executor,
-};
+use crate::execute::{BatchExecutor, BlockExecutorProvider, Executor};
 use reth_execution_errors::BlockExecutionError;
-use reth_execution_types::ExecutionOutcome;
+use reth_execution_types::{BlockExecutionInput, BlockExecutionOutput, ExecutionOutcome};
 use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -1,9 +1,10 @@
 //! Traits for execution.
 
-use reth_execution_types::ExecutionOutcome;
-use reth_primitives::{BlockNumber, BlockWithSenders, Receipt, Request, U256};
+// Re-export execution types
+pub use reth_execution_types::{BlockExecutionInput, BlockExecutionOutput, ExecutionOutcome};
+
+use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
 use reth_prune_types::PruneModes;
-use revm::db::BundleState;
 use revm_primitives::db::Database;
 use std::fmt::Display;
 
@@ -96,45 +97,6 @@ pub trait BatchExecutor<DB> {
     fn size_hint(&self) -> Option<usize>;
 }
 
-/// The output of an ethereum block.
-///
-/// Contains the state changes, transaction receipts, and total gas used in the block.
-///
-/// TODO(mattsse): combine with `ExecutionOutcome`
-#[derive(Debug, PartialEq, Eq)]
-pub struct BlockExecutionOutput<T> {
-    /// The changed state of the block after execution.
-    pub state: BundleState,
-    /// All the receipts of the transactions in the block.
-    pub receipts: Vec<T>,
-    /// All the EIP-7685 requests of the transactions in the block.
-    pub requests: Vec<Request>,
-    /// The total gas used by the block.
-    pub gas_used: u64,
-}
-
-/// A helper type for ethereum block inputs that consists of a block and the total difficulty.
-#[derive(Debug)]
-pub struct BlockExecutionInput<'a, Block> {
-    /// The block to execute.
-    pub block: &'a Block,
-    /// The total difficulty of the block.
-    pub total_difficulty: U256,
-}
-
-impl<'a, Block> BlockExecutionInput<'a, Block> {
-    /// Creates a new input.
-    pub const fn new(block: &'a Block, total_difficulty: U256) -> Self {
-        Self { block, total_difficulty }
-    }
-}
-
-impl<'a, Block> From<(&'a Block, U256)> for BlockExecutionInput<'a, Block> {
-    fn from((block, total_difficulty): (&'a Block, U256)) -> Self {
-        Self::new(block, total_difficulty)
-    }
-}
-
 /// A type that can create a new executor for block execution.
 pub trait BlockExecutorProvider: Send + Sync + Clone + Unpin + 'static {
     /// An executor that can execute a single block given a database.
@@ -184,6 +146,7 @@ mod tests {
     use super::*;
     use reth_primitives::Block;
     use revm::db::{CacheDB, EmptyDBTyped};
+    use revm_primitives::U256;
     use std::marker::PhantomData;
 
     #[derive(Clone, Default)]

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -3,15 +3,13 @@
 use std::fmt::Display;
 
 use reth_execution_errors::BlockExecutionError;
-use reth_execution_types::ExecutionOutcome;
+use reth_execution_types::{BlockExecutionInput, BlockExecutionOutput, ExecutionOutcome};
 use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
 use revm_primitives::db::Database;
 
-use crate::execute::{
-    BatchExecutor, BlockExecutionInput, BlockExecutionOutput, BlockExecutorProvider, Executor,
-};
+use crate::execute::{BatchExecutor, BlockExecutorProvider, Executor};
 
 const UNAVAILABLE_FOR_NOOP: &str = "execution unavailable for noop";
 


### PR DESCRIPTION
Otherwise you need to import the whole `reth-evm` crate if you want to use the output type of the ExEx backfill https://github.com/paradigmxyz/reth/blob/390f30aadebcdd509e72cc04327c3b854de076a6/crates/exex/exex/src/backfill/stream.rs#L79