### PR TITLE
fix(trie): filter out removed nodes on extend

### DIFF
--- a/crates/trie/trie/src/updates.rs
+++ b/crates/trie/trie/src/updates.rs
@@ -36,6 +36,7 @@ impl TrieUpdates {
 
     /// Extends the trie updates.
     pub fn extend(&mut self, other: Self) {
+        self.account_nodes.retain(|nibbles, _| !other.removed_nodes.contains(nibbles));
         self.account_nodes.extend(ExcludeEmptyFromPair::from_iter(other.account_nodes));
         self.removed_nodes.extend(ExcludeEmpty::from_iter(other.removed_nodes));
         for (hashed_address, storage_trie) in other.storage_tries {
@@ -157,6 +158,7 @@ impl StorageTrieUpdates {
             self.removed_nodes.clear();
         }
         self.is_deleted |= other.is_deleted;
+        self.storage_nodes.retain(|nibbles, _| !other.removed_nodes.contains(nibbles));
         self.storage_nodes.extend(ExcludeEmptyFromPair::from_iter(other.storage_nodes));
         self.removed_nodes.extend(ExcludeEmpty::from_iter(other.removed_nodes));
     }


### PR DESCRIPTION
## Description

Filter out removed in-memory nodes on extend. This led to stale cached nodes being picked up during state root calculation for long chain of in-memory blocks.