### PR TITLE
fix(stages): do not panic in `disable_all`

### DIFF
--- a/crates/stages/api/src/pipeline/set.rs
+++ b/crates/stages/api/src/pipeline/set.rs
@@ -198,12 +198,11 @@ where
     }
 
     /// Disables all given stages. See [`disable`](Self::disable).
+    ///
+    /// If any of the stages is not in this set, it is ignored.
     pub fn disable_all(mut self, stages: &[StageId]) -> Self {
         for stage_id in stages {
-            let entry = self
-                .stages
-                .get_mut(stage_id)
-                .expect("Cannot disable a stage that is not in the set.");
+            let Some(entry) = self.stages.get_mut(stage_id) else { continue };
             entry.enabled = false;
         }
         self


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/9628

## Before

```console
$ ./target/debug/op-reth import-op ~/.local/share/reth/bedrock-blocks.rlp --datadir temp_data --chain optimism
2024-07-18T19:16:06.927052Z  INFO Initialized tracing, debug log directory: /home/ubuntu/.cache/reth/logs/optimism
2024-07-18T19:16:06.932870Z  INFO reth 1.0.3-dev (fbef7f3f) starting
2024-07-18T19:16:06.932991Z  INFO Disabled stages requiring state, since cannot execute OVM state changes
2024-07-18T19:16:06.934222Z  INFO Opening storage db_path="temp_data/db" sf_path="temp_data/static_files"
2024-07-18T19:16:07.070956Z  INFO Verifying storage consistency.
2024-07-18T19:20:48.553267Z  INFO Importing chain file chunk
2024-07-18T19:20:48.613197Z  INFO Chain file chunk read
2024-07-18T19:20:50.133452Z  INFO Downloading bodies count=1166778 range=0..=1166777
thread 'tokio-runtime-worker' panicked at /home/ubuntu/reth/crates/stages/api/src/pipeline/set.rs:208:17:
Cannot disable a stage that is not in the set: PruneSenderRecover
```

## After

```console
$ ./target/release/op-reth import-op ~/.local/share/reth/bedrock-blocks.rlp --datadir temp_data --chain optimism
2024-07-18T19:12:37.095233Z  INFO Initialized tracing, debug log directory: /home/ubuntu/.cache/reth/logs/optimism
2024-07-18T19:12:37.098697Z  INFO reth 1.0.3-dev (39399bba) starting
2024-07-18T19:12:37.098739Z  INFO Disabled stages requiring state, since cannot execute OVM state changes
2024-07-18T19:12:37.098981Z  INFO Opening storage db_path="temp_data/db" sf_path="temp_data/static_files"
2024-07-18T19:12:37.256235Z  INFO Verifying storage consistency.
2024-07-18T19:12:45.822568Z  INFO Importing chain file chunk
2024-07-18T19:12:45.831160Z  INFO Chain file chunk read
2024-07-18T19:12:46.083424Z  INFO Downloading bodies count=1166778 range=0..=1166777
2024-07-18T19:12:46.092446Z  INFO Starting sync pipeline
2024-07-18T19:12:46.094324Z  INFO Preparing stage pipeline_stages=1/5 stage=Headers checkpoint=0 target=1166777
2024-07-18T19:12:46.100294Z  INFO Received headers total=10000 from_block=1166777 to_block=1156778
```