### PR TITLE
feat: handle downloaded blocks

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -693,7 +693,7 @@ where
     fn on_downloaded_block(&mut self, block: SealedBlockWithSenders) -> Option<TreeEvent> {
         let block_hash = block.hash();
         let lowest_buffered_ancestor = self.lowest_buffered_ancestor_or(block_hash);
-        if let Some(status) =
+        if let Some(_) =
             self.check_invalid_ancestor_with_head(lowest_buffered_ancestor, block_hash).ok()?
         {
             return None

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -704,17 +704,14 @@ where
         }
 
         // try to append the block
-        if let Ok(status) = self.insert_block(block) {
-            match status {
-                InsertPayloadOk::Inserted(BlockStatus::Valid(_)) => {
-                    if self.is_sync_target_head(block_hash) {
-                        return Some(TreeEvent::TreeAction(TreeAction::MakeCanonical(block_hash)))
-                    }
+        match self.insert_block(block) {
+            Ok(InsertPayloadOk::Inserted(BlockStatus::Valid(_))) => {
+                if self.is_sync_target_head(block_hash) {
+                    return Some(TreeEvent::TreeAction(TreeAction::MakeCanonical(block_hash)))
                 }
-                _ => return None,
             }
+            _ => return None,
         }
-
         None
     }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -693,8 +693,10 @@ where
     fn on_downloaded_block(&mut self, block: SealedBlockWithSenders) -> Option<TreeEvent> {
         let block_hash = block.hash();
         let lowest_buffered_ancestor = self.lowest_buffered_ancestor_or(block_hash);
-        if let Some(_) =
-            self.check_invalid_ancestor_with_head(lowest_buffered_ancestor, block_hash).ok()?
+        if self
+            .check_invalid_ancestor_with_head(lowest_buffered_ancestor, block_hash)
+            .ok()?
+            .is_some()
         {
             return None
         }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -268,8 +268,8 @@ pub enum TreeEvent {
 
 impl TreeEvent {
     /// Returns true if the event is a backfill action.
-    fn is_backfill_action(&self) -> bool {
-        matches!(self, TreeEvent::BackfillAction(_))
+    const fn is_backfill_action(&self) -> bool {
+        matches!(self, Self::BackfillAction(_))
     }
 }
 


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/9673

executes downloaded blocks and determines whether we need to make canonical based on downloaded block.

needs some followup work to improve treevent handling a bit