### PR TITLE
chore: require enginetypes 'static

### DIFF
--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -85,7 +85,7 @@ where
     Client: StateProviderFactory + CanonChainTracker + Clone + Unpin + 'static,
     Pool: TransactionPool + Unpin + 'static,
     <Pool as TransactionPool>::Transaction: IntoRecoveredTransaction,
-    Engine: EngineTypes + 'static,
+    Engine: EngineTypes,
     Executor: BlockExecutorProvider,
 {
     type Output = ();

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -235,7 +235,7 @@ where
         + ChainSpecProvider
         + 'static,
     Client: HeadersClient + BodiesClient + Clone + Unpin + 'static,
-    EngineT: EngineTypes + Unpin + 'static,
+    EngineT: EngineTypes + Unpin,
 {
     /// Create a new instance of the [`BeaconConsensusEngine`].
     #[allow(clippy::too_many_arguments)]
@@ -1801,7 +1801,7 @@ where
         + ChainSpecProvider
         + Unpin
         + 'static,
-    EngineT: EngineTypes + Unpin + 'static,
+    EngineT: EngineTypes + Unpin,
 {
     type Output = Result<(), BeaconConsensusEngineError>;
 

--- a/crates/e2e-test-utils/src/engine_api.rs
+++ b/crates/e2e-test-utils/src/engine_api.rs
@@ -23,7 +23,7 @@ pub struct EngineApiTestContext<E> {
     pub _marker: PhantomData<E>,
 }
 
-impl<E: EngineTypes + 'static> EngineApiTestContext<E> {
+impl<E: EngineTypes> EngineApiTestContext<E> {
     /// Retrieves a v3 payload from the engine api
     pub async fn get_payload_v3(
         &self,

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -4,13 +4,13 @@ use reth_payload_builder::{Events, PayloadBuilderHandle, PayloadId};
 use tokio_stream::wrappers::BroadcastStream;
 
 /// Helper for payload operations
-pub struct PayloadTestContext<E: EngineTypes + 'static> {
+pub struct PayloadTestContext<E: EngineTypes> {
     pub payload_event_stream: BroadcastStream<Events<E>>,
     payload_builder: PayloadBuilderHandle<E>,
     pub timestamp: u64,
 }
 
-impl<E: EngineTypes + 'static> PayloadTestContext<E> {
+impl<E: EngineTypes> PayloadTestContext<E> {
     /// Creates a new payload helper
     pub async fn new(payload_builder: PayloadBuilderHandle<E>) -> eyre::Result<Self> {
         let payload_events = payload_builder.subscribe().await?;

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -27,6 +27,7 @@ pub trait EngineTypes:
                           + TryInto<Self::ExecutionPayloadV4>,
     > + DeserializeOwned
     + Serialize
+    + 'static
 {
     /// Execution Payload V1 type.
     type ExecutionPayloadV1: DeserializeOwned + Serialize + Clone + Unpin + Send + Sync + 'static;

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -293,7 +293,7 @@ impl<P, E, T> EngineApiTreeHandlerImpl<P, E, T>
 where
     P: BlockReader + StateProviderFactory + Clone + 'static,
     E: BlockExecutorProvider,
-    T: EngineTypes + 'static,
+    T: EngineTypes,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -744,7 +744,7 @@ impl<P, E, T> EngineApiTreeHandler for EngineApiTreeHandlerImpl<P, E, T>
 where
     P: BlockReader + StateProviderFactory + Clone + 'static,
     E: BlockExecutorProvider,
-    T: EngineTypes + 'static,
+    T: EngineTypes,
 {
     type Engine = T;
 

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -47,7 +47,7 @@ impl<P, E> AnyNodeTypes<P, E> {
 impl<P, E> NodeTypes for AnyNodeTypes<P, E>
 where
     P: NodePrimitives + Send + Sync + Unpin + 'static,
-    E: EngineTypes + Send + Sync + Unpin + 'static,
+    E: EngineTypes + Send + Sync + Unpin,
 {
     type Primitives = P;
 

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -198,7 +198,7 @@ impl AuthRpcModule {
     /// Create a new `AuthRpcModule` with the given `engine_api`.
     pub fn new<EngineApi, EngineT>(engine: EngineApi) -> Self
     where
-        EngineT: EngineTypes + 'static,
+        EngineT: EngineTypes,
         EngineApi: EngineApiServer<EngineT>,
     {
         let mut module = RpcModule::new(());

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -93,7 +93,7 @@
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events: CanonStateSubscriptions + Clone + 'static,
 //!     EngineApi: EngineApiServer<EngineT>,
-//!     EngineT: EngineTypes + 'static,
+//!     EngineT: EngineTypes,
 //!     EvmConfig: ConfigureEvm,
 //! {
 //!     // configure the rpc module per transport
@@ -436,7 +436,7 @@ where
         RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi>,
     )
     where
-        EngineT: EngineTypes + 'static,
+        EngineT: EngineTypes,
         EngineApi: EngineApiServer<EngineT>,
         EthApi: FullEthApiServer,
     {
@@ -976,7 +976,7 @@ where
     /// Note: This does _not_ register the `engine_` in this registry.
     pub fn create_auth_module<EngineApi, EngineT>(&self, engine_api: EngineApi) -> AuthRpcModule
     where
-        EngineT: EngineTypes + 'static,
+        EngineT: EngineTypes,
         EngineApi: EngineApiServer<EngineT>,
     {
         let mut module = RpcModule::new(());

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -65,7 +65,7 @@ struct EngineApiInner<Provider, EngineT: EngineTypes> {
 impl<Provider, EngineT> EngineApi<Provider, EngineT>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + EvmEnvProvider + 'static,
-    EngineT: EngineTypes + 'static,
+    EngineT: EngineTypes,
 {
     /// Create new instance of [`EngineApi`].
     pub fn new(
@@ -612,7 +612,7 @@ where
 impl<Provider, EngineT> EngineApiServer<EngineT> for EngineApi<Provider, EngineT>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + EvmEnvProvider + 'static,
-    EngineT: EngineTypes + 'static,
+    EngineT: EngineTypes,
 {
     /// Handler for `engine_newPayloadV1`
     /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/paris.md#engine_newpayloadv1>


### PR DESCRIPTION
these are always known and should be 'static on trait level