### PR TITLE
chore(lint): allow needless update for tests

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -177,6 +177,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_configure() {
         // Create a default `EthEvmConfig`
         let evm_config = EthEvmConfig::default();
@@ -218,6 +219,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_with_env_default_spec() {
         let evm_config = EthEvmConfig::default();
 
@@ -238,6 +240,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_with_env_custom_cfg() {
         let evm_config = EthEvmConfig::default();
 
@@ -268,6 +271,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_with_env_custom_block_and_tx() {
         let evm_config = EthEvmConfig::default();
 
@@ -324,6 +328,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_with_inspector() {
         let evm_config = EthEvmConfig::default();
 
@@ -368,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_with_env_and_default_inspector() {
         let evm_config = EthEvmConfig::default();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
@@ -387,6 +393,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_with_env_inspector_and_custom_cfg() {
         let evm_config = EthEvmConfig::default();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
@@ -411,6 +418,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_update)]
     fn test_evm_with_env_inspector_and_custom_block_tx() {
         let evm_config = EthEvmConfig::default();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();


### PR DESCRIPTION
Adds `#[allow(clippy::needless_update)]` to tests failing lint