### PR TITLE
Add support for optimism granite hardfork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5222,7 +5222,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 [[package]]
 name = "op-alloy-consensus"
 version = "0.1.4"
-source = "git+https://github.com/brianbland/op-alloy.git?branch=op-granite-time#47007df9ddb1d250be5542b759a93a4c54901d5e"
+source = "git+https://github.com/alloy-rs/op-alloy.git?rev=8dde493#8dde493b423d8e2ef9c41c9f7bd7200973f00ea5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5236,7 +5236,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.1.4"
-source = "git+https://github.com/brianbland/op-alloy.git?branch=op-granite-time#47007df9ddb1d250be5542b759a93a4c54901d5e"
+source = "git+https://github.com/alloy-rs/op-alloy.git?rev=8dde493#8dde493b423d8e2ef9c41c9f7bd7200973f00ea5"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8954,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "git+https://github.com/brianbland/revm.git?branch=op-granite-bn256pairing-input-limit#ef376fef4cf91236b94abd8967690f1f2a92effb"
+source = "git+https://github.com/bluealloy/revm.git?rev=ab42581#ab42581b7462a4b71a88fa5708859071ceaabf8e"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -8973,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "git+https://github.com/brianbland/revm.git?branch=op-granite-bn256pairing-input-limit#ef376fef4cf91236b94abd8967690f1f2a92effb"
+source = "git+https://github.com/bluealloy/revm.git?rev=ab42581#ab42581b7462a4b71a88fa5708859071ceaabf8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4453,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8912,9 +8912,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "12.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cfb48bce8ca2113e157bdbddbd5eeb09daac1c903d79ec17085897c38c7c91"
+checksum = "6b2f635bbbf4002b1b5c0219f841ec1a317723883ed7662c0d138617539a6087"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -8927,9 +8927,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a785dafff303a335980e317669c4e9800cdd5dd2830c6880c3247022761e88"
+checksum = "43cbb1576a147317c6990cf69d6cd5ef402df99f638616ba911006e9ec45866b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -8945,9 +8945,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b0daddea06fc6da5346acc39b32a357bbe3579e9e3d94117d9ae125cd596fc"
+checksum = "f2ad04c7d87dc3421a5ccca76e56dbd0b29a358c03bb41fe9e80976e9d3f397d"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -8955,9 +8955,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "9.2.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef55228211251d7b6c7707c3ee13bb70dea4d2fd81ec4034521e4fe31010b2ea"
+checksum = "3526a4ba5ec400e7bbe71affbc10fe2e67c1cd1fb782bab988873d09a102e271"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -8975,9 +8975,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "7.1.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
+checksum = "4093d98a26601f0a793871c5bc7928410592f76b1f03fc89fde77180c554643c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5222,22 +5222,21 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 [[package]]
 name = "op-alloy-consensus"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d10e10cbbdb3931fed5109bbd570c0a6cf0ce08db1f93401cfb5cefc51998d1"
+source = "git+https://github.com/brianbland/op-alloy.git?branch=op-granite-time#47007df9ddb1d250be5542b759a93a4c54901d5e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "derive_more",
  "serde",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9978c3d449abb03526d378988ae6d51b049ef36205cc97bf284574df9f578021"
+source = "git+https://github.com/brianbland/op-alloy.git?branch=op-granite-time#47007df9ddb1d250be5542b759a93a4c54901d5e"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8955,8 +8954,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef55228211251d7b6c7707c3ee13bb70dea4d2fd81ec4034521e4fe31010b2ea"
+source = "git+https://github.com/brianbland/revm.git?branch=op-granite-bn256pairing-input-limit#ef376fef4cf91236b94abd8967690f1f2a92effb"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -8975,8 +8973,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
+source = "git+https://github.com/brianbland/revm.git?branch=op-granite-bn256pairing-input-limit#ef376fef4cf91236b94abd8967690f1f2a92effb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4453,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5221,8 +5221,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/op-alloy.git?rev=8dde493#8dde493b423d8e2ef9c41c9f7bd7200973f00ea5"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e41c4537e76555df708c8372ec2c4254da9631eb129c2530f2baea00d645b422"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5235,8 +5236,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.1.4"
-source = "git+https://github.com/alloy-rs/op-alloy.git?rev=8dde493#8dde493b423d8e2ef9c41c9f7bd7200973f00ea5"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bf0c126082234c15b6051c1f06d2d666adf68e7de305a5352022f06a84be78"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8954,7 +8956,8 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "git+https://github.com/bluealloy/revm.git?rev=ab42581#ab42581b7462a4b71a88fa5708859071ceaabf8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef55228211251d7b6c7707c3ee13bb70dea4d2fd81ec4034521e4fe31010b2ea"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -8973,7 +8976,8 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "git+https://github.com/bluealloy/revm.git?rev=ab42581#ab42581b7462a4b71a88fa5708859071ceaabf8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -542,6 +542,6 @@ tempfile = "3.8"
 test-fuzz = "5"
 
 [patch.crates-io]
