### PR TITLE
feat(evm): use `RethEvmBuilder` inside `ConfigureEvm`

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -116,6 +116,8 @@ impl ConfigureEvm for EthEvmConfig {
     ) -> reth_revm::Evm<'_, Self::DefaultExternalContext<'_>, DB> {
         EvmBuilder::default().with_db(db).build()
     }
+
+    fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a> {}
 }
 
 #[cfg(test)]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -55,10 +55,7 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         db: DB,
         env: EnvWithHandlerCfg,
     ) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
-        let mut evm =
-            RethEvmBuilder::new(db, self.default_external_context()).with_env(env.env).build();
-        evm.modify_spec_id(evm.spec_id());
-        evm
+        RethEvmBuilder::new(db, self.default_external_context()).with_env(env.into()).build()
     }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
@@ -77,11 +74,9 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         DB: Database,
         I: GetInspector<DB>,
     {
-        let mut evm = RethEvmBuilder::new(db, self.default_external_context())
-            .with_env(env.env)
-            .build_with_inspector(inspector);
-        evm.modify_spec_id(evm.spec_id());
-        evm
+        RethEvmBuilder::new(db, self.default_external_context())
+            .with_env(env.into())
+            .build_with_inspector(inspector)
     }
 
     /// Returns a new EVM with the given inspector.

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -55,7 +55,10 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         db: DB,
         env: EnvWithHandlerCfg,
     ) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
-        RethEvmBuilder::new(db, self.default_external_context()).with_env(env.env).build()
+        let mut evm =
+            RethEvmBuilder::new(db, self.default_external_context()).with_env(env.env).build();
+        evm.modify_spec_id(evm.spec_id());
+        evm
     }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
@@ -74,9 +77,11 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         DB: Database,
         I: GetInspector<DB>,
     {
-        RethEvmBuilder::new(db, self.default_external_context())
+        let mut evm = RethEvmBuilder::new(db, self.default_external_context())
             .with_env(env.env)
-            .build_with_inspector(inspector)
+            .build_with_inspector(inspector);
+        evm.modify_spec_id(evm.spec_id());
+        evm
     }
 
     /// Returns a new EVM with the given inspector.

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -14,9 +14,10 @@ extern crate alloc;
 
 use core::ops::Deref;
 
+use crate::builder::RethEvmBuilder;
 use reth_chainspec::ChainSpec;
 use reth_primitives::{Address, Header, TransactionSigned, TransactionSignedEcRecovered, U256};
-use revm::{inspector_handle_register, Database, Evm, EvmBuilder, GetInspector};
+use revm::{Database, Evm, GetInspector};
 use revm_primitives::{
     BlockEnv, Bytes, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, SpecId, TxEnv,
 };
@@ -54,10 +55,7 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         db: DB,
         env: EnvWithHandlerCfg,
     ) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
-        let mut evm = self.evm(db);
-        evm.modify_spec_id(env.spec_id());
-        evm.context.evm.env = env.env;
-        evm
+        RethEvmBuilder::new(db, self.default_external_context()).with_env(env.env).build()
     }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
@@ -76,10 +74,9 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         DB: Database,
         I: GetInspector<DB>,
     {
-        let mut evm = self.evm_with_inspector(db, inspector);
-        evm.modify_spec_id(env.spec_id());
-        evm.context.evm.env = env.env;
-        evm
+        RethEvmBuilder::new(db, self.default_external_context())
+            .with_env(env.env)
+            .build_with_inspector(inspector)
     }
 
     /// Returns a new EVM with the given inspector.
@@ -92,12 +89,11 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         DB: Database,
         I: GetInspector<DB>,
     {
-        EvmBuilder::default()
-            .with_db(db)
-            .with_external_context(inspector)
-            .append_handler_register(inspector_handle_register)
-            .build()
+        RethEvmBuilder::new(db, self.default_external_context()).build_with_inspector(inspector)
     }
+
+    /// Provides the default external context.
+    fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a>;
 }
 
 /// This represents the set of methods used to configure the EVM's environment before block

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -129,6 +129,8 @@ impl ConfigureEvm for OptimismEvmConfig {
             .append_handler_register(inspector_handle_register)
             .build()
     }
+
+    fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a> {}
 }
 
 #[cfg(test)]

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -130,6 +130,8 @@ impl ConfigureEvm for MyEvmConfig {
             .append_handler_register(inspector_handle_register)
             .build()
     }
+
+    fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a> {}
 }
 
 /// Builds a regular ethereum block executor that uses the custom EVM.

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -193,6 +193,8 @@ impl ConfigureEvm for MyEvmConfig {
             .append_handler_register(inspector_handle_register)
             .build()
     }
+
+    fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a> {}
 }
 
 /// Builds a regular ethereum block executor that uses the custom EVM.


### PR DESCRIPTION
Now that https://github.com/paradigmxyz/reth/pull/9655 is merged, we are now poised to begin the transition towards fully utilizing `EvmFactory` in place of `ConfigureEvm`. 

This pull request initiates this process by incorporating `RethEvmBuilder` within the existing `ConfigureEvm` structure.