### PR TITLE
fix: persistence action initial block insertion

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -124,6 +124,7 @@ pub fn init_genesis<DB: Database>(factory: ProviderFactory<DB>) -> Result<B256, 
         provider_rw.save_stage_checkpoint(stage, Default::default())?;
     }
 
+    // Static file segments start empty, so we need to initialize the genesis block.
     let segment = StaticFileSegment::Receipts;
     static_file_provider.latest_writer(segment)?.increment_block(segment, 0)?;
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -124,6 +124,12 @@ pub fn init_genesis<DB: Database>(factory: ProviderFactory<DB>) -> Result<B256, 
         provider_rw.save_stage_checkpoint(stage, Default::default())?;
     }
 
+    let segment = StaticFileSegment::Receipts;
+    static_file_provider.latest_writer(segment)?.increment_block(segment, 0)?;
+
+    let segment = StaticFileSegment::Transactions;
+    static_file_provider.latest_writer(segment)?.increment_block(segment, 0)?;
+
     provider_rw.commit()?;
     static_file_provider.commit()?;
 


### PR DESCRIPTION
* Initializes `Receipts` and `Transactions` static file segments during `init_genesis`. These were not necessary before since it was handled by the `pipeline`/`copy_to_static_files`. However, with the persistence task writing directly to it, it is necessary.
* `TerminalDifficulty` should be queried from the provider instead of manually, since it can be in either DB or static files