### PR TITLE
chore(rpc): remove parent beacon root from conversion functions

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -97,7 +97,8 @@ impl Command {
 
             let versioned_hashes: Vec<B256> =
                 block.blob_versioned_hashes().into_iter().copied().collect();
-            let (payload, parent_beacon_block_root) = block_to_payload(block);
+            let parent_beacon_block_root = block.parent_beacon_block_root;
+            let payload = block_to_payload(block);
 
             debug!(?block_number, "Sending payload",);
 

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -71,7 +71,8 @@ impl Command {
 
             let versioned_hashes: Vec<B256> =
                 block.blob_versioned_hashes().into_iter().copied().collect();
-            let (payload, parent_beacon_block_root) = block_to_payload(block);
+            let parent_beacon_block_root = block.parent_beacon_block_root;
+            let payload = block_to_payload(block);
 
             let block_number = payload.block_number();
 

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -112,7 +112,7 @@ impl From<EthBuiltPayload> for ExecutionPayloadEnvelopeV3 {
         let EthBuiltPayload { block, fees, sidecars, .. } = value;
 
         Self {
-            execution_payload: block_to_payload_v3(block).0,
+            execution_payload: block_to_payload_v3(block),
             block_value: fees,
             // From the engine API spec:
             //

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -261,7 +261,7 @@ impl From<OptimismBuiltPayload> for OptimismExecutionPayloadEnvelopeV3 {
                 B256::ZERO
             };
         Self {
-            execution_payload: block_to_payload_v3(block).0,
+            execution_payload: block_to_payload_v3(block),
             block_value: fees,
             // From the engine API spec:
             //

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -27,7 +27,6 @@ fn transform_block<F: FnOnce(Block) -> Block>(src: SealedBlock, f: F) -> Executi
         withdrawals: transformed.withdrawals,
         requests: transformed.requests,
     })
-    .0
 }
 
 #[test]

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -121,19 +121,19 @@ pub fn try_payload_v4_to_block(payload: ExecutionPayloadV4) -> Result<Block, Pay
 }
 
 /// Converts [`SealedBlock`] to [`ExecutionPayload`]
-pub fn block_to_payload(value: SealedBlock) -> (ExecutionPayload, Option<B256>) {
+pub fn block_to_payload(value: SealedBlock) -> ExecutionPayload {
     if value.header.requests_root.is_some() {
-        (ExecutionPayload::V4(block_to_payload_v4(value)), None)
+        // block with requests root: V3
+        ExecutionPayload::V4(block_to_payload_v4(value))
     } else if value.header.parent_beacon_block_root.is_some() {
         // block with parent beacon block root: V3
-        let (payload, beacon_block_root) = block_to_payload_v3(value);
-        (ExecutionPayload::V3(payload), beacon_block_root)
+        ExecutionPayload::V3(block_to_payload_v3(value))
     } else if value.withdrawals.is_some() {
         // block with withdrawals: V2
-        (ExecutionPayload::V2(block_to_payload_v2(value)), None)
+        ExecutionPayload::V2(block_to_payload_v2(value))
     } else {
         // otherwise V1
-        (ExecutionPayload::V1(block_to_payload_v1(value)), None)
+        ExecutionPayload::V1(block_to_payload_v1(value))
     }
 }
 
@@ -184,11 +184,9 @@ pub fn block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
 }
 
 /// Converts [`SealedBlock`] to [`ExecutionPayloadV3`], and returns the parent beacon block root.
-pub fn block_to_payload_v3(value: SealedBlock) -> (ExecutionPayloadV3, Option<B256>) {
+pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
     let transactions = value.raw_transactions();
-
-    let parent_beacon_block_root = value.header.parent_beacon_block_root;
-    let payload = ExecutionPayloadV3 {
+    ExecutionPayloadV3 {
         blob_gas_used: value.blob_gas_used.unwrap_or_default(),
         excess_blob_gas: value.excess_blob_gas.unwrap_or_default(),
         payload_inner: ExecutionPayloadV2 {
@@ -210,9 +208,7 @@ pub fn block_to_payload_v3(value: SealedBlock) -> (ExecutionPayloadV3, Option<B2
             },
             withdrawals: value.withdrawals.unwrap_or_default().into_inner(),
         },
-    };
-
-    (payload, parent_beacon_block_root)
+    }
 }
 
 /// Converts [`SealedBlock`] to [`ExecutionPayloadV4`]
@@ -242,7 +238,7 @@ pub fn block_to_payload_v4(mut value: SealedBlock) -> ExecutionPayloadV4 {
         deposit_requests,
         withdrawal_requests,
         consolidation_requests,
-        payload_inner: block_to_payload_v3(value).0,
+        payload_inner: block_to_payload_v3(value),
     }
 }
 
@@ -497,7 +493,7 @@ mod tests {
         let converted_payload = block_to_payload_v3(block.seal_slow());
 
         // ensure the payloads are the same
-        assert_eq!((new_payload, Some(parent_beacon_block_root)), converted_payload);
+        assert_eq!(new_payload, converted_payload);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Remove parent beacon root from return type of conversion functions. Keep the interface same between all of the conversion functions.