### PR TITLE
fix: use saturating sub for getting safe and finalized hashes

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -57,11 +57,11 @@ impl Command {
                 };
 
                 let head_block_hash = block.hash();
-                let safe_block_hash =
-                    block_provider.get_block_by_number((block.number - 32).into(), false);
+                let safe_block_hash = block_provider
+                    .get_block_by_number(block.number.saturating_sub(32).into(), false);
 
-                let finalized_block_hash =
-                    block_provider.get_block_by_number((block.number - 64).into(), false);
+                let finalized_block_hash = block_provider
+                    .get_block_by_number(block.number.saturating_sub(64).into(), false);
 
                 let (safe, finalized) = tokio::join!(safe_block_hash, finalized_block_hash,);
 


### PR DESCRIPTION
this overflows when running the command with `--from 1 --to 2`