### PR TITLE
feat(rpc): improve error message for nonce too low

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -1,5 +1,4 @@
 //! Async caching support for eth RPC
-
 use futures::{future::Either, Stream, StreamExt};
 use reth_chain_state::CanonStateNotification;
 use reth_errors::{ProviderError, ProviderResult};

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -267,7 +267,7 @@ where
 #[derive(thiserror::Error, Debug)]
 pub enum RpcInvalidTransactionError {
     /// returned if the nonce of a transaction is lower than the one present in the local chain.
-    #[error("nonce too low")]
+    #[error("nonce too low: next nonce {state}, tx nonce {tx}")]
     NonceTooLow {
          /// The nonce of the transaction.
         tx: u64,

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1,5 +1,6 @@
 //! Ethereum transaction validator.
 
+use crate::error::EthApiError;
 use super::constants::DEFAULT_MAX_TX_INPUT_BYTES;
 use crate::{
     blobstore::BlobStore,
@@ -339,7 +340,7 @@ where
         if transaction.nonce() < account.nonce {
             return TransactionValidationOutcome::Invalid(
                 transaction,
-                InvalidTransactionError::NonceNotConsistent.into(),
+                EthApiError::detailed_nonce_error(transaction.nonce(), account.nonce).into(),
             )
         }
 


### PR DESCRIPTION
ref #10464. closes https://github.com/paradigmxyz/reth/issues/10498.

The current error wasn't very helpful: nonce too low

So ideally it should now be:

nonce too low: next nonce 72, tx nonce 71