### PR TITLE
`reth-eth-types`: Do not import `JsInspectorError` by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,7 +357,7 @@ reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }
 reth-rpc-builder = { path = "crates/rpc/rpc-builder" }
 reth-rpc-engine-api = { path = "crates/rpc/rpc-engine-api" }
 reth-rpc-eth-api = { path = "crates/rpc/rpc-eth-api" }
-reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types" }
+reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = false }
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-types = { path = "crates/rpc/rpc-types" }

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -55,4 +55,5 @@ optimism = [
     "reth-primitives/optimism",
     "revm/optimism",
     "reth-provider/optimism",
+    "reth-rpc-eth-types/js-tracer",
 ]

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -27,7 +27,7 @@ reth-tasks = { workspace = true, features = ["rayon"] }
 reth-transaction-pool.workspace = true
 reth-chainspec.workspace = true
 reth-execution-types.workspace = true
-reth-rpc-eth-types.workspace = true
+reth-rpc-eth-types = { workspace = true, features = ["js-tracer"] }
 reth-rpc-server-types.workspace = true
 reth-network-api.workspace = true
 
@@ -55,5 +55,4 @@ optimism = [
     "reth-primitives/optimism",
     "revm/optimism",
     "reth-provider/optimism",
-    "reth-rpc-eth-types/js-tracer",
 ]

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -31,7 +31,7 @@ reth-trie.workspace = true
 # ethereum
 alloy-sol-types.workspace = true
 revm.workspace = true
-revm-inspectors = { workspace = true }
+revm-inspectors.workspace
 revm-primitives = { workspace = true, features = ["dev"] }
 
 # rpc

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -31,7 +31,7 @@ reth-trie.workspace = true
 # ethereum
 alloy-sol-types.workspace = true
 revm.workspace = true
-revm-inspectors = { workspace = true, features = ["js-tracer"] }
+revm-inspectors = { workspace = true }
 revm-primitives = { workspace = true, features = ["dev"] }
 
 # rpc
@@ -56,3 +56,8 @@ tracing.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+
+[features]
+default = ["js_tracer_errors"]
+js_tracer_errors = ["revm-inspectors/js-tracer"]

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -31,7 +31,7 @@ reth-trie.workspace = true
 # ethereum
 alloy-sol-types.workspace = true
 revm.workspace = true
-revm-inspectors.workspace
+revm-inspectors.workspace = true
 revm-primitives = { workspace = true, features = ["dev"] }
 
 # rpc

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -59,5 +59,5 @@ serde_json.workspace = true
 
 
 [features]
-default = ["js_tracer_errors"]
-js_tracer_errors = ["revm-inspectors/js-tracer"]
+default = ["js-tracer"]
+js-tracer = ["revm-inspectors/js-tracer"]

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -16,7 +16,9 @@ use reth_transaction_pool::error::{
     PoolTransactionError,
 };
 use revm::primitives::{EVMError, ExecutionResult, HaltReason, OutOfGasError};
-use revm_inspectors::tracing::{js::JsInspectorError, MuxError};
+use revm_inspectors::tracing::MuxError;
+#[cfg(feature = "js_tracer_errors")]
+use revm_inspectors::tracing::{js::JsInspectorError};
 use tracing::error;
 
 /// Result alias
@@ -191,6 +193,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     }
 }
 
+#[cfg(feature = "js_tracer_errors")]
 impl From<JsInspectorError> for EthApiError {
     fn from(error: JsInspectorError) -> Self {
         match error {

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -16,9 +16,9 @@ use reth_transaction_pool::error::{
     PoolTransactionError,
 };
 use revm::primitives::{EVMError, ExecutionResult, HaltReason, OutOfGasError};
-use revm_inspectors::tracing::MuxError;
 #[cfg(feature = "js_tracer_errors")]
-use revm_inspectors::tracing::{js::JsInspectorError};
+use revm_inspectors::tracing::js::JsInspectorError;
+use revm_inspectors::tracing::MuxError;
 use tracing::error;
 
 /// Result alias

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -16,7 +16,7 @@ use reth_transaction_pool::error::{
     PoolTransactionError,
 };
 use revm::primitives::{EVMError, ExecutionResult, HaltReason, OutOfGasError};
-#[cfg(feature = "js_tracer_errors")]
+#[cfg(feature = "js-tracer")]
 use revm_inspectors::tracing::js::JsInspectorError;
 use revm_inspectors::tracing::MuxError;
 use tracing::error;
@@ -193,7 +193,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     }
 }
 
-#[cfg(feature = "js_tracer_errors")]
+#[cfg(feature = "js-tracer")]
 impl From<JsInspectorError> for EthApiError {
     fn from(error: JsInspectorError) -> Self {
         match error {

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -30,7 +30,7 @@ reth-rpc-types-compat.workspace = true
 revm-inspectors = { workspace = true, features = ["js-tracer"] }
 reth-network-peers = { workspace = true, features = ["secp256k1"] }
 reth-evm.workspace = true
-reth-rpc-eth-types.workspace = true
+reth-rpc-eth-types = { workspace = true, features = ["js-tracer"] }
 reth-rpc-server-types.workspace = true
 reth-node-api.workspace = true
 reth-network-types.workspace = true
@@ -91,5 +91,4 @@ optimism = [
     "reth-provider/optimism",
     "reth-rpc-eth-api/optimism",
     "reth-revm/optimism",
-    "reth-rpc-eth-types/js-tracer",
 ]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -91,4 +91,5 @@ optimism = [
     "reth-provider/optimism",
     "reth-rpc-eth-api/optimism",
     "reth-revm/optimism",
+    "reth-rpc-eth-types/js-tracer",
 ]


### PR DESCRIPTION
For purpose of serving EthApiErrors in RPC for sovereign rollup I use `reth-eth-types` crate. 

As it was fixed to using it in https://github.com/paradigmxyz/reth/pull/10175

This PR removes approximately 42 dependencies from my tree if I use this crate without default features.

```
git diff | grep '\-name'
-name = "boa_ast"
-name = "boa_engine"
-name = "boa_gc"
-name = "boa_interner"
-name = "boa_macros"
-name = "boa_parser"
-name = "boa_profiler"
-name = "boa_string"
-name = "fast-float"
-name = "icu_collections"
-name = "icu_locid"
-name = "icu_locid_transform"
-name = "icu_locid_transform_data"
-name = "icu_normalizer"
-name = "icu_normalizer_data"
-name = "icu_properties"
-name = "icu_properties_data"
-name = "icu_provider"
-name = "icu_provider_macros"
-name = "intrusive-collections"
-name = "litemap"
-name = "memoffset"
-name = "num_threads"
-name = "phf_generator"
-name = "phf_macros"
-name = "pollster"
-name = "regress"
-name = "ryu-js"
-name = "sptr"
-name = "synstructure"
-name = "thin-vec"
-name = "tinystr"
-name = "utf16_iter"
-name = "utf8_iter"
-name = "write16"
-name = "writeable"
-name = "yoke"
-name = "yoke-derive"
-name = "zerofrom"
-name = "zerofrom-derive"
-name = "zerovec"
-name = "zerovec-derive"
```

Another approach might be modifying `revm-inspectors` and have JsError not to be feature gated, so then `reth-eth-types` can import it without default features.