-revm-precompile = { git = "https://github.com/brianbland/revm.git", branch = "op-granite-bn256pairing-input-limit" }
-revm-primitives = { git = "https://github.com/brianbland/revm.git", branch = "op-granite-bn256pairing-input-limit" }
-op-alloy-rpc-types = { git = "https://github.com/brianbland/op-alloy.git", branch = "op-granite-time" }
+revm-precompile = { git = "https://github.com/bluealloy/revm.git", rev = "ab42581" }
+revm-primitives = { git = "https://github.com/bluealloy/revm.git", rev = "ab42581" }
+op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy.git", rev = "8dde493" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -540,3 +540,8 @@ serial_test = "3"
 similar-asserts = "1.5.0"
 tempfile = "3.8"
 test-fuzz = "5"
+
+[patch.crates-io]
+revm-precompile = { git = "https://github.com/brianbland/revm.git", branch = "op-granite-bn256pairing-input-limit" }
+revm-primitives = { git = "https://github.com/brianbland/revm.git", branch = "op-granite-bn256pairing-input-limit" }
+op-alloy-rpc-types = { git = "https://github.com/brianbland/op-alloy.git", branch = "op-granite-time" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -540,8 +540,3 @@ serial_test = "3"
 similar-asserts = "1.5.0"
 tempfile = "3.8"
 test-fuzz = "5"
-
-[patch.crates-io]
-revm-precompile = { git = "https://github.com/bluealloy/revm.git", rev = "ab42581" }
-revm-primitives = { git = "https://github.com/bluealloy/revm.git", rev = "ab42581" }
-op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy.git", rev = "8dde493" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,13 +380,13 @@ reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 
 # revm
-revm = { version = "12.1.0", features = [
+revm = { version = "13.0.0", features = [
     "std",
     "secp256k1",
     "blst",
 ], default-features = false }
 revm-inspectors = "0.5"
-revm-primitives = { version = "7.1.0", features = [
+revm-primitives = { version = "8.0.0", features = [
     "std",
 ], default-features = false }
 

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1722,7 +1722,15 @@ Post-merge hard forks (timestamp based):
                 ),
                 (
                     Head { number: 0, timestamp: 1716998400, ..Default::default() },
-                    ForkId { hash: ForkHash([0x54, 0x0a, 0x8c, 0x5d]), next: 0 },
+                    ForkId { hash: ForkHash([0x54, 0x0a, 0x8c, 0x5d]), next: 1723478400 },
+                ),
+                (
+                    Head { number: 0, timestamp: 1723478399, ..Default::default() },
+                    ForkId { hash: ForkHash([0x54, 0x0a, 0x8c, 0x5d]), next: 1723478400 },
+                ),
+                (
+                    Head { number: 0, timestamp: 1723478400, ..Default::default() },
+                    ForkId { hash: ForkHash([0x75, 0xde, 0xa4, 0x1e]), next: 0 },
                 ),
             ],
         );

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -758,6 +758,8 @@ impl From<Genesis> for ChainSpec {
             (OptimismHardfork::Ecotone.boxed(), genesis_info.ecotone_time),
             #[cfg(feature = "optimism")]
             (OptimismHardfork::Fjord.boxed(), genesis_info.fjord_time),
+            #[cfg(feature = "optimism")]
+            (OptimismHardfork::Granite.boxed(), genesis_info.granite_time),
         ];
 
         let time_hardforks = time_hardfork_opts
@@ -1002,6 +1004,14 @@ impl ChainSpecBuilder {
     pub fn fjord_activated(mut self) -> Self {
         self = self.ecotone_activated();
         self.hardforks.insert(OptimismHardfork::Fjord, ForkCondition::Timestamp(0));
+        self
+    }
+
+    /// Enable Granite at genesis
+    #[cfg(feature = "optimism")]
+    pub fn granite_activated(mut self) -> Self {
+        self = self.fjord_activated();
+        self.hardforks.insert(OptimismHardfork::Granite, ForkCondition::Timestamp(0));
         self
     }
 
@@ -2638,6 +2648,7 @@ Post-merge hard forks (timestamp based):
         "canyonTime": 30,
         "ecotoneTime": 40,
         "fjordTime": 50,
+        "graniteTime": 51,
         "optimism": {
           "eip1559Elasticity": 60,
           "eip1559Denominator": 70
@@ -2657,6 +2668,8 @@ Post-merge hard forks (timestamp based):
         assert_eq!(actual_ecotone_timestamp, Some(serde_json::Value::from(40)).as_ref());
         let actual_fjord_timestamp = genesis.config.extra_fields.get("fjordTime");
         assert_eq!(actual_fjord_timestamp, Some(serde_json::Value::from(50)).as_ref());
+        let actual_granite_timestamp = genesis.config.extra_fields.get("graniteTime");
+        assert_eq!(actual_granite_timestamp, Some(serde_json::Value::from(51)).as_ref());
 
         let optimism_object = genesis.config.extra_fields.get("optimism").unwrap();
         assert_eq!(
@@ -2679,12 +2692,14 @@ Post-merge hard forks (timestamp based):
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, 0));
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Ecotone, 0));
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Fjord, 0));
+        assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Granite, 0));
 
         assert!(chain_spec.is_fork_active_at_block(OptimismHardfork::Bedrock, 10));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Regolith, 20));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, 30));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Ecotone, 40));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Fjord, 50));
