### PR TITLE
fix: detect invalid buffered block when insert fails

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1392,7 +1392,7 @@ where
                 Err(err) => {
                     debug!(target: "engine", ?err, "failed to connect buffered block to tree");
                     if let Err(fatal) = self.on_insert_block_error(err) {
-                        warn!(target: "engine", ?fatal, "fatal error occurred while connecting buffered blocks");
+                        warn!(target: "engine", %fatal, "fatal error occurred while connecting buffered blocks");
                     }
                 }
             }
@@ -1638,7 +1638,7 @@ where
             Err(err) => {
                 debug!(target: "engine", err=%err.kind(), "failed to insert downloaded block");
                 if let Err(fatal) = self.on_insert_block_error(err) {
-                    warn!(target: "engine", ?fatal, "fatal error occurred while inserting downloaded block");
+                    warn!(target: "engine", %fatal, "fatal error occurred while inserting downloaded block");
                 }
             }
         }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1391,11 +1391,14 @@ where
                 }
                 Err(err) => {
                     debug!(target: "engine", ?err, "failed to connect buffered block to tree");
+                    if let Err(fatal) = self.on_insert_block_error(err) {
+                        warn!(target: "engine", ?fatal, "fatal error occurred while connecting buffered blocks");
+                    }
                 }
             }
         }
 
-        debug!(target: "engine", elapsed = ?now.elapsed(), %block_count ,"connected buffered blocks");
+        debug!(target: "engine", elapsed = ?now.elapsed(), %block_count, "connected buffered blocks");
     }
 
     /// Attempts to recover the block's senders and then buffers it.
@@ -1634,6 +1637,9 @@ where
             }
             Err(err) => {
                 debug!(target: "engine", err=%err.kind(), "failed to insert downloaded block");
+                if let Err(fatal) = self.on_insert_block_error(err) {
+                    warn!(target: "engine", ?fatal, "fatal error occurred while inserting downloaded block");
+                }
             }
         }
         None


### PR DESCRIPTION
This progresses us further in the `Invalid Missing Ancestor Syncing ReOrg` test, and allows us to actually detect the invalid ancestor block. Instead of just `debug` logging on each insert block error, we now perform the `on_insert_block_error` check whenever we get an error. This will inspect the error and insert it into the invalid headers cache if it was an actual invalid block.