### PR TITLE
feat: ensure consistent forkchoice state always

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -684,6 +684,12 @@ where
         if self.state.tree_state.canonical_block_hash() == state.head_block_hash {
             trace!(target: "engine", "fcu head hash is already canonical");
 
+            // update the safe and finalized blocks and ensure their values are valid
+            if let Err(outcome) = self.ensure_consistent_forkchoice_state(state) {
+                // safe or finalized hashes are invalid
+                return Ok(TreeOutcome::new(outcome))
+            }
+
             // we still need to process payload attributes if the head is already canonical
             if let Some(attr) = attrs {
                 let tip = self
@@ -706,8 +712,7 @@ where
             let tip = chain_update.tip().header.clone();
             self.on_canonical_chain_update(chain_update);
 
-            // update the safe and finalized blocks and ensure their values are valid, but only
-            // after the head block is made canonical
+            // update the safe and finalized blocks and ensure their values are valid
             if let Err(outcome) = self.ensure_consistent_forkchoice_state(state) {
                 // safe or finalized hashes are invalid
                 return Ok(TreeOutcome::new(outcome))


### PR DESCRIPTION
This still needs to be checked even when the head is already the head.

Fixes the `Inconsistent Safe in ForkchoiceState` test and `Inconsistent Finalized in ForkchoiceState` hive tests