### PR TITLE
fix: `transaction_by_hash_with_meta` implementation of `CanonicalInMemoryState`

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -530,7 +530,7 @@ impl CanonicalInMemoryState {
         &self,
         tx_hash: TxHash,
     ) -> Option<(TransactionSigned, TransactionMeta)> {
-        for (block_number, block_state) in self.canonical_chain().enumerate() {
+        for block_state in self.canonical_chain() {
             if let Some((index, tx)) = block_state
                 .block()
                 .block()
@@ -543,7 +543,7 @@ impl CanonicalInMemoryState {
                     tx_hash,
                     index: index as u64,
                     block_hash: block_state.hash(),
-                    block_number: block_number as u64,
+                    block_number: block_state.block().block.number,
                     base_fee: block_state.block().block().header.base_fee_per_gas,
                     timestamp: block_state.block().block.timestamp,
                     excess_blob_gas: block_state.block().block.excess_blob_gas,


### PR DESCRIPTION
Fixes the block number for the `TransactionMeta` returned by `transaction_by_hash_with_meta` which was returning the index of the block in the in-memory state, which doesn't match its block number.