+        assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Granite, 51));
     }
 
     #[cfg(feature = "optimism")]
@@ -2698,6 +2713,7 @@ Post-merge hard forks (timestamp based):
         "canyonTime": 30,
         "ecotoneTime": 40,
         "fjordTime": 50,
+        "graniteTime": 51,
         "optimism": {
           "eip1559Elasticity": 60,
           "eip1559Denominator": 70,
@@ -2718,6 +2734,8 @@ Post-merge hard forks (timestamp based):
         assert_eq!(actual_ecotone_timestamp, Some(serde_json::Value::from(40)).as_ref());
         let actual_fjord_timestamp = genesis.config.extra_fields.get("fjordTime");
         assert_eq!(actual_fjord_timestamp, Some(serde_json::Value::from(50)).as_ref());
+        let actual_granite_timestamp = genesis.config.extra_fields.get("graniteTime");
+        assert_eq!(actual_granite_timestamp, Some(serde_json::Value::from(51)).as_ref());
 
         let optimism_object = genesis.config.extra_fields.get("optimism").unwrap();
         assert_eq!(
@@ -2747,12 +2765,14 @@ Post-merge hard forks (timestamp based):
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, 0));
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Ecotone, 0));
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Fjord, 0));
+        assert!(!chain_spec.is_fork_active_at_block(OptimismHardfork::Granite, 0));
 
         assert!(chain_spec.is_fork_active_at_block(OptimismHardfork::Bedrock, 10));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Regolith, 20));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, 30));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Ecotone, 40));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Fjord, 50));
+        assert!(chain_spec.is_fork_active_at_block(OptimismHardfork::Granite, 51));
     }
 
     #[cfg(feature = "optimism")]

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -2765,14 +2765,14 @@ Post-merge hard forks (timestamp based):
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, 0));
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Ecotone, 0));
         assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Fjord, 0));
-        assert!(!chain_spec.is_fork_active_at_block(OptimismHardfork::Granite, 0));
+        assert!(!chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Granite, 0));
 
         assert!(chain_spec.is_fork_active_at_block(OptimismHardfork::Bedrock, 10));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Regolith, 20));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Canyon, 30));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Ecotone, 40));
         assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Fjord, 50));
-        assert!(chain_spec.is_fork_active_at_block(OptimismHardfork::Granite, 51));
+        assert!(chain_spec.is_fork_active_at_timestamp(OptimismHardfork::Granite, 51));
     }
 
     #[cfg(feature = "optimism")]

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1779,7 +1779,15 @@ Post-merge hard forks (timestamp based):
                 ),
                 (
                     Head { number: 0, timestamp: 1716998400, ..Default::default() },
-                    ForkId { hash: ForkHash([0x4e, 0x45, 0x7a, 0x49]), next: 0 },
+                    ForkId { hash: ForkHash([0x4e, 0x45, 0x7a, 0x49]), next: 1723478400 },
+                ),
+                (
+                    Head { number: 0, timestamp: 1723478399, ..Default::default() },
+                    ForkId { hash: ForkHash([0x4e, 0x45, 0x7a, 0x49]), next: 1723478400 },
+                ),
+                (
+                    Head { number: 0, timestamp: 1723478400, ..Default::default() },
+                    ForkId { hash: ForkHash([0x5e, 0xdf, 0xa3, 0xb6]), next: 0 },
                 ),
             ],
         );

