### PR TITLE
chore: make `consensus/debug-client` helpers public

### DIFF
--- a/crates/consensus/debug-client/src/client.rs
+++ b/crates/consensus/debug-client/src/client.rs
@@ -152,27 +152,27 @@ impl<P: BlockProvider + Clone> DebugConsensusClient<P> {
 
 /// Cancun "new payload" event.
 #[derive(Debug)]
-struct ExecutionNewPayload {
-    execution_payload_v3: ExecutionPayloadV3,
-    versioned_hashes: Vec<B256>,
-    parent_beacon_block_root: B256,
+pub struct ExecutionNewPayload {
+    pub execution_payload_v3: ExecutionPayloadV3,
+    pub versioned_hashes: Vec<B256>,
+    pub parent_beacon_block_root: B256,
 }
 
 impl ExecutionNewPayload {
     /// Get block hash from block in the payload
-    const fn block_hash(&self) -> B256 {
+    pub const fn block_hash(&self) -> B256 {
         self.execution_payload_v3.payload_inner.payload_inner.block_hash
     }
 
     /// Get block number from block in the payload
-    const fn block_number(&self) -> u64 {
+    pub const fn block_number(&self) -> u64 {
         self.execution_payload_v3.payload_inner.payload_inner.block_number
     }
 }
 
 /// Convert a rich block from RPC / Etherscan to params for an execution client's "new payload"
 /// method. Assumes that the block contains full transactions.
-fn rich_block_to_execution_payload_v3(block: RichBlock) -> ExecutionNewPayload {
+pub fn rich_block_to_execution_payload_v3(block: RichBlock) -> ExecutionNewPayload {
     let transactions = match &block.transactions {
         BlockTransactions::Full(txs) => txs.clone(),
         // Empty array gets deserialized as BlockTransactions::Hashes.

--- a/crates/consensus/debug-client/src/lib.rs
+++ b/crates/consensus/debug-client/src/lib.rs
@@ -15,5 +15,5 @@
 mod client;
 mod providers;
 
-pub use client::{BlockProvider, DebugConsensusClient};
+pub use client::{rich_block_to_execution_payload_v3, BlockProvider, DebugConsensusClient};
 pub use providers::{EtherscanBlockProvider, RpcBlockProvider};

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -27,6 +27,30 @@ impl EtherscanBlockProvider {
         self.interval = interval;
         self
     }
+
+    /// Load block using Etherscan API. Note: only `BlockNumberOrTag::Latest`,
+    /// `BlockNumberOrTag::Earliest`, `BlockNumberOrTag::Pending`, `BlockNumberOrTag::Number(u64)`
+    /// are supported.
+    pub async fn load_block(
+        &self,
+        block_number_or_tag: BlockNumberOrTag,
+    ) -> eyre::Result<RichBlock> {
+        let block: EtherscanBlockResponse = self
+            .http_client
+            .get(&self.base_url)
+            .query(&[
+                ("module", "proxy"),
+                ("action", "eth_getBlockByNumber"),
+                ("tag", &block_number_or_tag.to_string()),
+                ("boolean", "true"),
+                ("apikey", &self.api_key),
+            ])
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(block.result)
+    }
 }
 
 impl BlockProvider for EtherscanBlockProvider {
@@ -35,14 +59,7 @@ impl BlockProvider for EtherscanBlockProvider {
         let mut interval = interval(self.interval);
         loop {
             interval.tick().await;
-            let block = match load_etherscan_block(
-                &self.http_client,
-                &self.base_url,
-                &self.api_key,
-                BlockNumberOrTag::Latest,
-            )
-            .await
-            {
+            let block = match self.load_block(BlockNumberOrTag::Latest).await {
                 Ok(block) => block,
                 Err(err) => {
                     warn!(target: "consensus::debug-client", %err, "failed to fetch a block from Etherscan");
@@ -64,42 +81,11 @@ impl BlockProvider for EtherscanBlockProvider {
     }
 
     async fn get_block(&self, block_number: u64) -> eyre::Result<RichBlock> {
-        load_etherscan_block(
-            &self.http_client,
-            &self.base_url,
-            &self.api_key,
-            BlockNumberOrTag::Number(block_number),
-        )
-        .await
+        self.load_block(BlockNumberOrTag::Number(block_number)).await
     }
 }
 
 #[derive(Deserialize, Debug)]
 struct EtherscanBlockResponse {
     result: RichBlock,
-}
-
-/// Load block using Etherscan API. Note: only `BlockNumberOrTag::Latest`,
-/// `BlockNumberOrTag::Earliest`, `BlockNumberOrTag::Pending`, `BlockNumberOrTag::Number(u64)` are
-/// supported.
-async fn load_etherscan_block(
-    http_client: &Client,
-    base_url: &str,
-    api_key: &str,
-    block_number_or_tag: BlockNumberOrTag,
-) -> eyre::Result<RichBlock> {
-    let block: EtherscanBlockResponse = http_client
-        .get(base_url)
-        .query(&[
-            ("module", "proxy"),
-            ("action", "eth_getBlockByNumber"),
-            ("tag", &block_number_or_tag.to_string()),
-            ("boolean", "true"),
-            ("apikey", api_key),
-        ])
-        .send()
-        .await?
-        .json()
-        .await?;
-    Ok(block.result)
 }


### PR DESCRIPTION
* Small refactor
* make type/methods public so they can be re-used externally (example: https://github.com/joshieDo/reth-tester/blob/main/src/main.rs#L91)