### PR TITLE
feat: invole on_request trackers

### DIFF
--- a/crates/engine/tree/src/tree.rs
+++ b/crates/engine/tree/src/tree.rs
@@ -543,7 +543,7 @@ where
                     }
                 }
                 BeaconEngineMessage::TransitionConfigurationExchanged => {
-                    // triggering this hook will allow us to register the timestamp when we receive FCUs 
+                    // triggering this hook will record that we received a request from the CL
                     self.canonical_in_memory_state.on_transition_configuration_exchanged();
                 }
             },

--- a/crates/engine/tree/src/tree.rs
+++ b/crates/engine/tree/src/tree.rs
@@ -545,6 +545,7 @@ where
                 BeaconEngineMessage::TransitionConfigurationExchanged => {
                     // this is a reporting no-op because the engine API impl does not need
                     // additional input to handle this request
+                    self.canonical_in_memory_state.on_transition_configuration_exchanged();
                 }
             },
             FromEngine::DownloadedBlocks(blocks) => {
@@ -1435,6 +1436,8 @@ where
         attrs: Option<<Self::Engine as PayloadTypes>::PayloadAttributes>,
     ) -> ProviderResult<TreeOutcome<OnForkChoiceUpdated>> {
         trace!(target: "engine", ?attrs, "invoked forkchoice update");
+        self.canonical_in_memory_state.on_forkchoice_update_received();
+
         if let Some(on_updated) = self.pre_validate_forkchoice_update(state)? {
             self.state.forkchoice_state_tracker.set_latest(state, on_updated.forkchoice_status());
             return Ok(TreeOutcome::new(on_updated))

--- a/crates/engine/tree/src/tree.rs
+++ b/crates/engine/tree/src/tree.rs
@@ -543,8 +543,7 @@ where
                     }
                 }
                 BeaconEngineMessage::TransitionConfigurationExchanged => {
-                    // this is a reporting no-op because the engine API impl does not need
-                    // additional input to handle this request
+                    // triggering this hook will allow us to register the timestamp when we receive FCUs 
                     self.canonical_in_memory_state.on_transition_configuration_exchanged();
                 }
             },


### PR DESCRIPTION
closes #9807

this records the timestamp when we receive fcus so we can detect if the CL is up