### PR TITLE
test: engine tree live sync, FCU extends canon chain with existing blocks

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2845,6 +2845,9 @@ mod tests {
             }
             _ => panic!("Unexpected event: {:#?}", event),
         }
+
+        // new head is the tip of the main chain
+        assert_eq!(test_harness.tree.state.tree_state.canonical_head().hash, main_chain_last_hash);
     }
 
     #[tokio::test]

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2713,6 +2713,17 @@ mod tests {
             }
             _ => panic!("Unexpected event: {:#?}", event),
         }
+
+        // setting up execution outcomes for the chain, the blocks will be
+        // executed starting from the oldest, so we need to reverse.
+        let mut main_chain_rev = main_chain.clone();
+        main_chain_rev.reverse();
+        test_harness.setup_range_insertion_for_chain(main_chain_rev);
+
+        let remaining = &main_chain[..main_chain.len()];
+        test_harness.tree.on_engine_message(FromEngine::DownloadedBlocks(remaining.to_vec()));
+
+        test_harness.check_fork_chain_insertion(main_chain.clone().iter()).await;
     }
 
     #[tokio::test]

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2749,10 +2749,12 @@ mod tests {
             _ => panic!("Unexpected event: {:#?}", event),
         }
 
+        // tell engine main chain tip downloaded
         test_harness
             .tree
             .on_engine_message(FromEngine::DownloadedBlocks(vec![main_chain_last.clone()]));
 
