### PR TITLE
chore: Update granite mainnet time

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1691,11 +1691,11 @@ Post-merge hard forks (timestamp based):
                 ),
                 (
                     Head { number: 0, timestamp: 1720627201, ..Default::default() },
-                    ForkId { hash: ForkHash([0xe4, 0x01, 0x0e, 0xb9]), next: 1725984001 },
+                    ForkId { hash: ForkHash([0xe4, 0x01, 0x0e, 0xb9]), next: 1726070401 },
                 ),
                 (
-                    Head { number: 0, timestamp: 1725984001, ..Default::default() },
-                    ForkId { hash: ForkHash([0xfa, 0x57, 0x86, 0x01]), next: 0 },
+                    Head { number: 0, timestamp: 1726070401, ..Default::default() },
+                    ForkId { hash: ForkHash([0xbc, 0x38, 0xf9, 0xca]), next: 0 },
                 ),
             ],
         );
@@ -2653,7 +2653,7 @@ Post-merge hard forks (timestamp based):
     #[test]
     fn latest_base_mainnet_fork_id() {
         assert_eq!(
-            ForkId { hash: ForkHash([0xfa, 0x57, 0x86, 0x01]), next: 0 },
+            ForkId { hash: ForkHash([0xbc, 0x38, 0xf9, 0xca]), next: 0 },
             BASE_MAINNET.latest_fork_id()
         )
     }

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -187,7 +187,7 @@ impl OptimismHardfork {
                 Self::Canyon => Some(1704992401),
                 Self::Ecotone => Some(1710374401),
                 Self::Fjord => Some(1720627201),
-                Self::Granite => Some(1725984001),
+                Self::Granite => Some(1726070401),
             },
         )
     }
@@ -219,7 +219,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1720627201)),
-            (Self::Granite.boxed(), ForkCondition::Timestamp(1725984001)),
+            (Self::Granite.boxed(), ForkCondition::Timestamp(1726070401)),
         ])
     }
 
@@ -312,7 +312,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1710374401)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1720627201)),
-            (Self::Granite.boxed(), ForkCondition::Timestamp(1725984001)),
+            (Self::Granite.boxed(), ForkCondition::Timestamp(1726070401)),
         ])
     }
 }


### PR DESCRIPTION
## Overview

The granite mainnet time has been updated to `Sep 11, 16:00:01 UTC`.

ref: https://github.com/ethereum-optimism/superchain-registry/pull/498