### PR TITLE
chore: allocate for encoded txs

### DIFF
--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -112,7 +112,7 @@ where
         {
             let l1_block_info = self.block_info.l1_block_info.read().clone();
 
-            let mut encoded = Vec::new();
+            let mut encoded = Vec::with_capacity(valid_tx.transaction().encoded_length());
             valid_tx.transaction().clone().into().encode_enveloped(&mut encoded);
 
             let cost_addition = match l1_block_info.l1_tx_data_fee(


### PR DESCRIPTION
we know the exact length and can pre allocate