### PR TITLE
chore(rpc): decompose function `reth_rpc_types_compat::from_block_full`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -5,7 +5,8 @@ use alloy_dyn_abi::TypedData;
 use alloy_json_rpc::RpcObject;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, types::ErrorObjectOwned};
 use reth_primitives::{
-    transaction::AccessListResult, Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64,
+    transaction::AccessListResult, Address, Block, BlockId, BlockNumberOrTag, BlockWithSenders,
+    Bytes, B256, B64, U256, U64,
 };
 use reth_rpc_eth_types::{utils::binary_search, EthApiError};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
@@ -13,9 +14,10 @@ use reth_rpc_types::{
     serde_helpers::JsonStorageKey,
     simulate::{SimBlock, SimulatedBlock},
     state::{EvmOverrides, StateOverride},
-    BlockOverrides, BlockTransactions, Bundle, EIP1186AccountProofResponse, EthCallResponse,
-    FeeHistory, Header, Index, StateContext, SyncStatus, TransactionRequest, Work,
+    BlockOverrides, Bundle, EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Header,
+    Index, StateContext, SyncStatus, TransactionRequest, Work,
 };
+use reth_rpc_types_compat::transaction::from_block_parts;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use tracing::trace;
 
@@ -604,11 +606,14 @@ where
         )
         .await?;
 
-        let Some(BlockTransactions::Full(transactions)) =
-            self.block_by_number(num.into(), true).await?.map(|block| block.transactions)
-        else {
-            return Err(EthApiError::UnknownBlockNumber.into());
-        };
+        let block_id = num.into();
+        let block = self
+            .block_with_senders(block_id)
+            .await?
+            .ok_or(EthApiError::UnknownBlockNumber.into())?;
+
+        let BlockWithSenders { block: Block { ref header, body, .. }, senders } = block.unseal();
+        let transactions = from_block_parts(None, header, body, senders);
 
         Ok(transactions.into_iter().find(|tx| *tx.from == *sender && tx.nonce == nonce))
     }

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -1,14 +1,17 @@
 //! Compatibility functions for rpc `Block` type.
 
-use crate::transaction::from_recovered_with_block_context;
+use std::mem;
+
 use alloy_rlp::Encodable;
-use alloy_rpc_types::{Transaction, TransactionInfo};
+use alloy_rpc_types::Transaction;
 use reth_primitives::{
     Block as PrimitiveBlock, BlockWithSenders, Header as PrimitiveHeader, Withdrawals, B256, U256,
 };
 use reth_rpc_types::{
     Block, BlockError, BlockTransactions, BlockTransactionsKind, Header, WithOtherFields,
 };
+
+use crate::transaction;
 
 /// Converts the given primitive block into a [`Block`] response with the given
 /// [`BlockTransactionsKind`]
@@ -61,30 +64,16 @@ pub fn from_block_full(
     block_hash: Option<B256>,
 ) -> Result<Block<WithOtherFields<Transaction>>, BlockError> {
     let block_hash = block_hash.unwrap_or_else(|| block.block.header.hash_slow());
-    let block_number = block.block.number;
-    let base_fee_per_gas = block.block.base_fee_per_gas;
-
     // NOTE: we can safely remove the body here because not needed to finalize the `Block` in
     // `from_block_with_transactions`, however we need to compute the length before
     let block_length = block.block.length();
-    let body = std::mem::take(&mut block.block.body);
-    let transactions_with_senders = body.into_iter().zip(block.senders);
-    let transactions = transactions_with_senders
-        .enumerate()
-        .map(|(idx, (tx, sender))| {
-            let tx_hash = tx.hash();
-            let signed_tx_ec_recovered = tx.with_signer(sender);
-            let tx_info = TransactionInfo {
-                hash: Some(tx_hash),
-                block_hash: Some(block_hash),
-                block_number: Some(block_number),
-                base_fee: base_fee_per_gas.map(u128::from),
-                index: Some(idx as u64),
-            };
+    let body = mem::take(&mut block.block.body);
+    let senders = block.senders;
 
-            from_recovered_with_block_context(signed_tx_ec_recovered, tx_info)
-        })
-        .collect::<Vec<_>>();
+    let transactions =
+        transaction::from_block_parts(Some(block_hash), &block.block.header, body, senders)
+            .into_iter()
+            .collect();
 
     Ok(from_block_with_transactions(
         block_length,

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -1,16 +1,19 @@
 //! Compatibility functions for rpc `Transaction` type.
 
+mod signature;
+mod typed;
+
+pub use typed::*;
+
 use alloy_rpc_types::{
     request::{TransactionInput, TransactionRequest},
     TransactionInfo,
 };
-use reth_primitives::{Address, TransactionSignedEcRecovered, TxKind, TxType};
+use reth_primitives::{
+    Address, Header, TransactionSigned, TransactionSignedEcRecovered, TxKind, TxType, B256,
+};
 use reth_rpc_types::{Transaction, WithOtherFields};
 use signature::from_primitive_signature;
-pub use typed::*;
-
-mod signature;
-mod typed;
 
 /// Create a new rpc transaction result for a mined transaction, using the given [`TransactionInfo`]
 /// to populate the corresponding fields in the rpc result.
@@ -154,4 +157,30 @@ pub fn transaction_to_call_request(tx: TransactionSignedEcRecovered) -> Transact
         sidecar: None,
         authorization_list,
     }
+}
+
+/// Extracts [`Transaction`]s from block parts.
+pub fn from_block_parts(
+    block_hash: Option<B256>,
+    header: &Header,
+    body: Vec<TransactionSigned>,
+    senders: Vec<Address>,
+) -> impl IntoIterator<Item = WithOtherFields<Transaction>> {
+    debug_assert!(body.len() == senders.len());
+
+    let mut tx_info = TransactionInfo {
+        block_hash: Some(block_hash.unwrap_or_else(|| header.hash_slow())),
+        block_number: Some(header.number),
+        base_fee: header.base_fee_per_gas.map(u128::from),
+        ..Default::default()
+    };
+
+    body.into_iter().zip(senders).enumerate().map(move |(idx, (tx, sender))| {
+        let tx_hash = tx.hash();
+        let signed_tx_ec_recovered = tx.with_signer(sender);
+        tx_info.hash = Some(tx_hash);
+        tx_info.index = Some(idx as u64);
+
+        from_recovered_with_block_context(signed_tx_ec_recovered, tx_info)
+    })
 }


### PR DESCRIPTION
Extracts code for assembling transactions from `reth_rpc_types_compat::block::from_block_full`, into new function `reth_rpc_types_compat::transaction::from_block_parts`.

Needed for https://github.com/paradigmxyz/reth/pull/7416