### PR TITLE
chore: add `get_account` method in `EthApi` trait

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -247,11 +247,7 @@ pub trait EthApi {
 
     /// Returns the account details by specifying an address and a block number/tag
     #[method(name = "getAccount")]
-    async fn get_account(
-        &self,
-        address: Address,
-        block_reference: BlockNumberOrTag,
-    ) -> RpcResult<Account>;
+    async fn get_account(&self, address: Address, block: BlockId) -> RpcResult<Account>;
 
     /// Introduced in EIP-1559, returns suggestion for the priority for dynamic fee transactions.
     #[method(name = "maxPriorityFeePerGas")]
@@ -630,12 +626,8 @@ where
     }
 
     /// Handler for: `eth_getAccount`
-    async fn get_account(
-        &self,
-        _address: Address,
-        _block_reference: BlockNumberOrTag,
-    ) -> RpcResult<Account> {
-        unimplemented!();
+    async fn get_account(&self, _address: Address, _block: BlockId) -> RpcResult<Account> {
+        Err(internal_rpc_err("unimplemented"))
     }
 
     /// Handler for: `eth_maxPriorityFeePerGas`

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -3,7 +3,7 @@
 
 use alloy_dyn_abi::TypedData;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64};
+use reth_primitives::{Account, Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_rpc_types::{
     serde_helpers::JsonStorageKey,
@@ -244,6 +244,14 @@ pub trait EthApi {
     /// Returns the current price per gas in wei.
     #[method(name = "gasPrice")]
     async fn gas_price(&self) -> RpcResult<U256>;
+
+    /// Returns the account details by specifying an address and a block number/tag
+    #[method(name = "getAccount")]
+    async fn get_account(
+        &self,
+        address: Address,
+        block_reference: BlockNumberOrTag,
+    ) -> RpcResult<Account>;
 
     /// Introduced in EIP-1559, returns suggestion for the priority for dynamic fee transactions.
     #[method(name = "maxPriorityFeePerGas")]
@@ -619,6 +627,15 @@ where
     async fn gas_price(&self) -> RpcResult<U256> {
         trace!(target: "rpc::eth", "Serving eth_gasPrice");
         return Ok(EthFees::gas_price(self).await?)
+    }
+
+    /// Handler for: `eth_getAccount`
+    async fn get_account(
+        &self,
+        _address: Address,
+        _block_reference: BlockNumberOrTag,
+    ) -> RpcResult<Account> {
+        unimplemented!();
     }
 
     /// Handler for: `eth_maxPriorityFeePerGas`


### PR DESCRIPTION
Towards  #9625 

Add the `get_account` method. All specifications are based on [this source](https://www.quicknode.com/docs/ethereum/eth_getAccount).