### PR TITLE
fix: use parent hash for chain traversal

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -166,7 +166,7 @@ impl TreeState {
                 // we have a reorg
                 todo!("handle reorg")
             }
-            let parent_block = self.blocks_by_hash.get(&new_head).cloned()?;
+            let parent_block = self.blocks_by_hash.get(&parent.hash).cloned()?;
             parent = parent_block.block.num_hash();
             new_chain.push(parent_block);
         }


### PR DESCRIPTION
closes #9787

we actually need to use the parent hash, this is a hot fix to unblock for testing, while we improve this impl #9773 

cc @fgimenez 