### PR TITLE
perf(trie): remove some clones

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -39,8 +39,8 @@ impl MemoryOverlayStateProvider {
         let mut hashed_post_state = HashedPostState::default();
         let mut trie_updates = TrieUpdates::default();
         for block in in_memory.iter().rev() {
-            hashed_post_state.extend(block.hashed_state.as_ref().clone());
-            trie_updates.extend(block.trie.as_ref().clone());
+            hashed_post_state.extend_ref(block.hashed_state.as_ref());
+            trie_updates.extend_ref(block.trie.as_ref());
         }
         Self { in_memory, hashed_post_state, trie_updates, historical }
     }

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -143,7 +143,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
                 )
             })
             .unwrap_or_else(|| HashedStorage::new(false));
-        storage.extend(hashed_storage);
+        storage.extend(&hashed_storage);
         self.state_provider.hashed_storage_root(address, storage)
     }
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -341,7 +341,7 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         let mut revert_storage = self.revert_storage(address)?;
-        revert_storage.extend(hashed_storage);
+        revert_storage.extend(&hashed_storage);
         StorageRoot::overlay_root(self.tx, address, revert_storage)
             .map_err(|err| ProviderError::Database(err.into()))
     }

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -6,7 +6,10 @@ use itertools::Itertools;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use reth_primitives::{keccak256, Account, Address, B256, U256};
 use revm::db::{states::CacheAccount, AccountStatus, BundleAccount};
-use std::collections::{hash_map, HashMap, HashSet};
+use std::{
+    borrow::Cow,
+    collections::{hash_map, HashMap, HashSet},
+};
 
 /// Representation of in-memory hashed state.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
@@ -99,17 +102,42 @@ impl HashedPostState {
     /// Extend this hashed post state with contents of another.
     /// Entries in the second hashed post state take precedence.
     pub fn extend(&mut self, other: Self) {
-        for (hashed_address, account) in other.accounts {
-            self.accounts.insert(hashed_address, account);
-        }
+        self.extend_inner(Cow::Owned(other));
+    }
 
-        for (hashed_address, storage) in other.storages {
+    /// Extend this hashed post state with contents of another.
+    /// Entries in the second hashed post state take precedence.
+    ///
+    /// Slightly less efficient than [`Self::extend`], but preferred to `extend(other.clone())`.
+    pub fn extend_ref(&mut self, other: &Self) {
+        self.extend_inner(Cow::Borrowed(other));
+    }
+
+    fn extend_inner(&mut self, other: Cow<'_, Self>) {
+        self.accounts.extend(other.accounts.iter().map(|(&k, &v)| (k, v)));
+
+        self.storages.reserve(other.storages.len());
+        match other {
+            Cow::Borrowed(other) => {
+                self.extend_storages(other.storages.iter().map(|(k, v)| (*k, Cow::Borrowed(v))))
+            }
+            Cow::Owned(other) => {
+                self.extend_storages(other.storages.into_iter().map(|(k, v)| (k, Cow::Owned(v))))
+            }
+        }
+    }
+
+    fn extend_storages<'a>(
+        &mut self,
+        storages: impl IntoIterator<Item = (B256, Cow<'a, HashedStorage>)>,
+    ) {
+        for (hashed_address, storage) in storages {
             match self.storages.entry(hashed_address) {
                 hash_map::Entry::Vacant(entry) => {
-                    entry.insert(storage);
+                    entry.insert(storage.into_owned());
                 }
                 hash_map::Entry::Occupied(mut entry) => {
-                    entry.get_mut().extend(storage);
+                    entry.get_mut().extend(&storage);
                 }
             }
         }
@@ -206,14 +234,12 @@ impl HashedStorage {
 
     /// Extend hashed storage with contents of other.
     /// The entries in second hashed storage take precedence.
-    pub fn extend(&mut self, other: Self) {
+    pub fn extend(&mut self, other: &Self) {
         if other.wiped {
             self.wiped = true;
             self.storage.clear();
         }
-        for (hashed_slot, value) in other.storage {
-            self.storage.insert(hashed_slot, value);
-        }
+        self.storage.extend(other.storage.iter().map(|(&k, &v)| (k, v)));
     }
 
     /// Converts hashed storage into [`HashedStorageSorted`].


### PR DESCRIPTION
Since extending hashmaps is always a linear operation, we can reduce cloning to only when necessary on a per-field/element basis.

Duplicate some `extend` fns to take refs to be more efficient than `extend(other.clone())`.

These show up in profiles under `EngineApiTreeHandler` -> `MemoryOverlayStateProvider::new`.