### PR TITLE
feat: execute downloaded blocks in batches

### DIFF
--- a/crates/engine/tree/src/tree/config.rs
+++ b/crates/engine/tree/src/tree/config.rs
@@ -4,6 +4,8 @@ const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 256;
 const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = 256;
 const DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH: u32 = 256;
 
+const DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE: usize = 4;
+
 /// The configuration of the engine tree.
 #[derive(Debug)]
 pub struct TreeConfig {
@@ -14,6 +16,8 @@ pub struct TreeConfig {
     block_buffer_limit: u32,
     /// Number of invalid headers to keep in cache.
     max_invalid_header_cache_length: u32,
+    /// Maximum number of blocks to execute sequentially in a batch.
+    max_execute_block_batch_size: usize,
 }
 
 impl Default for TreeConfig {
@@ -22,6 +26,7 @@ impl Default for TreeConfig {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
             block_buffer_limit: DEFAULT_BLOCK_BUFFER_LIMIT,
             max_invalid_header_cache_length: DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH,
+            max_execute_block_batch_size: DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE,
         }
     }
 }
@@ -32,8 +37,14 @@ impl TreeConfig {
         persistence_threshold: u64,
         block_buffer_limit: u32,
         max_invalid_header_cache_length: u32,
+        max_execute_block_batch_size: usize,
     ) -> Self {
-        Self { persistence_threshold, block_buffer_limit, max_invalid_header_cache_length }
+        Self {
+            persistence_threshold,
+            block_buffer_limit,
+            max_invalid_header_cache_length,
+            max_execute_block_batch_size,
+        }
     }
 
     /// Return the persistence threshold.
@@ -49,6 +60,11 @@ impl TreeConfig {
     /// Return the maximum invalid cache header length.
     pub const fn max_invalid_header_cache_length(&self) -> u32 {
         self.max_invalid_header_cache_length
+    }
+
+    /// Return the maximum execute block batch size.
+    pub const fn max_execute_block_batch_size(&self) -> usize {
+        self.max_execute_block_batch_size
     }
 
     /// Setter for persistence threshold.
@@ -69,6 +85,15 @@ impl TreeConfig {
         max_invalid_header_cache_length: u32,
     ) -> Self {
         self.max_invalid_header_cache_length = max_invalid_header_cache_length;
+        self
+    }
+
+    /// Setter for maximum execute block batch size.
+    pub const fn with_max_execute_block_batch_size(
+        mut self,
+        max_execute_block_batch_size: usize,
+    ) -> Self {
+        self.max_execute_block_batch_size = max_execute_block_batch_size;
         self
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2771,6 +2771,7 @@ mod tests {
 
         let chain_spec = MAINNET.clone();
         let mut test_harness = TestHarness::new(chain_spec.clone());
+        test_harness.tree.config = test_harness.tree.config.with_max_execute_block_batch_size(100);
 
         // create base chain and setup test harness with it
         let base_chain: Vec<_> = test_harness.block_builder.get_executed_blocks(0..1).collect();


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/9685

introduces another config setting for how many downloaded blocks we're allowed to execute sequentially.
the remaining blocks are sent as a followup message, so that engine requests that arrived in between are prioritized.

This prevents timeout errors on CL when we're executing a larger range of blocks