### PR TITLE
test: add engine tree test, FCU triggers reorg with all the blocks present

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -147,8 +147,8 @@ impl TreeState {
         }
     }
 
-    /// Determines if the given block is part of a fork by checking if its
-    /// parent is already registered in the `parent_to_child` relationship.
+    /// Determines if the given block is part of a fork by walking back the
+    /// canonical chain and checking if the given block is included.
     fn is_fork(&self, block: &Block) -> bool {
         self.parent_to_child.contains_key(&block.parent_hash)
     }
@@ -2390,6 +2390,79 @@ mod tests {
             }
             _ => panic!("Unexpected event: {:#?}", event),
         }
+    }
+
+    #[tokio::test]
+    async fn test_engine_tree_fcu_canon_chain_insertion() {
+        let chain_spec = MAINNET.clone();
+        let mut test_harness = TestHarness::new(chain_spec.clone());
+
+        let base_chain: Vec<_> = test_harness.block_builder.get_executed_blocks(0..1).collect();
+        let main_chain = test_harness.block_builder.create_fork(base_chain[0].block(), 3);
+        test_harness = test_harness.with_blocks(base_chain.clone());
+
+        // add main chain blocks to the tree
+        for (index, block) in main_chain.iter().enumerate() {
+            test_harness.insert_block(block.clone()).unwrap();
+        }
+
+        // create FCU for the tip of the fork
+        let fcu_state = ForkchoiceState {
+            head_block_hash: main_chain.last().unwrap().hash(),
+            safe_block_hash: B256::ZERO,
+            finalized_block_hash: B256::ZERO,
+        };
+
+        let (tx, rx) = oneshot::channel();
+        test_harness.tree.on_engine_message(FromEngine::Request(
+            BeaconEngineMessage::ForkchoiceUpdated { state: fcu_state, payload_attrs: None, tx },
+        ));
+
+        let response = rx.await.unwrap().unwrap().await.unwrap();
+        assert!(response.payload_status.is_valid());
+
+        // check for CanonicalBlockAdded events, we expect main_chain.len() blocks added
+        for index in 0..main_chain.len() {
+            let event = test_harness.from_tree_rx.recv().await.unwrap();
+            match event {
+                EngineApiEvent::BeaconConsensus(
+                    BeaconConsensusEngineEvent::CanonicalBlockAdded(block, _),
+                ) => {
+                    assert!(main_chain.iter().any(|b| b.hash() == block.hash()));
+                }
+                _ => panic!("Unexpected event: {:#?}", event),
+            }
+        }
+
+        // check for CanonicalChainCommitted event
+        let event = test_harness.from_tree_rx.recv().await.unwrap();
+        match event {
+            EngineApiEvent::BeaconConsensus(
+                BeaconConsensusEngineEvent::CanonicalChainCommitted(header, _),
+            ) => {
+                assert_eq!(header.hash(), main_chain.last().unwrap().hash());
+            }
+            _ => panic!("Unexpected event: {:#?}", event),
+        }
+
+        // check for ForkchoiceUpdated event
+        let event = test_harness.from_tree_rx.recv().await.unwrap();
+        match event {
+            EngineApiEvent::BeaconConsensus(BeaconConsensusEngineEvent::ForkchoiceUpdated(
+                state,
+                status,
+            )) => {
+                assert_eq!(state, fcu_state);
+                assert_eq!(status, ForkchoiceStatus::Valid);
+            }
+            _ => panic!("Unexpected event: {:#?}", event),
+        }
+
+        // new head is the tip of the main chain
+        assert_eq!(
+            test_harness.tree.state.tree_state.canonical_head().hash,
+            main_chain.last().unwrap().hash()
+        );
     }
 
     #[tokio::test]

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -147,6 +147,8 @@ impl TreeState {
         }
     }
 
+    /// Determines if the given block is part of a fork by checking if its
+    /// parent is already registered in the `parent_to_child` relationship.
     fn is_fork(&self, block: &Block) -> bool {
         self.parent_to_child.contains_key(&block.parent_hash)
     }


### PR DESCRIPTION
Towards #9749 

The test raised the lack of some events not being emitted, they are added now to `EngineApiTreeHandlerImpl`:  `EngineApiEvent::BeaconConsensus(BeaconConsensusEngineEvent::ForkBlockAdded)`, `EngineApiEvent::BeaconConsensus(BeaconConsensusEngineEvent::CanonicalBlockAdded)` and `EngineApiEvent::BeaconConsensus(BeaconConsensusEngineEvent::CanonicalChainCommitted)`.

Besides the test and the changes above, the PR also includes:
* Changes in `TestBlockBuilder` to get the execution outcome of a given block
* Changes in `MockEthProvider` to include a state root store, and use it in the `StateRootProvider` impl methods.