### PR TITLE
feat: set pending block in canonical memory

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1311,6 +1311,13 @@ where
             hashed_state: Arc::new(hashed_state),
             trie: Arc::new(trie_output),
         };
+
+        if self.state.tree_state.canonical_block_hash() == executed.block().parent_hash {
+            debug!(target: "engine", pending = ?executed.block().num_hash() ,"updating pending block");
+            // if the parent is the canonical head, we can insert the block as the pending block
+            self.canonical_in_memory_state.set_pending_block(executed.clone());
+        }
+
         self.state.tree_state.insert_executed(executed);
 
         let attachment = BlockAttachment::Canonical; // TODO: remove or revise attachment


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/9829

if the freshly executed block has the canonical head as the parent block, we can insert it as the pending block