### PR TITLE
fix: various eip-7702 rpc fixes

### DIFF
--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -60,7 +60,7 @@ where
             chain_id,
             blob_versioned_hashes,
             max_fee_per_blob_gas,
-            // authorization_list,
+            authorization_list,
             ..
         } = request;
 
@@ -98,7 +98,7 @@ where
             // EIP-4844 fields
             blob_hashes: blob_versioned_hashes.unwrap_or_default(),
             max_fee_per_blob_gas,
-            authorization_list: Default::default(),
+            authorization_list: authorization_list.map(Into::into),
             optimism: OptimismFields { enveloped_tx: Some(Bytes::new()), ..Default::default() },
         };
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -853,7 +853,7 @@ pub trait Call: LoadState + SpawnBlocking {
             chain_id,
             blob_versioned_hashes,
             max_fee_per_blob_gas,
-            // authorization_list,
+            authorization_list,
             ..
         } = request;
 
@@ -892,7 +892,7 @@ pub trait Call: LoadState + SpawnBlocking {
             blob_hashes: blob_versioned_hashes.unwrap_or_default(),
             max_fee_per_blob_gas,
             // EIP-7702 fields
-            // authorization_list: TODO
+            authorization_list: authorization_list.map(Into::into),
             ..Default::default()
         };
 

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -44,7 +44,7 @@ fn fill(
     #[allow(unreachable_patterns)]
     let (gas_price, max_fee_per_gas) = match signed_tx.tx_type() {
         TxType::Legacy | TxType::Eip2930 => (Some(signed_tx.max_fee_per_gas()), None),
-        TxType::Eip1559 | TxType::Eip4844 => {
+        TxType::Eip1559 | TxType::Eip4844 | TxType::Eip7702 => {
             // the gas price field for EIP1559 is set to `min(tip, gasFeeCap - baseFee) +
             // baseFee`
             let gas_price = tx_info


### PR DESCRIPTION
Adds authorization list to RPC types where it's missing, and handles EIP-7702 tx's in rpc-types-compat.

cc @klkvr as I am merging into your bump PR.

Supersedes https://github.com/paradigmxyz/reth/pull/10374