### PR TITLE
feat: add engine2 Dockerfile

### DIFF
--- a/EngineTwoDockerfile
+++ b/EngineTwoDockerfile
@@ -1,0 +1,52 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+
+# Install system dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+
+# Builds a cargo-chef plan
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+
+# Build profile, release by default
+ARG BUILD_PROFILE=release
+ENV BUILD_PROFILE $BUILD_PROFILE
+
+# Extra Cargo flags
+ARG RUSTFLAGS=""
+ENV RUSTFLAGS "$RUSTFLAGS"
+
+# Extra Cargo features
+ARG FEATURES=""
+ENV FEATURES $FEATURES
+
+# Builds dependencies
+RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json
+
+# Build application
+COPY . .
+RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin engine2
+
+# ARG is not resolved in COPY so we have to hack around it by copying the
+# binary to a temporary location
+RUN cp /app/target/$BUILD_PROFILE/engine2 /app/reth
+
+# Use Ubuntu as the release image
+FROM ubuntu AS runtime
+WORKDIR /app
+
+# Copy reth over from the build stage
+COPY --from=builder /app/reth /usr/local/bin
+
+# Copy licenses
+COPY LICENSE-* ./
+
+EXPOSE 30303 30303/udp 9001 8545 8546
+ENTRYPOINT ["/usr/local/bin/reth"]


### PR DESCRIPTION
This can be built by calling:

```
docker build . -f EngineTwoDockerfile -t <TAG>
```

in the root of the repo.

This is useful for running hive tests and kurtosis with the new engine for example.