### PR TITLE
fix(op): empty receipts for block not counted by file client

### DIFF
--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -398,7 +398,6 @@ impl ChunkedFileReader {
         T: FromReader,
     {
         if self.file_byte_len == 0 && self.chunk.is_empty() {
-            dbg!(self.chunk.is_empty());
             // eof
             return Ok(None)
         }

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -216,9 +216,6 @@ where
             debug_assert!(genesis_receipts.is_empty());
             // this ensures the execution outcome and static file producer start at block 1
             first_block = 1;
-            // we don't count this as decoded so the partial import check later does not error if
-            // this branch is executed
-            total_decoded_receipts -= 1; // safe because chunk will be `None` if empty
         }
 
         // We're reusing receipt writing code internal to


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/10580

Fixes error message 
```
2024-08-27T20:56:38.042297Z ERROR reth::cli: Receipts were partially imported total_decoded_receipts=105235062 total_imported_receipts=105235057 total_filtered_out_dup_txns=6
```