### PR TITLE
feat: introduce EngineApiRequest type

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -6,7 +6,9 @@ use crate::{
     download::{BlockDownloader, DownloadAction, DownloadOutcome},
 };
 use futures::{Stream, StreamExt};
-use reth_beacon_consensus::BeaconConsensusEngineEvent;
+use reth_beacon_consensus::{BeaconConsensusEngineEvent, BeaconEngineMessage};
+use reth_chain_state::ExecutedBlock;
+use reth_engine_primitives::EngineTypes;
 use reth_primitives::{SealedBlockWithSenders, B256};
 use std::{
     collections::HashSet,
@@ -215,6 +217,21 @@ pub enum EngineApiKind {
     Ethereum,
     /// The chain contains Optimism configuration.
     OpStack,
+}
+
+/// The request variants that the engine API handler can receive.
+#[derive(Debug)]
+pub enum EngineApiRequest<T: EngineTypes> {
+    /// A request received from the consensus engine.
+    Beacon(BeaconEngineMessage<T>),
+    /// Request to insert an already executed block, e.g. via payload building.
+    InsertExecutedBlock(ExecutedBlock),
+}
+
+impl<T: EngineTypes> From<BeaconEngineMessage<T>> for EngineApiRequest<T> {
+    fn from(msg: BeaconEngineMessage<T>) -> Self {
+        Self::Beacon(msg)
+    }
 }
 
 /// Events emitted by the engine API handler.

--- a/crates/ethereum/engine/src/service.rs
+++ b/crates/ethereum/engine/src/service.rs
@@ -6,7 +6,7 @@ use reth_db_api::database::Database;
 use reth_engine_tree::{
     backfill::PipelineSync,
     download::BasicBlockDownloader,
-    engine::{EngineApiRequestHandler, EngineHandler},
+    engine::{EngineApiRequest, EngineApiRequestHandler, EngineHandler},
     persistence::PersistenceHandle,
     tree::{EngineApiTreeHandler, TreeConfig},
 };
@@ -33,7 +33,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 /// Alias for Ethereum chain orchestrator.
 type EthServiceType<DB, Client> = ChainOrchestrator<
     EngineHandler<
-        EngineApiRequestHandler<BeaconEngineMessage<EthEngineTypes>>,
+        EngineApiRequestHandler<EngineApiRequest<EthEngineTypes>>,
         UnboundedReceiverStream<BeaconEngineMessage<EthEngineTypes>>,
         BasicBlockDownloader<Client>,
     >,


### PR DESCRIPTION
closes #10098

this makes it possible to introduce additional request variants that the tree can handle, for example insert an executed block manually, which will be useful if we want to insert our own built block