### PR TITLE
feat(ci): compile `reth-consensus` crate for Wasm

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -6,7 +6,6 @@ crates=($(cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name'
 # Array of crates to exclude
 exclude_crates=(
   # The following are not working yet, but known to be fixable
-  reth-consensus
   reth-exex-types # https://github.com/paradigmxyz/reth/issues/9946
   # The following require investigation if they can be fixed
   reth-auto-seal-consensus


### PR DESCRIPTION
Blocked by https://github.com/paradigmxyz/reth/pull/10278

Done by https://github.com/paradigmxyz/reth/pull/9663