### PR TITLE
chore(txpool): rename the function of tx_by_sender_and_nonce

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -485,7 +485,7 @@ where
         self.pool.get_transactions_by_sender(sender)
     }
 
-    fn get_transactions_by_sender_and_nonce(
+    fn get_transaction_by_sender_and_nonce(
         &self,
         sender: Address,
         nonce: u64,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -203,7 +203,7 @@ impl TransactionPool for NoopTransactionPool {
         vec![]
     }
 
-    fn get_transactions_by_sender_and_nonce(
+    fn get_transaction_by_sender_and_nonce(
         &self,
         _sender: Address,
         _nonce: u64,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -331,8 +331,8 @@ pub trait TransactionPool: Send + Sync + Clone {
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
-    /// Returns a transaction sent by a given user with a given nonce
-    fn get_transactions_by_sender_and_nonce(
+    /// Returns a transaction sent by a given user and a nonce
+    fn get_transaction_by_sender_and_nonce(
         &self,
         sender: Address,
         nonce: u64,


### PR DESCRIPTION
This function only returns one tx, so we should use `transaction` instead of `transactions`, else the user may be confused about whether a `sender+nonce` will return one or more txs.