### PR TITLE
chore: remove unused PreCancunBlock beacon error

### DIFF
--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -87,9 +87,6 @@ pub enum BeaconOnNewPayloadError {
     /// Thrown when the engine task is unavailable/stopped.
     #[error("beacon consensus engine task stopped")]
     EngineUnavailable,
-    /// Thrown when a block has blob transactions, but is not after the Cancun fork.
-    #[error("block has blob transactions, but is not after the Cancun fork")]
-    PreCancunBlockWithBlobTransactions,
     /// An internal error occurred, not necessarily related to the payload.
     #[error(transparent)]
     Internal(Box<dyn std::error::Error + Send + Sync>),

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -173,30 +173,10 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                     )
                 }
             },
-            EngineApiError::NewPayload(ref err) => match err {
-                BeaconOnNewPayloadError::Internal(_) => jsonrpsee_types::error::ErrorObject::owned(
-                    INTERNAL_ERROR_CODE,
-                    SERVER_ERROR_MSG,
-                    Some(ErrorData::new(error)),
-                ),
-                BeaconOnNewPayloadError::PreCancunBlockWithBlobTransactions => {
-                    jsonrpsee_types::error::ErrorObject::owned(
-                        INVALID_PARAMS_CODE,
-                        INVALID_PARAMS_MSG,
-                        Some(ErrorData::new(error)),
-                    )
-                }
-                BeaconOnNewPayloadError::EngineUnavailable => {
-                    jsonrpsee_types::error::ErrorObject::owned(
-                        INTERNAL_ERROR_CODE,
-                        SERVER_ERROR_MSG,
-                        Some(ErrorData::new(error)),
-                    )
-                }
-            },
             // Any other server error
             EngineApiError::TerminalTD { .. } |
             EngineApiError::TerminalBlockHash { .. } |
+            EngineApiError::NewPayload(_) |
             EngineApiError::Internal(_) |
             EngineApiError::GetPayloadError(_) => jsonrpsee_types::error::ErrorObject::owned(
                 INTERNAL_ERROR_CODE,


### PR DESCRIPTION
This was unused, replaced by a payload error in https://github.com/paradigmxyz/reth/pull/4845

see context in https://github.com/paradigmxyz/reth/issues/4670