### PR TITLE
fix(txpool/blob): make blob delete failed more accurate

### DIFF
--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -62,12 +62,16 @@ impl BlobStore for DiskFileBlobStore {
     }
 
     fn delete(&self, tx: B256) -> Result<(), BlobStoreError> {
-        self.inner.txs_to_delete.write().insert(tx);
+        if self.inner.contains(tx)? {
+            self.inner.txs_to_delete.write().insert(tx);
+        }
         Ok(())
     }
 
     fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
-        self.inner.txs_to_delete.write().extend(txs);
+        for tx in txs {
+            let _ = self.delete(tx);
+        }
         Ok(())
     }
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -188,13 +188,12 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
         if let Some(finalized) =
             last_finalized_block.update(client.finalized_block_number().ok().flatten())
         {
-            match blob_store_tracker.on_finalized_block(finalized) {
-                BlobStoreUpdates::None => {}
-                BlobStoreUpdates::Finalized(blobs) => {
-                    metrics.inc_deleted_tracked_blobs(blobs.len());
-                    // remove all finalized blobs from the blob store
-                    pool.delete_blobs(blobs);
-                }
+            if let BlobStoreUpdates::Finalized(blobs) =
+                blob_store_tracker.on_finalized_block(finalized)
+            {
+                metrics.inc_deleted_tracked_blobs(blobs.len());
+                // remove all finalized blobs from the blob store
+                pool.delete_blobs(blobs);
             }
             // also do periodic cleanup of the blob store
             let pool = pool.clone();

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -194,13 +194,13 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                 metrics.inc_deleted_tracked_blobs(blobs.len());
                 // remove all finalized blobs from the blob store
                 pool.delete_blobs(blobs);
+                // and also do periodic cleanup
+                let pool = pool.clone();
+                task_spawner.spawn_blocking(Box::pin(async move {
+                    debug!(target: "txpool", finalized_block = %finalized, "cleaning up blob store");
+                    pool.cleanup_blobs();
+                }));
             }
-            // also do periodic cleanup of the blob store
-            let pool = pool.clone();
-            task_spawner.spawn_blocking(Box::pin(async move {
-                debug!(target: "txpool", finalized_block = %finalized, "cleaning up blob store");
-                pool.cleanup_blobs();
-            }));
         }
 
         // outcomes of the futures we are waiting on

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -61,14 +61,16 @@ pub struct BlobStoreMetrics {
 #[derive(Metrics)]
 #[metrics(scope = "transaction_pool")]
 pub struct MaintainPoolMetrics {
-    /// Number of currently dirty addresses that need to be updated in the pool by fetching account
-    /// info
+    /// Gauge indicating the number of addresses with pending updates in the pool,
+    /// requiring their account information to be fetched.
     pub(crate) dirty_accounts: Gauge,
-    /// How often the pool drifted from the canonical state.
+    /// Counter for the number of times the pool state diverged from the canonical blockchain
+    /// state.
     pub(crate) drift_count: Counter,
-    /// Number of transaction reinserted into the pool after reorg.
+    /// Counter for the number of transactions reinserted into the pool following a blockchain
+    /// reorganization (reorg).
     pub(crate) reinserted_transactions: Counter,
-    /// Number of transactions finalized blob transactions we were tracking.
+    /// Counter for the number of finalized blob transactions that have been removed from tracking.
     pub(crate) deleted_tracked_finalized_blobs: Counter,
 }
 


### PR DESCRIPTION
From the metric of `reth_transaction_pool_blobstore_failed_deletes` I saw too many blob failed:

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/b806cbc0-c25b-4993-bcc7-78688b299ee4">

Then run the reth node with `-vvvv` debug mode, found all the blob delete failed logs was caused by file not found:

```bash
2024-07-26T12:38:06.848876Z DEBUG txpool::blob: err=[0xc4dedce22285ec1747b2a916d32c2106c59bf55701d6f18193bec639519b6f6a] failed to delete blob file at /data/blobstore/c4dedce22285ec1747b2a916d32c2106c59bf55701d6f18193bec639519b6f6a: No such file or directory (os error 2)
2024-07-26T12:38:06.848888Z DEBUG txpool::blob: err=[0xf8acf98e52632ff89cc76e07d3095bfb7be27ea3aed6a2432e30a8fc7f8070d8] failed to delete blob file at /data/blobstore/f8acf98e52632ff89cc76e07d3095bfb7be27ea3aed6a2432e30a8fc7f8070d8: No such file or directory (os error 2)
2024-07-26T12:38:06.848900Z DEBUG txpool::blob: err=[0xf1cb35953efd2868ed049f6fd1d43b675e0f18daef5be6f979eac4cc9efcba7e] failed to delete blob file at /data/blobstore/f1cb35953efd2868ed049f6fd1d43b675e0f18daef5be6f979eac4cc9efcba7e: No such file or directory (os error 2)
```

After some digging, I think maybe the blob sidecar was inserted in the txpool module:
https://github.com/paradigmxyz/reth/blob/1ffa3d147df51328e27140faf7038b090c0b4955/crates/transaction-pool/src/pool/mod.rs#L429-L458

however, some blobs were not propagated into our node, so the blob wasn't tracked in the blobstore.

But the to be cleaned the blobs were extracted from the blocks, the results were mucher than our tracked ones.

https://github.com/paradigmxyz/reth/blob/1ffa3d147df51328e27140faf7038b090c0b4955/crates/transaction-pool/src/blobstore/tracker.rs#L36-L67
