### PR TITLE
refactor(trie): use `reth-storage-errors` for `DatabaseError` type

### DIFF
--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -13,11 +13,12 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives.workspace = true
-reth-execution-errors.workspace = true
-reth-db.workspace = true
 reth-db-api.workspace = true
+reth-db.workspace = true
+reth-execution-errors.workspace = true
+reth-primitives.workspace = true
 reth-stages-types.workspace = true
+reth-storage-errors.workspace = true
 reth-trie-common.workspace = true
 
 revm.workspace = true
@@ -50,7 +51,6 @@ reth-chainspec.workspace = true
 reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-storage-errors.workspace = true
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 
 # trie

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -3,8 +3,8 @@ use crate::{
     forward_cursor::ForwardInMemoryCursor, HashedAccountsSorted, HashedPostStateSorted,
     HashedStorageSorted,
 };
-use reth_db::DatabaseError;
 use reth_primitives::{Account, B256, U256};
+use reth_storage_errors::db::DatabaseError;
 use std::collections::HashSet;
 
 /// The hashed cursor factory for the post state.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -1,6 +1,6 @@
 use crate::{hashed_cursor::HashedCursor, trie_cursor::TrieCursor, walker::TrieWalker, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
+use reth_storage_errors::db::DatabaseError;
 
 /// Represents a branch node in the trie.
 #[derive(Debug)]

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -4,13 +4,14 @@ use crate::{
 };
 use itertools::Itertools;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-use reth_db::{tables, DatabaseError};
+use reth_db::tables;
 use reth_db_api::{
     cursor::DbCursorRO,
     models::{AccountBeforeTx, BlockNumberAddress},
     transaction::DbTx,
 };
 use reth_primitives::{keccak256, Account, Address, BlockNumber, B256, U256};
+use reth_storage_errors::db::DatabaseError;
 use revm::db::BundleAccount;
 use std::collections::{hash_map, HashMap, HashSet};
 

--- a/crates/trie/trie/src/trie_cursor/database_cursors.rs
+++ b/crates/trie/trie/src/trie_cursor/database_cursors.rs
@@ -4,13 +4,14 @@ use crate::{
 };
 use reth_db::{
     cursor::{DbCursorRW, DbDupCursorRW},
-    tables, DatabaseError,
+    tables,
 };
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     transaction::DbTx,
 };
 use reth_primitives::B256;
+use reth_storage_errors::db::DatabaseError;
 use reth_trie_common::StorageTrieEntry;
 
 /// Wrapper struct for database transaction implementing trie cursor factory trait.

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -3,8 +3,8 @@ use crate::{
     forward_cursor::ForwardInMemoryCursor,
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
 };
-use reth_db::DatabaseError;
 use reth_primitives::B256;
+use reth_storage_errors::db::DatabaseError;
 use reth_trie_common::{BranchNodeCompact, Nibbles};
 use std::collections::HashSet;
 

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -1,6 +1,6 @@
 use crate::{BranchNodeCompact, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
+use reth_storage_errors::db::DatabaseError;
 
 /// Database implementations of trie cursors.
 mod database_cursors;

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -1,7 +1,7 @@
 use super::{TrieCursor, TrieCursorFactory};
 use crate::{BranchNodeCompact, Nibbles};
-use reth_db::DatabaseError;
 use reth_primitives::B256;
+use reth_storage_errors::db::DatabaseError;
 
 /// Noop trie cursor factory.
 #[derive(Default, Debug)]

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -3,8 +3,8 @@ use crate::{
     trie_cursor::{CursorSubNode, TrieCursor},
     BranchNodeCompact, Nibbles,
 };
-use reth_db::DatabaseError;
 use reth_primitives::B256;
+use reth_storage_errors::db::DatabaseError;
 use std::collections::HashSet;
 
 /// `TrieWalker` is a structure that enables traversal of a Merkle trie.


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/8514, https://github.com/paradigmxyz/reth/pull/9282#issuecomment-2222740349

Supersedes https://github.com/paradigmxyz/reth/pull/9937

`DatabaseError` is in `reth-storage-errors` crate that doesn't have any DB dependencies, so we can safely use it for our goal of making the trie independent of DB crates.