### PR TITLE
perf(trie): pass owned hashed state to trie methods

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -699,26 +699,22 @@ mod tests {
     }
 
     impl StateRootProvider for MockStateProvider {
-        fn hashed_state_root(&self, _hashed_state: &HashedPostState) -> ProviderResult<B256> {
+        fn hashed_state_root(&self, _hashed_state: HashedPostState) -> ProviderResult<B256> {
             Ok(B256::random())
         }
 
         fn hashed_state_root_with_updates(
             &self,
-            _hashed_state: &HashedPostState,
+            _hashed_state: HashedPostState,
         ) -> ProviderResult<(B256, TrieUpdates)> {
             Ok((B256::random(), TrieUpdates::default()))
-        }
-
-        fn state_root(&self, _bundle_state: &revm::db::BundleState) -> ProviderResult<B256> {
-            Ok(B256::random())
         }
     }
 
     impl StateProofProvider for MockStateProvider {
         fn hashed_proof(
             &self,
-            _hashed_state: &HashedPostState,
+            _hashed_state: HashedPostState,
             _address: Address,
             _slots: &[B256],
         ) -> ProviderResult<AccountProof> {

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -76,20 +76,20 @@ impl AccountReader for MemoryOverlayStateProvider {
 
 impl StateRootProvider for MemoryOverlayStateProvider {
     // TODO: Currently this does not reuse available in-memory trie nodes.
-    fn hashed_state_root(&self, hashed_state: &HashedPostState) -> ProviderResult<B256> {
+    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let mut state = self.hashed_post_state.clone();
-        state.extend(hashed_state.clone());
-        self.historical.hashed_state_root(&state)
+        state.extend(hashed_state);
+        self.historical.hashed_state_root(state)
     }
 
     // TODO: Currently this does not reuse available in-memory trie nodes.
     fn hashed_state_root_with_updates(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let mut state = self.hashed_post_state.clone();
-        state.extend(hashed_state.clone());
-        self.historical.hashed_state_root_with_updates(&state)
+        state.extend(hashed_state);
+        self.historical.hashed_state_root_with_updates(state)
     }
 }
 
@@ -97,13 +97,13 @@ impl StateProofProvider for MemoryOverlayStateProvider {
     // TODO: Currently this does not reuse available in-memory trie nodes.
     fn hashed_proof(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
         address: Address,
         slots: &[B256],
     ) -> ProviderResult<AccountProof> {
         let mut state = self.hashed_post_state.clone();
-        state.extend(hashed_state.clone());
-        self.historical.hashed_proof(&state, address, slots)
+        state.extend(hashed_state);
+        self.historical.hashed_proof(state, address, slots)
     }
 }
 

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -68,13 +68,13 @@ impl BlockHashReader for StateProviderTest {
 }
 
 impl StateRootProvider for StateProviderTest {
-    fn hashed_state_root(&self, _hashed_state: &HashedPostState) -> ProviderResult<B256> {
+    fn hashed_state_root(&self, _hashed_state: HashedPostState) -> ProviderResult<B256> {
         unimplemented!("state root computation is not supported")
     }
 
     fn hashed_state_root_with_updates(
         &self,
-        _hashed_state: &HashedPostState,
+        _hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         unimplemented!("state root computation is not supported")
     }
@@ -83,7 +83,7 @@ impl StateRootProvider for StateProviderTest {
 impl StateProofProvider for StateProviderTest {
     fn hashed_proof(
         &self,
-        _hashed_state: &HashedPostState,
+        _hashed_state: HashedPostState,
         _address: Address,
         _slots: &[B256],
     ) -> ProviderResult<AccountProof> {

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -18,14 +18,14 @@ pub struct StateProviderTraitObjWrapper<'a>(pub &'a dyn StateProvider);
 impl<'a> reth_provider::StateRootProvider for StateProviderTraitObjWrapper<'a> {
     fn hashed_state_root(
         &self,
-        hashed_state: &reth_trie::HashedPostState,
+        hashed_state: reth_trie::HashedPostState,
     ) -> reth_errors::ProviderResult<B256> {
         self.0.hashed_state_root(hashed_state)
     }
 
     fn hashed_state_root_with_updates(
         &self,
-        hashed_state: &reth_trie::HashedPostState,
+        hashed_state: reth_trie::HashedPostState,
     ) -> reth_errors::ProviderResult<(B256, reth_trie::updates::TrieUpdates)> {
         self.0.hashed_state_root_with_updates(hashed_state)
     }
@@ -34,7 +34,7 @@ impl<'a> reth_provider::StateRootProvider for StateProviderTraitObjWrapper<'a> {
 impl<'a> reth_provider::StateProofProvider for StateProviderTraitObjWrapper<'a> {
     fn hashed_proof(
         &self,
-        hashed_state: &reth_trie::HashedPostState,
+        hashed_state: reth_trie::HashedPostState,
         address: revm_primitives::Address,
         slots: &[B256],
     ) -> reth_errors::ProviderResult<reth_trie::AccountProof> {

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -71,11 +71,11 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
         self.state_provider.state_root(&state)
     }
 
-    fn hashed_state_root(&self, hashed_state: &reth_trie::HashedPostState) -> ProviderResult<B256> {
+    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
-        state.extend(hashed_state.clone());
-        self.state_provider.hashed_state_root(&state)
+        state.extend(hashed_state);
+        self.state_provider.hashed_state_root(state)
     }
 
     fn state_root_with_updates(
@@ -89,12 +89,12 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
 
     fn hashed_state_root_with_updates(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
         state.extend(hashed_state.clone());
-        self.state_provider.hashed_state_root_with_updates(&state)
+        self.state_provider.hashed_state_root_with_updates(state)
     }
 }
 
@@ -103,14 +103,14 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProofProvider
 {
     fn hashed_proof(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
         address: Address,
         slots: &[B256],
     ) -> ProviderResult<AccountProof> {
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
-        state.extend(hashed_state.clone());
-        self.state_provider.hashed_proof(&state, address, slots)
+        state.extend(hashed_state);
+        self.state_provider.hashed_proof(state, address, slots)
     }
 }
 

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -93,7 +93,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
-        state.extend(hashed_state.clone());
+        state.extend(hashed_state);
         self.state_provider.hashed_state_root_with_updates(state)
     }
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -257,19 +257,19 @@ impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
 }
 
 impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
-    fn hashed_state_root(&self, hashed_state: &HashedPostState) -> ProviderResult<B256> {
+    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let mut revert_state = self.revert_state()?;
-        revert_state.extend(hashed_state.clone());
+        revert_state.extend(hashed_state);
         StateRoot::overlay_root(self.tx, revert_state)
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
     fn hashed_state_root_with_updates(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let mut revert_state = self.revert_state()?;
-        revert_state.extend(hashed_state.clone());
+        revert_state.extend(hashed_state);
         StateRoot::overlay_root_with_updates(self.tx, revert_state)
             .map_err(|err| ProviderError::Database(err.into()))
     }
@@ -279,12 +279,12 @@ impl<'b, TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'b, TX> {
     /// Get account and storage proofs.
     fn hashed_proof(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
         address: Address,
         slots: &[B256],
     ) -> ProviderResult<AccountProof> {
         let mut revert_state = self.revert_state()?;
-        revert_state.extend(hashed_state.clone());
+        revert_state.extend(hashed_state);
         Proof::overlay_account_proof(self.tx, revert_state, address, slots)
             .map_err(Into::<ProviderError>::into)
     }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -75,16 +75,16 @@ impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
 }
 
 impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
-    fn hashed_state_root(&self, hashed_state: &HashedPostState) -> ProviderResult<B256> {
-        StateRoot::overlay_root(self.tx, hashed_state.clone())
+    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        StateRoot::overlay_root(self.tx, hashed_state)
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
     fn hashed_state_root_with_updates(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
-        StateRoot::overlay_root_with_updates(self.tx, hashed_state.clone())
+        StateRoot::overlay_root_with_updates(self.tx, hashed_state)
             .map_err(|err| ProviderError::Database(err.into()))
     }
 }
@@ -92,11 +92,11 @@ impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
 impl<'b, TX: DbTx> StateProofProvider for LatestStateProviderRef<'b, TX> {
     fn hashed_proof(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
         address: Address,
         slots: &[B256],
     ) -> ProviderResult<AccountProof> {
-        Proof::overlay_account_proof(self.tx, hashed_state.clone(), address, slots)
+        Proof::overlay_account_proof(self.tx, hashed_state, address, slots)
             .map_err(Into::<ProviderError>::into)
     }
 }

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -43,13 +43,13 @@ macro_rules! delegate_provider_impls {
             }
             StateRootProvider $(where [$($generics)*])? {
                 fn state_root(&self, state: &revm::db::BundleState) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
-                fn hashed_state_root(&self, state: &reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
+                fn hashed_state_root(&self, state: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
                 fn state_root_with_updates(&self, state: &revm::db::BundleState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
-                fn hashed_state_root_with_updates(&self, state: &reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
+                fn hashed_state_root_with_updates(&self, state: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
             }
             StateProofProvider $(where [$($generics)*])? {
                 fn proof(&self, state: &revm::db::BundleState, address: reth_primitives::Address, slots: &[reth_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;
-                fn hashed_proof(&self, state: &reth_trie::HashedPostState, address: reth_primitives::Address, slots: &[reth_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;
+                fn hashed_proof(&self, state: reth_trie::HashedPostState, address: reth_primitives::Address, slots: &[reth_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;
             }
         );
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -539,13 +539,13 @@ impl AccountReader for MockEthProvider {
 }
 
 impl StateRootProvider for MockEthProvider {
-    fn hashed_state_root(&self, _state: &HashedPostState) -> ProviderResult<B256> {
+    fn hashed_state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
         Ok(B256::default())
     }
 
     fn hashed_state_root_with_updates(
         &self,
-        _state: &HashedPostState,
+        _state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         Ok((B256::default(), Default::default()))
     }
@@ -554,7 +554,7 @@ impl StateRootProvider for MockEthProvider {
 impl StateProofProvider for MockEthProvider {
     fn hashed_proof(
         &self,
-        _hashed_state: &HashedPostState,
+        _hashed_state: HashedPostState,
         address: Address,
         _slots: &[B256],
     ) -> ProviderResult<AccountProof> {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -312,13 +312,13 @@ impl ChangeSetReader for NoopProvider {
 }
 
 impl StateRootProvider for NoopProvider {
-    fn hashed_state_root(&self, _state: &HashedPostState) -> ProviderResult<B256> {
+    fn hashed_state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
         Ok(B256::default())
     }
 
     fn hashed_state_root_with_updates(
         &self,
-        _state: &HashedPostState,
+        _state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         Ok((B256::default(), TrieUpdates::default()))
     }
@@ -327,7 +327,7 @@ impl StateRootProvider for NoopProvider {
 impl StateProofProvider for NoopProvider {
     fn hashed_proof(
         &self,
-        _hashed_state: &HashedPostState,
+        _hashed_state: HashedPostState,
         address: Address,
         _slots: &[B256],
     ) -> ProviderResult<AccountProof> {

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -14,12 +14,11 @@ pub trait StateRootProvider: Send + Sync {
     /// `state_root_with_updates` since it affects the memory usage during state root
     /// computation.
     fn state_root(&self, bundle_state: &BundleState) -> ProviderResult<B256> {
-        let hashed_state = HashedPostState::from_bundle_state(&bundle_state.state);
-        self.hashed_state_root(&hashed_state)
+        self.hashed_state_root(HashedPostState::from_bundle_state(&bundle_state.state))
     }
 
     /// Returns the state root of the `HashedPostState` on top of the current state.
-    fn hashed_state_root(&self, hashed_state: &HashedPostState) -> ProviderResult<B256>;
+    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256>;
 
     /// Returns the state root of the BundleState on top of the current state with trie
     /// updates to be committed to the database.
@@ -27,15 +26,14 @@ pub trait StateRootProvider: Send + Sync {
         &self,
         bundle_state: &BundleState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
-        let hashed_state = HashedPostState::from_bundle_state(&bundle_state.state);
-        self.hashed_state_root_with_updates(&hashed_state)
+        self.hashed_state_root_with_updates(HashedPostState::from_bundle_state(&bundle_state.state))
     }
 
     /// Returns the state root of the `HashedPostState` on top of the current state with trie
     /// updates to be committed to the database.
     fn hashed_state_root_with_updates(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)>;
 }
 
@@ -51,14 +49,14 @@ pub trait StateProofProvider: Send + Sync {
         slots: &[B256],
     ) -> ProviderResult<AccountProof> {
         let hashed_state = HashedPostState::from_bundle_state(&state.state);
-        self.hashed_proof(&hashed_state, address, slots)
+        self.hashed_proof(hashed_state, address, slots)
     }
 
     /// Get account and storage proofs of target keys in the `HashedPostState`
     /// on top of the current state.
     fn hashed_proof(
         &self,
-        hashed_state: &HashedPostState,
+        hashed_state: HashedPostState,
         address: Address,
         slots: &[B256],
     ) -> ProviderResult<AccountProof>;


### PR DESCRIPTION
## Description

Given that we often layer state providers on top of each other and extend the passed hashed state, we often end up doing redundant clones. Pass owned hashed state instead. 