### PR TITLE
chore: ensure highest gas limit tracks txenv.gaslimit of success

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -614,7 +614,11 @@ pub trait Call: LoadState + SpawnBlocking {
 
         // At this point we know the call succeeded but want to find the _best_ (lowest) gas the
         // transaction succeeds with. We find this by doing a binary search over the possible range.
-        //
+
+        // we know the tx succeeded with the configured gas limit, so we can use that as the
+        // highest, in case we applied a gas cap due to caller allowance above
+        highest_gas_limit = env.tx.gas_limit;
+
         // NOTE: this is the gas the transaction used, which is less than the
         // transaction requires to succeed.
         let mut gas_used = res.result.gas_used();


### PR DESCRIPTION
make it explicit that `highest_gas_limit` tracks the highest gas with which the tx succeeds, since we have a cap check:

https://github.com/paradigmxyz/reth/blob/8013f7218e0ea5f3b1bab887e9f865831175f298/crates/rpc/rpc-eth-api/src/helpers/call.rs#L576-L577

