### PR TITLE
feat: use in memory state for header_td

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -194,7 +194,11 @@ where
     }
 
     fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
-        self.database.header_td(hash)
+        if let Some(num) = self.block_number(*hash)? {
+            self.header_td_by_number(num)
+        } else {
+            Ok(None)
+        }
     }
 
     fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/10180

This first converts the hash to a number, and uses the existing `header_td_by_number` method to get the td.