### PR TITLE
fix: use in memory state for state_by_hash

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -894,19 +894,26 @@ where
         self.database.history_by_block_hash(block_hash)
     }
 
-    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
-        trace!(target: "providers::blockchain", ?block, "Getting state by block hash");
-        let mut state = self.history_by_block_hash(block);
-
-        // we failed to get the state by hash, from disk, hash block be the pending block
-        if state.is_err() {
-            if let Ok(Some(pending)) = self.pending_state_by_hash(block) {
-                // we found pending block by hash
-                state = Ok(pending)
-            }
+    fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {
+        trace!(target: "providers::blockchain", ?hash, "Getting state by block hash");
+        if let Ok(state) = self.history_by_block_hash(hash) {
+            // This could be tracked by a historical block
+            Ok(state)
+        } else if self.canonical_in_memory_state.state_by_hash(hash).is_some() {
+            // ... or this could be tracked by the in memory state
+            let last_persisted_block_number = self.database.last_block_number()?;
+            let latest_historical =
+                self.database.history_by_block_number(last_persisted_block_number)?;
+            let state_provider =
+                self.canonical_in_memory_state.state_provider(hash, latest_historical);
+            Ok(Box::new(state_provider))
+        } else if let Ok(Some(pending)) = self.pending_state_by_hash(hash) {
+            // .. or this could be the pending state
+            Ok(pending)
+        } else {
+            // if we couldn't find it anywhere, then we should return an error
+            Err(ProviderError::StateForHashNotFound(hash))
         }
-
-        state
     }
 
     /// Returns the state provider for pending state.

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -901,8 +901,8 @@ where
             Ok(state)
         } else if let Some(state) = self.canonical_in_memory_state.state_by_hash(hash) {
             // ... or this could be tracked by the in memory state
-            let anchor_num = state.anchor().number;
-            let latest_historical = self.database.history_by_block_number(anchor_num)?;
+            let anchor_hash = state.anchor().hash;
+            let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
             let state_provider =
                 self.canonical_in_memory_state.state_provider(hash, latest_historical);
             Ok(Box::new(state_provider))

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -899,11 +899,10 @@ where
         if let Ok(state) = self.history_by_block_hash(hash) {
             // This could be tracked by a historical block
             Ok(state)
-        } else if self.canonical_in_memory_state.state_by_hash(hash).is_some() {
+        } else if let Some(state) = self.canonical_in_memory_state.state_by_hash(hash) {
             // ... or this could be tracked by the in memory state
-            let last_persisted_block_number = self.database.last_block_number()?;
-            let latest_historical =
-                self.database.history_by_block_number(last_persisted_block_number)?;
+            let anchor_num = state.anchor().number;
+            let latest_historical = self.database.history_by_block_number(anchor_num)?;
             let state_provider =
                 self.canonical_in_memory_state.state_provider(hash, latest_historical);
             Ok(Box::new(state_provider))


### PR DESCRIPTION
Previously we would just go to the database for state, when the state for that block may only exist in memory. This caused payload building to fail in hive.

Now, we check for state in the following order:

 1. Database
 2. Canonical in-memory state
 3. Pending block

Otherwise, an error will be returned.