### PR TITLE
chore: prevent warnings on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,15 @@ COPY --from=planner /app/recipe.json recipe.json
 
 # Build profile, release by default
 ARG BUILD_PROFILE=release
-ENV BUILD_PROFILE $BUILD_PROFILE
+ENV BUILD_PROFILE=$BUILD_PROFILE
 
 # Extra Cargo flags
 ARG RUSTFLAGS=""
-ENV RUSTFLAGS "$RUSTFLAGS"
+ENV RUSTFLAGS="$RUSTFLAGS"
 
 # Extra Cargo features
 ARG FEATURES=""
-ENV FEATURES $FEATURES
+ENV FEATURES=$FEATURES
 
 # Builds dependencies
 RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json


### PR DESCRIPTION
Currently building the docker image shows these warnings:
```
3 warnings found (use --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 20)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 24)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 28)
```