### PR TITLE
fix(net): Increase max fetch retries per tx per peer

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -390,7 +390,7 @@ impl TransactionFetcher {
                 // peer has not yet requested hash
                 fallback_peers.insert(peer_id);
             } else {
-                if *retries >= DEFAULT_MAX_RETRIES {
+                if *retries >= 100 {
                     trace!(target: "net::tx",
                         %hash,
                         retries,


### PR DESCRIPTION
Increases the max tx fetch retries per peer from default 2 to 100. Some local transactions never made it to sequencer, attempts to fix this, if this is due to too low cap on retries.