### PR TITLE
Remove redundant `EthChainSpec::Hardfork`

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,27 +1,17 @@
 use crate::ChainSpec;
 use alloy_chains::Chain;
-use reth_ethereum_forks::{EthereumHardfork, ForkCondition};
 
 /// Trait representing type configuring a chain spec.
 pub trait EthChainSpec: Send + Sync + Unpin + 'static {
-    /// Enumw with chain hardforks.
-    type Hardfork: Clone + Copy + 'static;
+    // todo: make chain spec type generic over hardfork
+    //type Hardfork: Clone + Copy + 'static;
 
     /// Chain id.
     fn chain(&self) -> Chain;
-
-    /// Activation condition for a given hardfork.
-    fn activation_condition(&self, hardfork: Self::Hardfork) -> ForkCondition;
 }
 
 impl EthChainSpec for ChainSpec {
-    type Hardfork = EthereumHardfork;
-
     fn chain(&self) -> Chain {
         self.chain
-    }
-
-    fn activation_condition(&self, hardfork: Self::Hardfork) -> ForkCondition {
-        self.hardforks.fork(hardfork)
     }
 }


### PR DESCRIPTION
Remove semantics which cause optimsim bug if used. `ChainSpec` is not an l1-exclusive type.