### PR TITLE
feat(rpc): get_account

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -650,10 +650,11 @@ where
     /// Handler for: `eth_getAccount`
     async fn get_account(
         &self,
-        _address: Address,
-        _block: BlockId,
+        address: Address,
+        block: BlockId,
     ) -> RpcResult<reth_rpc_types::Account> {
-        Err(internal_rpc_err("unimplemented"))
+        trace!(target: "rpc::eth", "Serving eth_getAccount");
+        Ok(EthState::get_account(self, address, block).await?)
     }
 
     /// Handler for: `eth_maxPriorityFeePerGas`

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -4,7 +4,7 @@
 use futures::Future;
 use reth_errors::RethError;
 use reth_evm::ConfigureEvmEnv;
-use reth_primitives::{Address, BlockId, Bytes, Header, B256, U256};
+use reth_primitives::{Address, BlockId, Bytes, Header, B256, KECCAK_EMPTY, U256};
 use reth_provider::{
     BlockIdReader, ChainSpecProvider, StateProvider, StateProviderBox, StateProviderFactory,
     StateRootProvider,
@@ -109,7 +109,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             .ok_or(EthApiError::UnknownBlockNumber)?;
         let max_window = self.max_proof_window();
         if chain_info.best_number.saturating_sub(block_number) > max_window {
-            return Err(EthApiError::ExceedsMaxProofWindow.into());
+            return Err(EthApiError::ExceedsMaxProofWindow.into())
         }
 
         Ok(async move {
@@ -144,7 +144,7 @@ pub trait EthState: LoadState + SpawnBlocking {
                 .unwrap_or_default();
             let balance = account.balance;
             let nonce = account.nonce;
-            let code_hash = account.bytecode_hash.unwrap_or_default();
+            let code_hash = account.bytecode_hash.unwrap_or(KECCAK_EMPTY);
 
             // Provide a default `HashedStorage` value in order to
             // get the storage root hash of the current state.
@@ -284,7 +284,7 @@ pub trait LoadState: EthApiTypes {
                     let tx_count = highest_nonce.checked_add(1).ok_or(Self::Error::from(
                         EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceMaxValue),
                     ))?;
-                    return Ok(U256::from(tx_count));
+                    return Ok(U256::from(tx_count))
                 }
             }
 

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -136,7 +136,7 @@ impl HashedPostState {
 }
 
 /// Representation of in-memory hashed storage.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Default)]
 pub struct HashedStorage {
     /// Flag indicating whether the storage was wiped or not.
     pub wiped: bool,


### PR DESCRIPTION
This PR adds the rpc endpoint `get_account` and solves #9625.

Makes use of the `hashed_storage_root` method from the `StateRootProvider` and passes an empty `HashedStorage` in order to only get the storage root of the current state for the provided account.