### PR TITLE
fix(engine): use provider to initialize persistence state

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1688,9 +1688,11 @@ mod tests {
         let last_executed_block = blocks.last().unwrap().clone();
         let last_header = last_executed_block.block().header();
 
+        // we expect the persistence state to be "at zero" - in practice there will be a genesis
+        // header hash
         let persistence_state = PersistenceState {
-            last_persisted_block_number: last_header.number,
-            last_persisted_block_hash: last_header.hash_slow(),
+            last_persisted_block_number: 0,
+            last_persisted_block_hash: B256::ZERO,
             rx: None,
         };
 


### PR DESCRIPTION
Previously, on node startup, these would be zero, making `should_persist` always true on startup, also causing the engine to send empty blocks to `save_blocks`.

Now these are initialized using values from the provider factory, which should correspond to the values that are actually on-disk.