### PR TITLE
refactor: remove `#[reth_codec]` and `#[derive_arbitrary]` macros

### DIFF
--- a/crates/net/eth-wire-types/src/blocks.rs
+++ b/crates/net/eth-wire-types/src/blocks.rs
@@ -3,7 +3,7 @@
 
 use crate::HeadersDirection;
 use alloy_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
-use reth_codecs_derive::{add_arbitrary_tests, derive_arbitrary};
+use reth_codecs_derive::add_arbitrary_tests;
 use reth_primitives::{BlockBody, BlockHashOrNumber, Header, B256};
 
 /// A request for a peer to return block headers starting at the requested block.
@@ -15,9 +15,10 @@ use reth_primitives::{BlockBody, BlockHashOrNumber, Header, B256};
 ///
 /// If the [`skip`](#structfield.skip) field is non-zero, the peer must skip that amount of headers
 /// in the direction specified by [`reverse`](#structfield.reverse).
-#[derive_arbitrary(rlp)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetBlockHeaders {
     /// The block number or hash that the peer should start returning headers from.
     pub start_block: BlockHashOrNumber,
@@ -71,9 +72,10 @@ impl From<Vec<Header>> for BlockHeaders {
 }
 
 /// A request for a peer to return block bodies for the given block hashes.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetBlockBodies(
     /// The block hashes to request bodies for.
     pub Vec<B256>,
