### PR TITLE
feat(rpc): Add method removal functionality for RPC transports

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1742,7 +1742,7 @@ impl TransportRpcModules {
     /// Removes the method with the given name from all configured transports.
     ///
     /// Returns `true` if the method was found and removed, `false` otherwise.
-    pub fn remove_method_from_all_transports(&mut self, method_name: &'static str) -> bool {
+    pub fn remove_method_from_configured(&mut self, method_name: &'static str) -> bool {
         let http_removed = self.remove_http_method(method_name);
         let ws_removed = self.remove_ws_method(method_name);
         let ipc_removed = self.remove_ipc_method(method_name);

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1709,6 +1709,10 @@ impl TransportRpcModules {
     /// Removes the method with the given name from the configured http methods.
     ///
     /// Returns `true` if the method was found and removed, `false` otherwise.
+    ///
+    /// Be aware that a subscription consist of two methods, `subscribe` and `unsubscribe` and
+    /// it's the caller responsibility to remove both `subscribe` and `unsubscribe` methods for
+    /// subscriptions.
     pub fn remove_http_method(&mut self, method_name: &'static str) -> bool {
         if let Some(http_module) = &mut self.http {
             http_module.remove_method(method_name).is_some()
@@ -1720,6 +1724,10 @@ impl TransportRpcModules {
     /// Removes the method with the given name from the configured ws methods.
     ///
     /// Returns `true` if the method was found and removed, `false` otherwise.
+    ///
+    /// Be aware that a subscription consist of two methods, `subscribe` and `unsubscribe` and
+    /// it's the caller responsibility to remove both `subscribe` and `unsubscribe` methods for
+    /// subscriptions.
     pub fn remove_ws_method(&mut self, method_name: &'static str) -> bool {
         if let Some(ws_module) = &mut self.ws {
             ws_module.remove_method(method_name).is_some()
@@ -1731,6 +1739,10 @@ impl TransportRpcModules {
     /// Removes the method with the given name from the configured ipc methods.
     ///
     /// Returns `true` if the method was found and removed, `false` otherwise.
+    /// 
+    /// Be aware that a subscription consist of two methods, `subscribe` and `unsubscribe` and
+    /// it's the caller responsibility to remove both `subscribe` and `unsubscribe` methods for
+    /// subscriptions.
     pub fn remove_ipc_method(&mut self, method_name: &'static str) -> bool {
         if let Some(ipc_module) = &mut self.ipc {
             ipc_module.remove_method(method_name).is_some()

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1739,7 +1739,7 @@ impl TransportRpcModules {
     /// Removes the method with the given name from the configured ipc methods.
     ///
     /// Returns `true` if the method was found and removed, `false` otherwise.
-    /// 
+    ///
     /// Be aware that a subscription consist of two methods, `subscribe` and `unsubscribe` and
     /// it's the caller responsibility to remove both `subscribe` and `unsubscribe` methods for
     /// subscriptions.

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -2078,7 +2078,7 @@ mod tests {
         }
 
         #[test]
-        fn test_remove_method_from_all_transports() {
+        fn test_remove_method_from_configured() {
             let mut modules = TransportRpcModules {
                 http: Some(create_test_module()),
                 ws: Some(create_test_module()),
@@ -2087,13 +2087,13 @@ mod tests {
             };
 
             // Remove a method that exists
-            assert!(modules.remove_method_from_all_transports("anything"));
+            assert!(modules.remove_method_from_configured("anything"));
 
             // Remove a method that was just removed (it does not exist anymore)
-            assert!(!modules.remove_method_from_all_transports("anything"));
+            assert!(!modules.remove_method_from_configured("anything"));
 
             // Remove a method that does not exist
-            assert!(!modules.remove_method_from_all_transports("non_existent_method"));
+            assert!(!modules.remove_method_from_configured("non_existent_method"));
 
             // Verify that the method was removed from all transports
             assert!(modules.http.as_ref().unwrap().method("anything").is_none());

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1705,6 +1705,50 @@ impl TransportRpcModules {
         self.merge_ipc(other)?;
         Ok(())
     }
+
+    /// Removes the method with the given name from the configured http methods.
+    ///
+    /// Returns `true` if the method was found and removed, `false` otherwise.
+    pub fn remove_http_method(&mut self, method_name: &'static str) -> bool {
+        if let Some(http_module) = &mut self.http {
+            http_module.remove_method(method_name).is_some()
+        } else {
+            false
+        }
+    }
+
+    /// Removes the method with the given name from the configured ws methods.
+    ///
+    /// Returns `true` if the method was found and removed, `false` otherwise.
+    pub fn remove_ws_method(&mut self, method_name: &'static str) -> bool {
+        if let Some(ws_module) = &mut self.ws {
+            ws_module.remove_method(method_name).is_some()
+        } else {
+            false
+        }
+    }
+
+    /// Removes the method with the given name from the configured ipc methods.
+    ///
+    /// Returns `true` if the method was found and removed, `false` otherwise.
+    pub fn remove_ipc_method(&mut self, method_name: &'static str) -> bool {
+        if let Some(ipc_module) = &mut self.ipc {
+            ipc_module.remove_method(method_name).is_some()
+        } else {
+            false
+        }
+    }
+
+    /// Removes the method with the given name from all configured transports.
+    ///
+    /// Returns `true` if the method was found and removed, `false` otherwise.
+    pub fn remove_method_from_all_transports(&mut self, method_name: &'static str) -> bool {
+        let http_removed = self.remove_http_method(method_name);
+        let ws_removed = self.remove_ws_method(method_name);
+        let ipc_removed = self.remove_ipc_method(method_name);
+
+        http_removed || ws_removed || ipc_removed
+    }
 }
 
 /// A handle to the spawned servers.
@@ -1966,5 +2010,83 @@ mod tests {
                 config: None,
             }
         )
+    }
+
+    mod remove_methods {
+        use super::*;
+
+        fn create_test_module() -> RpcModule<()> {
+            let mut module = RpcModule::new(());
+            module.register_method("anything", |_, _, _| "succeed").unwrap();
+            module
+        }
+
+        #[test]
+        fn test_remove_http_method() {
+            let mut modules =
+                TransportRpcModules { http: Some(create_test_module()), ..Default::default() };
+            // Remove a method that exists
+            assert!(modules.remove_http_method("anything"));
+
+            // Remove a method that does not exist
+            assert!(!modules.remove_http_method("non_existent_method"));
+
+            // Verify that the method was removed
+            assert!(modules.http.as_ref().unwrap().method("anything").is_none());
+        }
+
+        #[test]
+        fn test_remove_ws_method() {
+            let mut modules =
+                TransportRpcModules { ws: Some(create_test_module()), ..Default::default() };
+
+            // Remove a method that exists
+            assert!(modules.remove_ws_method("anything"));
+
+            // Remove a method that does not exist
+            assert!(!modules.remove_ws_method("non_existent_method"));
+
+            // Verify that the method was removed
+            assert!(modules.ws.as_ref().unwrap().method("anything").is_none());
+        }
+
+        #[test]
+        fn test_remove_ipc_method() {
+            let mut modules =
+                TransportRpcModules { ipc: Some(create_test_module()), ..Default::default() };
+
+            // Remove a method that exists
+            assert!(modules.remove_ipc_method("anything"));
+
+            // Remove a method that does not exist
+            assert!(!modules.remove_ipc_method("non_existent_method"));
+
+            // Verify that the method was removed
+            assert!(modules.ipc.as_ref().unwrap().method("anything").is_none());
+        }
+
+        #[test]
+        fn test_remove_method_from_all_transports() {
+            let mut modules = TransportRpcModules {
+                http: Some(create_test_module()),
+                ws: Some(create_test_module()),
+                ipc: Some(create_test_module()),
+                ..Default::default()
+            };
+
+            // Remove a method that exists
+            assert!(modules.remove_method_from_all_transports("anything"));
+
+            // Remove a method that was just removed (it does not exist anymore)
+            assert!(!modules.remove_method_from_all_transports("anything"));
+
+            // Remove a method that does not exist
+            assert!(!modules.remove_method_from_all_transports("non_existent_method"));
+
+            // Verify that the method was removed from all transports
+            assert!(modules.http.as_ref().unwrap().method("anything").is_none());
+            assert!(modules.ws.as_ref().unwrap().method("anything").is_none());
+            assert!(modules.ipc.as_ref().unwrap().method("anything").is_none());
+        }
     }
 }


### PR DESCRIPTION
Fixes #9798 

This PR introduces new methods to remove RPC methods from specific 
transports (HTTP, WebSocket, IPC) or from all transports simultaneously:

- remove_http_method: Removes a method from the HTTP transport
- remove_ws_method: Removes a method from the WebSocket transport
- remove_ipc_method: Removes a method from the IPC transport
- remove_method_from_all_transports: Removes a method from all configured transports

Unit tests have been added to verify the correct functionality of these new methods.