### PR TITLE
dev(pool): trait object safe `BestTransactions`

### DIFF
--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -42,6 +42,8 @@ impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransaction
     }
 }
 
+impl<T: TransactionOrdering> crate::traits::BestTransactionsFilter for BestTransactionsWithFees<T> {}
+
 impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
     type Item = Arc<ValidPoolTransaction<T::Transaction>>;
 
@@ -160,6 +162,8 @@ impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransaction
         self.skip_blobs = skip_blobs;
     }
 }
+
+impl<T: TransactionOrdering> crate::traits::BestTransactionsFilter for BestTransactions<T> {}
 
 impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
     type Item = Arc<ValidPoolTransaction<T::Transaction>>;
@@ -593,5 +597,35 @@ mod tests {
         // Verify that the new transaction has not been added to the 'independent' set
         assert_eq!(best.independent.len(), 2);
         assert!(!best.independent.contains(&pending_tx2));
+    }
+
+    #[test]
+    fn test_best_transactions_filter_trait_object() {
+        // Initialize a new PendingPool with default MockOrdering and MockTransactionFactory
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Add 5 transactions with increasing nonces to the pool
+        let num_tx = 5;
+        let tx = MockTransaction::eip1559();
+        for nonce in 0..num_tx {
+            let tx = tx.clone().rng_hash().with_nonce(nonce);
+            let valid_tx = f.validated(tx);
+            pool.add_transaction(Arc::new(valid_tx), 0);
+        }
+
+        // Create a trait object of BestTransactions iterator from the pool
+        let best: Box<dyn crate::traits::BestTransactions<Item = _>> = Box::new(pool.best());
+
+        // Create a filter that only returns transactions with even nonces
+        let filter =
+            BestTransactionFilter::new(best, |tx: &Arc<ValidPoolTransaction<MockTransaction>>| {
+                tx.nonce() % 2 == 0
+            });
+
+        // Verify that the filter only returns transactions with even nonces
+        for tx in filter {
+            assert_eq!(tx.nonce() % 2, 0);
+        }
     }
 }

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -42,8 +42,6 @@ impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransaction
     }
 }
 
-impl<T: TransactionOrdering> crate::traits::BestTransactionsFilter for BestTransactionsWithFees<T> {}
-
 impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
     type Item = Arc<ValidPoolTransaction<T::Transaction>>;
 
@@ -162,8 +160,6 @@ impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransaction
         self.skip_blobs = skip_blobs;
     }
 }
-
-impl<T: TransactionOrdering> crate::traits::BestTransactionsFilter for BestTransactions<T> {}
 
 impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
     type Item = Arc<ValidPoolTransaction<T::Transaction>>;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -756,6 +756,8 @@ pub trait BestTransactionsFilter: BestTransactions {
     }
 }
 
+impl<T> BestTransactionsFilter for T where T: BestTransactions {}
+
 /// A no-op implementation that yields no transactions.
 impl<T> BestTransactions for std::iter::Empty<T> {
     fn mark_invalid(&mut self, _tx: &T) {}
@@ -766,8 +768,6 @@ impl<T> BestTransactions for std::iter::Empty<T> {
 
     fn set_skip_blobs(&mut self, _skip_blobs: bool) {}
 }
-
-impl<T> BestTransactionsFilter for std::iter::Empty<T> {}
 
 /// A Helper type that bundles the best transactions attributes together.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -716,7 +716,31 @@ pub trait BestTransactions: Iterator + Send {
     ///
     /// If set to true, no blob transactions will be returned.
     fn set_skip_blobs(&mut self, skip_blobs: bool);
+}
 
+impl<T> BestTransactions for Box<T>
+where
+    T: BestTransactions + ?Sized,
+{
+    fn mark_invalid(&mut self, transaction: &Self::Item) {
+        (**self).mark_invalid(transaction);
+    }
+
+    fn no_updates(&mut self) {
+        (**self).no_updates();
+    }
+
+    fn skip_blobs(&mut self) {
+        (**self).skip_blobs();
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        (**self).set_skip_blobs(skip_blobs);
+    }
+}
+
+/// A subtrait on the [`BestTransactions`] trait that allows to filter transactions.
+pub trait BestTransactionsFilter: BestTransactions {
     /// Creates an iterator which uses a closure to determine if a transaction should be yielded.
     ///
     /// Given an element the closure must return true or false. The returned iterator will yield
@@ -743,7 +767,9 @@ impl<T> BestTransactions for std::iter::Empty<T> {
     fn set_skip_blobs(&mut self, _skip_blobs: bool) {}
 }
 
-/// A Helper type that bundles best transactions attributes together.
+impl<T> BestTransactionsFilter for std::iter::Empty<T> {}
+
+/// A Helper type that bundles the best transactions attributes together.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BestTransactionsAttributes {
     /// The base fee attribute for best transactions.


### PR DESCRIPTION
- Split the `BestTransactions` in two traits in order to make the `BestTransactions` trait object safe. 
- Add a test for a `BestTransactionsFilter` trait object that verifies that the predicates only keeps transactions with even nonces.
