### PR TITLE
fix: block_range

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -638,7 +638,7 @@ where
         blocks.append(&mut database_blocks);
 
         // Advance the range iterator by the number of blocks fetched from the database
-        range.nth(database_blocks.len() - 1);
+        range.nth(blocks.len() - 1);
 
         // Fetch the remaining blocks from the in-memory state
         for num in range {


### PR DESCRIPTION
Fixes a bug in block_range implementation for BlockchainProvider2. The current implementation was using `database_blocks` in order to get the length of the block retrieved from database. 

However, because `database_blocks` was passed to `blocks.append`, this caused its length to always be `0` (see Rust [documentation](https://doc.rust-lang.org/1.80.1/src/alloc/vec/mod.rs.html#2133)).