### PR TITLE
chore: fix `unnameable-types` lint on `core`, `payload` and `primitives-traits` crates

### DIFF
--- a/crates/net/downloaders/src/receipt_file_client.rs
+++ b/crates/net/downloaders/src/receipt_file_client.rs
@@ -232,6 +232,7 @@ mod test {
     use tokio_util::codec::Decoder;
 
     #[derive(Debug, PartialEq, Eq, RlpDecodable)]
+    #[allow(unnameable_types)]
     pub struct MockReceipt {
         tx_type: u8,
         status: u64,

--- a/crates/net/downloaders/src/receipt_file_client.rs
+++ b/crates/net/downloaders/src/receipt_file_client.rs
@@ -232,8 +232,7 @@ mod test {
     use tokio_util::codec::Decoder;
 
     #[derive(Debug, PartialEq, Eq, RlpDecodable)]
-    #[allow(unnameable_types)]
-    pub struct MockReceipt {
+    struct MockReceipt {
         tx_type: u8,
         status: u64,
         cumulative_gas_used: u64,

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -22,7 +22,7 @@ pub use database::DatabaseArgs;
 
 /// LogArgs struct for configuring the logger
 mod log;
-pub use log::{ColorMode, LogArgs};
+pub use log::{ColorMode, LogArgs, Verbosity};
 
 /// `PayloadBuilderArgs` struct for configuring the payload builder
 mod payload_builder;

--- a/crates/payload/builder/src/events.rs
+++ b/crates/payload/builder/src/events.rs
@@ -25,7 +25,7 @@ pub struct PayloadEvents<Engine: PayloadTypes> {
 }
 
 impl<Engine: PayloadTypes + 'static> PayloadEvents<Engine> {
-    /// Convert this receiver into a stream of PayloadEvents.
+    /// Convert this receiver into a stream of `PayloadEvents`.
     pub fn into_stream(self) -> BroadcastStream<Events<Engine>> {
         BroadcastStream::new(self.receiver)
     }

--- a/crates/payload/builder/src/events.rs
+++ b/crates/payload/builder/src/events.rs
@@ -20,11 +20,12 @@ pub enum Events<Engine: PayloadTypes> {
 /// Represents a receiver for various payload events.
 #[derive(Debug)]
 pub struct PayloadEvents<Engine: PayloadTypes> {
+    /// The receiver for the payload events.
     pub receiver: broadcast::Receiver<Events<Engine>>,
 }
 
 impl<Engine: PayloadTypes + 'static> PayloadEvents<Engine> {
-    // Convert this receiver into a stream of PayloadEvents.
+    /// Convert this receiver into a stream of PayloadEvents.
     pub fn into_stream(self) -> BroadcastStream<Events<Engine>> {
         BroadcastStream::new(self.receiver)
     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -113,7 +113,7 @@ pub mod noop;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
-pub use events::Events;
+pub use events::{Events, PayloadEvents};
 pub use reth_rpc_types::engine::PayloadId;
 pub use service::{
     PayloadBuilderHandle, PayloadBuilderService, PayloadServiceCommand, PayloadStore,

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -25,7 +25,7 @@ pub mod account;
 pub use account::{Account, Bytecode};
 
 mod integer_list;
-pub use integer_list::IntegerList;
+pub use integer_list::{IntegerList, RoaringBitmapError};
 
 pub mod request;
 pub use request::{Request, Requests};


### PR DESCRIPTION
## Description

Partially addresses #9401 

fix `unnameable-types` lint on `core`, `payload` and `primitives-traits` crates