### PR TITLE
feat(trie): implement change set walker

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -16,8 +16,8 @@ use reth_primitives::{
 use reth_storage_api::StateProofProvider;
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
-    proof::Proof, updates::TrieUpdates, witness::TrieWitness, AccountProof, HashedPostState,
-    StateRoot,
+    proof::Proof, trie_cursor::DatabaseTrieCursorFactory, updates::TrieUpdates,
+    witness::TrieWitness, AccountProof, HashedPostState, StateRoot,
 };
 use reth_trie_db::{DatabaseProof, DatabaseStateRoot, DatabaseTrieWitness};
 use std::{collections::HashMap, fmt::Debug};
@@ -134,7 +134,10 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
             );
         }
 
-        Ok(HashedPostState::from_reverts(self.tx, self.block_number)?)
+        Ok(HashedPostState::from_reverts(
+            &DatabaseTrieCursorFactory::new(self.tx),
+            self.block_number,
+        )?)
     }
 
     fn history_info<T, K>(

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -1,6 +1,7 @@
 use crate::{BranchNodeCompact, Nibbles};
-use reth_primitives::B256;
+use reth_primitives::{Account, Address, BlockNumber, B256, U256};
 use reth_storage_errors::db::DatabaseError;
+use std::ops::RangeBounds;
 
 /// Database implementations of trie cursors.
 mod database_cursors;
@@ -51,4 +52,33 @@ pub trait TrieCursor: Send + Sync {
 
     /// Get the current entry.
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError>;
+}
+
+/// A trait for iterating change sets over a range of block numbers.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait ChangeSetWalker: Send + Sync {
+    /// The associated change set being iterated over.
+    type Value;
+
+    /// Creates an iterator that walks over a range of block numbers.
+    fn walk_range(
+        &mut self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> Result<impl Iterator<Item = Result<Self::Value, DatabaseError>>, DatabaseError>;
+}
+
+/// Creates readable change set iterators over a range of block numbers.
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait ChangeSetWalkerFactory: Send + Sync {
+    /// Cursor that iterates over a range of account change sets.
+    type AccountCursor: ChangeSetWalker<Value = (Address, Option<Account>)>;
+
+    /// Cursor that iterates over a range of storage change sets.
+    type StorageCursor: ChangeSetWalker<Value = (Address, B256, U256)>;
+
+    /// Creates account change sets cursor.
+    fn account_change_sets(&self) -> Result<Self::AccountCursor, DatabaseError>;
+
+    /// Creates storage change sets cursor.
+    fn storage_change_sets(&self) -> Result<Self::StorageCursor, DatabaseError>;
 }


### PR DESCRIPTION
## About
This PR is about decoupling trait and implementation of an iterator over change sets in a transaction.

## Motivation
Expanding on #9282 with a focus on `state` module of `reth-trie` crate.

## Goals
* Remove dependencies on `reth-db` and `reth-db-api` in `state` module of `reth-trie` crate.

## Solution
* Decouple trait and a database implementation of an iterator over a range of change sets of accounts and storage.
  * Create a new trait `TrieRangeWalker` and `TrieRangeWalkerFactory`
  * Implement above mentioned traits using a newly created `DatabaseAccountChangeSetsCursor` and `DatabaseStorageChangeSetsCursor`
  * Update all usages in `reth-trie` to use the trait only
  * Update all usages outside of `reth-trie` to supply the proper implementation

## Additional notes
The newly created database implementations of `TrieRangeWalker` and `TrieRangeWalkerFactory` should be a part of `reth-trie-db` crate instead of `reth-trie` as done here. However, this is not a concern of this PR, instead will be a concern of a PR focusing on moving all database implementations of trie readers/writers to `reth-trie-db`. Mostly in favor of keeping the PRs small and focused as explained in #9585 motivation section.