### PR TITLE
refactor: derive `PartialEq` for `CanonStateNotification`

### DIFF
--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -60,42 +60,36 @@ impl Stream for CanonStateNotificationStream {
     }
 }
 
-/// Chain action that is triggered when a new block is imported or old block is reverted.
-/// and will return all `ExecutionOutcome` and
-/// [`reth_primitives::SealedBlockWithSenders`] of both reverted and committed blocks.
-#[derive(Clone, Debug)]
+/// A notification that is sent when a new block is imported, or an old block is reverted.
+///
+/// The notification contains at least one [`Chain`] with the imported segment. If some blocks were
+/// reverted (e.g. during a reorg), the old chain is also returned.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CanonStateNotification {
-    /// Chain got extended without reorg and only new chain is returned.
+    /// The canonical chain was extended.
     Commit {
-        /// The newly extended chain.
+        /// The newly added chain segment.
         new: Arc<Chain>,
     },
-    /// Chain reorgs and both old and new chain are returned.
-    /// Revert is just a subset of reorg where the new chain is empty.
+    /// A chain segment was reverted or reorged.
+    ///
+    /// - In the case of a reorg, the reverted blocks are present in `old`, and the new blocks are
+    ///   present in `new`.
+    /// - In the case of a revert, the reverted blocks are present in `old`, and `new` is an empty
+    ///   chain segment.
     Reorg {
-        /// The old chain before reorganization.
+        /// The chain segment that was reverted.
         old: Arc<Chain>,
-        /// The new chain after reorganization.
+        /// The chain segment that was added on top of the canonical chain, minus the reverted
+        /// blocks.
+        ///
+        /// In the case of a revert, not a reorg, this chain segment is empty.
         new: Arc<Chain>,
     },
-}
-
-// For one reason or another, the compiler can't derive PartialEq for CanonStateNotification.
-// so we are forced to implement it manually.
-impl PartialEq for CanonStateNotification {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Reorg { old: old1, new: new1 }, Self::Reorg { old: old2, new: new2 }) => {
-                old1 == old2 && new1 == new2
-            }
-            (Self::Commit { new: new1 }, Self::Commit { new: new2 }) => new1 == new2,
-            _ => false,
-        }
-    }
 }
 
 impl CanonStateNotification {
-    /// Get old chain if any.
+    /// Get the chain segment that was reverted, if any.
     pub fn reverted(&self) -> Option<Arc<Chain>> {
         match self {
             Self::Commit { .. } => None,
@@ -103,16 +97,14 @@ impl CanonStateNotification {
         }
     }
 
-    /// Get the new chain if any.
-    ///
-    /// Returns the new committed [Chain] for [`Self::Reorg`] and [`Self::Commit`] variants.
+    /// Get the newly imported chain segment, if any.
     pub fn committed(&self) -> Arc<Chain> {
         match self {
             Self::Commit { new } | Self::Reorg { new, .. } => new.clone(),
         }
     }
 
-    /// Returns the new tip of the chain.
+    /// Get the new tip of the chain.
     ///
     /// Returns the new tip for [`Self::Reorg`] and [`Self::Commit`] variants which commit at least
     /// 1 new block.
@@ -122,9 +114,11 @@ impl CanonStateNotification {
         }
     }
 
-    /// Return receipt with its block number and transaction hash.
+    /// Get receipts in the reverted and newly imported chain segments with their corresponding
+    /// block numbers and transaction hashes.
     ///
-    /// Last boolean is true if receipt is from reverted block.
+    /// The boolean in the tuple (2nd element) denotes whether the receipt was from the reverted
+    /// chain segment.
     pub fn block_receipts(&self) -> Vec<(BlockReceipts, bool)> {
         let mut receipts = Vec::new();
 


### PR DESCRIPTION
For some reason we couldn't derive `PartialEq` for `CanonStateNotification` before, but we can now.

Also cleans up some docs.