### PR TITLE
fix: add missing commit calls for persistence

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -202,8 +202,8 @@ impl<DB: Database> PersistenceService<DB> {
             storage_writer.append_receipts_from_blocks(current_block, receipts_iter)?;
         }
 
-        provider_rw.commit()?;
         provider.commit()?;
+        provider_rw.commit()?;
 
         Ok(())
     }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -186,7 +186,7 @@ impl<DB: Database> PersistenceService<DB> {
         let current_block = first_block.number;
         debug!(target: "tree::persistence", len=blocks.len(), ?current_block, "Writing execution data to static files");
 
-        let receipts_writer =
+        let mut receipts_writer =
             provider.get_writer(first_block.number, StaticFileSegment::Receipts)?;
 
         let mut storage_writer = StorageWriter::new(Some(&provider_rw), Some(receipts_writer));
@@ -196,6 +196,9 @@ impl<DB: Database> PersistenceService<DB> {
             receipts.first().unwrap().clone()
         });
         storage_writer.append_receipts_from_blocks(current_block, receipts_iter)?;
+
+        provider.commit()?;
+        receipts_writer.commit()?;
 
         Ok(())
     }


### PR DESCRIPTION
some commit calls were missing, perhaps there are more, like

https://github.com/paradigmxyz/reth/blob/73bc8ae65015c798c899a7857a185908e725f6b6/crates/engine/tree/src/persistence.rs#L192-L198

~~but unclear how to commit on a `StorageWriter`~~ @Rjected @joshieDo 