### PR TITLE
chore: replace unreachable error variant

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -378,11 +378,6 @@ pub enum RpcInvalidTransactionError {
     /// Any other error
     #[error("{0}")]
     Other(Box<dyn ToRpcError>),
-    /// Unexpected [`InvalidTransaction`](revm::primitives::InvalidTransaction) error, Optimism
-    /// errors should not be handled on this level.
-    // TODO: Remove when optimism feature removed in revm
-    #[error("unexpected transaction error")]
-    UnexpectedTransactionError,
 }
 
 impl RpcInvalidTransactionError {
@@ -477,13 +472,13 @@ impl From<revm::primitives::InvalidTransaction> for RpcInvalidTransactionError {
                 Self::AuthorizationListInvalidFields
             }
             #[allow(unreachable_patterns)]
-            _ => {
+            err => {
                 error!(target: "rpc",
                     ?err,
                     "unexpected transaction error"
                 );
 
-                Self::UnexpectedTransactionError
+                Self::other(internal_rpc_err(format!("unexpected transaction error: {err}")))
             }
         }
     }

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -7,3 +7,9 @@ pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
     /// Converts the error to a JSON-RPC error object.
     fn to_rpc_error(&self) -> ErrorObject<'static>;
 }
+
+impl ToRpcError for ErrorObject<'static> {
+    fn to_rpc_error(&self) -> ErrorObject<'static> {
+        self.clone()
+    }
+}


### PR DESCRIPTION
this branch should be unreachable if configured properly.

removes the error variant and replaces it with `Other` instead