### PR TITLE
refactor: random_block(s) function

### DIFF
--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -183,15 +183,13 @@ impl BlockBuffer {
 mod tests {
     use crate::BlockBuffer;
     use reth_primitives::{BlockHash, BlockNumHash, SealedBlockWithSenders};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block, Rng},
-    };
+    use reth_testing_utils::generators::{self, random_block, BlockParams, Rng};
     use std::collections::HashMap;
 
     /// Create random block with specified number and parent hash.
     fn create_block<R: Rng>(rng: &mut R, number: u64, parent: BlockHash) -> SealedBlockWithSenders {
-        let block = random_block(rng, number, Some(parent), None, None, None, None);
+        let block =
+            random_block(rng, BlockParams { number, parent: Some(parent), ..Default::default() });
         block.seal_with_senders().unwrap()
     }
 

--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -189,7 +189,7 @@ mod tests {
     /// Create random block with specified number and parent hash.
     fn create_block<R: Rng>(rng: &mut R, number: u64, parent: BlockHash) -> SealedBlockWithSenders {
         let block =
-            random_block(rng, BlockParams { number, parent: Some(parent), ..Default::default() });
+            random_block(rng, number, BlockParams { parent: Some(parent), ..Default::default() });
         block.seal_with_senders().unwrap()
     }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2636,27 +2636,14 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis =
-                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let genesis = random_block(&mut rng, BlockParams { number: 0, ..Default::default() });
             let block1 = random_block(
                 &mut rng,
-                BlockParams {
-                    number: 1,
-                    parent: Some(genesis.hash()),
-                    ommers_count: Some(0),
-                    ..Default::default()
-                },
+                BlockParams { number: 1, parent: Some(genesis.hash()), ..Default::default() },
             );
             let block2 = random_block(
                 &mut rng,
-                BlockParams {
-                    number: 2,
-                    parent: Some(block1.hash()),
-                    tx_count: None,
-                    ommers_count: Some(0),
-                    requests_count: None,
-                    withdrawals_count: None,
-                },
+                BlockParams { number: 2, parent: Some(block1.hash()), ..Default::default() },
             );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2654,16 +2654,28 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, BlockParams::default());
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
             let block1 = random_block(
                 &mut rng,
                 1,
-                BlockParams { parent: Some(genesis.hash()), ..Default::default() },
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
             );
             let block2 = random_block(
                 &mut rng,
                 2,
-                BlockParams { parent: Some(block1.hash()), ..Default::default() },
+                BlockParams {
+                    parent: Some(block1.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
             );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2175,6 +2175,7 @@ mod tests {
 
     mod fork_choice_updated {
         use super::*;
+        use generators::BlockParams;
         use reth_db::{tables, test_utils::create_test_static_files_dir};
         use reth_db_api::transaction::DbTxMut;
         use reth_primitives::U256;
@@ -2230,8 +2231,17 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis =
+                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let block1 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 1,
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
             insert_blocks(
@@ -2289,8 +2299,12 @@ mod tests {
                 .disable_blockchain_tree_sync()
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis =
+                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let block1 = random_block(
+                &mut rng,
+                BlockParams { number: 1, parent: Some(genesis.hash()), ..Default::default() },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
@@ -2304,9 +2318,15 @@ mod tests {
             );
 
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
-
-            let next_head =
-                random_block(&mut rng, 2, Some(block1.hash()), None, Some(0), None, None);
+            let next_head = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 2,
+                    parent: Some(block1.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             let next_forkchoice_state = ForkchoiceState {
                 head_block_hash: next_head.hash(),
                 finalized_block_hash: block1.hash(),
@@ -2358,8 +2378,17 @@ mod tests {
                 .disable_blockchain_tree_sync()
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis =
+                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let block1 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 1,
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
@@ -2405,19 +2434,41 @@ mod tests {
                 ]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let mut block1 =
-                random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis =
+                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let mut block1 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 1,
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             block1.header.set_difficulty(U256::from(1));
 
             // a second pre-merge block
-            let mut block2 =
-                random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let mut block2 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 1,
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             block2.header.set_difficulty(U256::from(1));
 
             // a transition block
-            let mut block3 =
-                random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let mut block3 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 1,
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             block3.header.set_difficulty(U256::from(1));
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
@@ -2465,8 +2516,17 @@ mod tests {
                 ]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis =
+                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let block1 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 1,
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
 
             let (_temp_dir, temp_dir_path) = create_test_static_files_dir();
 
@@ -2500,6 +2560,7 @@ mod tests {
     mod new_payload {
         use super::*;
         use alloy_genesis::Genesis;
+        use generators::BlockParams;
         use reth_db::test_utils::create_test_static_files_dir;
         use reth_primitives::{EthereumHardfork, U256};
         use reth_provider::{
@@ -2529,7 +2590,10 @@ mod tests {
             // Send new payload
             let res = env
                 .send_new_payload(
-                    block_to_payload_v1(random_block(&mut rng, 0, None, None, Some(0), None, None)),
+                    block_to_payload_v1(random_block(
+                        &mut rng,
+                        BlockParams { ommers_count: Some(0), ..Default::default() },
+                    )),
                     None,
                 )
                 .await;
@@ -2540,7 +2604,10 @@ mod tests {
             // Send new payload
             let res = env
                 .send_new_payload(
-                    block_to_payload_v1(random_block(&mut rng, 1, None, None, Some(0), None, None)),
+                    block_to_payload_v1(random_block(
+                        &mut rng,
+                        BlockParams { number: 1, ommers_count: Some(0), ..Default::default() },
+                    )),
                     None,
                 )
                 .await;
@@ -2569,9 +2636,28 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
-            let block2 = random_block(&mut rng, 2, Some(block1.hash()), None, Some(0), None, None);
+            let genesis =
+                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let block1 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 1,
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
+            let block2 = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 2,
+                    parent: Some(block1.hash()),
+                    tx_count: None,
+                    ommers_count: Some(0),
+                    requests_count: None,
+                    withdrawals_count: None,
+                },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
             insert_blocks(
@@ -2641,12 +2727,12 @@ mod tests {
                 SealedBlock { header: chain_spec.sealed_genesis_header(), ..Default::default() };
             let block1 = random_block(
                 &mut rng,
-                1,
-                Some(chain_spec.genesis_hash()),
-                None,
-                Some(0),
-                None,
-                None,
+                BlockParams {
+                    number: 1,
+                    parent: Some(chain_spec.genesis_hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
             );
 
             // TODO: add transactions that transfer from the alloc accounts, generating the new
@@ -2696,8 +2782,8 @@ mod tests {
                     done: true,
                 })]))
                 .build();
-
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
+            let genesis =
+                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
@@ -2726,7 +2812,15 @@ mod tests {
 
             // Send new payload
             let parent = rng.gen();
-            let block = random_block(&mut rng, 2, Some(parent), None, Some(0), None, None);
+            let block = random_block(
+                &mut rng,
+                BlockParams {
+                    number: 2,
+                    parent: Some(parent),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             let res = env.send_new_payload(block_to_payload_v1(block), None).await;
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Syncing);
             assert_matches!(res, Ok(result) => assert_eq!(result, expected_result));

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2231,12 +2231,15 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis =
-                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
             let block1 = random_block(
                 &mut rng,
+                1,
                 BlockParams {
-                    number: 1,
                     parent: Some(genesis.hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2299,11 +2302,15 @@ mod tests {
                 .disable_blockchain_tree_sync()
                 .build();
 
-            let genesis =
-                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
             let block1 = random_block(
                 &mut rng,
-                BlockParams { number: 1, parent: Some(genesis.hash()), ..Default::default() },
+                1,
+                BlockParams { parent: Some(genesis.hash()), ..Default::default() },
             );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
@@ -2320,8 +2327,8 @@ mod tests {
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
             let next_head = random_block(
                 &mut rng,
+                2,
                 BlockParams {
-                    number: 2,
                     parent: Some(block1.hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2378,12 +2385,15 @@ mod tests {
                 .disable_blockchain_tree_sync()
                 .build();
 
-            let genesis =
-                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
             let block1 = random_block(
                 &mut rng,
+                1,
                 BlockParams {
-                    number: 1,
                     parent: Some(genesis.hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2434,12 +2444,15 @@ mod tests {
                 ]))
                 .build();
 
-            let genesis =
-                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
             let mut block1 = random_block(
                 &mut rng,
+                1,
                 BlockParams {
-                    number: 1,
                     parent: Some(genesis.hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2450,8 +2463,8 @@ mod tests {
             // a second pre-merge block
             let mut block2 = random_block(
                 &mut rng,
+                1,
                 BlockParams {
-                    number: 1,
                     parent: Some(genesis.hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2462,8 +2475,8 @@ mod tests {
             // a transition block
             let mut block3 = random_block(
                 &mut rng,
+                1,
                 BlockParams {
-                    number: 1,
                     parent: Some(genesis.hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2516,12 +2529,15 @@ mod tests {
                 ]))
                 .build();
 
-            let genesis =
-                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
             let block1 = random_block(
                 &mut rng,
+                1,
                 BlockParams {
-                    number: 1,
                     parent: Some(genesis.hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2592,6 +2608,7 @@ mod tests {
                 .send_new_payload(
                     block_to_payload_v1(random_block(
                         &mut rng,
+                        0,
                         BlockParams { ommers_count: Some(0), ..Default::default() },
                     )),
                     None,
@@ -2606,7 +2623,8 @@ mod tests {
                 .send_new_payload(
                     block_to_payload_v1(random_block(
                         &mut rng,
-                        BlockParams { number: 1, ommers_count: Some(0), ..Default::default() },
+                        1,
+                        BlockParams { ommers_count: Some(0), ..Default::default() },
                     )),
                     None,
                 )
@@ -2636,14 +2654,16 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis = random_block(&mut rng, BlockParams { number: 0, ..Default::default() });
+            let genesis = random_block(&mut rng, 0, BlockParams::default());
             let block1 = random_block(
                 &mut rng,
-                BlockParams { number: 1, parent: Some(genesis.hash()), ..Default::default() },
+                1,
+                BlockParams { parent: Some(genesis.hash()), ..Default::default() },
             );
             let block2 = random_block(
                 &mut rng,
-                BlockParams { number: 2, parent: Some(block1.hash()), ..Default::default() },
+                2,
+                BlockParams { parent: Some(block1.hash()), ..Default::default() },
             );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
@@ -2714,8 +2734,8 @@ mod tests {
                 SealedBlock { header: chain_spec.sealed_genesis_header(), ..Default::default() };
             let block1 = random_block(
                 &mut rng,
+                1,
                 BlockParams {
-                    number: 1,
                     parent: Some(chain_spec.genesis_hash()),
                     ommers_count: Some(0),
                     ..Default::default()
@@ -2769,8 +2789,11 @@ mod tests {
                     done: true,
                 })]))
                 .build();
-            let genesis =
-                random_block(&mut rng, BlockParams { ommers_count: Some(0), ..Default::default() });
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
@@ -2801,12 +2824,8 @@ mod tests {
             let parent = rng.gen();
             let block = random_block(
                 &mut rng,
-                BlockParams {
-                    number: 2,
-                    parent: Some(parent),
-                    ommers_count: Some(0),
-                    ..Default::default()
-                },
+                2,
+                BlockParams { parent: Some(parent), ommers_count: Some(0), ..Default::default() },
             );
             let res = env.send_new_payload(block_to_payload_v1(block), None).await;
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Syncing);

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -609,7 +609,7 @@ mod tests {
     use reth_db::test_utils::{create_test_rw_db, create_test_static_files_dir};
     use reth_primitives::{BlockBody, B256};
     use reth_provider::{providers::StaticFileProvider, ProviderFactory};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockParams};
     use std::collections::HashMap;
 
     // Check that the blocks are emitted in order of block number, not in order of
@@ -652,7 +652,11 @@ mod tests {
         // Generate some random blocks
         let db = create_test_rw_db();
         let mut rng = generators::rng();
-        let blocks = random_block_range(&mut rng, 0..=199, B256::ZERO, 1..2, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=199,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(1..2), ..Default::default() },
+        );
 
         let headers = blocks.iter().map(|block| block.header.clone()).collect::<Vec<_>>();
         let bodies = blocks

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -5,7 +5,7 @@
 use crate::{bodies::test_utils::create_raw_bodies, file_codec::BlockFileCodec};
 use futures::SinkExt;
 use reth_primitives::{BlockBody, SealedHeader, B256};
-use reth_testing_utils::{generators, generators::random_block_range};
+use reth_testing_utils::generators::{self, random_block_range, BlockParams};
 use std::{collections::HashMap, io::SeekFrom, ops::RangeInclusive};
 use tokio::{fs::File, io::AsyncSeekExt};
 use tokio_util::codec::FramedWrite;
@@ -21,7 +21,11 @@ pub(crate) fn generate_bodies(
     range: RangeInclusive<u64>,
 ) -> (Vec<SealedHeader>, HashMap<B256, BlockBody>) {
     let mut rng = generators::rng();
-    let blocks = random_block_range(&mut rng, range, B256::ZERO, 0..2, None, None);
+    let blocks = random_block_range(
+        &mut rng,
+        range,
+        BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..2), ..Default::default() },
+    );
 
     let headers = blocks.iter().map(|block| block.header.clone()).collect();
     let bodies = blocks

--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -88,10 +88,7 @@ mod tests {
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_receipt},
-    };
+    use reth_testing_utils::generators::{self, random_block_range, random_receipt, BlockParams};
     use std::ops::Sub;
 
     #[test]
@@ -99,7 +96,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=10, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=10,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(2..3), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let mut receipts = Vec::new();

--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -97,7 +97,7 @@ mod tests {
         PruneSegment, SegmentOutput,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockParams};
     use std::ops::Sub;
 
     #[test]
@@ -105,7 +105,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=100, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=100,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(2..3), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let transactions = blocks.iter().flat_map(|block| &block.body).collect::<Vec<_>>();

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -140,9 +140,8 @@ mod tests {
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_eoa_accounts},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_eoa_accounts, BlockParams,
     };
     use std::{collections::BTreeMap, ops::AddAssign};
 
@@ -151,7 +150,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=5000, B256::ZERO, 0..1, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=5000,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..1), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -227,9 +227,8 @@ mod tests {
     use reth_provider::{PruneCheckpointReader, TransactionsProvider};
     use reth_prune_types::{PruneLimiter, PruneMode, PruneSegment, ReceiptsLogPruneConfig};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_eoa_account, random_log, random_receipt},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_eoa_account, random_log, random_receipt, BlockParams,
     };
     use std::collections::BTreeMap;
 
@@ -242,9 +241,33 @@ mod tests {
 
         let tip = 20000;
         let blocks = [
-            random_block_range(&mut rng, 0..=100, B256::ZERO, 1..5, None, None),
-            random_block_range(&mut rng, (100 + 1)..=(tip - 100), B256::ZERO, 0..1, None, None),
-            random_block_range(&mut rng, (tip - 100 + 1)..=tip, B256::ZERO, 1..5, None, None),
+            random_block_range(
+                &mut rng,
+                0..=100,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(1..5),
+                    ..Default::default()
+                },
+            ),
+            random_block_range(
+                &mut rng,
+                (100 + 1)..=(tip - 100),
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(0..1),
+                    ..Default::default()
+                },
+            ),
+            random_block_range(
+                &mut rng,
+                (tip - 100 + 1)..=tip,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(1..5),
+                    ..Default::default()
+                },
+            ),
         ]
         .concat();
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -93,7 +93,7 @@ mod tests {
     use reth_provider::PruneCheckpointReader;
     use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneMode, PruneProgress, PruneSegment};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockParams};
     use std::ops::Sub;
 
     #[test]
@@ -101,7 +101,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=10, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=10,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(2..3), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let mut transaction_senders = Vec::new();

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -146,9 +146,8 @@ mod tests {
     use reth_provider::PruneCheckpointReader;
     use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneMode, PruneProgress, PruneSegment};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_eoa_accounts},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_eoa_accounts, BlockParams,
     };
     use std::{collections::BTreeMap, ops::AddAssign};
 
@@ -157,7 +156,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 0..=5000, B256::ZERO, 0..1, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=5000,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..1), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -122,7 +122,7 @@ mod tests {
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockParams};
     use std::ops::Sub;
 
     #[test]
@@ -130,7 +130,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=10, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=10,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(2..3), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let mut tx_hash_numbers = Vec::new();

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -133,7 +133,7 @@ mod tests {
         let blocks = random_block_range(
             &mut rng,
             1..=10,
-            BlockParams { parent: Some(B256::ZERO), tx_count: Some(2..3), ..Default::default() },
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..2), ..Default::default() },
         );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -925,7 +925,7 @@ mod tests {
 
     use reth_chainspec::MAINNET;
     use reth_payload_builder::test_utils::spawn_test_payload_service;
-    use reth_primitives::{SealedBlock, B256};
+    use reth_primitives::SealedBlock;
     use reth_provider::test_utils::MockEthProvider;
     use reth_rpc_types::engine::{ClientCode, ClientVersionV1};
     use reth_rpc_types_compat::engine::payload::execution_payload_from_sealed_block;
@@ -995,7 +995,7 @@ mod tests {
     // tests covering `engine_getPayloadBodiesByRange` and `engine_getPayloadBodiesByHash`
     mod get_payload_bodies {
         use super::*;
-        use reth_testing_utils::{generators, generators::random_block_range};
+        use reth_testing_utils::generators::{self, random_block_range, BlockParams};
 
         #[tokio::test]
         async fn invalid_params() {
@@ -1033,10 +1033,7 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 start..=start + count - 1,
-                B256::default(),
-                0..2,
-                None,
-                None,
+                BlockParams { tx_count: Some(0..2), ..Default::default() },
             );
             handle.provider.extend_blocks(blocks.iter().cloned().map(|b| (b.hash(), b.unseal())));
 
@@ -1059,10 +1056,7 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 start..=start + count - 1,
-                B256::default(),
-                0..2,
-                None,
-                None,
+                BlockParams { tx_count: Some(0..2), ..Default::default() },
             );
 
             // Insert only blocks in ranges 1-25 and 50-75

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1148,14 +1148,10 @@ mod tests {
             let (handle, api) = setup_engine_api();
 
             let terminal_block_number = 1000;
-            let consensus_terminal_block = random_block(
-                &mut rng,
-                BlockParams { number: terminal_block_number, ..Default::default() },
-            );
-            let execution_terminal_block = random_block(
-                &mut rng,
-                BlockParams { number: terminal_block_number, ..Default::default() },
-            );
+            let consensus_terminal_block =
+                random_block(&mut rng, terminal_block_number, BlockParams::default());
+            let execution_terminal_block =
+                random_block(&mut rng, terminal_block_number, BlockParams::default());
 
             let transition_config = TransitionConfiguration {
                 terminal_total_difficulty: handle
@@ -1196,10 +1192,8 @@ mod tests {
             let (handle, api) = setup_engine_api();
 
             let terminal_block_number = 1000;
-            let terminal_block = random_block(
-                &mut generators::rng(),
-                BlockParams { number: terminal_block_number, ..Default::default() },
-            );
+            let terminal_block =
+                random_block(&mut generators::rng(), terminal_block_number, BlockParams::default());
 
             let transition_config = TransitionConfiguration {
                 terminal_total_difficulty: handle

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1122,7 +1122,7 @@ mod tests {
     mod exchange_transition_configuration {
         use super::*;
         use reth_primitives::U256;
-        use reth_testing_utils::generators;
+        use reth_testing_utils::generators::{self, BlockParams};
 
         #[tokio::test]
         async fn terminal_td_mismatch() {
@@ -1154,10 +1154,14 @@ mod tests {
             let (handle, api) = setup_engine_api();
 
             let terminal_block_number = 1000;
-            let consensus_terminal_block =
-                random_block(&mut rng, terminal_block_number, None, None, None, None, None);
-            let execution_terminal_block =
-                random_block(&mut rng, terminal_block_number, None, None, None, None, None);
+            let consensus_terminal_block = random_block(
+                &mut rng,
+                BlockParams { number: terminal_block_number, ..Default::default() },
+            );
+            let execution_terminal_block = random_block(
+                &mut rng,
+                BlockParams { number: terminal_block_number, ..Default::default() },
+            );
 
             let transition_config = TransitionConfiguration {
                 terminal_total_difficulty: handle
@@ -1200,12 +1204,7 @@ mod tests {
             let terminal_block_number = 1000;
             let terminal_block = random_block(
                 &mut generators::rng(),
-                terminal_block_number,
-                None,
-                None,
-                None,
-                None,
-                None,
+                BlockParams { number: terminal_block_number, ..Default::default() },
             );
 
             let transition_config = TransitionConfiguration {

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -2,9 +2,7 @@
 
 use alloy_rlp::{Decodable, Error as RlpError};
 use assert_matches::assert_matches;
-use reth_primitives::{
-    proofs, Block, Bytes, SealedBlock, TransactionSigned, Withdrawals, B256, U256,
-};
+use reth_primitives::{proofs, Block, Bytes, SealedBlock, TransactionSigned, Withdrawals, U256};
 use reth_rpc_types::engine::{
     ExecutionPayload, ExecutionPayloadBodyV1, ExecutionPayloadV1, PayloadError,
 };
@@ -34,7 +32,11 @@ fn transform_block<F: FnOnce(Block) -> Block>(src: SealedBlock, f: F) -> Executi
 #[test]
 fn payload_body_roundtrip() {
     let mut rng = generators::rng();
-    for block in random_block_range(&mut rng, 0..=99, B256::default(), 0..2, None, None) {
+    for block in random_block_range(
+        &mut rng,
+        0..=99,
+        BlockParams { tx_count: Some(0..2), ..Default::default() },
+    ) {
         let unsealed = block.clone().unseal();
         let payload_body: ExecutionPayloadBodyV1 = convert_to_payload_body_v1(unsealed);
 
@@ -60,7 +62,7 @@ fn payload_validation() {
         BlockParams {
             number: 100,
             parent: Some(parent),
-            tx_count: Some(3),
+            tx_count: Some(0..2),
             ommers_count: Some(0),
             ..Default::default()
         },

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -59,8 +59,8 @@ fn payload_validation() {
     let parent = rng.gen();
     let block = random_block(
         &mut rng,
+        100,
         BlockParams {
-            number: 100,
             parent: Some(parent),
             tx_count: Some(0..2),
             ommers_count: Some(0),

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -12,7 +12,9 @@ use reth_rpc_types_compat::engine::payload::{
     block_to_payload, block_to_payload_v1, convert_to_payload_body_v1, try_into_sealed_block,
     try_payload_v1_to_block,
 };
-use reth_testing_utils::generators::{self, random_block, random_block_range, random_header, Rng};
+use reth_testing_utils::generators::{
+    self, random_block, random_block_range, random_header, BlockParams, Rng,
+};
 
 fn transform_block<F: FnOnce(Block) -> Block>(src: SealedBlock, f: F) -> ExecutionPayload {
     let unsealed = src.unseal();
@@ -53,7 +55,16 @@ fn payload_body_roundtrip() {
 fn payload_validation() {
     let mut rng = generators::rng();
     let parent = rng.gen();
-    let block = random_block(&mut rng, 100, Some(parent), Some(3), Some(0), None, None);
+    let block = random_block(
+        &mut rng,
+        BlockParams {
+            number: 100,
+            parent: Some(parent),
+            tx_count: Some(3),
+            ommers_count: Some(0),
+            ..Default::default()
+        },
+    );
 
     // Valid extra data
     let block_with_valid_extra_data = transform_block(block.clone(), |mut b| {

--- a/crates/stages/stages/benches/setup/mod.rs
+++ b/crates/stages/stages/benches/setup/mod.rs
@@ -11,12 +11,9 @@ use reth_stages::{
     stages::{AccountHashingStage, StorageHashingStage},
     test_utils::{StorageKind, TestStageDB},
 };
-use reth_testing_utils::{
-    generators,
-    generators::{
-        random_block_range, random_changeset_range, random_contract_account_range,
-        random_eoa_accounts,
-    },
+use reth_testing_utils::generators::{
+    self, random_block_range, random_changeset_range, random_contract_account_range,
+    random_eoa_accounts, BlockParams,
 };
 use reth_trie::StateRoot;
 use std::{collections::BTreeMap, fs, path::Path, sync::Arc};
@@ -116,8 +113,15 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> TestStageDB {
         .into_iter()
         .collect();
 
-        let mut blocks =
-            random_block_range(&mut rng, 0..=num_blocks, B256::ZERO, txs_range, None, None);
+        let mut blocks = random_block_range(
+            &mut rng,
+            0..=num_blocks,
+            BlockParams {
+                parent: Some(B256::ZERO),
+                tx_count: Some(txs_range),
+                ..Default::default()
+            },
+        );
 
         let (transitions, start_state) = random_changeset_range(
             &mut rng,

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -640,9 +640,8 @@ mod tests {
             StaticFileProviderFactory, TransactionsProvider,
         };
         use reth_stages_api::{ExecInput, ExecOutput, UnwindInput};
-        use reth_testing_utils::{
-            generators,
-            generators::{random_block_range, random_signed_tx},
+        use reth_testing_utils::generators::{
+            self, random_block_range, random_signed_tx, BlockParams,
         };
         use std::{
             collections::{HashMap, VecDeque},
@@ -719,7 +718,15 @@ mod tests {
                 let mut rng = generators::rng();
 
                 // Static files do not support gaps in headers, so we need to generate 0 to end
-                let blocks = random_block_range(&mut rng, 0..=end, GENESIS_HASH, 0..2, None, None);
+                let blocks = random_block_range(
+                    &mut rng,
+                    0..=end,
+                    BlockParams {
+                        parent: Some(GENESIS_HASH),
+                        tx_count: Some(0..2),
+                        ..Default::default()
+                    },
+                );
                 self.db.insert_headers_with_td(blocks.iter().map(|block| &block.header))?;
                 if let Some(progress) = blocks.get(start as usize) {
                     // Insert last progress data

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -67,13 +67,20 @@ impl AccountHashingStage {
         use reth_provider::providers::StaticFileWriter;
         use reth_testing_utils::{
             generators,
-            generators::{random_block_range, random_eoa_accounts},
+            generators::{random_block_range, random_eoa_accounts, BlockParams},
         };
 
         let mut rng = generators::rng();
 
-        let blocks =
-            random_block_range(&mut rng, opts.blocks.clone(), B256::ZERO, opts.txs, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            opts.blocks.clone(),
+            BlockParams {
+                parent: Some(B256::ZERO),
+                tx_count: Some(opts.txs),
+                ..Default::default()
+            },
+        );
 
         for block in blocks {
             provider.insert_historical_block(block.try_seal_with_senders().unwrap()).unwrap();

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -223,9 +223,8 @@ mod tests {
     };
     use reth_primitives::{Address, SealedBlock, U256};
     use reth_provider::providers::StaticFileWriter;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_contract_account_range},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_contract_account_range, BlockParams,
     };
 
     stage_test_suite_ext!(StorageHashingTestRunner, storage_hashing);
@@ -341,8 +340,15 @@ mod tests {
             let n_accounts = 31;
             let mut accounts = random_contract_account_range(&mut rng, &mut (0..n_accounts));
 
-            let blocks =
-                random_block_range(&mut rng, stage_progress..=end, B256::ZERO, 0..3, None, None);
+            let blocks = random_block_range(
+                &mut rng,
+                stage_progress..=end,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(0..3),
+                    ..Default::default()
+                },
+            );
 
             self.db.insert_headers(blocks.iter().map(|block| &block.header))?;
 

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -158,9 +158,9 @@ mod tests {
     };
     use reth_primitives::{address, BlockNumber, B256};
     use reth_provider::providers::StaticFileWriter;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_contract_account_range},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_contract_account_range,
+        BlockParams,
     };
     use std::collections::BTreeMap;
 
@@ -538,7 +538,15 @@ mod tests {
                 .into_iter()
                 .collect::<BTreeMap<_, _>>();
 
-            let blocks = random_block_range(&mut rng, start..=end, B256::ZERO, 0..3, None, None);
+            let blocks = random_block_range(
+                &mut rng,
+                start..=end,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(0..3),
+                    ..Default::default()
+                },
+            );
 
             let (changesets, _) = random_changeset_range(
                 &mut rng,

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -164,9 +164,9 @@ mod tests {
     };
     use reth_primitives::{address, b256, Address, BlockNumber, StorageEntry, B256, U256};
     use reth_provider::providers::StaticFileWriter;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_contract_account_range},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_contract_account_range,
+        BlockParams,
     };
     use std::collections::BTreeMap;
 
@@ -560,7 +560,15 @@ mod tests {
                 .into_iter()
                 .collect::<BTreeMap<_, _>>();
 
-            let blocks = random_block_range(&mut rng, start..=end, B256::ZERO, 0..3, None, None);
+            let blocks = random_block_range(
+                &mut rng,
+                start..=end,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(0..3),
+                    ..Default::default()
+                },
+            );
 
             let (changesets, _) = random_changeset_range(
                 &mut rng,

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -517,11 +517,8 @@ mod tests {
 
             let SealedBlock { header, body, ommers, withdrawals, requests } = random_block(
                 &mut rng,
-                BlockParams {
-                    number: stage_progress,
-                    parent: preblocks.last().map(|b| b.hash()),
-                    ..Default::default()
-                },
+                stage_progress,
+                BlockParams { parent: preblocks.last().map(|b| b.hash()), ..Default::default() },
             );
             let mut header = header.unseal();
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -370,11 +370,9 @@ mod tests {
     use reth_primitives::{keccak256, SealedBlock, StaticFileSegment, StorageEntry, U256};
     use reth_provider::{providers::StaticFileWriter, StaticFileProviderFactory};
     use reth_stages_api::StageUnitCheckpoint;
-    use reth_testing_utils::{
-        generators,
-        generators::{
-            random_block, random_block_range, random_changeset_range, random_contract_account_range,
-        },
+    use reth_testing_utils::generators::{
+        self, random_block, random_block_range, random_changeset_range,
+        random_contract_account_range, BlockParams,
     };
     use reth_trie::test_utils::{state_root, state_root_prehashed};
     use std::collections::BTreeMap;
@@ -518,12 +516,12 @@ mod tests {
 
             let SealedBlock { header, body, ommers, withdrawals, requests } = random_block(
                 &mut rng,
-                stage_progress,
-                preblocks.last().map(|b| b.hash()),
-                Some(0),
-                None,
-                None,
-                None,
+                BlockParams {
+                    number: stage_progress,
+                    parent: preblocks.last().map(|b| b.hash()),
+                    tx_count: Some(0),
+                    ..Default::default()
+                },
             );
             let mut header = header.unseal();
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -497,10 +497,11 @@ mod tests {
                 preblocks.append(&mut random_block_range(
                     &mut rng,
                     0..=stage_progress - 1,
-                    B256::ZERO,
-                    0..1,
-                    None,
-                    None,
+                    BlockParams {
+                        parent: Some(B256::ZERO),
+                        tx_count: Some(0..1),
+                        ..Default::default()
+                    },
                 ));
                 self.db.insert_blocks(preblocks.iter(), StorageKind::Static)?;
             }
@@ -519,7 +520,6 @@ mod tests {
                 BlockParams {
                     number: stage_progress,
                     parent: preblocks.last().map(|b| b.hash()),
-                    tx_count: Some(0),
                     ..Default::default()
                 },
             );
@@ -536,7 +536,11 @@ mod tests {
 
             let head_hash = sealed_head.hash();
             let mut blocks = vec![sealed_head];
-            blocks.extend(random_block_range(&mut rng, start..=end, head_hash, 0..3, None, None));
+            blocks.extend(random_block_range(
+                &mut rng,
+                start..=end,
+                BlockParams { parent: Some(head_hash), tx_count: Some(0..3), ..Default::default() },
+            ));
             let last_block = blocks.last().cloned().unwrap();
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
 

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -70,7 +70,9 @@ mod tests {
     use reth_stages_api::{
         ExecInput, ExecutionStageThresholds, PipelineTarget, Stage, StageCheckpoint, StageId,
     };
-    use reth_testing_utils::generators::{self, random_block, random_block_range, random_receipt};
+    use reth_testing_utils::generators::{
+        self, random_block, random_block_range, random_receipt, BlockParams,
+    };
     use std::{io::Write, sync::Arc};
 
     #[tokio::test]
@@ -260,7 +262,11 @@ mod tests {
         let genesis_hash = B256::ZERO;
         let tip = (num_blocks - 1) as u64;
 
-        let blocks = random_block_range(&mut rng, 0..=tip, genesis_hash, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=tip,
+            BlockParams { parent: Some(genesis_hash), tx_count: Some(2..3), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Static)?;
 
         let mut receipts = Vec::new();

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -98,11 +98,8 @@ mod tests {
         for block_number in 2..=tip {
             let nblock = random_block(
                 &mut rng,
-                generators::BlockParams {
-                    number: block_number,
-                    parent: Some(head),
-                    ..Default::default()
-                },
+                block_number,
+                generators::BlockParams { parent: Some(head), ..Default::default() },
             );
             head = nblock.hash();
             provider_rw.insert_historical_block(nblock.try_seal_with_senders().unwrap()).unwrap();

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -94,8 +94,14 @@ mod tests {
         let mut head = block.hash();
         let mut rng = generators::rng();
         for block_number in 2..=tip {
-            let nblock =
-                random_block(&mut rng, block_number, Some(head), Some(0), Some(0), None, None);
+            let nblock = random_block(
+                &mut rng,
+                generators::BlockParams {
+                    number: block_number,
+                    parent: Some(head),
+                    ..Default::default()
+                },
+            );
             head = nblock.hash();
             provider_rw.insert_historical_block(nblock.try_seal_with_senders().unwrap()).unwrap();
         }

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -165,7 +165,7 @@ mod tests {
         providers::StaticFileWriter, TransactionsProvider, TransactionsProviderExt,
     };
     use reth_prune::PruneMode;
-    use reth_testing_utils::generators::{self, random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockParams};
 
     stage_test_suite_ext!(PruneTestRunner, prune);
 
@@ -200,10 +200,11 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 input.checkpoint().block_number..=input.target(),
-                B256::ZERO,
-                1..3,
-                None,
-                None,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(1..3),
+                    ..Default::default()
+                },
             );
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
             self.db.insert_transaction_senders(

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -318,8 +318,8 @@ mod tests {
             .map(|number| {
                 random_block(
                     &mut rng,
+                    number,
                     BlockParams {
-                        number,
                         tx_count: Some(0..(number == non_empty_block_number) as u8),
                         ..Default::default()
                     },

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -289,10 +289,7 @@ mod tests {
     };
     use reth_prune_types::{PruneCheckpoint, PruneMode};
     use reth_stages_api::StageUnitCheckpoint;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block, random_block_range},
-    };
+    use reth_testing_utils::generators::{self, random_block, random_block_range, BlockParams};
 
     use super::*;
     use crate::test_utils::{
@@ -321,12 +318,11 @@ mod tests {
             .map(|number| {
                 random_block(
                     &mut rng,
-                    number,
-                    None,
-                    Some((number == non_empty_block_number) as u8),
-                    None,
-                    None,
-                    None,
+                    BlockParams {
+                        number,
+                        tx_count: Some((number == non_empty_block_number) as u8),
+                        ..Default::default()
+                    },
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -320,7 +320,7 @@ mod tests {
                     &mut rng,
                     BlockParams {
                         number,
-                        tx_count: Some((number == non_empty_block_number) as u8),
+                        tx_count: Some(0..(number == non_empty_block_number) as u8),
                         ..Default::default()
                     },
                 )
@@ -364,10 +364,7 @@ mod tests {
         let seed = random_block_range(
             &mut rng,
             stage_progress + 1..=previous_stage,
-            B256::ZERO,
-            0..4,
-            None,
-            None,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..4), ..Default::default() },
         ); // set tx count range high enough to hit the threshold
         runner
             .db
@@ -438,7 +435,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 0..=100, B256::ZERO, 0..10, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=100,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..10), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Static).expect("insert blocks");
 
         let max_pruned_block = 30;
@@ -551,8 +552,15 @@ mod tests {
             let stage_progress = input.checkpoint().block_number;
             let end = input.target();
 
-            let blocks =
-                random_block_range(&mut rng, stage_progress..=end, B256::ZERO, 0..2, None, None);
+            let blocks = random_block_range(
+                &mut rng,
+                stage_progress..=end,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(0..2),
+                    ..Default::default()
+                },
+            );
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
             Ok(blocks)
         }

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -271,7 +271,7 @@ mod tests {
                     &mut rng,
                     BlockParams {
                         number,
-                        tx_count: Some((number == non_empty_block_number) as u8),
+                        tx_count: Some(0..(number == non_empty_block_number) as u8),
                         ..Default::default()
                     },
                 )
@@ -319,10 +319,7 @@ mod tests {
         let seed = random_block_range(
             &mut rng,
             stage_progress + 1..=previous_stage,
-            B256::ZERO,
-            0..2,
-            None,
-            None,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..2), ..Default::default() },
         );
         runner
             .db
@@ -357,7 +354,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 0..=100, B256::ZERO, 0..10, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=100,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..10), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Static).expect("insert blocks");
 
         let max_pruned_block = 30;
@@ -486,10 +487,11 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 stage_progress + 1..=end,
-                B256::ZERO,
-                0..2,
-                None,
-                None,
+                BlockParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: Some(0..2),
+                    ..Default::default()
+                },
             );
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
             Ok(blocks)

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -245,10 +245,7 @@ mod tests {
     use reth_primitives::{BlockNumber, SealedBlock, B256};
     use reth_provider::{providers::StaticFileWriter, StaticFileProviderFactory};
     use reth_stages_api::StageUnitCheckpoint;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block, random_block_range},
-    };
+    use reth_testing_utils::generators::{self, random_block, random_block_range, BlockParams};
     use std::ops::Sub;
 
     // Implement stage test suite.
@@ -272,12 +269,11 @@ mod tests {
             .map(|number| {
                 random_block(
                     &mut rng,
-                    number,
-                    None,
-                    Some((number == non_empty_block_number) as u8),
-                    None,
-                    None,
-                    None,
+                    BlockParams {
+                        number,
+                        tx_count: Some((number == non_empty_block_number) as u8),
+                        ..Default::default()
+                    },
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -269,8 +269,8 @@ mod tests {
             .map(|number| {
                 random_block(
                     &mut rng,
+                    number,
                     BlockParams {
-                        number,
                         tx_count: Some(0..(number == non_empty_block_number) as u8),
                         ..Default::default()
                     },

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -265,10 +265,7 @@ mod tests {
     use reth_prune_types::PruneModes;
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_static_file_types::{HighestStaticFiles, StaticFileSegment};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_receipt},
-    };
+    use reth_testing_utils::generators::{self, random_block_range, random_receipt, BlockParams};
     use std::{
         sync::{mpsc::channel, Arc},
         time::Duration,
@@ -279,7 +276,11 @@ mod tests {
         let mut rng = generators::rng();
         let db = TestStageDB::default();
 
-        let blocks = random_block_range(&mut rng, 0..=3, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=3,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(2..3), ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
         // Unwind headers from static_files and manually insert them into the database, so we're
         // able to check that static_file_producer works

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1860,7 +1860,11 @@ mod tests {
         let factory = create_test_provider_factory();
 
         // Generate 10 random blocks and split them into database and in-memory blocks
-        let mut blocks = random_block_range(&mut rng, 0..=10, B256::ZERO, 0..1, None, None);
+        let mut blocks = random_block_range(
+            &mut rng,
+            0..=10,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..1), ..Default::default() },
+        );
         let (database_blocks, in_memory_blocks) = blocks.split_at_mut(5);
 
         // Take the first in-memory block and add 7 ommers to it

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1785,8 +1785,11 @@ mod tests {
 
         // Generate a random block
         let mut rng = generators::rng();
-        let block =
-            random_block(&mut rng, BlockParams { parent: Some(B256::ZERO), ..Default::default() });
+        let block = random_block(
+            &mut rng,
+            0,
+            BlockParams { parent: Some(B256::ZERO), ..Default::default() },
+        );
 
         // Set the block as pending
         provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1485,10 +1485,13 @@ mod tests {
         let blocks = random_block_range(
             rng,
             0..=block_range,
-            B256::ZERO,
-            0..1,
-            requests_count,
-            withdrawals_count,
+            BlockParams {
+                parent: Some(B256::ZERO),
+                tx_count: Some(0..1),
+                requests_count,
+                withdrawals_count,
+                ..Default::default()
+            },
         );
         let (database_blocks, in_memory_blocks) = blocks.split_at(database_blocks);
         (database_blocks.to_vec(), in_memory_blocks.to_vec())
@@ -1500,8 +1503,7 @@ mod tests {
         chain_spec: Arc<ChainSpec>,
         database_blocks: usize,
         in_memory_blocks: usize,
-        requests_count: Option<Range<u8>>,
-        withdrawals_count: Option<Range<u8>>,
+        block_params: BlockParams,
     ) -> eyre::Result<(
         BlockchainProvider2<Arc<TempDatabase<DatabaseEnv>>>,
         Vec<SealedBlock>,
@@ -1512,8 +1514,8 @@ mod tests {
             rng,
             database_blocks,
             in_memory_blocks,
-            requests_count,
-            withdrawals_count,
+            block_params.requests_count,
+            block_params.withdrawals_count,
         );
         let receipts: Vec<Vec<_>> = database_blocks
             .iter()
@@ -1585,8 +1587,7 @@ mod tests {
         rng: &mut impl Rng,
         database_blocks: usize,
         in_memory_blocks: usize,
-        requests_count: Option<Range<u8>>,
-        withdrawals_count: Option<Range<u8>>,
+        block_params: BlockParams,
     ) -> eyre::Result<(
         BlockchainProvider2<Arc<TempDatabase<DatabaseEnv>>>,
         Vec<SealedBlock>,
@@ -1598,8 +1599,7 @@ mod tests {
             MAINNET.clone(),
             database_blocks,
             in_memory_blocks,
-            requests_count,
-            withdrawals_count,
+            block_params,
         )
     }
 
@@ -1610,7 +1610,11 @@ mod tests {
         let factory = create_test_provider_factory();
 
         // Generate 10 random blocks and split into database and in-memory blocks
-        let blocks = random_block_range(&mut rng, 0..=10, B256::ZERO, 0..1, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=10,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..1), ..Default::default() },
+        );
         let (database_blocks, in_memory_blocks) = blocks.split_at(5);
 
         // Insert first 5 blocks into the database
@@ -1704,7 +1708,11 @@ mod tests {
         let factory = create_test_provider_factory();
 
         // Generate 10 random blocks and split into database and in-memory blocks
-        let blocks = random_block_range(&mut rng, 0..=10, B256::ZERO, 0..1, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=10,
+            BlockParams { parent: Some(B256::ZERO), tx_count: Some(0..1), ..Default::default() },
+        );
         let (database_blocks, in_memory_blocks) = blocks.split_at(5);
 
         // Insert first 5 blocks into the database
@@ -1772,8 +1780,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         // Generate a random block
@@ -1814,8 +1821,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let first_in_mem_block = in_memory_blocks.first().unwrap();
@@ -1932,8 +1938,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -1961,8 +1966,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2078,8 +2082,7 @@ mod tests {
                 chain_spec.clone(),
                 TEST_BLOCKS_COUNT,
                 TEST_BLOCKS_COUNT,
-                None,
-                Some(1..3),
+                BlockParams { withdrawals_count: Some(1..3), ..Default::default() },
             )?;
         let blocks = [database_blocks, in_memory_blocks].concat();
 
@@ -2129,8 +2132,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         assert_eq!(provider.best_block_number()?, in_memory_blocks.last().unwrap().number);
@@ -2151,8 +2153,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2191,8 +2192,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2249,8 +2249,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2308,8 +2307,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2349,8 +2347,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2390,8 +2387,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2547,8 +2543,7 @@ mod tests {
                 chain_spec.clone(),
                 TEST_BLOCKS_COUNT,
                 TEST_BLOCKS_COUNT,
-                Some(1..2),
-                None,
+                BlockParams { requests_count: Some(1..2), ..Default::default() },
             )?;
 
         let database_block = database_blocks.first().unwrap().clone();
@@ -2576,8 +2571,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         let before = Instant::now();
@@ -2607,8 +2601,7 @@ mod tests {
             &mut rng,
             TEST_BLOCKS_COUNT,
             TEST_BLOCKS_COUNT,
-            None,
-            None,
+            BlockParams::default(),
         )?;
 
         // Set the pending block in memory

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1468,7 +1468,7 @@ mod tests {
     };
     use reth_testing_utils::generators::{
         self, random_block, random_block_range, random_changeset_range, random_eoa_accounts,
-        random_receipt, random_signed_tx,
+        random_receipt, random_signed_tx, BlockParams,
     };
     use revm::db::BundleState;
 
@@ -1778,7 +1778,8 @@ mod tests {
 
         // Generate a random block
         let mut rng = generators::rng();
-        let block = random_block(&mut rng, 0, Some(B256::ZERO), None, None, None, None);
+        let block =
+            random_block(&mut rng, BlockParams { parent: Some(B256::ZERO), ..Default::default() });
 
         // Set the block as pending
         provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -622,10 +622,7 @@ mod tests {
     use reth_primitives::{StaticFileSegment, TxNumber, B256, U256};
     use reth_prune_types::{PruneMode, PruneModes};
     use reth_storage_errors::provider::ProviderError;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block, random_header},
-    };
+    use reth_testing_utils::generators::{self, random_block, random_header, BlockParams};
     use std::{ops::RangeInclusive, sync::Arc};
     use tokio::sync::watch;
 
@@ -713,7 +710,7 @@ mod tests {
         let factory = create_test_provider_factory();
 
         let mut rng = generators::rng();
-        let block = random_block(&mut rng, 0, None, Some(3), None, None, None);
+        let block = random_block(&mut rng, BlockParams { tx_count: Some(3), ..Default::default() });
 
         let tx_ranges: Vec<RangeInclusive<TxNumber>> = vec![0..=0, 1..=1, 2..=2, 0..=1, 1..=2];
         for range in tx_ranges {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -711,7 +711,7 @@ mod tests {
 
         let mut rng = generators::rng();
         let block =
-            random_block(&mut rng, BlockParams { tx_count: Some(0..3), ..Default::default() });
+            random_block(&mut rng, 0, BlockParams { tx_count: Some(0..3), ..Default::default() });
 
         let tx_ranges: Vec<RangeInclusive<TxNumber>> = vec![0..=0, 1..=1, 2..=2, 0..=1, 1..=2];
         for range in tx_ranges {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -710,7 +710,8 @@ mod tests {
         let factory = create_test_provider_factory();
 
         let mut rng = generators::rng();
-        let block = random_block(&mut rng, BlockParams { tx_count: Some(3), ..Default::default() });
+        let block =
+            random_block(&mut rng, BlockParams { tx_count: Some(0..3), ..Default::default() });
 
         let tx_ranges: Vec<RangeInclusive<TxNumber>> = vec![0..=0, 1..=1, 2..=2, 0..=1, 1..=2];
         for range in tx_ranges {

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -23,8 +23,6 @@ use std::{
 /// Used to pass arguments for random block generation function in tests
 #[derive(Debug, Default)]
 pub struct BlockParams {
-    /// The block number.
-    pub number: u64,
     /// The parent hash of the block.
     pub parent: Option<B256>,
     /// The number of transactions in the block.
@@ -148,7 +146,7 @@ pub fn generate_keys<R: Rng>(rng: &mut R, count: usize) -> Vec<Keypair> {
 /// transactions in the block.
 ///
 /// The ommer headers are not assumed to be valid.
-pub fn random_block<R: Rng>(rng: &mut R, block_params: BlockParams) -> SealedBlock {
+pub fn random_block<R: Rng>(rng: &mut R, number: u64, block_params: BlockParams) -> SealedBlock {
     // Generate transactions
     let tx_count = block_params.tx_count;
     let tx_count = tx_count.unwrap_or_else(|| (0..rng.gen::<u8>()));
@@ -156,7 +154,6 @@ pub fn random_block<R: Rng>(rng: &mut R, block_params: BlockParams) -> SealedBlo
     let total_gas = transactions.iter().fold(0, |sum, tx| sum + tx.transaction.gas_limit());
 
     // Generate ommers
-    let number = block_params.number;
     let parent = block_params.parent;
     let ommers_count = block_params.ommers_count.unwrap_or_else(|| rng.gen_range(0..2));
     let ommers =
@@ -222,8 +219,8 @@ pub fn random_block_range<R: Rng>(
     for idx in block_numbers {
         blocks.push(random_block(
             rng,
+            idx,
             BlockParams {
-                number: idx,
                 parent: Some(
                     blocks
                         .last()


### PR DESCRIPTION
Closes #10457 

Implementation Details: 
- created new struct `BlockParams` used to pass arguments for random block generation
- refactored both `random_block` (generates one block) + `random_block_range` functions to use new struct (could've been done separately, but decided to combine both since they were so similar)