### PR TITLE
chore(trie): clean up state root methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6204,6 +6204,7 @@ dependencies = [
  "reth-stages-api",
  "reth-tokio-util",
  "reth-transaction-pool",
+ "reth-trie",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6984,6 +6985,7 @@ dependencies = [
  "reth-revm",
  "reth-rpc-types",
  "reth-rpc-types-compat",
+ "reth-trie",
  "revm-primitives",
  "serde",
  "serde_json",
@@ -7132,6 +7134,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "tracing",
 ]
@@ -8358,6 +8361,7 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-tasks",
  "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8605,7 +8609,6 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie",
- "revm",
 ]
 
 [[package]]

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -22,7 +22,7 @@ use reth_provider::{
     FullExecutionDataProvider, ProviderError, StateRootProvider,
 };
 use reth_revm::database::StateProviderDatabase;
-use reth_trie::updates::TrieUpdates;
+use reth_trie::{updates::TrieUpdates, HashedPostState};
 use reth_trie_parallel::parallel_root::ParallelStateRoot;
 use std::{
     collections::BTreeMap,
@@ -232,7 +232,10 @@ impl AppendableChain {
                     .map(|(root, updates)| (root, Some(updates)))
                     .map_err(ProviderError::from)?
             } else {
-                (provider.state_root(initial_execution_outcome.state())?, None)
+                let hashed_state =
+                    HashedPostState::from_bundle_state(&initial_execution_outcome.state().state);
+                let state_root = provider.state_root(hashed_state)?;
+                (state_root, None)
             };
             if block.state_root != state_root {
                 return Err(ConsensusError::BodyStateRootDiff(

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -886,11 +886,11 @@ mod tests {
     }
 
     impl StateRootProvider for MockStateProvider {
-        fn hashed_state_root(&self, _hashed_state: HashedPostState) -> ProviderResult<B256> {
+        fn state_root(&self, _hashed_state: HashedPostState) -> ProviderResult<B256> {
             Ok(B256::random())
         }
 
-        fn hashed_state_root_from_nodes(
+        fn state_root_from_nodes(
             &self,
             _nodes: TrieUpdates,
             _post_state: HashedPostState,
@@ -899,14 +899,14 @@ mod tests {
             Ok(B256::random())
         }
 
-        fn hashed_state_root_with_updates(
+        fn state_root_with_updates(
             &self,
             _hashed_state: HashedPostState,
         ) -> ProviderResult<(B256, TrieUpdates)> {
             Ok((B256::random(), TrieUpdates::default()))
         }
 
-        fn hashed_state_root_from_nodes_with_updates(
+        fn state_root_from_nodes_with_updates(
             &self,
             _nodes: TrieUpdates,
             _post_state: HashedPostState,
@@ -917,7 +917,7 @@ mod tests {
     }
 
     impl StorageRootProvider for MockStateProvider {
-        fn hashed_storage_root(
+        fn storage_root(
             &self,
             _address: Address,
             _hashed_storage: HashedStorage,

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -102,12 +102,12 @@ impl AccountReader for MemoryOverlayStateProvider {
 }
 
 impl StateRootProvider for MemoryOverlayStateProvider {
-    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let prefix_sets = hashed_state.construct_prefix_sets();
-        self.hashed_state_root_from_nodes(TrieUpdates::default(), hashed_state, prefix_sets)
+        self.state_root_from_nodes(TrieUpdates::default(), hashed_state, prefix_sets)
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         nodes: TrieUpdates,
         state: HashedPostState,
@@ -116,22 +116,18 @@ impl StateRootProvider for MemoryOverlayStateProvider {
         let MemoryOverlayTrieState { mut trie_nodes, mut hashed_state } = self.trie_state().clone();
         trie_nodes.extend(nodes);
         hashed_state.extend(state);
-        self.historical.hashed_state_root_from_nodes(trie_nodes, hashed_state, prefix_sets)
+        self.historical.state_root_from_nodes(trie_nodes, hashed_state, prefix_sets)
     }
 
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let prefix_sets = hashed_state.construct_prefix_sets();
-        self.hashed_state_root_from_nodes_with_updates(
-            TrieUpdates::default(),
-            hashed_state,
-            prefix_sets,
-        )
+        self.state_root_from_nodes_with_updates(TrieUpdates::default(), hashed_state, prefix_sets)
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         nodes: TrieUpdates,
         state: HashedPostState,
@@ -140,21 +136,13 @@ impl StateRootProvider for MemoryOverlayStateProvider {
         let MemoryOverlayTrieState { mut trie_nodes, mut hashed_state } = self.trie_state().clone();
         trie_nodes.extend(nodes);
         hashed_state.extend(state);
-        self.historical.hashed_state_root_from_nodes_with_updates(
-            trie_nodes,
-            hashed_state,
-            prefix_sets,
-        )
+        self.historical.state_root_from_nodes_with_updates(trie_nodes, hashed_state, prefix_sets)
     }
 }
 
 impl StorageRootProvider for MemoryOverlayStateProvider {
     // TODO: Currently this does not reuse available in-memory trie nodes.
-    fn hashed_storage_root(
-        &self,
-        address: Address,
-        storage: HashedStorage,
-    ) -> ProviderResult<B256> {
+    fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256> {
         let mut hashed_storage = self
             .trie_state()
             .hashed_state
@@ -163,7 +151,7 @@ impl StorageRootProvider for MemoryOverlayStateProvider {
             .cloned()
             .unwrap_or_default();
         hashed_storage.extend(&storage);
-        self.historical.hashed_storage_root(address, hashed_storage)
+        self.historical.storage_root(address, hashed_storage)
     }
 }
 

--- a/crates/consensus/auto-seal/Cargo.toml
+++ b/crates/consensus/auto-seal/Cargo.toml
@@ -29,6 +29,7 @@ reth-consensus.workspace = true
 reth-rpc-types.workspace = true
 reth-network-peers.workspace = true
 reth-tokio-util.workspace = true
+reth-trie.workspace = true
 
 # async
 futures-util.workspace = true

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1776,7 +1776,7 @@ where
 
         let root_time = Instant::now();
         let (state_root, trie_output) =
-            state_provider.hashed_state_root_with_updates(hashed_state.clone())?;
+            state_provider.state_root_with_updates(hashed_state.clone())?;
         if state_root != block.state_root {
             return Err(ConsensusError::BodyStateRootDiff(
                 GotExpected { got: state_root, expected: block.state_root }.into(),

--- a/crates/engine/util/Cargo.toml
+++ b/crates/engine/util/Cargo.toml
@@ -25,6 +25,7 @@ reth-revm.workspace = true
 reth-provider.workspace = true
 reth-ethereum-forks.workspace = true
 revm-primitives.workspace = true
+reth-trie.workspace = true
 
 # async
 tokio = { workspace = true, default-features = false }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -23,6 +23,7 @@ use reth_rpc_types::{
     ExecutionPayload,
 };
 use reth_rpc_types_compat::engine::payload::block_to_payload;
+use reth_trie::HashedPostState;
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EVMError, EnvWithHandlerCfg};
 use std::{
     collections::VecDeque,
@@ -367,6 +368,7 @@ where
         reorg_target.number,
         Default::default(),
     );
+    let hashed_state = HashedPostState::from_bundle_state(&outcome.state().state);
 
     let (blob_gas_used, excess_blob_gas) =
         if chain_spec.is_cancun_active_at_timestamp(reorg_target.timestamp) {
@@ -406,7 +408,7 @@ where
             gas_used: cumulative_gas_used,
             blob_gas_used,
             excess_blob_gas,
-            state_root: state_provider.state_root(outcome.state())?,
+            state_root: state_provider.state_root(hashed_state)?,
         },
         body: transactions,
         ommers: reorg_target.ommers,

--- a/crates/ethereum/payload/Cargo.toml
+++ b/crates/ethereum/payload/Cargo.toml
@@ -23,6 +23,7 @@ reth-basic-payload-builder.workspace = true
 reth-evm.workspace = true
 reth-evm-ethereum.workspace = true
 reth-errors.workspace = true
+reth-trie.workspace = true
 
 # ethereum
 revm.workspace = true

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -155,7 +155,8 @@ where
 
         // calculate the state root
         let bundle_state = db.take_bundle();
-        let state_root = db.database.state_root(&bundle_state).map_err(|err| {
+        let hashed_state = HashedPostState::from_bundle_state(&bundle_state.state);
+        let state_root = db.database.state_root(hashed_state).map_err(|err| {
             warn!(target: "payload_builder",
                 parent_hash=%parent_block.hash(),
                 %err,
@@ -529,15 +530,13 @@ where
     let hashed_state = HashedPostState::from_bundle_state(&execution_outcome.state().state);
     let (state_root, trie_output) = {
         let state_provider = db.database.0.inner.borrow_mut();
-        state_provider.db.hashed_state_root_with_updates(hashed_state.clone()).inspect_err(
-            |err| {
-                warn!(target: "payload_builder",
-                    parent_hash=%parent_block.hash(),
-                    %err,
-                    "failed to calculate state root for empty payload"
-                );
-            },
-        )?
+        state_provider.db.state_root_with_updates(hashed_state.clone()).inspect_err(|err| {
+            warn!(target: "payload_builder",
+                parent_hash=%parent_block.hash(),
+                %err,
+                "failed to calculate state root for empty payload"
+            );
+        })?
     };
 
     // create the block header

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -72,11 +72,11 @@ impl BlockHashReader for StateProviderTest {
 }
 
 impl StateRootProvider for StateProviderTest {
-    fn hashed_state_root(&self, _hashed_state: HashedPostState) -> ProviderResult<B256> {
+    fn state_root(&self, _hashed_state: HashedPostState) -> ProviderResult<B256> {
         unimplemented!("state root computation is not supported")
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         _nodes: TrieUpdates,
         _hashed_state: HashedPostState,
@@ -85,14 +85,14 @@ impl StateRootProvider for StateProviderTest {
         unimplemented!("state root computation is not supported")
     }
 
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         _hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         unimplemented!("state root computation is not supported")
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         _nodes: TrieUpdates,
         _hashed_state: HashedPostState,
@@ -103,7 +103,7 @@ impl StateRootProvider for StateProviderTest {
 }
 
 impl StorageRootProvider for StateProviderTest {
-    fn hashed_storage_root(
+    fn storage_root(
         &self,
         _address: Address,
         _hashed_storage: HashedStorage,

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -30,6 +30,7 @@ reth-execution-types.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-api.workspace = true
+reth-trie.workspace = true
 
 # ethereum
 alloy-dyn-abi = { workspace = true, features = ["eip712"] }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -30,6 +30,7 @@ use reth_revm::{
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
 use reth_transaction_pool::{BestTransactionsAttributes, TransactionPool};
+use reth_trie::HashedPostState;
 use revm::{db::states::bundle_state::BundleRetention, DatabaseCommit, State};
 use tokio::sync::Mutex;
 use tracing::debug;
@@ -386,6 +387,7 @@ pub trait LoadPendingBlock: EthApiTypes {
             block_number,
             Vec::new(),
         );
+        let hashed_state = HashedPostState::from_bundle_state(&execution_outcome.state().state);
 
         let receipts_root = self.receipts_root(&block_env, &execution_outcome, block_number);
 
@@ -394,9 +396,8 @@ pub trait LoadPendingBlock: EthApiTypes {
 
         // calculate the state root
         let state_provider = &db.database;
-        let state_root = state_provider
-            .state_root(execution_outcome.state())
-            .map_err(Self::Error::from_eth_err)?;
+        let state_root =
+            state_provider.state_root(hashed_state).map_err(Self::Error::from_eth_err)?;
 
         // create the block header
         let transactions_root = calculate_transaction_root(&executed_txs);

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -147,7 +147,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             // Provide a default `HashedStorage` value in order to
             // get the storage root hash of the current state.
             let storage_root = state
-                .hashed_storage_root(address, Default::default())
+                .storage_root(address, Default::default())
                 .map_err(Self::Error::from_eth_err)?;
 
             Ok(Some(Account { balance, nonce, code_hash, storage_root }))

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -18,46 +18,46 @@ pub type StateCacheDb<'a> = CacheDB<StateProviderDatabase<StateProviderTraitObjW
 pub struct StateProviderTraitObjWrapper<'a>(pub &'a dyn StateProvider);
 
 impl<'a> reth_storage_api::StateRootProvider for StateProviderTraitObjWrapper<'a> {
-    fn hashed_state_root(
+    fn state_root(
         &self,
         hashed_state: reth_trie::HashedPostState,
     ) -> reth_errors::ProviderResult<B256> {
-        self.0.hashed_state_root(hashed_state)
+        self.0.state_root(hashed_state)
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         nodes: reth_trie::updates::TrieUpdates,
         hashed_state: reth_trie::HashedPostState,
         prefix_sets: reth_trie::prefix_set::TriePrefixSetsMut,
     ) -> reth_errors::ProviderResult<B256> {
-        self.0.hashed_state_root_from_nodes(nodes, hashed_state, prefix_sets)
+        self.0.state_root_from_nodes(nodes, hashed_state, prefix_sets)
     }
 
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         hashed_state: reth_trie::HashedPostState,
     ) -> reth_errors::ProviderResult<(B256, reth_trie::updates::TrieUpdates)> {
-        self.0.hashed_state_root_with_updates(hashed_state)
+        self.0.state_root_with_updates(hashed_state)
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         nodes: reth_trie::updates::TrieUpdates,
         hashed_state: reth_trie::HashedPostState,
         prefix_sets: reth_trie::prefix_set::TriePrefixSetsMut,
     ) -> reth_errors::ProviderResult<(B256, reth_trie::updates::TrieUpdates)> {
-        self.0.hashed_state_root_from_nodes_with_updates(nodes, hashed_state, prefix_sets)
+        self.0.state_root_from_nodes_with_updates(nodes, hashed_state, prefix_sets)
     }
 }
 
 impl<'a> reth_storage_api::StorageRootProvider for StateProviderTraitObjWrapper<'a> {
-    fn hashed_storage_root(
+    fn storage_root(
         &self,
         address: Address,
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
-        self.0.hashed_storage_root(address, hashed_storage)
+        self.0.storage_root(address, hashed_storage)
     }
 }
 

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -8,7 +8,6 @@ use reth_trie::{
     prefix_set::TriePrefixSetsMut, updates::TrieUpdates, AccountProof, HashedPostState,
     HashedStorage,
 };
-use revm::db::BundleState;
 use std::collections::HashMap;
 
 /// A state provider that resolves to data from either a wrapped [`crate::ExecutionOutcome`]
@@ -69,20 +68,14 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> AccountReader for BundleStat
 impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
     for BundleStateProvider<SP, EDP>
 {
-    fn state_root(&self, bundle_state: &BundleState) -> ProviderResult<B256> {
-        let mut state = self.block_execution_data_provider.execution_outcome().state().clone();
-        state.extend(bundle_state.clone());
-        self.state_provider.state_root(&state)
-    }
-
-    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
         state.extend(hashed_state);
-        self.state_provider.hashed_state_root(state)
+        self.state_provider.state_root(state)
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         _nodes: TrieUpdates,
         _hashed_state: HashedPostState,
@@ -93,24 +86,15 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
 
     fn state_root_with_updates(
         &self,
-        bundle_state: &BundleState,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        let mut state = self.block_execution_data_provider.execution_outcome().state().clone();
-        state.extend(bundle_state.clone());
-        self.state_provider.state_root_with_updates(&state)
-    }
-
-    fn hashed_state_root_with_updates(
-        &self,
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
         state.extend(hashed_state);
-        self.state_provider.hashed_state_root_with_updates(state)
+        self.state_provider.state_root_with_updates(state)
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         nodes: TrieUpdates,
         hashed_state: HashedPostState,
@@ -121,18 +105,14 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
         let mut state_prefix_sets = state.construct_prefix_sets();
         state.extend(hashed_state);
         state_prefix_sets.extend(prefix_sets);
-        self.state_provider.hashed_state_root_from_nodes_with_updates(
-            nodes,
-            state,
-            state_prefix_sets,
-        )
+        self.state_provider.state_root_from_nodes_with_updates(nodes, state, state_prefix_sets)
     }
 }
 
 impl<SP: StateProvider, EDP: ExecutionDataProvider> StorageRootProvider
     for BundleStateProvider<SP, EDP>
 {
-    fn hashed_storage_root(
+    fn storage_root(
         &self,
         address: Address,
         hashed_storage: HashedStorage,
@@ -148,7 +128,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StorageRootProvider
             })
             .unwrap_or_else(|| HashedStorage::new(false));
         storage.extend(&hashed_storage);
-        self.state_provider.hashed_storage_root(address, storage)
+        self.state_provider.storage_root(address, storage)
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -285,14 +285,14 @@ impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
 }
 
 impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
-    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let mut revert_state = self.revert_state()?;
         revert_state.extend(hashed_state);
         StateRoot::overlay_root(self.tx, revert_state)
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         nodes: TrieUpdates,
         hashed_state: HashedPostState,
@@ -306,7 +306,7 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
@@ -316,7 +316,7 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         nodes: TrieUpdates,
         hashed_state: HashedPostState,
@@ -337,7 +337,7 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
 }
 
 impl<'b, TX: DbTx> StorageRootProvider for HistoricalStateProviderRef<'b, TX> {
-    fn hashed_storage_root(
+    fn storage_root(
         &self,
         address: Address,
         hashed_storage: HashedStorage,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -81,12 +81,12 @@ impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
 }
 
 impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
-    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         StateRoot::overlay_root(self.tx, hashed_state)
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         nodes: TrieUpdates,
         hashed_state: HashedPostState,
@@ -96,7 +96,7 @@ impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
@@ -104,7 +104,7 @@ impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
             .map_err(|err| ProviderError::Database(err.into()))
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         nodes: TrieUpdates,
         hashed_state: HashedPostState,
@@ -116,7 +116,7 @@ impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
 }
 
 impl<'b, TX: DbTx> StorageRootProvider for LatestStateProviderRef<'b, TX> {
-    fn hashed_storage_root(
+    fn storage_root(
         &self,
         address: Address,
         hashed_storage: HashedStorage,

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -42,15 +42,13 @@ macro_rules! delegate_provider_impls {
                 fn bytecode_by_hash(&self, code_hash: reth_primitives::B256) -> reth_storage_errors::provider::ProviderResult<Option<reth_primitives::Bytecode>>;
             }
             StateRootProvider $(where [$($generics)*])? {
-                fn state_root(&self, state: &revm::db::BundleState) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
-                fn hashed_state_root(&self, state: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
-                fn hashed_state_root_from_nodes(&self,  nodes: reth_trie::updates::TrieUpdates, state: reth_trie::HashedPostState, prefix_sets: reth_trie::prefix_set::TriePrefixSetsMut) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
-                fn state_root_with_updates(&self, state: &revm::db::BundleState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
-                fn hashed_state_root_with_updates(&self, state: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
-                fn hashed_state_root_from_nodes_with_updates(&self,  nodes: reth_trie::updates::TrieUpdates, state: reth_trie::HashedPostState, prefix_sets: reth_trie::prefix_set::TriePrefixSetsMut) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
+                fn state_root(&self, state: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
+                fn state_root_from_nodes(&self,  nodes: reth_trie::updates::TrieUpdates, state: reth_trie::HashedPostState, prefix_sets: reth_trie::prefix_set::TriePrefixSetsMut) -> reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
+                fn state_root_with_updates(&self, state: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
+                fn state_root_from_nodes_with_updates(&self,  nodes: reth_trie::updates::TrieUpdates, state: reth_trie::HashedPostState, prefix_sets: reth_trie::prefix_set::TriePrefixSetsMut) -> reth_storage_errors::provider::ProviderResult<(reth_primitives::B256, reth_trie::updates::TrieUpdates)>;
             }
             StorageRootProvider $(where [$($generics)*])? {
-                fn hashed_storage_root(&self, address: reth_primitives::Address, storage: reth_trie::HashedStorage) ->  reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
+                fn storage_root(&self, address: reth_primitives::Address, storage: reth_trie::HashedStorage) ->  reth_storage_errors::provider::ProviderResult<reth_primitives::B256>;
             }
             StateProofProvider $(where [$($generics)*])? {
                 fn proof(&self, state: reth_trie::HashedPostState, address: reth_primitives::Address, slots: &[reth_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -568,11 +568,11 @@ impl StageCheckpointReader for MockEthProvider {
 }
 
 impl StateRootProvider for MockEthProvider {
-    fn hashed_state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
+    fn state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
         Ok(self.state_roots.lock().pop().unwrap_or_default())
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         _nodes: TrieUpdates,
         _hashed_state: HashedPostState,
@@ -581,7 +581,7 @@ impl StateRootProvider for MockEthProvider {
         Ok(self.state_roots.lock().pop().unwrap_or_default())
     }
 
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         _state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
@@ -589,7 +589,7 @@ impl StateRootProvider for MockEthProvider {
         Ok((state_root, Default::default()))
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         _nodes: TrieUpdates,
         _hashed_state: HashedPostState,
@@ -601,7 +601,7 @@ impl StateRootProvider for MockEthProvider {
 }
 
 impl StorageRootProvider for MockEthProvider {
-    fn hashed_storage_root(
+    fn storage_root(
         &self,
         _address: Address,
         _hashed_storage: HashedStorage,

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -322,11 +322,11 @@ impl ChangeSetReader for NoopProvider {
 }
 
 impl StateRootProvider for NoopProvider {
-    fn hashed_state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
+    fn state_root(&self, _state: HashedPostState) -> ProviderResult<B256> {
         Ok(B256::default())
     }
 
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         _nodes: TrieUpdates,
         _hashed_state: HashedPostState,
@@ -335,14 +335,14 @@ impl StateRootProvider for NoopProvider {
         Ok(B256::default())
     }
 
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         _state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         Ok((B256::default(), TrieUpdates::default()))
     }
 
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         _nodes: TrieUpdates,
         _hashed_state: HashedPostState,
@@ -353,7 +353,7 @@ impl StateRootProvider for NoopProvider {
 }
 
 impl StorageRootProvider for NoopProvider {
-    fn hashed_storage_root(
+    fn storage_root(
         &self,
         _address: Address,
         _hashed_storage: HashedStorage,

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -22,6 +22,4 @@ reth-stages-types.workspace = true
 reth-storage-errors.workspace = true
 reth-trie.workspace = true
 
-revm.workspace = true
-
 auto_impl.workspace = true

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -36,7 +36,7 @@ pub trait StateRootProvider: Send + Sync {
     ) -> ProviderResult<(B256, TrieUpdates)>;
 
     /// Returns state root and trie updates.
-    /// See [`StateRootProvider::hashed_state_root_from_nodes`] for more info.
+    /// See [`StateRootProvider::state_root_from_nodes`] for more info.
     fn state_root_from_nodes_with_updates(
         &self,
         nodes: TrieUpdates,

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -4,7 +4,6 @@ use reth_trie::{
     prefix_set::TriePrefixSetsMut, updates::TrieUpdates, AccountProof, HashedPostState,
     HashedStorage,
 };
-use revm::db::BundleState;
 use std::collections::HashMap;
 
 /// A type that can compute the state root of a given post state.
@@ -17,42 +16,28 @@ pub trait StateRootProvider: Send + Sync {
     /// It is recommended to provide a different implementation from
     /// `state_root_with_updates` since it affects the memory usage during state root
     /// computation.
-    fn state_root(&self, bundle_state: &BundleState) -> ProviderResult<B256> {
-        self.hashed_state_root(HashedPostState::from_bundle_state(&bundle_state.state))
-    }
-
-    /// Returns the state root of the `HashedPostState` on top of the current state.
-    fn hashed_state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256>;
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256>;
 
     /// Returns the state root of the `HashedPostState` on top of the current state but re-uses the
     /// intermediate nodes to speed up the computation. It's up to the caller to construct the
     /// prefix sets and inform the provider of the trie paths that have changes.
-    fn hashed_state_root_from_nodes(
+    fn state_root_from_nodes(
         &self,
         nodes: TrieUpdates,
         hashed_state: HashedPostState,
         prefix_sets: TriePrefixSetsMut,
     ) -> ProviderResult<B256>;
 
-    /// Returns the state root of the BundleState on top of the current state with trie
-    /// updates to be committed to the database.
-    fn state_root_with_updates(
-        &self,
-        bundle_state: &BundleState,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        self.hashed_state_root_with_updates(HashedPostState::from_bundle_state(&bundle_state.state))
-    }
-
     /// Returns the state root of the `HashedPostState` on top of the current state with trie
     /// updates to be committed to the database.
-    fn hashed_state_root_with_updates(
+    fn state_root_with_updates(
         &self,
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)>;
 
     /// Returns state root and trie updates.
     /// See [`StateRootProvider::hashed_state_root_from_nodes`] for more info.
-    fn hashed_state_root_from_nodes_with_updates(
+    fn state_root_from_nodes_with_updates(
         &self,
         nodes: TrieUpdates,
         hashed_state: HashedPostState,
@@ -65,11 +50,8 @@ pub trait StateRootProvider: Send + Sync {
 pub trait StorageRootProvider: Send + Sync {
     /// Returns the storage root of the `HashedStorage` for target address on top of the current
     /// state.
-    fn hashed_storage_root(
-        &self,
-        address: Address,
-        hashed_storage: HashedStorage,
-    ) -> ProviderResult<B256>;
+    fn storage_root(&self, address: Address, hashed_storage: HashedStorage)
+        -> ProviderResult<B256>;
 }
 
 /// A type that can generate state proof on top of a given post state.


### PR DESCRIPTION
## Description

* Remove state root methods that accept bundle state
* Rename all `hashed_state_root_*` methods to `state_root_*`