### PR TITLE
fix(reth-evm-ethereum): no_std test compilation errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,7 +321,7 @@ reth-ethereum-forks = { path = "crates/ethereum-forks" }
 reth-ethereum-payload-builder = { path = "crates/ethereum/payload" }
 reth-etl = { path = "crates/etl" }
 reth-evm = { path = "crates/evm" }
-reth-evm-ethereum = { path = "crates/ethereum/evm" }
+reth-evm-ethereum = { path = "crates/ethereum/evm", default-features = false }
 reth-evm-optimism = { path = "crates/optimism/evm" }
 reth-execution-errors = { path = "crates/evm/execution-errors" }
 reth-execution-types = { path = "crates/evm/execution-types" }

--- a/crates/ethereum/evm/src/eip6110.rs
+++ b/crates/ethereum/evm/src/eip6110.rs
@@ -7,7 +7,7 @@ use reth_primitives::{Receipt, Request};
 use revm_primitives::Log;
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::ToString, vec::Vec};
+use alloc::{string::ToString, vec, vec::Vec};
 
 sol! {
     #[allow(missing_docs)]

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -481,7 +481,9 @@ mod tests {
     use reth_testing_utils::generators::{self, sign_tx_with_key_pair};
     use revm_primitives::{b256, fixed_bytes, Bytes, BLOCKHASH_SERVE_WINDOW};
     use secp256k1::{Keypair, Secp256k1};
-    use std::collections::HashMap;
+    use revm_primitives::HashMap;
+    #[cfg(not(feature = "std"))]
+    use alloc::{vec, boxed::Box, string::ToString};
 
     fn create_state_provider_with_beacon_root_contract() -> StateProviderTest {
         let mut db = StateProviderTest::default();

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -465,6 +465,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::{boxed::Box, string::ToString, vec};
     use alloy_eips::{
         eip2935::{HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_CODE},
         eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE, SYSTEM_ADDRESS},
@@ -479,11 +481,8 @@ mod tests {
         database::StateProviderDatabase, test_utils::StateProviderTest, TransitionState,
     };
     use reth_testing_utils::generators::{self, sign_tx_with_key_pair};
-    use revm_primitives::{b256, fixed_bytes, Bytes, BLOCKHASH_SERVE_WINDOW};
+    use revm_primitives::{b256, fixed_bytes, Bytes, HashMap, BLOCKHASH_SERVE_WINDOW};
     use secp256k1::{Keypair, Secp256k1};
-    use revm_primitives::HashMap;
-    #[cfg(not(feature = "std"))]
-    use alloc::{vec, boxed::Box, string::ToString};
 
     fn create_state_provider_with_beacon_root_contract() -> StateProviderTest {
         let mut db = StateProviderTest::default();

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -18,7 +18,7 @@ use reth_primitives::{transaction::FillTxEnv, Address, Header, TransactionSigned
 use revm_primitives::{AnalysisKind, Bytes, CfgEnvWithHandlerCfg, Env, TxEnv, TxKind};
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 mod config;
 pub use config::{revm_spec, revm_spec_by_timestamp_after_merge};
@@ -126,8 +126,7 @@ mod tests {
         inspectors::NoOpInspector,
         JournaledState,
     };
-    use revm_primitives::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
-    use std::collections::HashSet;
+    use revm_primitives::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg, HashSet};
 
     #[test]
     fn test_fill_cfg_and_block_env() {


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/10088

In `reth-evm-ethereum`

The tests fail when running:

`cargo t -p reth-evm-ethereum --no-default-features`

These changes fix the compilation issues