### PR TITLE
fix: set first block at the beginning of batch execution

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -418,6 +418,11 @@ where
 
     fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
         let BlockExecutionInput { block, total_difficulty } = input;
+
+        if self.batch_record.first_block().is_none() {
+            self.batch_record.set_first_block(block.number);
+        }
+
         let EthExecuteOutput { receipts, requests, gas_used: _ } =
             self.executor.execute_without_verification(block, total_difficulty)?;
 
@@ -432,10 +437,6 @@ where
 
         // store requests in the set
         self.batch_record.save_requests(requests);
-
-        if self.batch_record.first_block().is_none() {
-            self.batch_record.set_first_block(block.number);
-        }
 
         Ok(())
     }

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -396,6 +396,11 @@ where
 
     fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
         let BlockExecutionInput { block, total_difficulty } = input;
+
+        if self.batch_record.first_block().is_none() {
+            self.batch_record.set_first_block(block.number);
+        }
+
         let (receipts, _gas_used) =
             self.executor.execute_without_verification(block, total_difficulty)?;
 
@@ -407,10 +412,6 @@ where
 
         // store receipts in the set
         self.batch_record.save_receipts(receipts)?;
-
-        if self.batch_record.first_block().is_none() {
-            self.batch_record.set_first_block(block.number);
-        }
 
         Ok(())
     }


### PR DESCRIPTION
save_receipts requires the first_block to be set, otherwise it won't ever prune the receipts from the first block

https://github.com/paradigmxyz/reth/blob/89c0c0f0ce048ee1065ea813781d12a3aea6cc0b/crates/revm/src/batch.rs#L117-L121

https://github.com/paradigmxyz/reth/blob/89c0c0f0ce048ee1065ea813781d12a3aea6cc0b/crates/revm/src/batch.rs#L128-L134