### PR TITLE
chore: use exact max full peer count or round

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -421,7 +421,7 @@ where
 
         // send full transactions to a fraction of the connected peers (square root of the total
         // number of connected peers)
-        let max_num_full = (self.peers.len() as f64).sqrt() as usize + 1;
+        let max_num_full = (self.peers.len() as f64).sqrt().round() as usize;
 
         // Note: Assuming ~random~ order due to random state of the peers map hasher
         for (peer_idx, (peer_id, peer)) in self.peers.iter_mut().enumerate() {


### PR DESCRIPTION
the + 1 skews the number of peers we should send txs in full if the sqrt is exact `sqrt(4) + 1` is 3 and we already do `>`, so we would send txs in full to all peers

https://github.com/paradigmxyz/reth/blob/05361de1c423f9165bfb3f5f18b1ace1d9498384/crates/net/network/src/transactions/mod.rs#L457-L457