### PR TITLE
perf(engine): parallel storage roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6978,6 +6978,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
+ "reth-trie-parallel",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -225,10 +225,16 @@ impl AppendableChain {
                     provider.block_execution_data_provider.execution_outcome().clone();
                 execution_outcome.extend(initial_execution_outcome.clone());
                 let hashed_state = execution_outcome.hash_state_slow();
-                ParallelStateRoot::new(consistent_view, hashed_state)
-                    .incremental_root_with_updates()
-                    .map(|(root, updates)| (root, Some(updates)))
-                    .map_err(ProviderError::from)?
+                let prefix_sets = hashed_state.construct_prefix_sets().freeze();
+                ParallelStateRoot::new(
+                    consistent_view,
+                    Default::default(),
+                    hashed_state,
+                    prefix_sets,
+                )
+                .incremental_root_with_updates()
+                .map(|(root, updates)| (root, Some(updates)))
+                .map_err(ProviderError::from)?
             } else {
                 let hashed_state =
                     HashedPostState::from_bundle_state(&initial_execution_outcome.state().state);

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -31,8 +31,9 @@ reth-revm.workspace = true
 reth-rpc-types.workspace = true
 reth-stages-api.workspace = true
 reth-tasks.workspace = true
-reth-trie.workspace = true
 reth-node-types.workspace = true
+reth-trie.workspace = true
+reth-trie-parallel.workspace = true
 
 # common
 futures.workspace = true

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2173,7 +2173,6 @@ where
         let mut state_root_result = None;
         let persistence_in_progress = self.persistence_state.in_progress();
         if !persistence_in_progress {
-            // NOTE: there is a possibility of a race condition here if some data was persisted. ???
             let consistent_view = ConsistentDbView::new_with_latest_tip(self.provider.clone())?;
             let mut trie_nodes = TrieUpdates::default();
             let mut state = HashedPostState::default();

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2277,7 +2277,7 @@ where
 
         // Extend with block we are validating root for.
         prefix_sets.extend(hashed_state.construct_prefix_sets());
-        state.extend_ref(&hashed_state);
+        state.extend_ref(hashed_state);
 
         Ok(ParallelStateRoot::new(consistent_view, trie_nodes, state, prefix_sets.freeze())
             .incremental_root_with_updates()?)

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2178,6 +2178,7 @@ where
             let mut trie_nodes = TrieUpdates::default();
             let mut state = HashedPostState::default();
             let mut prefix_sets = TriePrefixSetsMut::default();
+
             if let Some((historical, blocks)) =
                 self.state.tree_state.blocks_by_hash(block.parent_hash)
             {

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -52,7 +52,13 @@ where
         let block_number = provider
             .block_number(block_hash)?
             .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
-        Ok(HashedPostState::from_reverts(provider.tx_ref(), block_number)?)
+        if block_number == provider.best_block_number()? &&
+            block_number == provider.last_block_number()?
+        {
+            Ok(HashedPostState::default())
+        } else {
+            Ok(HashedPostState::from_reverts(provider.tx_ref(), block_number + 1)?)
+        }
     }
 
     /// Creates new read-only provider and performs consistency checks on the current tip.

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -1,7 +1,10 @@
 use crate::{BlockNumReader, DatabaseProviderFactory, HeaderProvider};
+use reth_errors::ProviderError;
 use reth_primitives::{GotExpected, B256};
-use reth_storage_api::BlockReader;
+use reth_storage_api::{BlockReader, DBProvider};
 use reth_storage_errors::provider::ProviderResult;
+use reth_trie::HashedPostState;
+use reth_trie_db::DatabaseHashedPostState;
 
 pub use reth_storage_errors::provider::ConsistentViewError;
 
@@ -41,6 +44,15 @@ where
         let last_num = provider_ro.last_block_number()?;
         let tip = provider_ro.sealed_header(last_num)?.map(|h| h.hash());
         Ok(Self::new(provider, tip))
+    }
+
+    /// Retrieve revert hashed state down to the given block hash.
+    pub fn revert_state(&self, block_hash: B256) -> ProviderResult<HashedPostState> {
+        let provider = self.provider_ro()?;
+        let block_number = provider
+            .block_number(block_hash)?
+            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        Ok(HashedPostState::from_reverts(provider.tx_ref(), block_number)?)
     }
 
     /// Creates new read-only provider and performs consistency checks on the current tip.

--- a/crates/trie/parallel/benches/root.rs
+++ b/crates/trie/parallel/benches/root.rs
@@ -67,7 +67,7 @@ pub fn calculate_state_root(c: &mut Criterion) {
                         view.clone(),
                         Default::default(),
                         updated_state.clone(),
-                        updated_state.construct_prefix_sets(),
+                        updated_state.construct_prefix_sets().freeze(),
                     )
                 },
                 |calculator| async { calculator.incremental_root() },

--- a/crates/trie/parallel/benches/root.rs
+++ b/crates/trie/parallel/benches/root.rs
@@ -62,7 +62,14 @@ pub fn calculate_state_root(c: &mut Criterion) {
         // parallel root
         group.bench_function(BenchmarkId::new("parallel root", size), |b| {
             b.to_async(&runtime).iter_with_setup(
-                || ParallelStateRoot::new(view.clone(), updated_state.clone()),
+                || {
+                    ParallelStateRoot::new(
+                        view.clone(),
+                        Default::default(),
+                        updated_state.clone(),
+                        updated_state.construct_prefix_sets(),
+                    )
+                },
                 |calculator| async { calculator.incremental_root() },
             );
         });

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -25,7 +25,7 @@ pub struct StateRoot<T, H> {
     pub trie_cursor_factory: T,
     /// The factory for hashed cursors.
     pub hashed_cursor_factory: H,
-    /// A set of prefix sets that have changes.
+    /// A set of prefix sets that have changed.
     pub prefix_sets: TriePrefixSets,
     /// Previous intermediate state.
     previous_state: Option<IntermediateStateRootState>,


### PR DESCRIPTION
## Description

Enables parallel storage roots in consensus engine. Parallel calculation will be _skipped_ if persistence is currently in progress or if consistency check _fails_ during calculation, it will fall back to regular one