### PR TITLE
fix(witness): allow no storage multiproof

### DIFF
--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -125,9 +125,6 @@ pub enum TrieWitnessError {
     Proof(StateProofError),
     /// RLP decoding error.
     Rlp(alloy_rlp::Error),
-    /// Missing storage multiproof.
-    #[display("missing storage multiproof for {_0}")]
-    MissingStorageMultiProof(B256),
     /// Missing account.
     #[display("missing account {_0}")]
     MissingAccount(B256),

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -74,7 +74,7 @@ where
                 }),
             ),
         );
-        let account_multiproof =
+        let mut account_multiproof =
             Proof::new(self.trie_cursor_factory.clone(), self.hashed_cursor_factory.clone())
                 .with_prefix_sets_mut(self.prefix_sets.clone())
                 .with_targets(proof_targets.clone())
@@ -85,11 +85,8 @@ where
         let mut account_rlp = Vec::with_capacity(128);
         let mut account_trie_nodes = BTreeMap::default();
         for (hashed_address, hashed_slots) in proof_targets {
-            let key = Nibbles::unpack(hashed_address);
-            let storage_multiproof = account_multiproof
-                .storages
-                .get(&hashed_address)
-                .ok_or(TrieWitnessError::MissingStorageMultiProof(hashed_address))?;
+            let storage_multiproof =
+                account_multiproof.storages.remove(&hashed_address).unwrap_or_default();
 
             // Gather and record account trie nodes.
             let account = state
@@ -104,6 +101,7 @@ where
             } else {
                 None
             };
+            let key = Nibbles::unpack(hashed_address);
             let proof = account_multiproof.account_subtree.iter().filter(|e| key.starts_with(e.0));
             account_trie_nodes.extend(self.target_nodes(key.clone(), value, proof)?);
 
@@ -124,7 +122,7 @@ where
                 )?);
             }
 
-            let root = Self::next_root_from_proofs(storage_trie_nodes, |key: Nibbles| {
+            let storage_root = Self::next_root_from_proofs(storage_trie_nodes, |key: Nibbles| {
                 // Right pad the target with 0s.
                 let mut padded_key = key.pack();
                 padded_key.resize(32, 0);
@@ -142,7 +140,7 @@ where
                 self.witness.insert(keccak256(node.as_ref()), node.clone()); // record in witness
                 Ok(node)
             })?;
-            debug_assert_eq!(storage_multiproof.root, root);
+            debug_assert_eq!(storage_multiproof.root, storage_root);
         }
 
         Self::next_root_from_proofs(account_trie_nodes, |key: Nibbles| {


### PR DESCRIPTION
## Description

Allow missing storage multiproof for witnessed accounts. This happens is account is touched but empty, non existent or destroyed. 