### PR TITLE
chore(trie): remove plain state proof variant

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -924,7 +924,7 @@ mod tests {
     }
 
     impl StateProofProvider for MockStateProvider {
-        fn hashed_proof(
+        fn proof(
             &self,
             _hashed_state: HashedPostState,
             _address: Address,

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -167,7 +167,7 @@ impl StateRootProvider for MemoryOverlayStateProvider {
 
 impl StateProofProvider for MemoryOverlayStateProvider {
     // TODO: Currently this does not reuse available in-memory trie nodes.
-    fn hashed_proof(
+    fn proof(
         &self,
         state: HashedPostState,
         address: Address,
@@ -175,7 +175,7 @@ impl StateProofProvider for MemoryOverlayStateProvider {
     ) -> ProviderResult<AccountProof> {
         let mut hashed_state = self.trie_state().hashed_state.clone();
         hashed_state.extend(state);
-        self.historical.hashed_proof(hashed_state, address, slots)
+        self.historical.proof(hashed_state, address, slots)
     }
 
     // TODO: Currently this does not reuse available in-memory trie nodes.

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -110,7 +110,7 @@ impl StateRootProvider for StateProviderTest {
 }
 
 impl StateProofProvider for StateProviderTest {
-    fn hashed_proof(
+    fn proof(
         &self,
         _hashed_state: HashedPostState,
         _address: Address,

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -14,7 +14,6 @@ use reth_rpc_eth_types::{EthApiError, EthStateCache, PendingBlockEnv, RpcInvalid
 use reth_rpc_types::{serde_helpers::JsonStorageKey, Account, EIP1186AccountProofResponse};
 use reth_rpc_types_compat::proof::from_primitive_account_proof;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
-use revm::db::BundleState;
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, SpecId};
 
 use crate::{EthApiTypes, FromEthApiError};
@@ -122,7 +121,7 @@ pub trait EthState: LoadState + SpawnBlocking {
                 let state = this.state_at_block_id(block_id)?;
                 let storage_keys = keys.iter().map(|key| key.0).collect::<Vec<_>>();
                 let proof = state
-                    .proof(&BundleState::default(), address, &storage_keys)
+                    .proof(Default::default(), address, &storage_keys)
                     .map_err(Self::Error::from_eth_err)?;
                 Ok(from_primitive_account_proof(proof))
             })

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -60,13 +60,13 @@ impl<'a> reth_storage_api::StateRootProvider for StateProviderTraitObjWrapper<'a
 }
 
 impl<'a> reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'a> {
-    fn hashed_proof(
+    fn proof(
         &self,
         hashed_state: reth_trie::HashedPostState,
         address: revm_primitives::Address,
         slots: &[B256],
     ) -> reth_errors::ProviderResult<reth_trie::AccountProof> {
-        self.0.hashed_proof(hashed_state, address, slots)
+        self.0.proof(hashed_state, address, slots)
     }
 
     fn witness(

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -151,7 +151,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
 impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProofProvider
     for BundleStateProvider<SP, EDP>
 {
-    fn hashed_proof(
+    fn proof(
         &self,
         hashed_state: HashedPostState,
         address: Address,
@@ -160,7 +160,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProofProvider
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
         state.extend(hashed_state);
-        self.state_provider.hashed_proof(state, address, slots)
+        self.state_provider.proof(state, address, slots)
     }
 
     fn witness(

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -349,7 +349,7 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
 
 impl<'b, TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'b, TX> {
     /// Get account and storage proofs.
-    fn hashed_proof(
+    fn proof(
         &self,
         hashed_state: HashedPostState,
         address: Address,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -125,7 +125,7 @@ impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
 }
 
 impl<'b, TX: DbTx> StateProofProvider for LatestStateProviderRef<'b, TX> {
-    fn hashed_proof(
+    fn proof(
         &self,
         hashed_state: HashedPostState,
         address: Address,

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -51,8 +51,7 @@ macro_rules! delegate_provider_impls {
                 fn hashed_storage_root(&self, address: reth_primitives::Address, storage: reth_trie::HashedStorage) ->  reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
             }
             StateProofProvider $(where [$($generics)*])? {
-                fn proof(&self, state: &revm::db::BundleState, address: reth_primitives::Address, slots: &[reth_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;
-                fn hashed_proof(&self, state: reth_trie::HashedPostState, address: reth_primitives::Address, slots: &[reth_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;
+                fn proof(&self, state: reth_trie::HashedPostState, address: reth_primitives::Address, slots: &[reth_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;
                 fn witness(&self, state: reth_trie::HashedPostState, target: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<std::collections::HashMap<reth_primitives::B256, reth_primitives::Bytes>>;
             }
         );

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -609,7 +609,7 @@ impl StateRootProvider for MockEthProvider {
 }
 
 impl StateProofProvider for MockEthProvider {
-    fn hashed_proof(
+    fn proof(
         &self,
         _hashed_state: HashedPostState,
         address: Address,

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -360,7 +360,7 @@ impl StateRootProvider for NoopProvider {
 }
 
 impl StateProofProvider for NoopProvider {
-    fn hashed_proof(
+    fn proof(
         &self,
         _hashed_state: HashedPostState,
         address: Address,

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -71,21 +71,9 @@ pub trait StateRootProvider: Send + Sync {
 /// A type that can generate state proof on top of a given post state.
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateProofProvider: Send + Sync {
-    /// Get account and storage proofs of target keys in the `BundleState`
-    /// on top of the current state.
-    fn proof(
-        &self,
-        state: &BundleState,
-        address: Address,
-        slots: &[B256],
-    ) -> ProviderResult<AccountProof> {
-        let hashed_state = HashedPostState::from_bundle_state(&state.state);
-        self.hashed_proof(hashed_state, address, slots)
-    }
-
     /// Get account and storage proofs of target keys in the `HashedPostState`
     /// on top of the current state.
-    fn hashed_proof(
+    fn proof(
         &self,
         hashed_state: HashedPostState,
         address: Address,


### PR DESCRIPTION
## Description

Remove proof method that accepts plain state as it's useless and only results in code bloat. Rename `hashed_proof` to `proof`.