### PR TITLE
fix: validate header against parent in engine2

### DIFF
--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -138,6 +138,8 @@ impl TestBlockBuilder {
                     EMPTY_ROOT_HASH,
                 ),
             )])),
+            // use the number as the timestamp so it is monotonically increasing
+            timestamp: number,
             ..Default::default()
         };
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1424,7 +1424,7 @@ where
             ))
         })?;
         if let Err(e) = self.consensus.validate_header_against_parent(&block, &parent_block) {
-            error!(?block, "Failed to validate header {} against parent: {e}", block.header.hash());
+            warn!(?block, "Failed to validate header {} against parent: {e}", block.header.hash());
             return Err(e.into())
         }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -896,6 +896,26 @@ where
             .remove_persisted_blocks(self.persistence_state.last_persisted_block_number);
     }
 
+    /// Return sealed block from database or in-memory state by hash.
+    fn sealed_header_by_hash(&self, hash: B256) -> ProviderResult<Option<SealedHeader>> {
+        // check database first
+        let block_num = self.provider.block_number(hash)?;
+        if let Some(block_num) = block_num {
+            self.provider.sealed_header(block_num)
+        } else {
+            // Note: it's fine to return the unsealed block because the caller already has
+            // the hash
+            let block = self
+                .state
+                .tree_state
+                .block_by_hash(hash)
+                // TODO: clone for compatibility. should we return an Arc here?
+                .map(|block| block.as_ref().clone().header);
+
+            Ok(block)
+        }
+    }
+
     /// Return block from database or in-memory state by hash.
     fn block_by_hash(&self, hash: B256) -> ProviderResult<Option<Block>> {
         // check database first
@@ -1375,6 +1395,7 @@ where
         }
 
         let start = Instant::now();
+
         // validate block consensus rules
         self.validate_block(&block)?;
 
@@ -1395,6 +1416,17 @@ where
                 missing_ancestor,
             }))
         };
+
+        // now validate against the parent
+        let parent_block = self.sealed_header_by_hash(block.parent_hash)?.ok_or_else(|| {
+            InsertBlockErrorKindTwo::Provider(ProviderError::HeaderNotFound(
+                block.parent_hash.into(),
+            ))
+        })?;
+        if let Err(e) = self.consensus.validate_header_against_parent(&block, &parent_block) {
+            error!(?block, "Failed to validate header {} against parent: {e}", block.header.hash());
+            return Err(e.into())
+        }
 
         let executor = self.executor_provider.executor(StateProviderDatabase::new(&state_provider));
 


### PR DESCRIPTION
Previously we were not validating the header against its parent, and did not do things like timestamp checks.

This causes the hive `engine-api/Invalid NewPayload, Timestamp, Syncing=True, EmptyTxs=False, DynFeeTxs=False` test (and probably more) to pass.

Adds a helper method for getting a sealed header by hash.