### PR TITLE
test: live sync test to check make canonical

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2838,5 +2838,8 @@ mod tests {
             }
             _ => panic!("Unexpected event: {:#?}", event),
         }
+
+        // new head is the tip of the main chain
+        assert_eq!(test_harness.tree.state.tree_state.canonical_head().hash, main_chain_last_hash);
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1336,7 +1336,14 @@ where
             match self.insert_block(child) {
                 Ok(res) => {
                     debug!(target: "engine", child =?child_num_hash, ?res, "connected buffered block");
-                    if self.is_sync_target_head(child_num_hash.hash) {
+                    if self.is_sync_target_head(child_num_hash.hash) &&
+                        matches!(
+                            res,
+                            InsertPayloadOk::Inserted(BlockStatus::Valid(
+                                BlockAttachment::Canonical
+                            ))
+                        )
+                    {
                         self.make_canonical(child_num_hash.hash);
                     }
                 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2828,7 +2828,7 @@ mod tests {
 
         test_harness.check_fork_chain_insertion(remaining).await;
 
-        // check canonical chain commited event with the hash of the latest block
+        // check canonical chain committed event with the hash of the latest block
         let event = test_harness.from_tree_rx.recv().await.unwrap();
         match event {
             EngineApiEvent::BeaconConsensus(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2663,6 +2663,58 @@ mod tests {
         let chain_spec = MAINNET.clone();
         let mut test_harness = TestHarness::new(chain_spec.clone());
 
+        let base_chain: Vec<_> = test_harness.block_builder.get_executed_blocks(0..1).collect();
+        test_harness = test_harness.with_blocks(base_chain.clone());
+
+        test_harness
+            .fcu_to(base_chain.last().unwrap().block().hash(), ForkchoiceStatus::Valid)
+            .await;
+
+        // extend main chain but don't insert the blocks
+        let main_chain = test_harness.block_builder.create_fork(base_chain[0].block(), 10);
+
+        let main_chain_last_hash = main_chain.last().unwrap().hash();
+        test_harness.send_fcu(main_chain_last_hash, ForkchoiceStatus::Syncing).await;
+
+        test_harness.check_fcu(main_chain_last_hash, ForkchoiceStatus::Syncing).await;
+
+        // create event for backfill finished
+        let backfill_finished = FromOrchestrator::BackfillSyncFinished(ControlFlow::Continue {
+            block_number: MIN_BLOCKS_FOR_PIPELINE_RUN + 1,
+        });
+
+        test_harness.tree.on_engine_message(FromEngine::Event(backfill_finished));
+
+        let event = test_harness.from_tree_rx.recv().await.unwrap();
+        match event {
+            EngineApiEvent::Download(DownloadRequest::BlockSet(hash_set)) => {
+                assert_eq!(hash_set, HashSet::from([main_chain_last_hash]));
+            }
+            _ => panic!("Unexpected event: {:#?}", event),
+        }
+
+        test_harness.tree.on_engine_message(FromEngine::DownloadedBlocks(vec![main_chain
+            .last()
+            .unwrap()
+            .clone()]));
+
+        let event = test_harness.from_tree_rx.recv().await.unwrap();
+        match event {
+            EngineApiEvent::Download(DownloadRequest::BlockRange(initial_hash, total_blocks)) => {
+                assert_eq!(total_blocks, (main_chain.len() - 1) as u64);
+                assert_eq!(initial_hash, main_chain.last().unwrap().parent_hash);
+            }
+            _ => panic!("Unexpected event: {:#?}", event),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_engine_tree_live_sync_transition_eventually_canonical() {
+        reth_tracing::init_test_tracing();
+
+        let chain_spec = MAINNET.clone();
+        let mut test_harness = TestHarness::new(chain_spec.clone());
+
         // create base chain and setup test harness with it
         let base_chain: Vec<_> = test_harness.block_builder.get_executed_blocks(0..1).collect();
         test_harness = test_harness.with_blocks(base_chain.clone());


### PR DESCRIPTION
Towards: #10015

Adds a test to verify that the live synced blocks after a backfill sync are eventually made canonical. 

These are the steps of the test 
* creates a chain with 10 more elements than required to trigger a backfill sync
* issues a fcu request to an element of the chain that should trigger a backfill sync
* once done, issues a fcu to the ti of the chain
* verifies that the tip is made canonical.

To make it work I needed to call `make_canonical` in `try_connect_buffered_blocks` on successful insertion, otherwise, this was only done on the code path for downloaded blocks, pls let me know if this is advisable.

There's also additional refactors and improvements in `TestHarness`, like setting up the inserted headers in mock provider to properly simulate a persisted chain. 