--- a/crates/ethereum-forks/src/hardfork/mod.rs
+++ b/crates/ethereum-forks/src/hardfork/mod.rs
@@ -101,13 +101,14 @@ mod tests {
 
     #[test]
     fn check_op_hardfork_from_str() {
-        let hardfork_str = ["beDrOck", "rEgOlITH", "cAnYoN", "eCoToNe", "FJorD"];
+        let hardfork_str = ["beDrOck", "rEgOlITH", "cAnYoN", "eCoToNe", "FJorD", "GRaNiTe"];
         let expected_hardforks = [
             OptimismHardfork::Bedrock,
             OptimismHardfork::Regolith,
             OptimismHardfork::Canyon,
             OptimismHardfork::Ecotone,
             OptimismHardfork::Fjord,
+            OptimismHardfork::Granite,
         ];
 
         let hardforks: Vec<OptimismHardfork> =

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -27,6 +27,8 @@ hardfork!(
         Ecotone,
         /// Fjord: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#fjord>
         Fjord,
+        /// Granite: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#granite>
+        Granite,
     }
 );
 
@@ -84,6 +86,7 @@ impl OptimismHardfork {
                 Self::Canyon => Some(2106456),
                 Self::Ecotone => Some(6383256),
                 Self::Fjord => Some(10615056),
+                _ => None,
             },
         )
     }
@@ -150,6 +153,7 @@ impl OptimismHardfork {
                 Self::Canyon => Some(1699981200),
                 Self::Ecotone => Some(1708534800),
                 Self::Fjord => Some(1716998400),
+                _ => None,
             },
         )
     }
@@ -183,6 +187,7 @@ impl OptimismHardfork {
                 Self::Canyon => Some(1704992401),
                 Self::Ecotone => Some(1710374401),
                 Self::Fjord => Some(1720627201),
+                _ => None,
             },
         )
     }

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -153,7 +153,7 @@ impl OptimismHardfork {
                 Self::Canyon => Some(1699981200),
                 Self::Ecotone => Some(1708534800),
                 Self::Fjord => Some(1716998400),
-                _ => None,
+                Self::Granite => Some(1723478400),
             },
         )
     }
@@ -249,6 +249,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1708534800)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1708534800)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1716998400)),
+            (Self::Granite.boxed(), ForkCondition::Timestamp(1723478400)),
         ])
     }
 
