### PR TITLE
chore(blockchain-tree): rename BlockchainId to SidechainId

### DIFF
--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -1,6 +1,6 @@
 //! Implementation of [`BlockIndices`] related to [`super::BlockchainTree`]
 
-use super::state::BlockchainId;
+use super::state::SidechainId;
 use crate::canonical_chain::CanonicalChain;
 use linked_hash_set::LinkedHashSet;
 use reth_execution_types::Chain;
@@ -39,7 +39,7 @@ pub struct BlockIndices {
     /// hashes.
     block_number_to_block_hashes: BTreeMap<BlockNumber, HashSet<BlockHash>>,
     /// Block hashes and side chain they belong
-    blocks_to_chain: HashMap<BlockHash, BlockchainId>,
+    blocks_to_chain: HashMap<BlockHash, SidechainId>,
 }
 
 impl BlockIndices {
@@ -62,9 +62,9 @@ impl BlockIndices {
         &self.fork_to_child
     }
 
-    /// Return block to chain id
+    /// Return block to sidechain id
     #[allow(dead_code)]
-    pub(crate) const fn blocks_to_chain(&self) -> &HashMap<BlockHash, BlockchainId> {
+    pub(crate) const fn blocks_to_chain(&self) -> &HashMap<BlockHash, SidechainId> {
         &self.blocks_to_chain
     }
 
@@ -104,14 +104,14 @@ impl BlockIndices {
         &mut self,
         block_number: BlockNumber,
         block_hash: BlockHash,
-        chain_id: BlockchainId,
+        chain_id: SidechainId,
     ) {
         self.block_number_to_block_hashes.entry(block_number).or_default().insert(block_hash);
         self.blocks_to_chain.insert(block_hash, chain_id);
     }
 
     /// Insert block to chain and fork child indices of the new chain
-    pub(crate) fn insert_chain(&mut self, chain_id: BlockchainId, chain: &Chain) {
+    pub(crate) fn insert_chain(&mut self, chain_id: SidechainId, chain: &Chain) {
         for (number, block) in chain.blocks() {
             // add block -> chain_id index
             self.blocks_to_chain.insert(block.hash(), chain_id);
@@ -123,8 +123,8 @@ impl BlockIndices {
         self.fork_to_child.entry(first.parent_hash).or_default().insert_if_absent(first.hash());
     }
 
-    /// Get the [`BlockchainId`] the given block belongs to if it exists.
-    pub(crate) fn get_block_chain_id(&self, block: &BlockHash) -> Option<BlockchainId> {
+    /// Get the [`SidechainId`] the given block belongs to if it exists.
+    pub(crate) fn get_block_chain_id(&self, block: &BlockHash) -> Option<SidechainId> {
         self.blocks_to_chain.get(block).cloned()
     }
 
@@ -134,7 +134,7 @@ impl BlockIndices {
     pub(crate) fn update_block_hashes(
         &mut self,
         hashes: BTreeMap<u64, BlockHash>,
-    ) -> (BTreeSet<BlockchainId>, Vec<BlockNumHash>) {
+    ) -> (BTreeSet<SidechainId>, Vec<BlockNumHash>) {
         // set new canonical hashes.
         self.canonical_chain.replace(hashes.clone());
 
@@ -203,7 +203,7 @@ impl BlockIndices {
 
     /// Remove chain from indices and return dependent chains that need to be removed.
     /// Does the cleaning of the tree and removing blocks from the chain.
-    pub(crate) fn remove_chain(&mut self, chain: &Chain) -> BTreeSet<BlockchainId> {
+    pub(crate) fn remove_chain(&mut self, chain: &Chain) -> BTreeSet<SidechainId> {
         chain
             .blocks()
             .iter()
@@ -219,7 +219,7 @@ impl BlockIndices {
         &mut self,
         block_number: BlockNumber,
         block_hash: BlockHash,
-    ) -> BTreeSet<BlockchainId> {
+    ) -> BTreeSet<SidechainId> {
         // rm number -> block
         if let btree_map::Entry::Occupied(mut entry) =
             self.block_number_to_block_hashes.entry(block_number)
@@ -312,7 +312,7 @@ impl BlockIndices {
         &mut self,
         finalized_block: BlockNumber,
         num_of_additional_canonical_hashes_to_retain: u64,
-    ) -> BTreeSet<BlockchainId> {
+    ) -> BTreeSet<SidechainId> {
         // get finalized chains. blocks between [self.last_finalized,finalized_block).
         // Dont remove finalized_block, as sidechain can point to it.
         let finalized_blocks: Vec<BlockHash> = self

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -38,7 +38,7 @@ pub struct BlockIndices {
     /// Note: This is a bijection: at all times `blocks_to_chain` and this map contain the block
     /// hashes.
     block_number_to_block_hashes: BTreeMap<BlockNumber, HashSet<BlockHash>>,
-    /// Block hashes and side chain they belong
+    /// Block hashes to the sidechain IDs they belong to.
     blocks_to_chain: HashMap<BlockHash, SidechainId>,
 }
 
@@ -123,8 +123,8 @@ impl BlockIndices {
         self.fork_to_child.entry(first.parent_hash).or_default().insert_if_absent(first.hash());
     }
 
-    /// Get the [`SidechainId`] the given block belongs to if it exists.
-    pub(crate) fn get_block_chain_id(&self, block: &BlockHash) -> Option<SidechainId> {
+    /// Get the [`SidechainId`] for the given block hash if it exists.
+    pub(crate) fn get_side_chain_id(&self, block: &BlockHash) -> Option<SidechainId> {
         self.blocks_to_chain.get(block).cloned()
     }
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     metrics::{MakeCanonicalAction, MakeCanonicalDurationsRecorder, TreeMetrics},
-    state::{BlockchainId, TreeState},
+    state::{SidechainId, TreeState},
     AppendableChain, BlockIndices, BlockchainTreeConfig, ExecutionData, TreeExternals,
 };
 use reth_blockchain_tree_api::{
@@ -452,7 +452,7 @@ where
     fn try_insert_block_into_side_chain(
         &mut self,
         block: SealedBlockWithSenders,
-        chain_id: BlockchainId,
+        chain_id: SidechainId,
         block_validation_kind: BlockValidationKind,
     ) -> Result<BlockStatus, InsertBlockErrorKind> {
         let block_num_hash = block.num_hash();
@@ -525,7 +525,7 @@ where
     /// # Note
     ///
     /// This is not cached in order to save memory.
-    fn all_chain_hashes(&self, chain_id: BlockchainId) -> BTreeMap<BlockNumber, BlockHash> {
+    fn all_chain_hashes(&self, chain_id: SidechainId) -> BTreeMap<BlockNumber, BlockHash> {
         let mut chain_id = chain_id;
         let mut hashes = BTreeMap::new();
         loop {
@@ -563,7 +563,7 @@ where
     /// the block on
     ///
     /// Returns `None` if the chain is unknown.
-    fn canonical_fork(&self, chain_id: BlockchainId) -> Option<ForkBlock> {
+    fn canonical_fork(&self, chain_id: SidechainId) -> Option<ForkBlock> {
         let mut chain_id = chain_id;
         let mut fork;
         loop {
@@ -582,13 +582,13 @@ where
     /// Insert a chain into the tree.
     ///
     /// Inserts a chain into the tree and builds the block indices.
-    fn insert_chain(&mut self, chain: AppendableChain) -> Option<BlockchainId> {
+    fn insert_chain(&mut self, chain: AppendableChain) -> Option<SidechainId> {
         self.state.insert_chain(chain)
     }
 
     /// Iterate over all child chains that depend on this block and return
     /// their ids.
-    fn find_all_dependent_chains(&self, block: &BlockHash) -> HashSet<BlockchainId> {
+    fn find_all_dependent_chains(&self, block: &BlockHash) -> HashSet<SidechainId> {
         // Find all forks of given block.
         let mut dependent_block =
             self.block_indices().fork_to_child().get(block).cloned().unwrap_or_default();
@@ -625,7 +625,7 @@ where
     /// plain state during the unwind.
     /// Returns the result of inserting the chain or None if any of the dependent chains is not
     /// in the tree.
-    fn insert_unwound_chain(&mut self, chain: AppendableChain) -> Option<BlockchainId> {
+    fn insert_unwound_chain(&mut self, chain: AppendableChain) -> Option<SidechainId> {
         // iterate over all blocks in chain and find any fork blocks that are in tree.
         for (number, block) in chain.blocks() {
             let hash = block.hash();
@@ -945,7 +945,7 @@ where
     /// The pending part of the chain is reinserted back into the tree with the same `chain_id`.
     fn remove_and_split_chain(
         &mut self,
-        chain_id: BlockchainId,
+        chain_id: SidechainId,
         split_at: ChainSplitTarget,
     ) -> Option<Chain> {
         let chain = self.state.chains.remove(&chain_id)?;
@@ -1458,7 +1458,7 @@ mod tests {
         /// Number of chains
         chain_num: Option<usize>,
         /// Check block to chain index
-        block_to_chain: Option<HashMap<BlockHash, BlockchainId>>,
+        block_to_chain: Option<HashMap<BlockHash, SidechainId>>,
         /// Check fork to child index
         fork_to_child: Option<HashMap<BlockHash, HashSet<BlockHash>>>,
         /// Pending blocks
@@ -1473,7 +1473,7 @@ mod tests {
             self
         }
 
-        fn with_block_to_chain(mut self, block_to_chain: HashMap<BlockHash, BlockchainId>) -> Self {
+        fn with_block_to_chain(mut self, block_to_chain: HashMap<BlockHash, SidechainId>) -> Self {
             self.block_to_chain = Some(block_to_chain);
             self
         }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -447,7 +447,7 @@ where
 
     /// Try inserting a block into the given side chain.
     ///
-    /// WARNING: This expects a valid side chain id, see [BlockIndices::get_block_chain_id]
+    /// WARNING: This expects a valid side chain id, see [BlockIndices::get_side_chain_id]
     #[instrument(level = "trace", skip_all, target = "blockchain_tree")]
     fn try_insert_block_into_side_chain(
         &mut self,
@@ -1783,8 +1783,7 @@ mod tests {
             InsertPayloadOk::Inserted(BlockStatus::Valid(BlockAttachment::Canonical)) /* TODO: this is incorrect, figure out why */
         );
 
-        let block3a_chain_id =
-            tree.state.block_indices.get_side_chain_id(&block3a.hash()).unwrap();
+        let block3a_chain_id = tree.state.block_indices.get_side_chain_id(&block3a.hash()).unwrap();
         assert_eq!(
             tree.all_chain_hashes(block3a_chain_id),
             BTreeMap::from([

--- a/crates/blockchain-tree/src/state.rs
+++ b/crates/blockchain-tree/src/state.rs
@@ -68,7 +68,7 @@ impl TreeState {
         &self,
         block_hash: BlockHash,
     ) -> Option<&SealedBlockWithSenders> {
-        let id = self.block_indices.get_block_chain_id(&block_hash)?;
+        let id = self.block_indices.get_side_chain_id(&block_hash)?;
         let chain = self.chains.get(&id)?;
         chain.block_with_senders(block_hash)
     }
@@ -77,7 +77,7 @@ impl TreeState {
     ///
     /// Caution: This will not return blocks from the canonical chain.
     pub(crate) fn receipts_by_block_hash(&self, block_hash: BlockHash) -> Option<Vec<&Receipt>> {
-        let id = self.block_indices.get_block_chain_id(&block_hash)?;
+        let id = self.block_indices.get_side_chain_id(&block_hash)?;
         let chain = self.chains.get(&id)?;
         chain.receipts_by_block_hash(block_hash)
     }

--- a/crates/blockchain-tree/src/state.rs
+++ b/crates/blockchain-tree/src/state.rs
@@ -10,7 +10,7 @@ pub(crate) struct TreeState {
     /// Keeps track of new unique identifiers for chains
     block_chain_id_generator: u64,
     /// The tracked chains and their current data.
-    pub(crate) chains: HashMap<BlockchainId, AppendableChain>,
+    pub(crate) chains: HashMap<SidechainId, AppendableChain>,
     /// Indices to block and their connection to the canonical chain.
     ///
     /// This gets modified by the tree itself and is read from engine API/RPC to access the pending
@@ -39,12 +39,12 @@ impl TreeState {
         }
     }
 
-    /// Issues a new unique identifier for a new chain.
+    /// Issues a new unique identifier for a new sidechain.
     #[inline]
-    fn next_id(&mut self) -> BlockchainId {
+    fn next_id(&mut self) -> SidechainId {
         let id = self.block_chain_id_generator;
         self.block_chain_id_generator += 1;
-        BlockchainId(id)
+        SidechainId(id)
     }
 
     /// Expose internal indices of the `BlockchainTree`.
@@ -85,7 +85,7 @@ impl TreeState {
     /// Insert a chain into the tree.
     ///
     /// Inserts a chain into the tree and builds the block indices.
-    pub(crate) fn insert_chain(&mut self, chain: AppendableChain) -> Option<BlockchainId> {
+    pub(crate) fn insert_chain(&mut self, chain: AppendableChain) -> Option<SidechainId> {
         if chain.is_empty() {
             return None
         }
@@ -113,16 +113,16 @@ impl TreeState {
 
 /// The ID of a sidechain internally in a [`BlockchainTree`][super::BlockchainTree].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub(crate) struct BlockchainId(u64);
+pub(crate) struct SidechainId(u64);
 
-impl From<BlockchainId> for u64 {
-    fn from(value: BlockchainId) -> Self {
+impl From<SidechainId> for u64 {
+    fn from(value: SidechainId) -> Self {
         value.0
     }
 }
 
 #[cfg(test)]
-impl From<u64> for BlockchainId {
+impl From<u64> for SidechainId {
     fn from(value: u64) -> Self {
         Self(value)
     }


### PR DESCRIPTION
As the `BlockchainId` is a little confused with the `chainId`(or rpc response of `eth_chainId`), so I suggest renaming it to `SidechainId` for better clarity.