### PR TITLE
fix(net): fix constants for `TransactionsManager` that use `LruMap` by length

### DIFF
--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -39,8 +39,8 @@ pub mod tx_manager {
 
     /// Default limit for number of transactions to keep track of for a single peer.
     ///
-    /// Default is 10 KiB.
-    pub const DEFAULT_CAPACITY_CACHE_SEEN_BY_PEER: u32 = 10 * 1024;
+    /// Default is 10 KiB, i.e. 320 transaction hashes.
+    pub const DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER: u32 = 10 * 1024 / 32;
 
     /// Default maximum pending pool imports to tolerate.
     ///
@@ -51,8 +51,8 @@ pub mod tx_manager {
 
     /// Default limit for number of bad imports to keep track of.
     ///
-    /// Default is 10 KiB.
-    pub const DEFAULT_CAPACITY_CACHE_BAD_IMPORTS: u32 = 100 * 1024;
+    /// Default is 100 KiB, i.e. 3 200 transaction hashes.
+    pub const DEFAULT_MAX_COUNT_BAD_IMPORTS: u32 = 100 * 1024 / 32;
 }
 
 /// Constants used by [`TransactionFetcher`](super::TransactionFetcher).

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -286,7 +286,7 @@ impl<Pool: TransactionPool> TransactionsManager<Pool> {
             pending_pool_imports_info: PendingPoolImportsInfo::new(
                 DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS,
             ),
-            bad_imports: LruCache::new(DEFAULT_CAPACITY_CACHE_BAD_IMPORTS),
+            bad_imports: LruCache::new(DEFAULT_MAX_COUNT_BAD_IMPORTS),
             peers: Default::default(),
             command_tx,
             command_rx: UnboundedReceiverStream::new(command_rx),
@@ -1615,7 +1615,7 @@ impl PeerMetadata {
     /// Returns a new instance of [`PeerMetadata`].
     fn new(request_tx: PeerRequestSender, version: EthVersion, client_version: Arc<str>) -> Self {
         Self {
-            seen_transactions: LruCache::new(DEFAULT_CAPACITY_CACHE_SEEN_BY_PEER),
+            seen_transactions: LruCache::new(DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER),
             request_tx,
             version,
             client_version,


### PR DESCRIPTION
Fix constants that are used as bounds in `LruMap` by length, and not byte size.