### PR TITLE
feat: impl StateReader for BlockchainProvider2

### DIFF
--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -603,6 +603,7 @@ impl<DB, Spec> Clone for ProviderFactory<DB, Spec> {
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -11,8 +11,8 @@ use crate::{
     FinalizedBlockWriter, HashingWriter, HeaderProvider, HeaderSyncGap, HeaderSyncGapProvider,
     HistoricalStateProvider, HistoryWriter, LatestStateProvider, OriginalValuesKnown,
     ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RequestsProvider, RevertsInit,
-    StageCheckpointReader, StateChangeWriter, StateProviderBox, StateWriter, StatsReader,
-    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
+    StageCheckpointReader, StateChangeWriter, StateProviderBox, StateReader, StateWriter,
+    StatsReader, StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
     TransactionsProviderExt, TrieWriter, WithdrawalsProvider,
 };
 use itertools::{izip, Itertools};
@@ -777,12 +777,14 @@ impl<TX: DbTx> DatabaseProvider<TX> {
     ///     1. Take the old value from the changeset
     ///     2. Take the new value from the local state
     ///     3. Set the local state to the value in the changeset
+    ///
+    /// If the range is empty, or there are no blocks for the given range, then this returns `None`.
     pub fn get_state(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<ExecutionOutcome> {
+    ) -> ProviderResult<Option<ExecutionOutcome>> {
         if range.is_empty() {
-            return Ok(ExecutionOutcome::default())
+            return Ok(None)
         }
         let start_block_number = *range.start();
 
@@ -790,10 +792,14 @@ impl<TX: DbTx> DatabaseProvider<TX> {
         let block_bodies = self.get::<tables::BlockBodyIndices>(range.clone())?;
 
         // get transaction receipts
-        let from_transaction_num =
-            block_bodies.first().expect("already checked if there are blocks").1.first_tx_num();
-        let to_transaction_num =
-            block_bodies.last().expect("already checked if there are blocks").1.last_tx_num();
+        let Some(from_transaction_num) = block_bodies.first().map(|bodies| bodies.1.first_tx_num())
+        else {
+            return Ok(None)
+        };
+        let Some(to_transaction_num) = block_bodies.last().map(|bodies| bodies.1.last_tx_num())
+        else {
+            return Ok(None)
+        };
 
         let storage_range = BlockNumberAddress::range(range.clone());
 
@@ -830,14 +836,14 @@ impl<TX: DbTx> DatabaseProvider<TX> {
             receipts.push(block_receipts);
         }
 
-        Ok(ExecutionOutcome::new_init(
+        Ok(Some(ExecutionOutcome::new_init(
             state,
             reverts,
             Vec::new(),
             receipts.into(),
             start_block_number,
             Vec::new(),
-        ))
+        )))
     }
 
     /// Populate a [`BundleStateInit`] and [`RevertsInit`] using cursors over the
@@ -3223,9 +3229,15 @@ impl<TX: DbTx> BlockExecutionReader for DatabaseProvider<TX> {
         let blocks = self.get_block_range(range.clone())?;
 
         // get execution res
-        let execution_state = self.get_state(range)?;
+        let execution_state = self.get_state(range)?.unwrap_or_default();
 
         Ok(Chain::new(blocks, execution_state, None))
+    }
+}
+
+impl<TX: DbTx> StateReader for DatabaseProvider<TX> {
+    fn get_state(&self, block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>> {
+        self.get_state(block..=block)
     }
 }
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -22,7 +22,7 @@ pub trait BlockExecutionWriter: BlockWriter + Send + Sync {
     ) -> ProviderResult<()>;
 }
 
-/// BlockExecution Writer
+/// BlockExecution Reader
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait BlockExecutionReader: BlockReader + Send + Sync {
     /// Get range of blocks and its execution result
@@ -30,6 +30,13 @@ pub trait BlockExecutionReader: BlockReader + Send + Sync {
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Chain>;
+}
+
+/// This just receives state, or [`ExecutionOutcome`], from the provider
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait StateReader: Send + Sync {
+    /// Get the [`ExecutionOutcome`] for the given block
+    fn get_state(&self, block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>>;
 }
 
 /// Block Writer


### PR DESCRIPTION
This introduces a new trait, `StateReader`, for fetching `ExecutionOutcome`s from disk. Currently this has one method, `get_state`, which gets the `ExecutionOutcome` for a single block. A range method could also be introduced in the future.

The original `get_state` method on `DatabaseProvider`, is changed to now output an `Option`, if the range is either empty, or if no blocks are returned from the DB.

This method is also implemented on `BlockchainProvider2`.