### PR TITLE
fix: use correct range to persist

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -734,7 +734,8 @@ where
         let start = self.persistence_state.last_persisted_block_number;
         let end = start + self.config.persistence_threshold();
 
-        // the range of blocks starts with the next highest block and takes up to the configured threshold
+        // the range of blocks starts with the next highest block and takes up to the configured
+        // threshold
         let range = (Bound::Excluded(start), Bound::Included(end));
 
         self.state


### PR DESCRIPTION
This excludes the last persisted block from the range of blocks we want to persist, this prevents and edge case where the last persisted block is still in the buffer