### PR TITLE
workflows: don't run assertoor tests on forks

### DIFF
--- a/.github/workflows/assertoor.yml
+++ b/.github/workflows/assertoor.yml
@@ -13,6 +13,7 @@ jobs:
       test_result: ${{ steps.test_result.outputs.test_result }}
       test_status: ${{ steps.test_result.outputs.test_status }}
       failed_test_status: ${{ steps.test_result.outputs.failed_test_status }}
+    if: github.repository == 'paradigmxyz/reth'
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4


### PR DESCRIPTION
The Assertoor Tests workflow fails once a day in forks of the repo. This PR skips it on forks.