### PR TITLE
feat: state housekeeping after backfill finished

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -90,6 +90,19 @@ pub(crate) struct CanonicalInMemoryStateInner {
     pub(crate) canon_state_notification_sender: CanonStateNotificationSender,
 }
 
+impl CanonicalInMemoryStateInner {
+    /// Clears all entries in the in memory state.
+    fn clear(&self) {
+        let mut blocks = self.in_memory_state.blocks.write();
+        let mut numbers = self.in_memory_state.numbers.write();
+        let mut pending = self.in_memory_state.pending.write();
+
+        blocks.clear();
+        numbers.clear();
+        pending.take();
+    }
+}
+
 /// This type is responsible for providing the blocks, receipts, and state for
 /// all canonical blocks not on disk yet and keeps track of the block range that
 /// is in memory.
@@ -142,6 +155,11 @@ impl CanonicalInMemoryState {
     /// Returns in the header corresponding to the given hash.
     pub fn header_by_hash(&self, hash: B256) -> Option<SealedHeader> {
         self.state_by_hash(hash).map(|block| block.block().block.header.clone())
+    }
+
+    /// Clears all entries in the in memory state.
+    pub fn clear_state(&self) {
+        self.inner.clear()
     }
 
     /// Updates the pending block with the given block.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -606,6 +606,10 @@ where
         // the canonical chain
         self.canonical_in_memory_state.clear_state();
 
+        if let Ok(Some(new_head)) = self.provider.sealed_header(backfill_height) {
+            self.state.tree_state.set_canonical_head(new_head.num_hash());
+        }
+
         // check if we need to run backfill again by comparing the most recent finalized height to
         // the backfill height
         let Some(sync_target_state) = self.state.forkchoice_state_tracker.sync_target_state()


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/issues/8742

this adds missing cleanup functions after backfill sync finished: resetting the tracked memory state to the height we just synced to