### PR TITLE
fix: start payload builder on already canon head

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -85,8 +85,3 @@ test-utils = [
   "reth-static-file",
   "reth-tracing",
 ]
-optimism = [
-    "reth-primitives/optimism",
-    "reth-provider/optimism",
-    "reth-revm/optimism"
-]

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -85,3 +85,8 @@ test-utils = [
   "reth-static-file",
   "reth-tracing",
 ]
+optimism = [
+    "reth-primitives/optimism",
+    "reth-provider/optimism",
+    "reth-revm/optimism"
+]

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1802,6 +1802,11 @@ where
             let tip = chain_update.tip().header.clone();
             self.on_canonical_chain_update(chain_update);
 
+            if let Some(attr) = attrs {
+                let updated = self.process_payload_attributes(attr, &tip, state);
+                return Ok(TreeOutcome::new(updated))
+            }
+
             // update the safe and finalized blocks and ensure their values are valid, but only
             // after the head block is made canonical
             if let Err(outcome) = self.ensure_consistent_forkchoice_state(state) {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1802,16 +1802,16 @@ where
             let tip = chain_update.tip().header.clone();
             self.on_canonical_chain_update(chain_update);
 
-            if let Some(attr) = attrs {
-                let updated = self.process_payload_attributes(attr, &tip, state);
-                return Ok(TreeOutcome::new(updated))
-            }
-
             // update the safe and finalized blocks and ensure their values are valid, but only
             // after the head block is made canonical
             if let Err(outcome) = self.ensure_consistent_forkchoice_state(state) {
                 // safe or finalized hashes are invalid
                 return Ok(TreeOutcome::new(outcome))
+            }
+
+            if let Some(attr) = attrs {
+                let updated = self.process_payload_attributes(attr, &tip, state);
+                return Ok(TreeOutcome::new(updated))
             }
 
             return Ok(valid_outcome(state.head_block_hash))

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1782,11 +1782,13 @@ where
 
             // we still need to process payload attributes if the head is already canonical
             if let Some(attr) = attrs {
-                let tip = self.block_by_hash(self.state.tree_state.canonical_block_hash())?.ok_or_else(|| {
-                    // If we can't find the canonical block, then something is wrong and we need to
-                    // return an error
-                    ProviderError::HeaderNotFound(state.head_block_hash.into())
-                })?;
+                let tip = self
+                    .block_by_hash(self.state.tree_state.canonical_block_hash())?
+                    .ok_or_else(|| {
+                        // If we can't find the canonical block, then something is wrong and we need
+                        // to return an error
+                        ProviderError::HeaderNotFound(state.head_block_hash.into())
+                    })?;
                 let updated = self.process_payload_attributes(attr, &tip, state);
                 return Ok(TreeOutcome::new(updated))
             }


### PR DESCRIPTION
This was stopping basically all hive tests, we still need to start a payload build process if the head is already canonical. In this case we also have to look up the canonical header.