### PR TITLE
refactor(provider): random_block and random_block_range functions

### DIFF
--- a/crates/blockchain-tree/src/block_buffer.rs
+++ b/crates/blockchain-tree/src/block_buffer.rs
@@ -183,15 +183,13 @@ impl BlockBuffer {
 mod tests {
     use crate::BlockBuffer;
     use reth_primitives::{BlockHash, BlockNumHash, SealedBlockWithSenders};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block, Rng},
-    };
+    use reth_testing_utils::generators::{self, random_block, BlockParams, Rng};
     use std::collections::HashMap;
 
     /// Create random block with specified number and parent hash.
     fn create_block<R: Rng>(rng: &mut R, number: u64, parent: BlockHash) -> SealedBlockWithSenders {
-        let block = random_block(rng, number, Some(parent), None, None, None, None);
+        let block =
+            random_block(rng, number, BlockParams { parent: Some(parent), ..Default::default() });
         block.seal_with_senders().unwrap()
     }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2175,6 +2175,7 @@ mod tests {
 
     mod fork_choice_updated {
         use super::*;
+        use generators::BlockParams;
         use reth_db::{tables, test_utils::create_test_static_files_dir};
         use reth_db_api::transaction::DbTxMut;
         use reth_primitives::U256;
@@ -2230,8 +2231,20 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
+            let block1 = random_block(
+                &mut rng,
+                1,
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
             insert_blocks(
@@ -2289,8 +2302,16 @@ mod tests {
                 .disable_blockchain_tree_sync()
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
+            let block1 = random_block(
+                &mut rng,
+                1,
+                BlockParams { parent: Some(genesis.hash()), ..Default::default() },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
@@ -2304,9 +2325,15 @@ mod tests {
             );
 
             let mut engine_rx = spawn_consensus_engine(consensus_engine);
-
-            let next_head =
-                random_block(&mut rng, 2, Some(block1.hash()), None, Some(0), None, None);
+            let next_head = random_block(
+                &mut rng,
+                2,
+                BlockParams {
+                    parent: Some(block1.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             let next_forkchoice_state = ForkchoiceState {
                 head_block_hash: next_head.hash(),
                 finalized_block_hash: block1.hash(),
@@ -2358,8 +2385,20 @@ mod tests {
                 .disable_blockchain_tree_sync()
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
+            let block1 = random_block(
+                &mut rng,
+                1,
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
@@ -2405,19 +2444,44 @@ mod tests {
                 ]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let mut block1 =
-                random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
+            let mut block1 = random_block(
+                &mut rng,
+                1,
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             block1.header.set_difficulty(U256::from(1));
 
             // a second pre-merge block
-            let mut block2 =
-                random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let mut block2 = random_block(
+                &mut rng,
+                1,
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             block2.header.set_difficulty(U256::from(1));
 
             // a transition block
-            let mut block3 =
-                random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let mut block3 = random_block(
+                &mut rng,
+                1,
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
             block3.header.set_difficulty(U256::from(1));
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
@@ -2465,8 +2529,20 @@ mod tests {
                 ]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
+            let block1 = random_block(
+                &mut rng,
+                1,
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
 
             let (_temp_dir, temp_dir_path) = create_test_static_files_dir();
 
@@ -2500,6 +2576,7 @@ mod tests {
     mod new_payload {
         use super::*;
         use alloy_genesis::Genesis;
+        use generators::BlockParams;
         use reth_db::test_utils::create_test_static_files_dir;
         use reth_primitives::{EthereumHardfork, U256};
         use reth_provider::{
@@ -2529,7 +2606,11 @@ mod tests {
             // Send new payload
             let res = env
                 .send_new_payload(
-                    block_to_payload_v1(random_block(&mut rng, 0, None, None, Some(0), None, None)),
+                    block_to_payload_v1(random_block(
+                        &mut rng,
+                        0,
+                        BlockParams { ommers_count: Some(0), ..Default::default() },
+                    )),
                     None,
                 )
                 .await;
@@ -2540,7 +2621,11 @@ mod tests {
             // Send new payload
             let res = env
                 .send_new_payload(
-                    block_to_payload_v1(random_block(&mut rng, 1, None, None, Some(0), None, None)),
+                    block_to_payload_v1(random_block(
+                        &mut rng,
+                        1,
+                        BlockParams { ommers_count: Some(0), ..Default::default() },
+                    )),
                     None,
                 )
                 .await;
@@ -2569,9 +2654,29 @@ mod tests {
                 })]))
                 .build();
 
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
-            let block1 = random_block(&mut rng, 1, Some(genesis.hash()), None, Some(0), None, None);
-            let block2 = random_block(&mut rng, 2, Some(block1.hash()), None, Some(0), None, None);
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
+            let block1 = random_block(
+                &mut rng,
+                1,
+                BlockParams {
+                    parent: Some(genesis.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
+            let block2 = random_block(
+                &mut rng,
+                2,
+                BlockParams {
+                    parent: Some(block1.hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
             insert_blocks(
@@ -2642,11 +2747,11 @@ mod tests {
             let block1 = random_block(
                 &mut rng,
                 1,
-                Some(chain_spec.genesis_hash()),
-                None,
-                Some(0),
-                None,
-                None,
+                BlockParams {
+                    parent: Some(chain_spec.genesis_hash()),
+                    ommers_count: Some(0),
+                    ..Default::default()
+                },
             );
 
             // TODO: add transactions that transfer from the alloc accounts, generating the new
@@ -2696,8 +2801,11 @@ mod tests {
                     done: true,
                 })]))
                 .build();
-
-            let genesis = random_block(&mut rng, 0, None, None, Some(0), None, None);
+            let genesis = random_block(
+                &mut rng,
+                0,
+                BlockParams { ommers_count: Some(0), ..Default::default() },
+            );
 
             let (_static_dir, static_dir_path) = create_test_static_files_dir();
 
@@ -2726,7 +2834,11 @@ mod tests {
 
             // Send new payload
             let parent = rng.gen();
-            let block = random_block(&mut rng, 2, Some(parent), None, Some(0), None, None);
+            let block = random_block(
+                &mut rng,
+                2,
+                BlockParams { parent: Some(parent), ommers_count: Some(0), ..Default::default() },
+            );
             let res = env.send_new_payload(block_to_payload_v1(block), None).await;
             let expected_result = PayloadStatus::from_status(PayloadStatusEnum::Syncing);
             assert_matches!(res, Ok(result) => assert_eq!(result, expected_result));

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -607,7 +607,7 @@ mod tests {
     use reth_db::test_utils::{create_test_rw_db, create_test_static_files_dir};
     use reth_primitives::{BlockBody, B256};
     use reth_provider::{providers::StaticFileProvider, ProviderFactory};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
     use std::collections::HashMap;
 
     // Check that the blocks are emitted in order of block number, not in order of
@@ -650,7 +650,11 @@ mod tests {
         // Generate some random blocks
         let db = create_test_rw_db();
         let mut rng = generators::rng();
-        let blocks = random_block_range(&mut rng, 0..=199, B256::ZERO, 1..2, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=199,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 1..2, ..Default::default() },
+        );
 
         let headers = blocks.iter().map(|block| block.header.clone()).collect::<Vec<_>>();
         let bodies = blocks

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -5,7 +5,7 @@
 use crate::{bodies::test_utils::create_raw_bodies, file_codec::BlockFileCodec};
 use futures::SinkExt;
 use reth_primitives::{BlockBody, SealedHeader, B256};
-use reth_testing_utils::{generators, generators::random_block_range};
+use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
 use std::{collections::HashMap, io::SeekFrom, ops::RangeInclusive};
 use tokio::{fs::File, io::AsyncSeekExt};
 use tokio_util::codec::FramedWrite;
@@ -21,7 +21,11 @@ pub(crate) fn generate_bodies(
     range: RangeInclusive<u64>,
 ) -> (Vec<SealedHeader>, HashMap<B256, BlockBody>) {
     let mut rng = generators::rng();
-    let blocks = random_block_range(&mut rng, range, B256::ZERO, 0..2, None, None);
+    let blocks = random_block_range(
+        &mut rng,
+        range,
+        BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..2, ..Default::default() },
+    );
 
     let headers = blocks.iter().map(|block| block.header.clone()).collect();
     let bodies = blocks

--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -88,9 +88,8 @@ mod tests {
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_receipt},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_receipt, BlockRangeParams,
     };
     use std::ops::Sub;
 
@@ -99,7 +98,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=10, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let mut receipts = Vec::new();

--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -97,7 +97,7 @@ mod tests {
         PruneSegment, SegmentOutput,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
     use std::ops::Sub;
 
     #[test]
@@ -105,7 +105,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=100, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=100,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let transactions = blocks.iter().flat_map(|block| &block.body).collect::<Vec<_>>();

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -140,9 +140,8 @@ mod tests {
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_eoa_accounts},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_eoa_accounts, BlockRangeParams,
     };
     use std::{collections::BTreeMap, ops::AddAssign};
 
@@ -151,7 +150,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=5000, B256::ZERO, 0..1, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=5000,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -227,9 +227,8 @@ mod tests {
     use reth_provider::{PruneCheckpointReader, TransactionsProvider};
     use reth_prune_types::{PruneLimiter, PruneMode, PruneSegment, ReceiptsLogPruneConfig};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_eoa_account, random_log, random_receipt},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_eoa_account, random_log, random_receipt, BlockRangeParams,
     };
     use std::collections::BTreeMap;
 
@@ -242,9 +241,21 @@ mod tests {
 
         let tip = 20000;
         let blocks = [
-            random_block_range(&mut rng, 0..=100, B256::ZERO, 1..5, None, None),
-            random_block_range(&mut rng, (100 + 1)..=(tip - 100), B256::ZERO, 0..1, None, None),
-            random_block_range(&mut rng, (tip - 100 + 1)..=tip, B256::ZERO, 1..5, None, None),
+            random_block_range(
+                &mut rng,
+                0..=100,
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 1..5, ..Default::default() },
+            ),
+            random_block_range(
+                &mut rng,
+                (100 + 1)..=(tip - 100),
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+            ),
+            random_block_range(
+                &mut rng,
+                (tip - 100 + 1)..=tip,
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 1..5, ..Default::default() },
+            ),
         ]
         .concat();
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -93,7 +93,7 @@ mod tests {
     use reth_provider::PruneCheckpointReader;
     use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneMode, PruneProgress, PruneSegment};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
     use std::ops::Sub;
 
     #[test]
@@ -101,7 +101,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=10, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let mut transaction_senders = Vec::new();

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -146,9 +146,8 @@ mod tests {
     use reth_provider::PruneCheckpointReader;
     use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneMode, PruneProgress, PruneSegment};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_eoa_accounts},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_eoa_accounts, BlockRangeParams,
     };
     use std::{collections::BTreeMap, ops::AddAssign};
 
@@ -157,7 +156,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 0..=5000, B256::ZERO, 0..1, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=5000,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -122,7 +122,7 @@ mod tests {
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
     use reth_stages::test_utils::{StorageKind, TestStageDB};
-    use reth_testing_utils::{generators, generators::random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
     use std::ops::Sub;
 
     #[test]
@@ -130,7 +130,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=10, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            1..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let mut tx_hash_numbers = Vec::new();

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -925,7 +925,7 @@ mod tests {
 
     use reth_chainspec::MAINNET;
     use reth_payload_builder::test_utils::spawn_test_payload_service;
-    use reth_primitives::{SealedBlock, B256};
+    use reth_primitives::SealedBlock;
     use reth_provider::test_utils::MockEthProvider;
     use reth_rpc_types::engine::{ClientCode, ClientVersionV1};
     use reth_rpc_types_compat::engine::payload::execution_payload_from_sealed_block;
@@ -995,7 +995,7 @@ mod tests {
     // tests covering `engine_getPayloadBodiesByRange` and `engine_getPayloadBodiesByHash`
     mod get_payload_bodies {
         use super::*;
-        use reth_testing_utils::{generators, generators::random_block_range};
+        use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
 
         #[tokio::test]
         async fn invalid_params() {
@@ -1033,10 +1033,7 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 start..=start + count - 1,
-                B256::default(),
-                0..2,
-                None,
-                None,
+                BlockRangeParams { tx_count: 0..2, ..Default::default() },
             );
             handle.provider.extend_blocks(blocks.iter().cloned().map(|b| (b.hash(), b.unseal())));
 
@@ -1059,10 +1056,7 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 start..=start + count - 1,
-                B256::default(),
-                0..2,
-                None,
-                None,
+                BlockRangeParams { tx_count: 0..2, ..Default::default() },
             );
 
             // Insert only blocks in ranges 1-25 and 50-75
@@ -1122,7 +1116,7 @@ mod tests {
     mod exchange_transition_configuration {
         use super::*;
         use reth_primitives::U256;
-        use reth_testing_utils::generators;
+        use reth_testing_utils::generators::{self, BlockParams};
 
         #[tokio::test]
         async fn terminal_td_mismatch() {
@@ -1155,9 +1149,9 @@ mod tests {
 
             let terminal_block_number = 1000;
             let consensus_terminal_block =
-                random_block(&mut rng, terminal_block_number, None, None, None, None, None);
+                random_block(&mut rng, terminal_block_number, BlockParams::default());
             let execution_terminal_block =
-                random_block(&mut rng, terminal_block_number, None, None, None, None, None);
+                random_block(&mut rng, terminal_block_number, BlockParams::default());
 
             let transition_config = TransitionConfiguration {
                 terminal_total_difficulty: handle
@@ -1198,15 +1192,8 @@ mod tests {
             let (handle, api) = setup_engine_api();
 
             let terminal_block_number = 1000;
-            let terminal_block = random_block(
-                &mut generators::rng(),
-                terminal_block_number,
-                None,
-                None,
-                None,
-                None,
-                None,
-            );
+            let terminal_block =
+                random_block(&mut generators::rng(), terminal_block_number, BlockParams::default());
 
             let transition_config = TransitionConfiguration {
                 terminal_total_difficulty: handle

--- a/crates/stages/stages/benches/setup/mod.rs
+++ b/crates/stages/stages/benches/setup/mod.rs
@@ -11,12 +11,9 @@ use reth_stages::{
     stages::{AccountHashingStage, StorageHashingStage},
     test_utils::{StorageKind, TestStageDB},
 };
-use reth_testing_utils::{
-    generators,
-    generators::{
-        random_block_range, random_changeset_range, random_contract_account_range,
-        random_eoa_accounts,
-    },
+use reth_testing_utils::generators::{
+    self, random_block_range, random_changeset_range, random_contract_account_range,
+    random_eoa_accounts, BlockRangeParams,
 };
 use reth_trie::StateRoot;
 use std::{collections::BTreeMap, fs, path::Path, sync::Arc};
@@ -116,8 +113,15 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> TestStageDB {
         .into_iter()
         .collect();
 
-        let mut blocks =
-            random_block_range(&mut rng, 0..=num_blocks, B256::ZERO, txs_range, None, None);
+        let mut blocks = random_block_range(
+            &mut rng,
+            0..=num_blocks,
+            BlockRangeParams {
+                parent: Some(B256::ZERO),
+                tx_count: txs_range,
+                ..Default::default()
+            },
+        );
 
         let (transitions, start_state) = random_changeset_range(
             &mut rng,

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -640,9 +640,8 @@ mod tests {
             StaticFileProviderFactory, TransactionsProvider,
         };
         use reth_stages_api::{ExecInput, ExecOutput, UnwindInput};
-        use reth_testing_utils::{
-            generators,
-            generators::{random_block_range, random_signed_tx},
+        use reth_testing_utils::generators::{
+            self, random_block_range, random_signed_tx, BlockRangeParams,
         };
         use std::{
             collections::{HashMap, VecDeque},
@@ -719,7 +718,15 @@ mod tests {
                 let mut rng = generators::rng();
 
                 // Static files do not support gaps in headers, so we need to generate 0 to end
-                let blocks = random_block_range(&mut rng, 0..=end, GENESIS_HASH, 0..2, None, None);
+                let blocks = random_block_range(
+                    &mut rng,
+                    0..=end,
+                    BlockRangeParams {
+                        parent: Some(GENESIS_HASH),
+                        tx_count: 0..2,
+                        ..Default::default()
+                    },
+                );
                 self.db.insert_headers_with_td(blocks.iter().map(|block| &block.header))?;
                 if let Some(progress) = blocks.get(start as usize) {
                     // Insert last progress data

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -67,13 +67,16 @@ impl AccountHashingStage {
         use reth_provider::providers::StaticFileWriter;
         use reth_testing_utils::{
             generators,
-            generators::{random_block_range, random_eoa_accounts},
+            generators::{random_block_range, random_eoa_accounts, BlockRangeParams},
         };
 
         let mut rng = generators::rng();
 
-        let blocks =
-            random_block_range(&mut rng, opts.blocks.clone(), B256::ZERO, opts.txs, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            opts.blocks.clone(),
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: opts.txs, ..Default::default() },
+        );
 
         for block in blocks {
             provider.insert_historical_block(block.try_seal_with_senders().unwrap()).unwrap();

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -223,9 +223,8 @@ mod tests {
     };
     use reth_primitives::{Address, SealedBlock, U256};
     use reth_provider::providers::StaticFileWriter;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_contract_account_range},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_contract_account_range, BlockRangeParams,
     };
 
     stage_test_suite_ext!(StorageHashingTestRunner, storage_hashing);
@@ -341,8 +340,11 @@ mod tests {
             let n_accounts = 31;
             let mut accounts = random_contract_account_range(&mut rng, &mut (0..n_accounts));
 
-            let blocks =
-                random_block_range(&mut rng, stage_progress..=end, B256::ZERO, 0..3, None, None);
+            let blocks = random_block_range(
+                &mut rng,
+                stage_progress..=end,
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..3, ..Default::default() },
+            );
 
             self.db.insert_headers(blocks.iter().map(|block| &block.header))?;
 

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -158,9 +158,9 @@ mod tests {
     };
     use reth_primitives::{address, BlockNumber, B256};
     use reth_provider::providers::StaticFileWriter;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_contract_account_range},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_contract_account_range,
+        BlockRangeParams,
     };
     use std::collections::BTreeMap;
 
@@ -538,7 +538,11 @@ mod tests {
                 .into_iter()
                 .collect::<BTreeMap<_, _>>();
 
-            let blocks = random_block_range(&mut rng, start..=end, B256::ZERO, 0..3, None, None);
+            let blocks = random_block_range(
+                &mut rng,
+                start..=end,
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..3, ..Default::default() },
+            );
 
             let (changesets, _) = random_changeset_range(
                 &mut rng,

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -164,9 +164,9 @@ mod tests {
     };
     use reth_primitives::{address, b256, Address, BlockNumber, StorageEntry, B256, U256};
     use reth_provider::providers::StaticFileWriter;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_changeset_range, random_contract_account_range},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_changeset_range, random_contract_account_range,
+        BlockRangeParams,
     };
     use std::collections::BTreeMap;
 
@@ -560,7 +560,11 @@ mod tests {
                 .into_iter()
                 .collect::<BTreeMap<_, _>>();
 
-            let blocks = random_block_range(&mut rng, start..=end, B256::ZERO, 0..3, None, None);
+            let blocks = random_block_range(
+                &mut rng,
+                start..=end,
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..3, ..Default::default() },
+            );
 
             let (changesets, _) = random_changeset_range(
                 &mut rng,

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -370,11 +370,9 @@ mod tests {
     use reth_primitives::{keccak256, SealedBlock, StaticFileSegment, StorageEntry, U256};
     use reth_provider::{providers::StaticFileWriter, StaticFileProviderFactory};
     use reth_stages_api::StageUnitCheckpoint;
-    use reth_testing_utils::{
-        generators,
-        generators::{
-            random_block, random_block_range, random_changeset_range, random_contract_account_range,
-        },
+    use reth_testing_utils::generators::{
+        self, random_block, random_block_range, random_changeset_range,
+        random_contract_account_range, BlockParams, BlockRangeParams,
     };
     use reth_trie::test_utils::{state_root, state_root_prehashed};
     use std::collections::BTreeMap;
@@ -499,10 +497,11 @@ mod tests {
                 preblocks.append(&mut random_block_range(
                     &mut rng,
                     0..=stage_progress - 1,
-                    B256::ZERO,
-                    0..1,
-                    None,
-                    None,
+                    BlockRangeParams {
+                        parent: Some(B256::ZERO),
+                        tx_count: 0..1,
+                        ..Default::default()
+                    },
                 ));
                 self.db.insert_blocks(preblocks.iter(), StorageKind::Static)?;
             }
@@ -519,11 +518,7 @@ mod tests {
             let SealedBlock { header, body, ommers, withdrawals, requests } = random_block(
                 &mut rng,
                 stage_progress,
-                preblocks.last().map(|b| b.hash()),
-                Some(0),
-                None,
-                None,
-                None,
+                BlockParams { parent: preblocks.last().map(|b| b.hash()), ..Default::default() },
             );
             let mut header = header.unseal();
 
@@ -538,7 +533,11 @@ mod tests {
 
             let head_hash = sealed_head.hash();
             let mut blocks = vec![sealed_head];
-            blocks.extend(random_block_range(&mut rng, start..=end, head_hash, 0..3, None, None));
+            blocks.extend(random_block_range(
+                &mut rng,
+                start..=end,
+                BlockRangeParams { parent: Some(head_hash), tx_count: 0..3, ..Default::default() },
+            ));
             let last_block = blocks.last().cloned().unwrap();
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
 

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -70,7 +70,9 @@ mod tests {
     use reth_stages_api::{
         ExecInput, ExecutionStageThresholds, PipelineTarget, Stage, StageCheckpoint, StageId,
     };
-    use reth_testing_utils::generators::{self, random_block, random_block_range, random_receipt};
+    use reth_testing_utils::generators::{
+        self, random_block, random_block_range, random_receipt, BlockRangeParams,
+    };
     use std::{io::Write, sync::Arc};
 
     #[tokio::test]
@@ -94,8 +96,11 @@ mod tests {
         let mut head = block.hash();
         let mut rng = generators::rng();
         for block_number in 2..=tip {
-            let nblock =
-                random_block(&mut rng, block_number, Some(head), Some(0), Some(0), None, None);
+            let nblock = random_block(
+                &mut rng,
+                block_number,
+                generators::BlockParams { parent: Some(head), ..Default::default() },
+            );
             head = nblock.hash();
             provider_rw.insert_historical_block(nblock.try_seal_with_senders().unwrap()).unwrap();
         }
@@ -254,7 +259,11 @@ mod tests {
         let genesis_hash = B256::ZERO;
         let tip = (num_blocks - 1) as u64;
 
-        let blocks = random_block_range(&mut rng, 0..=tip, genesis_hash, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=tip,
+            BlockRangeParams { parent: Some(genesis_hash), tx_count: 2..3, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Static)?;
 
         let mut receipts = Vec::new();

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -165,7 +165,7 @@ mod tests {
         providers::StaticFileWriter, TransactionsProvider, TransactionsProviderExt,
     };
     use reth_prune::PruneMode;
-    use reth_testing_utils::generators::{self, random_block_range};
+    use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
 
     stage_test_suite_ext!(PruneTestRunner, prune);
 
@@ -200,10 +200,7 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 input.checkpoint().block_number..=input.target(),
-                B256::ZERO,
-                1..3,
-                None,
-                None,
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 1..3, ..Default::default() },
             );
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
             self.db.insert_transaction_senders(

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -245,9 +245,8 @@ mod tests {
     use reth_primitives::{BlockNumber, SealedBlock, B256};
     use reth_provider::{providers::StaticFileWriter, StaticFileProviderFactory};
     use reth_stages_api::StageUnitCheckpoint;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block, random_block_range},
+    use reth_testing_utils::generators::{
+        self, random_block, random_block_range, BlockParams, BlockRangeParams,
     };
     use std::ops::Sub;
 
@@ -273,11 +272,10 @@ mod tests {
                 random_block(
                     &mut rng,
                     number,
-                    None,
-                    Some((number == non_empty_block_number) as u8),
-                    None,
-                    None,
-                    None,
+                    BlockParams {
+                        tx_count: Some((number == non_empty_block_number) as u8),
+                        ..Default::default()
+                    },
                 )
             })
             .collect::<Vec<_>>();
@@ -323,10 +321,7 @@ mod tests {
         let seed = random_block_range(
             &mut rng,
             stage_progress + 1..=previous_stage,
-            B256::ZERO,
-            0..2,
-            None,
-            None,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..2, ..Default::default() },
         );
         runner
             .db
@@ -361,7 +356,11 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 0..=100, B256::ZERO, 0..10, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=100,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..10, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Static).expect("insert blocks");
 
         let max_pruned_block = 30;
@@ -490,10 +489,7 @@ mod tests {
             let blocks = random_block_range(
                 &mut rng,
                 stage_progress + 1..=end,
-                B256::ZERO,
-                0..2,
-                None,
-                None,
+                BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..2, ..Default::default() },
             );
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
             Ok(blocks)

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -265,9 +265,8 @@ mod tests {
     use reth_prune_types::PruneModes;
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_static_file_types::{HighestStaticFiles, StaticFileSegment};
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block_range, random_receipt},
+    use reth_testing_utils::generators::{
+        self, random_block_range, random_receipt, BlockRangeParams,
     };
     use std::{
         sync::{mpsc::channel, Arc},
@@ -279,7 +278,11 @@ mod tests {
         let mut rng = generators::rng();
         let db = TestStageDB::default();
 
-        let blocks = random_block_range(&mut rng, 0..=3, B256::ZERO, 2..3, None, None);
+        let blocks = random_block_range(
+            &mut rng,
+            0..=3,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
         // Unwind headers from static_files and manually insert them into the database, so we're
         // able to check that static_file_producer works

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -622,10 +622,7 @@ mod tests {
     use reth_primitives::{StaticFileSegment, TxNumber, B256, U256};
     use reth_prune_types::{PruneMode, PruneModes};
     use reth_storage_errors::provider::ProviderError;
-    use reth_testing_utils::{
-        generators,
-        generators::{random_block, random_header},
-    };
+    use reth_testing_utils::generators::{self, random_block, random_header, BlockParams};
     use std::{ops::RangeInclusive, sync::Arc};
     use tokio::sync::watch;
 
@@ -713,7 +710,8 @@ mod tests {
         let factory = create_test_provider_factory();
 
         let mut rng = generators::rng();
-        let block = random_block(&mut rng, 0, None, Some(3), None, None, None);
+        let block =
+            random_block(&mut rng, 0, BlockParams { tx_count: Some(3), ..Default::default() });
 
         let tx_ranges: Vec<RangeInclusive<TxNumber>> = vec![0..=0, 1..=1, 2..=2, 0..=1, 1..=2];
         for range in tx_ranges {

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -20,6 +20,36 @@ use std::{
     ops::{Range, RangeInclusive},
 };
 
+/// Used to pass arguments for random block generation function in tests
+#[derive(Debug, Default)]
+pub struct BlockParams {
+    /// The parent hash of the block.
+    pub parent: Option<B256>,
+    /// The number of transactions in the block.
+    pub tx_count: Option<u8>,
+    /// The number of ommers (uncles) in the block.
+    pub ommers_count: Option<u8>,
+    /// The number of requests in the block.
+    pub requests_count: Option<u8>,
+    /// The number of withdrawals in the block.
+    pub withdrawals_count: Option<u8>,
+}
+
+/// Used to pass arguments for random block generation function in tests
+#[derive(Debug, Default)]
+pub struct BlockRangeParams {
+    /// The parent hash of the block.
+    pub parent: Option<B256>,
+    /// The range of transactions in the block.
+    /// If set, a random count between the range will be used.
+    /// If not set, a random number of transactions will be used.
+    pub tx_count: Range<u8>,
+    /// The number of requests in the block.
+    pub requests_count: Option<Range<u8>>,
+    /// The number of withdrawals in the block.
+    pub withdrawals_count: Option<Range<u8>>,
+}
+
 /// Returns a random number generator that can be seeded using the `SEED` environment variable.
 ///
 /// If `SEED` is not set, a random seed is used.
@@ -131,35 +161,29 @@ pub fn generate_keys<R: Rng>(rng: &mut R, count: usize) -> Vec<Keypair> {
 /// transactions in the block.
 ///
 /// The ommer headers are not assumed to be valid.
-pub fn random_block<R: Rng>(
-    rng: &mut R,
-    number: u64,
-    parent: Option<B256>,
-    tx_count: Option<u8>,
-    ommers_count: Option<u8>,
-    requests_count: Option<u8>,
-    withdrawals_count: Option<u8>,
-) -> SealedBlock {
+pub fn random_block<R: Rng>(rng: &mut R, number: u64, block_params: BlockParams) -> SealedBlock {
     // Generate transactions
-    let tx_count = tx_count.unwrap_or_else(|| rng.gen::<u8>());
+    let tx_count = block_params.tx_count.unwrap_or_else(|| rng.gen::<u8>());
     let transactions: Vec<TransactionSigned> =
         (0..tx_count).map(|_| random_signed_tx(rng)).collect();
     let total_gas = transactions.iter().fold(0, |sum, tx| sum + tx.transaction.gas_limit());
 
     // Generate ommers
-    let ommers_count = ommers_count.unwrap_or_else(|| rng.gen_range(0..2));
-    let ommers =
-        (0..ommers_count).map(|_| random_header(rng, number, parent).unseal()).collect::<Vec<_>>();
+    let ommers_count = block_params.ommers_count.unwrap_or_else(|| rng.gen_range(0..2));
+    let ommers = (0..ommers_count)
+        .map(|_| random_header(rng, number, block_params.parent).unseal())
+        .collect::<Vec<_>>();
 
     // Calculate roots
     let transactions_root = proofs::calculate_transaction_root(&transactions);
     let ommers_hash = proofs::calculate_ommers_root(&ommers);
 
-    let requests =
-        requests_count.map(|count| (0..count).map(|_| random_request(rng)).collect::<Vec<_>>());
+    let requests = block_params
+        .requests_count
+        .map(|count| (0..count).map(|_| random_request(rng)).collect::<Vec<_>>());
     let requests_root = requests.as_ref().map(|requests| proofs::calculate_requests_root(requests));
 
-    let withdrawals = withdrawals_count.map(|count| {
+    let withdrawals = block_params.withdrawals_count.map(|count| {
         (0..count)
             .map(|i| Withdrawal {
                 amount: rng.gen(),
@@ -173,7 +197,7 @@ pub fn random_block<R: Rng>(
 
     SealedBlock {
         header: Header {
-            parent_hash: parent.unwrap_or_default(),
+            parent_hash: block_params.parent.unwrap_or_default(),
             number,
             gas_used: total_gas,
             gas_limit: total_gas,
@@ -201,25 +225,29 @@ pub fn random_block<R: Rng>(
 pub fn random_block_range<R: Rng>(
     rng: &mut R,
     block_numbers: RangeInclusive<BlockNumber>,
-    head: B256,
-    tx_count: Range<u8>,
-    requests_count: Option<Range<u8>>,
-    withdrawals_count: Option<Range<u8>>,
+    block_range_params: BlockRangeParams,
 ) -> Vec<SealedBlock> {
     let mut blocks =
         Vec::with_capacity(block_numbers.end().saturating_sub(*block_numbers.start()) as usize);
     for idx in block_numbers {
-        let tx_count = tx_count.clone().sample_single(rng);
-        let requests_count = requests_count.clone().map(|r| r.sample_single(rng));
-        let withdrawals_count = withdrawals_count.clone().map(|r| r.sample_single(rng));
+        let tx_count = block_range_params.tx_count.clone().sample_single(rng);
+        let requests_count =
+            block_range_params.requests_count.clone().map(|r| r.sample_single(rng));
+        let withdrawals_count =
+            block_range_params.withdrawals_count.clone().map(|r| r.sample_single(rng));
+        let parent = block_range_params.parent.unwrap_or_default();
         blocks.push(random_block(
             rng,
             idx,
-            Some(blocks.last().map(|block: &SealedBlock| block.header.hash()).unwrap_or(head)),
-            Some(tx_count),
-            None,
-            requests_count,
-            withdrawals_count,
+            BlockParams {
+                parent: Some(
+                    blocks.last().map(|block: &SealedBlock| block.header.hash()).unwrap_or(parent),
+                ),
+                tx_count: Some(tx_count),
+                ommers_count: None,
+                requests_count,
+                withdrawals_count,
+            },
         ));
     }
     blocks


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/10457

Implementation Details:
- created new struct BlockParams and BlockRangeParams used to pass arguments for random block generation
- decided to keep them separate now for simplicity, could be refactored further 