### PR TITLE
test: `CanonChainTracker` implementation for `BlockchainProvider2`

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1489,7 +1489,7 @@ where
 mod tests {
     use std::{ops::Range, sync::Arc, time::Instant};
 
-	use itertools::Itertools;
+    use itertools::Itertools;
     use rand::Rng;
     use reth_chain_state::{ExecutedBlock, NewCanonicalChain};
     use reth_chainspec::{
@@ -2357,28 +2357,28 @@ mod tests {
         Ok(())
     }
 
-	#[test]
-	fn test_canon_state_tracker() -> eyre::Result<()> {
-		let mut rng = generators::rng();
-		let (provider, _, _, _) =
-			provider_with_random_blocks(&mut rng, TEST_BLOCKS_COUNT, TEST_BLOCKS_COUNT)?;
+    #[test]
+    fn test_canon_state_tracker() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let (provider, _, _, _) =
+            provider_with_random_blocks(&mut rng, TEST_BLOCKS_COUNT, TEST_BLOCKS_COUNT)?;
 
-		let before = Instant::now();
-		provider.on_forkchoice_update_received(&Default::default());
-		let last_update_ts = provider.last_received_update_timestamp().unwrap();
-		let after = Instant::now();
+        let before = Instant::now();
+        provider.on_forkchoice_update_received(&Default::default());
+        let last_update_ts = provider.last_received_update_timestamp().unwrap();
+        let after = Instant::now();
 
-		// Ensure the timestamp is updated and between the before and after timestamps
-		assert!(before < last_update_ts && last_update_ts < after);
+        // Ensure the timestamp is updated and between the before and after timestamps
+        assert!(before < last_update_ts && last_update_ts < after);
 
-		let before = Instant::now();
-		provider.on_transition_configuration_exchanged();
-		let last_update_ts = provider.last_exchanged_transition_configuration_timestamp().unwrap();
-		let after = Instant::now();
+        let before = Instant::now();
+        provider.on_transition_configuration_exchanged();
+        let last_update_ts = provider.last_exchanged_transition_configuration_timestamp().unwrap();
+        let after = Instant::now();
 
-		// Ensure the timestamp is updated and between the before and after timestamps
-		assert!(before < last_update_ts && last_update_ts < after);
+        // Ensure the timestamp is updated and between the before and after timestamps
+        assert!(before < last_update_ts && last_update_ts < after);
 
-		Ok(())
-	}
+        Ok(())
+    }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2361,7 +2361,7 @@ mod tests {
     fn test_canon_state_tracker() -> eyre::Result<()> {
         let mut rng = generators::rng();
         let (provider, _, _, _) =
-            provider_with_random_blocks(&mut rng, TEST_BLOCKS_COUNT, TEST_BLOCKS_COUNT)?;
+            provider_with_random_blocks(&mut rng, TEST_BLOCKS_COUNT, TEST_BLOCKS_COUNT, None)?;
 
         let before = Instant::now();
         provider.on_forkchoice_update_received(&Default::default());

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1487,9 +1487,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{ops::Range, sync::Arc};
+    use std::{ops::Range, sync::Arc, time::Instant};
 
-    use itertools::Itertools;
+	use itertools::Itertools;
     use rand::Rng;
     use reth_chain_state::{ExecutedBlock, NewCanonicalChain};
     use reth_chainspec::{
@@ -2356,4 +2356,29 @@ mod tests {
 
         Ok(())
     }
+
+	#[test]
+	fn test_canon_state_tracker() -> eyre::Result<()> {
+		let mut rng = generators::rng();
+		let (provider, _, _, _) =
+			provider_with_random_blocks(&mut rng, TEST_BLOCKS_COUNT, TEST_BLOCKS_COUNT)?;
+
+		let before = Instant::now();
+		provider.on_forkchoice_update_received(&Default::default());
+		let last_update_ts = provider.last_received_update_timestamp().unwrap();
+		let after = Instant::now();
+
+		// Ensure the timestamp is updated and between the before and after timestamps
+		assert!(before < last_update_ts && last_update_ts < after);
+
+		let before = Instant::now();
+		provider.on_transition_configuration_exchanged();
+		let last_update_ts = provider.last_exchanged_transition_configuration_timestamp().unwrap();
+		let after = Instant::now();
+
+		// Ensure the timestamp is updated and between the before and after timestamps
+		assert!(before < last_update_ts && last_update_ts < after);
+
+		Ok(())
+	}
 }


### PR DESCRIPTION
Adds tests for the `CanonChainTracker` implementation of the `BlockchainProvider2` and closes #10352.