### PR TITLE
fix: also set configured bootnodes for discv5

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -299,6 +299,27 @@ impl Config {
         }
     }
 
+    /// Inserts a new boot node to the list of boot nodes.
+    pub fn insert_boot_node(&mut self, boot_node: BootNode) {
+        self.bootstrap_nodes.insert(boot_node);
+    }
+
+    /// Inserts a new unsigned enode boot node to the list of boot nodes if it can be parsed, see
+    /// also [`BootNode::from_unsigned`].
+    pub fn insert_unsigned_boot_node(&mut self, node_record: NodeRecord) {
+        let _ = BootNode::from_unsigned(node_record).map(|node| self.insert_boot_node(node));
+    }
+
+    /// Extends the list of boot nodes with a list of enode boot nodes if they can be parsed.
+    pub fn extend_unsigned_boot_nodes(
+        &mut self,
+        node_records: impl IntoIterator<Item = NodeRecord>,
+    ) {
+        for node_record in node_records {
+            self.insert_unsigned_boot_node(node_record);
+        }
+    }
+
     /// Returns the discovery (UDP) socket contained in the [`discv5::Config`]. Returns the IPv6
     /// socket, if both IPv4 and v6 are configured. This socket will be advertised to peers in the
     /// local [`Enr`](discv5::enr::Enr).

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -385,10 +385,15 @@ impl NetworkConfigBuilder {
         self.boot_nodes(sepolia_nodes())
     }
 
-    /// Sets the boot nodes.
+    /// Sets the boot nodes to use to bootstrap the configured discovery services (discv4 + discv5).
     pub fn boot_nodes<T: Into<TrustedPeer>>(mut self, nodes: impl IntoIterator<Item = T>) -> Self {
         self.boot_nodes = nodes.into_iter().map(Into::into).collect();
         self
+    }
+
+    /// Returns an iterator over all configured boot nodes.
+    pub fn boot_nodes_iter(&self) -> impl Iterator<Item = &TrustedPeer> + '_ {
+        self.boot_nodes.iter()
     }
 
     /// Disable the DNS discovery.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -173,7 +173,7 @@ impl NetworkManager {
             secret_key,
             discovery_v4_addr,
             mut discovery_v4_config,
-            discovery_v5_config,
+            mut discovery_v5_config,
             listener_addr,
             peers_config,
             sessions_config,
@@ -208,12 +208,16 @@ impl NetworkManager {
             resolved_boot_nodes.push(resolved);
         }
 
-        discovery_v4_config = discovery_v4_config.map(|mut disc_config| {
+        if let Some(disc_config) = discovery_v4_config.as_mut() {
             // merge configured boot nodes
             disc_config.bootstrap_nodes.extend(resolved_boot_nodes.clone());
             disc_config.add_eip868_pair("eth", status.forkid);
-            disc_config
-        });
+        }
+
+        if let Some(discv5) = discovery_v5_config.as_mut() {
+            // merge configured boot nodes
+            discv5.extend_unsigned_boot_nodes(resolved_boot_nodes)
+        }
 
         let discovery = Discovery::new(
             listener_addr,

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -118,6 +118,13 @@ pub struct NetworkArgs {
 }
 
 impl NetworkArgs {
+    /// Returns the resolved bootnodes if any are provided.
+    pub fn resolved_bootnodes(&self) -> Option<Vec<NodeRecord>> {
+        self.bootnodes.clone().map(|bootnodes| {
+            bootnodes.into_iter().filter_map(|node| node.resolve_blocking().ok()).collect()
+        })
+    }
+
     /// Build a [`NetworkConfigBuilder`] from a [`Config`] and a [`ChainSpec`], in addition to the
     /// values in this option struct.
     ///
@@ -137,14 +144,7 @@ impl NetworkArgs {
         default_peers_file: PathBuf,
     ) -> NetworkConfigBuilder {
         let chain_bootnodes = self
-            .bootnodes
-            .clone()
-            .map(|bootnodes| {
-                bootnodes
-                    .into_iter()
-                    .filter_map(|trusted_peer| trusted_peer.resolve_blocking().ok())
-                    .collect()
-            })
+            .resolved_bootnodes()
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -300,10 +300,16 @@ where
                 let rlpx_socket = (args.addr, args.port).into();
 
                 if !args.discovery.disable_discovery {
-                    builder = builder.discovery_v5(args.discovery.discovery_v5_builder(
-                        rlpx_socket,
-                        ctx.chain_spec().bootnodes().unwrap_or_default(),
-                    ));
+                    builder = builder.discovery_v5(
+                        args.discovery.discovery_v5_builder(
+                            rlpx_socket,
+                            ctx.config()
+                                .network
+                                .resolved_bootnodes()
+                                .or_else(|| ctx.chain_spec().bootnodes())
+                                .unwrap_or_default(),
+                        ),
+                    );
                 }
 
                 builder


### PR DESCRIPTION
closes #9883

we didn't configure the provided --bootnodes for discv5.

geth also uses the --bootnodes values to initialize discv5 bootnodes:

https://github.com/ethereum/go-ethereum/blob/380688c636a654becc8f114438c2a5d93d2db032/cmd/utils/flags.go#L1087-L1087

so this fix is reasonable imo.

I also added extend the discv5 bootnodes during network launch, this is redundant if the discv5 is already configured with the bootnodes, but doesn't hurt

https://github.com/paradigmxyz/reth/blob/76513e46ecad9a0893d46af4164da23bf90511aa/crates/net/network/src/manager.rs#L217-L220 