### PR TITLE
fix: add requests root when converting alloy header

### DIFF
--- a/crates/primitives-traits/src/alloy_compat.rs
+++ b/crates/primitives-traits/src/alloy_compat.rs
@@ -41,8 +41,7 @@ impl TryFrom<RpcHeader> for Header {
             timestamp: header.timestamp,
             transactions_root: header.transactions_root,
             withdrawals_root: header.withdrawals_root,
-            // TODO: requests_root: header.requests_root,
-            requests_root: None,
+            requests_root: header.requests_root,
         })
     }
 }


### PR DESCRIPTION
We have `requests_root` in Alloy's RPC header now so we can finish this conversion