### PR TITLE
chore: re-export reth_chainspec in reth

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -90,6 +90,11 @@ pub mod dirs {
     pub use reth_node_core::dirs::*;
 }
 
+/// Re-exported from `reth_chainspec`
+pub mod chainspec {
+    pub use reth_chainspec::*;
+}
+
 /// Re-exported from `reth_provider`.
 pub mod providers {
     pub use reth_provider::*;


### PR DESCRIPTION
This is useful when we're trying to use the chainspec.