### PR TITLE
chore(net): Expose max seen transactions history size as cli arg

### DIFF
--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -199,6 +199,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
       --to <TO>
           The maximum block height
 

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -180,7 +180,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -202,7 +202,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -177,6 +177,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -198,13 +205,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
       --to <TO>
           The maximum block height

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -177,6 +177,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -198,13 +205,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
       --retries <RETRIES>
           The number of retries per request

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -199,6 +199,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
       --retries <RETRIES>
           The number of retries per request
 

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -180,7 +180,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -202,7 +202,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -177,6 +177,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -198,13 +205,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
       --retries <RETRIES>
           The number of retries per request

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -199,6 +199,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
       --retries <RETRIES>
           The number of retries per request
 

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -180,7 +180,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -202,7 +202,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -199,6 +199,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
       --engine-api-store <PATH>
           The path to read engine API messages from
 

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -180,7 +180,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -202,7 +202,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -177,6 +177,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -198,13 +205,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
       --engine-api-store <PATH>
           The path to read engine API messages from

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -169,6 +169,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -190,13 +197,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
 RPC:
       --http

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -191,6 +191,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
 RPC:
       --http
           Enable the HTTP-RPC server

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -194,7 +194,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -172,7 +172,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -154,6 +154,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -175,13 +182,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
 Datadir:
       --datadir <DATA_DIR>

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -176,6 +176,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
 Datadir:
       --datadir <DATA_DIR>
           The path to the data dir for all reth files and subdirectories.

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -179,7 +179,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -157,7 +157,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -223,7 +223,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -220,6 +220,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -241,13 +248,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
 Logging:
       --log.stdout.format <FORMAT>

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -245,7 +245,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -242,6 +242,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -182,6 +182,13 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 10 KiB, i.e. 320 transaction hashes.
+
+          [default: 320]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -203,13 +210,6 @@ Networking:
           Default is 128 KiB.
 
           [default: 131072]
-
-      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
-          Max number of seen transactions to remember per peer.
-
-          Default is 10 KiB, i.e. 320 transaction hashes.
-
-          [default: 320]
 
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -204,6 +204,13 @@ Networking:
 
           [default: 131072]
 
+      --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
+          Max number of seen transactions to remember per peer.
+
+          Default is 320 transaction hashes.
+
+          [default: 320]
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -185,7 +185,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 10 KiB, i.e. 320 transaction hashes.
+          Default is 320 transaction hashes.
 
           [default: 320]
 

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -207,7 +207,7 @@ Networking:
       --max-seen-tx-history <MAX_SEEN_TX_HISTORY>
           Max number of seen transactions to remember per peer.
 
-          Default is 320 transaction hashes.
+          Default is 10 KiB, i.e. 320 transaction hashes.
 
           [default: 320]
 

