### PR TITLE
feat: swap `Dashmap` for `StaticFileWriters` on `StaticFileProvider`

### DIFF
--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -70,7 +70,7 @@ pub struct StaticFileProviderRWRefMut<'a>(
 impl<'a> std::ops::DerefMut for StaticFileProviderRWRefMut<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // This is always created by [`StaticFileWriters::get_or_create`]
-        self.0.as_mut().expect("should exist")
+        self.0.as_mut().expect("static file writer provider should be init")
     }
 }
 
@@ -79,7 +79,7 @@ impl<'a> std::ops::Deref for StaticFileProviderRWRefMut<'a> {
 
     fn deref(&self) -> &Self::Target {
         // This is always created by [`StaticFileWriters::get_or_create`]
-        self.0.as_ref().expect("should exist")
+        self.0.as_ref().expect("static file writer provider should be init")
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -21,6 +21,9 @@ use std::{
 use tracing::debug;
 
 /// Static file writers for every known [`StaticFileSegment`].
+///
+/// WARNING: Trying to use more than one writer for the same segment type **will result in a
+/// deadlock**.
 #[derive(Debug, Default)]
 pub(crate) struct StaticFileWriters {
     headers: RwLock<Option<StaticFileProviderRW>>,

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -58,8 +58,8 @@ impl StaticFileWriters {
     }
 }
 
-#[derive(Debug)]
 /// Mutable reference to a [`StaticFileProviderRW`] behind a [`RwLockWriteGuard`].
+#[derive(Debug)]
 pub struct StaticFileProviderRWRefMut<'a>(
     pub(crate) RwLockWriteGuard<'a, RawRwLock, Option<StaticFileProviderRW>>,
 );

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -163,8 +163,7 @@ where
         } else {
             UnifiedStorageWriter::from(
                 self.database(),
-                self.static_file()
-                    .get_writer(first_block.number, StaticFileSegment::Receipts)?,
+                self.static_file().get_writer(first_block.number, StaticFileSegment::Receipts)?,
             )
         };
 

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -157,6 +157,17 @@ where
 
         debug!(target: "provider::storage_writer", block_count = %blocks.len(), "Writing blocks and execution data to storage");
 
+        // Only write receipts to static files if there is no receipt pruning configured.
+        let mut state_writer = if self.database().prune_modes_ref().has_receipts_pruning() {
+            UnifiedStorageWriter::from_database(self.database())
+        } else {
+            UnifiedStorageWriter::from(
+                self.database(),
+                self.static_file()
+                    .get_writer(first_block.number, StaticFileSegment::Receipts)?,
+            )
+        };
+
         // TODO: remove all the clones and do performant / batched writes for each type of object
         // instead of a loop over all blocks,
         // meaning:
@@ -175,21 +186,6 @@ where
             // Write state and changesets to the database.
             // Must be written after blocks because of the receipt lookup.
             let execution_outcome = block.execution_outcome().clone();
-
-            // Only write receipts to static files if there is no receipt pruning configured.
-            let mut state_writer = if self.database().prune_modes_ref().has_receipts_pruning() {
-                UnifiedStorageWriter::from_database(self.database())
-            } else {
-                // This should be inside the hotloop, because preferably there should only be one
-                // mutable reference to a static file writer, since there's a 3 in 100 chance that
-                // another segment shares the same shard as the `Receipts` one. Which would result
-                // in a deadlock.
-                UnifiedStorageWriter::from(
-                    self.database(),
-                    self.static_file()
-                        .get_writer(first_block.number, StaticFileSegment::Receipts)?,
-                )
-            };
             state_writer.write_to_storage(execution_outcome, OriginalValuesKnown::No)?;
 
             // insert hashes and intermediate merkle nodes


### PR DESCRIPTION
Introduces:
```
pub(crate) struct StaticFileWriters {
    headers: RwLock<Option<StaticFileProviderRW>>,
    transactions: RwLock<Option<StaticFileProviderRW>>,
    receipts: RwLock<Option<StaticFileProviderRW>>,
}
```

This allows holding mutable references to two different static file segment writers without risk of deadlocking. Which is not possible with dashmap

This allows reverting https://github.com/paradigmxyz/reth/pull/10069 . 

Run the script with 0/100 failures

