### PR TITLE
feat: add block_body_indices for BlockchainProvider2

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -207,7 +207,7 @@ impl CanonicalInMemoryState {
         Self { inner: Arc::new(inner) }
     }
 
-    /// Returns the block hash corresponding to the given number
+    /// Returns the block hash corresponding to the given number.
     pub fn hash_by_number(&self, number: u64) -> Option<B256> {
         self.inner.in_memory_state.hash_by_number(number)
     }

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -100,8 +100,11 @@ pub enum ProviderError {
     #[error("unknown block {0}")]
     UnknownBlockHash(B256),
     /// Thrown when we were unable to find a state for a block hash.
-    #[error("no state found for block {0}")]
+    #[error("no state found for block hash {0}")]
     StateForHashNotFound(B256),
+    /// Thrown when we were unable to find a state for a block number.
+    #[error("no state found for block number {0}")]
+    StateForNumberNotFound(u64),
     /// Unable to find the block number for a given transaction index.
     #[error("unable to find the block number for a given transaction index")]
     BlockNumberForTransactionIndexNotFound,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -441,6 +441,7 @@ where
                 .database
                 .block_body_indices(anchor_num)?
                 .ok_or_else(|| ProviderError::BlockBodyIndicesNotFound(anchor_num))?;
+            stored_indices.first_tx_num += 1;
 
             for state in parent_chain {
                 let txs = state.block().block.body.len() as u64;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -441,7 +441,7 @@ where
                 .database
                 .block_body_indices(anchor_num)?
                 .ok_or_else(|| ProviderError::BlockBodyIndicesNotFound(anchor_num))?;
-            stored_indices.first_tx_num += 1;
+            stored_indices.first_tx_num = stored_indices.next_tx_num();
 
             for state in parent_chain {
                 let txs = state.block().block.body.len() as u64;


### PR DESCRIPTION
I would like some review on the correctness of this method, specifically whether or not `next_tx` is accurate. Previously this would just go to the database, when it should be possible to fetch block body indices for the in memory canonical state.