--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -11,6 +11,8 @@ use super::{
 pub struct TransactionsManagerConfig {
     /// Configuration for fetching transactions.
     pub transaction_fetcher_config: TransactionFetcherConfig,
+    /// Max number of seen transactions to store for each peer.
+    pub max_transactions_seen_by_peer_history: u32,
 }
 
 /// Configuration for fetching transactions.

--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -1,18 +1,28 @@
 use derive_more::Constructor;
 
 use super::{
+    DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
     DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,
     SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
 };
 
 /// Configuration for managing transactions within the network.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransactionsManagerConfig {
     /// Configuration for fetching transactions.
     pub transaction_fetcher_config: TransactionFetcherConfig,
     /// Max number of seen transactions to store for each peer.
     pub max_transactions_seen_by_peer_history: u32,
+}
+
+impl Default for TransactionsManagerConfig {
+    fn default() -> Self {
+        Self {
+            transaction_fetcher_config: TransactionFetcherConfig::default(),
+            max_transactions_seen_by_peer_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+        }
+    }
 }
 
 /// Configuration for fetching transactions.

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -39,7 +39,7 @@ pub mod tx_manager {
 
     /// Default limit for number of transactions to keep track of for a single peer.
     ///
-    /// Default is 10 KiB, i.e. 320 transaction hashes.
+    /// Default is 320 transaction hashes.
     pub const DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER: u32 = 10 * 1024 / 32;
 
     /// Default maximum pending pool imports to tolerate.

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -39,8 +39,8 @@ pub mod tx_manager {
 
     /// Default limit for number of transactions to keep track of for a single peer.
     ///
-    /// Default is 10 KiB.
-    pub const DEFAULT_CAPACITY_CACHE_SEEN_BY_PEER: u32 = 10 * 1024;
+    /// Default is 10 KiB, i.e. 320 transaction hashes.
+    pub const DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER: u32 = 10 * 1024 / 32;
 
     /// Default maximum pending pool imports to tolerate.
     ///
@@ -51,8 +51,8 @@ pub mod tx_manager {
 
     /// Default limit for number of bad imports to keep track of.
     ///
-    /// Default is 10 KiB.
-    pub const DEFAULT_CAPACITY_CACHE_BAD_IMPORTS: u32 = 100 * 1024;
+    /// Default is 100 KiB, i.e. 3 200 transaction hashes.
+    pub const DEFAULT_MAX_COUNT_BAD_IMPORTS: u32 = 100 * 1024 / 32;
 }
 
 /// Constants used by [`TransactionFetcher`](super::TransactionFetcher).

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -286,7 +286,7 @@ impl<Pool: TransactionPool> TransactionsManager<Pool> {
             pending_pool_imports_info: PendingPoolImportsInfo::new(
                 DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS,
             ),
-            bad_imports: LruCache::new(DEFAULT_CAPACITY_CACHE_BAD_IMPORTS),
+            bad_imports: LruCache::new(DEFAULT_MAX_COUNT_BAD_IMPORTS),
             peers: Default::default(),
             command_tx,
             command_rx: UnboundedReceiverStream::new(command_rx),
@@ -1615,7 +1615,7 @@ impl PeerMetadata {
     /// Returns a new instance of [`PeerMetadata`].
     fn new(request_tx: PeerRequestSender, version: EthVersion, client_version: Arc<str>) -> Self {
         Self {
-            seen_transactions: LruCache::new(DEFAULT_CAPACITY_CACHE_SEEN_BY_PEER),
+            seen_transactions: LruCache::new(DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER),
             request_tx,
             version,
             client_version,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1796,6 +1796,7 @@ mod tests {
                 PeerRequestSender::new(peer_id, to_mock_session_tx),
                 version,
                 Arc::from(""),
+                DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
             ),
             to_mock_session_rx,
         )

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -245,6 +245,8 @@ pub struct TransactionsManager<Pool> {
     pending_transactions: ReceiverStream<TxHash>,
     /// Incoming events from the [`NetworkManager`](crate::NetworkManager).
     transaction_events: UnboundedMeteredReceiver<NetworkTransactionEvent>,
+    /// Max number of seen transactions to store for each peer.
+    max_transactions_seen_by_peer_history: u32,
     /// `TransactionsManager` metrics
     metrics: TransactionsManagerMetrics,
 }
@@ -295,6 +297,8 @@ impl<Pool: TransactionPool> TransactionsManager<Pool> {
                 from_network,
                 NETWORK_POOL_TRANSACTIONS_SCOPE,
             ),
+            max_transactions_seen_by_peer_history: transactions_manager_config
+                .max_transactions_seen_by_peer_history,
             metrics,
         }
     }
@@ -904,7 +908,12 @@ where
                 peer_id, client_version, messages, version, ..
             } => {
                 // Insert a new peer into the peerset.
-                let peer = PeerMetadata::new(messages, version, client_version);
+                let peer = PeerMetadata::new(
+                    messages,
+                    version,
+                    client_version,
+                    self.max_transactions_seen_by_peer_history,
+                );
                 let peer = match self.peers.entry(peer_id) {
                     Entry::Occupied(mut entry) => {
                         entry.insert(peer);
@@ -1613,9 +1622,14 @@ pub struct PeerMetadata {
 
 impl PeerMetadata {
     /// Returns a new instance of [`PeerMetadata`].
-    fn new(request_tx: PeerRequestSender, version: EthVersion, client_version: Arc<str>) -> Self {
+    fn new(
+        request_tx: PeerRequestSender,
+        version: EthVersion,
+        client_version: Arc<str>,
+        max_transactions_seen_by_peer: u32,
+    ) -> Self {
         Self {
-            seen_transactions: LruCache::new(DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER),
+            seen_transactions: LruCache::new(max_transactions_seen_by_peer),
             request_tx,
             version,
             client_version,

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -119,7 +119,7 @@ pub struct NetworkArgs {
 
     /// Max number of seen transactions to remember per peer.
     ///
-    /// Default is 320 transaction hashes.
+    /// Default is 10 KiB, i.e. 320 transaction hashes.
     #[arg(long = "max-seen-tx-history", value_name = "MAX_SEEN_TX_HISTORY", default_value_t = DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, verbatim_doc_comment)]
     pub max_seen_tx_history: u32,
 }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -97,6 +97,12 @@ pub struct NetworkArgs {
     #[arg(long)]
     pub max_inbound_peers: Option<usize>,
 
+    /// Max number of seen transactions to remember per peer.
+    ///
+    /// Default is 10 KiB, i.e. 320 transaction hashes.
+    #[arg(long = "max-seen-tx-history", value_name = "MAX_SEEN_TX_HISTORY", default_value_t = DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, verbatim_doc_comment)]
+    pub max_seen_tx_history: u32,
+
     /// Experimental, for usage in research. Sets the max accumulated byte size of transactions
     /// to pack in one response.
     /// Spec'd at 2MiB.
@@ -116,12 +122,6 @@ pub struct NetworkArgs {
     /// Default is 128 KiB.
     #[arg(long = "pooled-tx-pack-soft-limit", value_name = "BYTES", default_value_t = DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ, verbatim_doc_comment)]
     pub soft_limit_byte_size_pooled_transactions_response_on_pack_request: usize,
-
-    /// Max number of seen transactions to remember per peer.
-    ///
-    /// Default is 10 KiB, i.e. 320 transaction hashes.
-    #[arg(long = "max-seen-tx-history", value_name = "MAX_SEEN_TX_HISTORY", default_value_t = DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, verbatim_doc_comment)]
-    pub max_seen_tx_history: u32,
 }
 
 impl NetworkArgs {

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -12,13 +12,13 @@ use reth_discv5::{
 use reth_net_nat::NatResolver;
 use reth_network::{
     transactions::{
+        constants::tx_manager::DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
         TransactionFetcherConfig, TransactionsManagerConfig,
         DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,
         SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
     },
     HelloMessageWithProtocols, NetworkConfigBuilder, SessionsConfig,
 };
-use reth_network::transactions::constants::tx_manager::DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER;
 use reth_network_peers::{mainnet_nodes, TrustedPeer};
 use secp256k1::SecretKey;
 use std::{
@@ -117,8 +117,9 @@ pub struct NetworkArgs {
     #[arg(long = "pooled-tx-pack-soft-limit", value_name = "BYTES", default_value_t = DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ, verbatim_doc_comment)]
     pub soft_limit_byte_size_pooled_transactions_response_on_pack_request: usize,
 
-    
     /// Max number of seen transactions to remember per peer.
+    ///
+    /// Default is 320 transaction hashes.
     #[arg(long = "max-seen-tx-history", value_name = "MAX_SEEN_TX_HISTORY", default_value_t = DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, verbatim_doc_comment)]
     pub max_seen_tx_history: u32,
 }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -18,6 +18,7 @@ use reth_network::{
     },
     HelloMessageWithProtocols, NetworkConfigBuilder, SessionsConfig,
 };
+use reth_network::transactions::constants::tx_manager::DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER;
 use reth_network_peers::{mainnet_nodes, TrustedPeer};
 use secp256k1::SecretKey;
 use std::{
@@ -115,6 +116,11 @@ pub struct NetworkArgs {
     /// Default is 128 KiB.
     #[arg(long = "pooled-tx-pack-soft-limit", value_name = "BYTES", default_value_t = DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ, verbatim_doc_comment)]
     pub soft_limit_byte_size_pooled_transactions_response_on_pack_request: usize,
+
+    
+    /// Max number of seen transactions to remember per peer.
+    #[arg(long = "max-seen-tx-history", value_name = "MAX_SEEN_TX_HISTORY", default_value_t = DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, verbatim_doc_comment)]
+    pub max_seen_tx_history: u32,
 }
 
 impl NetworkArgs {
@@ -161,6 +167,7 @@ impl NetworkArgs {
                 self.soft_limit_byte_size_pooled_transactions_response,
                 self.soft_limit_byte_size_pooled_transactions_response_on_pack_request,
             ),
+            max_transactions_seen_by_peer_history: self.max_seen_tx_history,
         };
 
         // Configure basic network stack
@@ -261,6 +268,7 @@ impl Default for NetworkArgs {
             soft_limit_byte_size_pooled_transactions_response:
                 SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
             soft_limit_byte_size_pooled_transactions_response_on_pack_request: DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,
+            max_seen_tx_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
         }
     }
 }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -99,7 +99,7 @@ pub struct NetworkArgs {
 
     /// Max number of seen transactions to remember per peer.
     ///
-    /// Default is 10 KiB, i.e. 320 transaction hashes.
+    /// Default is 320 transaction hashes.
     #[arg(long = "max-seen-tx-history", value_name = "MAX_SEEN_TX_HISTORY", default_value_t = DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, verbatim_doc_comment)]
     pub max_seen_tx_history: u32,
 


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/10326

Exposes number of seen transactions to remember per peer as a cli arg.