### PR TITLE
feat: a trait for opening and creating dbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6739,6 +6739,7 @@ dependencies = [
  "bytes",
  "criterion",
  "derive_more",
+ "eyre",
  "iai-callgrind",
  "metrics",
  "modular-bitfield",

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -35,7 +35,6 @@ mod macros;
 
 /// Re-exported utils.
 pub mod utils {
-    pub use reth_db::open_db_read_only;
 
     /// Re-exported from `reth_node_core`, also to prevent a breaking change. See the comment
     /// on the `reth_node_core::args` re-export for more details.

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use reth_beacon_consensus::EthBeaconConsensus;
 use reth_chainspec::ChainSpec;
 use reth_config::{config::EtlConfig, Config};
-use reth_db::{init_db, open_db_read_only, DatabaseEnv};
+use reth_db::{DatabaseConfig, DatabaseEnv};
 use reth_db_common::init::init_genesis;
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_evm::noop::NoopBlockExecutorProvider;
@@ -79,11 +79,11 @@ impl EnvironmentArgs {
         info!(target: "reth::cli", ?db_path, ?sf_path, "Opening storage");
         let (db, sfp) = match access {
             AccessRights::RW => (
-                Arc::new(self.db.database_args().open()?),
+                Arc::new(self.db.database_args(db_path).open()?),
                 StaticFileProvider::read_write(sf_path)?,
             ),
             AccessRights::RO => (
-                Arc::new(open_db_read_only(&db_path, self.db.database_args())?),
+                Arc::new(self.db.database_args(db_path).open_ro()?),
                 StaticFileProvider::read_only(sf_path)?,
             ),
         };

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -79,7 +79,7 @@ impl EnvironmentArgs {
         info!(target: "reth::cli", ?db_path, ?sf_path, "Opening storage");
         let (db, sfp) = match access {
             AccessRights::RW => (
-                Arc::new(init_db(db_path, self.db.database_args())?),
+                Arc::new(self.db.database_args().open()?),
                 StaticFileProvider::read_write(sf_path)?,
             ),
             AccessRights::RO => (

--- a/crates/cli/commands/src/db/diff.rs
+++ b/crates/cli/commands/src/db/diff.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use reth_db::{open_db_read_only, tables_to_generic, DatabaseEnv, Tables};
+use reth_db::{tables_to_generic, DatabaseConfig, DatabaseEnv, Tables};
 use reth_db_api::{cursor::DbCursorRO, database::Database, table::Table, transaction::DbTx};
 use reth_db_common::DbTool;
 use reth_node_core::{
@@ -55,7 +55,7 @@ impl Command {
         warn!("Make sure the node is not running when running `reth db diff`!");
         // open second db
         let second_db_path: PathBuf = self.secondary_datadir.join("db").into();
-        let second_db = open_db_read_only(&second_db_path, self.second_db.database_args())?;
+        let second_db = self.second_db.database_args(second_db_path).open_ro()?;
 
         let tables = match &self.table {
             Some(table) => std::slice::from_ref(table),

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -4,7 +4,7 @@ use clap::{value_parser, Args, Parser};
 use reth_chainspec::ChainSpec;
 use reth_cli_runner::CliContext;
 use reth_cli_util::parse_socket_address;
-use reth_db::{init_db, DatabaseEnv};
+use reth_db::{DatabaseConfig, DatabaseEnv};
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_node_core::{
     args::{
@@ -179,7 +179,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
         let db_path = data_dir.db();
 
         tracing::info!(target: "reth::cli", path = ?db_path, "Opening database");
-        let database = Arc::new(self.db.database_args().open()?.with_metrics());
+        let database = Arc::new(self.db.database_args(db_path).open()?.with_metrics());
 
         if with_unused_ports {
             node_config = node_config.with_unused_ports();

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -179,7 +179,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
         let db_path = data_dir.db();
 
         tracing::info!(target: "reth::cli", path = ?db_path, "Opening database");
-        let database = Arc::new(init_db(db_path.clone(), self.db.database_args())?.with_metrics());
+        let database = Arc::new(self.db.database_args().open()?.with_metrics());
 
         if with_unused_ports {
             node_config = node_config.with_unused_ports();

--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -2,7 +2,7 @@
 use crate::common::{AccessRights, Environment, EnvironmentArgs};
 use clap::Parser;
 use reth_chainspec::ChainSpec;
-use reth_db::{init_db, mdbx::DatabaseArguments, tables, DatabaseEnv};
+use reth_db::{mdbx::DatabaseArguments, tables, DatabaseConfig, DatabaseEnv};
 use reth_db_api::{
     cursor::DbCursorRO, database::Database, models::ClientVersion, table::TableImporter,
     transaction::DbTx,
@@ -120,7 +120,7 @@ pub(crate) fn setup<DB: Database>(
 
     info!(target: "reth::cli", ?output_db, "Creating separate db");
 
-    let db = DatabaseArguments::new(output_db, ClientVersion::default()).open()?;
+    let db = DatabaseArguments::new(output_db.clone(), ClientVersion::default()).open()?;
 
     db.update(|tx| {
         tx.import_table_with_range::<tables::BlockBodyIndices, _>(

--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -120,9 +120,9 @@ pub(crate) fn setup<DB: Database>(
 
     info!(target: "reth::cli", ?output_db, "Creating separate db");
 
-    let output_datadir = init_db(output_db, DatabaseArguments::new(ClientVersion::default()))?;
+    let db = DatabaseArguments::new(output_db, ClientVersion::default()).open()?;
 
-    output_datadir.update(|tx| {
+    db.update(|tx| {
         tx.import_table_with_range::<tables::BlockBodyIndices, _>(
             &db_tool.provider_factory.db_ref().tx()?,
             Some(from - 1),
@@ -136,5 +136,5 @@ pub(crate) fn setup<DB: Database>(
         .view(|tx| tx.cursor_read::<tables::BlockBodyIndices>()?.last())??
         .expect("some");
 
-    Ok((output_datadir, tip_block_number))
+    Ok((db, tip_block_number))
 }

--- a/crates/node/core/src/args/database.rs
+++ b/crates/node/core/src/args/database.rs
@@ -1,5 +1,7 @@
 //! clap [Args](clap::Args) for database configuration
 
+use std::path::PathBuf;
+
 use crate::version::default_client_version;
 use clap::{
     builder::{PossibleValue, TypedValueParser},
@@ -23,8 +25,8 @@ pub struct DatabaseArgs {
 
 impl DatabaseArgs {
     /// Returns default database arguments with configured log level and client version.
-    pub fn database_args(&self) -> reth_db::mdbx::DatabaseArguments {
-        reth_db::mdbx::DatabaseArguments::new(default_client_version())
+    pub fn database_args(&self, path: PathBuf) -> reth_db::mdbx::DatabaseArguments {
+        reth_db::mdbx::DatabaseArguments::new(path, default_client_version())
             .with_log_level(self.log_level)
             .with_exclusive(self.exclusive)
     }

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -32,6 +32,7 @@ metrics.workspace = true
 # misc
 derive_more.workspace = true
 bytes.workspace = true
+eyre.workspace = true
 
 # arbitrary utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }
@@ -65,9 +66,5 @@ assert_matches.workspace = true
 
 [features]
 test-utils = ["arbitrary"]
-arbitrary = [
-    "reth-primitives/arbitrary",
-    "dep:arbitrary",
-    "dep:proptest",
-]
+arbitrary = ["reth-primitives/arbitrary", "dep:arbitrary", "dep:proptest"]
 optimism = ["reth-primitives/optimism"]

--- a/crates/storage/db-api/src/database.rs
+++ b/crates/storage/db-api/src/database.rs
@@ -1,9 +1,23 @@
 use crate::{
-    table::{Table, TableImporter},
+    table::TableImporter,
     transaction::{DbTx, DbTxMut},
     DatabaseError,
 };
 use std::{fmt::Debug, sync::Arc};
+
+/// A trait for database configuration, used as the main entrypoint for opening or creating a
+/// database.
+pub trait DatabaseConfig {
+    /// The database this config configures.
+    type DB: Database;
+
+    /// Open the database in read-write mode with the given options, initializing it with the given
+    /// tables if it does not already exist.
+    fn open(self) -> eyre::Result<Self::DB>;
+
+    /// Open the database in readonly mode with the given options.
+    fn open_ro(self) -> eyre::Result<Self::DB>;
+}
 
 /// Main Database trait that can open read-only and read-write transactions.
 ///
@@ -13,15 +27,6 @@ pub trait Database: Sized + Send + Sync {
     type TX: DbTx + Send + Sync + Debug + 'static;
     /// A read-write database transaction
     type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug + 'static;
-    /// Database-specific options for opening an existing database, and initializing a new database.
-    type Opts: Debug;
-
-    /// Open the database in read-write mode with the given options, initializing it with the given
-    /// tables if it does not already exist.
-    fn open(opts: Self::Opts) -> eyre::Result<Self>;
-
-    /// Open the database in readonly mode with the given options.
-    fn open_ro(opts: Self::Opts) -> eyre::Result<Self>;
 
     /// Create read only transaction.
     #[track_caller]
@@ -63,7 +68,6 @@ pub trait Database: Sized + Send + Sync {
 impl<DB: Database> Database for Arc<DB> {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
-    type Opts = <DB as Database>::Opts;
 
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
@@ -71,25 +75,12 @@ impl<DB: Database> Database for Arc<DB> {
 
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
-    }
-
-    fn open(opts: Self::Opts) -> eyre::Result<Self> {
-        <DB as Database>::open(opts).map(Arc::new)
-    }
-
-    fn init(opts: Self::Opts) -> eyre::Result<Self> {
-        <DB as Database>::init(opts).map(Arc::new)
-    }
-
-    fn open_ro(opts: Self::Opts) -> eyre::Result<Self> {
-        <DB as Database>::open_ro(opts).map(Arc::new)
     }
 }
 
 impl<DB: Database> Database for &DB {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
-    type Opts = <DB as Database>::Opts;
 
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
@@ -97,17 +88,5 @@ impl<DB: Database> Database for &DB {
 
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
-    }
-
-    fn open(_: Self::Opts) -> eyre::Result<Self> {
-        unimplemented!()
-    }
-
-    fn init(_: Self::Opts) -> eyre::Result<Self> {
-        unimplemented!()
-    }
-
-    fn open_ro(_: Self::Opts) -> eyre::Result<Self> {
-        unimplemented!()
     }
 }

--- a/crates/storage/db-api/src/database.rs
+++ b/crates/storage/db-api/src/database.rs
@@ -1,5 +1,5 @@
 use crate::{
-    table::TableImporter,
+    table::{Table, TableImporter},
     transaction::{DbTx, DbTxMut},
     DatabaseError,
 };
@@ -8,11 +8,20 @@ use std::{fmt::Debug, sync::Arc};
 /// Main Database trait that can open read-only and read-write transactions.
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for consumption.
-pub trait Database: Send + Sync {
-    /// Read-Only database transaction
+pub trait Database: Sized + Send + Sync {
+    /// A read-only database transaction
     type TX: DbTx + Send + Sync + Debug + 'static;
-    /// Read-Write database transaction
+    /// A read-write database transaction
     type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug + 'static;
+    /// Database-specific options for opening an existing database, and initializing a new database.
+    type Opts: Debug;
+
+    /// Open the database in read-write mode with the given options, initializing it with the given
+    /// tables if it does not already exist.
+    fn open(opts: Self::Opts) -> eyre::Result<Self>;
+
+    /// Open the database in readonly mode with the given options.
+    fn open_ro(opts: Self::Opts) -> eyre::Result<Self>;
 
     /// Create read only transaction.
     #[track_caller]
@@ -54,6 +63,7 @@ pub trait Database: Send + Sync {
 impl<DB: Database> Database for Arc<DB> {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
+    type Opts = <DB as Database>::Opts;
 
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
@@ -61,12 +71,25 @@ impl<DB: Database> Database for Arc<DB> {
 
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
+    }
+
+    fn open(opts: Self::Opts) -> eyre::Result<Self> {
+        <DB as Database>::open(opts).map(Arc::new)
+    }
+
+    fn init(opts: Self::Opts) -> eyre::Result<Self> {
+        <DB as Database>::init(opts).map(Arc::new)
+    }
+
+    fn open_ro(opts: Self::Opts) -> eyre::Result<Self> {
+        <DB as Database>::open_ro(opts).map(Arc::new)
     }
 }
 
 impl<DB: Database> Database for &DB {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
+    type Opts = <DB as Database>::Opts;
 
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
@@ -74,5 +97,17 @@ impl<DB: Database> Database for &DB {
 
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
+    }
+
+    fn open(_: Self::Opts) -> eyre::Result<Self> {
+        unimplemented!()
+    }
+
+    fn init(_: Self::Opts) -> eyre::Result<Self> {
+        unimplemented!()
+    }
+
+    fn open_ro(_: Self::Opts) -> eyre::Result<Self> {
+        unimplemented!()
     }
 }

--- a/crates/storage/db-api/src/lib.rs
+++ b/crates/storage/db-api/src/lib.rs
@@ -80,4 +80,4 @@ mod scale;
 
 mod utils;
 
-pub use database::Database;
+pub use database::{Database, DatabaseConfig};

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -25,6 +25,7 @@ pub struct DatabaseMock {
 impl Database for DatabaseMock {
     type TX = TxMock;
     type TXMut = TxMock;
+
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         Ok(TxMock::default())
     }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -146,7 +146,7 @@ impl DatabaseConfig for DatabaseArguments {
         use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};
 
         let rpath: &Path = self.path.as_ref();
-        if is_database_empty(&rpath) {
+        if is_database_empty(rpath) {
             reth_fs_util::create_dir_all(rpath).wrap_err_with(|| {
                 format!("Could not create database directory {}", rpath.display())
             })?;

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -406,10 +406,7 @@ mod tests {
         sleep(MAX_DURATION + Duration::from_millis(100));
 
         // Transaction has not timed out.
-        assert_eq!(
-            tx.get::<tables::Transactions>(0),
-            Err(DatabaseError::Open(reth_libmdbx::Error::NotFound.into()))
-        );
+        assert_eq!(tx.get::<tables::Transactions>(0), Ok(None));
         // Backtrace is not recorded.
         assert!(!tx.metrics_handler.unwrap().backtrace_recorded.load(Ordering::Relaxed));
     }

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -377,8 +377,12 @@ impl DbTxMut for Tx<RW> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{mdbx::DatabaseArguments, tables, DatabaseEnv, DatabaseEnvKind};
-    use reth_db_api::{database::Database, models::ClientVersion, transaction::DbTx};
+    use crate::{mdbx::DatabaseArguments, tables};
+    use reth_db_api::{
+        database::{Database, DatabaseConfig},
+        models::ClientVersion,
+        transaction::DbTx,
+    };
     use reth_libmdbx::MaxReadTransactionDuration;
     use reth_storage_errors::db::DatabaseError;
     use std::{sync::atomic::Ordering, thread::sleep, time::Duration};
@@ -389,11 +393,11 @@ mod tests {
         const MAX_DURATION: Duration = Duration::from_secs(1);
 
         let dir = tempdir().unwrap();
-        let args = DatabaseArguments::new(ClientVersion::default())
+        let args = DatabaseArguments::new(dir.path().into(), ClientVersion::default())
             .with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Set(
                 MAX_DURATION,
             )));
-        let db = DatabaseEnv::open(dir.path(), DatabaseEnvKind::RW, args).unwrap().with_metrics();
+        let db = args.open().unwrap().with_metrics();
 
         let mut tx = db.tx().unwrap();
         tx.metrics_handler.as_mut().unwrap().long_transaction_duration = MAX_DURATION;
@@ -415,11 +419,11 @@ mod tests {
         const MAX_DURATION: Duration = Duration::from_secs(1);
 
         let dir = tempdir().unwrap();
-        let args = DatabaseArguments::new(ClientVersion::default())
+        let args = DatabaseArguments::new(dir.path().into(), ClientVersion::default())
             .with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Set(
                 MAX_DURATION,
             )));
-        let db = DatabaseEnv::open(dir.path(), DatabaseEnvKind::RW, args).unwrap().with_metrics();
+        let db = args.open().unwrap().with_metrics();
 
         let mut tx = db.tx().unwrap();
         tx.metrics_handler.as_mut().unwrap().long_transaction_duration = MAX_DURATION;

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -34,7 +34,7 @@ pub use tables::*;
 pub use utils::is_database_empty;
 
 #[cfg(feature = "mdbx")]
-pub use mdbx::{init_db, open_db_read_only, DatabaseEnv, DatabaseEnvKind};
+pub use mdbx::{DatabaseEnv, DatabaseEnvKind};
 
 pub use reth_db_api::*;
 
@@ -208,8 +208,7 @@ mod tests {
 
         // Database is not empty, version file is malformed
         {
-            reth_fs_util::write(path.clone().join(db_version_file_path(&path)), "invalid-version")
-                .unwrap();
+            reth_fs_util::write(path.join(db_version_file_path(&path)), "invalid-version").unwrap();
             let db = args.clone().open();
             assert!(db.is_err());
             assert_matches!(

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -1,17 +1,4 @@
 //! Bindings for [MDBX](https://libmdbx.dqdkfa.ru/).
 
-use std::path::Path;
-
 pub use crate::implementation::mdbx::*;
 pub use reth_libmdbx::*;
-
-/// Opens up an existing database or creates a new one at the specified path. Creates tables if
-/// necessary. Read/Write mode.
-pub fn init_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    todo!()
-}
-
-/// Opens up an existing database. Read only mode. It doesn't create it or create tables if missing.
-pub fn open_db_read_only(path: &Path, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    todo!()
-}

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -1,54 +1,17 @@
 //! Bindings for [MDBX](https://libmdbx.dqdkfa.ru/).
 
-use crate::is_database_empty;
-use eyre::Context;
 use std::path::Path;
 
 pub use crate::implementation::mdbx::*;
 pub use reth_libmdbx::*;
 
-/// Creates a new database at the specified path if it doesn't exist. Does NOT create tables. Check
-/// [`init_db`].
-pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};
-
-    let rpath = path.as_ref();
-    if is_database_empty(rpath) {
-        reth_fs_util::create_dir_all(rpath)
-            .wrap_err_with(|| format!("Could not create database directory {}", rpath.display()))?;
-        create_db_version_file(rpath)?;
-    } else {
-        match check_db_version_file(rpath) {
-            Ok(_) => (),
-            Err(DatabaseVersionError::MissingFile) => create_db_version_file(rpath)?,
-            Err(err) => return Err(err.into()),
-        }
-    }
-
-    Ok(DatabaseEnv::open(rpath, DatabaseEnvKind::RW, args)?)
-}
-
 /// Opens up an existing database or creates a new one at the specified path. Creates tables if
 /// necessary. Read/Write mode.
 pub fn init_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    let client_version = args.client_version().clone();
-    let db = create_db(path, args)?;
-    db.create_tables()?;
-    db.record_client_version(client_version)?;
-    Ok(db)
+    todo!()
 }
 
 /// Opens up an existing database. Read only mode. It doesn't create it or create tables if missing.
 pub fn open_db_read_only(path: &Path, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    DatabaseEnv::open(path, DatabaseEnvKind::RO, args)
-        .with_context(|| format!("Could not open database at path: {}", path.display()))
-}
-
-/// Opens up an existing database. Read/Write mode with `WriteMap` enabled. It doesn't create it or
-/// create tables if missing.
-pub fn open_db(path: &Path, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
-    let db = DatabaseEnv::open(path, DatabaseEnvKind::RW, args.clone())
-        .with_context(|| format!("Could not open database at path: {}", path.display()))?;
-    db.record_client_version(args.client_version().clone())?;
-    Ok(db)
+    todo!()
 }

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -1,4 +1,5 @@
 use reth_chainspec::ChainSpecBuilder;
+use reth_db::mdbx::DatabaseArguments;
 use reth_primitives::{Address, B256};
 use reth_provider::{
     providers::StaticFileProvider, AccountReader, BlockReader, BlockSource, HeaderProvider,
@@ -21,10 +22,9 @@ fn main() -> eyre::Result<()> {
     // Instantiate a provider factory for Ethereum mainnet using the provided DB.
     // TODO: Should the DB version include the spec so that you do not need to specify it here?
     let spec = ChainSpecBuilder::mainnet().build();
-    let factory = ProviderFactory::new_with_database_path(
-        db_path,
+    let factory = ProviderFactory::new_with_database_args(
         spec.into(),
-        Default::default(),
+        DatabaseArguments::new(db_path.into(), Default::default()),
         StaticFileProvider::read_only(db_path.join("static_files"))?,
     )?;
 

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -20,10 +20,9 @@ use reth::{
         ProviderFactory,
     },
     rpc::eth::EthApi,
-    utils::open_db_read_only,
 };
 use reth_chainspec::ChainSpecBuilder;
-use reth_db::mdbx::DatabaseArguments;
+use reth_db::{mdbx::DatabaseArguments, DatabaseConfig};
 use reth_db_api::models::ClientVersion;
 
 // Bringing up the RPC
@@ -44,10 +43,8 @@ async fn main() -> eyre::Result<()> {
     // 1. Setup the DB
     let db_path = std::env::var("RETH_DB_PATH")?;
     let db_path = Path::new(&db_path);
-    let db = Arc::new(open_db_read_only(
-        db_path.join("db").as_path(),
-        DatabaseArguments::new(ClientVersion::default()),
-    )?);
+    let db =
+        Arc::new(DatabaseArguments::new(db_path.join("db"), ClientVersion::default()).open_ro()?);
     let spec = Arc::new(ChainSpecBuilder::mainnet().build());
     let factory = ProviderFactory::new(
         db.clone(),


### PR DESCRIPTION
**Motivation**

We want to split mdbx into a new crate instead of it living inside of reth-db

**Current issues**

The database abstraction (and reth) has a lot of mdbx specific logic and a lot of mdbx specific utilities. In order to remove mdbx, we have to:

- Remove reliance on the util fns `open_db`/`init_db`/`create_db` in favor of something more generic (this PR)
- Remove the assumption that we know all tables beforehand from some static data
- Streamline metric collection a bit (because of the above point)

If we do not address these then moving mdbx out of reth-db is hard without introducing circular dependencies

**This PR**

Removes the `init_db`/`open_db`/`...` functions and replaces them with a `DatabaseConfig` trait that can open a database (`DatabaseConfig::open`/`DatabaseConfig::open_ro`). This trait is implemented for `DatabaseArguments`.

I considered just adding `open` and `open_ro` to the `Database` trait, but it would introduce a lot of ugly code for the `&DB` impl and some of the mock/temp databases, since for `&DB` it is not possible to impl `open`/`open_ro`, and for the mock database it does not really exist as a concept

Since we also technically cannot rely on the fact that a database is located at a path (e.g. for a remote db), I chose to roll the `path` argument we ferried around into `DatabaseArguments` as well