### PR TITLE
fix(op): ensure `EthApiServer` helper trait method default impls, call `OpEthApi` overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7994,6 +7994,7 @@ name = "reth-optimism-rpc"
 version = "1.0.3"
 dependencies = [
  "alloy-primitives",
+ "derive_more",
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7568,6 +7568,7 @@ version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
+ "auto_impl",
  "enr",
  "reth-eth-wire",
  "reth-network-peers",
@@ -8000,6 +8001,7 @@ dependencies = [
  "reth-errors",
  "reth-evm",
  "reth-evm-optimism",
+ "reth-network-api",
  "reth-node-api",
  "reth-primitives",
  "reth-provider",
@@ -8420,6 +8422,7 @@ dependencies = [
  "reth-errors",
  "reth-evm",
  "reth-execution-types",
+ "reth-network-api",
  "reth-primitives",
  "reth-provider",
  "reth-revm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8001,6 +8001,7 @@ dependencies = [
  "reth-errors",
  "reth-evm",
  "reth-evm-optimism",
+ "reth-network",
  "reth-network-api",
  "reth-node-api",
  "reth-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7997,8 +7997,6 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
- "reth-chainspec",
- "reth-errors",
  "reth-evm",
  "reth-evm-optimism",
  "reth-network",

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -27,6 +27,7 @@ enr = { workspace = true, default-features = false, features = ["rust-secp256k1"
 thiserror.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 tokio = { workspace = true, features = ["sync"] }
+auto_impl.workspace = true
 
 [features]
 default = ["serde"]

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -32,6 +32,7 @@ pub mod reputation;
 pub mod noop;
 
 /// Provides general purpose information about the network.
+#[auto_impl::auto_impl(&, Arc)]
 pub trait NetworkInfo: Send + Sync {
     /// Returns the [`SocketAddr`] that listens for incoming connections.
     fn local_addr(&self) -> SocketAddr;

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -19,7 +19,6 @@ use reth_optimism_consensus::OptimismBeaconConsensus;
 use reth_optimism_rpc::OpEthApi;
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::CanonStateSubscriptions;
-use reth_rpc::EthApi;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
     blobstore::DiskFileBlobStore, CoinbaseTipOrdering, TransactionPool,
@@ -105,7 +104,7 @@ impl NodeTypes for OptimismNode {
 pub struct OptimismAddOns;
 
 impl<N: FullNodeComponents> NodeAddOns<N> for OptimismAddOns {
-    type EthApi = OpEthApi<EthApi<N::Provider, N::Pool, NetworkHandle, N::Evm>>;
+    type EthApi = OpEthApi<N>;
 }
 
 /// A regular optimism evm and executor builder.

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -13,8 +13,6 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec.workspace = true
-reth-errors.workspace = true
 reth-evm-optimism.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
@@ -57,7 +55,6 @@ client = [
 ]
 
 optimism = [
-    "reth-chainspec/optimism",
     "reth-evm-optimism/optimism",
     "reth-primitives/optimism",
     "reth-provider/optimism",

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -43,6 +43,7 @@ jsonrpsee-types.workspace = true
 # misc
 thiserror.workspace = true
 serde = { workspace = true, features = ["derive"] }
+derive_more.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -27,6 +27,8 @@ reth-tasks = { workspace = true, features = ["rayon"] }
 reth-transaction-pool.workspace = true
 reth-rpc.workspace = true
 reth-node-api.workspace = true
+reth-network-api.workspace = true
+reth-network.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -21,6 +21,7 @@ where
     Self::Error: From<OpEthApiError>,
     N: FullNodeComponents,
 {
+    #[inline]
     fn provider(&self) -> impl HeaderProvider {
         self.inner.provider()
     }
@@ -80,10 +81,12 @@ where
     Self: LoadPendingBlock + SpawnBlocking,
     N: FullNodeComponents,
 {
+    #[inline]
     fn provider(&self) -> impl BlockReaderIdExt {
         self.inner.provider()
     }
 
+    #[inline]
     fn cache(&self) -> &EthStateCache {
         self.inner.cache()
     }

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -1,22 +1,28 @@
 //! Loads and formats OP block RPC response.   
 
+use reth_node_api::FullNodeComponents;
 use reth_primitives::TransactionMeta;
 use reth_provider::{BlockReaderIdExt, HeaderProvider};
 use reth_rpc_eth_api::{
-    helpers::{EthApiSpec, EthBlocks, LoadBlock, LoadReceipt, LoadTransaction},
+    helpers::{
+        EthApiSpec, EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, LoadTransaction,
+        SpawnBlocking,
+    },
     FromEthApiError,
 };
 use reth_rpc_eth_types::{EthStateCache, ReceiptBuilder};
 use reth_rpc_types::{AnyTransactionReceipt, BlockId};
 
-use crate::{op_receipt_fields, OpEthApi};
+use crate::{op_receipt_fields, OpEthApi, OpEthApiError};
 
-impl<Eth> EthBlocks for OpEthApi<Eth>
+impl<N> EthBlocks for OpEthApi<N>
 where
-    Eth: EthBlocks + EthApiSpec + LoadTransaction,
+    Self: LoadBlock + EthApiSpec + LoadTransaction,
+    Self::Error: From<OpEthApiError>,
+    N: FullNodeComponents,
 {
     fn provider(&self) -> impl HeaderProvider {
-        EthBlocks::provider(&self.inner)
+        self.inner.provider()
     }
 
     async fn block_receipts(
@@ -69,9 +75,13 @@ where
     }
 }
 
-impl<Eth: LoadBlock> LoadBlock for OpEthApi<Eth> {
+impl<N> LoadBlock for OpEthApi<N>
+where
+    Self: LoadPendingBlock + SpawnBlocking,
+    N: FullNodeComponents,
+{
     fn provider(&self) -> impl BlockReaderIdExt {
-        LoadBlock::provider(&self.inner)
+        self.inner.provider()
     }
 
     fn cache(&self) -> &EthStateCache {

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -26,10 +26,12 @@ where
     Self::Error: From<OpEthApiError>,
     N: FullNodeComponents,
 {
+    #[inline]
     fn call_gas_limit(&self) -> u64 {
         self.inner.gas_cap()
     }
 
+    #[inline]
     fn evm_config(&self) -> &impl ConfigureEvm {
         self.inner.evm_config()
     }

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -6,9 +6,9 @@ use reth_primitives::{
 };
 use reth_rpc_eth_api::{
     helpers::{Call, EthCall, LoadState, SpawnBlocking},
-    EthApiTypes, FromEthApiError, IntoEthApiError,
+    FromEthApiError, IntoEthApiError,
 };
-use reth_rpc_eth_types::{revm_utils::CallFees, EthApiError, RpcInvalidTransactionError};
+use reth_rpc_eth_types::{revm_utils::CallFees, RpcInvalidTransactionError};
 use reth_rpc_types::TransactionRequest;
 
 use crate::{OpEthApi, OpEthApiError};

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,26 +1,33 @@
 use reth_evm::ConfigureEvm;
+use reth_node_api::FullNodeComponents;
 use reth_primitives::{
     revm_primitives::{BlockEnv, OptimismFields, TxEnv},
-    Bytes,
+    Bytes, TxKind, U256,
 };
 use reth_rpc_eth_api::{
-    helpers::{Call, EthCall},
-    EthApiTypes, FromEthApiError,
+    helpers::{Call, EthCall, LoadState, SpawnBlocking},
+    EthApiTypes, FromEthApiError, IntoEthApiError,
 };
-use reth_rpc_eth_types::EthApiError;
+use reth_rpc_eth_types::{revm_utils::CallFees, EthApiError, RpcInvalidTransactionError};
 use reth_rpc_types::TransactionRequest;
 
-use crate::OpEthApi;
+use crate::{OpEthApi, OpEthApiError};
 
-impl<Eth: EthCall> EthCall for OpEthApi<Eth> where EthApiError: From<Eth::Error> {}
-
-impl<Eth> Call for OpEthApi<Eth>
+impl<N> EthCall for OpEthApi<N>
 where
-    Eth: Call + EthApiTypes,
-    EthApiError: From<Eth::Error>,
+    Self: Call,
+    N: FullNodeComponents,
+{
+}
+
+impl<N> Call for OpEthApi<N>
+where
+    Self: LoadState + SpawnBlocking,
+    Self::Error: From<OpEthApiError>,
+    N: FullNodeComponents,
 {
     fn call_gas_limit(&self) -> u64 {
-        self.inner.call_gas_limit()
+        self.inner.gas_cap()
     }
 
     fn evm_config(&self) -> &impl ConfigureEvm {
@@ -32,10 +39,68 @@ where
         block_env: &BlockEnv,
         request: TransactionRequest,
     ) -> Result<TxEnv, Self::Error> {
-        let mut env =
-            self.inner.create_txn_env(block_env, request).map_err(Self::Error::from_eth_err)?;
+        // Ensure that if versioned hashes are set, they're not empty
+        if request.blob_versioned_hashes.as_ref().map_or(false, |hashes| hashes.is_empty()) {
+            return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into_eth_err())
+        }
 
-        env.optimism = OptimismFields { enveloped_tx: Some(Bytes::new()), ..Default::default() };
+        let TransactionRequest {
+            from,
+            to,
+            gas_price,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            gas,
+            value,
+            input,
+            nonce,
+            access_list,
+            chain_id,
+            blob_versioned_hashes,
+            max_fee_per_blob_gas,
+            // authorization_list,
+            ..
+        } = request;
+
+        let CallFees { max_priority_fee_per_gas, gas_price, max_fee_per_blob_gas } =
+            CallFees::ensure_fees(
+                gas_price.map(U256::from),
+                max_fee_per_gas.map(U256::from),
+                max_priority_fee_per_gas.map(U256::from),
+                block_env.basefee,
+                blob_versioned_hashes.as_deref(),
+                max_fee_per_blob_gas.map(U256::from),
+                block_env.get_blob_gasprice().map(U256::from),
+            )?;
+
+        let gas_limit = gas.unwrap_or_else(|| block_env.gas_limit.min(U256::from(u64::MAX)).to());
+
+        #[allow(clippy::needless_update)]
+        let env = TxEnv {
+            gas_limit: gas_limit
+                .try_into()
+                .map_err(|_| RpcInvalidTransactionError::GasUintOverflow)
+                .map_err(Self::Error::from_eth_err)?,
+            nonce,
+            caller: from.unwrap_or_default(),
+            gas_price,
+            gas_priority_fee: max_priority_fee_per_gas,
+            transact_to: to.unwrap_or(TxKind::Create),
+            value: value.unwrap_or_default(),
+            data: input
+                .try_into_unique_input()
+                .map_err(Self::Error::from_eth_err)?
+                .unwrap_or_default(),
+            chain_id,
+            access_list: access_list.unwrap_or_default().into(),
+            // EIP-4844 fields
+            blob_hashes: blob_versioned_hashes.unwrap_or_default(),
+            max_fee_per_blob_gas,
+            // EIP-7702 fields
+            // authorization_list: TODO
+            authorization_list: Default::default(),
+            optimism: OptimismFields { enveloped_tx: Some(Bytes::new()), ..Default::default() },
+        };
 
         Ok(env)
     }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -97,18 +97,22 @@ impl<N> EthApiSpec for OpEthApi<N>
 where
     N: FullNodeComponents,
 {
+    #[inline]
     fn provider(&self) -> impl ChainSpecProvider + BlockNumReader {
         self.inner.provider()
     }
 
+    #[inline]
     fn network(&self) -> impl NetworkInfo {
         self.inner.network()
     }
 
+    #[inline]
     fn starting_block(&self) -> U256 {
         self.inner.starting_block()
     }
 
+    #[inline]
     fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn reth_rpc_eth_api::helpers::EthSigner>>> {
         self.inner.signers()
     }
@@ -140,18 +144,22 @@ where
     Self: LoadBlock,
     N: FullNodeComponents,
 {
+    #[inline]
     fn provider(&self) -> impl BlockIdReader + HeaderProvider + ChainSpecProvider {
         self.inner.provider()
     }
 
+    #[inline]
     fn cache(&self) -> &EthStateCache {
         self.inner.cache()
     }
 
+    #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<impl BlockReaderIdExt> {
         self.inner.gas_oracle()
     }
 
+    #[inline]
     fn fee_history_cache(&self) -> &FeeHistoryCache {
         self.inner.fee_history_cache()
     }
@@ -162,14 +170,17 @@ where
     Self: Send + Sync,
     N: FullNodeComponents,
 {
+    #[inline]
     fn provider(&self) -> impl StateProviderFactory + ChainSpecProvider {
         self.inner.provider()
     }
 
+    #[inline]
     fn cache(&self) -> &EthStateCache {
         self.inner.cache()
     }
 
+    #[inline]
     fn pool(&self) -> impl TransactionPool {
         self.inner.pool()
     }
@@ -180,6 +191,7 @@ where
     Self: LoadState + SpawnBlocking,
     N: FullNodeComponents,
 {
+    #[inline]
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_proof_window()
     }
@@ -197,6 +209,7 @@ where
     Self: LoadState,
     N: FullNodeComponents,
 {
+    #[inline]
     fn evm_config(&self) -> &impl ConfigureEvm {
         self.inner.evm_config()
     }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -37,7 +37,7 @@ use reth_transaction_pool::TransactionPool;
 use crate::OpEthApiError;
 
 /// Adapter for [`EthApiInner`], which holds all the data required to serve core `eth_` API.
-pub type EthApiHandles<N> = EthApiInner<
+pub type EthApiNodeBackend<N> = EthApiInner<
     <N as FullNodeTypes>::Provider,
     <N as FullNodeComponents>::Pool,
     NetworkHandle,
@@ -66,7 +66,7 @@ pub type EthApiBuilderCtx<N> = reth_rpc_eth_types::EthApiBuilderCtx<
 /// all the `Eth` helper traits and prerequisite traits.
 #[derive(Clone, Deref)]
 pub struct OpEthApi<N: FullNodeComponents> {
-    inner: Arc<EthApiHandles<N>>,
+    inner: Arc<EthApiNodeBackend<N>>,
 }
 
 impl<N: FullNodeComponents> OpEthApi<N> {

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -7,11 +7,9 @@ mod block;
 mod call;
 mod pending_block;
 
-use std::{fmt, future::Future, sync::Arc};
+use std::{fmt, sync::Arc};
 
-use alloy_primitives::{Address, U256, U64};
-use reth_chainspec::{ChainInfo, ChainSpec};
-use reth_errors::RethResult;
+use alloy_primitives::U256;
 use reth_evm::ConfigureEvm;
 use reth_network::NetworkHandle;
 use reth_network_api::NetworkInfo;
@@ -23,19 +21,17 @@ use reth_provider::{
 use reth_rpc::eth::{core::EthApiInner, DevSigner};
 use reth_rpc_eth_api::{
     helpers::{
-        AddDevSigners, EthApiSpec, EthFees, EthSigner, EthState, LoadBlock, LoadFee, LoadState,
-        SpawnBlocking, Trace, UpdateRawTxForwarder,
+        AddDevSigners, EthApiSpec, EthFees, EthState, LoadBlock, LoadFee, LoadState, SpawnBlocking,
+        Trace, UpdateRawTxForwarder,
     },
     EthApiTypes, RawTransactionForwarder,
 };
 use reth_rpc_eth_types::{EthApiBuilderCtx, EthStateCache, FeeHistoryCache, GasPriceOracle};
-use reth_rpc_types::SyncStatus;
 use reth_tasks::{
     pool::{BlockingTaskGuard, BlockingTaskPool},
     TaskExecutor, TaskSpawner,
 };
 use reth_transaction_pool::TransactionPool;
-use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 
 use crate::OpEthApiError;
 

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -1,19 +1,21 @@
 //! Loads OP pending block for a RPC response.   
 
 use reth_evm::ConfigureEvm;
+use reth_node_api::FullNodeComponents;
 use reth_primitives::{revm_primitives::BlockEnv, BlockNumber, B256};
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ExecutionOutcome, StateProviderFactory,
 };
-use reth_rpc_eth_api::helpers::LoadPendingBlock;
+use reth_rpc_eth_api::helpers::{LoadPendingBlock, SpawnBlocking};
 use reth_rpc_eth_types::PendingBlock;
 use reth_transaction_pool::TransactionPool;
 
 use crate::OpEthApi;
 
-impl<Eth> LoadPendingBlock for OpEthApi<Eth>
+impl<N> LoadPendingBlock for OpEthApi<N>
 where
-    Eth: LoadPendingBlock,
+    Self: SpawnBlocking,
+    N: FullNodeComponents,
 {
     #[inline]
     fn provider(

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -1,5 +1,6 @@
 //! Loads and formats OP receipt RPC response.   
 
+use reth_node_api::FullNodeComponents;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
 use reth_rpc_eth_api::{
     helpers::{EthApiSpec, LoadReceipt, LoadTransaction},
@@ -8,15 +9,17 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{EthApiError, EthStateCache, ReceiptBuilder};
 use reth_rpc_types::{AnyTransactionReceipt, OptimismTransactionReceiptFields};
 
-use crate::{OpEthApi, OptimismTxMeta};
+use crate::{OpEthApi, OpEthApiError, OptimismTxMeta};
 
-impl<Eth> LoadReceipt for OpEthApi<Eth>
+impl<N> LoadReceipt for OpEthApi<N>
 where
-    Eth: LoadReceipt + EthApiSpec + LoadTransaction,
+    Self: EthApiSpec + LoadTransaction,
+    Self::Error: From<OpEthApiError>,
+    N: FullNodeComponents,
 {
     #[inline]
     fn cache(&self) -> &EthStateCache {
-        LoadReceipt::cache(&self.inner)
+        self.inner.cache()
     }
 
     async fn build_transaction_receipt(

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -29,6 +29,7 @@ reth-chainspec.workspace = true
 reth-execution-types.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
+reth-network-api.workspace = true
 
 # ethereum
 alloy-dyn-abi = { workspace = true, features = ["eip712"] }

--- a/crates/rpc/rpc-eth-api/src/helpers/signer.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/signer.rs
@@ -41,9 +41,6 @@ dyn_clone::clone_trait_object!(EthSigner);
 /// Adds 20 random dev signers for access via the API. Used in dev mode.
 #[auto_impl::auto_impl(&)]
 pub trait AddDevSigners {
-    /// Returns a handle to the signers.
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>>;
-
     /// Generates 20 random developer accounts.
     /// Used in DEV mode.
     fn with_dev_accounts(&self);

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -4,33 +4,80 @@ use std::sync::Arc;
 
 use futures::Future;
 use reth_chainspec::{ChainInfo, ChainSpec};
-use reth_errors::RethResult;
-use reth_primitives::{Address, U64};
-use reth_rpc_types::SyncStatus;
+use reth_errors::{RethError, RethResult};
+use reth_network_api::NetworkInfo;
+use reth_primitives::{Address, U256, U64};
+use reth_provider::{BlockNumReader, ChainSpecProvider};
+use reth_rpc_types::{SyncInfo, SyncStatus};
+
+use super::EthSigner;
 
 /// `Eth` API trait.
 ///
 /// Defines core functionality of the `eth` API implementation.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait EthApiSpec: Send + Sync {
+    /// Returns a handle for reading data from disk.
+    fn provider(&self) -> impl ChainSpecProvider + BlockNumReader;
+
+    /// Returns a handle for reading network data summary.
+    fn network(&self) -> impl NetworkInfo;
+
+    /// Returns the block node is started on.
+    fn starting_block(&self) -> U256;
+
+    /// Returns a handle to the signers owned by provider.
+    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>>;
+
     /// Returns the current ethereum protocol version.
-    fn protocol_version(&self) -> impl Future<Output = RethResult<U64>> + Send;
+    fn protocol_version(&self) -> impl Future<Output = RethResult<U64>> + Send {
+        async move {
+            let status = self.network().network_status().await.map_err(RethError::other)?;
+            Ok(U64::from(status.protocol_version))
+        }
+    }
 
     /// Returns the chain id
-    fn chain_id(&self) -> U64;
+    fn chain_id(&self) -> U64 {
+        U64::from(self.network().chain_id())
+    }
 
     /// Returns provider chain info
-    fn chain_info(&self) -> RethResult<ChainInfo>;
+    fn chain_info(&self) -> RethResult<ChainInfo> {
+        Ok(self.provider().chain_info()?)
+    }
 
     /// Returns a list of addresses owned by provider.
-    fn accounts(&self) -> Vec<Address>;
+    fn accounts(&self) -> Vec<Address> {
+        self.signers().read().iter().flat_map(|s| s.accounts()).collect()
+    }
 
     /// Returns `true` if the network is undergoing sync.
-    fn is_syncing(&self) -> bool;
+    fn is_syncing(&self) -> bool {
+        self.network().is_syncing()
+    }
 
     /// Returns the [`SyncStatus`] of the network
-    fn sync_status(&self) -> RethResult<SyncStatus>;
+    fn sync_status(&self) -> RethResult<SyncStatus> {
+        let status = if self.is_syncing() {
+            let current_block = U256::from(
+                self.provider().chain_info().map(|info| info.best_number).unwrap_or_default(),
+            );
+            SyncStatus::Info(SyncInfo {
+                starting_block: self.starting_block(),
+                current_block,
+                highest_block: current_block,
+                warp_chunks_amount: None,
+                warp_chunks_processed: None,
+            })
+        } else {
+            SyncStatus::None
+        };
+        Ok(status)
+    }
 
     /// Returns the configured [`ChainSpec`].
-    fn chain_spec(&self) -> Arc<ChainSpec>;
+    fn chain_spec(&self) -> Arc<ChainSpec> {
+        self.provider().chain_spec()
+    }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -102,8 +102,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         let block_id = block_id.unwrap_or_default();
 
         // Check whether the distance to the block exceeds the maximum configured window.
-        let block_number = self
-            .provider()
+        let block_number = LoadState::provider(self)
             .block_number_for_id(block_id)
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::UnknownBlockNumber)?;

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 
 use derive_more::Deref;
-use futures::Future;
 use reth_node_api::{BuilderProvider, FullNodeComponents};
 use reth_primitives::{BlockNumberOrTag, U256};
 use reth_provider::{BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider};
@@ -139,29 +138,21 @@ impl<Provider, Pool, Network, EvmConfig> Clone for EthApi<Provider, Pool, Networ
 impl<Provider, Pool, Network, EvmConfig> SpawnBlocking
     for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: EthApiTypes + Clone + Send + Sync + 'static,
+    Self: Clone + Send + Sync + 'static,
 {
     #[inline]
-    fn io_task_spawner(&self) -> impl reth_tasks::TaskSpawner {
+    fn io_task_spawner(&self) -> impl TaskSpawner {
         self.inner.task_spawner()
     }
 
     #[inline]
-    fn tracing_task_pool(&self) -> &reth_tasks::pool::BlockingTaskPool {
+    fn tracing_task_pool(&self) -> &BlockingTaskPool {
         self.inner.blocking_task_pool()
     }
 
-    fn acquire_owned(
-        &self,
-    ) -> impl Future<Output = Result<OwnedSemaphorePermit, AcquireError>> + Send {
-        self.blocking_task_guard.clone().acquire_owned()
-    }
-
-    fn acquire_many_owned(
-        &self,
-        n: u32,
-    ) -> impl Future<Output = Result<OwnedSemaphorePermit, AcquireError>> + Send {
-        self.blocking_task_guard.clone().acquire_many_owned(n)
+    #[inline]
+    fn tracing_task_guard(&self) -> &BlockingTaskGuard {
+        self.inner.blocking_task_guard()
     }
 }
 
@@ -357,6 +348,12 @@ impl<Provider, Pool, Network, EvmConfig> EthApiInner<Provider, Pool, Network, Ev
     #[inline]
     pub const fn eth_proof_window(&self) -> u64 {
         self.eth_proof_window
+    }
+
+    /// Returns reference to [`BlockingTaskGuard`].
+    #[inline]
+    pub const fn blocking_task_guard(&self) -> &BlockingTaskGuard {
+        &self.blocking_task_guard
     }
 }
 

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -19,7 +19,7 @@ use reth_tasks::{
     pool::{BlockingTaskGuard, BlockingTaskPool},
     TaskExecutor, TaskSpawner, TokioTaskExecutor,
 };
-use tokio::sync::{AcquireError, Mutex, OwnedSemaphorePermit};
+use tokio::sync::Mutex;
 
 /// `Eth` API implementation.
 ///

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -14,7 +14,7 @@ where
     Self: SpawnBlocking,
     Provider: BlockReaderIdExt + EvmEnvProvider + ChainSpecProvider + StateProviderFactory,
     Pool: TransactionPool,
-    EvmConfig: reth_evm::ConfigureEvm,
+    EvmConfig: ConfigureEvm,
 {
     #[inline]
     fn provider(

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,13 +1,13 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
-use reth_rpc_eth_api::{helpers::LoadReceipt, EthApiTypes};
+use reth_rpc_eth_api::helpers::LoadReceipt;
 use reth_rpc_eth_types::EthStateCache;
 
 use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> LoadReceipt for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: EthApiTypes,
+    Self: Send + Sync,
 {
     #[inline]
     fn cache(&self) -> &EthStateCache {

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -17,12 +17,8 @@ use crate::EthApi;
 impl<Provider, Pool, Network, EvmConfig> AddDevSigners
     for EthApi<Provider, Pool, Network, EvmConfig>
 {
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>> {
-        self.inner.signers()
-    }
-
     fn with_dev_accounts(&self) {
-        *self.signers().write() = DevSigner::random_signers(20)
+        *self.inner.signers().write() = DevSigner::random_signers(20)
     }
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,13 +1,7 @@
-use std::sync::Arc;
-
-use reth_chainspec::{ChainInfo, ChainSpec};
-use reth_errors::{RethError, RethResult};
-use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
-use reth_primitives::{Address, U256, U64};
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
+use reth_primitives::U256;
+use reth_provider::{BlockNumReader, ChainSpecProvider};
 use reth_rpc_eth_api::helpers::EthApiSpec;
-use reth_rpc_types::{SyncInfo, SyncStatus};
 use reth_transaction_pool::TransactionPool;
 
 use crate::EthApi;
@@ -15,57 +9,23 @@ use crate::EthApi;
 impl<Provider, Pool, Network, EvmConfig> EthApiSpec for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Pool: TransactionPool + 'static,
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockNumReader + ChainSpecProvider + 'static,
     Network: NetworkInfo + 'static,
-    EvmConfig: ConfigureEvm,
+    EvmConfig: Send + Sync,
 {
-    /// Returns the current ethereum protocol version.
-    ///
-    /// Note: This returns an [`U64`], since this should return as hex string.
-    async fn protocol_version(&self) -> RethResult<U64> {
-        let status = self.network().network_status().await.map_err(RethError::other)?;
-        Ok(U64::from(status.protocol_version))
+    fn provider(&self) -> impl ChainSpecProvider + BlockNumReader {
+        self.inner.provider()
     }
 
-    /// Returns the chain id
-    fn chain_id(&self) -> U64 {
-        U64::from(self.network().chain_id())
+    fn network(&self) -> impl NetworkInfo {
+        self.inner.network()
     }
 
-    /// Returns the current info for the chain
-    fn chain_info(&self) -> RethResult<ChainInfo> {
-        Ok(self.provider().chain_info()?)
+    fn starting_block(&self) -> U256 {
+        self.inner.starting_block()
     }
 
-    fn accounts(&self) -> Vec<Address> {
-        self.inner.signers().read().iter().flat_map(|s| s.accounts()).collect()
-    }
-
-    fn is_syncing(&self) -> bool {
-        self.network().is_syncing()
-    }
-
-    /// Returns the [`SyncStatus`] of the network
-    fn sync_status(&self) -> RethResult<SyncStatus> {
-        let status = if self.is_syncing() {
-            let current_block = U256::from(
-                self.provider().chain_info().map(|info| info.best_number).unwrap_or_default(),
-            );
-            SyncStatus::Info(SyncInfo {
-                starting_block: self.inner.starting_block(),
-                current_block,
-                highest_block: current_block,
-                warp_chunks_amount: None,
-                warp_chunks_processed: None,
-            })
-        } else {
-            SyncStatus::None
-        };
-        Ok(status)
-    }
-
-    fn chain_spec(&self) -> Arc<ChainSpec> {
-        self.inner.provider().chain_spec()
+    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn reth_rpc_eth_api::helpers::EthSigner>>> {
+        self.inner.signers()
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -3,10 +3,7 @@
 use reth_provider::{ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
-use reth_rpc_eth_api::{
-    helpers::{EthState, LoadState, SpawnBlocking},
-    EthApiTypes,
-};
+use reth_rpc_eth_api::helpers::{EthState, LoadState, SpawnBlocking};
 use reth_rpc_eth_types::EthStateCache;
 
 use crate::EthApi;
@@ -16,13 +13,13 @@ where
     Self: LoadState + SpawnBlocking,
 {
     fn max_proof_window(&self) -> u64 {
-        self.eth_proof_window()
+        self.inner.eth_proof_window()
     }
 }
 
 impl<Provider, Pool, Network, EvmConfig> LoadState for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: EthApiTypes,
+    Self: Send + Sync,
     Provider: StateProviderFactory + ChainSpecProvider,
     Pool: TransactionPool,
 {


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/9868

- Replaces inner type on `OpEthApi` with `EthApiInner`. This ensure that the default trait method impls kept by `OpEthApi`, will actually invoke the `OpEthApi` overrides of other trait methods.
- Inlines getters in `EthApiServer` helper trait impls for `OpEthApi`
- Adds getter trait methods for `EthState` and `EthApiSpec`, and moves impl of trait methods for `EthApi`, into default impl, to simplify impl for re-worked `OpEthApi` type