### PR TITLE
chore: remove unused second BlockchainTreeError variant

### DIFF
--- a/crates/blockchain-tree-api/src/error.rs
+++ b/crates/blockchain-tree-api/src/error.rs
@@ -231,9 +231,6 @@ pub enum InsertBlockErrorKind {
     /// Canonical error.
     #[error(transparent)]
     Canonical(#[from] CanonicalError),
-    /// `BlockchainTree` error.
-    #[error(transparent)]
-    BlockchainTree(BlockchainTreeError),
 }
 
 impl InsertBlockErrorKind {
@@ -326,7 +323,6 @@ impl InsertBlockErrorKind {
                 CanonicalError::Provider(_) => false,
                 CanonicalError::Validation(_) => true,
             },
-            Self::BlockchainTree(_) => false,
         }
     }
 


### PR DESCRIPTION
The other variant has special handling in the `is_invalid_block` method. The other has also a `#[from]` attribute. This one seems to have never been constructed. So this one is likely the redundant one