### PR TITLE
docs: add pruning related documentation for db service

### DIFF
--- a/crates/engine/tree/src/database.rs
+++ b/crates/engine/tree/src/database.rs
@@ -39,7 +39,10 @@ pub struct DatabaseService<DB> {
 }
 
 impl<DB: Database> DatabaseService<DB> {
-    /// Create a new database service
+    /// Create a new database service.
+    ///
+    /// NOTE: The [`ProviderFactory`] and [`Pruner`] should be built using an identical
+    /// [`PruneModes`](reth_prune::PruneModes).
     pub const fn new(
         provider: ProviderFactory<DB>,
         incoming: Receiver<DatabaseAction>,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3142,6 +3142,27 @@ impl<DB: Database> BlockExecutionWriter for DatabaseProviderRW<DB> {
 }
 
 impl<DB: Database> BlockWriter for DatabaseProviderRW<DB> {
+    /// Inserts the block into the database, always modifying the following tables:
+    /// * [`CanonicalHeaders`](tables::CanonicalHeaders)
+    /// * [`Headers`](tables::Headers)
+    /// * [`HeaderNumbers`](tables::HeaderNumbers)
+    /// * [`HeaderTerminalDifficulties`](tables::HeaderTerminalDifficulties)
+    /// * [`BlockBodyIndices`](tables::BlockBodyIndices)
+    ///
+    /// If there are transactions in the block, the following tables will be modified:
+    /// * [`Transactions`](tables::Transactions)
+    /// * [`TransactionBlocks`](tables::TransactionBlocks)
+    ///
+    /// If ommers are not empty, this will modify [`BlockOmmers`](tables::BlockOmmers).
+    /// If withdrawals are not empty, this will modify
+    /// [`BlockWithdrawals`](tables::BlockWithdrawals).
+    /// If requests are not empty, this will modify [`BlockRequests`](tables::BlockRequests).
+    ///
+    /// If the provider has __not__ configured full sender pruning, this will modify
+    /// [`TransactionSenders`](tables::TransactionSenders).
+    ///
+    /// If the provider has __not__ configured full transaction lookup pruning, this will modify
+    /// [`TransactionHashNumbers`](tables::TransactionHashNumbers).
     fn insert_block(
         &self,
         block: SealedBlockWithSenders,


### PR DESCRIPTION
This documents the database service constructor, and the `DatabaseProviderRW::insert_block` method, making it clear how the `PruneModes` will be used.