### PR TITLE
fix: temporary attribute to prevent clippy warnings

### DIFF
--- a/crates/storage/db/src/static_file/mask.rs
+++ b/crates/storage/db/src/static_file/mask.rs
@@ -26,6 +26,9 @@ macro_rules! add_segments {
             $(
                 #[doc = concat!("Mask for ", stringify!($segment), " static file segment. See [`Mask`] for more.")]
                 #[derive(Debug)]
+                // TODO: remove next attribute when nightly is fixed (ie. does
+                // not return wrong warnings for never constructed structs).
+                #[allow(dead_code)]
                 pub struct [<$segment Mask>]<FIRST, SECOND = (), THIRD = ()>(Mask<FIRST, SECOND, THIRD>);
             )+
         }


### PR DESCRIPTION
with latest nightly `1.82.0-nightly (f8060d282 2024-07-30)` i'm getting:
```
warning: struct `HeaderMask` is never constructed
  --> crates/storage/db/src/static_file/mask.rs:29:28
   |
29 |                 pub struct [<$segment Mask>]<FIRST, SECOND = (), THIRD = ()>(Mask<FIRST, SECOND, THIRD>);
   |                            ^^^^^^^^^^^^^^^^^
...
34 | add_segments!(Header, Receipt, Transaction);
   | ------------------------------------------- in this macro invocation
   |
   = note: `#[warn(dead_code)]` on by default
   = note: this warning originates in the macro `add_segments` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: struct `ReceiptMask` is never constructed
  --> crates/storage/db/src/static_file/mask.rs:29:28
   |
29 |                 pub struct [<$segment Mask>]<FIRST, SECOND = (), THIRD = ()>(Mask<FIRST, SECOND, THIRD>);
   |                            ^^^^^^^^^^^^^^^^^
...
34 | add_segments!(Header, Receipt, Transaction);
   | ------------------------------------------- in this macro invocation
   |
   = note: this warning originates in the macro `add_segments` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: struct `TransactionMask` is never constructed
  --> crates/storage/db/src/static_file/mask.rs:29:28
   |
29 |                 pub struct [<$segment Mask>]<FIRST, SECOND = (), THIRD = ()>(Mask<FIRST, SECOND, THIRD>);
   |                            ^^^^^^^^^^^^^^^^^
...
34 | add_segments!(Header, Receipt, Transaction);
   | ------------------------------------------- in this macro invocation
   |
   = note: this warning originates in the macro `add_segments` (in Nightly builds, run with -Z macro-backtrace for more info)
```
even though these structs are actually constructed.