### PR TITLE
chore(trie): move `PrefixSetLoader` to db crate

### DIFF
--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -1,10 +1,12 @@
 //! An integration of [`reth-trie`] with [`reth-db`].
 
+mod prefix_set;
 mod proof;
 mod state;
 mod storage;
 mod witness;
 
+pub use prefix_set::PrefixSetLoader;
 pub use proof::DatabaseProof;
 pub use state::DatabaseStateRoot;
 pub use storage::DatabaseStorageRoot;

--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -1,5 +1,3 @@
-use super::{PrefixSetMut, TriePrefixSets};
-use crate::Nibbles;
 use derive_more::Deref;
 use reth_db::tables;
 use reth_db_api::{
@@ -9,10 +7,13 @@ use reth_db_api::{
     DatabaseError,
 };
 use reth_primitives::{keccak256, BlockNumber, StorageEntry, B256};
+use reth_trie::prefix_set::{PrefixSetMut, TriePrefixSets};
+use reth_trie_common::Nibbles;
 use std::{
     collections::{HashMap, HashSet},
     ops::RangeInclusive,
 };
+
 /// A wrapper around a database transaction that loads prefix sets within a given block range.
 #[derive(Deref, Debug)]
 pub struct PrefixSetLoader<'a, TX>(&'a TX);

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -1,9 +1,9 @@
+use crate::PrefixSetLoader;
 use reth_db_api::transaction::DbTx;
 use reth_execution_errors::StateRootError;
 use reth_primitives::{BlockNumber, B256};
 use reth_trie::{
     hashed_cursor::{DatabaseHashedCursorFactory, HashedPostStateCursorFactory},
-    prefix_set::PrefixSetLoader,
     trie_cursor::{DatabaseTrieCursorFactory, InMemoryTrieCursorFactory},
     updates::TrieUpdates,
     HashedPostState, StateRoot, StateRootProgress,

--- a/crates/trie/trie/src/prefix_set.rs
+++ b/crates/trie/trie/src/prefix_set.rs
@@ -5,9 +5,6 @@ use std::{
     sync::Arc,
 };
 
-mod loader;
-pub use loader::PrefixSetLoader;
-
 /// Collection of mutable prefix sets.
 #[derive(Clone, Default, Debug)]
 pub struct TriePrefixSetsMut {


### PR DESCRIPTION
## Description

~~Supersedes #9970.~~ Moves `PrefixSetLoader` from `reth-trie` to `reth-trie-db`. See https://github.com/paradigmxyz/reth/pull/9970#issuecomment-2262992253.