### PR TITLE
fix(storage): do not call freeze on `NippyJarWriter::new`

### DIFF
--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -55,9 +55,6 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
         let (data_file, offsets_file, is_created) =
             Self::create_or_open_files(jar.data_path(), &jar.offsets_path())?;
 
-        // Makes sure we don't have dangling data and offset files
-        jar.freeze_config()?;
-
         let mut writer = Self {
             jar,
             data_file: BufWriter::new(data_file),


### PR DESCRIPTION
The doc below is outdated, since it's no longer the behaviour of `freeze_config` and it's unnecessary to call it.
```rust
// Makes sure we don't have dangling data and offset files
jar.freeze_config()?;
```

Even in read-only mode, we currently open the `NippyJarWriter` mode to check for consistency. In `RO`, it will throw an error instead of modifying/healing the file.

However, if let alone, this `freeze_config` will actually update the configuration file on disk (eg `reth db stats`).

This is problematic if the node is at the same time calling `freeze_config` (eg. appending a block during live sync), which can result in the following crash:

```bash
_headers_20500000_20999999..tmp\" to \"/home/ubuntu/.local/share/reth/mainnet/static_files/static_file_headers_20500000_20999999.conf\": No such file or directory (os error 2)")) 
```