### PR TITLE
doc: replace expired example

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -18,7 +18,7 @@ The main difference between metrics and traces is therefore that metrics are sys
 To add metrics use the [`metrics`][metrics] crate.
 
 1. Add the code emitting the metric.
-2. Add the metrics description in the crate's metrics describer module, e.g.: [stages metrics describer](https://github.com/paradigmxyz/reth/blob/main/crates/stages/src/metrics.rs).
+2. Add the metrics description in the crate's metrics describer module, e.g.: [network metrics describer](https://github.com/paradigmxyz/reth/blob/main/crates/net/network/src/metrics.rs).
 3. Document the metric in this file.
 
 #### Metric anatomy


### PR DESCRIPTION
The stages metrics describer example can't be found. so I choose a appropriate new example