@@ -87,9 +89,10 @@ impl From<Vec<B256>> for GetBlockBodies {
 
 /// The response to [`GetBlockBodies`], containing the block bodies that the peer knows about if
 /// any were found.
-#[derive_arbitrary(rlp, 16)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp, 16)]
 pub struct BlockBodies(
     /// The requested block bodies, each of which should correspond to a hash in the request.
     pub Vec<BlockBody>,

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -6,7 +6,7 @@ use alloy_rlp::{
 };
 
 use derive_more::{Constructor, Deref, DerefMut, From, IntoIterator};
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 use reth_primitives::{
     Block, Bytes, PooledTransactionsElement, TransactionSigned, TxHash, B256, U128,
 };
@@ -23,9 +23,10 @@ use proptest::{collection::vec, prelude::*};
 use proptest_arbitrary_interop::arb;
 
 /// This informs peers of new blocks that have appeared on the network.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct NewBlockHashes(
     /// New block hashes and the block number for each blockhash.
     /// Clients should request blocks using a [`GetBlockBodies`](crate::GetBlockBodies) message.
@@ -47,9 +48,10 @@ impl NewBlockHashes {
 }
 
 /// A block hash _and_ a block number.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct BlockHashNumber {
     /// The block hash
     pub hash: B256,
@@ -73,7 +75,8 @@ impl From<NewBlockHashes> for Vec<BlockHashNumber> {
 /// block.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive_arbitrary(rlp, 25)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp, 25)]
 pub struct NewBlock {
     /// A new block.
     pub block: Block,
@@ -83,9 +86,10 @@ pub struct NewBlock {
 
 /// This informs peers of transactions that have appeared on the network and are not yet included
 /// in a block.
-#[derive_arbitrary(rlp, 10)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp, 10)]
 pub struct Transactions(
     /// New transactions for the peer to include in its mempool.
     pub Vec<TransactionSigned>,
@@ -114,8 +118,9 @@ impl From<Transactions> for Vec<TransactionSigned> {
 ///
 /// The list of transactions is constructed on per-peers basis, but the underlying transaction
 /// objects are shared.
-#[derive_arbitrary(rlp, 20)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp, 20)]
 pub struct SharedTransactions(
     /// New transactions for the peer to include in its mempool.
     pub Vec<Arc<TransactionSigned>>,
@@ -288,9 +293,10 @@ impl From<NewPooledTransactionHashes68> for NewPooledTransactionHashes {
 
 /// This informs peers of transaction hashes for transactions that have appeared on the network,
 /// but have not been included in a block.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct NewPooledTransactionHashes66(
     /// Transaction hashes for new transactions that have appeared on the network.
     /// Clients should request the transactions with the given hashes using a

--- a/crates/net/eth-wire-types/src/disconnect_reason.rs
+++ b/crates/net/eth-wire-types/src/disconnect_reason.rs
@@ -2,14 +2,15 @@
 
 use alloy_rlp::{Decodable, Encodable, Header};
 use derive_more::Display;
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 use reth_primitives::bytes::{Buf, BufMut};
 use thiserror::Error;
 
 /// RLPx disconnect reason.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Display)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub enum DisconnectReason {
     /// Disconnect requested by the local node or remote peer.
     #[default]

--- a/crates/net/eth-wire-types/src/header.rs
+++ b/crates/net/eth-wire-types/src/header.rs
@@ -2,7 +2,7 @@
 
 use alloy_rlp::{Decodable, Encodable};
 use bytes::BufMut;
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 
 /// Represents the direction for a headers request depending on the `reverse` field of the request.
 /// > The response must contain a number of block headers, of rising number when reverse is 0,
@@ -14,9 +14,10 @@ use reth_codecs_derive::derive_arbitrary;
 /// [`HeadersDirection::Falling`] block numbers for `reverse == 1 == true`
 ///
 /// See also <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getblockheaders-0x03>
-#[derive_arbitrary(rlp)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub enum HeadersDirection {
     /// Falling block number.
     Falling,

--- a/crates/net/eth-wire-types/src/receipts.rs
+++ b/crates/net/eth-wire-types/src/receipts.rs
@@ -1,13 +1,14 @@
 //! Implements the `GetReceipts` and `Receipts` message types.
 
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 use reth_primitives::{ReceiptWithBloom, B256};
 
 /// A request for transaction receipts from the given block hashes.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetReceipts(
     /// The block hashes to request receipts for.
     pub Vec<B256>,
@@ -15,9 +16,10 @@ pub struct GetReceipts(
 
 /// The response to [`GetReceipts`], containing receipt lists that correspond to each block
 /// requested.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct Receipts(
     /// Each receipt hash should correspond to a block hash in the request.
     pub Vec<Vec<ReceiptWithBloom>>,

--- a/crates/net/eth-wire-types/src/state.rs
+++ b/crates/net/eth-wire-types/src/state.rs
@@ -1,15 +1,16 @@
 //! Implements the `GetNodeData` and `NodeData` message types.
 
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 use reth_primitives::{Bytes, B256};
 
 /// A request for state tree nodes corresponding to the given hashes.
 /// This message was removed in `eth/67`, only clients running `eth/66` or earlier will respond to
 /// this message.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetNodeData(pub Vec<B256>);
 
 /// The response to [`GetNodeData`], containing the state tree nodes or contract bytecode
@@ -17,9 +18,10 @@ pub struct GetNodeData(pub Vec<B256>);
 ///
 /// Not all nodes are guaranteed to be returned by the peer.
 /// This message was removed in `eth/67`.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct NodeData(pub Vec<Bytes>);
 
 #[cfg(test)]

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -3,7 +3,7 @@ use alloy_chains::{Chain, NamedChain};
 use alloy_genesis::Genesis;
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use reth_chainspec::{ChainSpec, MAINNET};
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 use reth_primitives::{hex, EthereumHardfork, ForkId, Head, B256, U256};
 use std::fmt::{Debug, Display};
 
@@ -12,9 +12,10 @@ use std::fmt::{Debug, Display};
 ///
 /// When performing a handshake, the total difficulty is not guaranteed to correspond to the block
 /// hash. This information should be treated as untrusted.
-#[derive_arbitrary(rlp)]
 #[derive(Copy, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct Status {
     /// The current protocol version. For example, peers running `eth/66` would have a version of
     /// 66.

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -2,15 +2,16 @@
 
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 use derive_more::{Constructor, Deref, IntoIterator};
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 use reth_primitives::{
     transaction::TransactionConversionError, PooledTransactionsElement, TransactionSigned, B256,
 };
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetPooledTransactions(
     /// The transaction hashes to request transaction bodies for.
     pub Vec<B256>,

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -5,7 +5,7 @@ use std::{fmt, str::FromStr};
 use alloy_rlp::{Decodable, Encodable, Error as RlpError};
 use bytes::BufMut;
 use derive_more::Display;
-use reth_codecs_derive::derive_arbitrary;
+use reth_codecs_derive::add_arbitrary_tests;
 
 /// Error thrown when failed to parse a valid [`EthVersion`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -131,9 +131,10 @@ impl From<EthVersion> for &'static str {
 }
 
 /// RLPx `p2p` protocol version
-#[derive_arbitrary(rlp)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub enum ProtocolVersion {
     /// `p2p` version 4
     V4 = 4,

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -1,6 +1,6 @@
 use crate::{Capability, EthVersion, ProtocolVersion};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
-use reth_codecs::derive_arbitrary;
+use reth_codecs::add_arbitrary_tests;
 use reth_network_peers::PeerId;
 use reth_primitives::constants::RETH_CLIENT_VERSION;
 
@@ -103,9 +103,10 @@ impl HelloMessageWithProtocols {
 /// supported RLPx protocol version and capabilities.
 ///
 /// See also <https://github.com/ethereum/devp2p/blob/master/rlpx.md#hello-0x00>
-#[derive_arbitrary(rlp)]
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct HelloMessage {
     /// The version of the `p2p` protocol.
     pub protocol_version: ProtocolVersion,

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloy_rlp::{Decodable, Encodable, Error as RlpError, EMPTY_LIST_CODE};
 use futures::{Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
-use reth_codecs::derive_arbitrary;
+use reth_codecs::add_arbitrary_tests;
 use reth_metrics::metrics::counter;
 use reth_primitives::{
     bytes::{Buf, BufMut, Bytes, BytesMut},
@@ -642,9 +642,10 @@ where
 }
 
 /// This represents only the reserved `p2p` subprotocol messages.
-#[derive_arbitrary(rlp)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub enum P2PMessage {
     /// The first packet sent over the connection, and sent once by both sides.
     Hello(HelloMessage),

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -49,7 +49,7 @@ macro_rules! fuzz_type_and_name {
 pub mod fuzz_rlp {
     use crate::roundtrip_encoding;
     use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
-    use reth_codecs::derive_arbitrary;
+    use reth_codecs::add_arbitrary_tests;
     use reth_eth_wire::{
         BlockBodies, BlockHeaders, DisconnectReason, GetBlockBodies, GetBlockHeaders, GetNodeData,
         GetPooledTransactions, GetReceipts, HelloMessage, NewBlock, NewBlockHashes,
@@ -78,7 +78,6 @@ pub mod fuzz_rlp {
 
     // see message below for why wrapper types are necessary for fuzzing types that do not have a
     // Default impl
-    #[derive_arbitrary(rlp)]
     #[derive(
         Clone,
         Debug,
@@ -89,6 +88,8 @@ pub mod fuzz_rlp {
         RlpEncodableWrapper,
         RlpDecodableWrapper,
     )]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+    #[add_arbitrary_tests(rlp)]
     struct HelloMessageWrapper(HelloMessage);
 
     impl Default for HelloMessageWrapper {
@@ -120,7 +121,6 @@ pub mod fuzz_rlp {
     //
     // We just provide a default value here so test-fuzz can auto-generate a corpus file for the
     // type.
-    #[derive_arbitrary(rlp)]
     #[derive(
         Clone,
         Debug,
@@ -131,6 +131,8 @@ pub mod fuzz_rlp {
         RlpEncodableWrapper,
         RlpDecodableWrapper,
     )]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+    #[add_arbitrary_tests(rlp)]
     struct GetBlockHeadersWrapper(GetBlockHeaders);
 
     impl Default for GetBlockHeadersWrapper {

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -4,13 +4,14 @@ use alloy_primitives::{keccak256, Bytes, B256, U256};
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::Buf;
 use derive_more::Deref;
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use revm_primitives::{AccountInfo, Bytecode as RevmBytecode, JumpTable};
 use serde::{Deserialize, Serialize};
 
 /// An Ethereum account.
-#[reth_codec]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct Account {
     /// Account nonce.
     pub nonce: u64,

--- a/crates/primitives-traits/src/header/mod.rs
+++ b/crates/primitives-traits/src/header/mod.rs
@@ -16,14 +16,13 @@ use alloy_primitives::{keccak256, Address, BlockNumber, Bloom, Bytes, B256, B64,
 use alloy_rlp::{length_of_length, Decodable, Encodable};
 use bytes::BufMut;
 use core::mem;
-use reth_codecs::{add_arbitrary_tests, reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use revm_primitives::{calc_blob_gasprice, calc_excess_blob_gas};
 use serde::{Deserialize, Serialize};
 
 /// Block header
-#[reth_codec(no_arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Compact)]
 #[add_arbitrary_tests(rlp, 25)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Header {
     /// The Keccak 256-bit hash of the parent
     /// block’s header, in its entirety; formally Hp.

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -7,14 +7,13 @@ use alloy_rlp::{Decodable, Encodable};
 use bytes::BufMut;
 use core::mem;
 use derive_more::{AsRef, Deref};
-use reth_codecs::{add_arbitrary_tests, reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 
 /// A [`Header`] that is sealed at a precalculated hash, use [`SealedHeader::unseal()`] if you want
 /// to modify header.
-#[reth_codec(no_arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref, Serialize, Deserialize, Compact)]
 #[add_arbitrary_tests(rlp, compact)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref, Serialize, Deserialize)]
 pub struct SealedHeader {
     /// Locked Header hash.
     hash: BlockHash,

--- a/crates/primitives-traits/src/log.rs
+++ b/crates/primitives-traits/src/log.rs
@@ -19,15 +19,25 @@ mod tests {
     use alloy_rlp::{RlpDecodable, RlpEncodable};
     use proptest::proptest;
     use proptest_arbitrary_interop::arb;
-    use reth_codecs::{reth_codec, Compact};
+    use reth_codecs::{add_arbitrary_tests, Compact};
     use serde::{Deserialize, Serialize};
 
     /// This type is kept for compatibility tests after the codec support was added to
     /// alloy-primitives Log type natively
-    #[reth_codec(rlp)]
     #[derive(
-        Clone, Debug, PartialEq, Eq, RlpDecodable, RlpEncodable, Default, Serialize, Deserialize,
+        Clone,
+        Debug,
+        PartialEq,
+        Eq,
+        RlpDecodable,
+        RlpEncodable,
+        Default,
+        Serialize,
+        Deserialize,
+        Compact,
     )]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+    #[add_arbitrary_tests(compact, rlp)]
     struct Log {
         /// Contract that emitted this log.
         address: Address,

--- a/crates/primitives-traits/src/request.rs
+++ b/crates/primitives-traits/src/request.rs
@@ -4,7 +4,7 @@ pub use alloy_consensus::Request;
 use alloy_eips::eip7685::{Decodable7685, Encodable7685};
 use alloy_rlp::{Decodable, Encodable};
 use derive_more::{Deref, DerefMut, From, IntoIterator};
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use revm_primitives::Bytes;
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use alloc::vec::Vec;
 
 /// A list of EIP-7685 requests.
-#[reth_codec]
 #[derive(
     Debug,
     Clone,
@@ -26,7 +25,10 @@ use alloc::vec::Vec;
     IntoIterator,
     Serialize,
     Deserialize,
+    Compact,
 )]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct Requests(pub Vec<Request>);
 
 impl Encodable for Requests {

--- a/crates/primitives-traits/src/storage.rs
+++ b/crates/primitives-traits/src/storage.rs
@@ -1,12 +1,13 @@
 use alloy_primitives::{B256, U256};
-use reth_codecs::{derive_arbitrary, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 
 /// Account storage entry.
 ///
 /// `key` is the subkey when used as a value in the `StorageChangeSets` table.
-#[derive_arbitrary(compact)]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct StorageEntry {
     /// Storage key.
     pub key: B256,

--- a/crates/primitives-traits/src/withdrawal.rs
+++ b/crates/primitives-traits/src/withdrawal.rs
@@ -2,7 +2,7 @@
 
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 use derive_more::{AsRef, Deref, DerefMut, From, IntoIterator};
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -13,7 +13,6 @@ pub use alloy_eips::eip4895::Withdrawal;
 use serde::{Deserialize, Serialize};
 
 /// Represents a collection of Withdrawals.
-#[reth_codec]
 #[derive(
     Debug,
     Clone,
@@ -30,7 +29,10 @@ use serde::{Deserialize, Serialize};
     RlpDecodableWrapper,
     Serialize,
     Deserialize,
+    Compact,
 )]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 #[as_ref(forward)]
 pub struct Withdrawals(Vec<Withdrawal>);
 
@@ -95,7 +97,6 @@ mod tests {
 
     /// This type is kept for compatibility tests after the codec support was added to alloy-eips
     /// Withdrawal type natively
-    #[reth_codec]
     #[derive(
         Debug,
         Clone,
@@ -107,7 +108,10 @@ mod tests {
         RlpDecodable,
         Serialize,
         Deserialize,
+        Compact,
     )]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+    #[add_arbitrary_tests(compact)]
     struct RethWithdrawal {
         /// Monotonically increasing identifier issued by consensus layer.
         index: u64,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -268,7 +268,8 @@ impl BlockWithSenders {
 /// Sealed Ethereum full block.
 ///
 /// Withdrawals can be optionally included at the end of the RLP encoded message.
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::derive_arbitrary(rlp 32))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(rlp, 32))]
 #[derive(
     Debug,
     Clone,

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -14,11 +14,11 @@ use serde::{Deserialize, Serialize};
 use alloc::{vec, vec::Vec};
 
 /// Receipt containing result of transaction execution.
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::reth_codec(no_arbitrary, zstd))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests)]
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize,
 )]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(CompactZstd))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests)]
 #[rlp(trailing)]
 pub struct Receipt {
     /// Receipt type.
@@ -142,8 +142,10 @@ impl From<Receipt> for ReceiptWithBloom {
 }
 
 /// [`Receipt`] with calculated bloom filter.
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::reth_codec)]
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct ReceiptWithBloom {
     /// Bloom filter build from logs.
     pub bloom: Bloom,

--- a/crates/primitives/src/transaction/access_list.rs
+++ b/crates/primitives/src/transaction/access_list.rs
@@ -11,12 +11,11 @@ mod tests {
     use alloy_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
     use proptest::proptest;
     use proptest_arbitrary_interop::arb;
-    use reth_codecs::{reth_codec, Compact};
+    use reth_codecs::{add_arbitrary_tests, Compact};
     use serde::{Deserialize, Serialize};
 
     /// This type is kept for compatibility tests after the codec support was added to alloy-eips
     /// AccessList type natively
-    #[reth_codec(rlp)]
     #[derive(
         Clone,
         Debug,
@@ -28,7 +27,10 @@ mod tests {
         RlpEncodableWrapper,
         Serialize,
         Deserialize,
+        Compact,
     )]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+    #[add_arbitrary_tests(compact, rlp)]
     struct RethAccessList(Vec<RethAccessListItem>);
 
     impl PartialEq<AccessList> for RethAccessList {
@@ -38,7 +40,6 @@ mod tests {
     }
 
     // This
-    #[reth_codec(rlp)]
     #[derive(
         Clone,
         Debug,
@@ -50,7 +51,10 @@ mod tests {
         RlpEncodable,
         Serialize,
         Deserialize,
+        Compact,
     )]
+    #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+    #[add_arbitrary_tests(compact, rlp)]
     #[serde(rename_all = "camelCase")]
     struct RethAccessListItem {
         /// Account address that would be loaded at the start of execution

--- a/crates/primitives/src/transaction/eip1559.rs
+++ b/crates/primitives/src/transaction/eip1559.rs
@@ -11,8 +11,10 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)).
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::reth_codec)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct TxEip1559 {
     /// Added as EIP-155: Simple replay attack protection
     pub chain_id: ChainId,

--- a/crates/primitives/src/transaction/eip2930.rs
+++ b/crates/primitives/src/transaction/eip2930.rs
@@ -11,8 +11,10 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::reth_codec)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(Compact))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct TxEip2930 {
     /// Added as EIP-155: Simple replay attack protection
     pub chain_id: ChainId,

--- a/crates/primitives/src/transaction/eip4844.rs
+++ b/crates/primitives/src/transaction/eip4844.rs
@@ -22,8 +22,10 @@ use serde::{Deserialize, Serialize};
 /// [EIP-4844 Blob Transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction)
 ///
 /// A transaction with blob hashes and max blob fee
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::reth_codec)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct TxEip4844 {
     /// Added as EIP-155: Simple replay attack protection
     pub chain_id: ChainId,

--- a/crates/primitives/src/transaction/eip7702.rs
+++ b/crates/primitives/src/transaction/eip7702.rs
@@ -15,8 +15,10 @@ use reth_codecs::Compact;
 /// [EIP-7702 Set Code Transaction](https://eips.ethereum.org/EIPS/eip-7702)
 ///
 /// Set EOA account code for one transaction
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::reth_codec)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct TxEip7702 {
     /// Added as EIP-155: Simple replay attack protection
     pub chain_id: ChainId,

--- a/crates/primitives/src/transaction/legacy.rs
+++ b/crates/primitives/src/transaction/legacy.rs
@@ -10,8 +10,10 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// Legacy transaction.
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::reth_codec)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct TxLegacy {
     /// Added as EIP-155: Simple replay attack protection
     pub chain_id: Option<ChainId>,

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -86,8 +86,9 @@ pub(crate) static PARALLEL_SENDER_RECOVERY_THRESHOLD: Lazy<usize> =
 /// A raw transaction.
 ///
 /// Transaction types were introduced in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::derive_arbitrary(compact))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub enum Transaction {
     /// Legacy transaction (type `0x0`).
     ///
@@ -810,8 +811,9 @@ impl Encodable for Transaction {
 /// Signed transaction without its Hash. Used type for inserting into the DB.
 ///
 /// This can by converted to [`TransactionSigned`] by calling [`TransactionSignedNoHash::hash`].
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::derive_arbitrary(compact))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct TransactionSignedNoHash {
     /// The transaction signature values
     pub signature: Signature,

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -5,12 +5,14 @@ use alloy_rlp::{
 use bytes::Buf;
 use core::mem;
 #[cfg(any(test, feature = "reth-codec"))]
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{Compact};
 use serde::{Deserialize, Serialize};
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codec)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct TxDeposit {
     /// Hash that uniquely identifies the source of the deposit.
     pub source_hash: B256,

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -5,7 +5,7 @@ use alloy_rlp::{
 use bytes::Buf;
 use core::mem;
 #[cfg(any(test, feature = "reth-codec"))]
-use reth_codecs::{Compact};
+use reth_codecs::Compact;
 use serde::{Deserialize, Serialize};
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -18,8 +18,9 @@ const SECP256K1N_HALF: U256 = U256::from_be_bytes([
 /// r, s: Values corresponding to the signature of the
 /// transaction and used to determine the sender of
 /// the transaction; formally Tr and Ts. This is expanded in Appendix F of yellow paper.
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::derive_arbitrary(compact))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct Signature {
     /// The R field of the signature; the point on the curve.
     pub r: U256,

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -38,10 +38,11 @@ pub const DEPOSIT_TX_TYPE_ID: u8 = 126;
 /// database format.
 ///
 /// Other required changes when adding a new type can be seen on [PR#3953](https://github.com/paradigmxyz/reth/pull/3953/files).
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::derive_arbitrary(compact))]
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize, Hash,
 )]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub enum TxType {
     /// Legacy transaction pre EIP-2929
     #[default]

--- a/crates/prune/types/src/checkpoint.rs
+++ b/crates/prune/types/src/checkpoint.rs
@@ -1,12 +1,12 @@
 use crate::PruneMode;
 use alloy_primitives::{BlockNumber, TxNumber};
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 
 /// Saves the pruning progress of a stage.
-#[reth_codec]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Default))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(Default, arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct PruneCheckpoint {
     /// Highest pruned block number. If it's [None], the pruning for block `0` is not finished yet.
     pub block_number: Option<BlockNumber>,

--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -1,12 +1,13 @@
 use crate::{segment::PrunePurpose, PruneSegment, PruneSegmentError};
 use alloy_primitives::BlockNumber;
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 
 /// Prune mode.
-#[reth_codec]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Compact)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub enum PruneMode {
     /// Prune all blocks.
     Full,

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -1,14 +1,15 @@
 use crate::MINIMUM_PRUNING_DISTANCE;
 use derive_more::Display;
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Segment of the data that can be pruned.
-#[reth_codec]
 #[derive(
-    Debug, Display, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
+    Debug, Display, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Compact
 )]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub enum PruneSegment {
     /// Prune segment responsible for the `TransactionSenders` table.
     SenderRecovery,

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -6,7 +6,18 @@ use thiserror::Error;
 
 /// Segment of the data that can be pruned.
 #[derive(
-    Debug, Display, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Compact
+    Debug,
+    Display,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    Compact,
 )]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 #[add_arbitrary_tests(compact)]

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, BlockNumber, B256};
 use bytes::Buf;
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use reth_trie_common::{hash_builder::HashBuilderState, StoredSubNode};
 use serde::{Deserialize, Serialize};
 use std::ops::RangeInclusive;
@@ -75,8 +75,9 @@ impl Compact for MerkleCheckpoint {
 }
 
 /// Saves the progress of AccountHashing stage.
-#[reth_codec]
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct AccountHashingCheckpoint {
     /// The next account to start hashing from.
     pub address: Option<Address>,
@@ -87,8 +88,9 @@ pub struct AccountHashingCheckpoint {
 }
 
 /// Saves the progress of StorageHashing stage.
-#[reth_codec]
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct StorageHashingCheckpoint {
     /// The next account to start hashing from.
     pub address: Option<Address>,
@@ -101,8 +103,9 @@ pub struct StorageHashingCheckpoint {
 }
 
 /// Saves the progress of Execution stage.
-#[reth_codec]
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct ExecutionCheckpoint {
     /// Block range which this checkpoint is valid for.
     pub block_range: CheckpointBlockRange,
@@ -111,8 +114,9 @@ pub struct ExecutionCheckpoint {
 }
 
 /// Saves the progress of Headers stage.
-#[reth_codec]
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct HeadersCheckpoint {
     /// Block range which this checkpoint is valid for.
     pub block_range: CheckpointBlockRange,
@@ -121,8 +125,9 @@ pub struct HeadersCheckpoint {
 }
 
 /// Saves the progress of Index History stages.
-#[reth_codec]
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct IndexHistoryCheckpoint {
     /// Block range which this checkpoint is valid for.
     pub block_range: CheckpointBlockRange,
@@ -131,8 +136,9 @@ pub struct IndexHistoryCheckpoint {
 }
 
 /// Saves the progress of abstract stage iterating over or downloading entities.
-#[reth_codec]
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct EntitiesCheckpoint {
     /// Number of entities already processed.
     pub processed: u64,
@@ -159,8 +165,9 @@ impl EntitiesCheckpoint {
 
 /// Saves the block range. Usually, it's used to check the validity of some stage checkpoint across
 /// multiple executions.
-#[reth_codec]
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct CheckpointBlockRange {
     /// The first block of the range, inclusive.
     pub from: BlockNumber,
@@ -181,8 +188,9 @@ impl From<&RangeInclusive<BlockNumber>> for CheckpointBlockRange {
 }
 
 /// Saves the progress of a stage.
-#[reth_codec]
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct StageCheckpoint {
     /// The maximum block processed by the stage.
     pub block_number: BlockNumber,
@@ -247,8 +255,9 @@ impl StageCheckpoint {
 // TODO(alexey): add a merkle checkpoint. Currently it's hard because [`MerkleCheckpoint`]
 //  is not a Copy type.
 /// Stage-specific checkpoint metrics.
-#[reth_codec]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub enum StageUnitCheckpoint {
     /// Saves the progress of AccountHashing stage.
     Account(AccountHashingCheckpoint),

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -32,7 +32,19 @@ pub fn derive_zstd(input: TokenStream) -> TokenStream {
     compact::derive(input, is_zstd)
 }
 
-/// To be used for types that implement `Arbitrary` manually. See [`derive_arbitrary()`] for more.
+/// Generates tests for given type.
+///
+/// If `compact` or `rlp` is passed to `add_arbitrary_tests`, there will be proptest roundtrip tests
+/// generated. An integer value passed will limit the number of proptest cases generated (default:
+/// 256).
+///
+/// Examples:
+/// * `#[add_arbitrary_tests]`: will derive arbitrary with no tests.
+/// * `#[add_arbitrary_tests(rlp)]`: will derive arbitrary and generate rlp roundtrip proptests.
+/// * `#[add_arbitrary_tests(rlp, 10)]`: will derive arbitrary and generate rlp roundtrip proptests.
+///   Limited to 10 cases.
+/// * `#[add_arbitrary_tests(compact, rlp)]`. will derive arbitrary and generate rlp and compact
+///   roundtrip proptests.
 #[proc_macro_attribute]
 pub fn add_arbitrary_tests(args: TokenStream, input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -9,7 +9,7 @@
 #![allow(unreachable_pub, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use proc_macro::{TokenStream, TokenTree};
+use proc_macro::{TokenStream};
 use quote::{format_ident, quote};
 use syn::{
     bracketed,
@@ -30,81 +30,6 @@ pub fn derive(input: TokenStream) -> TokenStream {
 pub fn derive_zstd(input: TokenStream) -> TokenStream {
     let is_zstd = true;
     compact::derive(input, is_zstd)
-}
-
-/// This code implements the main codec. If the codec supports it, it will also provide the [`derive_arbitrary()`] function, which automatically implements arbitrary traits and roundtrip fuzz tests.
-///
-/// If you prefer to manually implement the arbitrary traits, you can still use the [`add_arbitrary_tests()`] function to add arbitrary fuzz tests.
-///
-/// Example usage:
-/// * `#[reth_codec(rlp)]`: will implement `derive_arbitrary(rlp)` or `derive_arbitrary(compact, rlp)`, if `compact` is the `reth_codec`.
-/// * `#[reth_codec(no_arbitrary)]`: will skip `derive_arbitrary` (both trait implementations and tests)
-#[proc_macro_attribute]
-#[rustfmt::skip]
-#[allow(unreachable_code)]
-pub fn reth_codec(args: TokenStream, input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-
-    let with_zstd = args.clone().into_iter().any(|tk| tk.to_string() == "zstd");
-    let without_arbitrary = args.clone().into_iter().any(|tk| tk.to_string() == "no_arbitrary");
-    
-    let compact = if with_zstd {
-        quote! {
-            #[derive(CompactZstd)]
-            #ast
-        }
-        .into()
-    } else {
-        quote! {
-            #[derive(Compact)]
-            #ast
-        }
-        .into()
-    };
-
-    if without_arbitrary {
-        return compact
-    }
-
-    let mut args = args.into_iter().collect::<Vec<_>>();
-    args.push(TokenTree::Ident(proc_macro::Ident::new("compact", proc_macro::Span::call_site())));
-
-    derive_arbitrary(TokenStream::from_iter(args), compact)
-}
-
-/// Adds `Arbitrary` imports into scope and derives the struct/enum.
-///
-/// If `compact` or `rlp` is passed to `derive_arbitrary`, there will be proptest roundtrip tests
-/// generated. An integer value passed will limit the number of proptest cases generated (default:
-/// 256).
-///
-/// Examples:
-/// * `#[derive_arbitrary]`: will derive arbitrary with no tests.
-/// * `#[derive_arbitrary(rlp)]`: will derive arbitrary and generate rlp roundtrip proptests.
-/// * `#[derive_arbitrary(rlp, 10)]`: will derive arbitrary and generate rlp roundtrip proptests.
-///   Limited to 10 cases.
-/// * `#[derive_arbitrary(compact, rlp)]`. will derive arbitrary and generate rlp and compact
-///   roundtrip proptests.
-#[proc_macro_attribute]
-pub fn derive_arbitrary(args: TokenStream, input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-
-    let tests =
-        arbitrary::maybe_generate_tests(args, &ast.ident, &format_ident!("{}Tests", ast.ident));
-
-    // Avoid duplicate names
-    let arb_import = format_ident!("{}Arbitrary", ast.ident);
-
-    quote! {
-        #[cfg(any(test, feature = "arbitrary"))]
-        use arbitrary::Arbitrary as #arb_import;
-
-        #[cfg_attr(any(test, feature = "arbitrary"), derive(#arb_import))]
-        #ast
-
-        #tests
-    }
-    .into()
 }
 
 /// To be used for types that implement `Arbitrary` manually. See [`derive_arbitrary()`] for more.

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -9,7 +9,7 @@
 #![allow(unreachable_pub, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use proc_macro::{TokenStream};
+use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
     bracketed,

--- a/crates/storage/codecs/src/alloy/authorization_list.rs
+++ b/crates/storage/codecs/src/alloy/authorization_list.rs
@@ -4,7 +4,7 @@ use crate::Compact;
 use alloy_eips::eip7702::{Authorization as AlloyAuthorization, SignedAuthorization};
 use alloy_primitives::{Address, ChainId, U256};
 use bytes::Buf;
-use reth_codecs_derive::{add_arbitrary_tests};
+use reth_codecs_derive::add_arbitrary_tests;
 use serde::{Deserialize, Serialize};
 
 /// Authorization acts as bridge which simplifies Compact implementation for AlloyAuthorization.

--- a/crates/storage/codecs/src/alloy/authorization_list.rs
+++ b/crates/storage/codecs/src/alloy/authorization_list.rs
@@ -4,14 +4,15 @@ use crate::Compact;
 use alloy_eips::eip7702::{Authorization as AlloyAuthorization, SignedAuthorization};
 use alloy_primitives::{Address, ChainId, U256};
 use bytes::Buf;
-use reth_codecs_derive::reth_codec;
+use reth_codecs_derive::{add_arbitrary_tests};
 use serde::{Deserialize, Serialize};
 
 /// Authorization acts as bridge which simplifies Compact implementation for AlloyAuthorization.
 ///
 /// Notice: Make sure this struct is 1:1 with `alloy_eips::eip7702::Authorization`
-#[reth_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 struct Authorization {
     chain_id: ChainId,
     address: Address,

--- a/crates/storage/codecs/src/alloy/genesis_account.rs
+++ b/crates/storage/codecs/src/alloy/genesis_account.rs
@@ -1,17 +1,16 @@
 use crate::Compact;
 use alloy_genesis::GenesisAccount as AlloyGenesisAccount;
 use alloy_primitives::{Bytes, B256, U256};
-use reth_codecs_derive::reth_codec;
+use reth_codecs_derive::{add_arbitrary_tests};
 use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-/// GenesisAccount acts as bridge which simplifies Compact implementation for AlloyGenesisAccount.
+/// `GenesisAccount` acts as bridge which simplifies Compact implementation for `AlloyGenesisAccount`.
 ///
 /// Notice: Make sure this struct is 1:1 with `alloy_genesis::GenesisAccount`
-#[reth_codec(no_arbitrary)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Compact)]
 struct GenesisAccountRef<'a> {
     /// The nonce of the account at genesis.
     nonce: Option<u64>,
@@ -25,8 +24,9 @@ struct GenesisAccountRef<'a> {
     private_key: Option<&'a B256>,
 }
 
-#[reth_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 struct GenesisAccount {
     /// The nonce of the account at genesis.
     nonce: Option<u64>,
@@ -40,14 +40,16 @@ struct GenesisAccount {
     private_key: Option<B256>,
 }
 
-#[reth_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 struct StorageEntries {
     entries: Vec<StorageEntry>,
 }
 
-#[reth_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 struct StorageEntry {
     key: B256,
     value: B256,

--- a/crates/storage/codecs/src/alloy/genesis_account.rs
+++ b/crates/storage/codecs/src/alloy/genesis_account.rs
@@ -1,13 +1,14 @@
 use crate::Compact;
 use alloy_genesis::GenesisAccount as AlloyGenesisAccount;
 use alloy_primitives::{Bytes, B256, U256};
-use reth_codecs_derive::{add_arbitrary_tests};
+use reth_codecs_derive::add_arbitrary_tests;
 use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-/// `GenesisAccount` acts as bridge which simplifies Compact implementation for `AlloyGenesisAccount`.
+/// `GenesisAccount` acts as bridge which simplifies Compact implementation for
+/// `AlloyGenesisAccount`.
 ///
 /// Notice: Make sure this struct is 1:1 with `alloy_genesis::GenesisAccount`
 #[derive(Debug, Clone, PartialEq, Eq, Compact)]

--- a/crates/storage/codecs/src/alloy/withdrawal.rs
+++ b/crates/storage/codecs/src/alloy/withdrawal.rs
@@ -1,7 +1,7 @@
 use crate::Compact;
 use alloy_eips::eip4895::Withdrawal as AlloyWithdrawal;
 use alloy_primitives::Address;
-use reth_codecs_derive::{add_arbitrary_tests};
+use reth_codecs_derive::add_arbitrary_tests;
 use serde::{Deserialize, Serialize};
 
 /// Withdrawal acts as bridge which simplifies Compact implementation for AlloyWithdrawal.

--- a/crates/storage/codecs/src/alloy/withdrawal.rs
+++ b/crates/storage/codecs/src/alloy/withdrawal.rs
@@ -1,14 +1,15 @@
 use crate::Compact;
 use alloy_eips::eip4895::Withdrawal as AlloyWithdrawal;
 use alloy_primitives::Address;
-use reth_codecs_derive::reth_codec;
+use reth_codecs_derive::{add_arbitrary_tests};
 use serde::{Deserialize, Serialize};
 
 /// Withdrawal acts as bridge which simplifies Compact implementation for AlloyWithdrawal.
 ///
 /// Notice: Make sure this struct is 1:1 with `alloy_eips::eip4895::Withdrawal`
-#[reth_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 struct Withdrawal {
     /// Monotonically increasing identifier issued by consensus layer.
     index: u64,

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -704,7 +704,9 @@ mod tests {
         );
     }
 
-    #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize, Compact, arbitrary::Arbitrary)]
+    #[derive(
+        Debug, PartialEq, Clone, Default, Serialize, Deserialize, Compact, arbitrary::Arbitrary,
+    )]
     #[add_arbitrary_tests(compact)]
     enum TestEnum {
         #[default]

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -652,8 +652,8 @@ mod tests {
         }
     }
 
-    #[reth_codec]
-    #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+    #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Compact, arbitrary::Arbitrary)]
+    #[add_arbitrary_tests(compact)]
     struct TestStruct {
         f_u64: u64,
         f_u256: U256,
@@ -704,8 +704,8 @@ mod tests {
         );
     }
 
-    #[reth_codec]
-    #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
+    #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize, Compact, arbitrary::Arbitrary)]
+    #[add_arbitrary_tests(compact)]
     enum TestEnum {
         #[default]
         Var0,

--- a/crates/storage/db-api/src/models/accounts.rs
+++ b/crates/storage/db-api/src/models/accounts.rs
@@ -7,15 +7,16 @@ use crate::{
     table::{Decode, Encode},
     DatabaseError,
 };
-use reth_codecs::{derive_arbitrary, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use reth_primitives::{Account, Address, BlockNumber, Buf, StorageKey};
 use serde::{Deserialize, Serialize};
 
 /// Account as it is saved in the database.
 ///
 /// [`Address`] is the subkey.
-#[derive_arbitrary(compact)]
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct AccountBeforeTx {
     /// Address for the account. Acts as `DupSort::SubKey`.
     pub address: Address,

--- a/crates/storage/db-api/src/models/blocks.rs
+++ b/crates/storage/db-api/src/models/blocks.rs
@@ -1,6 +1,6 @@
 //! Block related models and types.
 
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use reth_primitives::{Header, TxNumber, Withdrawals, B256};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
@@ -12,8 +12,9 @@ pub type NumTransactions = u64;
 ///
 /// It has the pointer to the transaction Number of the first
 /// transaction in the block and the total number of transactions.
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
-#[reth_codec]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, Compact)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct StoredBlockBodyIndices {
     /// The number of the first transaction in this block
     ///
@@ -69,16 +70,18 @@ impl StoredBlockBodyIndices {
 /// The storage representation of a block's ommers.
 ///
 /// It is stored as the headers of the block's uncles.
-#[reth_codec]
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, Compact)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct StoredBlockOmmers {
     /// The block headers of this block's uncles.
     pub ommers: Vec<Header>,
 }
 
 /// The storage representation of block withdrawals.
-#[reth_codec]
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, Compact)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct StoredBlockWithdrawals {
     /// The block withdrawals.
     pub withdrawals: Withdrawals,

--- a/crates/storage/db-api/src/models/client_version.rs
+++ b/crates/storage/db-api/src/models/client_version.rs
@@ -1,11 +1,12 @@
 //! Client version model.
 
-use reth_codecs::{derive_arbitrary, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 
 /// Client version that accessed the database.
-#[derive_arbitrary(compact)]
 #[derive(Clone, Eq, PartialEq, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct ClientVersion {
     /// Client version
     pub version: String,

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     table::{Compress, Decode, Decompress, Encode},
     DatabaseError,
 };
-use reth_codecs::{reth_codec, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use reth_primitives::{Address, B256, *};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::StageCheckpoint;
@@ -264,8 +264,9 @@ macro_rules! add_wrapper_struct {
     ($(($name:tt, $wrapper:tt)),+) => {
         $(
             /// Wrapper struct so it can use StructFlags from Compact, when used as pure table values.
-            #[reth_codec]
-            #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+            #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+            #[add_arbitrary_tests(compact)]
             pub struct $wrapper(pub $name);
 
             impl From<$name> for $wrapper {

--- a/crates/trie/common/src/hash_builder/state.rs
+++ b/crates/trie/common/src/hash_builder/state.rs
@@ -2,13 +2,14 @@ use crate::TrieMask;
 use alloy_trie::{hash_builder::HashBuilderValue, HashBuilder};
 use bytes::Buf;
 use nybbles::Nibbles;
-use reth_codecs::{derive_arbitrary, Compact};
+use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
 
 /// The hash builder state for storing in the database.
 /// Check the `reth-trie` crate for more info on hash builder.
-#[derive_arbitrary(compact)]
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
 pub struct HashBuilderState {
     /// The current key.
     pub key: Vec<u8>,


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/10238

Removes and replaces `reth_codec` and `derive_arbitrary` derive macros with explicit `cfg_attr` attributes and `add_arbitrary_tests` invocations