### PR TITLE
fix: dont use prune mode full

### DIFF
--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -32,7 +32,7 @@ impl PruningArgs {
                     .deposit_contract
                     .as_ref()
                     .map(|contract| PruneMode::Before(contract.block))
-                    .or(Some(PruneMode::Full)),
+                    .or(Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE))),
                 account_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                 storage_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                 receipts_log_filter: ReceiptsLogPruneConfig(


### PR DESCRIPTION
closes #10199

if there's no deposit contract then this would use Full for receipts which is't allowed by serde and would result in an error on restart

```
[prune.segments]
sender_recovery = "full"
receipts = "full"
```

@shekhirin @joshieDo idk if this is the proper fix though