### PR TITLE
fix: use in memory state for state_by_block_number_or_tag

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -987,8 +987,7 @@ where
             BlockNumberOrTag::Pending => self.pending(),
             BlockNumberOrTag::Number(num) => {
                 let hash = self
-                    .canonical_in_memory_state
-                    .hash_by_number(num)
+                    .block_hash(num)?
                     .ok_or_else(|| ProviderError::HeaderNotFound(num.into()))?;
                 self.state_by_block_hash(hash)
             }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -965,7 +965,7 @@ where
         Ok(None)
     }
 
-    /// Returns a [StateProvider] indexed by the given block number or tag.
+    /// Returns a [`StateProvider`] indexed by the given block number or tag.
     fn state_by_block_number_or_tag(
         &self,
         number_or_tag: BlockNumberOrTag,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -965,7 +965,7 @@ where
         Ok(None)
     }
 
-    /// Returns a [`StateProvider`] indexed by the given block number or tag.
+    /// Returns a [`StateProviderBox`] indexed by the given block number or tag.
     fn state_by_block_number_or_tag(
         &self,
         number_or_tag: BlockNumberOrTag,

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -661,6 +661,38 @@ where
         state
     }
 
+    /// Returns a [StateProvider] indexed by the given block number or tag.
+    ///
+    /// Note: if a number is provided this will only look at historical(canonical) state.
+    fn state_by_block_number_or_tag(
+        &self,
+        number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
+        match number_or_tag {
+            BlockNumberOrTag::Latest => self.latest(),
+            BlockNumberOrTag::Finalized => {
+                // we can only get the finalized state by hash, not by num
+                let hash =
+                    self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
+
+                // only look at historical state
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Safe => {
+                // we can only get the safe state by hash, not by num
+                let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
+
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Earliest => self.history_by_block_number(0),
+            BlockNumberOrTag::Pending => self.pending(),
+            BlockNumberOrTag::Number(num) => {
+                // Note: The `BlockchainProvider` could also lookup the tree for the given block number, if for example the block number is `latest + 1`, however this should only support canonical state: <https://github.com/paradigmxyz/reth/issues/4515>
+                self.history_by_block_number(num)
+            }
+        }
+    }
+
     /// Returns the state provider for pending state.
     ///
     /// If there's no pending block available then the latest state provider is returned:

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -661,7 +661,7 @@ where
         state
     }
 
-    /// Returns a [`StateProvider`] indexed by the given block number or tag.
+    /// Returns a [`StateProviderBox`] indexed by the given block number or tag.
     ///
     /// Note: if a number is provided this will only look at historical(canonical) state.
     fn state_by_block_number_or_tag(

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -661,7 +661,7 @@ where
         state
     }
 
-    /// Returns a [StateProvider] indexed by the given block number or tag.
+    /// Returns a [`StateProvider`] indexed by the given block number or tag.
     ///
     /// Note: if a number is provided this will only look at historical(canonical) state.
     fn state_by_block_number_or_tag(

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -11,9 +11,10 @@ use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber,
-    BlockWithSenders, Bytecode, Bytes, Header, Receipt, SealedBlock, SealedBlockWithSenders,
-    SealedHeader, StorageKey, StorageValue, TransactionMeta, TransactionSigned,
-    TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256, U256,
+    BlockNumberOrTag, BlockWithSenders, Bytecode, Bytes, Header, Receipt, SealedBlock,
+    SealedBlockWithSenders, SealedHeader, StorageKey, StorageValue, TransactionMeta,
+    TransactionSigned, TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256,
+    U256,
 };
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{StageCheckpointReader, StateProofProvider};
@@ -692,6 +693,13 @@ impl StateProviderFactory for MockEthProvider {
     }
 
     fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn state_by_block_number_or_tag(
+        &self,
+        _number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -7,6 +7,7 @@ use std::{
 use reth_chain_state::{CanonStateNotifications, CanonStateSubscriptions};
 use reth_chainspec::{ChainInfo, ChainSpec, MAINNET};
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
+use reth_errors::ProviderError;
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
     Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag,
@@ -441,9 +442,28 @@ impl StateProviderFactory for NoopProvider {
 
     fn state_by_block_number_or_tag(
         &self,
-        _number_or_tag: BlockNumberOrTag,
+        number_or_tag: BlockNumberOrTag,
     ) -> ProviderResult<StateProviderBox> {
-        Ok(Box::new(*self))
+        match number_or_tag {
+            BlockNumberOrTag::Latest => self.latest(),
+            BlockNumberOrTag::Finalized => {
+                // we can only get the finalized state by hash, not by num
+                let hash =
+                    self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
+
+                // only look at historical state
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Safe => {
+                // we can only get the safe state by hash, not by num
+                let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
+
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Earliest => self.history_by_block_number(0),
+            BlockNumberOrTag::Pending => self.pending(),
+            BlockNumberOrTag::Number(num) => self.history_by_block_number(num),
+        }
     }
 
     fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -9,10 +9,10 @@ use reth_chainspec::{ChainInfo, ChainSpec, MAINNET};
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
-    Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, BlockWithSenders,
-    Bytecode, Bytes, Header, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
-    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash,
-    TxNumber, Withdrawal, Withdrawals, B256, U256,
+    Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber, BlockNumberOrTag,
+    BlockWithSenders, Bytecode, Bytes, Header, Receipt, SealedBlock, SealedBlockWithSenders,
+    SealedHeader, StorageKey, StorageValue, TransactionMeta, TransactionSigned,
+    TransactionSignedNoHash, TxHash, TxNumber, Withdrawal, Withdrawals, B256, U256,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
@@ -436,6 +436,13 @@ impl StateProviderFactory for NoopProvider {
     }
 
     fn pending(&self) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(*self))
+    }
+
+    fn state_by_block_number_or_tag(
+        &self,
+        _number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(*self))
     }
 

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -118,31 +118,31 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     fn state_by_block_number_or_tag(
         &self,
         number_or_tag: BlockNumberOrTag,
-    ) -> ProviderResult<StateProviderBox> {
-        match number_or_tag {
-            BlockNumberOrTag::Latest => self.latest(),
-            BlockNumberOrTag::Finalized => {
-                // we can only get the finalized state by hash, not by num
-                let hash =
-                    self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
+    ) -> ProviderResult<StateProviderBox>;
+    // match number_or_tag {
+    //     BlockNumberOrTag::Latest => self.latest(),
+    //     BlockNumberOrTag::Finalized => {
+    //         // we can only get the finalized state by hash, not by num
+    //         let hash =
+    //             self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
 
-                // only look at historical state
-                self.history_by_block_hash(hash)
-            }
-            BlockNumberOrTag::Safe => {
-                // we can only get the safe state by hash, not by num
-                let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
+    //         // only look at historical state
+    //         self.history_by_block_hash(hash)
+    //     }
+    //     BlockNumberOrTag::Safe => {
+    //         // we can only get the safe state by hash, not by num
+    //         let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
 
-                self.history_by_block_hash(hash)
-            }
-            BlockNumberOrTag::Earliest => self.history_by_block_number(0),
-            BlockNumberOrTag::Pending => self.pending(),
-            BlockNumberOrTag::Number(num) => {
-                // Note: The `BlockchainProvider` could also lookup the tree for the given block number, if for example the block number is `latest + 1`, however this should only support canonical state: <https://github.com/paradigmxyz/reth/issues/4515>
-                self.history_by_block_number(num)
-            }
-        }
-    }
+    //         self.history_by_block_hash(hash)
+    //     }
+    //     BlockNumberOrTag::Earliest => self.history_by_block_number(0),
+    //     BlockNumberOrTag::Pending => self.pending(),
+    //     BlockNumberOrTag::Number(num) => {
+    //         // Note: The `BlockchainProvider` could also lookup the tree for the given block number, if for example the block number is `latest + 1`, however this should only support canonical state: <https://github.com/paradigmxyz/reth/issues/4515>
+    //         self.history_by_block_number(num)
+    //     }
+    // }
+    // }
 
     /// Returns a historical [StateProvider] indexed by the given historic block number.
     ///

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -119,30 +119,6 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
         &self,
         number_or_tag: BlockNumberOrTag,
     ) -> ProviderResult<StateProviderBox>;
-    // match number_or_tag {
-    //     BlockNumberOrTag::Latest => self.latest(),
-    //     BlockNumberOrTag::Finalized => {
-    //         // we can only get the finalized state by hash, not by num
-    //         let hash =
-    //             self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
-
-    //         // only look at historical state
-    //         self.history_by_block_hash(hash)
-    //     }
-    //     BlockNumberOrTag::Safe => {
-    //         // we can only get the safe state by hash, not by num
-    //         let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
-
-    //         self.history_by_block_hash(hash)
-    //     }
-    //     BlockNumberOrTag::Earliest => self.history_by_block_number(0),
-    //     BlockNumberOrTag::Pending => self.pending(),
-    //     BlockNumberOrTag::Number(num) => {
-    //         // Note: The `BlockchainProvider` could also lookup the tree for the given block number, if for example the block number is `latest + 1`, however this should only support canonical state: <https://github.com/paradigmxyz/reth/issues/4515>
-    //         self.history_by_block_number(num)
-    //     }
-    // }
-    // }
 
     /// Returns a historical [StateProvider] indexed by the given historic block number.
     ///


### PR DESCRIPTION
Previously this would only look at the database, when we may want to look in memory for state. For example, in `eth_getStorageAt` we use this method. The auto implementation is removed, and implemented directly on the old tree. The new tree now uses `state_by_block_hash`.

This fixes numerous `cancun/` tests