### PR TITLE
reth book: add instruction to update rust version

### DIFF
--- a/book/installation/source.md
+++ b/book/installation/source.md
@@ -32,6 +32,9 @@ operating system:
 
 These are needed to build bindings for Reth's database.
 
+The Minimum Supported Rust Version (MSRV) of this project is 1.80.0. If you already have a version of Rust installed,
+you can check your version by running `rustc --version`. To update your version of Rust, run `rustup update`.
+
 ## Build Reth
 
 With Rust and the dependencies installed, you're ready to build Reth. First, clone the repository:


### PR DESCRIPTION
I was following the book to build reth, but I got error 

```
error: rustc 1.78.0 is not supported by the following packages:
```

then I found the GH README mentioned "The Minimum Supported Rust Version (MSRV) of this project is [1.80.0](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html)." but this is not in the book.

So I am adding it to the book to keep consistent. Also add the instructions for checking and updating rust version

Note: the trouble shooting section briefly mentioned if there is compile error, you can upgrade rust. but I think it's better to avoid such error in the first place.