### PR TITLE
fix(provider): move consistency check methods from `NippyJarWriter` to `NippyJarChecker`

### DIFF
--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -6,16 +6,16 @@ use std::{
     path::Path,
 };
 
-/// Performs consistency checks on the [`NippyJar`] file
+/// Performs consistency checks or heals on the [`NippyJar`] file
 /// * Is the offsets file size expected?
 /// * Is the data file size expected?
 ///
 /// This is based on the assumption that [`NippyJar`] configuration is **always** the last one
 /// to be updated when something is written, as by the `NippyJarWriter::commit()` function shows.
 ///
-/// **For read-only: use `check_consistency` method.**
+/// **For checks (read-only) use `check_consistency` method.**
 ///
-/// **For read-write: use `ensure_consistency`method.**
+/// **For heals (read-write) use `ensure_consistency` method.**
 #[derive(Debug)]
 pub struct NippyJarChecker<H: NippyJarHeader = ()> {
     /// Associated [`NippyJar`], containing all necessary configurations for data

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -85,7 +85,10 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 // Freeze row count changed
                 self.jar.freeze_config()?;
             }
-            Ordering::Equal => {}
+            Ordering::Equal => {
+                // Checked above
+                unimplemented!()
+            }
         }
 
         // last offset should match the data_file_len
@@ -127,7 +130,10 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                     }
                 }
             }
