### PR TITLE
docs: add engine kind flag to op-mainnet book

### DIFF
--- a/book/run/sync-op-mainnet.md
+++ b/book/run/sync-op-mainnet.md
@@ -60,5 +60,5 @@ $ op-reth init-state --chain optimism <state-dump>
 Running the node with `--debug.tip <block-hash>`syncs the node without help from CL until a fixed tip. The
 block hash can be taken from the latest block on <https://optimistic.etherscan.io>.
 
-Use `op-node` to track the tip. Start `op-node` with `--syncmode=execution-layer`. If `op-node`'s RPC
+Use `op-node` to track the tip. Start `op-node` with `--syncmode=execution-layer` and `--l2.enginekind=reth`. If `op-node`'s RPC
 connection to L1 is over localhost, `--l1.trustrpc` can be set to improve performance.


### PR DESCRIPTION
It was previously added on https://github.com/paradigmxyz/reth/pull/9901, but not on the op-mainnet docs.
