### PR TITLE
chore: fix clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ future_not_send = "allow"
 needless_collect = "allow"
 non_send_fields_in_send_ty = "allow"
 redundant_pub_crate = "allow"
+too_long_first_doc_paragraph = "allow"
 significant_drop_in_scrutinee = "allow"
 significant_drop_tightening = "allow"
 

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tempfile.workspace = true
 reth-db-api.workspace = true

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -64,7 +64,7 @@ where
     /// Create a new collector with some capacity.
     ///
     /// Once the capacity (in bytes) is reached, the data is sorted and flushed to disk.
-    pub fn new(buffer_capacity_bytes: usize, parent_dir: Option<PathBuf>) -> Self {
+    pub const fn new(buffer_capacity_bytes: usize, parent_dir: Option<PathBuf>) -> Self {
         Self {
             parent_dir,
             dir: None,
@@ -77,12 +77,12 @@ where
     }
 
     /// Returns number of elements currently in the collector.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
     /// Returns `true` if there are currently no elements in the collector.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
 


### PR DESCRIPTION
## Description

* Allow newly introduced `too_long_first_doc_paragraph` lint (too pedantic)
* Inherit workspace lints in `reth-etl`