### PR TITLE
fix(trie): filter in-memory storage node on `seek_exact`

### DIFF
--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -199,7 +199,7 @@ impl<'a, C: TrieCursor> InMemoryStorageTrieCursor<'a, C> {
         if self.storage_trie_cleared ||
             (exact && in_memory.as_ref().map_or(false, |entry| entry.0 == key))
         {
-            return Ok(in_memory)
+            return Ok(in_memory.filter(|(nibbles, _)| !exact || nibbles == &key))
         }
 
         // Reposition the cursor to the first greater or equal node that wasn't removed.


### PR DESCRIPTION
## Description

If storage was cleared, the in-memory trie cursor would return an in-memory trie node on `seek_exact` without checking if it is an exact match.