### PR TITLE
chore(metrics): summable reth_info value

### DIFF
--- a/crates/node/core/src/metrics/version_metrics.rs
+++ b/crates/node/core/src/metrics/version_metrics.rs
@@ -45,7 +45,7 @@ impl VersionInfo {
             ("build_profile", self.build_profile),
         ];
 
-        let _gauge = gauge!("info", &labels);
-        _gauge.set(1)
+        let gauge = gauge!("info", &labels);
+        gauge.set(1)
     }
 }

--- a/crates/node/core/src/metrics/version_metrics.rs
+++ b/crates/node/core/src/metrics/version_metrics.rs
@@ -46,5 +46,6 @@ impl VersionInfo {
         ];
 
         let _gauge = gauge!("info", &labels);
+        _gauge.set(1)
     }
 }


### PR DESCRIPTION
### Description
This PR sets the value of the reth_info gauge to 1. This makes it easy for node operators to sum by the reth_info variable and produce a table in the following format:

| Version | # of Nodes |
|--------|--------|
| 1.0.3 | 2 |
| 1.0 | 1 |

FWIW this makes the metric also match the Geth behavior.
```
curl -s http://localhost:7300/debug/metrics/prometheus | grep geth_info
# TYPE geth_info gauge
geth_info {arch="amd64", os="linux", protocols="eth/68,snap/1", version="1.101315.2-stable-7c281983"} 1
```

```
curl -s localhost:3000/metrics | grep reth_info
# TYPE reth_info gauge
reth_info{version="1.0.3",build_timestamp="2024-07-20T17:16:33.544425000Z",cargo_features="jemalloc,optimism",git_sha="c43152da",target_triple="aarch64-apple-darwin",build_profile="debug"} 1
```