### PR TITLE
op-reth: Enable eth_getProof inside authrpc

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -13,7 +13,8 @@ use reth_rpc_types::{
         ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus, TransitionConfiguration,
     },
     state::StateOverride,
-    BlockOverrides, Filter, Log, RichBlock, SyncStatus, TransactionRequest,
+    BlockOverrides, EIP1186AccountProofResponse, Filter, JsonStorageKey, Log, RichBlock,
+    SyncStatus, TransactionRequest,
 };
 // NOTE: We can't use associated types in the `EngineApi` trait because of jsonrpsee, so we use a
 // generic here. It would be nice if the rpc macro would understand which types need to have serde.
@@ -264,4 +265,14 @@ pub trait EngineEthApi {
     /// Returns logs matching given filter object.
     #[method(name = "getLogs")]
     async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+
+    /// Returns the account and storage values of the specified account including the Merkle-proof.
+    /// This call can be used to verify that the data you are pulling from is not tampered with.
+    #[method(name = "getProof")]
+    async fn get_proof(
+        &self,
+        address: Address,
+        keys: Vec<JsonStorageKey>,
+        block_number: Option<BlockId>,
+    ) -> RpcResult<EIP1186AccountProofResponse>;
 }

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -4,7 +4,8 @@ use reth_rpc_api::{EngineEthApiServer, EthApiServer, EthFilterApiServer};
 /// Re-export for convenience
 pub use reth_rpc_engine_api::EngineApi;
 use reth_rpc_types::{
-    state::StateOverride, BlockOverrides, Filter, Log, RichBlock, SyncStatus, TransactionRequest,
+    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, JsonStorageKey, Log,
+    RichBlock, SyncStatus, TransactionRequest,
 };
 use tracing_futures::Instrument;
 
@@ -97,5 +98,15 @@ where
     /// Handler for `eth_getLogs`
     async fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
         self.eth_filter.logs(filter).instrument(engine_span!()).await
+    }
+
+    /// Handler for `eth_getProof`
+    async fn get_proof(
+        &self,
+        address: Address,
+        keys: Vec<JsonStorageKey>,
+        block_number: Option<BlockId>,
+    ) -> Result<EIP1186AccountProofResponse> {
+        self.eth.get_proof(address, keys, block_number).instrument(engine_span!()).await
     }
 }


### PR DESCRIPTION
For op-reth, op-challenger will periodically query op-node's `outputAtBlock` rpc in order to properly monitor and defend the fault dispute games.

`outputAtBlock` from op-node underlyingly calls [eth_getProof](https://github.com/ethereum-optimism/optimism/blob/develop/op-service/sources/l2_client.go#L183), and while op-geth supports this function call inside authrpc scope, op-reth currently does not.

This PR aims to enable the `eth_getProof` rpc call within authrpc module.