### PR TITLE
feat: disable l1 data gas cost in --dev mode

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -161,7 +161,12 @@ where
                 ctx.task_executor().clone(),
                 blob_store.clone(),
             )
-            .map(OpTransactionValidator::new);
+            .map(|validator| {
+                OpTransactionValidator::new(validator)
+                    // In --dev mode we can't require gas fees because we're unable to decode the L1
+                    // block info
+                    .require_l1_data_gas_fee(!ctx.config().dev.dev)
+            });
 
         let transaction_pool = reth_transaction_pool::Pool::new(
             validator,


### PR DESCRIPTION
in OP --dev mode we don't have an L1 block, this would just result in a bunch of issues.

hence we should just disable this entirely