### PR TITLE
fix(op):skip db consistency check for op mainnet

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -114,8 +114,6 @@ impl EnvironmentArgs {
         let factory = ProviderFactory::new(db, self.chain.clone(), static_file_provider)
             .with_prune_modes(prune_modes.clone());
 
-        info!(target: "reth::cli", "Verifying storage consistency.");
-
         // Check for consistency between database and static files.
         if let Some(unwind_target) = factory
             .static_file_provider()

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -371,54 +371,49 @@ where
         let has_receipt_pruning =
             self.toml_config().prune.as_ref().map_or(false, |a| a.has_receipts_pruning());
 
-        info!(target: "reth::cli", "Verifying storage consistency.");
+        // Check for consistency between database and static files. If it fails, it unwinds to
+        // the first block that's consistent between database and static files.
+        if let Some(unwind_target) = factory
+            .static_file_provider()
+            .check_consistency(&factory.provider()?, has_receipt_pruning)?
+        {
+            // Highly unlikely to happen, and given its destructive nature, it's better to panic
+            // instead.
+            assert_ne!(unwind_target, PipelineTarget::Unwind(0), "A static file <> database inconsistency was found that would trigger an unwind to block 0");
 
-        // OVM chain contains duplicate transactions, so is inconsistent by default
-        if !self.chain_spec().is_optimism_mainnet() {
-            // Check for consistency between database and static files. If it fails, it unwinds to
-            // the first block that's consistent between database and static files.
-            if let Some(unwind_target) = factory
-                .static_file_provider()
-                .check_consistency(&factory.provider()?, has_receipt_pruning)?
-            {
-                // Highly unlikely to happen, and given its destructive nature, it's better to panic
-                // instead.
-                assert_ne!(unwind_target, PipelineTarget::Unwind(0), "A static file <> database inconsistency was found that would trigger an unwind to block 0");
+            info!(target: "reth::cli", unwind_target = %unwind_target, "Executing an unwind after a failed storage consistency check.");
 
-                info!(target: "reth::cli", unwind_target = %unwind_target, "Executing an unwind after a failed storage consistency check.");
+            let (_tip_tx, tip_rx) = watch::channel(B256::ZERO);
 
-                let (_tip_tx, tip_rx) = watch::channel(B256::ZERO);
-
-                // Builds an unwind-only pipeline
-                let pipeline = Pipeline::builder()
-                    .add_stages(DefaultStages::new(
-                        factory.clone(),
-                        tip_rx,
-                        Arc::new(EthBeaconConsensus::new(self.chain_spec())),
-                        NoopHeaderDownloader::default(),
-                        NoopBodiesDownloader::default(),
-                        NoopBlockExecutorProvider::default(),
-                        self.toml_config().stages.clone(),
-                        self.prune_modes(),
-                    ))
-                    .build(
-                        factory.clone(),
-                        StaticFileProducer::new(factory.clone(), self.prune_modes()),
-                    );
-
-                // Unwinds to block
-                let (tx, rx) = oneshot::channel();
-
-                // Pipeline should be run as blocking and panic if it fails.
-                self.task_executor().spawn_critical_blocking(
-                    "pipeline task",
-                    Box::pin(async move {
-                        let (_, result) = pipeline.run_as_fut(Some(unwind_target)).await;
-                        let _ = tx.send(result);
-                    }),
+            // Builds an unwind-only pipeline
+            let pipeline = Pipeline::builder()
+                .add_stages(DefaultStages::new(
+                    factory.clone(),
+                    tip_rx,
+                    Arc::new(EthBeaconConsensus::new(self.chain_spec())),
+                    NoopHeaderDownloader::default(),
+                    NoopBodiesDownloader::default(),
+                    NoopBlockExecutorProvider::default(),
+                    self.toml_config().stages.clone(),
+                    self.prune_modes(),
+                ))
+                .build(
+                    factory.clone(),
+                    StaticFileProducer::new(factory.clone(), self.prune_modes()),
                 );
-                rx.await??;
-            }
+
+            // Unwinds to block
+            let (tx, rx) = oneshot::channel();
+
+            // Pipeline should be run as blocking and panic if it fails.
+            self.task_executor().spawn_critical_blocking(
+                "pipeline task",
+                Box::pin(async move {
+                    let (_, result) = pipeline.run_as_fut(Some(unwind_target)).await;
+                    let _ = tx.send(result);
+                }),
+            );
+            rx.await??;
         }
 
         Ok(factory)

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -532,6 +532,17 @@ impl StaticFileProvider {
         provider: &DatabaseProvider<TX>,
         has_receipt_pruning: bool,
     ) -> ProviderResult<Option<PipelineTarget>> {
+        // OVM chain contains duplicate transactions, so is inconsistent by default since reth db
+        // not designed for duplicate transactions (see <https://github.com/paradigmxyz/reth/blob/v1.0.3/crates/optimism/primitives/src/bedrock_import.rs>). Undefined behaviour for queries
+        // to OVM chain is also in op-erigon.
+        if provider.chain_spec().is_optimism_mainnet() {
+            info!(target: "reth::cli",
+                "Skipping storage verification for OP mainnet, expected inconsistency in OVM chain"
+            );
+        }
+
+        info!(target: "reth::cli", "Verifying storage consistency.");
+
         let mut unwind_target: Option<BlockNumber> = None;
         let mut update_unwind_target = |new_target: BlockNumber| {
             if let Some(target) = unwind_target.as_mut() {

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -539,6 +539,7 @@ impl StaticFileProvider {
             info!(target: "reth::cli",
                 "Skipping storage verification for OP mainnet, expected inconsistency in OVM chain"
             );
+            return Ok(None);
         }
 
         info!(target: "reth::cli", "Verifying storage consistency.");


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/9725

OVM chain is knowingly inconsistent, due to duplicate txns. Undefined behaviour for RPC queries for transactions below bedrock is allowed in op-reth, as well as op-erigon.