### PR TITLE
Add generic BlockStateNotificationStream type for pending, safe, finalized watchers

### DIFF
--- a/crates/chain-state/src/lib.rs
+++ b/crates/chain-state/src/lib.rs
@@ -16,9 +16,9 @@ pub use chain_info::ChainInfoTracker;
 
 mod notifications;
 pub use notifications::{
-    CanonStateNotification, CanonStateNotificationSender, CanonStateNotificationStream,
-    CanonStateNotifications, CanonStateSubscriptions, ForkChoiceNotifications, ForkChoiceStream,
-    ForkChoiceSubscriptions,
+    BlockStateNotificationStream, CanonStateNotification, CanonStateNotificationSender,
+    CanonStateNotificationStream, CanonStateNotifications, CanonStateSubscriptions,
+    ForkChoiceNotifications, ForkChoiceStream, ForkChoiceSubscriptions,
 };
 
 mod memory_overlay;


### PR DESCRIPTION
Closes #10204 

Usage Examples: 

```
let pending_state = BlockState::new(pending_block);
let (_, rx) = watch::channel(Some(pending_state));
let mut stream = BlockStateNotificationStream::<BlockState>::new(rx);

let finalized_state = SealedHeader::new(Header::default(), hash);
let (_, rx) = watch::channel(Some(finalized_state));
let mut stream = BlockStateNotificationStream::<SealedHeader>::new(rx);
```