### PR TITLE
chore: dont disable discv4 on op

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -292,8 +292,6 @@ where
 
         let network_builder = ctx
             .network_config_builder()?
-            // purposefully disable discv4
-            .disable_discv4_discovery()
             // apply discovery settings
             .apply(|mut builder| {
                 let rlpx_socket = (args.addr, args.port).into();


### PR DESCRIPTION
doesn't hurt and could be beneficial in case there are op nodes that run discv4

and op-geth also has it:

https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/p2p/server.go#L555-L556

even though the default is flipped and requires opt-in and not op-out like geth

https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/cmd/utils/flags.go#L792

we could mirror this with an additional op cli arg