### PR TITLE
chore(rpc): include call stipend for optimistic gas limit

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -21,7 +21,9 @@ use reth_rpc_eth_types::{
     },
     EthApiError, EthResult, RevertError, RpcInvalidTransactionError, StateCacheDb,
 };
-use reth_rpc_server_types::constants::gas_oracle::{ESTIMATE_GAS_ERROR_RATIO, MIN_TRANSACTION_GAS};
+use reth_rpc_server_types::constants::gas_oracle::{
+    CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO, MIN_TRANSACTION_GAS,
+};
 use reth_rpc_types::{
     state::{EvmOverrides, StateOverride},
     AccessListWithGasUsed, BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
@@ -627,7 +629,7 @@ pub trait Call: LoadState + SpawnBlocking {
         //
         // Calculate the optimistic gas limit by adding gas used and gas refund,
         // then applying a 64/63 multiplier to account for gas forwarding rules.
-        let optimistic_gas_limit = (gas_used + gas_refund) * 64 / 63;
+        let optimistic_gas_limit = (gas_used + gas_refund + CALL_STIPEND_GAS) * 64 / 63;
         if optimistic_gas_limit < highest_gas_limit {
             // Set the transaction's gas limit to the calculated optimistic gas limit.
             env.tx.gas_limit = optimistic_gas_limit;

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -87,6 +87,9 @@ pub mod gas_oracle {
     /// Taken from Geth's implementation in order to pass the hive tests
     /// <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/internal/ethapi/api.go#L56>
     pub const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
+
+    /// Gas required at the beginning of a call.
+    pub const CALL_STIPEND_GAS: u64 = 2_300;
 }
 
 /// Cache specific constants


### PR DESCRIPTION
mirrors geth's check

https://github.com/ethereum/go-ethereum/blob/380688c636a654becc8f114438c2a5d93d2db032/eth/gasestimator/gasestimator.go#L145-L145

the callstipend has to be paid upfront