### PR TITLE
chore(db): enable `arbitrary` feature on `reth-db-models`

### DIFF
--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -66,6 +66,7 @@ assert_matches.workspace = true
 test-utils = ["arbitrary"]
 arbitrary = [
     "reth-primitives/arbitrary",
+    "reth-db-models/arbitrary",
     "dep:arbitrary",
     "dep:proptest",
 ]


### PR DESCRIPTION
## Description

Enable `reth-db-models/arbitrary` for arbitrary feature in `reth-db-api`. Fixes failing CI on main (ref https://github.com/paradigmxyz/reth/actions/runs/10445060758/job/28920456314).