### PR TITLE
docs: update optimism book with new `op-node` flag `--l2.enginekind=reth`

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -85,6 +85,7 @@ op-node \
     --rpc.port=7000 \
     --l1.beacon=<your-beacon-node-http-endpoint>
     --syncmode=execution-layer
+    --l2.enginekind=reth
 ```
 
 Consider adding the `--l1.trustrpc` flag to improve performance, if the connection to l1 is over localhost.


### PR DESCRIPTION
ref https://github.com/ethereum-optimism/optimism/pull/10767
related https://github.com/paradigmxyz/reth/pull/9898

This flag should now be used alongside `--syncmode=execution-layer`
