### PR TITLE
refactor(trie): introduce associated type for errors

### DIFF
--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -8,9 +8,9 @@ use thiserror_no_std::Error;
 /// State root errors.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum StateProofError {
-    /// Internal database error.
+    /// Internal cursor error.
     #[error(transparent)]
-    Database(#[from] DatabaseError),
+    Cursor(#[from] DatabaseError),
     /// RLP decoding error.
     #[error(transparent)]
     Rlp(#[from] alloy_rlp::Error),
@@ -19,7 +19,7 @@ pub enum StateProofError {
 impl From<StateProofError> for ProviderError {
     fn from(value: StateProofError) -> Self {
         match value {
-            StateProofError::Database(error) => Self::Database(error),
+            StateProofError::Cursor(error) => Self::Database(error),
             StateProofError::Rlp(error) => Self::Rlp(error),
         }
     }
@@ -60,7 +60,7 @@ impl From<StateRootError> for DatabaseError {
     fn from(err: StateRootError) -> Self {
         match err {
             StateRootError::Database(err) |
-            StateRootError::StorageRootError(StorageRootError::Database(err)) => err,
+            StateRootError::StorageRootError(StorageRootError::Cursor(err)) => err,
         }
     }
 }
@@ -68,7 +68,7 @@ impl From<StateRootError> for DatabaseError {
 /// Storage root error.
 #[derive(Error, PartialEq, Eq, Clone, Debug)]
 pub enum StorageRootError {
-    /// Internal database error.
+    /// Internal cursor error.
     #[error(transparent)]
-    Database(#[from] DatabaseError),
+    Cursor(#[from] DatabaseError),
 }

--- a/crates/trie/parallel/src/parallel_root.rs
+++ b/crates/trie/parallel/src/parallel_root.rs
@@ -211,7 +211,7 @@ impl From<ParallelStateRootError> for ProviderError {
     fn from(error: ParallelStateRootError) -> Self {
         match error {
             ParallelStateRootError::Provider(error) => error,
-            ParallelStateRootError::StorageRoot(StorageRootError::Database(error)) => {
+            ParallelStateRootError::StorageRoot(StorageRootError::Cursor(error)) => {
                 Self::Database(error)
             }
         }

--- a/crates/trie/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/trie/src/hashed_cursor/mod.rs
@@ -1,4 +1,5 @@
 use reth_primitives::{Account, B256, U256};
+use std::fmt::Debug;
 
 /// Default implementation of the hashed state cursor traits.
 mod default;
@@ -10,36 +11,40 @@ pub use post_state::*;
 
 /// The factory trait for creating cursors over the hashed state.
 pub trait HashedCursorFactory {
+    /// Error returned by cursor types.
+    type Error: Debug;
     /// The hashed account cursor type.
-    type AccountCursor: HashedCursor<Value = Account>;
+    type AccountCursor: HashedCursor<Error = Self::Error, Value = Account>;
     /// The hashed storage cursor type.
-    type StorageCursor: HashedStorageCursor<Value = U256>;
+    type StorageCursor: HashedStorageCursor<Error = Self::Error, Value = U256>;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, Self::Error>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
+    ) -> Result<Self::StorageCursor, Self::Error>;
 }
 
 /// The cursor for iterating over hashed entries.
 pub trait HashedCursor {
+    /// Error returned by the cursor.
+    type Error: Debug;
     /// Value returned by the cursor.
-    type Value: std::fmt::Debug;
+    type Value: Debug;
 
     /// Seek an entry greater or equal to the given key and position the cursor there.
     /// Returns the first entry with the key greater or equal to the sought key.
-    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, Self::Error>;
 
     /// Move the cursor to the next entry and return it.
-    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, Self::Error>;
 }
 
 /// The cursor for iterating over hashed storage entries.
 pub trait HashedStorageCursor: HashedCursor {
     /// Returns `true` if there are no entries for a given key.
-    fn is_storage_empty(&mut self) -> Result<bool, reth_db::DatabaseError>;
+    fn is_storage_empty(&mut self) -> Result<bool, Self::Error>;
 }

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -3,7 +3,6 @@ use crate::{
     forward_cursor::ForwardInMemoryCursor, HashedAccountsSorted, HashedPostStateSorted,
     HashedStorageSorted,
 };
-use reth_db::DatabaseError;
 use reth_primitives::{Account, B256, U256};
 use std::collections::HashSet;
 
@@ -22,10 +21,11 @@ impl<'a, CF> HashedPostStateCursorFactory<'a, CF> {
 }
 
 impl<'a, CF: HashedCursorFactory> HashedCursorFactory for HashedPostStateCursorFactory<'a, CF> {
+    type Error = CF::Error;
     type AccountCursor = HashedPostStateAccountCursor<'a, CF::AccountCursor>;
     type StorageCursor = HashedPostStateStorageCursor<'a, CF::StorageCursor>;
 
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError> {
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, Self::Error> {
         let cursor = self.cursor_factory.hashed_account_cursor()?;
         Ok(HashedPostStateAccountCursor::new(cursor, &self.post_state.accounts))
     }
@@ -33,7 +33,7 @@ impl<'a, CF: HashedCursorFactory> HashedCursorFactory for HashedPostStateCursorF
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageCursor, DatabaseError> {
+    ) -> Result<Self::StorageCursor, Self::Error> {
         let cursor = self.cursor_factory.hashed_storage_cursor(hashed_address)?;
         Ok(HashedPostStateStorageCursor::new(cursor, self.post_state.storages.get(&hashed_address)))
     }
@@ -74,7 +74,7 @@ where
         self.destroyed_accounts.contains(account)
     }
 
-    fn seek_inner(&mut self, key: B256) -> Result<Option<(B256, Account)>, DatabaseError> {
+    fn seek_inner(&mut self, key: B256) -> Result<Option<(B256, Account)>, C::Error> {
         // Take the next account from the post state with the key greater than or equal to the
         // sought key.
         let post_state_entry = self.post_state_cursor.seek(&key);
@@ -96,7 +96,7 @@ where
         Ok(Self::compare_entries(post_state_entry, db_entry))
     }
 
-    fn next_inner(&mut self, last_account: B256) -> Result<Option<(B256, Account)>, DatabaseError> {
+    fn next_inner(&mut self, last_account: B256) -> Result<Option<(B256, Account)>, C::Error> {
         // Take the next account from the post state with the key greater than the last sought key.
         let post_state_entry = self.post_state_cursor.first_after(&last_account);
 
@@ -135,6 +135,7 @@ impl<'a, C> HashedCursor for HashedPostStateAccountCursor<'a, C>
 where
     C: HashedCursor<Value = Account>,
 {
+    type Error = C::Error;
     type Value = Account;
 
     /// Seek the next entry for a given hashed account key.
@@ -145,7 +146,7 @@ where
     ///
     /// The returned account key is memoized and the cursor remains positioned at that key until
     /// [`HashedCursor::seek`] or [`HashedCursor::next`] are called.
-    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, Self::Error> {
         // Find the closes account.
         let entry = self.seek_inner(key)?;
         self.last_account = entry.as_ref().map(|entry| entry.0);
@@ -159,7 +160,7 @@ where
     ///
     /// NOTE: This function will not return any entry unless [`HashedCursor::seek`] has been
     /// called.
-    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, Self::Error> {
         let next = match self.last_account {
             Some(account) => {
                 let entry = self.next_inner(account)?;
@@ -210,7 +211,7 @@ where
     }
 
     /// Find the storage entry in post state or database that's greater or equal to provided subkey.
-    fn seek_inner(&mut self, subkey: B256) -> Result<Option<(B256, U256)>, DatabaseError> {
+    fn seek_inner(&mut self, subkey: B256) -> Result<Option<(B256, U256)>, C::Error> {
         // Attempt to find the account's storage in post state.
         let post_state_entry = self.post_state_cursor.as_mut().and_then(|c| c.seek(&subkey));
 
@@ -232,7 +233,7 @@ where
     }
 
     /// Find the storage entry that is right after current cursor position.
-    fn next_inner(&mut self, last_slot: B256) -> Result<Option<(B256, U256)>, DatabaseError> {
+    fn next_inner(&mut self, last_slot: B256) -> Result<Option<(B256, U256)>, C::Error> {
         // Attempt to find the account's storage in post state.
         let post_state_entry =
             self.post_state_cursor.as_mut().and_then(|c| c.first_after(&last_slot));
@@ -279,17 +280,18 @@ impl<'a, C> HashedCursor for HashedPostStateStorageCursor<'a, C>
 where
     C: HashedStorageCursor<Value = U256>,
 {
+    type Error = C::Error;
     type Value = U256;
 
     /// Seek the next account storage entry for a given hashed key pair.
-    fn seek(&mut self, subkey: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+    fn seek(&mut self, subkey: B256) -> Result<Option<(B256, Self::Value)>, Self::Error> {
         let entry = self.seek_inner(subkey)?;
         self.last_slot = entry.as_ref().map(|entry| entry.0);
         Ok(entry)
     }
 
     /// Return the next account storage entry for the current account key.
-    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, Self::Error> {
         let next = match self.last_slot {
             Some(last_slot) => {
                 let entry = self.next_inner(last_slot)?;
@@ -311,7 +313,7 @@ where
     ///
     /// This function should be called before attempting to call [`HashedCursor::seek`] or
     /// [`HashedCursor::next`].
-    fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
+    fn is_storage_empty(&mut self) -> Result<bool, Self::Error> {
         let is_empty = match &self.post_state_cursor {
             Some(cursor) => {
                 // If the storage has been wiped at any point

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -1,5 +1,4 @@
 use crate::{hashed_cursor::HashedCursor, trie_cursor::TrieCursor, walker::TrieWalker, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
 
 /// Represents a branch node in the trie.
@@ -68,7 +67,7 @@ impl<C, H: HashedCursor> TrieNodeIter<C, H> {
 
 impl<C, H> TrieNodeIter<C, H>
 where
-    C: TrieCursor<Error = DatabaseError>,
+    C: TrieCursor,
     H: HashedCursor<Error = C::Error>,
 {
     /// Return the next trie node to be added to the hash builder.
@@ -84,7 +83,7 @@ where
     /// NOTE: The iteration will start from the key of the previous hashed entry if it was supplied.
     pub fn try_next(
         &mut self,
-    ) -> Result<Option<TrieElement<<H as HashedCursor>::Value>>, DatabaseError> {
+    ) -> Result<Option<TrieElement<<H as HashedCursor>::Value>>, C::Error> {
         loop {
             // If the walker has a key...
             if let Some(key) = self.walker.key() {

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -69,7 +69,7 @@ impl<C, H: HashedCursor> TrieNodeIter<C, H> {
 impl<C, H> TrieNodeIter<C, H>
 where
     C: TrieCursor<Error = DatabaseError>,
-    H: HashedCursor,
+    H: HashedCursor<Error = C::Error>,
 {
     /// Return the next trie node to be added to the hash builder.
     ///

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -68,7 +68,7 @@ impl<C, H: HashedCursor> TrieNodeIter<C, H> {
 
 impl<C, H> TrieNodeIter<C, H>
 where
-    C: TrieCursor,
+    C: TrieCursor<Error = DatabaseError>,
     H: HashedCursor,
 {
     /// Return the next trie node to be added to the hash builder.

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -7,6 +7,7 @@ use crate::{
     HashBuilder, Nibbles,
 };
 use alloy_rlp::{BufMut, Encodable};
+use reth_db::DatabaseError;
 use reth_execution_errors::trie::StateProofError;
 use reth_primitives::{keccak256, Address, B256};
 use reth_trie_common::{
@@ -67,7 +68,7 @@ impl<T, H> Proof<T, H> {
 
 impl<T, H> Proof<T, H>
 where
-    T: TrieCursorFactory,
+    T: TrieCursorFactory<Error = DatabaseError>,
     H: HashedCursorFactory + Clone,
 {
     /// Generate an account proof from intermediate nodes.

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -69,7 +69,7 @@ impl<T, H> Proof<T, H> {
 impl<T, H> Proof<T, H>
 where
     T: TrieCursorFactory<Error = DatabaseError>,
-    H: HashedCursorFactory + Clone,
+    H: HashedCursorFactory<Error = T::Error> + Clone,
 {
     /// Generate an account proof from intermediate nodes.
     pub fn account_proof(
@@ -130,8 +130,10 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<StorageMultiProof, StateProofError> {
-        let mut hashed_storage_cursor =
-            self.hashed_cursor_factory.hashed_storage_cursor(hashed_address)?;
+        let mut hashed_storage_cursor = self
+            .hashed_cursor_factory
+            .hashed_storage_cursor(hashed_address)
+            .map_err(StateProofError::Cursor)?;
 
         // short circuit on empty storage
         if hashed_storage_cursor.is_storage_empty()? {

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -108,7 +108,7 @@ impl<T, H> StateRoot<T, H> {
 impl<T, H> StateRoot<T, H>
 where
     T: TrieCursorFactory<Error = DatabaseError> + Clone,
-    H: HashedCursorFactory + Clone,
+    H: HashedCursorFactory<Error = T::Error> + Clone,
 {
     /// Walks the intermediate nodes of existing state trie (if any) and hashed entries. Feeds the
     /// nodes into the hash builder. Collects the updates in the process.
@@ -366,7 +366,7 @@ impl<T, H> StorageRoot<T, H> {
 impl<T, H> StorageRoot<T, H>
 where
     T: TrieCursorFactory<Error = DatabaseError>,
-    H: HashedCursorFactory,
+    H: HashedCursorFactory<Error = T::Error>,
 {
     /// Walks the hashed storage table entries for a given address and calculates the storage root.
     ///

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -10,6 +10,7 @@ use crate::{
     HashBuilder, Nibbles, TrieAccount,
 };
 use alloy_rlp::{BufMut, Encodable};
+use reth_db::DatabaseError;
 use reth_execution_errors::{StateRootError, StorageRootError};
 use reth_primitives::{constants::EMPTY_ROOT_HASH, keccak256, Address, B256};
 use tracing::trace;
@@ -106,7 +107,7 @@ impl<T, H> StateRoot<T, H> {
 
 impl<T, H> StateRoot<T, H>
 where
-    T: TrieCursorFactory + Clone,
+    T: TrieCursorFactory<Error = DatabaseError> + Clone,
     H: HashedCursorFactory + Clone,
 {
     /// Walks the intermediate nodes of existing state trie (if any) and hashed entries. Feeds the
@@ -364,7 +365,7 @@ impl<T, H> StorageRoot<T, H> {
 
 impl<T, H> StorageRoot<T, H>
 where
-    T: TrieCursorFactory,
+    T: TrieCursorFactory<Error = DatabaseError>,
     H: HashedCursorFactory,
 {
     /// Walks the hashed storage table entries for a given address and calculates the storage root.

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -1,6 +1,6 @@
 use crate::{BranchNodeCompact, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
+use std::fmt::Debug;
 
 /// Database implementations of trie cursors.
 mod database_cursors;
@@ -18,37 +18,41 @@ pub use self::{database_cursors::*, in_memory::*, subnode::CursorSubNode};
 
 /// Factory for creating trie cursors.
 pub trait TrieCursorFactory {
+    /// Error returned by cursor types.
+    type Error: Debug;
     /// The account trie cursor type.
-    type AccountTrieCursor: TrieCursor;
+    type AccountTrieCursor: TrieCursor<Error = Self::Error>;
     /// The storage trie cursor type.
-    type StorageTrieCursor: TrieCursor;
+    type StorageTrieCursor: TrieCursor<Error = Self::Error>;
 
     /// Create an account trie cursor.
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError>;
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, Self::Error>;
 
     /// Create a storage tries cursor.
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError>;
+    ) -> Result<Self::StorageTrieCursor, Self::Error>;
 }
 
 /// A cursor for navigating a trie that works with both Tables and DupSort tables.
 #[auto_impl::auto_impl(&mut, Box)]
 pub trait TrieCursor: Send + Sync {
+    /// Error returned by the cursor type.
+    type Error: Debug;
+
     /// Move the cursor to the key and return if it is an exact match.
     fn seek_exact(
         &mut self,
         key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error>;
 
     /// Move the cursor to the key and return a value matching of greater than the key.
-    fn seek(&mut self, key: Nibbles)
-        -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
+    fn seek(&mut self, key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error>;
 
     /// Move the cursor to the next key.
-    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
+    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error>;
 
     /// Get the current entry.
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError>;
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Error>;
 }

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -1,6 +1,5 @@
 use super::{TrieCursor, TrieCursorFactory};
 use crate::{BranchNodeCompact, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
 
 /// Noop trie cursor factory.
@@ -9,11 +8,12 @@ use reth_primitives::B256;
 pub struct NoopTrieCursorFactory;
 
 impl TrieCursorFactory for NoopTrieCursorFactory {
+    type Error = ();
     type AccountTrieCursor = NoopAccountTrieCursor;
     type StorageTrieCursor = NoopStorageTrieCursor;
 
     /// Generates a noop account trie cursor.
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError> {
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, Self::Error> {
         Ok(NoopAccountTrieCursor::default())
     }
 
@@ -21,7 +21,7 @@ impl TrieCursorFactory for NoopTrieCursorFactory {
     fn storage_trie_cursor(
         &self,
         _hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError> {
+    ) -> Result<Self::StorageTrieCursor, Self::Error> {
         Ok(NoopStorageTrieCursor::default())
     }
 }
@@ -32,25 +32,24 @@ impl TrieCursorFactory for NoopTrieCursorFactory {
 pub struct NoopAccountTrieCursor;
 
 impl TrieCursor for NoopAccountTrieCursor {
+    type Error = ();
+
     fn seek_exact(
         &mut self,
         _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error> {
         Ok(None)
     }
 
-    fn seek(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error> {
         Ok(None)
     }
 
-    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error> {
         Ok(None)
     }
 
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Error> {
         Ok(None)
     }
 }
@@ -61,25 +60,24 @@ impl TrieCursor for NoopAccountTrieCursor {
 pub struct NoopStorageTrieCursor;
 
 impl TrieCursor for NoopStorageTrieCursor {
+    type Error = ();
+
     fn seek_exact(
         &mut self,
         _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error> {
         Ok(None)
     }
 
-    fn seek(
-        &mut self,
-        _key: Nibbles,
-    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn seek(&mut self, _key: Nibbles) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error> {
         Ok(None)
     }
 
-    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, Self::Error> {
         Ok(None)
     }
 
-    fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<Nibbles>, Self::Error> {
         Ok(None)
     }
 }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -3,7 +3,6 @@ use crate::{
     trie_cursor::{CursorSubNode, TrieCursor},
     BranchNodeCompact, Nibbles,
 };
-use reth_db::DatabaseError;
 use reth_primitives::B256;
 use std::collections::HashSet;
 
@@ -130,7 +129,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     /// # Returns
     ///
     /// * `Result<Option<Nibbles>, Error>` - The next key in the trie or an error.
-    pub fn advance(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    pub fn advance(&mut self) -> Result<Option<Nibbles>, C::Error> {
         if let Some(last) = self.stack.last() {
             if !self.can_skip_current_node && self.children_are_in_trie() {
                 // If we can't skip the current node and the children are in the trie,
@@ -153,7 +152,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Retrieves the current root node from the DB, seeking either the exact node or the next one.
-    fn node(&mut self, exact: bool) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+    fn node(&mut self, exact: bool) -> Result<Option<(Nibbles, BranchNodeCompact)>, C::Error> {
         let key = self.key().expect("key must exist").clone();
         let entry = if exact { self.cursor.seek_exact(key)? } else { self.cursor.seek(key)? };
 
@@ -165,7 +164,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Consumes the next node in the trie, updating the stack.
-    fn consume_node(&mut self) -> Result<(), DatabaseError> {
+    fn consume_node(&mut self) -> Result<(), C::Error> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
             self.stack.clear();
@@ -197,10 +196,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Moves to the next sibling node in the trie, updating the stack.
-    fn move_to_next_sibling(
-        &mut self,
-        allow_root_to_child_nibble: bool,
-    ) -> Result<(), DatabaseError> {
+    fn move_to_next_sibling(&mut self, allow_root_to_child_nibble: bool) -> Result<(), C::Error> {
         let Some(subnode) = self.stack.last_mut() else { return Ok(()) };
 
         // Check if the walker needs to backtrack to the previous level in the trie during its

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use alloy_rlp::{BufMut, Decodable, Encodable};
 use itertools::Either;
+use reth_db::DatabaseError;
 use reth_execution_errors::{StateProofError, TrieWitnessError};
 use reth_primitives::{constants::EMPTY_ROOT_HASH, keccak256, Bytes, B256};
 use reth_trie_common::{
@@ -54,7 +55,7 @@ impl<T, H> TrieWitness<T, H> {
 
 impl<T, H> TrieWitness<T, H>
 where
-    T: TrieCursorFactory + Clone,
+    T: TrieCursorFactory<Error = DatabaseError> + Clone,
     H: HashedCursorFactory + Clone,
 {
     /// Compute the state transition witness for the trie. Gather all required nodes

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -56,7 +56,7 @@ impl<T, H> TrieWitness<T, H> {
 impl<T, H> TrieWitness<T, H>
 where
     T: TrieCursorFactory<Error = DatabaseError> + Clone,
-    H: HashedCursorFactory + Clone,
+    H: HashedCursorFactory<Error = T::Error> + Clone,
 {
     /// Compute the state transition witness for the trie. Gather all required nodes
     /// to apply `state` on top of the current trie state.


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/8514, https://github.com/paradigmxyz/reth/pull/9282#issuecomment-2222740349

Supersedes https://github.com/paradigmxyz/reth/pull/9474

This PR introduces an associated type for the error to all trie traits and propagates it to all downstream usages.

We still have a dependency on `DatabaseError` in `reth-trie` and it's specified explicitly everywhere, but it's for another PR where we will move all database interactions into `reth-db-trie`.