### PR TITLE
chore: remove ownership requirement for static file methods

### DIFF
--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -123,7 +123,7 @@ where
             // receipt is pruned
             for maybe_receipt in receipts.first().unwrap() {
                 if let Some(receipt) = maybe_receipt {
-                    receipts_writer.append_receipt(current_receipt, &receipt)?;
+                    receipts_writer.append_receipt(current_receipt, receipt)?;
                 }
                 current_receipt += 1;
             }

--- a/crates/engine/tree/src/static_files.rs
+++ b/crates/engine/tree/src/static_files.rs
@@ -64,13 +64,13 @@ where
             provider.get_writer(block.number, StaticFileSegment::Transactions)?;
 
         // TODO: does to_compact require ownership?
-        header_writer.append_header(block.header().clone(), td, block.hash())?;
+        header_writer.append_header(block.header(), td, &block.hash())?;
         let no_hash_transactions =
             block.body.clone().into_iter().map(TransactionSignedNoHash::from);
 
         let mut tx_number = start_tx_number;
         for tx in no_hash_transactions {
-            transactions_writer.append_transaction(tx_number, tx)?;
+            transactions_writer.append_transaction(tx_number, &tx)?;
             tx_number += 1;
         }
 
@@ -123,7 +123,7 @@ where
             // receipt is pruned
             for maybe_receipt in receipts.first().unwrap() {
                 if let Some(receipt) = maybe_receipt {
-                    receipts_writer.append_receipt(current_receipt, receipt.clone())?;
+                    receipts_writer.append_receipt(current_receipt, &receipt)?;
                 }
                 current_receipt += 1;
             }

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -206,7 +206,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
                     // Write transactions
                     for transaction in block.body {
                         let appended_tx_number = static_file_producer
-                            .append_transaction(next_tx_num, transaction.into())?;
+                            .append_transaction(next_tx_num, &transaction.into())?;
 
                         if appended_tx_number != next_tx_num {
                             // This scenario indicates a critical error in the logic of adding new
@@ -740,7 +740,7 @@ mod tests {
                         body.tx_num_range().try_for_each(|tx_num| {
                             let transaction = random_signed_tx(&mut rng);
                             static_file_producer
-                                .append_transaction(tx_num, transaction.into())
+                                .append_transaction(tx_num, &transaction.into())
                                 .map(drop)
                         })?;
 

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -138,7 +138,7 @@ where
             })?;
 
             // Append to Headers segment
-            writer.append_header(header, td, header_hash)?;
+            writer.append_header(&header, td, &header_hash)?;
         }
 
         info!(target: "sync::stages::headers", total = total_headers, "Writing headers hash index");

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -581,7 +581,7 @@ mod tests {
             let hash = last_header.hash_slow();
             writer.prune_headers(1).unwrap();
             writer.commit().unwrap();
-            writer.append_header(last_header, U256::ZERO, hash).unwrap();
+            writer.append_header(&last_header, U256::ZERO, &hash).unwrap();
             writer.commit().unwrap();
 
             Ok(blocks)

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -156,11 +156,11 @@ impl TestStageDB {
                 for block_number in 0..header.number {
                     let mut prev = header.clone().unseal();
                     prev.number = block_number;
-                    writer.append_header(prev, U256::ZERO, B256::ZERO)?;
+                    writer.append_header(&prev, U256::ZERO, &B256::ZERO)?;
                 }
             }
 
-            writer.append_header(header.header().clone(), td, header.hash())?;
+            writer.append_header(header.header(), td, &header.hash())?;
         } else {
             tx.put::<tables::CanonicalHeaders>(header.number, header.hash())?;
             tx.put::<tables::HeaderTerminalDifficulties>(header.number, td.into())?;
@@ -266,7 +266,7 @@ impl TestStageDB {
 
                 let res = block.body.iter().try_for_each(|body_tx| {
                     if let Some(txs_writer) = &mut txs_writer {
-                        txs_writer.append_transaction(next_tx_num, body_tx.clone().into())?;
+                        txs_writer.append_transaction(next_tx_num, &body_tx.clone().into())?;
                     } else {
                         tx.put::<tables::Transactions>(next_tx_num, body_tx.clone().into())?
                     }

--- a/crates/static-file/static-file/src/segments/headers.rs
+++ b/crates/static-file/static-file/src/segments/headers.rs
@@ -50,7 +50,7 @@ impl<DB: Database> Segment<DB> for Headers {
             debug_assert_eq!(header_td_block, canonical_header_block);
 
             let _static_file_block =
-                static_file_writer.append_header(header, header_td.0, canonical_header)?;
+                static_file_writer.append_header(&header, header_td.0, &canonical_header)?;
             debug_assert_eq!(_static_file_block, header_block);
         }
 

--- a/crates/static-file/static-file/src/segments/transactions.rs
+++ b/crates/static-file/static-file/src/segments/transactions.rs
@@ -47,7 +47,7 @@ impl<DB: Database> Segment<DB> for Transactions {
             for entry in transactions_walker {
                 let (tx_number, transaction) = entry?;
 
-                static_file_writer.append_transaction(tx_number, transaction)?;
+                static_file_writer.append_transaction(tx_number, &transaction)?;
             }
         }
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -283,7 +283,7 @@ pub fn insert_genesis_header<DB: Database>(
         Ok(None) | Err(ProviderError::MissingStaticFileBlock(StaticFileSegment::Headers, 0)) => {
             let (difficulty, hash) = (header.difficulty, block_hash);
             let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-            writer.append_header(header, difficulty, hash)?;
+            writer.append_header(&header, difficulty, &hash)?;
         }
         Ok(Some(_)) => {}
         Err(e) => return Err(e),

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -774,7 +774,7 @@ mod tests {
         // Checkpoint and no gap
         let mut static_file_writer =
             provider.static_file_provider().latest_writer(StaticFileSegment::Headers).unwrap();
-        static_file_writer.append_header(head.header().clone(), U256::ZERO, head.hash()).unwrap();
+        static_file_writer.append_header(&head.header(), U256::ZERO, &head.hash()).unwrap();
         static_file_writer.commit().unwrap();
         drop(static_file_writer);
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -774,7 +774,7 @@ mod tests {
         // Checkpoint and no gap
         let mut static_file_writer =
             provider.static_file_provider().latest_writer(StaticFileSegment::Headers).unwrap();
-        static_file_writer.append_header(&head.header(), U256::ZERO, &head.hash()).unwrap();
+        static_file_writer.append_header(head.header(), U256::ZERO, &head.hash()).unwrap();
         static_file_writer.commit().unwrap();
         drop(static_file_writer);
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -202,11 +202,11 @@ impl<DB: Database> DatabaseProviderRW<DB> {
             for block_number in 0..block.number {
                 let mut prev = block.header.clone().unseal();
                 prev.number = block_number;
-                writer.append_header(prev, U256::ZERO, B256::ZERO)?;
+                writer.append_header(&prev, U256::ZERO, &B256::ZERO)?;
             }
         }
 
-        writer.append_header(block.header.as_ref().clone(), ttd, block.hash())?;
+        writer.append_header(block.header.as_ref(), ttd, &block.hash())?;
 
         self.insert_block(block)
     }

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -107,7 +107,7 @@ mod tests {
             for header in headers.clone() {
                 td += header.header().difficulty;
                 let hash = header.hash();
-                writer.append_header(header.unseal(), td, hash).unwrap();
+                writer.append_header(&header.unseal(), td, &hash).unwrap();
             }
             writer.commit().unwrap();
         }

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -13,6 +13,7 @@ use reth_primitives::{
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::{
+    borrow::Borrow,
     path::{Path, PathBuf},
     sync::{Arc, Weak},
     time::Instant,
@@ -466,9 +467,9 @@ impl StaticFileProviderRW {
     /// Returns the current [`BlockNumber`] as seen in the static file.
     pub fn append_header(
         &mut self,
-        header: Header,
+        header: &Header,
         total_difficulty: U256,
-        hash: BlockHash,
+        hash: &BlockHash,
     ) -> ProviderResult<BlockNumber> {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;
@@ -501,7 +502,7 @@ impl StaticFileProviderRW {
     pub fn append_transaction(
         &mut self,
         tx_num: TxNumber,
-        tx: TransactionSignedNoHash,
+        tx: &TransactionSignedNoHash,
     ) -> ProviderResult<TxNumber> {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;
@@ -528,7 +529,7 @@ impl StaticFileProviderRW {
     pub fn append_receipt(
         &mut self,
         tx_num: TxNumber,
-        receipt: Receipt,
+        receipt: &Receipt,
     ) -> ProviderResult<TxNumber> {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;
@@ -549,9 +550,10 @@ impl StaticFileProviderRW {
     /// Appends multiple receipts to the static file.
     ///
     /// Returns the current [`TxNumber`] as seen in the static file, if any.
-    pub fn append_receipts<I>(&mut self, receipts: I) -> ProviderResult<Option<TxNumber>>
+    pub fn append_receipts<I, R>(&mut self, receipts: I) -> ProviderResult<Option<TxNumber>>
     where
-        I: IntoIterator<Item = Result<(TxNumber, Receipt), ProviderError>>,
+        I: Iterator<Item = Result<(TxNumber, R), ProviderError>>,
+        R: Borrow<Receipt>,
     {
         let mut receipts_iter = receipts.into_iter().peekable();
         // If receipts are empty, we can simply return None
@@ -568,7 +570,8 @@ impl StaticFileProviderRW {
 
         for receipt_result in receipts_iter {
             let (tx_num, receipt) = receipt_result?;
-            tx_number = self.append_with_tx_number(StaticFileSegment::Receipts, tx_num, receipt)?;
+            tx_number =
+                self.append_with_tx_number(StaticFileSegment::Receipts, tx_num, receipt.borrow())?;
             count += 1;
         }
 

--- a/crates/storage/provider/src/writer/static_file.rs
+++ b/crates/storage/provider/src/writer/static_file.rs
@@ -14,10 +14,12 @@ impl<'a> ReceiptWriter for StaticFileWriter<'a, StaticFileProviderRWRefMut<'_>> 
     ) -> ProviderResult<()> {
         // Increment block on static file header.
         self.0.increment_block(StaticFileSegment::Receipts, block_number)?;
-        let receipts = receipts.into_iter().enumerate().map(|(tx_idx, receipt)| {
+        let receipts = receipts.iter().enumerate().map(|(tx_idx, receipt)| {
             Ok((
                 first_tx_index + tx_idx as u64,
-                receipt.expect("receipt should not be filtered when saving to static files."),
+                receipt
+                    .as_ref()
+                    .expect("receipt should not be filtered when saving to static files."),
             ))
         });
         self.0.append_receipts(receipts)?;


### PR DESCRIPTION
Previously static file methods required ownership, because `Compact` did not act on `&self`. This is now not the case, so we can remove some clones in the static files task by taking references.