### PR TITLE
fix(engine2): ensure static files are up to the tip when coming from an old engine node

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -177,6 +177,9 @@ where
             pipeline_exex_handle,
         )?;
 
+        // The new engine writes directly to static files. This ensures that they're up to the tip.
+        pipeline.move_to_static_files()?;
+
         let pipeline_events = pipeline.events();
 
         let mut pruner_builder = ctx.pruner_builder();


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/10268

The new engine writes directly to static files, so we need to make sure that they're up to the tip when coming from an old engine node.