### PR TITLE
chore: remove reference to EngineApiTreeHandlerImpl

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -402,7 +402,7 @@ where
     E: BlockExecutorProvider,
     T: EngineTypes,
 {
-    /// Creates a new `EngineApiTreeHandlerImpl`.
+    /// Creates a new [`EngineApiTreeHandler`].
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         provider: P,


### PR DESCRIPTION
That type no longer exists, also make it an actual link