### PR TITLE
fix: op fee fields

### DIFF
--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -59,14 +59,30 @@ pub fn op_receipt_fields(
         op_fields.deposit_nonce = receipt.deposit_nonce;
         op_fields.deposit_receipt_version = receipt.deposit_receipt_version;
     } else if let Some(l1_block_info) = optimism_tx_meta.l1_block_info {
+        // always present
         op_fields.l1_fee = optimism_tx_meta.l1_fee;
+        op_fields.l1_gas_price = Some(l1_block_info.l1_base_fee.saturating_to());
         op_fields.l1_gas_used = optimism_tx_meta.l1_data_gas.map(|dg| {
             dg.saturating_add(
                 l1_block_info.l1_fee_overhead.unwrap_or_default().saturating_to::<u128>(),
             )
         });
-        op_fields.l1_fee_scalar = Some(f64::from(l1_block_info.l1_base_fee_scalar) / 1_000_000.0);
-        op_fields.l1_gas_price = Some(l1_block_info.l1_base_fee.saturating_to());
+
+        // we know if we're __pre__ Ecotone by checking the l1 fee overhead value which is
+        // None if ecotone is active
+        if l1_block_info.l1_fee_overhead.is_some() {
+            // only pre Ecotone
+            op_fields.l1_fee_scalar =
+                Some(f64::from(l1_block_info.l1_base_fee_scalar) / 1_000_000.0);
+        } else {
+            // base fee scalar is enabled post Ecotone
+            op_fields.l1_base_fee_scalar = Some(l1_block_info.l1_base_fee_scalar.saturating_to());
+        }
+
+        // 4844 post Ecotone
+        op_fields.l1_blob_base_fee = l1_block_info.l1_blob_base_fee.map(|v| v.saturating_to());
+        op_fields.l1_blob_base_fee_scalar =
+            l1_block_info.l1_blob_base_fee_scalar.map(|v| v.saturating_to());
     }
 
     resp_builder.add_other_fields(op_fields.into())


### PR DESCRIPTION
closes #10462

we now have the post ecotone fee fields and need to set them accordingly:

pre ecotone:
    l1_fee_scalar

post ecotone
    "l1BaseFeeScalar": "0x8dd",
    "l1BlobBaseFee": "0x1",
    "l1BlobBaseFeeScalar": "0x101c12",

always:
    "l1Fee": "0x125f723f3",
    "l1GasPrice": "0x50f928b4",
    "l1GasUsed": "0x640",