### PR TITLE
feat: update backfill sync state to pending when we request it

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -216,6 +216,13 @@ pub enum EngineApiEvent {
     Download(DownloadRequest),
 }
 
+impl EngineApiEvent {
+    /// Returns `true` if the event is a backfill action.
+    pub const fn is_backfill_action(&self) -> bool {
+        matches!(self, Self::BackfillAction(_))
+    }
+}
+
 impl From<BeaconConsensusEngineEvent> for EngineApiEvent {
     fn from(event: BeaconConsensusEngineEvent) -> Self {
         Self::BeaconConsensus(event)


### PR DESCRIPTION
we need to also track when we emit a request for backfill sync until we receive the started event