### PR TITLE
chore(trie): `StorageRootProvider`

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -814,6 +814,7 @@ mod tests {
     };
     use reth_storage_api::{
         AccountReader, BlockHashReader, StateProofProvider, StateProvider, StateRootProvider,
+        StorageRootProvider,
     };
     use reth_trie::{prefix_set::TriePrefixSetsMut, AccountProof, HashedStorage};
 
@@ -913,7 +914,9 @@ mod tests {
         ) -> ProviderResult<(B256, TrieUpdates)> {
             Ok((B256::random(), TrieUpdates::default()))
         }
+    }
 
+    impl StorageRootProvider for MockStateProvider {
         fn hashed_storage_root(
             &self,
             _address: Address,

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -5,7 +5,7 @@ use reth_primitives::{
 };
 use reth_storage_api::{
     AccountReader, BlockHashReader, StateProofProvider, StateProvider, StateProviderBox,
-    StateRootProvider,
+    StateRootProvider, StorageRootProvider,
 };
 use reth_trie::{
     prefix_set::TriePrefixSetsMut, updates::TrieUpdates, AccountProof, HashedPostState,
@@ -146,7 +146,9 @@ impl StateRootProvider for MemoryOverlayStateProvider {
             prefix_sets,
         )
     }
+}
 
+impl StorageRootProvider for MemoryOverlayStateProvider {
     // TODO: Currently this does not reuse available in-memory trie nodes.
     fn hashed_storage_root(
         &self,

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -4,6 +4,7 @@ use reth_primitives::{
 };
 use reth_storage_api::{
     AccountReader, BlockHashReader, StateProofProvider, StateProvider, StateRootProvider,
+    StorageRootProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
@@ -99,7 +100,9 @@ impl StateRootProvider for StateProviderTest {
     ) -> ProviderResult<(B256, TrieUpdates)> {
         unimplemented!("state root computation is not supported")
     }
+}
 
+impl StorageRootProvider for StateProviderTest {
     fn hashed_storage_root(
         &self,
         _address: Address,

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -8,7 +8,6 @@ use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{Address, BlockId, Bytes, Header, B256, KECCAK_EMPTY, U256};
 use reth_provider::{
     BlockIdReader, ChainSpecProvider, StateProvider, StateProviderBox, StateProviderFactory,
-    StateRootProvider,
 };
 use reth_rpc_eth_types::{EthApiError, EthStateCache, PendingBlockEnv, RpcInvalidTransactionError};
 use reth_rpc_types::{serde_helpers::JsonStorageKey, Account, EIP1186AccountProofResponse};

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -49,7 +49,9 @@ impl<'a> reth_storage_api::StateRootProvider for StateProviderTraitObjWrapper<'a
     ) -> reth_errors::ProviderResult<(B256, reth_trie::updates::TrieUpdates)> {
         self.0.hashed_state_root_from_nodes_with_updates(nodes, hashed_state, prefix_sets)
     }
+}
 
+impl<'a> reth_storage_api::StorageRootProvider for StateProviderTraitObjWrapper<'a> {
     fn hashed_storage_root(
         &self,
         address: Address,

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -2,7 +2,7 @@ use crate::{
     AccountReader, BlockHashReader, ExecutionDataProvider, StateProvider, StateRootProvider,
 };
 use reth_primitives::{Account, Address, BlockNumber, Bytecode, Bytes, B256};
-use reth_storage_api::StateProofProvider;
+use reth_storage_api::{StateProofProvider, StorageRootProvider};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
     prefix_set::TriePrefixSetsMut, updates::TrieUpdates, AccountProof, HashedPostState,
@@ -127,7 +127,11 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
             state_prefix_sets,
         )
     }
+}
 
+impl<SP: StateProvider, EDP: ExecutionDataProvider> StorageRootProvider
+    for BundleStateProvider<SP, EDP>
+{
     fn hashed_storage_root(
         &self,
         address: Address,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -13,7 +13,7 @@ use reth_primitives::{
     constants::EPOCH_SLOTS, Account, Address, BlockNumber, Bytecode, Bytes, StaticFileSegment,
     StorageKey, StorageValue, B256,
 };
-use reth_storage_api::StateProofProvider;
+use reth_storage_api::{StateProofProvider, StorageRootProvider};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
     prefix_set::TriePrefixSetsMut, proof::Proof, updates::TrieUpdates, witness::TrieWitness,
@@ -334,7 +334,9 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
         )
         .map_err(|err| ProviderError::Database(err.into()))
     }
+}
 
+impl<'b, TX: DbTx> StorageRootProvider for HistoricalStateProviderRef<'b, TX> {
     fn hashed_storage_root(
         &self,
         address: Address,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -13,7 +13,7 @@ use reth_primitives::{
     Account, Address, BlockNumber, Bytecode, Bytes, StaticFileSegment, StorageKey, StorageValue,
     B256,
 };
-use reth_storage_api::StateProofProvider;
+use reth_storage_api::{StateProofProvider, StorageRootProvider};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::{
     prefix_set::TriePrefixSetsMut, proof::Proof, updates::TrieUpdates, witness::TrieWitness,
@@ -113,7 +113,9 @@ impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
         StateRoot::overlay_root_from_nodes_with_updates(self.tx, nodes, hashed_state, prefix_sets)
             .map_err(|err| ProviderError::Database(err.into()))
     }
+}
 
+impl<'b, TX: DbTx> StorageRootProvider for LatestStateProviderRef<'b, TX> {
     fn hashed_storage_root(
         &self,
         address: Address,

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -48,6 +48,8 @@ macro_rules! delegate_provider_impls {
                 fn state_root_with_updates(&self, state: &revm::db::BundleState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
                 fn hashed_state_root_with_updates(&self, state: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
                 fn hashed_state_root_from_nodes_with_updates(&self,  nodes: reth_trie::updates::TrieUpdates, state: reth_trie::HashedPostState, prefix_sets: reth_trie::prefix_set::TriePrefixSetsMut) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
+            }
+            StorageRootProvider $(where [$($generics)*])? {
                 fn hashed_storage_root(&self, address: reth_primitives::Address, storage: reth_trie::HashedStorage) ->  reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
             }
             StateProofProvider $(where [$($generics)*])? {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -17,7 +17,7 @@ use reth_primitives::{
     U256,
 };
 use reth_stages_types::{StageCheckpoint, StageId};
-use reth_storage_api::{StageCheckpointReader, StateProofProvider};
+use reth_storage_api::{StageCheckpointReader, StateProofProvider, StorageRootProvider};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::{
     prefix_set::TriePrefixSetsMut, updates::TrieUpdates, AccountProof, HashedPostState,
@@ -589,14 +589,6 @@ impl StateRootProvider for MockEthProvider {
         Ok((state_root, Default::default()))
     }
 
-    fn hashed_storage_root(
-        &self,
-        _address: Address,
-        _hashed_storage: HashedStorage,
-    ) -> ProviderResult<B256> {
-        Ok(B256::default())
-    }
-
     fn hashed_state_root_from_nodes_with_updates(
         &self,
         _nodes: TrieUpdates,
@@ -605,6 +597,16 @@ impl StateRootProvider for MockEthProvider {
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let state_root = self.state_roots.lock().pop().unwrap_or_default();
         Ok((state_root, Default::default()))
+    }
+}
+
+impl StorageRootProvider for MockEthProvider {
+    fn hashed_storage_root(
+        &self,
+        _address: Address,
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        Ok(B256::default())
     }
 }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -20,10 +20,11 @@ use reth_primitives::{
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
-use reth_storage_api::StateProofProvider;
+use reth_storage_api::{StateProofProvider, StorageRootProvider};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
     prefix_set::TriePrefixSetsMut, updates::TrieUpdates, AccountProof, HashedPostState,
+    HashedStorage,
 };
 use revm::primitives::{BlockEnv, CfgEnvWithHandlerCfg};
 use tokio::sync::{broadcast, watch};
@@ -349,11 +350,13 @@ impl StateRootProvider for NoopProvider {
     ) -> ProviderResult<(B256, TrieUpdates)> {
         Ok((B256::default(), TrieUpdates::default()))
     }
+}
 
+impl StorageRootProvider for NoopProvider {
     fn hashed_storage_root(
         &self,
         _address: Address,
-        _hashed_storage: reth_trie::HashedStorage,
+        _hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         Ok(B256::default())
     }

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -1,4 +1,7 @@
-use super::{AccountReader, BlockHashReader, BlockIdReader, StateProofProvider, StateRootProvider};
+use super::{
+    AccountReader, BlockHashReader, BlockIdReader, StateProofProvider, StateRootProvider,
+    StorageRootProvider,
+};
 use auto_impl::auto_impl;
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{
@@ -13,7 +16,13 @@ pub type StateProviderBox = Box<dyn StateProvider>;
 /// An abstraction for a type that provides state data.
 #[auto_impl(&, Arc, Box)]
 pub trait StateProvider:
-    BlockHashReader + AccountReader + StateRootProvider + StateProofProvider + Send + Sync
+    BlockHashReader
+    + AccountReader
+    + StateRootProvider
+    + StorageRootProvider
+    + StateProofProvider
+    + Send
+    + Sync
 {
     /// Get storage of given account.
     fn storage(

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -58,7 +58,11 @@ pub trait StateRootProvider: Send + Sync {
         hashed_state: HashedPostState,
         prefix_sets: TriePrefixSetsMut,
     ) -> ProviderResult<(B256, TrieUpdates)>;
+}
 
+/// A type that can compute the storage root for a given account.
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait StorageRootProvider: Send + Sync {
     /// Returns the storage root of the `HashedStorage` for target address on top of the current
     /// state.
     fn hashed_storage_root(


### PR DESCRIPTION
## Description

Extract storage root computation to a separate `StorageRootProvider`.