### PR TITLE
fix: set pipeline state back to idel

### DIFF
--- a/crates/engine/tree/src/backfill.rs
+++ b/crates/engine/tree/src/backfill.rs
@@ -139,7 +139,10 @@ where
             }
         };
         let ev = match res {
-            Ok((_, result)) => BackfillEvent::Finished(result),
+            Ok((pipeline, result)) => {
+                self.pipeline_state = PipelineState::Idle(Some(pipeline));
+                BackfillEvent::Finished(result)
+            }
             Err(why) => {
                 // failed to receive the pipeline
                 BackfillEvent::TaskDropped(why.to_string())


### PR DESCRIPTION
we need to reset the pipeline state once ready

ref:
https://github.com/paradigmxyz/reth/blob/45b23750d082615d6d72e9b5329e19e6bd312dcf/crates/consensus/beacon/src/engine/sync.rs#L250-L250