### PR TITLE
chore(trie): accept `from` block instead of range in hashed state

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -130,7 +130,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
             );
         }
 
-        Ok(HashedPostState::from_revert_range(self.tx, self.block_number..=tip)?)
+        Ok(HashedPostState::from_reverts(self.tx, self.block_number)?)
     }
 
     fn history_info<T, K>(


### PR DESCRIPTION
## Description

Ref https://github.com/paradigmxyz/reth/pull/9659#discussion_r1685321346

Replace revert range by `from` block in method to construct the revert hashed post state.