### PR TITLE
chore(chainspec): impl conversion `alloy_genesis::Genesis` to `ChainSpec` with `EthChainSpec::Hardfork`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6536,6 +6536,7 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "derive_more 1.0.0",
+ "dyn-clone",
  "once_cell",
  "op-alloy-rpc-types",
  "reth-ethereum-forks",

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -34,6 +34,7 @@ once_cell.workspace = true
 serde = { workspace = true, optional = true }
 serde_json.workspace = true
 derive_more.workspace = true
+dyn-clone = { workspace = true, optional = true }
 
 [dev-dependencies]
 # eth
@@ -51,6 +52,7 @@ optimism = [
     "reth-ethereum-forks/optimism",
     "serde",
     "dep:op-alloy-rpc-types",
+    "dep:dyn-clone",
 ]
 std = []
 arbitrary = [

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use alloy_chains::Chain;
 use alloy_genesis::ChainConfig;
 use derive_more::{Deref, DerefMut, Into};

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,17 +1,143 @@
-use crate::ChainSpec;
 use alloy_chains::Chain;
+use alloy_genesis::ChainConfig;
+use derive_more::{Deref, DerefMut, Into};
+#[cfg(feature = "optimism")]
+use reth_ethereum_forks::OptimismHardfork;
+use reth_ethereum_forks::{ConfigureHardforks, EthereumHardfork, ForkCondition, Hardfork};
+
+#[cfg(feature = "optimism")]
+use crate::spec::OptimismGenesisInfo;
+use crate::{BaseFeeParamsKind, ChainSpec};
+
+/// Wrapper of [`Hardfork`] trait object.
+// todo: remove when `BaseFeeParamsKind` is moved to new crate `reth-chainspec-types`
+#[derive(Deref, Debug, DerefMut, Clone, Into)]
+pub struct AnyHardfork(Box<dyn Hardfork>);
+
+impl Hardfork for AnyHardfork {
+    fn name(&self) -> &'static str {
+        self.0.name()
+    }
+}
 
 /// Trait representing type configuring a chain spec.
 pub trait EthChainSpec: Send + Sync + Unpin + 'static {
-    // todo: make chain spec type generic over hardfork
-    //type Hardfork: Clone + Copy + 'static;
+    /// Chain hardforks.
+    type Hardfork: Clone;
 
     /// Chain id.
     fn chain(&self) -> Chain;
