### PR TITLE
chore(trie): remove `PrefixSetMut::contains`

### DIFF
--- a/crates/trie/trie/benches/prefix_set.rs
+++ b/crates/trie/trie/benches/prefix_set.rs
@@ -7,7 +7,7 @@ use proptest::{
     strategy::ValueTree,
     test_runner::{basic_result_cache, TestRunner},
 };
-use reth_trie::{prefix_set::PrefixSetMut, Nibbles};
+use reth_trie::{prefix_set::PrefixSet, Nibbles};
 use std::collections::BTreeSet;
 
 /// Abstractions used for benching
@@ -16,7 +16,7 @@ pub trait PrefixSetAbstraction: Default {
     fn contains(&mut self, key: Nibbles) -> bool;
 }
 
-impl PrefixSetAbstraction for PrefixSetMut {
+impl PrefixSetAbstraction for PrefixSet {
     fn insert(&mut self, key: Nibbles) {
         Self::insert(self, key)
     }
@@ -66,7 +66,7 @@ fn prefix_set_bench<T: PrefixSetAbstraction>(
         for key in &preload {
             prefix_set.insert(key.clone());
         }
-        (prefix_set, input.clone(), expected.clone())
+        (prefix_set.freeze(), input.clone(), expected.clone())
     };
 
     let group_id = format!(

--- a/crates/trie/trie/benches/prefix_set.rs
+++ b/crates/trie/trie/benches/prefix_set.rs
@@ -13,6 +13,8 @@ use reth_trie::{
 };
 use std::collections::BTreeSet;
 
+/// Abstraction for aggregating nibbles and freezing it to a type
+/// that can be later used for benching.
 pub trait PrefixSetMutAbstraction: Default {
     type Frozen;
     fn insert(&mut self, key: Nibbles);

--- a/crates/trie/trie/benches/prefix_set.rs
+++ b/crates/trie/trie/benches/prefix_set.rs
@@ -7,20 +7,36 @@ use proptest::{
     strategy::ValueTree,
     test_runner::{basic_result_cache, TestRunner},
 };
-use reth_trie::{prefix_set::PrefixSet, Nibbles};
+use reth_trie::{
+    prefix_set::{PrefixSet, PrefixSetMut},
+    Nibbles,
+};
 use std::collections::BTreeSet;
+
+pub trait PrefixSetMutAbstraction: Default {
+    type Frozen;
+    fn insert(&mut self, key: Nibbles);
+    fn freeze(self) -> Self::Frozen;
+}
 
 /// Abstractions used for benching
 pub trait PrefixSetAbstraction: Default {
-    fn insert(&mut self, key: Nibbles);
     fn contains(&mut self, key: Nibbles) -> bool;
 }
 
-impl PrefixSetAbstraction for PrefixSet {
+impl PrefixSetMutAbstraction for PrefixSetMut {
+    type Frozen = PrefixSet;
+
     fn insert(&mut self, key: Nibbles) {
         Self::insert(self, key)
     }
 
+    fn freeze(self) -> Self::Frozen {
+        Self::freeze(self)
+    }
+}
+
+impl PrefixSetAbstraction for PrefixSet {
     fn contains(&mut self, key: Nibbles) -> bool {
         Self::contains(self, &key)
     }
@@ -56,11 +72,14 @@ pub fn prefix_set_lookups(c: &mut Criterion) {
     }
 }
 
-fn prefix_set_bench<T: PrefixSetAbstraction>(
+fn prefix_set_bench<T>(
     group: &mut BenchmarkGroup<'_, WallTime>,
     description: &str,
     (preload, input, expected): (Vec<Nibbles>, Vec<Nibbles>, Vec<bool>),
-) {
+) where
+    T: PrefixSetMutAbstraction,
+    T::Frozen: PrefixSetAbstraction,
+{
     let setup = || {
         let mut prefix_set = T::default();
         for key in &preload {
@@ -119,11 +138,19 @@ mod implementations {
         keys: BTreeSet<Nibbles>,
     }
 
-    impl PrefixSetAbstraction for BTreeAnyPrefixSet {
+    impl PrefixSetMutAbstraction for BTreeAnyPrefixSet {
+        type Frozen = Self;
+
         fn insert(&mut self, key: Nibbles) {
             self.keys.insert(key);
         }
 
+        fn freeze(self) -> Self::Frozen {
+            self
+        }
+    }
+
+    impl PrefixSetAbstraction for BTreeAnyPrefixSet {
         fn contains(&mut self, key: Nibbles) -> bool {
             self.keys.iter().any(|k| k.has_prefix(&key))
         }
@@ -135,11 +162,19 @@ mod implementations {
         last_checked: Option<Nibbles>,
     }
 
-    impl PrefixSetAbstraction for BTreeRangeLastCheckedPrefixSet {
+    impl PrefixSetMutAbstraction for BTreeRangeLastCheckedPrefixSet {
+        type Frozen = Self;
+
         fn insert(&mut self, key: Nibbles) {
             self.keys.insert(key);
         }
 
+        fn freeze(self) -> Self::Frozen {
+            self
+        }
+    }
+
+    impl PrefixSetAbstraction for BTreeRangeLastCheckedPrefixSet {
         fn contains(&mut self, prefix: Nibbles) -> bool {
             let range = match self.last_checked.as_ref() {
                 // presumably never hit
@@ -169,12 +204,20 @@ mod implementations {
         sorted: bool,
     }
 
-    impl PrefixSetAbstraction for VecBinarySearchPrefixSet {
+    impl PrefixSetMutAbstraction for VecBinarySearchPrefixSet {
+        type Frozen = Self;
+
         fn insert(&mut self, key: Nibbles) {
             self.sorted = false;
             self.keys.push(key);
         }
 
+        fn freeze(self) -> Self::Frozen {
+            self
+        }
+    }
+
+    impl PrefixSetAbstraction for VecBinarySearchPrefixSet {
         fn contains(&mut self, prefix: Nibbles) -> bool {
             if !self.sorted {
                 self.keys.sort();
@@ -198,12 +241,20 @@ mod implementations {
         index: usize,
     }
 
-    impl PrefixSetAbstraction for VecCursorPrefixSet {
+    impl PrefixSetMutAbstraction for VecCursorPrefixSet {
+        type Frozen = Self;
+
         fn insert(&mut self, nibbles: Nibbles) {
             self.sorted = false;
             self.keys.push(nibbles);
         }
 
+        fn freeze(self) -> Self::Frozen {
+            self
+        }
+    }
+
+    impl PrefixSetAbstraction for VecCursorPrefixSet {
         fn contains(&mut self, prefix: Nibbles) -> bool {
             if !self.sorted {
                 self.keys.sort();
@@ -239,12 +290,20 @@ mod implementations {
         sorted: bool,
     }
 
-    impl PrefixSetAbstraction for VecBinarySearchWithLastFoundPrefixSet {
+    impl PrefixSetMutAbstraction for VecBinarySearchWithLastFoundPrefixSet {
+        type Frozen = Self;
+
         fn insert(&mut self, key: Nibbles) {
             self.sorted = false;
             self.keys.push(key);
         }
 
+        fn freeze(self) -> Self::Frozen {
+            self
+        }
+    }
+
+    impl PrefixSetAbstraction for VecBinarySearchWithLastFoundPrefixSet {
         fn contains(&mut self, prefix: Nibbles) -> bool {
             if !self.sorted {
                 self.keys.sort();

--- a/crates/trie/trie/src/prefix_set.rs
+++ b/crates/trie/trie/src/prefix_set.rs
@@ -222,7 +222,7 @@ mod tests {
         prefix_set_mut.insert(Nibbles::from_nibbles([4, 5, 6]));
         prefix_set_mut.insert(Nibbles::from_nibbles([1, 2, 3])); // Duplicate
 
-        assert_eq!(prefix_set_mut.keys.len(), 3); // Length should be 3 (excluding duplicate)
+        assert_eq!(prefix_set_mut.keys.len(), 4); // Length should be 3 (including duplicate)
         assert_eq!(prefix_set_mut.keys.capacity(), 4); // Capacity should be 4 (including duplicate)
 
         let mut prefix_set = prefix_set_mut.freeze();
@@ -242,7 +242,7 @@ mod tests {
         prefix_set_mut.insert(Nibbles::from_nibbles([4, 5, 6]));
         prefix_set_mut.insert(Nibbles::from_nibbles([1, 2, 3])); // Duplicate
 
-        assert_eq!(prefix_set_mut.keys.len(), 3); // Length should be 3 (excluding duplicate)
+        assert_eq!(prefix_set_mut.keys.len(), 4); // Length should be 3 (including duplicate)
         assert_eq!(prefix_set_mut.keys.capacity(), 101); // Capacity should be 101 (including duplicate)
 
         let mut prefix_set = prefix_set_mut.freeze();

--- a/crates/trie/trie/src/prefix_set.rs
+++ b/crates/trie/trie/src/prefix_set.rs
@@ -78,7 +78,7 @@ pub struct TriePrefixSets {
 /// let mut prefix_set_mut = PrefixSetMut::default();
 /// prefix_set_mut.insert(Nibbles::from_nibbles_unchecked(&[0xa, 0xb]));
 /// prefix_set_mut.insert(Nibbles::from_nibbles_unchecked(&[0xa, 0xb, 0xc]));
-/// let prefix_set = prefix_set_mut.freeze();
+/// let mut prefix_set = prefix_set_mut.freeze();
 /// assert!(prefix_set.contains(&[0xa, 0xb]));
 /// assert!(prefix_set.contains(&[0xa, 0xb, 0xc]));
 /// ```
@@ -207,7 +207,7 @@ mod tests {
         prefix_set_mut.insert(Nibbles::from_nibbles([4, 5, 6]));
         prefix_set_mut.insert(Nibbles::from_nibbles([1, 2, 3])); // Duplicate
 
-        let prefix_set = prefix_set_mut.freeze();
+        let mut prefix_set = prefix_set_mut.freeze();
         assert!(prefix_set.contains(&[1, 2]));
         assert!(prefix_set.contains(&[4, 5]));
         assert!(!prefix_set.contains(&[7, 8]));
@@ -225,7 +225,7 @@ mod tests {
         assert_eq!(prefix_set_mut.keys.len(), 3); // Length should be 3 (excluding duplicate)
         assert_eq!(prefix_set_mut.keys.capacity(), 4); // Capacity should be 4 (including duplicate)
 
-        let prefix_set = prefix_set_mut.freeze();
+        let mut prefix_set = prefix_set_mut.freeze();
         assert!(prefix_set.contains(&[1, 2]));
         assert!(prefix_set.contains(&[4, 5]));
         assert!(!prefix_set.contains(&[7, 8]));
@@ -245,7 +245,7 @@ mod tests {
         assert_eq!(prefix_set_mut.keys.len(), 3); // Length should be 3 (excluding duplicate)
         assert_eq!(prefix_set_mut.keys.capacity(), 101); // Capacity should be 101 (including duplicate)
 
-        let prefix_set = prefix_set_mut.freeze();
+        let mut prefix_set = prefix_set_mut.freeze();
         assert!(prefix_set.contains(&[1, 2]));
         assert!(prefix_set.contains(&[4, 5]));
         assert!(!prefix_set.contains(&[7, 8]));


### PR DESCRIPTION
## Description

Remove `PrefixSetMut::contains` given that this is a mutable collection not intended for searching.