### PR TITLE
chore(docs): update op-reth discovery config v4 to v5

### DIFF
--- a/book/run/optimism.md
+++ b/book/run/optimism.md
@@ -62,7 +62,7 @@ The `optimism` feature flag in `op-reth` adds several new CLI flags to the `reth
 1. `--rollup.sequencer-http <uri>` - The sequencer endpoint to connect to. Transactions sent to the `op-reth` EL are also forwarded to this sequencer endpoint for inclusion, as the sequencer is the entity that builds blocks on OP Stack chains.
 1. `--rollup.disable-tx-pool-gossip` - Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
 1. `--rollup.enable-genesis-walkback` - Disables setting the forkchoice status to tip on startup, making the `op-node` walk back to genesis and verify the integrity of the chain before starting to sync. This can be omitted unless a corruption of local chainstate is suspected.
-1. `--rollup.discovery.v4` - Enables the discovery v4 protocol for peer discovery.
+1. `--enable-discv5-discovery` - Enables the discovery v5 protocol for peer discovery. See `Networking` [section](https://reth.rs/cli/reth/node.html?highlight=discovery#reth-node) for more peer discovery config.
 
 First, ensure that your L1 archival node is running and synced to tip. Also make sure that the beacon node / consensus layer client is running and has http APIs enabled. Then, start `op-reth` with the `--rollup.sequencer-http` flag set to the `Base Mainnet` sequencer endpoint:
 ```sh


### PR DESCRIPTION
`--rollup.discovery.v4` is no longer available. I'm not sure if the v5 flag should replace it. Would be nice to have recommended discovery config if the default isn't sufficient, or some info on p2p discovery on this page.