+
+    /// Returns base fee params.
+    // todo: better suited on chain spec builder.
+    fn base_fee_params(config: &ChainConfig) -> BaseFeeParamsKind;
 }
 
 impl EthChainSpec for ChainSpec {
+    type Hardfork = AnyHardfork;
+
     fn chain(&self) -> Chain {
         self.chain
+    }
+
+    /// Returns base fee params.
+    #[allow(unreachable_code)]
+    fn base_fee_params(_config: &ChainConfig) -> BaseFeeParamsKind {
+        #[cfg(feature = "optimism")]
+        {
+            return OptimismGenesisInfo::extract_from(_config).base_fee_params
+        }
+
+        BaseFeeParamsKind::default()
+    }
+}
+
+impl ConfigureHardforks for AnyHardfork {
+    #[allow(unreachable_code)]
+    fn super_chain_mainnet_hardforks() -> impl Iterator<Item = (Self, ForkCondition)> {
+        #[cfg(feature = "optimism")]
+        {
+            return OptimismHardfork::op_mainnet()
+                .forks_iter()
+                .map(|(hf, opt)| (Self(dyn_clone::clone_box(hf)), opt))
+                .collect::<Vec<_>>()
+                .into_iter()
+        }
+
+        EthereumHardfork::hardforks(Chain::mainnet())
+            .iter()
+            .map(|(hf, opt)| (Self(Box::new(hf) as Box<dyn Hardfork>), *opt))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    fn init_block_hardforks(
+        config: &ChainConfig,
+    ) -> impl IntoIterator<Item = (Self, ForkCondition)> {
+        #[cfg(feature = "optimism")]
+        let genesis_info = OptimismGenesisInfo::extract_from(config)
+            .optimism_chain_info
+            .genesis_info
+            .unwrap_or_default();
+
+        [
+            (EthereumHardfork::Homestead.boxed(), config.homestead_block),
+            (EthereumHardfork::Dao.boxed(), config.dao_fork_block),
+            (EthereumHardfork::Tangerine.boxed(), config.eip150_block),
+            (EthereumHardfork::SpuriousDragon.boxed(), config.eip155_block),
+            (EthereumHardfork::Byzantium.boxed(), config.byzantium_block),
+            (EthereumHardfork::Constantinople.boxed(), config.constantinople_block),
+            (EthereumHardfork::Petersburg.boxed(), config.petersburg_block),
+            (EthereumHardfork::Istanbul.boxed(), config.istanbul_block),
+            (EthereumHardfork::MuirGlacier.boxed(), config.muir_glacier_block),
+            (EthereumHardfork::Berlin.boxed(), config.berlin_block),
+            (EthereumHardfork::London.boxed(), config.london_block),
+            (EthereumHardfork::ArrowGlacier.boxed(), config.arrow_glacier_block),
+            (EthereumHardfork::GrayGlacier.boxed(), config.gray_glacier_block),
+            #[cfg(feature = "optimism")]
+            (OptimismHardfork::Bedrock.boxed(), genesis_info.bedrock_block),
+        ]
+        .into_iter()
+        .filter_map(|(hardfork, opt)| {
+            opt.map(|block| (Self(hardfork), ForkCondition::Block(block)))
+        })
+    }
+
+    fn init_paris(config: &ChainConfig) -> Option<(Self, ForkCondition)> {
+        let ttd = config.terminal_total_difficulty?;
+        Some((
+            Self(EthereumHardfork::Paris.boxed()),
+            ForkCondition::TTD { total_difficulty: ttd, fork_block: config.merge_netsplit_block },
+        ))
+    }
+
+    fn init_time_hardforks(
+        config: &ChainConfig,
+    ) -> impl IntoIterator<Item = (Self, ForkCondition)> {
+        #[cfg(feature = "optimism")]
+        let genesis_info = OptimismGenesisInfo::extract_from(config)
+            .optimism_chain_info
+            .genesis_info
+            .unwrap_or_default();
+
+        [
+            (EthereumHardfork::Shanghai.boxed(), config.shanghai_time),
+            (EthereumHardfork::Cancun.boxed(), config.cancun_time),
+            (EthereumHardfork::Prague.boxed(), config.prague_time),
+            #[cfg(feature = "optimism")]
+            (OptimismHardfork::Regolith.boxed(), genesis_info.regolith_time),
+            #[cfg(feature = "optimism")]
+            (OptimismHardfork::Canyon.boxed(), genesis_info.canyon_time),
+            #[cfg(feature = "optimism")]
+            (OptimismHardfork::Ecotone.boxed(), genesis_info.ecotone_time),
+            #[cfg(feature = "optimism")]
+            (OptimismHardfork::Fjord.boxed(), genesis_info.fjord_time),
+            #[cfg(feature = "optimism")]
+            (OptimismHardfork::Granite.boxed(), genesis_info.granite_time),
+        ]
+        .into_iter()
+        .filter_map(|(hardfork, time)| {
+            time.map(|time| (Self(hardfork), ForkCondition::Timestamp(time)))
+        })
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -701,7 +701,7 @@ impl ChainSpec {
 impl From<Genesis> for ChainSpec {
     fn from(genesis: Genesis) -> Self {
         #[cfg(feature = "optimism")]
-        let optimism_genesis_info = OptimismGenesisInfo::extract_from(&genesis);
+        let optimism_genesis_info = OptimismGenesisInfo::extract_from(&genesis.config);
         #[cfg(feature = "optimism")]
         let genesis_info =
             optimism_genesis_info.optimism_chain_info.genesis_info.unwrap_or_default();
@@ -1085,18 +1085,18 @@ impl DepositContract {
 #[cfg(feature = "optimism")]
 #[derive(Default, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct OptimismGenesisInfo {
-    optimism_chain_info: op_alloy_rpc_types::genesis::OptimismChainInfo,
+pub(crate) struct OptimismGenesisInfo {
+    pub optimism_chain_info: op_alloy_rpc_types::genesis::OptimismChainInfo,
     #[serde(skip)]
-    base_fee_params: BaseFeeParamsKind,
+    pub base_fee_params: BaseFeeParamsKind,
 }
 
 #[cfg(feature = "optimism")]
 impl OptimismGenesisInfo {
-    fn extract_from(genesis: &Genesis) -> Self {
+    pub(crate) fn extract_from(config: &alloy_genesis::ChainConfig) -> Self {
         let mut info = Self {
             optimism_chain_info: op_alloy_rpc_types::genesis::OptimismChainInfo::extract_from(
-                &genesis.config.extra_fields,
+                &config.extra_fields,
             )
             .unwrap_or_default(),
             ..Default::default()

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -5,6 +5,7 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
+use reth_ethereum_forks::Hardfork;
 use alloy_chains::{Chain, ChainKind, NamedChain};
 use alloy_genesis::Genesis;
 use alloy_primitives::{address, b256, Address, BlockNumber, B256, U256};

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -5,7 +5,6 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
-use reth_ethereum_forks::Hardfork;
 use alloy_chains::{Chain, ChainKind, NamedChain};
 use alloy_genesis::Genesis;
 use alloy_primitives::{address, b256, Address, BlockNumber, B256, U256};

--- a/crates/ethereum-forks/src/hardfork/ethereum.rs
+++ b/crates/ethereum-forks/src/hardfork/ethereum.rs
@@ -405,7 +405,7 @@ impl EthereumHardfork {
         (Self::Cancun, ForkCondition::Timestamp(1707305664)),
     ];
 
-    /// Returns hardforks for given chain.
+    /// Returns the hardforks for the given chain, if recognized.
     pub fn hardforks(chain: Chain) -> &'static [(Self, ForkCondition)] {
         if chain == Chain::mainnet() {
             return &Self::MAINNET
@@ -417,7 +417,7 @@ impl EthereumHardfork {
             return &Self::HOLESKY
         }
 
-        panic!("l1 chain list should be exhaustive")
+        &[]
     }
 }
 
@@ -432,6 +432,10 @@ impl<const N: usize> From<[(EthereumHardfork, ForkCondition); N]> for ChainHardf
 }
 
 impl ConfigureHardforks for EthereumHardfork {
+    fn super_chain_mainnet_hardforks() -> impl Iterator<Item = (Self, ForkCondition)> {
+        Self::hardforks(Chain::mainnet()).iter().copied()
+    }
+
     fn init_block_hardforks(
         config: &ChainConfig,
     ) -> impl IntoIterator<Item = (Self, ForkCondition)> {

--- a/crates/ethereum-forks/src/hardfork/mod.rs
+++ b/crates/ethereum-forks/src/hardfork/mod.rs
@@ -1,7 +1,6 @@
 mod macros;
 
 mod ethereum;
-use alloy_genesis::ChainConfig;
 pub use ethereum::EthereumHardfork;
 
 mod optimism;
@@ -14,6 +13,8 @@ use core::{
     any::Any,
     hash::{Hash, Hasher},
 };
+
+use alloy_genesis::ChainConfig;
 use dyn_clone::DynClone;
 
 use crate::ForkCondition;
@@ -49,6 +50,9 @@ impl Hash for dyn Hardfork + 'static {
 
 /// Configures hardforks from genesis [`ChainConfig`].
 pub trait ConfigureHardforks: Sized {
+    /// Returns super chain mainnet hardforks.
+    fn super_chain_mainnet_hardforks() -> impl Iterator<Item = (Self, ForkCondition)>;
+
     /// Initializes block based hardforks from [`ChainConfig`].
     fn init_block_hardforks(
         config: &ChainConfig,

--- a/crates/ethereum-forks/src/hardfork/mod.rs
+++ b/crates/ethereum-forks/src/hardfork/mod.rs
@@ -64,6 +64,14 @@ pub trait ConfigureHardforks: Sized {
     /// Initializes time based hardforks from [`ChainConfig`].
     fn init_time_hardforks(config: &ChainConfig)
         -> impl IntoIterator<Item = (Self, ForkCondition)>;
+
+    /// Initializes hardforks from [`ChainConfig`].
+    fn init(config: &ChainConfig) -> impl IntoIterator<Item = (Self, ForkCondition)> {
+        Self::init_block_hardforks(config)
+            .into_iter()
+            .chain(Self::init_paris(config))
+            .chain(Self::init_time_hardforks(config))
+    }
 }
 
 #[cfg(test)]

--- a/crates/ethereum-forks/src/hardforks/mod.rs
+++ b/crates/ethereum-forks/src/hardforks/mod.rs
@@ -148,3 +148,14 @@ impl core::fmt::Debug for ChainHardforks {
             .finish()
     }
 }
+
+impl<H: Hardfork> FromIterator<(H, ForkCondition)> for ChainHardforks {
+    fn from_iter<T: IntoIterator<Item = (H, ForkCondition)>>(iter: T) -> Self {
+        let forks: Vec<(Box<dyn Hardfork>, ForkCondition)> =
+            iter.into_iter().map(|(hf, cnd)| (Box::new(hf) as Box<dyn Hardfork>, cnd)).collect();
+
+        let map = forks.iter().map(|(fork, condition)| (fork.name(), *condition)).collect();
+
+        Self { forks, map }
+    }
+}


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/8904. Closes https://github.com/paradigmxyz/reth/issues/10725.

Implements conversion `From<alloy_genesis::Genesis> for ChainSpec` using AT `EthChainSpec::Hardfork`

Enables https://github.com/paradigmxyz/reth/issues/10468, which in turn enables using `ChainSpec` type as inner type of an op chain spec type (chain spec type approx 400 loc of reusable code) https://github.com/paradigmxyz/reth/blob/e834f7c9a7ae569ed19bc20a6cd73ebcbce8bf0a/crates/chainspec/src/spec.rs#L274-L700

