### PR TITLE
Feature gate `jsonrpsee` related crates and check features powerset for `reth-rpc-types`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,4 +473,5 @@ check-features:
 		--package reth-codecs \
 		--package reth-primitives-traits \
 		--package reth-primitives \
+		--package reth-rpc-types \
 		--feature-powerset

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -15,15 +15,15 @@ workspace = true
 
 # ethereum
 alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
-alloy-rpc-types = { workspace = true, features = ["jsonrpsee-types"] }
+alloy-rpc-types = { workspace = true }
 alloy-rpc-types-admin.workspace = true
 alloy-rpc-types-anvil.workspace = true
-alloy-rpc-types-beacon.workspace = true
+alloy-rpc-types-beacon = { workspace = true, optional = true }
 alloy-rpc-types-mev.workspace = true
 alloy-rpc-types-trace.workspace = true
 alloy-rpc-types-txpool.workspace = true
 alloy-serde.workspace = true
-alloy-rpc-types-engine = { workspace = true, features = ["jsonrpsee-types"] }
+alloy-rpc-types-engine = { workspace = true, features = ["jsonrpsee-types"], optional = true }
 
 # misc
 jsonrpsee-types = { workspace = true, optional = true }
@@ -38,5 +38,11 @@ bytes.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["jsonrpsee-types"]
+default = [
+    "dep:jsonrpsee-types",
+    "dep:alloy-rpc-types-beacon",
+    "dep:alloy-rpc-types-engine",
+    "alloy-rpc-types/jsonrpsee-types",
+    "alloy-rpc-types-engine/jsonrpsee-types"
+]
 arbitrary = ["alloy-primitives/arbitrary", "alloy-rpc-types/arbitrary"]

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -38,7 +38,8 @@ bytes.workspace = true
 serde_json.workspace = true
 
 [features]
-default = [
+default = ["jsonrpsee-types-tree"]
+jsonrpsee-types-tree = [
     "dep:jsonrpsee-types",
     "dep:alloy-rpc-types-beacon",
     "dep:alloy-rpc-types-engine",

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -38,8 +38,8 @@ bytes.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["jsonrpsee-types-tree"]
-jsonrpsee-types-tree = [
+default = ["jsonrpsee-types"]
+jsonrpsee-types = [
     "dep:jsonrpsee-types",
     "dep:alloy-rpc-types-beacon",
     "dep:alloy-rpc-types-engine",

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 # ethereum
 alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
-alloy-rpc-types = { workspace = true }
+alloy-rpc-types.workspace = true
 alloy-rpc-types-admin.workspace = true
 alloy-rpc-types-anvil.workspace = true
 alloy-rpc-types-beacon = { workspace = true, optional = true }

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -1,15 +1,15 @@
 //! Implementation specific Errors for the `eth_` namespace.
 
-use jsonrpsee_types::ErrorObject;
-
 /// A trait to convert an error to an RPC error.
+#[cfg(feature = "default")]
 pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
     /// Converts the error to a JSON-RPC error object.
-    fn to_rpc_error(&self) -> ErrorObject<'static>;
+    fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static>;
 }
 
-impl ToRpcError for ErrorObject<'static> {
-    fn to_rpc_error(&self) -> ErrorObject<'static> {
+#[cfg(feature = "default")]
+impl ToRpcError for jsonrpsee_types::ErrorObject<'static> {
+    fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static> {
         self.clone()
     }
 }

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -1,13 +1,13 @@
 //! Implementation specific Errors for the `eth_` namespace.
 
 /// A trait to convert an error to an RPC error.
-#[cfg(feature = "default")]
+#[cfg(feature = "jsonrpsee-types")]
 pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
     /// Converts the error to a JSON-RPC error object.
     fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static>;
 }
 
-#[cfg(feature = "default")]
+#[cfg(feature = "jsonrpsee-types")]
 impl ToRpcError for jsonrpsee_types::ErrorObject<'static> {
     fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static> {
         self.clone()

--- a/crates/rpc/rpc-types/src/eth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod error;
 pub mod transaction;
 
 // re-export
+#[cfg(feature = "default")]
 pub use alloy_rpc_types_engine as engine;

--- a/crates/rpc/rpc-types/src/eth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/mod.rs
@@ -4,5 +4,5 @@ pub(crate) mod error;
 pub mod transaction;
 
 // re-export
-#[cfg(feature = "default")]
+#[cfg(feature = "jsonrpsee-types")]
 pub use alloy_rpc_types_engine as engine;

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -40,17 +40,20 @@ pub use alloy_rpc_types_anvil as anvil;
 pub use alloy_rpc_types_mev as mev;
 
 // re-export beacon
+#[cfg(feature = "default")]
 pub use alloy_rpc_types_beacon as beacon;
 
 // re-export txpool
 pub use alloy_rpc_types_txpool as txpool;
 
 // Ethereum specific rpc types related to typed transaction requests and the engine API.
+#[cfg(feature = "default")]
+pub use eth::error::ToRpcError;
+pub use eth::transaction::{self, TransactionRequest, TypedTransactionRequest};
+#[cfg(feature = "default")]
 pub use eth::{
     engine,
     engine::{
         ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, PayloadError,
     },
-    error::ToRpcError,
-    transaction::{self, TransactionRequest, TypedTransactionRequest},
 };

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -40,17 +40,17 @@ pub use alloy_rpc_types_anvil as anvil;
 pub use alloy_rpc_types_mev as mev;
 
 // re-export beacon
-#[cfg(feature = "default")]
+#[cfg(feature = "jsonrpsee-types")]
 pub use alloy_rpc_types_beacon as beacon;
 
 // re-export txpool
 pub use alloy_rpc_types_txpool as txpool;
 
 // Ethereum specific rpc types related to typed transaction requests and the engine API.
-#[cfg(feature = "default")]
+#[cfg(feature = "jsonrpsee-types")]
 pub use eth::error::ToRpcError;
 pub use eth::transaction::{self, TransactionRequest, TypedTransactionRequest};
-#[cfg(feature = "default")]
+#[cfg(feature = "jsonrpsee-types")]
 pub use eth::{
     engine,
     engine::{


### PR DESCRIPTION
Third frollow up of https://github.com/paradigmxyz/reth/pull/10130/

`jsonrpsee` related crates contain several dependencies that cannot be easily compiled with riscv, for instance ring v17.


This PR feature gates all `jsonrpsee` dependencies behind `default` feature