### PR TITLE
feat: Add OP cli flag to opt-in into discv4 discovery

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -62,6 +62,7 @@ The `optimism` feature flag in `op-reth` adds several new CLI flags to the `reth
 1. `--rollup.sequencer-http <uri>` - The sequencer endpoint to connect to. Transactions sent to the `op-reth` EL are also forwarded to this sequencer endpoint for inclusion, as the sequencer is the entity that builds blocks on OP Stack chains.
 1. `--rollup.disable-tx-pool-gossip` - Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
 1. `--rollup.enable-genesis-walkback` - Disables setting the forkchoice status to tip on startup, making the `op-node` walk back to genesis and verify the integrity of the chain before starting to sync. This can be omitted unless a corruption of local chainstate is suspected.
+1. `--rollup.discovery.v4` - Enables the discovery v4 protocol for peer discovery.
 
 First, ensure that your L1 archival node is running and synced to tip. Also make sure that the beacon node / consensus layer client is running and has http APIs enabled. Then, start `op-reth` with the `--rollup.sequencer-http` flag set to the `Base Mainnet` sequencer endpoint:
 ```sh

--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -62,7 +62,7 @@ The `optimism` feature flag in `op-reth` adds several new CLI flags to the `reth
 1. `--rollup.sequencer-http <uri>` - The sequencer endpoint to connect to. Transactions sent to the `op-reth` EL are also forwarded to this sequencer endpoint for inclusion, as the sequencer is the entity that builds blocks on OP Stack chains.
 1. `--rollup.disable-tx-pool-gossip` - Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
 1. `--rollup.enable-genesis-walkback` - Disables setting the forkchoice status to tip on startup, making the `op-node` walk back to genesis and verify the integrity of the chain before starting to sync. This can be omitted unless a corruption of local chainstate is suspected.
-1. `--rollup.discovery.v4` - Enables the discovery v4 protocol for peer discovery.
+1. `--rollup.discovery.v4` - Enables the discovery v4 protocol for peer discovery, allowing the network node to find and connect to peers using the discovery v4 protocol.
 
 First, ensure that your L1 archival node is running and synced to tip. Also make sure that the beacon node / consensus layer client is running and has http APIs enabled. Then, start `op-reth` with the `--rollup.sequencer-http` flag set to the `Base Mainnet` sequencer endpoint:
 ```sh

--- a/crates/optimism/node/src/args.rs
+++ b/crates/optimism/node/src/args.rs
@@ -31,7 +31,7 @@ pub struct RollupArgs {
     pub compute_pending_block: bool,
 
     /// Enable discv4 discovery protocol
-    #[arg(long = "rollup.discovery.v4")]
+    #[arg(long = "rollup.discovery.v4", default_value = "false")]
     pub discovery_v4: bool,
 }
 

--- a/crates/optimism/node/src/args.rs
+++ b/crates/optimism/node/src/args.rs
@@ -29,6 +29,10 @@ pub struct RollupArgs {
     /// that this flag is not yet functional.
     #[arg(long = "rollup.compute-pending-block")]
     pub compute_pending_block: bool,
+
+    /// Enable discv4 discovery protocol
+    #[arg(long = "discovery.v4")]
+    pub discovery_v4: bool,
 }
 
 #[cfg(test)]

--- a/crates/optimism/node/src/args.rs
+++ b/crates/optimism/node/src/args.rs
@@ -31,7 +31,7 @@ pub struct RollupArgs {
     pub compute_pending_block: bool,
 
     /// Enable discv4 discovery protocol
-    #[arg(long = "discovery.v4")]
+    #[arg(long = "rollup.discovery.v4")]
     pub discovery_v4: bool,
 }
 

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -69,7 +69,7 @@ impl OptimismNode {
             ))
             .network(OptimismNetworkBuilder { 
                 disable_txpool_gossip, 
-                discovery_v4: !discovery_v4, 
+                disable_discovery_v4: !discovery_v4, 
             })
             .executor(OptimismExecutorBuilder::default())
             .consensus(OptimismConsensusBuilder::default())

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -277,6 +277,9 @@ where
 pub struct OptimismNetworkBuilder {
     /// Disable transaction pool gossip
     pub disable_txpool_gossip: bool,
+
+    /// Disable discovery v4
+    pub disable_discovery_v4: bool,
 }
 
 impl<Node, Pool> NetworkBuilder<Node, Pool> for OptimismNetworkBuilder
@@ -289,7 +292,7 @@ where
         ctx: &BuilderContext<Node>,
         pool: Pool,
     ) -> eyre::Result<NetworkHandle> {
-        let Self { disable_txpool_gossip } = self;
+        let Self { disable_txpool_gossip, disable_discovery_v4 } = self;
 
         let args = &ctx.config().network;
 
@@ -299,6 +302,12 @@ where
             .apply(|mut builder| {
                 let rlpx_socket = (args.addr, args.port).into();
 
+                // Apply discovery v4 settings
+                if disable_discovery_v4 || args.discovery.disable_discovery {
+                    builder = builder.disable_discv4_discovery();
+                }
+
+                // Apply discovery v5 settings
                 if !args.discovery.disable_discovery {
                     builder = builder.discovery_v5(
                         args.discovery.discovery_v5_builder(

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -59,7 +59,7 @@ impl OptimismNode {
     where
         Node: FullNodeTypes<Engine = OptimismEngineTypes>,
     {
-        let RollupArgs { disable_txpool_gossip, compute_pending_block, .. } = args;
+        let RollupArgs { disable_txpool_gossip, compute_pending_block, discovery_v4, .. } = args;
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(OptimismPoolBuilder::default())
@@ -67,7 +67,7 @@ impl OptimismNode {
                 compute_pending_block,
                 OptimismEvmConfig::default(),
             ))
-            .network(OptimismNetworkBuilder { disable_txpool_gossip })
+            .network(OptimismNetworkBuilder { disable_txpool_gossip, discovery_v4 })
             .executor(OptimismExecutorBuilder::default())
             .consensus(OptimismConsensusBuilder::default())
     }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -67,7 +67,10 @@ impl OptimismNode {
                 compute_pending_block,
                 OptimismEvmConfig::default(),
             ))
-            .network(OptimismNetworkBuilder { disable_txpool_gossip, discovery_v4 })
+            .network(OptimismNetworkBuilder { 
+                disable_txpool_gossip, 
+                discovery_v4: !discovery_v4, 
+            })
             .executor(OptimismExecutorBuilder::default())
             .consensus(OptimismConsensusBuilder::default())
     }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -321,7 +321,7 @@ where
                     );
                 }
 
-                builder
+                Ok(builder) 
             });
 
         let mut network_config = ctx.build_network_config(network_builder);


### PR DESCRIPTION
Added the --rollup.discovery.v4 flag to enable the discovery v4 protocol for peer discovery. This flag has been added to the RollupArgs struct.

Added the disable_discovery_v4 flag to OptimismNetworkBuilder to allow disabling the discovery v4 protocol. Applied discovery v4 and v5 settings conditionally within the apply method. Enhanced network configuration flexibility by using both disable_txpool_gossip and disable_discovery_v4 flags. 

Added explicit error handling within the apply closure to propagate potential errors to the upper level. Included comments in key code blocks to improve readability and maintainability.

Issue: https://github.com/paradigmxyz/reth/issues/9919
