### PR TITLE
evm: use `RethEvmBuilder` for `Optimism` config

### DIFF
--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -338,6 +338,9 @@ mod tests {
 
         // Optimism in handler
         assert_eq!(evm.handler.cfg, HandlerCfg { spec_id: SpecId::ECOTONE, is_optimism: true });
+
+        // Latest spec ID in journaled state
+        assert_eq!(evm.context.evm.journaled_state.spec, SpecId::LATEST);
     }
 
     #[test]
@@ -482,5 +485,8 @@ mod tests {
 
         // Optimism in handler
         assert_eq!(evm.handler.cfg, HandlerCfg { spec_id: SpecId::ECOTONE, is_optimism: true });
+
+        // Latest spec ID in journaled state
+        assert_eq!(evm.context.evm.journaled_state.spec, SpecId::LATEST);
     }
 }

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -116,7 +116,12 @@ impl ConfigureEvm for OptimismEvmConfig {
 
     fn evm<DB: Database>(&self, db: DB) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
         // Define a default EVM configuration
-        let mut evm = RethEvmBuilder::new(db, self.default_external_context()).build();
+        let mut evm = {
+            self.default_external_context();
+            RethEvmBuilder::new(db, ())
+        }
+        .build();
+
         // Apply the Optimism configuration to the EVM
         evm.handler = Handler::optimism_with_spec(evm.handler.cfg.spec_id);
         evm
@@ -128,8 +133,12 @@ impl ConfigureEvm for OptimismEvmConfig {
         I: GetInspector<DB>,
     {
         // Define a default EVM configuration with an inspector
-        let mut evm = RethEvmBuilder::new(db, self.default_external_context())
-            .build_with_inspector(inspector);
+        let mut evm = {
+            self.default_external_context();
+            RethEvmBuilder::new(db, ())
+        }
+        .build_with_inspector(inspector);
+
         // Apply the Optimism configuration to the EVM
         evm.handler = Handler::optimism_with_spec(evm.handler.cfg.spec_id);
         evm


### PR DESCRIPTION
As a follow up to our use of the Evm builder (related https://github.com/paradigmxyz/reth/pull/10210), this PR uses the `RethEvmBuilder` for the Optimism configuration in order to gradually eliminate the `EvmBuilder` from the codebase.
- The unit tests added in https://github.com/paradigmxyz/reth/pull/10280 should cover the entire EVM building for the Optimism cfg. I hope I didn't miss any untested edge cases that would be problematic.
- Before we used the `optimism()` function which is part of the `EvmBuilder` https://github.com/bluealloy/revm/blob/1ad860469755e3cf71383f45d71c3faaf61d3029/crates/revm/src/builder.rs#L162-L169 to modify the handler to apply the spec ID changes needed by Optimism but with the new approach using `RethEvmBuilder`, it is not practical to do like that. So I opted for another approach which consists of first building a default EVM which is an Ethereum EVM before modifying the handler.

@mattsse Don't hesitate to tell me what you think and if the chosen approach seems correct to you. The goal of this PR is really to extend the usage of our `RethEvmBuilder` and to no longer have an `EvmBuilder` in the Optimism implementation.