### PR TITLE
chore: return content type for prometheus metrics

### DIFF
--- a/crates/node/core/src/metrics/prometheus_exporter.rs
+++ b/crates/node/core/src/metrics/prometheus_exporter.rs
@@ -2,9 +2,7 @@
 
 use crate::metrics::version_metrics::VersionInfo;
 use eyre::WrapErr;
-use http::HeaderValue;
-use http::header::CONTENT_TYPE;
-use http::Response;
+use http::{header::CONTENT_TYPE, HeaderValue, Response};
 use metrics::describe_gauge;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_util::layers::{PrefixLayer, Stack};
@@ -87,9 +85,7 @@ async fn start_endpoint<F: Hook + 'static>(
                 (hook)();
                 let metrics = handle.render();
                 let mut response = Response::new(metrics);
-                response.headers_mut().insert(
-                    CONTENT_TYPE,
-                    HeaderValue::from_static("text/plain"));
+                response.headers_mut().insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
                 async move { Ok::<_, Infallible>(response) }
             });
 


### PR DESCRIPTION
### Description
Set the content type header on the Prometheus endpoint to be `text/plain`. We noticed some Prometheus clients expect this header to be set as they have support for the [legacy Protobuf format](https://prometheus.io/docs/instrumenting/exposition_formats/#protobuf-format) too. (e.g. [Datadog agent](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py#L190-L245))