### PR TITLE
chore: remove `segment` argument from `increment_block`

### DIFF
--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -181,8 +181,7 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
 
             // Increment block on static file header.
             if block_number > 0 {
-                let appended_block_number = static_file_producer
-                    .increment_block(StaticFileSegment::Transactions, block_number)?;
+                let appended_block_number = static_file_producer.increment_block(block_number)?;
 
                 if appended_block_number != block_number {
                     // This scenario indicates a critical error in the logic of adding new

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -854,7 +854,7 @@ mod tests {
         {
             let mut receipts_writer =
                 provider.static_file_provider().latest_writer(StaticFileSegment::Receipts).unwrap();
-            receipts_writer.increment_block(StaticFileSegment::Receipts, 0).unwrap();
+            receipts_writer.increment_block(0).unwrap();
             receipts_writer.commit().unwrap();
         }
         provider.commit().unwrap();
@@ -1000,7 +1000,7 @@ mod tests {
         {
             let mut receipts_writer =
                 provider.static_file_provider().latest_writer(StaticFileSegment::Receipts).unwrap();
-            receipts_writer.increment_block(StaticFileSegment::Receipts, 0).unwrap();
+            receipts_writer.increment_block(0).unwrap();
             receipts_writer.commit().unwrap();
         }
         provider.commit().unwrap();
@@ -1117,7 +1117,7 @@ mod tests {
         {
             let mut receipts_writer =
                 provider.static_file_provider().latest_writer(StaticFileSegment::Receipts).unwrap();
-            receipts_writer.increment_block(StaticFileSegment::Receipts, 0).unwrap();
+            receipts_writer.increment_block(0).unwrap();
             receipts_writer.commit().unwrap();
         }
         provider.commit().unwrap();

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -282,10 +282,10 @@ impl TestStageDB {
                         segment_header.expected_block_start() == 0
                     {
                         for block in 0..block.number {
-                            txs_writer.increment_block(StaticFileSegment::Transactions, block)?;
+                            txs_writer.increment_block(block)?;
                         }
                     }
-                    txs_writer.increment_block(StaticFileSegment::Transactions, block.number)?;
+                    txs_writer.increment_block(block.number)?;
                 }
                 res
             })?;
@@ -349,7 +349,7 @@ impl TestStageDB {
                 let provider = self.factory.static_file_provider();
                 let mut writer = provider.latest_writer(StaticFileSegment::Receipts)?;
                 let res = receipts.into_iter().try_for_each(|(block_num, receipts)| {
-                    writer.increment_block(StaticFileSegment::Receipts, block_num)?;
+                    writer.increment_block(block_num)?;
                     writer.append_receipts(receipts.into_iter().map(Ok))?;
                     Ok(())
                 });

--- a/crates/static-file/static-file/src/segments/receipts.rs
+++ b/crates/static-file/static-file/src/segments/receipts.rs
@@ -29,8 +29,7 @@ impl<DB: Database> Segment<DB> for Receipts {
             static_file_provider.get_writer(*block_range.start(), StaticFileSegment::Receipts)?;
 
         for block in block_range {
-            let _static_file_block =
-                static_file_writer.increment_block(StaticFileSegment::Receipts, block)?;
+            let _static_file_block = static_file_writer.increment_block(block)?;
             debug_assert_eq!(_static_file_block, block);
 
             let block_body_indices = provider

--- a/crates/static-file/static-file/src/segments/transactions.rs
+++ b/crates/static-file/static-file/src/segments/transactions.rs
@@ -31,8 +31,7 @@ impl<DB: Database> Segment<DB> for Transactions {
             .get_writer(*block_range.start(), StaticFileSegment::Transactions)?;
 
         for block in block_range {
-            let _static_file_block =
-                static_file_writer.increment_block(StaticFileSegment::Transactions, block)?;
+            let _static_file_block = static_file_writer.increment_block(block)?;
             debug_assert_eq!(_static_file_block, block);
 
             let block_body_indices = provider

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -126,10 +126,10 @@ pub fn init_genesis<DB: Database>(factory: ProviderFactory<DB>) -> Result<B256, 
 
     // Static file segments start empty, so we need to initialize the genesis block.
     let segment = StaticFileSegment::Receipts;
-    static_file_provider.latest_writer(segment)?.increment_block(segment, 0)?;
+    static_file_provider.latest_writer(segment)?.increment_block(0)?;
 
     let segment = StaticFileSegment::Transactions;
-    static_file_provider.latest_writer(segment)?.increment_block(segment, 0)?;
+    static_file_provider.latest_writer(segment)?.increment_block(0)?;
 
     provider_rw.commit()?;
     static_file_provider.commit()?;

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -270,9 +270,10 @@ impl StaticFileProviderRW {
     /// Returns the current [`BlockNumber`] as seen in the static file.
     pub fn increment_block(
         &mut self,
-        segment: StaticFileSegment,
         expected_block_number: BlockNumber,
     ) -> ProviderResult<BlockNumber> {
+        let segment = self.writer.user_header().segment();
+
         self.check_next_block_number(expected_block_number, segment)?;
 
         let start = Instant::now();
@@ -476,7 +477,7 @@ impl StaticFileProviderRW {
 
         debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Headers);
 
-        let block_number = self.increment_block(StaticFileSegment::Headers, header.number)?;
+        let block_number = self.increment_block(header.number)?;
 
         self.append_column(header)?;
         self.append_column(CompactU256::from(total_difficulty))?;

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -10,9 +10,7 @@ use reth_db::{
 };
 use reth_errors::{ProviderError, ProviderResult};
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives::{
-    BlockNumber, Header, StaticFileSegment, TransactionSignedNoHash, B256, U256,
-};
+use reth_primitives::{BlockNumber, Header, TransactionSignedNoHash, B256, U256};
 use reth_storage_api::{HeaderProvider, ReceiptWriter};
 use reth_storage_errors::writer::StorageWriterError;
 use revm::db::OriginalValuesKnown;
@@ -197,8 +195,7 @@ where
                 tx_index += 1;
             }
 
-            self.static_file_writer()
-                .increment_block(StaticFileSegment::Transactions, block_number)?;
+            self.static_file_writer().increment_block(block_number)?;
 
             // update index
             last_tx_idx = Some(tx_index);

--- a/crates/storage/provider/src/writer/static_file.rs
+++ b/crates/storage/provider/src/writer/static_file.rs
@@ -1,6 +1,6 @@
 use crate::providers::StaticFileProviderRWRefMut;
 use reth_errors::ProviderResult;
-use reth_primitives::{BlockNumber, Receipt, StaticFileSegment, TxNumber};
+use reth_primitives::{BlockNumber, Receipt, TxNumber};
 use reth_storage_api::ReceiptWriter;
 
 pub(crate) struct StaticFileWriter<'a, W>(pub(crate) &'a mut W);
@@ -13,7 +13,7 @@ impl<'a> ReceiptWriter for StaticFileWriter<'a, StaticFileProviderRWRefMut<'_>> 
         receipts: Vec<Option<Receipt>>,
     ) -> ProviderResult<()> {
         // Increment block on static file header.
-        self.0.increment_block(StaticFileSegment::Receipts, block_number)?;
+        self.0.increment_block(block_number)?;
         let receipts = receipts.iter().enumerate().map(|(tx_idx, receipt)| {
             Ok((
                 first_tx_index + tx_idx as u64,

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -106,7 +106,7 @@ impl Case for BlockchainTestCase {
                         .static_file_provider()
                         .latest_writer(StaticFileSegment::Receipts)
                         .unwrap();
-                    receipts_writer.increment_block(StaticFileSegment::Receipts, 0).unwrap();
+                    receipts_writer.increment_block(0).unwrap();
                     receipts_writer.commit_without_sync_all().unwrap();
                 }
 


### PR DESCRIPTION
`segment` argument is unnecessary since it can be taken from the writer itself.