### PR TITLE
feat: add better engine insert block error type

### DIFF
--- a/crates/blockchain-tree-api/src/error.rs
+++ b/crates/blockchain-tree-api/src/error.rs
@@ -1,7 +1,9 @@
 //! Error handling for the blockchain tree
 
 use reth_consensus::ConsensusError;
-use reth_execution_errors::{BlockExecutionError, BlockValidationError};
+use reth_execution_errors::{
+    BlockExecutionError, BlockValidationError, InternalBlockExecutionError,
+};
 use reth_primitives::{BlockHash, BlockNumber, SealedBlock};
 pub use reth_storage_errors::provider::ProviderError;
 
@@ -205,6 +207,168 @@ impl InsertBlockErrorData {
     fn boxed(block: SealedBlock, kind: InsertBlockErrorKind) -> Box<Self> {
         Box::new(Self::new(block, kind))
     }
+}
+
+/// Error thrown when inserting a block failed because the block is considered invalid.
+#[derive(thiserror::Error)]
+#[error(transparent)]
+pub struct InsertBlockErrorTwo {
+    inner: Box<InsertBlockErrorDataTwo>,
+}
+
+// === impl InsertBlockErrorTwo ===
+
+impl InsertBlockErrorTwo {
+    /// Create a new `InsertInvalidBlockErrorTwo`
+    pub fn new(block: SealedBlock, kind: InsertBlockErrorKindTwo) -> Self {
+        Self { inner: InsertBlockErrorDataTwo::boxed(block, kind) }
+    }
+
+    /// Create a new `InsertInvalidBlockError` from a consensus error
+    pub fn consensus_error(error: ConsensusError, block: SealedBlock) -> Self {
+        Self::new(block, InsertBlockErrorKindTwo::Consensus(error))
+    }
+
+    /// Create a new `InsertInvalidBlockError` from a consensus error
+    pub fn sender_recovery_error(block: SealedBlock) -> Self {
+        Self::new(block, InsertBlockErrorKindTwo::SenderRecovery)
+    }
+
+    /// Create a new `InsertInvalidBlockError` from an execution error
+    pub fn execution_error(error: BlockExecutionError, block: SealedBlock) -> Self {
+        Self::new(block, InsertBlockErrorKindTwo::Execution(error))
+    }
+
+    /// Consumes the error and returns the block that resulted in the error
+    #[inline]
+    pub fn into_block(self) -> SealedBlock {
+        self.inner.block
+    }
+
+    /// Returns the error kind
+    #[inline]
+    pub const fn kind(&self) -> &InsertBlockErrorKindTwo {
+        &self.inner.kind
+    }
+
+    /// Returns the block that resulted in the error
+    #[inline]
+    pub const fn block(&self) -> &SealedBlock {
+        &self.inner.block
+    }
+
+    /// Consumes the type and returns the block and error kind.
+    #[inline]
+    pub fn split(self) -> (SealedBlock, InsertBlockErrorKindTwo) {
+        let inner = *self.inner;
+        (inner.block, inner.kind)
+    }
+}
+
+impl std::fmt::Debug for InsertBlockErrorTwo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+struct InsertBlockErrorDataTwo {
+    block: SealedBlock,
+    kind: InsertBlockErrorKindTwo,
+}
+
+impl std::fmt::Display for InsertBlockErrorDataTwo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Failed to insert block (hash={}, number={}, parent_hash={}): {}",
+            self.block.hash(),
+            self.block.number,
+            self.block.parent_hash,
+            self.kind
+        )
+    }
+}
+
+impl std::fmt::Debug for InsertBlockErrorDataTwo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InsertBlockError")
+            .field("error", &self.kind)
+            .field("hash", &self.block.hash())
+            .field("number", &self.block.number)
+            .field("parent_hash", &self.block.parent_hash)
+            .field("num_txs", &self.block.body.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::error::Error for InsertBlockErrorDataTwo {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.kind)
+    }
+}
+
+impl InsertBlockErrorDataTwo {
+    const fn new(block: SealedBlock, kind: InsertBlockErrorKindTwo) -> Self {
+        Self { block, kind }
+    }
+
+    fn boxed(block: SealedBlock, kind: InsertBlockErrorKindTwo) -> Box<Self> {
+        Box::new(Self::new(block, kind))
+    }
+}
+
+/// All error variants possible when inserting a block
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockErrorKindTwo {
+    /// Failed to recover senders for the block
+    #[error("failed to recover senders for block")]
+    SenderRecovery,
+    /// Block violated consensus rules.
+    #[error(transparent)]
+    Consensus(#[from] ConsensusError),
+    /// Block execution failed.
+    #[error(transparent)]
+    Execution(#[from] BlockExecutionError),
+    /// Provider error.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+}
+
+impl InsertBlockErrorKindTwo {
+    /// Returns true if the error is caused by an invalid block
+    ///
+    /// This is intended to be used to determine if the block should be marked as invalid.
+    #[allow(clippy::match_same_arms)]
+    pub fn is_invalid_block(self) -> Result<(), InsertBlockFatalError> {
+        match self {
+            Self::SenderRecovery | Self::Consensus(_) => Ok(()),
+            // other execution errors that are considered internal errors
+            Self::Execution(err) => {
+                match err {
+                    BlockExecutionError::Validation(_) | BlockExecutionError::Consensus(_) => {
+                        // this is caused by an invalid block
+                        Ok(())
+                    }
+                    // these are internal errors, not caused by an invalid block
+                    BlockExecutionError::Internal(error) => {
+                        Err(InsertBlockFatalError::BlockExecutionError(error))
+                    }
+                }
+            }
+            Self::Provider(err) => Err(InsertBlockFatalError::Provider(err)),
+        }
+    }
+}
+
+/// Error variants that are not caused by invalid blocks
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockFatalError {
+    /// A provider error
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    /// An internal / fatal block execution error
+    #[error(transparent)]
+    BlockExecutionError(#[from] InternalBlockExecutionError),
 }
 
 /// All error variants possible when inserting a block


### PR DESCRIPTION
Introduces an error type that can be used in the new engine, to distinguish between invalid blocks and other types of errors

depends on https://github.com/paradigmxyz/reth/pull/9911