### PR TITLE
feat: support ms for --builder.interval

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -441,8 +441,10 @@ Builder:
 
           [default: 30000000]
 
-      --builder.interval <SECONDS>
-          The interval at which the job should build a new payload after the last (in seconds)
+      --builder.interval <DURATION>
+          The interval at which the job should build a new payload after the last.
+
+          Interval is specified in seconds or in milliseconds if the value ends with `ms`: * `50ms` -> 50 milliseconds * `1` -> 1 second
 
           [default: 1]
 

--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -14,7 +14,10 @@ pub use load_secret_key::get_secret_key;
 
 /// Cli parsers functions.
 pub mod parsers;
-pub use parsers::{hash_or_num_value_parser, parse_duration_from_secs, parse_socket_address};
+pub use parsers::{
+    hash_or_num_value_parser, parse_duration_from_secs, parse_duration_from_secs_or_ms,
+    parse_socket_address,
+};
 
 #[cfg(all(unix, any(target_env = "gnu", target_os = "macos")))]
 pub mod sigsegv_handler;

--- a/crates/cli/util/src/parsers.rs
+++ b/crates/cli/util/src/parsers.rs
@@ -12,6 +12,23 @@ pub fn parse_duration_from_secs(arg: &str) -> eyre::Result<Duration, std::num::P
     Ok(Duration::from_secs(seconds))
 }
 
+/// Helper to parse a [Duration] from seconds if it's a number or milliseconds if the input contains
+/// a `ms` suffix:
+///  * `5ms` -> 5 milliseconds
+///  * `5` -> 5 seconds
+///  * `5s` -> 5 seconds
+pub fn parse_duration_from_secs_or_ms(
+    arg: &str,
+) -> eyre::Result<Duration, std::num::ParseIntError> {
+    if arg.ends_with("ms") {
+        arg.trim_end_matches("ms").parse::<u64>().map(Duration::from_millis)
+    } else if arg.ends_with('s') {
+        arg.trim_end_matches('s').parse::<u64>().map(Duration::from_secs)
+    } else {
+        arg.parse::<u64>().map(Duration::from_secs)
+    }
+}
+
 /// Parse [`BlockHashOrNumber`]
 pub fn hash_or_num_value_parser(value: &str) -> eyre::Result<BlockHashOrNumber, eyre::Error> {
     match B256::from_str(value) {
@@ -92,5 +109,19 @@ mod tests {
             assert!(socket_addr.ip().is_loopback());
             assert_eq!(socket_addr.port(), port);
         }
+    }
+
+    #[test]
+    fn parse_ms_or_seconds() {
+        let ms = parse_duration_from_secs_or_ms("5ms").unwrap();
+        assert_eq!(ms, Duration::from_millis(5));
+
+        let seconds = parse_duration_from_secs_or_ms("5").unwrap();
+        assert_eq!(seconds, Duration::from_secs(5));
+
+        let seconds = parse_duration_from_secs_or_ms("5s").unwrap();
+        assert_eq!(seconds, Duration::from_secs(5));
+
+        assert!(parse_duration_from_secs_or_ms("5ns").is_err());
     }
 }


### PR DESCRIPTION
closes #10167

this is non breaking change that adds support for --builder.interval with `ms` suffix