### PR TITLE
chore(revm): rm no longer used BlockExecutorStats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8217,7 +8217,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "revm",
- "tracing",
 ]
 
 [[package]]

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -24,7 +24,7 @@ use reth_primitives::{
 };
 use reth_prune_types::PruneModes;
 use reth_revm::{
-    batch::{BlockBatchRecord, BlockExecutorStats},
+    batch::BlockBatchRecord,
     db::states::bundle_state::BundleRetention,
     state_change::{apply_blockhashes_update, post_block_balance_increments},
     Evm, State,
@@ -103,11 +103,7 @@ where
         DB: Database<Error: Into<ProviderError> + Display>,
     {
         let executor = self.eth_executor(db);
-        EthBatchExecutor {
-            executor,
-            batch_record: BlockBatchRecord::default(),
-            stats: BlockExecutorStats::default(),
-        }
+        EthBatchExecutor { executor, batch_record: BlockBatchRecord::default() }
     }
 }
 
@@ -401,7 +397,6 @@ pub struct EthBatchExecutor<EvmConfig, DB> {
     executor: EthBlockExecutor<EvmConfig, DB>,
     /// Keeps track of the batch and records receipts based on the configured prune mode
     batch_record: BlockBatchRecord,
-    stats: BlockExecutorStats,
 }
 
 impl<EvmConfig, DB> EthBatchExecutor<EvmConfig, DB> {
@@ -446,8 +441,6 @@ where
     }
 
     fn finalize(mut self) -> Self::Output {
-        self.stats.log_debug();
-
         ExecutionOutcome::new(
             self.executor.state.take_bundle(),
             self.batch_record.take_receipts(),

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -15,10 +15,8 @@ use reth_optimism_consensus::validate_block_post_execution;
 use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt, Receipts, TxType, U256};
 use reth_prune_types::PruneModes;
 use reth_revm::{
-    batch::{BlockBatchRecord, BlockExecutorStats},
-    db::states::bundle_state::BundleRetention,
-    state_change::post_block_balance_increments,
-    Evm, State,
+    batch::BlockBatchRecord, db::states::bundle_state::BundleRetention,
+    state_change::post_block_balance_increments, Evm, State,
 };
 use revm_primitives::{
     db::{Database, DatabaseCommit},
@@ -85,11 +83,7 @@ where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
         let executor = self.op_executor(db);
-        OpBatchExecutor {
-            executor,
-            batch_record: BlockBatchRecord::default(),
-            stats: BlockExecutorStats::default(),
-        }
+        OpBatchExecutor { executor, batch_record: BlockBatchRecord::default() }
     }
 }
 
@@ -376,7 +370,6 @@ pub struct OpBatchExecutor<EvmConfig, DB> {
     executor: OpBlockExecutor<EvmConfig, DB>,
     /// Keeps track of the batch and record receipts based on the configured prune mode
     batch_record: BlockBatchRecord,
-    stats: BlockExecutorStats,
 }
 
 impl<EvmConfig, DB> OpBatchExecutor<EvmConfig, DB> {
@@ -423,8 +416,6 @@ where
     }
 
     fn finalize(mut self) -> Self::Output {
-        self.stats.log_debug();
-
         ExecutionOutcome::new(
             self.executor.state.take_bundle(),
             self.batch_record.take_receipts(),

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -28,9 +28,6 @@ revm.workspace = true
 # alloy
 alloy-eips.workspace = true
 
-# common
-tracing.workspace = true
-
 [dev-dependencies]
 reth-trie.workspace = true
 reth-ethereum-forks.workspace = true

--- a/crates/revm/src/batch.rs
+++ b/crates/revm/src/batch.rs
@@ -4,12 +4,10 @@ use crate::{
     precompile::{Address, HashSet},
     primitives::alloy_primitives::BlockNumber,
 };
-use core::time::Duration;
 use reth_execution_errors::BlockExecutionError;
 use reth_primitives::{Receipt, Receipts, Request, Requests};
 use reth_prune_types::{PruneMode, PruneModes, PruneSegmentError, MINIMUM_PRUNING_DISTANCE};
 use revm::db::states::bundle_state::BundleRetention;
-use tracing::debug;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -179,37 +177,6 @@ impl BlockBatchRecord {
     /// Save EIP-7685 requests to the executor.
     pub fn save_requests(&mut self, requests: Vec<Request>) {
         self.requests.push(requests.into());
-    }
-}
-
-/// Block execution statistics. Contains duration of each step of block execution.
-#[derive(Clone, Debug, Default)]
-pub struct BlockExecutorStats {
-    /// Execution duration.
-    pub execution_duration: Duration,
-    /// Time needed to apply output of revm execution to revm cached state.
-    pub apply_state_duration: Duration,
-    /// Time needed to apply post execution state changes.
-    pub apply_post_execution_state_changes_duration: Duration,
-    /// Time needed to merge transitions and create reverts.
-    /// It this time transitions are applies to revm bundle state.
-    pub merge_transitions_duration: Duration,
-    /// Time needed to calculate receipt roots.
-    pub receipt_root_duration: Duration,
-}
-
-impl BlockExecutorStats {
-    /// Log duration to debug level log.
-    pub fn log_debug(&self) {
-        debug!(
-            target: "evm",
-            evm_transact = ?self.execution_duration,
-            apply_state = ?self.apply_state_duration,
-            apply_post_state = ?self.apply_post_execution_state_changes_duration,
-            merge_transitions = ?self.merge_transitions_duration,
-            receipt_root = ?self.receipt_root_duration,
-            "Execution time"
-        );
     }
 }
 


### PR DESCRIPTION
I found some wired logs from the reth's debug log(`-vvvv`):

```
2024-07-26T12:11:05.501982Z DEBUG evm: Execution time evm_transact=0ns apply_state=0ns apply_post_state=0ns merge_transitions=0ns receipt_root=0ns
2024-07-26T12:11:21.520248Z DEBUG evm: Execution time evm_transact=0ns apply_state=0ns apply_post_state=0ns merge_transitions=0ns receipt_root=0ns
2024-07-26T12:11:45.635212Z DEBUG evm: Execution time evm_transact=0ns apply_state=0ns apply_post_state=0ns merge_transitions=0ns receipt_root=0ns
2024-07-26T12:12:01.102102Z DEBUG evm: Execution time evm_transact=0ns apply_state=0ns apply_post_state=0ns merge_transitions=0ns receipt_root=0ns
```

then found the stats is no longer used, I think it's safe to delete it.