### PR TITLE
Adding Canyon hardfork to optimism devnet

### DIFF
--- a/crates/ethereum-forks/src/hardfork/dev.rs
+++ b/crates/ethereum-forks/src/hardfork/dev.rs
@@ -31,5 +31,7 @@ pub static DEV_HARDFORKS: Lazy<ChainHardforks> = Lazy::new(|| {
         (crate::OptimismHardfork::Bedrock.boxed(), ForkCondition::Block(0)),
         #[cfg(feature = "optimism")]
         (crate::OptimismHardfork::Ecotone.boxed(), ForkCondition::Timestamp(0)),
+        #[cfg(feature = "optimism")]
+        (crate::OptimismHardfork::Canyon.boxed(), ForkCondition::Timestamp(0)),
     ])
 });


### PR DESCRIPTION
I was messing around with an op-reth node running the devnet and could not get it to accept a new payload with "engine_NewPayloadV?"

- "engine_NewPayloadV2" would throw an "UnsupportedFork" error
   - I believe getting caught on [this](https://github.com/paradigmxyz/reth/blob/main/crates/payload/primitives/src/lib.rs#L51) check
- "engine_NewPayloadV3" would throw an "HasWithdrawalsPreShanghai" error
   - I believe getting caught on [this](https://github.com/paradigmxyz/reth/blob/main/crates/optimism/node/src/engine.rs#L90) check

Digging into it I think the issue was that the Canyon hardfork wasn't part of the devnet settings. Adding this locally and building seemed to work. 

