### PR TITLE
test(exex): some small enhancements for finished height

### DIFF
--- a/crates/exex/exex/src/event.rs
+++ b/crates/exex/exex/src/event.rs
@@ -12,6 +12,7 @@ pub enum ExExEvent {
     FinishedHeight(BlockNumber),
 }
 
+#[cfg(test)]
 impl Default for ExExEvent {
     fn default() -> Self {
         Self::FinishedHeight(0)

--- a/crates/exex/exex/src/event.rs
+++ b/crates/exex/exex/src/event.rs
@@ -11,3 +11,9 @@ pub enum ExExEvent {
     /// On reorgs, it's possible for the height to go down.
     FinishedHeight(BlockNumber),
 }
+
+impl Default for ExExEvent {
+    fn default() -> Self {
+        Self::FinishedHeight(0)
+    }
+}

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -353,7 +353,7 @@ impl Future for ExExManager {
             }
         });
         if let Ok(finished_height) = finished_height {
-            let _ = self.finished_height.send(FinishedExExHeight::Height(finished_height));
+            let _ = self.finished_height.send(finished_height.into());
         }
 
         Poll::Pending

--- a/crates/exex/types/src/finished_height.rs
+++ b/crates/exex/types/src/finished_height.rs
@@ -1,10 +1,9 @@
 use alloy_primitives::BlockNumber;
 
 /// The finished height of all `ExEx`'s.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub enum FinishedExExHeight {
     /// No `ExEx`'s are installed, so there is no finished height.
-    #[default]
     NoExExs,
     /// Not all `ExExs` have emitted a `FinishedHeight` event yet.
     NotReady,

--- a/crates/exex/types/src/finished_height.rs
+++ b/crates/exex/types/src/finished_height.rs
@@ -1,9 +1,10 @@
 use alloy_primitives::BlockNumber;
 
 /// The finished height of all `ExEx`'s.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum FinishedExExHeight {
     /// No `ExEx`'s are installed, so there is no finished height.
+    #[default]
     NoExExs,
     /// Not all `ExExs` have emitted a `FinishedHeight` event yet.
     NotReady,
@@ -21,5 +22,11 @@ impl FinishedExExHeight {
     /// Returns `true` if not all `ExExs` have emitted a `FinishedHeight` event yet.
     pub const fn is_not_ready(&self) -> bool {
         matches!(self, Self::NotReady)
+    }
+}
+
+impl From<u64> for FinishedExExHeight {
+    fn from(value: u64) -> Self {
+        Self::Height(value)
     }
 }

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -371,11 +371,11 @@ mod tests {
         assert!(!pruner.is_pruning_needed(third_block_number));
 
         // Adjust tip block number to the finished ExEx height that doesn't reach the threshold
-        finished_exex_height_tx.send(FinishedExExHeight::Height(second_block_number)).unwrap();
+        finished_exex_height_tx.send(second_block_number.into()).unwrap();
         assert!(!pruner.is_pruning_needed(third_block_number));
 
         // Adjust tip block number to the finished ExEx height that reaches the threshold
-        finished_exex_height_tx.send(FinishedExExHeight::Height(third_block_number)).unwrap();
+        finished_exex_height_tx.send(third_block_number.into()).unwrap();
         assert!(pruner.is_pruning_needed(third_block_number));
     }
 }


### PR DESCRIPTION
- Default for `ExExEvent` is useful especially for testing scenarios.
- `NoExExs` in `FinishedExExHeight` should be defined as default setting for simplicity as a no brainer.
- `From<u64> for FinishedExExHeight` is really practical to manipulate stuff in an easy manner.