### PR TITLE
fix(payload): 7702 hardfork activation validation

### DIFF
--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -165,7 +165,7 @@ impl ExecutionPayloadValidator {
             return Err(PayloadError::PreShanghaiBlockWithWitdrawals)
         }
 
-        if self.is_prague_active_at_timestamp(sealed_block.timestamp) &&
+        if !self.is_prague_active_at_timestamp(sealed_block.timestamp) &&
             sealed_block.has_eip7702_transactions()
         {
             return Err(PayloadError::PrePragueBlockWithEip7702Transactions)


### PR DESCRIPTION
If Prague is not enabled and we have EIP-7702 transactions, we should report an error.