@@ -279,6 +280,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1708534800)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1708534800)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1716998400)),
+            (Self::Granite.boxed(), ForkCondition::Timestamp(1723478400)),
         ])
     }
 

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -9,7 +9,9 @@ pub fn revm_spec_by_timestamp_after_bedrock(
     chain_spec: &ChainSpec,
     timestamp: u64,
 ) -> revm_primitives::SpecId {
-    if chain_spec.fork(OptimismHardfork::Fjord).active_at_timestamp(timestamp) {
+    if chain_spec.fork(OptimismHardfork::Granite).active_at_timestamp(timestamp) {
+        revm_primitives::GRANITE
+    } else if chain_spec.fork(OptimismHardfork::Fjord).active_at_timestamp(timestamp) {
         revm_primitives::FJORD
     } else if chain_spec.fork(OptimismHardfork::Ecotone).active_at_timestamp(timestamp) {
         revm_primitives::ECOTONE
@@ -24,7 +26,9 @@ pub fn revm_spec_by_timestamp_after_bedrock(
 
 /// return `revm_spec` from spec configuration.
 pub fn revm_spec(chain_spec: &ChainSpec, block: &Head) -> revm_primitives::SpecId {
-    if chain_spec.fork(OptimismHardfork::Fjord).active_at_head(block) {
+    if chain_spec.fork(OptimismHardfork::Granite).active_at_head(block) {
+        revm_primitives::GRANITE
+    } else if chain_spec.fork(OptimismHardfork::Fjord).active_at_head(block) {
         revm_primitives::FJORD
     } else if chain_spec.fork(OptimismHardfork::Ecotone).active_at_head(block) {
         revm_primitives::ECOTONE
@@ -81,6 +85,10 @@ mod tests {
             f(cs).build()
         }
         assert_eq!(
+            revm_spec_by_timestamp_after_bedrock(&op_cs(|cs| cs.granite_activated()), 0),
+            revm_primitives::GRANITE
+        );
+        assert_eq!(
             revm_spec_by_timestamp_after_bedrock(&op_cs(|cs| cs.fjord_activated()), 0),
             revm_primitives::FJORD
         );
@@ -109,6 +117,10 @@ mod tests {
             let cs = ChainSpecBuilder::mainnet().chain(reth_chainspec::Chain::from_id(10));
             f(cs).build()
         }
+        assert_eq!(
+            revm_spec(&op_cs(|cs| cs.granite_activated()), &Head::default()),
+            revm_primitives::GRANITE
+        );
         assert_eq!(
             revm_spec(&op_cs(|cs| cs.fjord_activated()), &Head::default()),
             revm_primitives::FJORD

--- a/crates/optimism/rpc/src/api.rs
+++ b/crates/optimism/rpc/src/api.rs
@@ -78,7 +78,10 @@ pub struct RollupConfig {
     pub block_time: u64,
     pub max_sequencer_drift: u64,
     pub seq_window_size: u64,
-    pub channel_timeout: u64,
+
+    #[serde(rename = "channel_timeout")]
+    pub channel_timeout_bedrock: u64,
+    pub channel_timeout_granite: u64,
     /// todo use u128 to represent *big.Int?
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub l1_chain_id: Option<u128>,
@@ -95,6 +98,8 @@ pub struct RollupConfig {
     pub ecotone_time: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fjord_time: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granite_time: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interop_time: Option<u64>,
     pub batch_inbox_address: Address,
@@ -333,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_rollup_config() {
-        let rollup_config_json = r#"{"genesis":{"l1":{"blockHash":"0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"},"l2":{"blockHash":"0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"},"l2_time":1686068903,"system_config":{"batcherAddr":"0x6887246668a3b87f54deb3b94ba47a6f63f32985","overhead":"0x00000000000000000000000000000000000000000000000000000000000000bc","scalar":"0x00000000000000000000000000000000000000000000000000000000000a6fe0","gasLimit":30000000}},"block_time":2,"max_sequencer_drift":600,"seq_window_size":3600,"channel_timeout":300,"l1_chain_id":1,"l2_chain_id":10,"regolith_time":0,"canyon_time":1704992401,"delta_time":1708560000,"ecotone_time":1710374401,"batch_inbox_address":"0xff00000000000000000000000000000000000010","deposit_contract_address":"0xbeb5fc579115071764c7423a4f12edde41f106ed","l1_system_config_address":"0x229047fed2591dbec1ef1118d64f7af3db9eb290","protocol_versions_address":"0x8062abc286f5e7d9428a0ccb9abd71e50d93b935","da_challenge_address":"0x0000000000000000000000000000000000000000","da_challenge_window":0,"da_resolve_window":0,"use_plasma":false}"#;
+        let rollup_config_json = r#"{"genesis":{"l1":{"blockHash":"0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"},"l2":{"blockHash":"0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"},"l2_time":1686068903,"system_config":{"batcherAddr":"0x6887246668a3b87f54deb3b94ba47a6f63f32985","overhead":"0x00000000000000000000000000000000000000000000000000000000000000bc","scalar":"0x00000000000000000000000000000000000000000000000000000000000a6fe0","gasLimit":30000000}},"block_time":2,"max_sequencer_drift":600,"seq_window_size":3600,"channel_timeout":300,"channel_timeout_granite":50,"l1_chain_id":1,"l2_chain_id":10,"regolith_time":0,"canyon_time":1704992401,"delta_time":1708560000,"ecotone_time":1710374401,"batch_inbox_address":"0xff00000000000000000000000000000000000010","deposit_contract_address":"0xbeb5fc579115071764c7423a4f12edde41f106ed","l1_system_config_address":"0x229047fed2591dbec1ef1118d64f7af3db9eb290","protocol_versions_address":"0x8062abc286f5e7d9428a0ccb9abd71e50d93b935","da_challenge_address":"0x0000000000000000000000000000000000000000","da_challenge_window":0,"da_resolve_window":0,"use_plasma":false}"#;
         test_helper::<RollupConfig>(rollup_config_json);
     }
 


### PR DESCRIPTION
Adds optimism granite hardfork definition and support for genesis file config, and defines the activation timestamp for op-sepolia and base-sepolia.
This PR depends on the following dependency changes:
* op-alloy: https://github.com/alloy-rs/op-alloy/pull/31
* revm: https://github.com/bluealloy/revm/pull/1685