### PR TITLE
docs(reth-engine-tree): slightly improve inline docs

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -131,7 +131,7 @@ where
 /// type via [`EngineRequestHandler::on_event`]. This type is responsible for processing the
 /// incoming requests and advancing the chain and emit events when it is polled.
 pub trait EngineRequestHandler: Send + Sync {
-    /// Even type this handler can emit
+    /// Event type this handler can emit
     type Event: Send;
     /// The request type this handler can process.
     type Request;
@@ -210,7 +210,7 @@ where
     }
 }
 
-/// The type for specify which is kind of engine api
+/// The type for specifying the kind of engine api
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EngineApiKind {
     /// The chain contains Ethereum configuration.


### PR DESCRIPTION
When I was going through `reth-engine-tree` I was confused about when the node could receive a block whose parent is unknown. I tried to add couple of statements clarifying that and fixed a couple of typos while I was at it too.