### PR TITLE
feat: use BTreemap for block numbers in CanonicalInMemoryState

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -13,9 +13,13 @@ use reth_primitives::{
 };
 use reth_storage_api::StateProviderBox;
 use reth_trie::{updates::TrieUpdates, HashedPostState};
-use std::{collections::HashMap, ops::Deref, sync::Arc, time::Instant};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Deref,
+    sync::Arc,
+    time::Instant,
+};
 use tokio::sync::broadcast;
-use std::collections::BTreeMap;
 
 /// Size of the broadcast channel used to notify canonical state events.
 const CANON_STATE_NOTIFICATION_CHANNEL_SIZE: usize = 256;

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1962,7 +1962,7 @@ mod tests {
             let mut blocks_by_hash = HashMap::new();
             let mut blocks_by_number = BTreeMap::new();
             let mut state_by_hash = HashMap::new();
-            let mut hash_by_number = HashMap::new();
+            let mut hash_by_number = BTreeMap::new();
             let mut parent_to_child: HashMap<B256, HashSet<B256>> = HashMap::new();
             let mut parent_hash = B256::ZERO;
 


### PR DESCRIPTION
Closes #10038 