### PR TITLE
chore: downgrade empty blocks to persist trace to debug

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -554,7 +554,7 @@ where
                 self.persistence.save_blocks(blocks_to_persist, tx);
                 self.persistence_state.start(rx);
             } else {
-                warn!(target: "engine", "Returned empty set of blocks to persist");
+                debug!(target: "engine", "Returned empty set of blocks to persist");
             }
         }
 
@@ -799,7 +799,7 @@ where
         }
 
         let min_block = self.persistence_state.last_persisted_block_number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >=
+        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
             self.config.persistence_threshold()
     }
 


### PR DESCRIPTION
Closes: #10009

Downgrades trace on empty blocks to persist to `debug`. Also changes the check in `should_persist` from `canon_head - last_persisted_block >= threshold` to `canon_head - last_persisted_block > threshold`