### PR TITLE
chore: remove reth-cli-util proptest dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6590,7 +6590,6 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "libc",
- "proptest",
  "rand 0.8.5",
  "reth-fs-util",
  "secp256k1",

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -25,8 +25,5 @@ rand.workspace = true
 thiserror.workspace = true
 eyre.workspace = true
 
-[dev-dependencies]
-proptest.workspace = true
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/cli/util/src/parsers.rs
+++ b/crates/cli/util/src/parsers.rs
@@ -68,7 +68,7 @@ pub fn parse_socket_address(value: &str) -> eyre::Result<SocketAddr, SocketAddre
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::prelude::Rng;
+    use rand::Rng;
 
     #[test]
     fn parse_socket_addresses() {


### PR DESCRIPTION
This was using a reexport of `rand`, we can remove `proptest` as a dev-dep since we already import `rand` in this crate.