### PR TITLE
refactor(trie): cursor factory traits

### DIFF
--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -13,11 +13,12 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives.workspace = true
-reth-execution-errors.workspace = true
-reth-db.workspace = true
 reth-db-api.workspace = true
+reth-db.workspace = true
+reth-execution-errors.workspace = true
+reth-primitives.workspace = true
 reth-stages-types.workspace = true
+reth-storage-errors.workspace = true
 reth-trie-common.workspace = true
 
 revm.workspace = true
@@ -50,7 +51,6 @@ reth-chainspec.workspace = true
 reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-storage-errors.workspace = true
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 
 # trie

--- a/crates/trie/trie/src/changesets_cursor.rs
+++ b/crates/trie/trie/src/changesets_cursor.rs
@@ -1,0 +1,30 @@
+use std::ops::RangeInclusive;
+
+use reth_primitives::{Account, Address, BlockNumber, B256, U256};
+use reth_storage_errors::db::DatabaseError;
+
+/// A trait for creating iterators walking over a range of block numbers.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait RangeWalker<V>: Send + Sync {
+    /// Creates an iterator that walks over a range of block numbers.
+    fn walk_range(
+        &mut self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> Result<impl Iterator<Item = Result<V, DatabaseError>>, DatabaseError>;
+}
+
+/// Factory for creating changeset range walkers.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait TrieRangeWalkerFactory: Send + Sync {
+    /// Cursor that walks over account changesets.
+    type AccountCursor: RangeWalker<(Address, Option<Account>)>;
+
+    /// Cursor that walks over storage changesets.
+    type StorageCursor: RangeWalker<(Address, B256, U256)>;
+
+    /// Creates account changesets cursor.
+    fn account_changesets(&self) -> Result<Self::AccountCursor, DatabaseError>;
+
+    /// Creates storage changesets cursor.
+    fn storage_changesets(&self) -> Result<Self::StorageCursor, DatabaseError>;
+}

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -56,6 +56,9 @@ pub use progress::{IntermediateStateRootState, StateRootProgress};
 /// Trie calculation stats.
 pub mod stats;
 
