### PR TITLE
chore: fix unnameable-types lint on `blockchain-tree` and `rpc` crates

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -63,7 +63,8 @@ impl BlockIndices {
     }
 
     /// Return block to chain id
-    pub const fn blocks_to_chain(&self) -> &HashMap<BlockHash, BlockchainId> {
+    #[allow(dead_code)]
+    pub(crate) const fn blocks_to_chain(&self) -> &HashMap<BlockHash, BlockchainId> {
         &self.blocks_to_chain
     }
 
@@ -202,7 +203,7 @@ impl BlockIndices {
 
     /// Remove chain from indices and return dependent chains that need to be removed.
     /// Does the cleaning of the tree and removing blocks from the chain.
-    pub fn remove_chain(&mut self, chain: &Chain) -> BTreeSet<BlockchainId> {
+    pub(crate) fn remove_chain(&mut self, chain: &Chain) -> BTreeSet<BlockchainId> {
         chain
             .blocks()
             .iter()

--- a/crates/blockchain-tree/src/lib.rs
+++ b/crates/blockchain-tree/src/lib.rs
@@ -56,4 +56,6 @@ pub mod noop;
 
 mod state;
 
+pub use state::BlockchainId;
+
 use aquamarine as _;

--- a/crates/blockchain-tree/src/lib.rs
+++ b/crates/blockchain-tree/src/lib.rs
@@ -56,6 +56,4 @@ pub mod noop;
 
 mod state;
 
-pub use state::BlockchainId;
-
 use aquamarine as _;

--- a/crates/blockchain-tree/src/state.rs
+++ b/crates/blockchain-tree/src/state.rs
@@ -113,7 +113,7 @@ impl TreeState {
 
 /// The ID of a sidechain internally in a [`BlockchainTree`][super::BlockchainTree].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct BlockchainId(u64);
+pub(crate) struct BlockchainId(u64);
 
 impl From<BlockchainId> for u64 {
     fn from(value: BlockchainId) -> Self {

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -32,10 +32,7 @@ use tower::{layer::util::Identity, Layer, Service};
 use tracing::{debug, instrument, trace, warn, Instrument};
 // re-export so can be used during builder setup
 use crate::{
-    server::{
-        connection::IpcConnDriver,
-        rpc_service::{RpcService, RpcServiceCfg},
-    },
+    server::{connection::IpcConnDriver, rpc_service::RpcServiceCfg},
     stream_codec::StreamCodec,
 };
 use tokio::sync::mpsc;
@@ -45,6 +42,8 @@ use tower::layer::{util::Stack, LayerFn};
 mod connection;
 mod ipc;
 mod rpc_service;
+
+pub use rpc_service::RpcService;
 
 /// Ipc Server implementation
 ///

--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -4,10 +4,19 @@ use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 /// Error thrown when parsing cors domains went wrong
 #[derive(Debug, thiserror::Error)]
 pub enum CorsDomainError {
+    /// Represents an invalid header value for a domain
     #[error("{domain} is an invalid header value")]
-    InvalidHeader { domain: String },
+    InvalidHeader {
+        /// The domain that caused the invalid header
+        domain: String,
+    },
+
+    /// Indicates that a wildcard origin was used incorrectly in a list
     #[error("wildcard origin (`*`) cannot be passed as part of a list: {input}")]
-    WildCardNotAllowed { input: String },
+    WildCardNotAllowed {
+        /// The input string containing the incorrectly used wildcard
+        input: String,
+    },
 }
 
 /// Creates a [`CorsLayer`] from the given domains

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -177,12 +177,9 @@ use serde::{Deserialize, Serialize};
 use tower::Layer;
 use tower_http::cors::CorsLayer;
 
-use crate::{
-    auth::AuthRpcModule,
-    cors::CorsDomainError,
-    error::WsHttpSamePortError,
-    metrics::{RpcRequestMetrics, RpcRequestMetricsService},
-};
+use crate::{auth::AuthRpcModule, error::WsHttpSamePortError, metrics::RpcRequestMetrics};
+
+pub use cors::CorsDomainError;
 
 // re-export for convenience
 pub use jsonrpsee::server::ServerBuilder;
@@ -210,6 +207,7 @@ pub use eth::EthHandlers;
 
 // Rpc server metrics
 mod metrics;
+pub use metrics::{MeteredRequestFuture, RpcRequestMetricsService};
 
 /// Convenience function for starting a server in one step.
 #[allow(clippy::too_many_arguments)]

--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -83,7 +83,9 @@ struct RpcServerMetricsInner {
 /// This is created per connection and captures metrics for each request.
 #[derive(Clone, Debug)]
 pub struct RpcRequestMetricsService<S> {
+    /// The metrics collector for RPC requests
     metrics: RpcRequestMetrics,
+    /// The inner service being wrapped
     inner: S,
 }
 

--- a/crates/rpc/rpc-layer/src/auth_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_layer.rs
@@ -106,7 +106,7 @@ where
 #[pin_project]
 #[allow(missing_debug_implementations)]
 pub struct ResponseFuture<F> {
-    /// The kind of response future, pinned for async operations
+    /// The kind of response future, error or pending
     #[pin]
     kind: Kind<F>,
 }

--- a/crates/rpc/rpc-layer/src/auth_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_layer.rs
@@ -102,9 +102,11 @@ where
     }
 }
 
+/// A future representing the response of an RPC request
 #[pin_project]
 #[allow(missing_debug_implementations)]
 pub struct ResponseFuture<F> {
+    /// The kind of response future, pinned for async operations
     #[pin]
     kind: Kind<F>,
 }

--- a/crates/rpc/rpc-layer/src/lib.rs
+++ b/crates/rpc/rpc-layer/src/lib.rs
@@ -15,6 +15,8 @@ mod auth_client_layer;
 mod auth_layer;
 mod jwt_validator;
 
+pub use auth_layer::{AuthService, ResponseFuture};
+
 // Export alloy JWT types
 pub use alloy_rpc_types_engine::{Claims, JwtError, JwtSecret};
 


### PR DESCRIPTION
## Description

Partially addresses #9401 

Fix unnameable-types lint on `blockchain-tree` and `rpc` crates