### PR TITLE
refactor(trie): move proof database related operations to an extension trait in `reth-trie-db` crate

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -15,8 +15,8 @@ use reth_primitives::{
 };
 use reth_storage_api::StateProofProvider;
 use reth_storage_errors::provider::ProviderResult;
-use reth_trie::{updates::TrieUpdates, AccountProof, HashedPostState, StateRoot};
-use reth_trie_db::DatabaseStateRoot;
+use reth_trie::{proof::Proof, updates::TrieUpdates, AccountProof, HashedPostState, StateRoot};
+use reth_trie_db::{DatabaseProof, DatabaseStateRoot};
 use std::fmt::Debug;
 
 /// State provider for a given block number which takes a tx reference.
@@ -285,8 +285,7 @@ impl<'b, TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'b, TX> {
     ) -> ProviderResult<AccountProof> {
         let mut revert_state = self.revert_state()?;
         revert_state.extend(hashed_state.clone());
-        revert_state
-            .account_proof(self.tx, address, slots)
+        Proof::overlay_account_proof(self.tx, revert_state, address, slots)
             .map_err(|err| ProviderError::Database(err.into()))
     }
 }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -12,8 +12,8 @@ use reth_primitives::{
 };
 use reth_storage_api::StateProofProvider;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
-use reth_trie::{updates::TrieUpdates, AccountProof, HashedPostState, StateRoot};
-use reth_trie_db::DatabaseStateRoot;
+use reth_trie::{proof::Proof, updates::TrieUpdates, AccountProof, HashedPostState, StateRoot};
+use reth_trie_db::{DatabaseProof, DatabaseStateRoot};
 
 /// State provider over latest state that takes tx reference.
 #[derive(Debug)]
@@ -96,8 +96,7 @@ impl<'b, TX: DbTx> StateProofProvider for LatestStateProviderRef<'b, TX> {
         address: Address,
         slots: &[B256],
     ) -> ProviderResult<AccountProof> {
-        Ok(hashed_state
-            .account_proof(self.tx, address, slots)
+        Ok(Proof::overlay_account_proof(self.tx, hashed_state.clone(), address, slots)
             .map_err(Into::<reth_db::DatabaseError>::into)?)
     }
 }

--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -1,7 +1,9 @@
 //! An integration of [`reth-trie`] with [`reth-db`].
 
+mod proof;
 mod state;
 mod storage;
 
+pub use proof::DatabaseProof;
 pub use state::DatabaseStateRoot;
 pub use storage::DatabaseStorageRoot;

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -1,0 +1,46 @@
+use reth_db_api::transaction::DbTx;
+use reth_execution_errors::StateRootError;
+use reth_primitives::{Address, B256};
+use reth_trie::{
+    hashed_cursor::{DatabaseHashedCursorFactory, HashedPostStateCursorFactory},
+    proof::Proof,
+    HashedPostState,
+};
+use reth_trie_common::AccountProof;
+
+/// Extends [`Proof`] with operations specific for working with a database transaction.
+pub trait DatabaseProof<'a, TX> {
+    /// Create a new [Proof] from database transaction.
+    fn from_tx(tx: &'a TX) -> Self;
+
+    /// Generates the state proof for target account and slots on top of this [`HashedPostState`].
+    fn overlay_account_proof(
+        tx: &'a TX,
+        post_state: HashedPostState,
+        address: Address,
+        slots: &[B256],
+    ) -> Result<AccountProof, StateRootError>;
+}
+
+impl<'a, TX: DbTx> DatabaseProof<'a, TX> for Proof<&'a TX, DatabaseHashedCursorFactory<'a, TX>> {
+    /// Create a new [Proof] instance from database transaction.
+    fn from_tx(tx: &'a TX) -> Self {
+        Self::new(tx, DatabaseHashedCursorFactory::new(tx))
+    }
+
+    fn overlay_account_proof(
+        tx: &'a TX,
+        post_state: HashedPostState,
+        address: Address,
+        slots: &[B256],
+    ) -> Result<AccountProof, StateRootError> {
+        let prefix_sets = post_state.construct_prefix_sets();
+        let sorted = post_state.into_sorted();
+        let hashed_cursor_factory =
+            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &sorted);
+        Proof::from_tx(tx)
+            .with_hashed_cursor_factory(hashed_cursor_factory)
+            .with_prefix_sets_mut(prefix_sets)
+            .account_proof(address, slots)
+    }
+}

