### PR TITLE
feat: Superchain mainnet - `Granite` hardfork timestamps

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1691,7 +1691,11 @@ Post-merge hard forks (timestamp based):
                 ),
                 (
                     Head { number: 0, timestamp: 1720627201, ..Default::default() },
-                    ForkId { hash: ForkHash([0xe4, 0x01, 0x0e, 0xb9]), next: 0 },
+                    ForkId { hash: ForkHash([0xe4, 0x01, 0x0e, 0xb9]), next: 1725984001 },
+                ),
+                (
+                    Head { number: 0, timestamp: 1725984001, ..Default::default() },
+                    ForkId { hash: ForkHash([0xfa, 0x57, 0x86, 0x01]), next: 0 },
                 ),
             ],
         );
@@ -2649,7 +2653,7 @@ Post-merge hard forks (timestamp based):
     #[test]
     fn latest_base_mainnet_fork_id() {
         assert_eq!(
-            ForkId { hash: ForkHash([0xe4, 0x01, 0x0e, 0xb9]), next: 0 },
+            ForkId { hash: ForkHash([0xfa, 0x57, 0x86, 0x01]), next: 0 },
             BASE_MAINNET.latest_fork_id()
         )
     }

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -187,7 +187,7 @@ impl OptimismHardfork {
                 Self::Canyon => Some(1704992401),
                 Self::Ecotone => Some(1710374401),
                 Self::Fjord => Some(1720627201),
-                _ => None,
+                Self::Granite => Some(1725984001),
             },
         )
     }
@@ -219,6 +219,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1720627201)),
+            (Self::Granite.boxed(), ForkCondition::Timestamp(1725984001)),
         ])
     }
 
@@ -311,6 +312,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1720627201)),
+            (Self::Granite.boxed(), ForkCondition::Timestamp(1725984001)),
         ])
     }
 }


### PR DESCRIPTION
## Overview

Adds the timestamps for the `Granite` hardfork for superchain mainnet chains supported by `op-reth`.

Reference: https://github.com/ethereum-optimism/superchain-registry/pull/491/files