### PR TITLE
fix(rpc/eth): remove cache when reorg occured

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
@@ -61,8 +61,9 @@ where
         }
     }
 
-    /// Remove consumers for a given key.
+    /// Remove consumers for a given key, this will also remove the key from the cache.
     pub fn remove(&mut self, key: &K) -> Option<Vec<S>> {
+        let _ = self.cache.remove(key);
         match self.queued.remove(key) {
             Some(removed) => {
                 self.metrics.queued_consumers_count.decrement(removed.len() as f64);

--- a/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
@@ -64,10 +64,9 @@ where
     /// Remove consumers for a given key, this will also remove the key from the cache.
     pub fn remove(&mut self, key: &K) -> Option<Vec<S>> {
         let _ = self.cache.remove(key);
-        self.queued.remove(key).map(|removed| {
-            self.metrics.queued_consumers_count.decrement(removed.len() as f64);
-            removed
-        })
+        self.queued
+            .remove(key)
+            .inspect(|removed| self.metrics.queued_consumers_count.decrement(removed.len() as f64))
     }
 
     /// Returns a reference to the value for a given key and promotes that element to be the most

--- a/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
@@ -64,13 +64,10 @@ where
     /// Remove consumers for a given key, this will also remove the key from the cache.
     pub fn remove(&mut self, key: &K) -> Option<Vec<S>> {
         let _ = self.cache.remove(key);
-        match self.queued.remove(key) {
-            Some(removed) => {
-                self.metrics.queued_consumers_count.decrement(removed.len() as f64);
-                Some(removed)
-            }
-            None => None,
-        }
+        self.queued.remove(key).map(|removed| {
+            self.metrics.queued_consumers_count.decrement(removed.len() as f64);
+            removed
+        })
     }
 
     /// Returns a reference to the value for a given key and promotes that element to be the most


### PR DESCRIPTION
# What's the problem?

`eth_getBlockByHash` returns the ReOrged block;

# How to reproduce

We're running ETL process to fetch blocks and transactions from the RPC server, and then save them into our DB, and after some epoch(eg: 64 blocks), recheck the saved blocks to see if it's forked blocks or canonical ones. 

If it's a forked one(**by checking the block hash can continue to be queried to determine**), we need to remove the saved transactions and re-fetch the block with the same block number. 

And this process runs when in geth's RPC, but failed on reth. After some digging, found geth will remove the hash -> number mapping when reorg occurs: https://github.com/ethereum/go-ethereum/blob/df3f0a81a7ef6fd56c90675c32b6d732380a9fd2/core/blockchain.go#L1322-L1327

Reth will also remove the mapping in the underlying DB(by restarting reth, this issue disappeared), but the cache is not fully removed, so I propose this PR.