### PR TITLE
chore: remove outdated TODOs on execution tests

### DIFF
--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -836,8 +836,6 @@ mod tests {
 
     #[tokio::test]
     async fn sanity_execution_of_block() {
-        // TODO cleanup the setup after https://github.com/paradigmxyz/reth/issues/332
-        // is merged as it has similar framework
         let factory = create_test_provider_factory();
         let provider = factory.provider_rw().unwrap();
         let input = ExecInput { target: Some(1), checkpoint: None };
@@ -984,9 +982,6 @@ mod tests {
 
     #[tokio::test]
     async fn sanity_execute_unwind() {
-        // TODO cleanup the setup after https://github.com/paradigmxyz/reth/issues/332
-        // is merged as it has similar framework
-
         let factory = create_test_provider_factory();
         let provider = factory.provider_rw().unwrap();
         let input = ExecInput { target: Some(1), checkpoint: None };


### PR DESCRIPTION
I think these tests are valuable, additionally they both cover some pruning behavior. So I would consider the TODOs obsolete, instead of removing the tests because we run state tests in CI.