### PR TITLE
chore: rm redundant event variant

### DIFF
--- a/crates/engine/tree/src/backfill.rs
+++ b/crates/engine/tree/src/backfill.rs
@@ -34,8 +34,6 @@ pub enum BackfillAction {
 /// The events that can be emitted on backfill sync.
 #[derive(Debug)]
 pub enum BackfillEvent {
-    /// Backfill sync idle.
-    Idle,
     /// Backfill sync started.
     Started(PipelineTarget),
     /// Backfill sync finished.

--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -81,7 +81,6 @@ where
             // try to poll the backfill sync to completion, if active
             match this.backfill_sync.poll(cx) {
                 Poll::Ready(backfill_sync_event) => match backfill_sync_event {
-                    BackfillEvent::Idle => {}
                     BackfillEvent::Started(_) => {
                         // notify handler that backfill sync started
                         this.handler.on_event(FromOrchestrator::BackfillSyncStarted);


### PR DESCRIPTION
this idle variant is also redundant because this expresses the same thing as `Pending`