### PR TITLE
fix(provider): fix subtract overflow on `block_state_by_tx_id`

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -165,7 +165,7 @@ where
             let Some(body_index) = provider.block_body_indices(block_number)? else {
                 return Ok(None)
             };
-            let tx_index =  body_index.last_tx_num() - id;
+            let tx_index = body_index.last_tx_num() - id;
             Ok(Some((None, tx_index as usize)))
         } else {
             // Otherwise, iterate through in-memory blocks and find the transaction with the

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -165,7 +165,7 @@ where
             let Some(body_index) = provider.block_body_indices(block_number)? else {
                 return Ok(None)
             };
-            let tx_index = id - body_index.last_tx_num();
+            let tx_index =  body_index.last_tx_num() - id;
             Ok(Some((None, tx_index as usize)))
         } else {
             // Otherwise, iterate through in-memory blocks and find the transaction with the


### PR DESCRIPTION
It fixes it, but I'm unsure on what good is a `Ok(Some(None,txindex))`