### PR TITLE
Add in-memory block TD lookup support

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -61,6 +61,11 @@ impl InMemoryState {
         self.numbers.read().get(&number).and_then(|hash| self.blocks.read().get(hash).cloned())
     }
 
+    /// Returns the hash for a specific block number
+    pub(crate) fn hash_by_number(&self, number: u64) -> Option<B256> {
+        self.numbers.read().get(&number).cloned()
+    }
+
     /// Returns the current chain head state.
     pub(crate) fn head_state(&self) -> Option<Arc<BlockState>> {
         self.numbers
@@ -165,7 +170,12 @@ impl CanonicalInMemoryState {
         Self { inner: Arc::new(inner) }
     }
 
-    /// Returns in the header corresponding to the given hash.
+    /// Returns the block hash corresponding to the given number
+    pub fn hash_by_number(&self, number: u64) -> Option<B256> {
+        self.inner.in_memory_state.hash_by_number(number)
+    }
+
+    /// Returns the header corresponding to the given hash.
     pub fn header_by_hash(&self, hash: B256) -> Option<SealedHeader> {
         self.state_by_hash(hash).map(|block| block.block().block.header.clone())
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -184,11 +184,21 @@ where
     }
 
     fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        // If the TD is recorded on disk, we can just return that
         if let Some(td) = self.database.header_td_by_number(number)? {
             Ok(Some(td))
-        } else {
+        } else if self.canonical_in_memory_state.hash_by_number(number).is_some() {
+            // Otherwise, if the block exists in memory, we should return a TD for it.
+            //
+            // This calculation assumes that we are post-merge. In this case, blocks should have
+            // zero difficulty. This means we can use the total difficulty for the last persisted
+            // block number.
             let last_persisted_block_number = self.database.last_block_number()?;
             self.database.header_td_by_number(last_persisted_block_number)
+        } else {
+            // If the block does not exist in memory, and does not exist on-disk, we should not
+            // return a TD for it.
+            Ok(None)
         }
     }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -187,14 +187,8 @@ where
         if let Some(td) = self.database.header_td_by_number(number)? {
             Ok(Some(td))
         } else {
-            let block_hash = self.canonical_in_memory_state.state_by_number(number)
-                .map(|state| state.block().block().hash());
-            if let Some(hash) = block_hash {
-                self.database.header_td(&hash)
-            } else {
-                let last_persisted_block_number = self.database.last_block_number()?;
-                self.database.header_td_by_number(last_persisted_block_number)
-            }
+            let last_persisted_block_number = self.database.last_block_number()?;
+            self.database.header_td_by_number(last_persisted_block_number)
         }
     }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -190,7 +190,7 @@ where
         } else if self.canonical_in_memory_state.hash_by_number(number).is_some() {
             // Otherwise, if the block exists in memory, we should return a TD for it.
             //
-            // The canonical in memory sate should only store post-merge blocks. Post-merge,
+            // The canonical in memory sate should only store post-merge blocks. Post-merge
             // blocks have zero difficulty. This means we can use the total difficulty for the last
             // persisted block number.
             let last_persisted_block_number = self.database.last_block_number()?;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -192,8 +192,6 @@ where
         }
     }
 
-
-
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
         let mut headers = Vec::new();
         let (start, end) = self.convert_range_bounds(range, || {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -190,9 +190,9 @@ where
         } else if self.canonical_in_memory_state.hash_by_number(number).is_some() {
             // Otherwise, if the block exists in memory, we should return a TD for it.
             //
-            // This calculation assumes that we are post-merge. In this case, blocks should have
-            // zero difficulty. This means we can use the total difficulty for the last persisted
-            // block number.
+            // The canonical in memory sate should only store post-merge blocks. Post-merge,
+            // blocks have zero difficulty. This means we can use the total difficulty for the last
+            // persisted block number.
             let last_persisted_block_number = self.database.last_block_number()?;
             self.database.header_td_by_number(last_persisted_block_number)
         } else {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -190,8 +190,8 @@ where
         } else if self.canonical_in_memory_state.hash_by_number(number).is_some() {
             // Otherwise, if the block exists in memory, we should return a TD for it.
             //
-            // The canonical in memory sate should only store post-merge blocks. Post-merge
-            // blocks have zero difficulty. This means we can use the total difficulty for the last
+            // The canonical in memory state should only store post-merge blocks. Post-merge blocks
+            // have zero difficulty. This means we can use the total difficulty for the last
             // persisted block number.
             let last_persisted_block_number = self.database.last_block_number()?;
             self.database.header_td_by_number(last_persisted_block_number)


### PR DESCRIPTION
fixes #10044

- Modified `BlockchainProvider2` to check in-memory state for block TD before querying the database.