### PR TITLE
feat: add TreeConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7765,6 +7765,7 @@ dependencies = [
  "reth-consensus",
  "reth-db",
  "reth-e2e-test-utils",
+ "reth-engine-tree",
  "reth-ethereum-engine",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",

--- a/crates/engine/tree/src/tree/config.rs
+++ b/crates/engine/tree/src/tree/config.rs
@@ -1,0 +1,103 @@
+//! Engine tree configuration.
+
+/// The configuration of the engine tree.
+#[derive(Debug)]
+pub struct TreeConfig {
+    /// Maximum number of blocks to be kept only in memory without triggering persistence.
+    persistence_threshold: u64,
+    /// Number of pending blocks that cannot be executed due to missing parent and
+    /// are kept in cache.
+    block_buffer_limit: u32,
+    /// Number of invalid headers to keep in cache.
+    max_invalid_header_cache_length: u32,
+}
+
+impl Default for TreeConfig {
+    fn default() -> Self {
+        Self {
+            persistence_threshold: 256,
+            block_buffer_limit: 256,
+            max_invalid_header_cache_length: 256,
+        }
+    }
+}
+
+impl TreeConfig {
+    /// Create engine tree configuration.
+    pub const fn new(
+        persistence_threshold: u64,
+        block_buffer_limit: u32,
+        max_invalid_header_cache_length: u32,
+    ) -> Self {
+        Self { persistence_threshold, block_buffer_limit, max_invalid_header_cache_length }
+    }
+
+    /// Return the persistence threshold.
+    pub const fn persistence_threshold(&self) -> u64 {
+        self.persistence_threshold
+    }
+
+    /// Return the block buffer limit.
+    pub const fn block_buffer_limit(&self) -> u32 {
+        self.block_buffer_limit
+    }
+
+    /// Return the maximum invalid cache header length.
+    pub const fn max_invalid_header_cache_length(&self) -> u32 {
+        self.max_invalid_header_cache_length
+    }
+
+    /// Return a builder for this type.
+    pub fn builder() -> TreeConfigBuilder {
+        TreeConfigBuilder::default()
+    }
+}
+
+/// Engine tree configuration builder.
+#[derive(Debug, Default)]
+pub struct TreeConfigBuilder {
+    persistence_threshold: Option<u64>,
+    block_buffer_limit: Option<u32>,
+    max_invalid_header_cache_length: Option<u32>,
+}
+
+impl TreeConfigBuilder {
+    /// Setter for persistence threshold.
+    pub const fn with_persistence_threshold(mut self, persistence_threshold: u64) -> Self {
+        self.persistence_threshold = Some(persistence_threshold);
+        self
+    }
+
+    /// Setter for block buffer limit.
+    pub const fn with_block_buffer_limit(mut self, block_buffer_limit: u32) -> Self {
+        self.block_buffer_limit = Some(block_buffer_limit);
+        self
+    }
+
+    /// Setter for maximum invalid header cache length.
+    pub const fn with_max_invalid_header_cache_length(
+        mut self,
+        max_invalid_header_cache_length: u32,
+    ) -> Self {
+        self.max_invalid_header_cache_length = Some(max_invalid_header_cache_length);
+        self
+    }
+
+    /// Generates the final `TreeConfig`.
+    pub fn build(self) -> TreeConfig {
+        let mut tree_config = TreeConfig::default();
+
+        if let Some(persistence_threshold) = self.persistence_threshold {
+            tree_config.persistence_threshold = persistence_threshold;
+        }
+
+        if let Some(block_buffer_limit) = self.block_buffer_limit {
+            tree_config.block_buffer_limit = block_buffer_limit;
+        }
+
+        if let Some(max_invalid_header_cache_length) = self.max_invalid_header_cache_length {
+            tree_config.max_invalid_header_cache_length = max_invalid_header_cache_length;
+        }
+        tree_config
+    }
+}

--- a/crates/engine/tree/src/tree/config.rs
+++ b/crates/engine/tree/src/tree/config.rs
@@ -1,5 +1,9 @@
 //! Engine tree configuration.
 
+const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 256;
+const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = 256;
+const DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH: u32 = 256;
+
 /// The configuration of the engine tree.
 #[derive(Debug)]
 pub struct TreeConfig {
@@ -15,9 +19,9 @@ pub struct TreeConfig {
 impl Default for TreeConfig {
     fn default() -> Self {
         Self {
-            persistence_threshold: 256,
-            block_buffer_limit: 256,
-            max_invalid_header_cache_length: 256,
+            persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
+            block_buffer_limit: DEFAULT_BLOCK_BUFFER_LIMIT,
+            max_invalid_header_cache_length: DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH,
         }
     }
 }
@@ -47,30 +51,15 @@ impl TreeConfig {
         self.max_invalid_header_cache_length
     }
 
-    /// Return a builder for this type.
-    pub fn builder() -> TreeConfigBuilder {
-        TreeConfigBuilder::default()
-    }
-}
-
-/// Engine tree configuration builder.
-#[derive(Debug, Default)]
-pub struct TreeConfigBuilder {
-    persistence_threshold: Option<u64>,
-    block_buffer_limit: Option<u32>,
-    max_invalid_header_cache_length: Option<u32>,
-}
-
-impl TreeConfigBuilder {
     /// Setter for persistence threshold.
     pub const fn with_persistence_threshold(mut self, persistence_threshold: u64) -> Self {
-        self.persistence_threshold = Some(persistence_threshold);
+        self.persistence_threshold = persistence_threshold;
         self
     }
 
     /// Setter for block buffer limit.
     pub const fn with_block_buffer_limit(mut self, block_buffer_limit: u32) -> Self {
-        self.block_buffer_limit = Some(block_buffer_limit);
+        self.block_buffer_limit = block_buffer_limit;
         self
     }
 
@@ -79,25 +68,7 @@ impl TreeConfigBuilder {
         mut self,
         max_invalid_header_cache_length: u32,
     ) -> Self {
-        self.max_invalid_header_cache_length = Some(max_invalid_header_cache_length);
+        self.max_invalid_header_cache_length = max_invalid_header_cache_length;
         self
-    }
-
-    /// Generates the final `TreeConfig`.
-    pub fn build(self) -> TreeConfig {
-        let mut tree_config = TreeConfig::default();
-
-        if let Some(persistence_threshold) = self.persistence_threshold {
-            tree_config.persistence_threshold = persistence_threshold;
-        }
-
-        if let Some(block_buffer_limit) = self.block_buffer_limit {
-            tree_config.block_buffer_limit = block_buffer_limit;
-        }
-
-        if let Some(max_invalid_header_cache_length) = self.max_invalid_header_cache_length {
-            tree_config.max_invalid_header_cache_length = max_invalid_header_cache_length;
-        }
-        tree_config
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -50,7 +50,7 @@ use tokio::sync::{
 use tracing::*;
 
 mod config;
-pub use config::{TreeConfig, TreeConfigBuilder};
+pub use config::TreeConfig;
 
 /// Keeps track of the state of the tree.
 ///

--- a/crates/ethereum/engine/src/service.rs
+++ b/crates/ethereum/engine/src/service.rs
@@ -8,7 +8,7 @@ use reth_engine_tree::{
     download::BasicBlockDownloader,
     engine::{EngineApiRequestHandler, EngineHandler},
     persistence::PersistenceHandle,
-    tree::EngineApiTreeHandlerImpl,
+    tree::{EngineApiTreeHandlerImpl, TreeConfig},
 };
 pub use reth_engine_tree::{
     chain::{ChainEvent, ChainOrchestrator},
@@ -68,6 +68,7 @@ where
         blockchain_db: BlockchainProvider2<DB>,
         pruner: Pruner<DB, ProviderFactory<DB>>,
         payload_builder: PayloadBuilderHandle<EthEngineTypes>,
+        tree_config: TreeConfig,
     ) -> Self {
         let consensus = Arc::new(EthBeaconConsensus::new(chain_spec.clone()));
         let downloader = BasicBlockDownloader::new(client, consensus.clone());
@@ -89,6 +90,7 @@ where
             persistence_handle,
             payload_builder,
             canonical_in_memory_state,
+            tree_config,
         );
 
         let engine_handler = EngineApiRequestHandler::new(to_tree_tx, from_tree);
@@ -174,6 +176,7 @@ mod tests {
             blockchain_db,
             pruner,
             PayloadBuilderHandle::new(tx),
+            TreeConfig::default(),
         );
     }
 }

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -36,6 +36,7 @@ reth-node-events.workspace = true
 reth-node-core.workspace = true
 reth-exex.workspace = true
 reth-blockchain-tree.workspace = true
+reth-engine-tree.workspace = true
 
 # misc
 eyre.workspace = true

--- a/crates/ethereum/node/src/launch.rs
+++ b/crates/ethereum/node/src/launch.rs
@@ -6,6 +6,7 @@ use reth_beacon_consensus::{
     BeaconConsensusEngineHandle,
 };
 use reth_blockchain_tree::BlockchainTreeConfig;
+use reth_engine_tree::tree::TreeConfig;
 use reth_ethereum_engine::service::{ChainEvent, EthService};
 use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_exex::ExExManagerHandle;
@@ -171,6 +172,8 @@ where
         let pruner_events = pruner.events();
         info!(target: "reth::cli", prune_config=?ctx.prune_config().unwrap_or_default(), "Pruner initialized");
 
+        let tree_config = TreeConfig::builder().with_persistence_threshold(120).build();
+
         // Configure the consensus engine
         let mut eth_service = EthService::new(
             ctx.chain_spec(),
@@ -182,6 +185,7 @@ where
             ctx.blockchain_db().clone(),
             pruner,
             ctx.components().payload_builder().clone(),
+            tree_config,
         );
 
         let event_sender = EventSender::default();

--- a/crates/ethereum/node/src/launch.rs
+++ b/crates/ethereum/node/src/launch.rs
@@ -172,7 +172,7 @@ where
         let pruner_events = pruner.events();
         info!(target: "reth::cli", prune_config=?ctx.prune_config().unwrap_or_default(), "Pruner initialized");
 
-        let tree_config = TreeConfig::builder().with_persistence_threshold(120).build();
+        let tree_config = TreeConfig::default().with_persistence_threshold(120);
 
         // Configure the consensus engine
         let mut eth_service = EthService::new(


### PR DESCRIPTION
Closes #9821

The configuration is done at the launcher level (which adds a new dep to `reth-ethereum-node`), we could do it at the service level too, let me know wdyt