### PR TITLE
chore: pick safe hash for initial download

### DIFF
--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -81,7 +81,7 @@ impl ForkchoiceStateTracker {
     }
 
     /// Returns true if no forkchoice state has been received yet.
-    pub(crate) const fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.latest.is_none()
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1709,7 +1709,7 @@ where
         // so we need to start syncing to it
         //
         // find the appropriate target to sync to, if we don't have the safe block hash then we
-        // start syncing to the safe block via pipeline first
+        // start syncing to the safe block via backfill first
         let target = if self.state.forkchoice_state_tracker.is_empty() &&
             // check that safe block is valid and missing
             !state.safe_block_hash.is_zero() &&


### PR DESCRIPTION
adds a few more traces and ports a previous check to pick the download target,
if this is the first FCU we download the head block first so we need to download fewer blocks before we can trigger backfill