### PR TITLE
Use `ProviderFactory::new_with_database_path` in example

### DIFF
--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -1,5 +1,5 @@
 use reth_chainspec::ChainSpecBuilder;
-use reth_db::open_db_read_only;
+use reth_db::mdbx::DatabaseArguments;
 use reth_primitives::{Address, B256};
 use reth_provider::{
     providers::StaticFileProvider, AccountReader, BlockReader, BlockSource, HeaderProvider,
@@ -16,20 +16,20 @@ use std::path::Path;
 // Other parts of the code which include caching are parts of the `EthApi` abstraction.
 fn main() -> eyre::Result<()> {
     // Opens a RO handle to the database file.
-    // TODO: Should be able to do `ProviderFactory::new_with_db_path_ro(...)` instead of
-    //  doing in 2 steps.
     let db_path = std::env::var("RETH_DB_PATH")?;
     let db_path = Path::new(&db_path);
-    let db = open_db_read_only(db_path.join("db").as_path(), Default::default())?;
 
     // Instantiate a provider factory for Ethereum mainnet using the provided DB.
     // TODO: Should the DB version include the spec so that you do not need to specify it here?
     let spec = ChainSpecBuilder::mainnet().build();
-    let factory = ProviderFactory::new(
-        db,
+
+    let factory = ProviderFactory::new_with_database_path(
+        db_path,
         spec.into(),
+        DatabaseArguments::new(Default::default()),
         StaticFileProvider::read_only(db_path.join("static_files"))?,
-    );
+    )
+    .unwrap();
 
     // This call opens a RO transaction on the database. To write to the DB you'd need to call
     // the `provider_rw` function and look for the `Writer` variants of the traits.

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -1,5 +1,4 @@
 use reth_chainspec::ChainSpecBuilder;
-use reth_db::mdbx::DatabaseArguments;
 use reth_primitives::{Address, B256};
 use reth_provider::{
     providers::StaticFileProvider, AccountReader, BlockReader, BlockSource, HeaderProvider,
@@ -26,10 +25,9 @@ fn main() -> eyre::Result<()> {
     let factory = ProviderFactory::new_with_database_path(
         db_path,
         spec.into(),
-        DatabaseArguments::new(Default::default()),
+        Default::default(),
         StaticFileProvider::read_only(db_path.join("static_files"))?,
-    )
-    .unwrap();
+    )?;
 
     // This call opens a RO transaction on the database. To write to the DB you'd need to call
     // the `provider_rw` function and look for the `Writer` variants of the traits.

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -21,7 +21,6 @@ fn main() -> eyre::Result<()> {
     // Instantiate a provider factory for Ethereum mainnet using the provided DB.
     // TODO: Should the DB version include the spec so that you do not need to specify it here?
     let spec = ChainSpecBuilder::mainnet().build();
-
     let factory = ProviderFactory::new_with_database_path(
         db_path,
         spec.into(),


### PR DESCRIPTION
This PR aims to use the `new_with_database_path` in the example that uses `Path`.