### PR TITLE
feat: improve in memory block tracking

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -563,7 +563,7 @@ mod tests {
     use reth_primitives::Receipt;
 
     fn create_mock_state(block_number: u64) -> BlockState {
-        BlockState::new(get_executed_block_with_number(block_number))
+        BlockState::new(get_executed_block_with_number(block_number, B256::random()))
     }
 
     #[test]
@@ -643,7 +643,7 @@ mod tests {
     #[test]
     fn test_state_new() {
         let number = rand::thread_rng().gen::<u64>();
-        let block = get_executed_block_with_number(number);
+        let block = get_executed_block_with_number(number, B256::random());
 
         let state = BlockState::new(block.clone());
 
@@ -653,7 +653,7 @@ mod tests {
     #[test]
     fn test_state_block() {
         let number = rand::thread_rng().gen::<u64>();
-        let block = get_executed_block_with_number(number);
+        let block = get_executed_block_with_number(number, B256::random());
 
         let state = BlockState::new(block.clone());
 
@@ -663,17 +663,17 @@ mod tests {
     #[test]
     fn test_state_hash() {
         let number = rand::thread_rng().gen::<u64>();
-        let block = get_executed_block_with_number(number);
+        let block = get_executed_block_with_number(number, B256::random());
 
         let state = BlockState::new(block.clone());
 
-        assert_eq!(state.hash(), block.block().hash());
+        assert_eq!(state.hash(), block.block.hash());
     }
 
     #[test]
     fn test_state_number() {
         let number = rand::thread_rng().gen::<u64>();
-        let block = get_executed_block_with_number(number);
+        let block = get_executed_block_with_number(number, B256::random());
 
         let state = BlockState::new(block);
 
@@ -683,7 +683,7 @@ mod tests {
     #[test]
     fn test_state_state_root() {
         let number = rand::thread_rng().gen::<u64>();
-        let block = get_executed_block_with_number(number);
+        let block = get_executed_block_with_number(number, B256::random());
 
         let state = BlockState::new(block.clone());
 
@@ -694,7 +694,7 @@ mod tests {
     fn test_state_receipts() {
         let receipts = Receipts { receipt_vec: vec![vec![Some(Receipt::default())]] };
 
-        let block = get_executed_block_with_receipts(receipts.clone());
+        let block = get_executed_block_with_receipts(receipts.clone(), B256::random());
 
         let state = BlockState::new(block);
 
@@ -704,8 +704,8 @@ mod tests {
     #[test]
     fn test_in_memory_state_chain_update() {
         let state = CanonicalInMemoryState::new(HashMap::new(), HashMap::new(), None);
-        let block1 = get_executed_block_with_number(0);
-        let block2 = get_executed_block_with_number(0);
+        let block1 = get_executed_block_with_number(0, B256::random());
+        let block2 = get_executed_block_with_number(0, B256::random());
         let chain = NewCanonicalChain::Commit { new: vec![block1.clone()] };
         state.update_chain(chain);
         assert_eq!(state.head_state().unwrap().block().block().hash(), block1.block().hash());

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -6,6 +6,7 @@ use rand::Rng;
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_primitives::{
     Address, Block, BlockNumber, Receipts, Requests, SealedBlockWithSenders, TransactionSigned,
+    B256,
 };
 use reth_trie::{updates::TrieUpdates, HashedPostState};
 use revm::db::BundleState;
@@ -15,18 +16,21 @@ use std::{
 };
 use tokio::sync::broadcast::{self, Sender};
 
-fn get_executed_block(block_number: BlockNumber, receipts: Receipts) -> ExecutedBlock {
+fn get_executed_block(
+    block_number: BlockNumber,
+    receipts: Receipts,
+    parent_hash: B256,
+) -> ExecutedBlock {
     let mut block = Block::default();
     let mut header = block.header.clone();
     header.number = block_number;
+    header.parent_hash = parent_hash;
     block.header = header;
-
     let sender = Address::random();
     let tx = TransactionSigned::default();
     block.body.push(tx);
     let sealed = block.seal_slow();
     let sealed_with_senders = SealedBlockWithSenders::new(sealed.clone(), vec![sender]).unwrap();
-
     ExecutedBlock::new(
         Arc::new(sealed),
         Arc::new(sealed_with_senders.senders),
@@ -42,20 +46,27 @@ fn get_executed_block(block_number: BlockNumber, receipts: Receipts) -> Executed
 }
 
 /// Generates an `ExecutedBlock` that includes the given `Receipts`.
-pub fn get_executed_block_with_receipts(receipts: Receipts) -> ExecutedBlock {
+pub fn get_executed_block_with_receipts(receipts: Receipts, parent_hash: B256) -> ExecutedBlock {
     let number = rand::thread_rng().gen::<u64>();
-
-    get_executed_block(number, receipts)
+    get_executed_block(number, receipts, parent_hash)
 }
 
 /// Generates an `ExecutedBlock` with the given `BlockNumber`.
-pub fn get_executed_block_with_number(block_number: BlockNumber) -> ExecutedBlock {
-    get_executed_block(block_number, Receipts { receipt_vec: vec![vec![]] })
+pub fn get_executed_block_with_number(
+    block_number: BlockNumber,
+    parent_hash: B256,
+) -> ExecutedBlock {
+    get_executed_block(block_number, Receipts { receipt_vec: vec![vec![]] }, parent_hash)
 }
 
 /// Generates a range of executed blocks with ascending block numbers.
 pub fn get_executed_blocks(range: Range<u64>) -> impl Iterator<Item = ExecutedBlock> {
-    range.map(get_executed_block_with_number)
+    let mut parent_hash = B256::default();
+    range.map(move |number| {
+        let block = get_executed_block_with_number(number, parent_hash);
+        parent_hash = block.block.hash();
+        block
+    })
 }
 
 /// A test `ChainEventSubscriptions`

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -25,11 +25,12 @@ fn get_executed_block(
     let mut header = block.header.clone();
     header.number = block_number;
     header.parent_hash = parent_hash;
+    header.ommers_hash = B256::random();
     block.header = header;
-    let sender = Address::random();
     let tx = TransactionSigned::default();
     block.body.push(tx);
     let sealed = block.seal_slow();
+    let sender = Address::random();
     let sealed_with_senders = SealedBlockWithSenders::new(sealed.clone(), vec![sender]).unwrap();
     ExecutedBlock::new(
         Arc::new(sealed),

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -442,7 +442,7 @@ mod tests {
         reth_tracing::init_test_tracing();
         let persistence_handle = default_persistence_handle();
         let block_number = 0;
-        let executed = get_executed_block_with_number(block_number);
+        let executed = get_executed_block_with_number(block_number, B256::random());
         let block_hash = executed.block().hash();
 
         let blocks = vec![executed];

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -108,31 +108,22 @@ impl TreeState {
         let parent_hash = executed.block.parent_hash;
         let block_number = executed.block.number;
 
-        // Check if the block already exists
         if self.blocks_by_hash.contains_key(&hash) {
-            // If the block already exists, we don't need to do anything
-            println!("block already exists");
             return;
         }
 
-        // Insert the block into blocks_by_hash
         self.blocks_by_hash.insert(hash, executed.clone());
 
-        // Update blocks_by_number
-        self.blocks_by_number.entry(block_number).or_default().push(executed.clone());
+        self.blocks_by_number.entry(block_number).or_default().push(executed);
 
-        // Update parent_to_child relationship
         self.parent_to_child.entry(parent_hash).or_default().insert(hash);
 
-        // Check if this block creates a fork
         if let Some(existing_blocks) = self.blocks_by_number.get(&block_number) {
             if existing_blocks.len() > 1 {
-                // This is a fork. We need to ensure the parent of the new block is aware of it
                 self.parent_to_child.entry(parent_hash).or_default().insert(hash);
             }
         }
 
-        // Remove any children from the parent_to_child map that are not in blocks_by_hash
         for children in self.parent_to_child.values_mut() {
             children.retain(|child| self.blocks_by_hash.contains_key(child));
         }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1795,8 +1795,8 @@ mod tests {
         assert!(!tree_state.parent_to_child.contains_key(&blocks[2].block.hash()));
     }
 
-    #[test]
-    fn test_tree_state_insert_executed_with_reorg() {
+    #[tokio::test]
+    async fn test_tree_state_insert_executed_with_reorg() {
         let mut tree_state = TreeState::new(BlockNumHash::default());
         let blocks: Vec<_> = get_executed_blocks(1..6).collect();
 
@@ -1869,8 +1869,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_tree_state_on_new_head() {
+    #[tokio::test]
+    async fn test_tree_state_on_new_head() {
         let mut tree_state = TreeState::new(BlockNumHash::default());
         let blocks: Vec<_> = get_executed_blocks(1..6).collect();
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -222,6 +222,7 @@ impl TreeState {
                     current_hash = block.block.parent_hash;
                 } else {
                     // current hash not found in memory
+                    warn!(target: "consensus::engine", invalid_hash=?current_hash, "Block not found in TreeState while walking back fork");
                     return None;
                 }
             }


### PR DESCRIPTION
Closes #9752

* Introduces `parent_to_child` field in `TreeState`, updates insertion and removal methods to use it.
* Updates `on_new_head` method to handle reorgs using `parent_to_child` field
* Changes in testing functions to allow to generate chains of `ExecutedBlock`s
* Adds unit tests