--- a/crates/trie/db/tests/proof.rs
+++ b/crates/trie/db/tests/proof.rs
@@ -8,7 +8,7 @@ use reth_provider::{test_utils::create_test_provider_factory, HashingWriter, Pro
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{proof::Proof, Nibbles, StateRoot};
 use reth_trie_common::{AccountProof, StorageProof};
-use reth_trie_db::DatabaseStateRoot;
+use reth_trie_db::{DatabaseProof, DatabaseStateRoot};
 use std::{str::FromStr, sync::Arc};
 
 /*

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -1,7 +1,5 @@
 use crate::{
-    hashed_cursor::{DatabaseHashedCursorFactory, HashedPostStateCursorFactory},
     prefix_set::{PrefixSetMut, TriePrefixSetsMut},
-    proof::Proof,
     Nibbles,
 };
 use itertools::Itertools;
@@ -12,9 +10,7 @@ use reth_db_api::{
     models::{AccountBeforeTx, BlockNumberAddress},
     transaction::DbTx,
 };
-use reth_execution_errors::StateRootError;
 use reth_primitives::{keccak256, Account, Address, BlockNumber, B256, U256};
-use reth_trie_common::AccountProof;
 use revm::db::BundleAccount;
 use std::collections::{hash_map, HashMap, HashSet};
 
@@ -192,23 +188,6 @@ impl HashedPostState {
         }
 
         TriePrefixSetsMut { account_prefix_set, storage_prefix_sets, destroyed_accounts }
-    }
-
-    /// Generates the state proof for target account and slots on top of this [`HashedPostState`].
-    pub fn account_proof<TX: DbTx>(
-        &self,
-        tx: &TX,
-        address: Address,
-        slots: &[B256],
-    ) -> Result<AccountProof, StateRootError> {
-        let sorted = self.clone().into_sorted();
-        let prefix_sets = self.construct_prefix_sets();
-        let hashed_cursor_factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &sorted);
-        Proof::from_tx(tx)
-            .with_hashed_cursor_factory(hashed_cursor_factory)
-            .with_prefix_sets_mut(prefix_sets)
-            .account_proof(address, slots)
     }
 }
 


### PR DESCRIPTION
## About
This PR is about moving the projection of behavior of `Proof` from `reth-trie` to `reth-db` into `reth-trie-db`.

It is a part of an ongoing effort #9282 to separate `reth-db` from `reth-trie`.

## Motivation
Same as in the PR mentioned above, extended by keeping the changes in focused, atomic and reasonably sized chunks to make them properly reviewable and include them with confidence.

## Goals
* Separate `reth_db` and `reth_db_api` dependency in `proof` module of `reth-trie` crate completely out of that crate.
* Place any database implementations of the `Proof` into `reth-trie-db`.
* Update all relevant places.

## Solution
Is consistent with and in a very similar spirit to the changes in #9721 and #9635.

Any references to `DbTx` in the `proof` module of `reth-trie` are replaced with existing `TrieCursorFactory` and `TrieCursor` traits.

Functions that are specific to database transactions were moved to a new trait in a new `proof` module of `reth-trie-db` crate.

The naming convention is consistent with the rest of the previously merged code in `reth-trie-db`. This includes adding the method `overlay_account_proof`, since it uses `HashedPostState` in a similar fashion to `overlay_root` and `overlay_root_with_updates` in `DatabaseStateRoot`.
