### PR TITLE
fix: use actual latest state for BlockchainProvider2

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -6,7 +6,8 @@ use reth_primitives::{
     Account, Address, BlockNumber, Bytecode, Bytes, StorageKey, StorageValue, B256,
 };
 use reth_storage_api::{
-    AccountReader, BlockHashReader, StateProofProvider, StateProvider, StateRootProvider,
+    AccountReader, BlockHashReader, StateProofProvider, StateProvider, StateProviderBox,
+    StateRootProvider,
 };
 use reth_trie::{updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage};
 
@@ -36,6 +37,11 @@ impl MemoryOverlayStateProvider {
             hashed_post_state.extend(block.hashed_state.as_ref().clone());
         }
         Self { in_memory, hashed_post_state, historical }
+    }
+
+    /// Turn this state provider into a [`StateProviderBox`]
+    pub fn boxed(self) -> StateProviderBox {
+        Box::new(self)
     }
 }
 


### PR DESCRIPTION
Fixes at least one more hive engine test, this time we needed to actually construct the state provider for the latest block, if the latest block is in memory.

Introduces a helper method to get a state provider from a `BlockState`