### PR TITLE
feat(tree): make remove_before aware of the finalized hash

### DIFF
--- a/crates/consensus/beacon/src/engine/forkchoice.rs
+++ b/crates/consensus/beacon/src/engine/forkchoice.rs
@@ -75,9 +75,53 @@ impl ForkchoiceStateTracker {
         self.last_syncing.as_ref().map(|s| s.head_block_hash)
     }
 
+    /// Returns the latest received `ForkchoiceState`.
+    ///
+    /// Caution: this can be invalid.
+    pub const fn latest_state(&self) -> Option<ForkchoiceState> {
+        self.last_valid
+    }
+
+    /// Returns the last valid `ForkchoiceState`.
+    pub const fn last_valid_state(&self) -> Option<ForkchoiceState> {
+        self.last_valid
+    }
+
+    /// Returns the last valid finalized hash.
+    ///
+    /// This will return [`None`], if either there is no valid finalized forkchoice state, or the
+    /// finalized hash for the latest valid forkchoice state is zero.
+    #[inline]
+    pub fn last_valid_finalized(&self) -> Option<B256> {
+        self.last_valid.and_then(|state| {
+            // if the hash is zero then we should act like there is no finalized hash
+            if state.finalized_block_hash.is_zero() {
+                None
+            } else {
+                Some(state.finalized_block_hash)
+            }
+        })
+    }
+
     /// Returns the last received `ForkchoiceState` to which we need to sync.
     pub const fn sync_target_state(&self) -> Option<ForkchoiceState> {
         self.last_syncing
+    }
+
+    /// Returns the sync target finalized hash.
+    ///
+    /// This will return [`None`], if either there is no sync target forkchoice state, or the
+    /// finalized hash for the sync target forkchoice state is zero.
+    #[inline]
+    pub fn sync_target_finalized(&self) -> Option<B256> {
+        self.last_syncing.and_then(|state| {
+            // if the hash is zero then we should act like there is no finalized hash
+            if state.finalized_block_hash.is_zero() {
+                None
+            } else {
+                Some(state.finalized_block_hash)
+            }
+        })
     }
 
     /// Returns true if no forkchoice state has been received yet.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -262,7 +262,7 @@ impl TreeState {
             let blocks_to_remove = self
                 .blocks_by_number
                 .range((Bound::Unbounded, Bound::Excluded(finalized)))
-                .flat_map(|(_, blocks)| blocks.into_iter().map(|b| b.block.hash()))
+                .flat_map(|(_, blocks)| blocks.iter().map(|b| b.block.hash()))
                 .collect::<Vec<_>>();
             for hash in blocks_to_remove {
                 self.remove_by_hash(hash);

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -222,7 +222,7 @@ impl TreeState {
     /// Canonical blocks below the upper bound will still be removed.
     ///
     /// NOTE: This assumes that the `finalized_num` is below or equal to the `upper_bound`
-    pub(crate) fn remove_before(
+    pub(crate) fn remove_until(
         &mut self,
         upper_bound: BlockNumber,
         finalized_num: Option<BlockNumber>,
@@ -1108,7 +1108,7 @@ where
         //
         // We set the `finalized_num` to `Some(backfill_height)` to ensure we remove all state
         // before that
-        self.state.tree_state.remove_before(backfill_height, Some(backfill_height));
+        self.state.tree_state.remove_until(backfill_height, Some(backfill_height));
         self.metrics.executed_blocks.set(self.state.tree_state.block_count() as f64);
 
         // remove all buffered blocks below the backfill height
@@ -2131,7 +2131,7 @@ where
         let num =
             if let Some(hash) = finalized_hash { self.provider.block_number(hash)? } else { None };
 
-        self.state.tree_state.remove_before(upper_bound, num);
+        self.state.tree_state.remove_until(upper_bound, num);
         Ok(())
     }
 }
@@ -2781,7 +2781,7 @@ mod tests {
         tree_state.set_canonical_head(last.block.num_hash());
 
         // inclusive bound, so we should remove anything up to and including 2
-        tree_state.remove_before(2, Some(2));
+        tree_state.remove_until(2, Some(2));
 
         assert!(!tree_state.blocks_by_hash.contains_key(&blocks[0].block.hash()));
         assert!(!tree_state.blocks_by_hash.contains_key(&blocks[1].block.hash()));
@@ -2826,7 +2826,7 @@ mod tests {
         tree_state.set_canonical_head(last.block.num_hash());
 
         // we should still remove everything up to and including 2
-        tree_state.remove_before(2, None);
+        tree_state.remove_until(2, None);
 
         assert!(!tree_state.blocks_by_hash.contains_key(&blocks[0].block.hash()));
         assert!(!tree_state.blocks_by_hash.contains_key(&blocks[1].block.hash()));
@@ -2871,7 +2871,7 @@ mod tests {
         tree_state.set_canonical_head(last.block.num_hash());
 
         // we have no forks so we should still remove anything up to and including 2
-        tree_state.remove_before(2, Some(1));
+        tree_state.remove_until(2, Some(1));
 
         assert!(!tree_state.blocks_by_hash.contains_key(&blocks[0].block.hash()));
         assert!(!tree_state.blocks_by_hash.contains_key(&blocks[1].block.hash()));


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/10558

This makes the `remove_before` method aware of the finalized hash, only removing sidechains that can never exist. The canonical chain is still removed based on the `upper_bound`.