### PR TITLE
fix: rm bad rpc error conversion

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -381,7 +381,6 @@ pub trait Call: LoadState + SpawnBlocking {
                 f(StateCacheDbRefMutWrapper(&mut db), env)
             })
             .await
-            .map_err(|_| EthApiError::InternalBlockingTaskError.into())
         }
     }
 


### PR DESCRIPTION
should close https://github.com/paradigmxyz/reth/issues/9853

the ethapi error was incorrectly mapped to blocktaskerror which is already taken care off in case the spawned task panics

https://github.com/paradigmxyz/reth/blob/0f1a806a4a5dd9528f7fd0a34ae7392b84932c8a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs#L65-L65