### PR TITLE
Bump tokio version to mitigate default error in `reth-chain-state`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,7 +481,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 # tokio
-tokio = { version = "1.21", default-features = false }
+tokio = { version = "1.37", default-features = false }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["codec"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,7 +481,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 # tokio
-tokio = { version = "1.37", default-features = false }
+tokio = { version = "1.39", default-features = false }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["codec"] }
 


### PR DESCRIPTION

As described in https://github.com/paradigmxyz/reth/issues/10206


First commit fails showing the problem