### PR TITLE
fix(provider): check list size before calling `range.nth`

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -126,12 +126,10 @@ where
         (start, end)
     }
 
-    /// Fetches ranges of data spanning in-memory state and storage.
+    /// Fetches a range of data from both in-memory state and storage.
     ///
-    /// `fetch_db_range`:  should return the whole range of items from the database.
-    ///
-    /// `map_block_state_item`: should return an Option of the value part of the nth block. If it
-    /// returns None (eg. fails predicate), it will stop fetching and return the list.
+    /// - `fetch_db_range`: Retrieves a range of items from the database.
+    /// - `map_block_state_item`: Maps a block number to an item in memory. Stops fetching if `None` is returned.
     fn fetch_db_mem_range<T, F, G, P>(
         &self,
         range: impl RangeBounds<BlockNumber>,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -129,7 +129,8 @@ where
     /// Fetches a range of data from both in-memory state and storage.
     ///
     /// - `fetch_db_range`: Retrieves a range of items from the database.
-    /// - `map_block_state_item`: Maps a block number to an item in memory. Stops fetching if `None` is returned.
+    /// - `map_block_state_item`: Maps a block number to an item in memory. Stops fetching if `None`
+    ///   is returned.
     fn fetch_db_mem_range<T, F, G, P>(
         &self,
         range: impl RangeBounds<BlockNumber>,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -295,7 +295,7 @@ where
         let mut db_headers = self.database.headers_range(range.clone())?;
 
         // Advance the range iterator by the number of headers fetched from the database
-        range.nth(db_headers.len() - 1);
+        range.nth(db_headers.len().saturating_sub(1));
 
         headers.append(&mut db_headers);
 
@@ -335,7 +335,7 @@ where
         let mut db_headers = self.database.sealed_headers_range(range.clone())?;
 
         // Advance the range iterator by the number of headers fetched from the database
-        range.nth(db_headers.len() - 1);
+        range.nth(db_headers.len().saturating_sub(1));
 
         sealed_headers.append(&mut db_headers);
 
@@ -368,7 +368,7 @@ where
         let mut db_headers = self.database.sealed_headers_while(range.clone(), &mut predicate)?;
 
         // Advance the range iterator by the number of headers fetched from the database
-        range.nth(db_headers.len() - 1);
+        range.nth(db_headers.len().saturating_sub(1));
 
         sealed_headers.append(&mut db_headers);
 
@@ -416,7 +416,7 @@ where
         let mut db_hashes = self.database.canonical_hashes_range(start, end)?;
 
         // Advance the range iterator by the number of blocks fetched from the database
-        range.nth(db_hashes.len() - 1);
+        range.nth(db_hashes.len().saturating_sub(1));
 
         hashes.append(&mut db_hashes);
 
@@ -638,7 +638,7 @@ where
         blocks.append(&mut database_blocks);
 
         // Advance the range iterator by the number of blocks fetched from the database
-        range.nth(blocks.len() - 1);
+        range.nth(blocks.len().saturating_sub(1));
 
         // Fetch the remaining blocks from the in-memory state
         for num in range {
@@ -666,7 +666,7 @@ where
         blocks.append(&mut database_blocks);
 
         // Advance the range iterator by the number of blocks fetched from the database
-        range.nth(blocks.len() - 1);
+        range.nth(blocks.len().saturating_sub(1));
 
         // Fetch the remaining blocks from the in-memory state
         for num in range {
@@ -696,7 +696,7 @@ where
         blocks.append(&mut database_blocks);
 
         // Advance the range iterator by the number of blocks fetched from the database
-        range.nth(blocks.len() - 1);
+        range.nth(blocks.len().saturating_sub(1));
 
         // Fetch the remaining blocks from the in-memory state
         for num in range {


### PR DESCRIPTION
If the range has 0 database it will overflow and return empty (or undefined?)

Ended up refactoring the range logic into using one method: `fetch_db_mem_range` and applied the fix. 
closes https://github.com/paradigmxyz/reth/issues/10461