### PR TITLE
fix: allow empty IP when decoding Ping's from field

### DIFF
--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -31,7 +31,7 @@ secp256k1 = { workspace = true, features = [
 enr.workspace = true
 
 # async/futures
-tokio = { workspace = true, features = ["io-util", "net", "time", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "net", "time"] }
 tokio-stream.workspace = true
 
 # misc

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -31,7 +31,7 @@ secp256k1 = { workspace = true, features = [
 enr.workspace = true
 
 # async/futures
-tokio = { workspace = true, features = ["io-util", "net", "time"] }
+tokio = { workspace = true, features = ["io-util", "net", "time", "rt-multi-thread"] }
 tokio-stream.workspace = true
 
 # misc

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -155,13 +155,10 @@ impl Message {
             return Err(DecodePacketError::HashMismatch)
         }
 
-        println!("past header check");
-
         let signature = &packet[32..96];
         let recovery_id = RecoveryId::from_i32(packet[96] as i32)?;
         let recoverable_sig = RecoverableSignature::from_compact(signature, recovery_id)?;
 
-        println!("past signature");
         // recover the public key
         let msg = secp256k1::Message::from_digest(keccak256(&packet[97..]).0);
 
@@ -171,10 +168,6 @@ impl Message {
         let msg_type = packet[97];
         let payload = &mut &packet[98..];
 
-        println!(
-            "got msg_type: {msg_type} for payload {payload:x?} {:?}",
-            MessageId::from_u8(msg_type)
-        );
         let msg = match MessageId::from_u8(msg_type).map_err(DecodePacketError::UnknownMessage)? {
             MessageId::Ping => Self::Ping(Ping::decode(payload).unwrap()),
             MessageId::Pong => Self::Pong(Pong::decode(payload)?),

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -241,25 +241,6 @@ impl alloy_rlp::Decodable for PingNodeEndpoint {
     }
 }
 
-impl From<NodeRecord> for PingNodeEndpoint {
-    fn from(NodeRecord { address, tcp_port, udp_port, .. }: NodeRecord) -> Self {
-        Self(NodeEndpoint { address, tcp_port, udp_port })
-    }
-}
-
-impl From<NodeEndpoint> for PingNodeEndpoint {
-    fn from(value: NodeEndpoint) -> Self {
-        Self(value)
-    }
-}
-
-impl PingNodeEndpoint {
-    /// Creates a new [`PingNodeEndpoint`] from a given UDP address and TCP port.
-    pub const fn from_udp_address(udp_address: &std::net::SocketAddr, tcp_port: u16) -> Self {
-        Self(NodeEndpoint { address: udp_address.ip(), udp_port: udp_address.port(), tcp_port })
-    }
-}
-
 /// Represents the `from`, `to` fields in the packets
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
 pub struct NodeEndpoint {

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -169,7 +169,7 @@ impl Message {
         let payload = &mut &packet[98..];
 
         let msg = match MessageId::from_u8(msg_type).map_err(DecodePacketError::UnknownMessage)? {
-            MessageId::Ping => Self::Ping(Ping::decode(payload).unwrap()),
+            MessageId::Ping => Self::Ping(Ping::decode(payload)?),
             MessageId::Pong => Self::Pong(Pong::decode(payload)?),
             MessageId::FindNode => Self::FindNode(FindNode::decode(payload)?),
             MessageId::Neighbours => Self::Neighbours(Neighbours::decode(payload)?),

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -196,7 +196,7 @@ pub struct Packet {
 
 /// Represents the `from` field in the `Ping` packet
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, RlpEncodableWrapper)]
-pub struct PingNodeEndpoint(pub NodeEndpoint);
+struct PingNodeEndpoint(NodeEndpoint);
 
 impl alloy_rlp::Decodable for PingNodeEndpoint {
     #[inline]

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -510,7 +510,6 @@ impl Decodable for Ping {
 
         // only decode the ENR sequence if there's more data in the datagram to decode else skip
         if b.has_remaining() {
-            println!("decoding enr seq");
             this.enr_sq = Some(Decodable::decode(b)?);
         }
 


### PR DESCRIPTION
This sets the IP to `UNSPECIFIED` when `0x80` is encountered as a `Ping` packet `from` field.