### PR TITLE
chore: remove outdated Bodies stage TODO

### DIFF
--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -25,7 +25,6 @@ use reth_stages_api::{
 };
 use reth_storage_errors::provider::ProviderResult;
 
-// TODO(onbjerg): Metrics and events (gradual status for e.g. CLI)
 /// The body stage downloads block bodies.
 ///
 /// The body stage downloads block bodies for all block headers stored locally in storage.


### PR DESCRIPTION
Removes another TODO from the beginning of the project, we have CLI and metrics now!