### PR TITLE
chore(tree): remove BlockAttachment usage

### DIFF
--- a/crates/blockchain-tree-api/src/lib.rs
+++ b/crates/blockchain-tree-api/src/lib.rs
@@ -198,6 +198,36 @@ impl CanonicalOutcome {
     }
 }
 
+/// Block inclusion can be valid, accepted, or invalid. Invalid blocks are returned as an error
+/// variant.
+///
+/// If we don't know the block's parent, we return `Disconnected`, as we can't claim that the block
+/// is valid or not.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlockStatus2 {
+    /// The block is valid and block extends canonical chain.
+    Valid,
+    /// The block may be valid and has an unknown missing ancestor.
+    Disconnected {
+        /// Current canonical head.
+        head: BlockNumHash,
+        /// The lowest ancestor block that is not connected to the canonical chain.
+        missing_ancestor: BlockNumHash,
+    },
+}
+
+/// How a payload was inserted if it was valid.
+///
+/// If the payload was valid, but has already been seen, [`InsertPayloadOk2::AlreadySeen(_)`] is
+/// returned, otherwise [`InsertPayloadOk2::Inserted(_)`] is returned.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InsertPayloadOk2 {
+    /// The payload was valid, but we have already seen it.
+    AlreadySeen(BlockStatus2),
+    /// The payload was valid and inserted into the tree.
+    Inserted(BlockStatus2),
+}
+
 /// From Engine API spec, block inclusion can be valid, accepted or invalid.
 /// Invalid case is already covered by error, but we need to make distinction
 /// between valid blocks that extend canonical chain and the ones that fork off


### PR DESCRIPTION
This introduces two new types, `BlockStatusTwo` and `InsertPayloadOkTwo`, which removes the `BlockAttachment` from `BlockStatusTwo::Valid`. This is now not necessary due to the new engine design.