### PR TITLE
fix(cli): set receipts pruning for chain without deposit contract

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -339,10 +339,6 @@ impl<R> LaunchContextWith<Attached<WithConfigs, R>> {
 
     /// Returns the configured [`PruneConfig`]
     pub fn prune_config(&self) -> Option<PruneConfig> {
-        let config = self.node_config().prune_config();
-        if config.is_some() {
-            return config
-        }
         self.toml_config().prune.clone().or_else(|| self.node_config().prune_config())
     }
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -339,6 +339,10 @@ impl<R> LaunchContextWith<Attached<WithConfigs, R>> {
 
     /// Returns the configured [`PruneConfig`]
     pub fn prune_config(&self) -> Option<PruneConfig> {
+        let config = self.node_config().prune_config();
+        if config.is_some() {
+            return config
+        }
         self.toml_config().prune.clone().or_else(|| self.node_config().prune_config())
     }
 

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -21,7 +21,7 @@ impl PruningArgs {
         if !self.full {
             return None
         }
-        Some(PruneConfig {
+        let mut config = PruneConfig {
             block_interval: 5,
             segments: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
@@ -41,7 +41,13 @@ impl PruningArgs {
                         .collect(),
                 ),
             },
-        })
+        };
+
+        if chain_spec.is_optimism_mainnet() {
+            config.segments.receipts = Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE))
+        }
+
+        Some(config)
     }
 }
 

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -21,7 +21,8 @@ impl PruningArgs {
         if !self.full {
             return None
         }
-        let mut config = PruneConfig {
+
+        Some(PruneConfig {
             block_interval: 5,
             segments: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
@@ -29,7 +30,8 @@ impl PruningArgs {
                 receipts: chain_spec
                     .deposit_contract
                     .as_ref()
-                    .map(|contract| PruneMode::Before(contract.block)),
+                    .map(|contract| PruneMode::Before(contract.block))
+                    .or(Some(PruneMode::Full)),
                 account_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                 storage_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                 receipts_log_filter: ReceiptsLogPruneConfig(
@@ -41,13 +43,7 @@ impl PruningArgs {
                         .collect(),
                 ),
             },
-        };
-
-        if chain_spec.is_optimism_mainnet() {
-            config.segments.receipts = Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE))
-        }
-
-        Some(config)
+        })
     }
 }
 

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -27,6 +27,7 @@ impl PruningArgs {
             segments: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
                 transaction_lookup: None,
+                // prune all receipts if chain doesn't have deposit contract specified in chain spec
                 receipts: chain_spec
                     .deposit_contract
                     .as_ref()


### PR DESCRIPTION
- Sets receipts prune mode to `PruneMode::Full`, for chains that don't have deposit contract in `ChainSpec`