### PR TITLE
fix: dont reset build interval when block finished

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -184,6 +184,7 @@ where
             pool: self.pool.clone(),
             executor: self.executor.clone(),
             deadline,
+            // ticks immediately
             interval: tokio::time::interval(self.config.interval),
             best_payload: None,
             pending_block: None,

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -423,23 +423,20 @@ where
         // poll the pending block
         if let Some(mut fut) = this.pending_block.take() {
             match fut.poll_unpin(cx) {
-                Poll::Ready(Ok(outcome)) => {
-                    this.interval.reset();
-                    match outcome {
-                        BuildOutcome::Better { payload, cached_reads } => {
-                            this.cached_reads = Some(cached_reads);
-                            debug!(target: "payload_builder", value = %payload.fees(), "built better payload");
-                            this.best_payload = Some(payload);
-                        }
-                        BuildOutcome::Aborted { fees, cached_reads } => {
-                            this.cached_reads = Some(cached_reads);
-                            trace!(target: "payload_builder", worse_fees = %fees, "skipped payload build of worse block");
-                        }
-                        BuildOutcome::Cancelled => {
-                            unreachable!("the cancel signal never fired")
-                        }
+                Poll::Ready(Ok(outcome)) => match outcome {
+                    BuildOutcome::Better { payload, cached_reads } => {
+                        this.cached_reads = Some(cached_reads);
+                        debug!(target: "payload_builder", value = %payload.fees(), "built better payload");
+                        this.best_payload = Some(payload);
                     }
-                }
+                    BuildOutcome::Aborted { fees, cached_reads } => {
+                        this.cached_reads = Some(cached_reads);
+                        trace!(target: "payload_builder", worse_fees = %fees, "skipped payload build of worse block");
+                    }
+                    BuildOutcome::Cancelled => {
+                        unreachable!("the cancel signal never fired")
+                    }
+                },
                 Poll::Ready(Err(error)) => {
                     // job failed, but we simply try again next interval
                     debug!(target: "payload_builder", %error, "payload build attempt failed");


### PR DESCRIPTION
closes #10165

this would delay the next payload job for a full tick, which is not what we want, we want this to be at most 1 tick and since we expect that time(payload) < `interval` this trigger a job again after `interval - time(payload)` after the payload was built.
