### PR TITLE
refactor(trie): remove dependency on `reth-db` and `reth-db-api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8797,8 +8797,6 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-chainspec",
- "reth-db",
- "reth-db-api",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives",

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -13,8 +13,6 @@ workspace = true
 
 [dependencies]
 # reth
-reth-db-api.workspace = true
-reth-db.workspace = true
 reth-execution-errors.workspace = true
 reth-primitives.workspace = true
 reth-stages-types.workspace = true
@@ -49,7 +47,6 @@ serde = { workspace = true, optional = true }
 # reth
 reth-chainspec.workspace = true
 reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
-reth-db = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 

--- a/crates/trie/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/trie/src/hashed_cursor/mod.rs
@@ -1,4 +1,5 @@
 use reth_primitives::{Account, B256, U256};
+use reth_storage_errors::db::DatabaseError;
 
 /// Implementation of hashed state cursor traits for the post state.
 mod post_state;
@@ -12,13 +13,13 @@ pub trait HashedCursorFactory {
     type StorageCursor: HashedStorageCursor<Value = U256>;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, reth_db::DatabaseError>;
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageCursor, reth_db::DatabaseError>;
+    ) -> Result<Self::StorageCursor, DatabaseError>;
 }
 
 /// The cursor for iterating over hashed entries.
@@ -28,14 +29,14 @@ pub trait HashedCursor {
 
     /// Seek an entry greater or equal to the given key and position the cursor there.
     /// Returns the first entry with the key greater or equal to the sought key.
-    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError>;
 
     /// Move the cursor to the next entry and return it.
-    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, reth_db::DatabaseError>;
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError>;
 }
 
 /// The cursor for iterating over hashed storage entries.
 pub trait HashedStorageCursor: HashedCursor {
     /// Returns `true` if there are no entries for a given key.
-    fn is_storage_empty(&mut self) -> Result<bool, reth_db::DatabaseError>;
+    fn is_storage_empty(&mut self) -> Result<bool, DatabaseError>;
 }


### PR DESCRIPTION
## About
This PR removes unused dependencies in `reth-trie` crate.

## Motivation
Expanding on #9282, the `reth-db` is now an unused dependency in `reth-trie`

## Goals
* Remove all dependencies on `reth-db` and `reth-db-api` from `reth-trie`

## Solution
* Removed `reth-db` and `reth-db-api` from Cargo.toml of `reth-trie` (including dev)
* Fixed some left off `DatabaseError` usage in `reth-trie`

## Additional notes
The moment you've been waiting for.

Closes #9282