### PR TITLE
chore: move tree module to single file

### DIFF
--- a/crates/engine/tree/src/tree.rs
+++ b/crates/engine/tree/src/tree.rs
@@ -1755,7 +1755,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_holesky_payload() {
-        let s = include_str!("../../test-data/holesky/1.rlp");
+        let s = include_str!("../test-data/holesky/1.rlp");
         let data = Bytes::from_str(s).unwrap();
         let block = Block::decode(&mut data.as_ref()).unwrap();
         let sealed = block.seal_slow();


### PR DESCRIPTION
After #9779 the `tree` module in `reth-engine-tree` consists of a single file, this PR removes the subdirectory