### PR TITLE
refactor(trie): move storage root database operations into an extension trait in the `reth-db-trie` crate

### DIFF
--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -1,4 +1,7 @@
 //! An integration of [`reth-trie`] with [`reth-db`].
 
 mod state;
+mod storage;
+
 pub use state::DatabaseStateRoot;
+pub use storage::DatabaseStorageRoot;

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -1,0 +1,39 @@
+use reth_db_api::transaction::DbTx;
+use reth_primitives::{Address, B256};
+use reth_trie::{hashed_cursor::DatabaseHashedCursorFactory, StorageRoot};
+
+#[cfg(feature = "metrics")]
+use reth_trie::metrics::{TrieRootMetrics, TrieType};
+
+/// Extends [`StorageRoot`] with operations specific for working with a database transaction.
+pub trait DatabaseStorageRoot<'a, TX> {
+    /// Create a new storage root calculator from database transaction and raw address.
+    fn from_tx(tx: &'a TX, address: Address) -> Self;
+
+    /// Create a new storage root calculator from database transaction and hashed address.
+    fn from_tx_hashed(tx: &'a TX, hashed_address: B256) -> Self;
+}
+
+impl<'a, TX: DbTx> DatabaseStorageRoot<'a, TX>
+    for StorageRoot<&'a TX, DatabaseHashedCursorFactory<'a, TX>>
+{
+    fn from_tx(tx: &'a TX, address: Address) -> Self {
+        Self::new(
+            tx,
+            DatabaseHashedCursorFactory::new(tx),
+            address,
+            #[cfg(feature = "metrics")]
+            TrieRootMetrics::new(TrieType::Storage),
+        )
+    }
+
+    fn from_tx_hashed(tx: &'a TX, hashed_address: B256) -> Self {
+        Self::new_hashed(
+            tx,
+            DatabaseHashedCursorFactory::new(tx),
+            hashed_address,
+            #[cfg(feature = "metrics")]
+            TrieRootMetrics::new(TrieType::Storage),
+        )
+    }
+}

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -13,7 +13,7 @@ use reth_trie::{
     BranchNodeCompact, StateRoot, StorageRoot, TrieMask,
 };
 use reth_trie_common::triehash::KeccakHasher;
-use reth_trie_db::DatabaseStateRoot;
+use reth_trie_db::{DatabaseStateRoot, DatabaseStorageRoot};
 use std::{
     collections::{BTreeMap, HashMap},
     ops::Mul,

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -1,5 +1,5 @@
 use crate::{
-    hashed_cursor::{DatabaseHashedCursorFactory, HashedCursorFactory, HashedStorageCursor},
+    hashed_cursor::{HashedCursorFactory, HashedStorageCursor},
     node_iter::{TrieElement, TrieNodeIter},
     prefix_set::{PrefixSet, TriePrefixSets},
     progress::{IntermediateStateRootState, StateRootProgress},
@@ -10,13 +10,12 @@ use crate::{
     HashBuilder, Nibbles, TrieAccount,
 };
 use alloy_rlp::{BufMut, Encodable};
-use reth_db_api::transaction::DbTx;
 use reth_execution_errors::{StateRootError, StorageRootError};
 use reth_primitives::{constants::EMPTY_ROOT_HASH, keccak256, Address, B256};
 use tracing::trace;
 
 #[cfg(feature = "metrics")]
-use crate::metrics::{StateRootMetrics, TrieRootMetrics, TrieType};
+use crate::metrics::{StateRootMetrics, TrieRootMetrics};
 
 /// `StateRoot` is used to compute the root node of a state trie.
 #[derive(Debug)]
@@ -360,30 +359,6 @@ impl<T, H> StorageRoot<T, H> {
             #[cfg(feature = "metrics")]
             metrics: self.metrics,
         }
-    }
-}
-
-impl<'a, TX: DbTx> StorageRoot<&'a TX, DatabaseHashedCursorFactory<'a, TX>> {
-    /// Create a new storage root calculator from database transaction and raw address.
-    pub fn from_tx(tx: &'a TX, address: Address) -> Self {
-        Self::new(
-            tx,
-            DatabaseHashedCursorFactory::new(tx),
-            address,
-            #[cfg(feature = "metrics")]
-            TrieRootMetrics::new(TrieType::Storage),
-        )
-    }
-
-    /// Create a new storage root calculator from database transaction and hashed address.
-    pub fn from_tx_hashed(tx: &'a TX, hashed_address: B256) -> Self {
-        Self::new_hashed(
-            tx,
-            DatabaseHashedCursorFactory::new(tx),
-            hashed_address,
-            #[cfg(feature = "metrics")]
-            TrieRootMetrics::new(TrieType::Storage),
-        )
     }
 }
 


### PR DESCRIPTION
### About
This is a continuation of #9282 and a follow-up to #9635

Moves `StorageRoot` operations specific to database transactions to the previously created `reth-trie-db` crate.

### Motivation
Extending #9282 and building on top of #9635, this one is an analogical version of the latter but for storage root.

### Goals
* Move `StorageRoot::from_tx` and others to `reth-trie-db`
* Update all usages to reflect the new structure

### Solution
* Created a new trait `DatabaseStorageRoot`
* Moved functions to the trait and implement it for `StorageRoot`
* Updated all affected places throughout the codebase (just added a trait usage)

### Additional notes
Happy to say since the last PR got merged, this one stands on its shoulder and constitutes just a few changes.