### PR TITLE
chore(net): expose pending pool imports bound in cli

### DIFF
--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -180,6 +180,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -177,6 +177,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -177,7 +177,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -180,6 +180,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -177,6 +177,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -177,7 +177,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -180,6 +180,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -177,6 +177,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -177,7 +177,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -180,6 +180,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -177,6 +177,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -177,7 +177,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -169,7 +169,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -169,6 +169,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -172,6 +172,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -154,7 +154,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -157,6 +157,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -154,6 +154,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -220,7 +220,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -220,6 +220,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -223,6 +223,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -182,6 +182,9 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
+      --max-pending-imports <PENDING_IMPORTS>
+          Max number of transactions to import concurrently.
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -185,6 +185,8 @@ Networking:
       --max-pending-imports <PENDING_IMPORTS>
           Max number of transactions to import concurrently.
 
+          [default: 4096]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -182,7 +182,7 @@ Networking:
       --max-inbound-peers <MAX_INBOUND_PEERS>
           Maximum number of inbound requests. default: 30
 
-      --max-pending-imports <PENDING_IMPORTS>
+      --max-pending-imports <COUNT>
           Max number of transactions to import concurrently.
 
           [default: 4096]

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -12,7 +12,8 @@ use reth_discv5::{
 use reth_net_nat::NatResolver;
 use reth_network::{
     transactions::{
-        TransactionFetcherConfig, TransactionsManagerConfig,
+        constants::tx_manager::DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS, TransactionFetcherConfig,
+        TransactionsManagerConfig,
         DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,
         SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
     },
@@ -95,6 +96,10 @@ pub struct NetworkArgs {
     /// Maximum number of inbound requests. default: 30
     #[arg(long)]
     pub max_inbound_peers: Option<usize>,
+
+    #[arg(long = "max-pending-imports", value_name = "PENDING_IMPORTS", default_value_t = DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS, verbatim_doc_comment)]
+    /// Max number of transactions to import concurrently.
+    pub max_pending_pool_imports: usize,
 
     /// Experimental, for usage in research. Sets the max accumulated byte size of transactions
     /// to pack in one response.
@@ -261,6 +266,7 @@ impl Default for NetworkArgs {
             soft_limit_byte_size_pooled_transactions_response:
                 SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
             soft_limit_byte_size_pooled_transactions_response_on_pack_request: DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,
+            max_pending_pool_imports: DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS,
         }
     }
 }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -97,7 +97,7 @@ pub struct NetworkArgs {
     #[arg(long)]
     pub max_inbound_peers: Option<usize>,
 
-    #[arg(long = "max-pending-imports", value_name = "PENDING_IMPORTS", default_value_t = DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS, verbatim_doc_comment)]
+    #[arg(long = "max-pending-imports", value_name = "COUNT", default_value_t = DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS, verbatim_doc_comment)]
     /// Max number of transactions to import concurrently.
     pub max_pending_pool_imports: usize,
 


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/10326

Exposes bound on pool import batch set by `TransactionsManager`