### PR TITLE
chore: relax some builder api trait bounds

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -269,6 +269,20 @@ where
         WithLaunchContext { builder: self.builder.with_types(), task_executor: self.task_executor }
     }
 
+    /// Configures the types of the node and the provider type that will be used by the node.
+    pub fn with_types_and_provider<T, P>(
+        self,
+    ) -> WithLaunchContext<NodeBuilderWithTypes<FullNodeTypesAdapter<T, DB, P>>>
+    where
+        T: NodeTypes,
+        P: FullProvider<DB>,
+    {
+        WithLaunchContext {
+            builder: self.builder.with_types_and_provider(),
+            task_executor: self.task_executor,
+        }
+    }
+
     /// Preconfigures the node with a specific node implementation.
     ///
     /// This is a convenience method that sets the node's types and components in one call.
@@ -319,18 +333,14 @@ where
     }
 }
 
-impl<T, DB> WithLaunchContext<NodeBuilderWithTypes<RethFullAdapter<DB, T>>>
-where
-    DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
-    T: NodeTypes,
-{
+impl<T: FullNodeTypes> WithLaunchContext<NodeBuilderWithTypes<T>> {
     /// Advances the state of the node builder to the next state where all components are configured
     pub fn with_components<CB>(
         self,
         components_builder: CB,
-    ) -> WithLaunchContext<NodeBuilderWithComponents<RethFullAdapter<DB, T>, CB, ()>>
+    ) -> WithLaunchContext<NodeBuilderWithComponents<T, CB, ()>>
     where
-        CB: NodeComponentsBuilder<RethFullAdapter<DB, T>>,
+        CB: NodeComponentsBuilder<T>,
     {
         WithLaunchContext {
             builder: self.builder.with_components(components_builder),
@@ -339,20 +349,16 @@ where
     }
 }
 
-impl<T, DB, CB> WithLaunchContext<NodeBuilderWithComponents<RethFullAdapter<DB, T>, CB, ()>>
+impl<T, CB> WithLaunchContext<NodeBuilderWithComponents<T, CB, ()>>
 where
-    DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
-    T: NodeTypes,
-    CB: NodeComponentsBuilder<RethFullAdapter<DB, T>>,
+    T: FullNodeTypes,
+    CB: NodeComponentsBuilder<T>,
 {
     /// Advances the state of the node builder to the next state where all customizable
     /// [`NodeAddOns`] types are configured.
-    pub fn with_add_ons<AO>(
-        self,
-    ) -> WithLaunchContext<NodeBuilderWithComponents<RethFullAdapter<DB, T>, CB, AO>>
+    pub fn with_add_ons<AO>(self) -> WithLaunchContext<NodeBuilderWithComponents<T, CB, AO>>
     where
-        CB: NodeComponentsBuilder<RethFullAdapter<DB, T>>,
-        AO: NodeAddOns<NodeAdapter<RethFullAdapter<DB, T>, CB::Components>>,
+        AO: NodeAddOns<NodeAdapter<T, CB::Components>>,
     {
         WithLaunchContext {
             builder: self.builder.with_add_ons::<AO>(),
@@ -361,20 +367,17 @@ where
     }
 }
 
-impl<T, DB, CB, AO> WithLaunchContext<NodeBuilderWithComponents<RethFullAdapter<DB, T>, CB, AO>>
+impl<T, CB, AO> WithLaunchContext<NodeBuilderWithComponents<T, CB, AO>>
 where
-    DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
-    T: NodeTypes,
-    CB: NodeComponentsBuilder<RethFullAdapter<DB, T>>,
-    AO: NodeAddOns<NodeAdapter<RethFullAdapter<DB, T>, CB::Components>>,
+    T: FullNodeTypes,
+    CB: NodeComponentsBuilder<T>,
+    AO: NodeAddOns<NodeAdapter<T, CB::Components>>,
     AO::EthApi: FullEthApiServer + AddDevSigners,
 {
     /// Sets the hook that is run once the node's components are initialized.
     pub fn on_component_initialized<F>(self, hook: F) -> Self
     where
-        F: FnOnce(NodeAdapter<RethFullAdapter<DB, T>, CB::Components>) -> eyre::Result<()>
-            + Send
-            + 'static,
+        F: FnOnce(NodeAdapter<T, CB::Components>) -> eyre::Result<()> + Send + 'static,
     {
         Self {
             builder: self.builder.on_component_initialized(hook),
@@ -385,9 +388,7 @@ where
     /// Sets the hook that is run once the node has started.
     pub fn on_node_started<F>(self, hook: F) -> Self
     where
-        F: FnOnce(
-                FullNode<NodeAdapter<RethFullAdapter<DB, T>, CB::Components>, AO>,
-            ) -> eyre::Result<()>
+        F: FnOnce(FullNode<NodeAdapter<T, CB::Components>, AO>) -> eyre::Result<()>
             + Send
             + 'static,
     {
@@ -398,7 +399,7 @@ where
     pub fn on_rpc_started<F>(self, hook: F) -> Self
     where
         F: FnOnce(
-                RpcContext<'_, NodeAdapter<RethFullAdapter<DB, T>, CB::Components>, AO::EthApi>,
+                RpcContext<'_, NodeAdapter<T, CB::Components>, AO::EthApi>,
                 RethRpcServerHandles,
             ) -> eyre::Result<()>
             + Send
@@ -410,9 +411,7 @@ where
     /// Sets the hook that is run to configure the rpc modules.
     pub fn extend_rpc_modules<F>(self, hook: F) -> Self
     where
-        F: FnOnce(
-                RpcContext<'_, NodeAdapter<RethFullAdapter<DB, T>, CB::Components>, AO::EthApi>,
-            ) -> eyre::Result<()>
+        F: FnOnce(RpcContext<'_, NodeAdapter<T, CB::Components>, AO::EthApi>) -> eyre::Result<()>
             + Send
             + 'static,
     {
@@ -426,9 +425,7 @@ where
     /// The `ExEx` ID must be unique.
     pub fn install_exex<F, R, E>(self, exex_id: impl Into<String>, exex: F) -> Self
     where
-        F: FnOnce(ExExContext<NodeAdapter<RethFullAdapter<DB, T>, CB::Components>>) -> R
-            + Send
-            + 'static,
+        F: FnOnce(ExExContext<NodeAdapter<T, CB::Components>>) -> R + Send + 'static,
         R: Future<Output = eyre::Result<E>> + Send,
         E: Future<Output = eyre::Result<()>> + Send,
     {
@@ -436,6 +433,14 @@ where
             builder: self.builder.install_exex(exex_id, exex),
             task_executor: self.task_executor,
         }
+    }
+
+    /// Launches the node with the given closure.
+    pub fn launch_with_fn<L, R>(self, launcher: L) -> R
+    where
+        L: FnOnce(Self) -> R,
+    {
+        launcher(self)
     }
 
     /// Check that the builder can be launched


### PR DESCRIPTION
this mirrors the trait bounds of the wrapped NodeBuilder type for the `WithLauncContext` wrapper