### PR TITLE
chore: remove WriteTransactions from PersistenceAction

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -3,13 +3,10 @@
 use reth_chain_state::ExecutedBlock;
 use reth_db::Database;
 use reth_errors::ProviderError;
-use reth_primitives::{SealedBlock, B256};
+use reth_primitives::B256;
 use reth_provider::{writer::UnifiedStorageWriter, ProviderFactory, StaticFileProviderFactory};
 use reth_prune::{Pruner, PrunerError, PrunerOutput};
-use std::sync::{
-    mpsc::{Receiver, SendError, Sender},
-    Arc,
-};
+use std::sync::mpsc::{Receiver, SendError, Sender};
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tracing::{debug, error};
@@ -95,15 +92,6 @@ where
                     // we ignore the error because the caller may or may not care about the result
                     let _ = sender.send(res);
                 }
-                PersistenceAction::WriteTransactions(_block, _sender) => {
-                    unimplemented!()
-                    // let (block_num, td) =
-                    //     self.write_transactions(block).expect("todo: handle errors");
-                    // self.update_transaction_meta(block_num, td).expect("todo: handle errors");
-
-                    // // we ignore the error because the caller may or may not care about the
-                    // result let _ = sender.send(());
-                }
             }
         }
         Ok(())
@@ -131,13 +119,6 @@ pub enum PersistenceAction {
     /// First, header, transaction, and receipt-related data should be written to static files.
     /// Then the execution history-related data will be written to the database.
     SaveBlocks(Vec<ExecutedBlock>, oneshot::Sender<Option<B256>>),
-
-    /// The given block has been added to the canonical chain, its transactions and headers will be
-    /// persisted for durability.
-    ///
-    /// This will first append the header and transactions to static files, then update the
-    /// checkpoints for headers and block bodies in the database.
-    WriteTransactions(Arc<SealedBlock>, oneshot::Sender<()>),
 
     /// Removes block data above the given block number from the database.
     ///


### PR DESCRIPTION
This is currently unused, and can be added back if we eventually have very long in-memory chains