### PR TITLE
[#10645] docs(prune): replace prune parts by segments

### DIFF
--- a/book/run/config.md
+++ b/book/run/config.md
@@ -352,7 +352,7 @@ i.e. keep the data for the last `100_000` blocks
 # Minimum pruning interval measured in blocks
 block_interval = 5
 
-[prune.parts]
+[prune.segments]
 # Sender Recovery pruning configuration
 sender_recovery = { distance = 100_000 } # Prune all transaction senders before the block `head-100000`, i.e. keep transaction senders for the last 100001 blocks
 
@@ -373,7 +373,7 @@ We can also prune receipts more granular, using the logs filtering:
 ```toml
 # Receipts pruning configuration by retaining only those receipts that contain logs emitted
 # by the specified addresses, discarding all others. This setting is overridden by `receipts`.
-[prune.parts.receipts_log_filter]
+[prune.segments.receipts_log_filter]
 # Prune all receipts, leaving only those which:
 # - Contain logs from address `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`, starting from the block 17000000
 # - Contain logs from address `0xdac17f958d2ee523a2206206994597c13d831ec7` in the last 1001 blocks

--- a/book/run/pruning.md
+++ b/book/run/pruning.md
@@ -80,14 +80,14 @@ Essentially, the full node is the same as following configuration for the pruned
 [prune]
 block_interval = 5
 
-[prune.parts]
+[prune.segments]
 sender_recovery = "full"
 # transaction_lookup is not pruned
 receipts = { before = 11052984 } # Beacon Deposit Contract deployment block: https://etherscan.io/tx/0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0
 account_history = { distance = 10_064 }
 storage_history = { distance = 10_064 }
 
-[prune.parts.receipts_log_filter]
+[prune.segments.receipts_log_filter]
 # Prune all receipts, leaving only those which contain logs from address `0x00000000219ab540356cbb839cbe05303d7705fa`,
 # starting from the block 11052984. This leaves receipts with the logs from the Beacon Deposit Contract.
 "0x00000000219ab540356cbb839cbe05303d7705fa" = { before = 11052984 }


### PR DESCRIPTION
Closes #10645 

## Describe the change

Update the documentation, on the `prune` part. Replaced `parts` by `segments`.