### PR TITLE
fix(node-core): build time cargo features

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -117,15 +117,14 @@ libc = "0.2"
 [dev-dependencies]
 reth-discv4.workspace = true
 
-
 [features]
 default = ["jemalloc"]
 
 dev = ["reth-cli-commands/dev"]
 
-asm-keccak = ["reth-primitives/asm-keccak"]
+asm-keccak = ["reth-node-core/asm-keccak", "reth-primitives/asm-keccak"]
 
-jemalloc = ["dep:tikv-jemallocator", "reth-node-metrics/jemalloc"]
+jemalloc = ["dep:tikv-jemallocator", "reth-node-core/jemalloc", "reth-node-metrics/jemalloc"]
 jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
 
 min-error-logs = ["tracing/release_max_level_error"]
@@ -135,15 +134,15 @@ min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
 optimism = [
+    "dep:reth-node-optimism",
     "dep:reth-optimism-cli",
-    "reth-optimism-cli?/optimism",
-    "reth-primitives/optimism",
-    "reth-rpc/optimism",
-    "reth-provider/optimism",
     "reth-beacon-consensus/optimism",
     "reth-blockchain-tree/optimism",
-    "dep:reth-node-optimism",
     "reth-node-core/optimism",
+    "reth-optimism-cli?/optimism",
+    "reth-primitives/optimism",
+    "reth-provider/optimism",
+    "reth-rpc/optimism",
 ]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -85,8 +85,9 @@ optimism = [
     "reth-rpc-types-compat/optimism",
     "reth-rpc-eth-api/optimism",
 ]
-
-
+# Features for vergen to generate correct env vars
+jemalloc = []
+asm-keccak = []
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/9862

```console
➜  reth git:(alexey/node-core-features) cargo r --bin reth --features jemalloc,asm-keccak --quiet -- --version
reth Version: 1.0.3
Commit SHA: c56c46933f142dcb5b21fd06385daf8c61d0d7bb
Build Timestamp: 2024-07-29T13:14:50.822557000Z
Build Features: asm_keccak,jemalloc
Build Profile: debug
```

`reth-node-core` crate didn't have features activated by the binary
> `CARGO_FEATURE_<name>` — For each activated feature of the package being built, this environment variable will be present where `<name>` is the name of the feature uppercased and having `-` translated to `_`.

from https://doc.rust-lang.org/cargo/reference/environment-variables.html