+        // check download range request
         let event = test_harness.from_tree_rx.recv().await.unwrap();
         match event {
             EngineApiEvent::Download(DownloadRequest::BlockRange(initial_hash, total_blocks)) => {
@@ -2761,6 +2763,33 @@ mod tests {
                     (main_chain.len() - MIN_BLOCKS_FOR_PIPELINE_RUN as usize - 2) as u64
                 );
                 assert_eq!(initial_hash, main_chain_last.parent_hash);
+            }
+            _ => panic!("Unexpected event: {:#?}", event),
+        }
+
+        let remaining: Vec<_> = main_chain
+            .clone()
+            .drain((MIN_BLOCKS_FOR_PIPELINE_RUN + 1) as usize..main_chain.len())
+            .collect();
+
+        // setting up execution outcomes for the chain, the blocks will be
+        // executed starting from the oldest, so we need to reverse.
+        let mut remaining_rev = remaining.clone();
+        remaining_rev.reverse();
+        test_harness.setup_range_insertion_for_chain(remaining_rev.to_vec());
+
+        // tell engine block range downloaded
+        test_harness.tree.on_engine_message(FromEngine::DownloadedBlocks(remaining.clone()));
+
+        test_harness.check_fork_chain_insertion(remaining).await;
+
+        // check canonical chain commited event with the hash of the latest block
+        let event = test_harness.from_tree_rx.recv().await.unwrap();
+        match event {
+            EngineApiEvent::BeaconConsensus(
+                BeaconConsensusEngineEvent::CanonicalChainCommitted(header, ..),
+            ) => {
+                assert_eq!(header.hash(), main_chain_last_hash);
             }
             _ => panic!("Unexpected event: {:#?}", event),
         }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2835,7 +2835,7 @@ mod tests {
 
         test_harness.check_fork_chain_insertion(remaining).await;
 
-        // check canonical chain commited event with the hash of the latest block
+        // check canonical chain committed event with the hash of the latest block
         let event = test_harness.from_tree_rx.recv().await.unwrap();
         match event {
             EngineApiEvent::BeaconConsensus(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2125,8 +2125,7 @@ mod tests {
             ));
 
             let response = rx.await.unwrap().unwrap().await.unwrap();
-            let fcu_status = fcu_status.into();
-            match fcu_status {
+            match fcu_status.into() {
                 ForkchoiceStatus::Valid => assert!(response.payload_status.is_valid()),
                 ForkchoiceStatus::Syncing => assert!(response.payload_status.is_syncing()),
                 ForkchoiceStatus::Invalid => assert!(response.payload_status.is_invalid()),
@@ -2231,6 +2230,10 @@ mod tests {
                 execution_outcomes.push(execution_outcome);
             }
             self.extend_execution_outcome(execution_outcomes);
+        }
+
+        fn check_canon_head(&self, head_hash: B256) {
+            assert_eq!(self.tree.state.tree_state.canonical_head().hash, head_hash);
         }
     }
 
@@ -2640,27 +2643,25 @@ mod tests {
         test_harness = test_harness.with_blocks(main_chain.clone());
 
         let fork_chain = test_harness.block_builder.create_fork(main_chain[2].block(), 3);
+        let fork_chain_last_hash = fork_chain.last().unwrap().hash();
 
         // add fork blocks to the tree
         for block in &fork_chain {
             test_harness.insert_block(block.clone()).unwrap();
         }
 
-        test_harness.send_fcu(fork_chain.last().unwrap().hash(), ForkchoiceStatus::Valid).await;
+        test_harness.send_fcu(fork_chain_last_hash, ForkchoiceStatus::Valid).await;
 
         // check for ForkBlockAdded events, we expect fork_chain.len() blocks added
         test_harness.check_fork_chain_insertion(fork_chain.clone()).await;
 
         // check for CanonicalChainCommitted event
-        test_harness.check_canon_commit(fork_chain.last().unwrap().hash()).await;
+        test_harness.check_canon_commit(fork_chain_last_hash).await;
 
-        test_harness.check_fcu(fork_chain.last().unwrap().hash(), ForkchoiceStatus::Valid).await;
+        test_harness.check_fcu(fork_chain_last_hash, ForkchoiceStatus::Valid).await;
 
         // new head is the tip of the fork chain
-        assert_eq!(
-            test_harness.tree.state.tree_state.canonical_head().hash,
-            fork_chain.last().unwrap().hash()
-        );
+        test_harness.check_canon_head(fork_chain_last_hash);
     }
 
     #[tokio::test]
@@ -2836,22 +2837,14 @@ mod tests {
         test_harness.check_fork_chain_insertion(remaining).await;
 
         // check canonical chain committed event with the hash of the latest block
-        let event = test_harness.from_tree_rx.recv().await.unwrap();
-        match event {
-            EngineApiEvent::BeaconConsensus(
-                BeaconConsensusEngineEvent::CanonicalChainCommitted(header, ..),
-            ) => {
-                assert_eq!(header.hash(), main_chain_last_hash);
-            }
-            _ => panic!("Unexpected event: {:#?}", event),
-        }
+        test_harness.check_canon_commit(main_chain_last_hash).await;
 
         // new head is the tip of the main chain
-        assert_eq!(test_harness.tree.state.tree_state.canonical_head().hash, main_chain_last_hash);
+        test_harness.check_canon_head(main_chain_last_hash);
     }
 
     #[tokio::test]
-    async fn test_engine_tree_live_sync_transition_eventually_canonical() {
+    async fn test_engine_tree_live_sync_fcu_extends_canon_chain() {
         reth_tracing::init_test_tracing();
 
         let chain_spec = MAINNET.clone();
@@ -2866,122 +2859,28 @@ mod tests {
             .fcu_to(base_chain.last().unwrap().block().hash(), ForkchoiceStatus::Valid)
             .await;
 
-        // create main chain, extension of base chain, with enough blocks to
-        // trigger backfill sync
-        let main_chain = test_harness
-            .block_builder
-            .create_fork(base_chain[0].block(), MIN_BLOCKS_FOR_PIPELINE_RUN + 10);
+        // create main chain, extension of base chain
+        let main_chain = test_harness.block_builder.create_fork(base_chain[0].block(), 10);
+        // determine target in the middle of main hain
+        let target = main_chain.get(5).unwrap();
+        let target_hash = target.hash();
+        let main_last = main_chain.last().unwrap();
+        let main_last_hash = main_last.hash();
 
-        let main_chain_last = main_chain.last().unwrap();
-        let main_chain_last_hash = main_chain_last.hash();
-        let main_chain_backfill_target =
-            main_chain.get(MIN_BLOCKS_FOR_PIPELINE_RUN as usize).unwrap();
-        let main_chain_backfill_target_hash = main_chain_backfill_target.hash();
+        // insert main chain
+        test_harness.insert_chain(main_chain).await;
 
-        // fcu to the element of main chain that should trigger backfill sync
-        test_harness.send_fcu(main_chain_backfill_target_hash, ForkchoiceStatus::Syncing).await;
-        test_harness.check_fcu(main_chain_backfill_target_hash, ForkchoiceStatus::Syncing).await;
+        // send fcu to target
+        test_harness.send_fcu(target_hash, ForkchoiceStatus::Valid).await;
 
-        // check download request for target
-        let event = test_harness.from_tree_rx.recv().await.unwrap();
-        match event {
-            EngineApiEvent::Download(DownloadRequest::BlockSet(hash_set)) => {
-                assert_eq!(hash_set, HashSet::from([main_chain_backfill_target_hash]));
-            }
-            _ => panic!("Unexpected event: {:#?}", event),
-        }
+        test_harness.check_canon_commit(target_hash).await;
+        test_harness.check_fcu(target_hash, ForkchoiceStatus::Valid).await;
 
-        // send message to tell the engine the requested block was downloaded
-        test_harness.tree.on_engine_message(FromEngine::DownloadedBlocks(vec![
-            main_chain_backfill_target.clone(),
-        ]));
+        // send fcu to main tip
+        test_harness.send_fcu(main_last_hash, ForkchoiceStatus::Valid).await;
 
-        // check that backfill is triggered
-        let event = test_harness.from_tree_rx.recv().await.unwrap();
-        match event {
-            EngineApiEvent::BackfillAction(BackfillAction::Start(
-                reth_stages::PipelineTarget::Sync(target_hash),
-            )) => {
-                assert_eq!(target_hash, main_chain_backfill_target_hash);
-            }
-            _ => panic!("Unexpected event: {:#?}", event),
-        }
-
-        // persist blocks of main chain, same as the backfill operation would do
-        let backfilled_chain: Vec<_> =
-            main_chain.clone().drain(0..(MIN_BLOCKS_FOR_PIPELINE_RUN + 1) as usize).collect();
-        test_harness.persist_blocks(backfilled_chain.clone());
-
-        // setting up execution outcomes for the chain, the blocks will be
-        // executed starting from the oldest, so we need to reverse.
-        let mut backfilled_chain_rev = backfilled_chain.clone();
-        backfilled_chain_rev.reverse();
-        test_harness.setup_range_insertion_for_chain(backfilled_chain_rev.to_vec());
-
-        // send message to mark backfill finished
-        test_harness.tree.on_engine_message(FromEngine::Event(
-            FromOrchestrator::BackfillSyncFinished(ControlFlow::Continue {
-                block_number: main_chain_backfill_target.number,
-            }),
-        ));
-
-        // send fcu to the tip of main
-        test_harness.fcu_to(main_chain_last_hash, ForkchoiceStatus::Syncing).await;
-
-        let event = test_harness.from_tree_rx.recv().await.unwrap();
-        match event {
-            EngineApiEvent::Download(DownloadRequest::BlockSet(target_hash)) => {
-                assert_eq!(target_hash, HashSet::from([main_chain_last_hash]));
-            }
-            _ => panic!("Unexpected event: {:#?}", event),
-        }
-
-        // tell engine main chain tip downloaded
-        test_harness
-            .tree
-            .on_engine_message(FromEngine::DownloadedBlocks(vec![main_chain_last.clone()]));
-
-        // check download range request
-        let event = test_harness.from_tree_rx.recv().await.unwrap();
-        match event {
-            EngineApiEvent::Download(DownloadRequest::BlockRange(initial_hash, total_blocks)) => {
-                assert_eq!(
-                    total_blocks,
-                    (main_chain.len() - MIN_BLOCKS_FOR_PIPELINE_RUN as usize - 2) as u64
-                );
-                assert_eq!(initial_hash, main_chain_last.parent_hash);
-            }
-            _ => panic!("Unexpected event: {:#?}", event),
-        }
-
-        let remaining: Vec<_> = main_chain
-            .clone()
-            .drain((MIN_BLOCKS_FOR_PIPELINE_RUN + 1) as usize..main_chain.len())
-            .collect();
-
-        // setting up execution outcomes for the chain, the blocks will be
-        // executed starting from the oldest, so we need to reverse.
-        let mut remaining_rev = remaining.clone();
-        remaining_rev.reverse();
-        test_harness.setup_range_insertion_for_chain(remaining_rev.to_vec());
-
-        // tell engine block range downloaded
-        test_harness.tree.on_engine_message(FromEngine::DownloadedBlocks(remaining.clone()));
-
-        test_harness.check_fork_chain_insertion(remaining).await;
-
-        // check canonical chain committed event with the hash of the latest block
-        let event = test_harness.from_tree_rx.recv().await.unwrap();
-        match event {
-            EngineApiEvent::BeaconConsensus(
-                BeaconConsensusEngineEvent::CanonicalChainCommitted(header, ..),
-            ) => {
-                assert_eq!(header.hash(), main_chain_last_hash);
-            }
-            _ => panic!("Unexpected event: {:#?}", event),
-        }
-
-        // new head is the tip of the main chain
-        assert_eq!(test_harness.tree.state.tree_state.canonical_head().hash, main_chain_last_hash);
+        test_harness.check_canon_commit(main_last_hash).await;
+        test_harness.check_fcu(main_last_hash, ForkchoiceStatus::Valid).await;
+        test_harness.check_canon_head(main_last_hash);
     }
 }


### PR DESCRIPTION
Closes #10015

As described in #10015, I was trying to reproduce a scenario where we request to download a block already present after receiving an FCU. Given how we call `lowest_buffered_ancestor_or` in `on_forkchoice_updated` I couldn't reproduce any issue (at least for chains connected to the current head), before the call we had already tried to extend the existing canon chain.

So the test ended up exercising canon chain extension.