-            Ordering::Equal => {}
+            Ordering::Equal => {
+                // Checked above
+                unimplemented!()
+            }
         }
 
         self.offsets_file().seek(SeekFrom::End(0))?;

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -1,0 +1,187 @@
+use crate::{writer::OFFSET_SIZE_BYTES, NippyJar, NippyJarError, NippyJarHeader};
+use std::{
+    cmp::Ordering,
+    fs::{File, OpenOptions},
+    io::{BufWriter, Seek, SeekFrom},
+    path::Path,
+};
+
+/// Performs consistency checks on the [`NippyJar`] file
+/// * Is the offsets file size expected?
+/// * Is the data file size expected?
+///
+/// This is based on the assumption that [`NippyJar`] configuration is **always** the last one
+/// to be updated when something is written, as by the `NippyJarWriter::commit()` function shows.
+///
+/// **For read-only: use `check_consistency` method.**
+///
+/// **For read-write: use `ensure_consistency`method.**
+#[derive(Debug)]
+pub struct NippyJarChecker<H: NippyJarHeader = ()> {
+    /// Associated [`NippyJar`], containing all necessary configurations for data
+    /// handling.
+    pub(crate) jar: NippyJar<H>,
+    /// File handle to where the data is stored.
+    pub(crate) data_file: Option<BufWriter<File>>,
+    /// File handle to where the offsets are stored.
+    pub(crate) offsets_file: Option<BufWriter<File>>,
+}
+
+impl<H: NippyJarHeader> NippyJarChecker<H> {
+    pub const fn new(jar: NippyJar<H>) -> Self {
+        Self { jar, data_file: None, offsets_file: None }
+    }
+
+    /// It will throw an error if the [`NippyJar`] is in a inconsistent state.
+    pub fn check_consistency(&mut self) -> Result<(), NippyJarError> {
+        self.consistency_guard(ConsistencyFailStrategy::ThrowError)
+    }
+
+    /// It will attempt to heal if the [`NippyJar`] is in a inconsistent state.
+    ///
+    /// **ATTENTION**: disk commit should be handled externally by consuming `Self`
+    pub fn ensure_consistency(&mut self) -> Result<(), NippyJarError> {
+        self.consistency_guard(ConsistencyFailStrategy::Heal)
+    }
+
+    fn consistency_guard(&mut self, mode: ConsistencyFailStrategy) -> Result<(), NippyJarError> {
+        self.load_files(mode)?;
+        let reader = self.jar.open_data_reader()?;
+
+        // When an offset size is smaller than the initial (8), we are dealing with immutable
+        // data.
+        if reader.offset_size() != OFFSET_SIZE_BYTES {
+            return Err(NippyJarError::FrozenJar)
+        }
+
+        let expected_offsets_file_size: u64 = (1 + // first byte is the size of one offset
+                OFFSET_SIZE_BYTES as usize* self.jar.rows * self.jar.columns + // `offset size * num rows * num columns`
+                OFFSET_SIZE_BYTES as usize) as u64; // expected size of the data file
+        let actual_offsets_file_size = self.offsets_file().get_ref().metadata()?.len();
+
+        if mode.should_err() &&
+            expected_offsets_file_size.cmp(&actual_offsets_file_size) != Ordering::Equal
+        {
+            return Err(NippyJarError::InconsistentState)
+        }
+
+        // Offsets configuration wasn't properly committed
+        match expected_offsets_file_size.cmp(&actual_offsets_file_size) {
+            Ordering::Less => {
+                // Happened during an appending job
+                // TODO: ideally we could truncate until the last offset of the last column of the
+                //  last row inserted
+                self.offsets_file().get_mut().set_len(expected_offsets_file_size)?;
+            }
+            Ordering::Greater => {
+                // Happened during a pruning job
+                // `num rows = (file size - 1 - size of one offset) / num columns`
+                self.jar.rows = ((actual_offsets_file_size.
+                        saturating_sub(1). // first byte is the size of one offset
+                        saturating_sub(OFFSET_SIZE_BYTES as u64) / // expected size of the data file
+                        (self.jar.columns as u64)) /
+                    OFFSET_SIZE_BYTES as u64) as usize;
+
+                // Freeze row count changed
+                self.jar.freeze_config()?;
+            }
+            Ordering::Equal => {}
+        }
+
+        // last offset should match the data_file_len
+        let last_offset = reader.reverse_offset(0)?;
+        let data_file_len = self.data_file().get_ref().metadata()?.len();
+
+        if mode.should_err() && last_offset.cmp(&data_file_len) != Ordering::Equal {
+            return Err(NippyJarError::InconsistentState)
+        }
+
+        // Offset list wasn't properly committed
+        match last_offset.cmp(&data_file_len) {
+            Ordering::Less => {
+                // Happened during an appending job, so we need to truncate the data, since there's
+                // no way to recover it.
+                self.data_file().get_mut().set_len(last_offset)?;
+            }
+            Ordering::Greater => {
+                // Happened during a pruning job, so we need to reverse iterate offsets until we
+                // find the matching one.
+                for index in 0..reader.offsets_count()? {
+                    let offset = reader.reverse_offset(index + 1)?;
+                    // It would only be equal if the previous row was fully pruned.
+                    if offset <= data_file_len {
+                        let new_len = self
+                            .offsets_file()
+                            .get_ref()
+                            .metadata()?
+                            .len()
+                            .saturating_sub(OFFSET_SIZE_BYTES as u64 * (index as u64 + 1));
+                        self.offsets_file().get_mut().set_len(new_len)?;
+
+                        drop(reader);
+
+                        // Since we decrease the offset list, we need to check the consistency of
+                        // `self.jar.rows` again
+                        self.consistency_guard(ConsistencyFailStrategy::Heal)?;
+                        break
+                    }
+                }
+            }
+            Ordering::Equal => {}
+        }
+
+        self.offsets_file().seek(SeekFrom::End(0))?;
+        self.data_file().seek(SeekFrom::End(0))?;
+
+        Ok(())
+    }
+
+    /// Loads data and offsets files.
+    fn load_files(&mut self, mode: ConsistencyFailStrategy) -> Result<(), NippyJarError> {
+        let load_file = |path: &Path| -> Result<BufWriter<File>, NippyJarError> {
+            let path = path
+                .exists()
+                .then_some(path)
+                .ok_or_else(|| NippyJarError::MissingFile(path.to_path_buf()))?;
+            Ok(BufWriter::new(OpenOptions::new().read(true).write(mode.should_heal()).open(path)?))
+        };
+        self.data_file = Some(load_file(self.jar.data_path())?);
+        self.offsets_file = Some(load_file(&self.jar.offsets_path())?);
+        Ok(())
+    }
+
+    /// Returns a mutable reference to offsets file.
+    ///
+    /// **Panics** if it does not exist.
+    fn offsets_file(&mut self) -> &mut BufWriter<File> {
+        self.offsets_file.as_mut().expect("should exist")
+    }
+
+    /// Returns a mutable reference to data file.
+    ///
+    /// **Panics** if it does not exist.
+    fn data_file(&mut self) -> &mut BufWriter<File> {
+        self.data_file.as_mut().expect("should exist")
+    }
+}
+
+/// Strategy on encountering an inconsistent state when creating a [`NippyJarWriter`].
+#[derive(Debug, Copy, Clone)]
+enum ConsistencyFailStrategy {
+    /// Writer should heal.
+    Heal,
+    /// Writer should throw an error.
+    ThrowError,
+}
+
+impl ConsistencyFailStrategy {
+    /// Whether writer should heal.
+    const fn should_heal(&self) -> bool {
+        matches!(self, Self::Heal)
+    }
+
+    /// Whether writer should throw an error.
+    const fn should_err(&self) -> bool {
+        matches!(self, Self::ThrowError)
+    }
+}

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -87,7 +87,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
             }
             Ordering::Equal => {
                 // Checked above
-                unimplemented!()
+                unreachable!()
             }
         }
 
