### PR TITLE
fix(rpc/otterscan): set fullblock.tx_count with block's

### DIFF
--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -233,7 +233,11 @@ where
                 OtsTransactionReceipt { receipt, timestamp }
             })
             .collect();
-        Ok(OtsBlockTransactions { fullblock: block.inner.into(), receipts })
+
+        // use `transaction_count` to indicate the paginate information
+        let mut block = OtsBlockTransactions { fullblock: block.inner.into(), receipts };
+        block.fullblock.transaction_count = tx_len;
+        Ok(block)
     }
 
     /// Handler for `searchTransactionsBefore`


### PR DESCRIPTION
Otterscan use `fullblock.transactionCount` to indicate the paginate, so we should set this field always to the full block's one, instead of the drained block.

ref https://github.com/erigontech/erigon/blob/a0049fe9687e79f33e2b191a933aca8a90bda42a/turbo/jsonrpc/otterscan_api.go#L490