+/// Changesets cursor for iterating over changesets.
+pub mod changesets_cursor;
+
 // re-export for convenience
 pub use reth_trie_common::*;
 

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -18,8 +18,7 @@ pub use self::{
 
 use crate::{BranchNodeCompact, Nibbles};
 use reth_db::DatabaseError;
-use reth_primitives::{Account, Address, BlockNumber, B256, U256};
-use std::ops::RangeInclusive;
+use reth_primitives::B256;
 
 /// Factory for creating trie cursors.
 pub trait TrieCursorFactory {
@@ -41,9 +40,9 @@ pub trait TrieCursorFactory {
 /// Factory for creating mutable trie cursors.
 pub trait TrieCursorRwFactory {
     /// The account trie cursor type.
-    type AccountTrieCursor: TrieCursorRw;
+    type AccountTrieCursor: TrieCursor + TrieCursorMut;
     /// The storage trie cursor type.
-    type StorageTrieCursor: TrieDupCursorRw;
+    type StorageTrieCursor: TrieDupCursor + TrieDupCursorMut;
 
     /// Create an account trie cursor.
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError>;
@@ -81,14 +80,6 @@ pub trait TrieCursorMut: Send + Sync {
     /// Update existing entry or insert new one if it does not exist.
     fn upsert(&mut self, key: Nibbles, node: BranchNodeCompact) -> Result<(), DatabaseError>;
 }
-
-/// A readable and mutable cursor for Tables.
-#[auto_impl::auto_impl(&mut, Box, TrieCursor + TrieCursorMut)]
-pub trait TrieCursorRw: TrieCursor + TrieCursorMut {}
-
-/// A readable and mutable cursor for DubSort tables.
-#[auto_impl::auto_impl(&mut, Box, TrieDupCursor + TrieDupCursorMut)]
-pub trait TrieDupCursorRw: TrieDupCursor + TrieDupCursorMut {}
 
 /// A cursor for navigating a trie that works with DupSort tables.
 #[auto_impl::auto_impl(&mut, Box)]

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -10,11 +10,7 @@ mod subnode;
 /// Noop trie cursor implementations.
 pub mod noop;
 
-pub use self::{
-    database_cursors::{DatabaseAccountTrieCursor, DatabaseStorageTrieCursor},
-    in_memory::*,
-    subnode::CursorSubNode,
-};
+pub use self::{database_cursors::*, in_memory::*, subnode::CursorSubNode};
 
 use crate::{BranchNodeCompact, Nibbles};
 use reth_db::DatabaseError;

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -1,7 +1,3 @@
-use crate::{BranchNodeCompact, Nibbles};
-use reth_db::DatabaseError;
-use reth_primitives::B256;
-
 /// Database implementations of trie cursors.
 mod database_cursors;
 
@@ -14,7 +10,16 @@ mod subnode;
 /// Noop trie cursor implementations.
 pub mod noop;
 
-pub use self::{database_cursors::*, in_memory::*, subnode::CursorSubNode};
+pub use self::{
+    database_cursors::{DatabaseAccountTrieCursor, DatabaseStorageTrieCursor},
+    in_memory::*,
+    subnode::CursorSubNode,
+};
+
+use crate::{BranchNodeCompact, Nibbles};
+use reth_db::DatabaseError;
+use reth_primitives::{Account, Address, BlockNumber, B256, U256};
+use std::ops::RangeInclusive;
 
 /// Factory for creating trie cursors.
 pub trait TrieCursorFactory {
@@ -33,7 +38,21 @@ pub trait TrieCursorFactory {
     ) -> Result<Self::StorageTrieCursor, DatabaseError>;
 }
 
-/// A cursor for navigating a trie that works with both Tables and DupSort tables.
+/// Factory for creating mutable trie cursors.
+pub trait TrieCursorRwFactory {
+    /// The account trie cursor type.
+    type AccountTrieCursor: TrieCursorRw;
+    /// The storage trie cursor type.
+    type StorageTrieCursor: TrieDupCursorRw;
+
+    /// Create an account trie cursor.
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError>;
+
+    /// Create a storage tries cursor.
+    fn storage_trie_cursor(&self) -> Result<Self::StorageTrieCursor, DatabaseError>;
+}
+
+/// A cursor for navigating a trie that works with Tables.
 #[auto_impl::auto_impl(&mut, Box)]
 pub trait TrieCursor: Send + Sync {
     /// Move the cursor to the key and return if it is an exact match.
@@ -51,4 +70,83 @@ pub trait TrieCursor: Send + Sync {
 
     /// Get the current entry.
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError>;
+}
+
+/// A cursor for mutating a trie that works with Tables.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait TrieCursorMut: Send + Sync {
+    /// Delete entry at current cursor position.
+    fn delete_current(&mut self) -> Result<(), DatabaseError>;
+
+    /// Update existing entry or insert new one if it does not exist.
+    fn upsert(&mut self, key: Nibbles, node: BranchNodeCompact) -> Result<(), DatabaseError>;
+}
+
+/// A readable and mutable cursor for Tables.
+#[auto_impl::auto_impl(&mut, Box, TrieCursor + TrieCursorMut)]
+pub trait TrieCursorRw: TrieCursor + TrieCursorMut {}
+
+/// A readable and mutable cursor for DubSort tables.
+#[auto_impl::auto_impl(&mut, Box, TrieDupCursor + TrieDupCursorMut)]
+pub trait TrieDupCursorRw: TrieDupCursor + TrieDupCursorMut {}
+
+/// A cursor for navigating a trie that works with DupSort tables.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait TrieDupCursor: Send + Sync {
+    /// Move the cursor to the key and return if it is an exact match.
+    fn seek_exact(
+        &mut self,
+        key: B256,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
+
+    /// Move the cursor to the key and return a value matching of greater than the key.
+    fn seek_by_key_subkey(
+        &mut self,
+        key: B256,
+        subkey: Nibbles,
+    ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
+}
+
+/// A cursor for mutating a trie that works with DupSort tables.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait TrieDupCursorMut: Send + Sync {
+    /// Delete entry at current cursor position.
+    fn delete_current(&mut self) -> Result<(), DatabaseError>;
+
+    /// Delete entry at current cursor position and all its duplicates.
+    fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError>;
+
+    /// Update existing entry or insert new one if it does not exist.
+    fn upsert(
+        &mut self,
+        key: B256,
+        subkey: Nibbles,
+        node: BranchNodeCompact,
+    ) -> Result<(), DatabaseError>;
+}
+
+/// A trait for creating iterators walking over a range of block numbers.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait TrieRangeWalker<V>: Send + Sync {
+    /// Creates an iterator that walks over a range of block numbers.
+    fn walk_range(
+        &mut self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> Result<impl Iterator<Item = Result<V, DatabaseError>>, DatabaseError>;
+}
+
+/// Factory for creating trie range walkers.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait TrieRangeWalkerFactory: Send + Sync {
+    /// Cursor that walks over account change sets.
+    type AccountCursor: TrieRangeWalker<(Address, Option<Account>)>;
+
+    /// Cursor that walks over storage change sets.
+    type StorageCursor: TrieRangeWalker<(Address, B256, U256)>;
+
+    /// Creates account changesets cursor.
+    fn account_changesets(&self) -> Result<Self::AccountCursor, DatabaseError>;
+
+    /// Creates storage changesets cursor.
+    fn storage_changesets(&self) -> Result<Self::StorageCursor, DatabaseError>;
 }

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -124,29 +124,3 @@ pub trait TrieDupCursorMut: Send + Sync {
         node: BranchNodeCompact,
     ) -> Result<(), DatabaseError>;
 }
-
-/// A trait for creating iterators walking over a range of block numbers.
-#[auto_impl::auto_impl(&mut, Box)]
-pub trait TrieRangeWalker<V>: Send + Sync {
-    /// Creates an iterator that walks over a range of block numbers.
-    fn walk_range(
-        &mut self,
-        range: RangeInclusive<BlockNumber>,
-    ) -> Result<impl Iterator<Item = Result<V, DatabaseError>>, DatabaseError>;
-}
-
-/// Factory for creating trie range walkers.
-#[auto_impl::auto_impl(&mut, Box)]
-pub trait TrieRangeWalkerFactory: Send + Sync {
-    /// Cursor that walks over account change sets.
-    type AccountCursor: TrieRangeWalker<(Address, Option<Account>)>;
-
-    /// Cursor that walks over storage change sets.
-    type StorageCursor: TrieRangeWalker<(Address, B256, U256)>;
-
-    /// Creates account changesets cursor.
-    fn account_changesets(&self) -> Result<Self::AccountCursor, DatabaseError>;
-
-    /// Creates storage changesets cursor.
-    fn storage_changesets(&self) -> Result<Self::StorageCursor, DatabaseError>;
-}


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/8514, https://github.com/paradigmxyz/reth/pull/9282#issuecomment-2222740349

Extracted from https://github.com/paradigmxyz/reth/pull/9282

Introduces traits for iterating/mutating the trie and for iterating over changesets. These traits will be used to replace the usage of `DbTx` and `DbTxMut` in `reth-trie` crate.