@@ -132,7 +132,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
             }
             Ordering::Equal => {
                 // Checked above
-                unimplemented!()
+                unreachable!()
             }
         }
 

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -85,10 +85,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 // Freeze row count changed
                 self.jar.freeze_config()?;
             }
-            Ordering::Equal => {
-                // Checked above
-                unreachable!()
-            }
+            Ordering::Equal => {}
         }
 
         // last offset should match the data_file_len
@@ -130,10 +127,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                     }
                 }
             }
-            Ordering::Equal => {
-                // Checked above
-                unreachable!()
-            }
+            Ordering::Equal => {}
         }
 
         self.offsets_file().seek(SeekFrom::End(0))?;

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -171,7 +171,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
     }
 }
 
-/// Strategy on encountering an inconsistent state when creating a [`NippyJarWriter`].
+/// Strategy on encountering an inconsistent state on [`NippyJarChecker`].
 #[derive(Debug, Copy, Clone)]
 enum ConsistencyFailStrategy {
     /// Writer should heal.

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -34,17 +34,17 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
 
     /// It will throw an error if the [`NippyJar`] is in a inconsistent state.
     pub fn check_consistency(&mut self) -> Result<(), NippyJarError> {
-        self.consistency_guard(ConsistencyFailStrategy::ThrowError)
+        self.handle_consistency(ConsistencyFailStrategy::ThrowError)
     }
 
     /// It will attempt to heal if the [`NippyJar`] is in a inconsistent state.
     ///
     /// **ATTENTION**: disk commit should be handled externally by consuming `Self`
     pub fn ensure_consistency(&mut self) -> Result<(), NippyJarError> {
-        self.consistency_guard(ConsistencyFailStrategy::Heal)
+        self.handle_consistency(ConsistencyFailStrategy::Heal)
     }
 
-    fn consistency_guard(&mut self, mode: ConsistencyFailStrategy) -> Result<(), NippyJarError> {
+    fn handle_consistency(&mut self, mode: ConsistencyFailStrategy) -> Result<(), NippyJarError> {
         self.load_files(mode)?;
         let reader = self.jar.open_data_reader()?;
 
@@ -122,7 +122,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
 
                         // Since we decrease the offset list, we need to check the consistency of
                         // `self.jar.rows` again
-                        self.consistency_guard(ConsistencyFailStrategy::Heal)?;
+                        self.handle_consistency(ConsistencyFailStrategy::Heal)?;
                         break
                     }
                 }

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use thiserror::Error;
 
 /// Errors associated with [`crate::NippyJar`].
@@ -60,4 +61,6 @@ pub enum NippyJarError {
     FrozenJar,
     #[error("File is in an inconsistent state.")]
     InconsistentState,
+    #[error("Missing file: {0}.")]
+    MissingFile(PathBuf),
 }

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -1,13 +1,15 @@
-use crate::{compression::Compression, ColumnResult, NippyJar, NippyJarError, NippyJarHeader};
+use crate::{
+    compression::Compression, ColumnResult, NippyJar, NippyJarChecker, NippyJarError,
+    NippyJarHeader,
+};
 use std::{
-    cmp::Ordering,
     fs::{File, OpenOptions},
     io::{BufWriter, Read, Seek, SeekFrom, Write},
     path::Path,
 };
 
 /// Size of one offset in bytes.
-const OFFSET_SIZE_BYTES: u8 = 8;
+pub(crate) const OFFSET_SIZE_BYTES: u8 = 8;
 
 /// Writer of [`NippyJar`]. Handles table data and offsets only.
 ///
@@ -46,22 +48,32 @@ pub struct NippyJarWriter<H: NippyJarHeader = ()> {
 impl<H: NippyJarHeader> NippyJarWriter<H> {
     /// Creates a [`NippyJarWriter`] from [`NippyJar`].
     ///
-    /// If `read_only` is set to `true`, any inconsistency issue won't be healed, and will return
-    /// [`NippyJarError::InconsistentState`] instead.
-    pub fn new(
-        jar: NippyJar<H>,
-        check_mode: ConsistencyFailStrategy,
-    ) -> Result<Self, NippyJarError> {
+    /// If will  **always** attempt to heal any inconsistent state when called.
+    pub fn new(jar: NippyJar<H>) -> Result<Self, NippyJarError> {
         let (data_file, offsets_file, is_created) =
             Self::create_or_open_files(jar.data_path(), &jar.offsets_path())?;
 
-        // Makes sure we don't have dangling data and offset files
-        jar.freeze_config()?;
+        let (jar, data_file, offsets_file) = if is_created {
+            // Makes sure we don't have dangling data and offset files when we just created the file
+            jar.freeze_config()?;
+
+            (jar, BufWriter::new(data_file), BufWriter::new(offsets_file))
+        } else {
+            // If we are opening a previously created jar, we need to check its consistency, and
+            // make changes if necessary.
+            let mut checker = NippyJarChecker::new(jar);
+            checker.ensure_consistency()?;
+
+            let NippyJarChecker { jar, data_file, offsets_file } = checker;
+
+            // Calling ensure_consistency, will fill data_file and offsets_file
+            (jar, data_file.expect("qed"), offsets_file.expect("qed"))
+        };
 
         let mut writer = Self {
             jar,
-            data_file: BufWriter::new(data_file),
-            offsets_file: BufWriter::new(offsets_file),
+            data_file,
+            offsets_file,
             tmp_buf: Vec::with_capacity(1_000_000),
             uncompressed_row_size: 0,
             offsets: Vec::with_capacity(1_000_000),
@@ -69,13 +81,9 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
             dirty: false,
         };
 
-        // If we are opening a previously created jar, we need to check its consistency, and make
-        // changes if necessary.
         if !is_created {
-            writer.ensure_file_consistency(check_mode)?;
-            if check_mode.should_heal() {
-                writer.commit()?;
-            }
+            // Commit any potential heals done above.
+            writer.commit()?;
         }
 
         Ok(writer)
@@ -145,107 +153,6 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
         }
 
         Ok((data_file, offsets_file, is_created))
-    }
-
-    /// Performs consistency checks on the [`NippyJar`] file and might self-heal or throw an error
-    /// according to [`ConsistencyFailStrategy`].
-    /// * Is the offsets file size expected?
-    /// * Is the data file size expected?
-    ///
-    /// This is based on the assumption that [`NippyJar`] configuration is **always** the last one
-    /// to be updated when something is written, as by the `commit()` function shows.
-    pub fn ensure_file_consistency(
-        &mut self,
-        check_mode: ConsistencyFailStrategy,
-    ) -> Result<(), NippyJarError> {
-        let reader = self.jar.open_data_reader()?;
-
-        // When an offset size is smaller than the initial (8), we are dealing with immutable
-        // data.
-        if reader.offset_size() != OFFSET_SIZE_BYTES {
-            return Err(NippyJarError::FrozenJar)
-        }
-
-        let expected_offsets_file_size: u64 = (1 + // first byte is the size of one offset
-            OFFSET_SIZE_BYTES as usize* self.jar.rows * self.jar.columns + // `offset size * num rows * num columns`
-            OFFSET_SIZE_BYTES as usize) as u64; // expected size of the data file
-        let actual_offsets_file_size = self.offsets_file.get_ref().metadata()?.len();
-
-        if check_mode.should_err() &&
-            expected_offsets_file_size.cmp(&actual_offsets_file_size) != Ordering::Equal
-        {
-            return Err(NippyJarError::InconsistentState)
-        }
-
-        // Offsets configuration wasn't properly committed
-        match expected_offsets_file_size.cmp(&actual_offsets_file_size) {
-            Ordering::Less => {
-                // Happened during an appending job
-                // TODO: ideally we could truncate until the last offset of the last column of the
-                //  last row inserted
-                self.offsets_file.get_mut().set_len(expected_offsets_file_size)?;
-            }
-            Ordering::Greater => {
-                // Happened during a pruning job
-                // `num rows = (file size - 1 - size of one offset) / num columns`
-                self.jar.rows = ((actual_offsets_file_size.
-                    saturating_sub(1). // first byte is the size of one offset
-                    saturating_sub(OFFSET_SIZE_BYTES as u64) / // expected size of the data file
-                    (self.jar.columns as u64)) /
-                    OFFSET_SIZE_BYTES as u64) as usize;
-
-                // Freeze row count changed
-                self.jar.freeze_config()?;
-            }
-            Ordering::Equal => {}
-        }
-
-        // last offset should match the data_file_len
-        let last_offset = reader.reverse_offset(0)?;
-        let data_file_len = self.data_file.get_ref().metadata()?.len();
-
-        if check_mode.should_err() && last_offset.cmp(&data_file_len) != Ordering::Equal {
-            return Err(NippyJarError::InconsistentState)
-        }
-
-        // Offset list wasn't properly committed
-        match last_offset.cmp(&data_file_len) {
-            Ordering::Less => {
-                // Happened during an appending job, so we need to truncate the data, since there's
-                // no way to recover it.
-                self.data_file.get_mut().set_len(last_offset)?;
-            }
-            Ordering::Greater => {
-                // Happened during a pruning job, so we need to reverse iterate offsets until we
-                // find the matching one.
-                for index in 0..reader.offsets_count()? {
-                    let offset = reader.reverse_offset(index + 1)?;
-                    // It would only be equal if the previous row was fully pruned.
-                    if offset <= data_file_len {
-                        let new_len = self
-                            .offsets_file
-                            .get_ref()
-                            .metadata()?
-                            .len()
-                            .saturating_sub(OFFSET_SIZE_BYTES as u64 * (index as u64 + 1));
-                        self.offsets_file.get_mut().set_len(new_len)?;
-
-                        drop(reader);
-
-                        // Since we decrease the offset list, we need to check the consistency of
-                        // `self.jar.rows` again
-                        self.ensure_file_consistency(ConsistencyFailStrategy::Heal)?;
-                        break
-                    }
-                }
-            }
-            Ordering::Equal => {}
-        }
-
-        self.offsets_file.seek(SeekFrom::End(0))?;
-        self.data_file.seek(SeekFrom::End(0))?;
-
-        Ok(())
     }
 
     /// Appends rows to data file.  `fn commit()` should be called to flush offsets and config to
@@ -538,26 +445,5 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
     #[cfg(any(test, feature = "test-utils"))]
     pub const fn jar(&self) -> &NippyJar<H> {
         &self.jar
-    }
-}
-
-/// Strategy on encountering an inconsistent state when creating a [`NippyJarWriter`].
-#[derive(Debug, Copy, Clone)]
-pub enum ConsistencyFailStrategy {
-    /// Writer should heal.
-    Heal,
-    /// Writer should throw an error.
-    ThrowError,
-}
-
-impl ConsistencyFailStrategy {
-    /// Whether writer should heal.
-    const fn should_heal(&self) -> bool {
-        matches!(self, Self::Heal)
-    }
-
-    /// Whether writer should throw an error.
-    const fn should_err(&self) -> bool {
-        matches!(self, Self::ThrowError)
     }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -660,7 +660,8 @@ impl StaticFileProvider {
         Ok(unwind_target.map(PipelineTarget::Unwind))
     }
 
-    /// Checks consistency of the latest static file segment and throws an error if at fault. Read-only.
+    /// Checks consistency of the latest static file segment and throws an error if at fault.
+    /// Read-only.
     pub fn check_segment_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()> {
         if let Some(latest_block) = self.get_highest_static_file_block(segment) {
             let file_path =

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -666,7 +666,7 @@ impl StaticFileProvider {
             let file_path =
                 self.directory().join(segment.filename(&find_fixed_range(latest_block)));
 
-            let jar = NippyJar::<SegmentHeader>::load(&self.directory().join(file_path))
+            let jar = NippyJar::<SegmentHeader>::load(&file_path)
                 .map_err(|e| ProviderError::NippyJar(e.to_string()))?;
 
             NippyJarChecker::new(jar)

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -22,7 +22,7 @@ use reth_db_api::{
     table::Table,
     transaction::DbTx,
 };
-use reth_nippy_jar::NippyJar;
+use reth_nippy_jar::{NippyJar, NippyJarChecker};
 use reth_primitives::{
     keccak256,
     static_file::{find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive},
@@ -573,7 +573,12 @@ impl StaticFileProvider {
             // * pruning data was interrupted before a config commit, then we have deleted data that
             //   we are expected to still have. We need to check the Database and unwind everything
             //   accordingly.
-            self.ensure_file_consistency(segment)?;
+            if self.access.is_read_only() {
+                self.check_file_consistency(segment)?;
+            } else {
+                // Fetching the writter will attempt to heal any file level inconsistency.
+                self.latest_writer(segment)?;
+            }
 
             // Only applies to block-based static files. (Headers)
             //
@@ -653,6 +658,22 @@ impl StaticFileProvider {
         }
 
         Ok(unwind_target.map(PipelineTarget::Unwind))
+    }
+
+    /// Checks consistency of the latest static file segment and throws an error if at fault.
+    pub fn check_file_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()> {
+        if let Some(latest_block) = self.get_highest_static_file_block(segment) {
+            let file_path =
+                self.directory().join(segment.filename(&find_fixed_range(latest_block)));
+
+            let jar = NippyJar::<SegmentHeader>::load(&self.directory().join(file_path))
+                .map_err(|e| ProviderError::NippyJar(e.to_string()))?;
+
+            NippyJarChecker::new(jar)
+                .check_consistency()
+                .map_err(|e| ProviderError::NippyJar(e.to_string()))?;
+        }
+        Ok(())
     }
 
     /// Check invariants for each corresponding table and static file segment:
@@ -1040,9 +1061,6 @@ pub trait StaticFileWriter {
 
     /// Commits all changes of all [`StaticFileProviderRW`] of all [`StaticFileSegment`].
     fn commit(&self) -> ProviderResult<()>;
-
-    /// Checks consistency of the segment latest file and heals if possible.
-    fn ensure_file_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()>;
 }
 
 impl StaticFileWriter for StaticFileProvider {
@@ -1070,28 +1088,6 @@ impl StaticFileWriter for StaticFileProvider {
 
     fn commit(&self) -> ProviderResult<()> {
         self.writers.commit()
-    }
-
-    fn ensure_file_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()> {
-        match self.access {
-            StaticFileAccess::RO => {
-                let latest_block = self.get_highest_static_file_block(segment).unwrap_or_default();
-
-                let mut writer = StaticFileProviderRW::new(
-                    segment,
-                    latest_block,
-                    Arc::downgrade(&self.0),
-                    self.metrics.clone(),
-                )?;
-
-                writer.ensure_file_consistency(self.access.is_read_only())?;
-            }
-            StaticFileAccess::RW => {
-                self.latest_writer(segment)?.ensure_file_consistency(self.access.is_read_only())?;
-            }
-        }
-
-        Ok(())
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -574,9 +574,9 @@ impl StaticFileProvider {
             //   we are expected to still have. We need to check the Database and unwind everything
             //   accordingly.
             if self.access.is_read_only() {
-                self.check_file_consistency(segment)?;
+                self.check_segment_consistency(segment)?;
             } else {
-                // Fetching the writter will attempt to heal any file level inconsistency.
+                // Fetching the writer will attempt to heal any file level inconsistency.
                 self.latest_writer(segment)?;
             }
 
@@ -660,8 +660,8 @@ impl StaticFileProvider {
         Ok(unwind_target.map(PipelineTarget::Unwind))
     }
 
-    /// Checks consistency of the latest static file segment and throws an error if at fault.
-    pub fn check_file_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()> {
+    /// Checks consistency of the latest static file segment and throws an error if at fault. Read-only.
+    pub fn check_segment_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()> {
         if let Some(latest_block) = self.get_highest_static_file_block(segment) {
             let file_path =
                 self.directory().join(segment.filename(&find_fixed_range(latest_block)));

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -106,8 +106,8 @@ pub struct StaticFileProviderRW {
 impl StaticFileProviderRW {
     /// Creates a new [`StaticFileProviderRW`] for a [`StaticFileSegment`].
     ///
-    /// Before use, transaction based segments should ensure the block end range is the expected one,
-    /// and heal if not. For more check [`Self::ensure_end_range_consistency`].
+    /// Before use, transaction based segments should ensure the block end range is the expected
+    /// one, and heal if not. For more check [`Self::ensure_end_range_consistency`].
     pub fn new(
         segment: StaticFileSegment,
         block: BlockNumber,
@@ -177,7 +177,7 @@ impl StaticFileProviderRW {
         Ok(result)
     }
 
-    /// If a file level healing happens happen, we need to update the end range on the
+    /// If a file level healing happens, we need to update the end range on the
     /// [`SegmentHeader`].
     ///
     /// However, for transaction based segments, the block end range has to be found and healed

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -5,7 +5,7 @@ use crate::providers::static_file::metrics::StaticFileProviderOperation;
 use parking_lot::{lock_api::RwLockWriteGuard, RawRwLock, RwLock};
 use reth_codecs::Compact;
 use reth_db_api::models::CompactU256;
-use reth_nippy_jar::{ConsistencyFailStrategy, NippyJar, NippyJarError, NippyJarWriter};
+use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
 use reth_primitives::{
     static_file::{find_fixed_range, SegmentHeader, SegmentRangeInclusive},
     BlockHash, BlockNumber, Header, Receipt, StaticFileSegment, TransactionSignedNoHash, TxNumber,
@@ -105,6 +105,9 @@ pub struct StaticFileProviderRW {
 
 impl StaticFileProviderRW {
     /// Creates a new [`StaticFileProviderRW`] for a [`StaticFileSegment`].
+    ///
+    /// Before use, transaction based segments should ensure the block end range is the expected one,
+    /// and heal if not. For more check [`Self::ensure_end_range_consistency`].
     pub fn new(
         segment: StaticFileSegment,
         block: BlockNumber,
@@ -112,14 +115,18 @@ impl StaticFileProviderRW {
         metrics: Option<Arc<StaticFileProviderMetrics>>,
     ) -> ProviderResult<Self> {
         let (writer, data_path) = Self::open(segment, block, reader.clone(), metrics.clone())?;
-        Ok(Self {
+        let mut writer = Self {
             writer,
             data_path,
             buf: Vec::with_capacity(100),
             reader,
             metrics,
             prune_on_commit: None,
-        })
+        };
+
+        writer.ensure_end_range_consistency()?;
+
+        Ok(writer)
     }
 
     fn open(
@@ -150,14 +157,7 @@ impl StaticFileProviderRW {
             Err(err) => return Err(err),
         };
 
-        let reader = Self::upgrade_provider_to_strong_reference(&reader);
-        let access = if reader.is_read_only() {
-            ConsistencyFailStrategy::ThrowError
-        } else {
-            ConsistencyFailStrategy::Heal
-        };
-
-        let result = match NippyJarWriter::new(jar, access) {
+        let result = match NippyJarWriter::new(jar) {
             Ok(writer) => Ok((writer, path)),
             Err(NippyJarError::FrozenJar) => {
                 // This static file has been frozen, so we should
@@ -177,33 +177,15 @@ impl StaticFileProviderRW {
         Ok(result)
     }
 
-    /// Checks the consistency of the file and heals it if necessary and `read_only` is set to
-    /// false. If the check fails, it will return an error.
+    /// If a file level healing happens happen, we need to update the end range on the
+    /// [`SegmentHeader`].
     ///
-    /// If healing does happen, it will update the end range on the [`SegmentHeader`]. However, for
-    /// transaction based segments, the block end range has to be found and healed externally.
+    /// However, for transaction based segments, the block end range has to be found and healed
+    /// externally.
     ///
-    /// Check [`NippyJarWriter::ensure_file_consistency`] for more on healing.
-    pub fn ensure_file_consistency(&mut self, read_only: bool) -> ProviderResult<()> {
-        let inconsistent_error = || {
-            ProviderError::NippyJar(
-                "Inconsistent state found. Restart the node to heal.".to_string(),
-            )
-        };
-
-        let check_mode = if read_only {
-            ConsistencyFailStrategy::ThrowError
-        } else {
-            ConsistencyFailStrategy::Heal
-        };
-
-        self.writer.ensure_file_consistency(check_mode).map_err(|error| {
-            if matches!(error, NippyJarError::InconsistentState) {
-                return inconsistent_error()
-            }
-            ProviderError::NippyJar(error.to_string())
-        })?;
-
+    /// Check [`reth_nippy_jar::consistency::NippyJarChecker`] &
+    /// [`reth_nippy_jar::writer::NippyJarWriter`] for more on healing.
+    fn ensure_end_range_consistency(&mut self) -> ProviderResult<()> {
         // If we have lost rows (in this run or previous), we need to update the [SegmentHeader].
         let expected_rows = if self.user_header().segment().is_headers() {
             self.user_header().block_len().unwrap_or_default()
@@ -212,9 +194,6 @@ impl StaticFileProviderRW {
         };
         let pruned_rows = expected_rows - self.writer.rows() as u64;
         if pruned_rows > 0 {
-            if read_only {
-                return Err(inconsistent_error())
-            }
             self.user_header_mut().prune(pruned_rows);
         }
 

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -107,7 +107,7 @@ impl StaticFileProviderRW {
     /// Creates a new [`StaticFileProviderRW`] for a [`StaticFileSegment`].
     ///
     /// Before use, transaction based segments should ensure the block end range is the expected
-    /// one, and heal if not. For more check [`Self::ensure_end_range_consistency`].
+    /// one, and heal if not. For more check `Self::ensure_end_range_consistency`.
     pub fn new(
         segment: StaticFileSegment,
         block: BlockNumber,
@@ -183,8 +183,8 @@ impl StaticFileProviderRW {
     /// However, for transaction based segments, the block end range has to be found and healed
     /// externally.
     ///
-    /// Check [`reth_nippy_jar::consistency::NippyJarChecker`] &
-    /// [`reth_nippy_jar::writer::NippyJarWriter`] for more on healing.
+    /// Check [`reth_nippy_jar::NippyJarChecker`] &
+    /// [`NippyJarWriter`] for more on healing.
     fn ensure_end_range_consistency(&mut self) -> ProviderResult<()> {
         // If we have lost rows (in this run or previous), we need to update the [SegmentHeader].
         let expected_rows = if self.user_header().segment().is_headers() {


### PR DESCRIPTION
redoes: https://github.com/paradigmxyz/reth/pull/10628
closes https://github.com/paradigmxyz/reth/issues/10631

`NippyJarWriter` was being reused for checking consistency, even in read-only modes, by using `ConsistencyFailStrategy::ThrowError`. However, as `NippyJarWriter::new` was being called...it was actually modifying/updating the file. Even in read-only mode. Which explains the race behaviour from the issue linked above.

This PR refactors the consistency verification/healing, so we stop using `NippyJarWriter`/`StaticFileProviderRW` in read-only mode:

* introduces `NippyJarChecker` which decouples this logic from `NippyJarWriter`.
  * `NippyJarChecker::check_consistency` will throw error (read-only)
  * `NippyJarChecker::ensure_consistency` will attempt to heal (read-write)
* removes `ensure_file_consistency` from `StaticFileWriter/StaticFileProvider`. This is now done automatically by `NippyJarWriter` at a low level, and `StaticFileProviderRW` on the `SegmentHeader` level.
* adds `StaticFileProvider::check_segment_consistency` which is a read-only method used for example for `reth db stats`

~~Still need to test it on a node~~