### PR TITLE
fix: dont select more rayon threads than cpus

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -167,9 +167,10 @@ impl LaunchContext {
             Err(err) => warn!(%err, "Failed to raise file descriptor limit"),
         }
 
-        // Limit the global rayon thread pool, reserving 2 cores for the rest of the system
+        // Limit the global rayon thread pool, reserving 2 cores for the rest of the system.
+        // If the system has less than 2 cores, it will use 1 core.
         let num_threads =
-            available_parallelism().map_or(0, |num| num.get().saturating_sub(2).max(2));
+            available_parallelism().map_or(0, |num| num.get().saturating_sub(2).max(1));
         if let Err(err) = ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .thread_name(|i| format!("reth-rayon-{i}"))


### PR DESCRIPTION
with 1 available CPU we would configure rayon with 2 threads, 
this makes sure that on systems with <=2 cpus, the rayon pool will use 1 cpu