### PR TITLE
chore: re-enable no_std CI checks

### DIFF
--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -5,15 +5,15 @@ set -eo pipefail
 no_std_packages=(
 #   reth-codecs
 #   reth-consensus
-#   reth-db
+    reth-db
 #   reth-errors
     reth-ethereum-forks
 #   reth-evm
 #   reth-evm-ethereum
-#   reth-network-peers
+    reth-network-peers
 #   reth-primitives
 #   reth-primitives-traits
-#   reth-revm
+    reth-revm
 )
 
 for package in "${no_std_packages[@]}"; do

--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -3,15 +3,16 @@ set -eo pipefail
 
 # TODO
 no_std_packages=(
+#   reth-db
+#   reth-primitives
 #   reth-codecs
 #   reth-consensus
-#   reth-db
+# the following are confirmed working
     reth-errors
     reth-ethereum-forks
-#   reth-evm
+    reth-evm
 #   reth-evm-ethereum
     reth-network-peers
-    reth-primitives
 #   reth-primitives-traits
     reth-revm
 )

--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -7,7 +7,7 @@ no_std_packages=(
 #   reth-consensus
 #   reth-db
 #   reth-errors
-#   reth-ethereum-forks
+    reth-ethereum-forks
 #   reth-evm
 #   reth-evm-ethereum
 #   reth-network-peers
@@ -17,7 +17,7 @@ no_std_packages=(
 )
 
 for package in "${no_std_packages[@]}"; do
-  cmd="cargo +stable build -p $package --target riscv32imac-unknown-none-elf --no-default-features"
+  cmd="cargo +stable build -p $package --target wasm32-wasip1 --no-default-features"
 
   if [ -n "$CI" ]; then
     echo "::group::$cmd"

--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -3,17 +3,18 @@ set -eo pipefail
 
 # TODO
 no_std_packages=(
+# The following were confirmed not working in the past, but could be enabled if issues have been resolved
 #   reth-db
 #   reth-primitives
 #   reth-codecs
+#   reth-evm
+#   reth-evm-ethereum
 #   reth-consensus
 # the following are confirmed working
     reth-errors
     reth-ethereum-forks
-    reth-evm
-#   reth-evm-ethereum
     reth-network-peers
-#   reth-primitives-traits
+    reth-primitives-traits
     reth-revm
 )
 

--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -5,13 +5,13 @@ set -eo pipefail
 no_std_packages=(
 #   reth-codecs
 #   reth-consensus
-    reth-db
-#   reth-errors
+#   reth-db
+    reth-errors
     reth-ethereum-forks
 #   reth-evm
 #   reth-evm-ethereum
     reth-network-peers
-#   reth-primitives
+    reth-primitives
 #   reth-primitives-traits
     reth-revm
 )

--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -6,7 +6,6 @@ no_std_packages=(
 # The following were confirmed not working in the past, but could be enabled if issues have been resolved
 #   reth-db
 #   reth-primitives
-#   reth-codecs
 #   reth-revm
 #   reth-evm
 #   reth-evm-ethereum
@@ -16,6 +15,7 @@ no_std_packages=(
     reth-ethereum-forks
     reth-network-peers
     reth-primitives-traits
+    reth-codecs
 )
 
 for package in "${no_std_packages[@]}"; do

--- a/.github/assets/check_no_std.sh
+++ b/.github/assets/check_no_std.sh
@@ -7,6 +7,7 @@ no_std_packages=(
 #   reth-db
 #   reth-primitives
 #   reth-codecs
+#   reth-revm
 #   reth-evm
 #   reth-evm-ethereum
 #   reth-consensus
@@ -15,7 +16,6 @@ no_std_packages=(
     reth-ethereum-forks
     reth-network-peers
     reth-primitives-traits
-    reth-revm
 )
 
 for package in "${no_std_packages[@]}"; do

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: riscv32imac-unknown-none-elf
+          target: wasm32-wasip1
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
         with:
@@ -168,7 +168,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Ensure no arbitrary or proptest dependency on default build
         run: cargo tree --package reth -e=features,no-dev | grep -Eq "arbitrary|proptest" && exit 1 || exit 0
-  
+
   lint-success:
     name: lint success
     runs-on: ubuntu-latest


### PR DESCRIPTION
Just attempting to enable the CI part of https://github.com/paradigmxyz/reth/pull/9347 and https://github.com/paradigmxyz/reth/pull/9430 for existing crates that should work and not attempting to fix any no_std errors