### PR TITLE
evm: add unit tests for `ConfigureEvm` trait

### DIFF
--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -38,3 +38,6 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = []
+optimism = [
+    "reth-primitives/optimism",
+]

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -38,4 +38,3 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = []
-optimism = []

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -38,6 +38,4 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = []
-optimism = [
-    "reth-primitives/optimism",
-]
+optimism = []

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -248,7 +248,7 @@ mod tests {
             handler_cfg: Default::default(),
         };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+        let evm = evm_config.evm_with_env(db, env_with_handler);
 
         // Check that the EVM environment is initialized with the custom environment
         assert_eq!(evm.context.evm.inner.env.cfg, cfg);
@@ -293,12 +293,11 @@ mod tests {
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let mut handler_cfg = HandlerCfg::default();
-        handler_cfg.spec_id = SpecId::CONSTANTINOPLE;
+        let handler_cfg = HandlerCfg { spec_id: SpecId::CONSTANTINOPLE, ..Default::default() };
 
         let env_with_handler = EnvWithHandlerCfg { env: Box::new(Env::default()), handler_cfg };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+        let evm = evm_config.evm_with_env(db, env_with_handler);
 
         // Check that the spec ID is setup properly
         assert_eq!(evm.handler.spec_id(), SpecId::CONSTANTINOPLE);

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -133,9 +133,7 @@ mod tests {
         db::{CacheDB, EmptyDBTyped},
         JournaledState,
     };
-    use revm_primitives::CfgEnvWithHandlerCfg;
-    #[cfg(not(feature = "optimism"))]
-    use revm_primitives::{EnvWithHandlerCfg, HandlerCfg};
+    use revm_primitives::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
     use std::collections::HashSet;
 
     #[test]
@@ -215,7 +213,6 @@ mod tests {
         assert!(evm.context.evm.inner.valid_authorizations.is_empty());
     }
 
-    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_env_default_spec() {
         let evm_config = EthEvmConfig::default();
@@ -233,7 +230,6 @@ mod tests {
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
     }
 
-    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_env_custom_cfg() {
         let evm_config = EthEvmConfig::default();
@@ -261,7 +257,6 @@ mod tests {
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
     }
 
-    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_env_custom_block_and_tx() {
         let evm_config = EthEvmConfig::default();
@@ -292,17 +287,16 @@ mod tests {
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
     }
 
-    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_spec_id() {
         let evm_config = EthEvmConfig::default();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env::default()),
-            handler_cfg: HandlerCfg { spec_id: SpecId::CONSTANTINOPLE },
-        };
+        let mut handler_cfg = HandlerCfg::default();
+        handler_cfg.spec_id = SpecId::CONSTANTINOPLE;
+
+        let env_with_handler = EnvWithHandlerCfg { env: Box::new(Env::default()), handler_cfg };
 
         let evm = evm_config.evm_with_env(db, env_with_handler.clone());
 

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -123,22 +123,45 @@ impl ConfigureEvm for EthEvmConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_chainspec::ChainSpec;
+    use reth_chainspec::{Chain, ChainSpec};
+    use reth_evm::execute::ProviderError;
     use reth_primitives::{
         revm_primitives::{BlockEnv, CfgEnv, SpecId},
-        Header, U256,
+        Genesis, Header, B256, KECCAK_EMPTY, U256,
     };
-    use revm_primitives::CfgEnvWithHandlerCfg;
+    use reth_revm::{
+        db::{CacheDB, EmptyDBTyped},
+        JournaledState,
+    };
+    use revm_primitives::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
+    use std::collections::HashSet;
 
     #[test]
-    #[ignore]
     fn test_fill_cfg_and_block_env() {
+        // Create a new configuration environment
         let mut cfg_env = CfgEnvWithHandlerCfg::new_with_spec_id(CfgEnv::default(), SpecId::LATEST);
+
+        // Create a default block environment
         let mut block_env = BlockEnv::default();
+
+        // Create a default header
         let header = Header::default();
-        let chain_spec = ChainSpec::default();
+
+        // Build the ChainSpec for Ethereum mainnet, activating London, Paris, and Shanghai
+        // hardforks
+        let chain_spec = ChainSpec::builder()
+            .chain(Chain::mainnet())
+            .genesis(Genesis::default())
+            .london_activated()
+            .paris_activated()
+            .shanghai_activated()
+            .build();
+
+        // Define the total difficulty as zero (default)
         let total_difficulty = U256::ZERO;
 
+        // Use the `EthEvmConfig` to fill the `cfg_env` and `block_env` based on the ChainSpec,
+        // Header, and total difficulty
         EthEvmConfig::default().fill_cfg_and_block_env(
             &mut cfg_env,
             &mut block_env,
@@ -147,6 +170,137 @@ mod tests {
             total_difficulty,
         );
 
+        // Assert that the chain ID in the `cfg_env` is correctly set to the chain ID of the
+        // ChainSpec
         assert_eq!(cfg_env.chain_id, chain_spec.chain().id());
+    }
+
+    #[test]
+    fn test_fill_cfg_and_block_env1() {
+        // Create a default `EthEvmConfig`
+        let evm_config = EthEvmConfig::default();
+
+        // Initialize an empty database wrapped in CacheDB
+        let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
+
+        // Create an EVM instance using the configuration and the database
+        let evm = evm_config.evm(db);
+
+        // Check that the EVM environment is initialized with default values
+        assert_eq!(evm.context.evm.inner.env, Box::new(Default::default()));
+
+        // Latest spec ID and no warm preloaded addresses
+        assert_eq!(
+            evm.context.evm.inner.journaled_state,
+            JournaledState::new(SpecId::LATEST, HashSet::default())
+        );
+
+        // Ensure that the accounts database is empty
+        assert!(evm.context.evm.inner.db.accounts.is_empty());
+
+        // Ensure that the block hashes database is empty
+        assert!(evm.context.evm.inner.db.block_hashes.is_empty());
+
+        // Verify that there are two default contracts in the contracts database
+        assert_eq!(evm.context.evm.inner.db.contracts.len(), 2);
+        assert!(evm.context.evm.inner.db.contracts.contains_key(&KECCAK_EMPTY));
+        assert!(evm.context.evm.inner.db.contracts.contains_key(&B256::ZERO));
+
+        // Ensure that the logs database is empty
+        assert!(evm.context.evm.inner.db.logs.is_empty());
+
+        // Ensure that there are no valid authorizations in the EVM context
+        assert!(evm.context.evm.inner.valid_authorizations.is_empty());
+    }
+
+    #[test]
+    fn test_evm_with_env_default_spec() {
+        let evm_config = EthEvmConfig::default();
+
+        let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
+
+        let env_with_handler = EnvWithHandlerCfg::default();
+
+        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+
+        // Check that the EVM environment
+        assert_eq!(evm.context.evm.env, env_with_handler.env);
+
+        // Default spec ID
+        assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
+    }
+
+    #[test]
+    fn test_evm_with_env_custom_cfg() {
+        let evm_config = EthEvmConfig::default();
+
+        let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
+
+        // Create a custom configuration environment with a chain ID of 111
+        let cfg = CfgEnv::default().with_chain_id(111);
+
+        let env_with_handler = EnvWithHandlerCfg {
+            env: Box::new(Env {
+                cfg: cfg.clone(),
+                block: BlockEnv::default(),
+                tx: TxEnv::default(),
+            }),
+            handler_cfg: Default::default(),
+        };
+
+        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+
+        // Check that the EVM environment is initialized with the custom environment
+        assert_eq!(evm.context.evm.inner.env.cfg, cfg);
+
+        // Default spec ID
+        assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
+    }
+
+    #[test]
+    fn test_evm_with_env_custom_block_and_tx() {
+        let evm_config = EthEvmConfig::default();
+
+        let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
+
+        // Create customs block and tx env
+        let block = BlockEnv {
+            basefee: U256::from(1000),
+            gas_limit: U256::from(10_000_000),
+            number: U256::from(42),
+            ..Default::default()
+        };
+        let tx = TxEnv { gas_limit: 5_000_000, gas_price: U256::from(50), ..Default::default() };
+
+        let env_with_handler = EnvWithHandlerCfg {
+            env: Box::new(Env { cfg: CfgEnv::default(), block, tx }),
+            handler_cfg: Default::default(),
+        };
+
+        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+
+        // Verify that the block and transaction environments are set correctly
+        assert_eq!(evm.context.evm.env.block, env_with_handler.env.block);
+        assert_eq!(evm.context.evm.env.tx, env_with_handler.env.tx);
+
+        // Default spec ID
+        assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
+    }
+
+    #[test]
+    fn test_evm_with_spec_id() {
+        let evm_config = EthEvmConfig::default();
+
+        let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
+
+        let env_with_handler = EnvWithHandlerCfg {
+            env: Box::new(Env::default()),
+            handler_cfg: HandlerCfg { spec_id: SpecId::CONSTANTINOPLE },
+        };
+
+        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+
+        // Check that the spec ID is setup properly
+        assert_eq!(evm.handler.spec_id(), SpecId::CONSTANTINOPLE);
     }
 }

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -133,7 +133,9 @@ mod tests {
         db::{CacheDB, EmptyDBTyped},
         JournaledState,
     };
-    use revm_primitives::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
+    use revm_primitives::CfgEnvWithHandlerCfg;
+    #[cfg(not(feature = "optimism"))]
+    use revm_primitives::{EnvWithHandlerCfg, HandlerCfg};
     use std::collections::HashSet;
 
     #[test]
@@ -187,7 +189,7 @@ mod tests {
         let evm = evm_config.evm(db);
 
         // Check that the EVM environment is initialized with default values
-        assert_eq!(evm.context.evm.inner.env, Box::new(Default::default()));
+        assert_eq!(evm.context.evm.inner.env, Box::default());
 
         // Latest spec ID and no warm preloaded addresses
         assert_eq!(

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_cfg_and_block_env1() {
+    fn test_evm_configure() {
         // Create a default `EthEvmConfig`
         let evm_config = EthEvmConfig::default();
 
@@ -213,6 +213,7 @@ mod tests {
         assert!(evm.context.evm.inner.valid_authorizations.is_empty());
     }
 
+    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_env_default_spec() {
         let evm_config = EthEvmConfig::default();
@@ -230,6 +231,7 @@ mod tests {
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
     }
 
+    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_env_custom_cfg() {
         let evm_config = EthEvmConfig::default();
@@ -257,6 +259,7 @@ mod tests {
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
     }
 
+    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_env_custom_block_and_tx() {
         let evm_config = EthEvmConfig::default();
@@ -287,6 +290,7 @@ mod tests {
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
     }
 
+    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_evm_with_spec_id() {
         let evm_config = EthEvmConfig::default();


### PR DESCRIPTION
To try to avoid scenarios like the one mentioned in #10210, unit tests have started to be added for the `ConfigureEvm` trait for Eth configuration. Follow up PRs will cover:
- More tests for missing methods.
- Additional tests for the Optimism cfg.