### PR TITLE
feat: `NodeTypesWithDB`

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -43,6 +43,7 @@ exclude_crates=(
   reth-net-nat
   reth-network
   reth-node-api
+  reth-node-types
   reth-node-builder
   reth-node-core
   reth-node-ethereum

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7498,6 +7498,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-evm",
  "reth-network-api",
+ "reth-node-types",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-provider",
@@ -7749,6 +7750,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "reth-node-types"
+version = "1.0.6"
+dependencies = [
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-engine-primitives",
 ]
 
 [[package]]
@@ -8025,6 +8035,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-p2p",
  "reth-nippy-jar",
+ "reth-node-types",
  "reth-primitives",
  "reth-prune-types",
  "reth-stages-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "crates/node/core/",
     "crates/node/events/",
     "crates/node/metrics",
+    "crates/node/types",
     "crates/optimism/bin",
     "crates/optimism/chainspec",
     "crates/optimism/cli",
@@ -350,6 +351,7 @@ reth-node-ethereum = { path = "crates/ethereum/node" }
 reth-node-events = { path = "crates/node/events" }
 reth-node-metrics = { path = "crates/node/metrics" }
 reth-node-optimism = { path = "crates/optimism/node" }
+reth-node-types = { path = "crates/node/types" }
 op-reth = { path = "crates/optimism/bin" }
 reth-optimism-chainspec = { path = "crates/optimism/chainspec" }
 reth-optimism-cli = { path = "crates/optimism/cli" }

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -15,7 +15,8 @@ use reth_chainspec::ChainSpec;
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_node_builder::{
     components::NodeComponentsBuilder, rpc::EthApiBuilderProvider, FullNodeTypesAdapter, Node,
-    NodeAdapter, NodeAddOns, NodeComponents, NodeTypesWithEngine, RethFullAdapter,
+    NodeAdapter, NodeAddOns, NodeComponents, NodeTypesWithDBAdapter, NodeTypesWithEngine,
+    RethFullAdapter,
 };
 use reth_provider::providers::BlockchainProvider;
 use tracing::{span, Level};
@@ -116,7 +117,8 @@ where
 // Type aliases
 
 type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
-type TmpNodeAdapter<N> = FullNodeTypesAdapter<N, TmpDB, BlockchainProvider<TmpDB>>;
+type TmpNodeAdapter<N> =
+    FullNodeTypesAdapter<NodeTypesWithDBAdapter<N, TmpDB>, BlockchainProvider<TmpDB>>;
 
 type Adapter<N> = NodeAdapter<
     RethFullAdapter<TmpDB, N>,

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -8,7 +8,6 @@ use reth::{
     api::{BuiltPayload, EngineTypes, FullNodeComponents, PayloadBuilderAttributes},
     builder::FullNode,
     network::PeersHandleProvider,
-    payload::PayloadTypes,
     providers::{BlockReader, BlockReaderIdExt, CanonStateSubscriptions, StageCheckpointReader},
     rpc::{
         api::eth::helpers::{EthApiSpec, EthTransactions, TraceExt},
@@ -37,18 +36,20 @@ where
     /// The core structure representing the full node.
     pub inner: FullNode<Node, AddOns>,
     /// Context for testing payload-related features.
-    pub payload: PayloadTestContext<Node::Engine>,
+    pub payload: PayloadTestContext<<Node::Types as NodeTypesWithEngine>::Engine>,
     /// Context for testing network functionalities.
     pub network: NetworkTestContext<Node::Network>,
     /// Context for testing the Engine API.
-    pub engine_api: EngineApiTestContext<Node::Engine>,
+    pub engine_api: EngineApiTestContext<<Node::Types as NodeTypesWithEngine>::Engine>,
     /// Context for testing RPC features.
     pub rpc: RpcTestContext<Node, AddOns::EthApi>,
 }
 
-impl<Node, AddOns> NodeTestContext<Node, AddOns>
+impl<Node, Engine, AddOns> NodeTestContext<Node, AddOns>
 where
-    Node: FullNodeComponents<ChainSpec = ChainSpec>,
+    Engine: EngineTypes,
+    Node: FullNodeComponents,
+    Node::Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Engine = Engine>,
     Node::Network: PeersHandleProvider,
     AddOns: NodeAddOns<Node>,
 {
@@ -63,7 +64,7 @@ where
             engine_api: EngineApiTestContext {
                 engine_api_client: node.auth_server_handle().http_client(),
                 canonical_stream: node.provider.canonical_state_stream(),
-                _marker: PhantomData::<Node::Engine>,
+                _marker: PhantomData::<Engine>,
             },
             rpc: RpcTestContext { inner: node.rpc_registry },
         })
@@ -83,17 +84,11 @@ where
         &mut self,
         length: u64,
         tx_generator: impl Fn(u64) -> Pin<Box<dyn Future<Output = Bytes>>>,
-        attributes_generator: impl Fn(u64) -> <Node::Engine as PayloadTypes>::PayloadBuilderAttributes
-            + Copy,
-    ) -> eyre::Result<
-        Vec<(
-            <Node::Engine as PayloadTypes>::BuiltPayload,
-            <Node::Engine as PayloadTypes>::PayloadBuilderAttributes,
-        )>,
-    >
+        attributes_generator: impl Fn(u64) -> Engine::PayloadBuilderAttributes + Copy,
+    ) -> eyre::Result<Vec<(Engine::BuiltPayload, Engine::PayloadBuilderAttributes)>>
     where
-        <Node::Engine as EngineTypes>::ExecutionPayloadV3:
-            From<<Node::Engine as PayloadTypes>::BuiltPayload> + PayloadEnvelopeExt,
+        <Engine as EngineTypes>::ExecutionPayloadV3:
+            From<Engine::BuiltPayload> + PayloadEnvelopeExt,
         AddOns::EthApi: EthApiSpec + EthTransactions + TraceExt,
         <AddOns::EthApi as EthApiTypes>::NetworkTypes:
             Network<TransactionResponse = WithOtherFields<alloy_rpc_types::Transaction>>,
@@ -117,14 +112,11 @@ where
     /// It triggers the resolve payload via engine api and expects the built payload event.
     pub async fn new_payload(
         &mut self,
-        attributes_generator: impl Fn(u64) -> <Node::Engine as PayloadTypes>::PayloadBuilderAttributes,
-    ) -> eyre::Result<(
-        <<Node as NodeTypesWithEngine>::Engine as PayloadTypes>::BuiltPayload,
-        <<Node as NodeTypesWithEngine>::Engine as PayloadTypes>::PayloadBuilderAttributes,
-    )>
+        attributes_generator: impl Fn(u64) -> Engine::PayloadBuilderAttributes,
+    ) -> eyre::Result<(Engine::BuiltPayload, Engine::PayloadBuilderAttributes)>
     where
-        <Node::Engine as EngineTypes>::ExecutionPayloadV3:
-            From<<Node::Engine as PayloadTypes>::BuiltPayload> + PayloadEnvelopeExt,
+        <Engine as EngineTypes>::ExecutionPayloadV3:
+            From<Engine::BuiltPayload> + PayloadEnvelopeExt,
     {
         // trigger new payload building draining the pool
         let eth_attr = self.payload.new_payload(attributes_generator).await.unwrap();
@@ -142,14 +134,11 @@ where
     pub async fn advance_block(
         &mut self,
         versioned_hashes: Vec<B256>,
-        attributes_generator: impl Fn(u64) -> <Node::Engine as PayloadTypes>::PayloadBuilderAttributes,
-    ) -> eyre::Result<(
-        <Node::Engine as PayloadTypes>::BuiltPayload,
-        <<Node as NodeTypesWithEngine>::Engine as PayloadTypes>::PayloadBuilderAttributes,
-    )>
+        attributes_generator: impl Fn(u64) -> Engine::PayloadBuilderAttributes,
+    ) -> eyre::Result<(Engine::BuiltPayload, Engine::PayloadBuilderAttributes)>
     where
-        <Node::Engine as EngineTypes>::ExecutionPayloadV3:
-            From<<Node::Engine as PayloadTypes>::BuiltPayload> + PayloadEnvelopeExt,
+        <Engine as EngineTypes>::ExecutionPayloadV3:
+            From<Engine::BuiltPayload> + PayloadEnvelopeExt,
     {
         let (payload, eth_attr) = self.new_payload(attributes_generator).await?;
 

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -15,6 +15,7 @@ use reth::{
         types::engine::PayloadStatusEnum,
     },
 };
+use reth_chainspec::ChainSpec;
 use reth_node_builder::{EthApiTypes, NodeAddOns, NodeTypesWithEngine};
 use reth_primitives::{BlockHash, BlockNumber, Bytes, B256};
 use reth_rpc_types::WithOtherFields;
@@ -47,7 +48,7 @@ where
 
 impl<Node, AddOns> NodeTestContext<Node, AddOns>
 where
-    Node: FullNodeComponents,
+    Node: FullNodeComponents<ChainSpec = ChainSpec>,
     Node::Network: PeersHandleProvider,
     AddOns: NodeAddOns<Node>,
 {

--- a/crates/e2e-test-utils/src/rpc.rs
+++ b/crates/e2e-test-utils/src/rpc.rs
@@ -7,6 +7,7 @@ use reth::{
         DebugApiServer,
     },
 };
+use reth_chainspec::ChainSpec;
 use reth_node_builder::EthApiTypes;
 use reth_primitives::{Bytes, B256};
 use reth_rpc_types::WithOtherFields;
@@ -18,7 +19,7 @@ pub struct RpcTestContext<Node: FullNodeComponents, EthApi: EthApiTypes> {
 
 impl<Node, EthApi> RpcTestContext<Node, EthApi>
 where
-    Node: FullNodeComponents,
+    Node: FullNodeComponents<ChainSpec = ChainSpec>,
     EthApi: EthApiSpec
         + EthTransactions<
             NetworkTypes: Network<

--- a/crates/e2e-test-utils/src/rpc.rs
+++ b/crates/e2e-test-utils/src/rpc.rs
@@ -8,7 +8,7 @@ use reth::{
     },
 };
 use reth_chainspec::ChainSpec;
-use reth_node_builder::EthApiTypes;
+use reth_node_builder::{EthApiTypes, NodeTypes};
 use reth_primitives::{Bytes, B256};
 use reth_rpc_types::WithOtherFields;
 
@@ -19,7 +19,7 @@ pub struct RpcTestContext<Node: FullNodeComponents, EthApi: EthApiTypes> {
 
 impl<Node, EthApi> RpcTestContext<Node, EthApi>
 where
-    Node: FullNodeComponents<ChainSpec = ChainSpec>,
+    Node: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
     EthApi: EthApiSpec
         + EthTransactions<
             NetworkTypes: Network<

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -47,8 +47,8 @@ impl EthereumNode {
         EthereumConsensusBuilder,
     >
     where
-        Node: FullNodeTypes<ChainSpec = ChainSpec>,
-        <Node as NodeTypesWithEngine>::Engine: PayloadTypes<
+        Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
+        <Node::Types as NodeTypesWithEngine>::Engine: PayloadTypes<
             BuiltPayload = EthBuiltPayload,
             PayloadAttributes = EthPayloadAttributes,
             PayloadBuilderAttributes = EthPayloadBuilderAttributes,
@@ -81,9 +81,10 @@ impl<N: FullNodeComponents> NodeAddOns<N> for EthereumAddOns {
     type EthApi = EthApi<N::Provider, N::Pool, NetworkHandle, N::Evm>;
 }
 
-impl<N> Node<N> for EthereumNode
+impl<Types, N> Node<N> for EthereumNode
 where
-    N: FullNodeTypes<Engine = EthEngineTypes, ChainSpec = ChainSpec>,
+    Types: NodeTypesWithEngine<Engine = EthEngineTypes, ChainSpec = ChainSpec>,
+    N: FullNodeTypes<Types = Types>,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -106,9 +107,10 @@ where
 #[non_exhaustive]
 pub struct EthereumExecutorBuilder;
 
-impl<Node> ExecutorBuilder<Node> for EthereumExecutorBuilder
+impl<Types, Node> ExecutorBuilder<Node> for EthereumExecutorBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types = Types>,
 {
     type EVM = EthEvmConfig;
     type Executor = EthExecutorProvider<Self::EVM>;
@@ -135,9 +137,10 @@ pub struct EthereumPoolBuilder {
     // TODO add options for txpool args
 }
 
-impl<Node> PoolBuilder<Node> for EthereumPoolBuilder
+impl<Types, Node> PoolBuilder<Node> for EthereumPoolBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types = Types>,
 {
     type Pool = EthTransactionPool<Node::Provider, DiskFileBlobStore>;
 
@@ -213,12 +216,13 @@ impl<EVM> EthereumPayloadBuilder<EVM> {
     }
 }
 
-impl<Node, Evm, Pool> PayloadServiceBuilder<Node, Pool> for EthereumPayloadBuilder<Evm>
+impl<Types, Node, Evm, Pool> PayloadServiceBuilder<Node, Pool> for EthereumPayloadBuilder<Evm>
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types = Types>,
     Evm: ConfigureEvm,
     Pool: TransactionPool + Unpin + 'static,
-    <Node as NodeTypesWithEngine>::Engine: PayloadTypes<
+    Types::Engine: PayloadTypes<
         BuiltPayload = EthBuiltPayload,
         PayloadAttributes = EthPayloadAttributes,
         PayloadBuilderAttributes = EthPayloadBuilderAttributes,
@@ -228,7 +232,7 @@ where
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> eyre::Result<PayloadBuilderHandle<Node::Engine>> {
+    ) -> eyre::Result<PayloadBuilderHandle<Types::Engine>> {
         let payload_builder =
             reth_ethereum_payload_builder::EthereumPayloadBuilder::new(self.evm_config);
         let conf = ctx.payload_builder_config();
@@ -285,9 +289,10 @@ pub struct EthereumConsensusBuilder {
     // TODO add closure to modify consensus
 }
 
-impl<Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
+impl<Types, Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types = Types>,
 {
     type Consensus = Arc<dyn reth_consensus::Consensus>;
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -289,10 +289,9 @@ pub struct EthereumConsensusBuilder {
     // TODO add closure to modify consensus
 }
 
-impl<Types, Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
+impl<Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
 where
-    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
-    Node: FullNodeTypes<Types = Types>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type Consensus = Arc<dyn reth_consensus::Consensus>;
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -47,7 +47,7 @@ impl EthereumNode {
         EthereumConsensusBuilder,
     >
     where
-        Node: FullNodeTypes,
+        Node: FullNodeTypes<ChainSpec = ChainSpec>,
         <Node as NodeTypesWithEngine>::Engine: PayloadTypes<
             BuiltPayload = EthBuiltPayload,
             PayloadAttributes = EthPayloadAttributes,
@@ -108,7 +108,7 @@ pub struct EthereumExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for EthereumExecutorBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type EVM = EthEvmConfig;
     type Executor = EthExecutorProvider<Self::EVM>;
@@ -137,7 +137,7 @@ pub struct EthereumPoolBuilder {
 
 impl<Node> PoolBuilder<Node> for EthereumPoolBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type Pool = EthTransactionPool<Node::Provider, DiskFileBlobStore>;
 
@@ -215,7 +215,7 @@ impl<EVM> EthereumPayloadBuilder<EVM> {
 
 impl<Node, Evm, Pool> PayloadServiceBuilder<Node, Pool> for EthereumPayloadBuilder<Evm>
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
     Evm: ConfigureEvm,
     Pool: TransactionPool + Unpin + 'static,
     <Node as NodeTypesWithEngine>::Engine: PayloadTypes<
@@ -287,7 +287,7 @@ pub struct EthereumConsensusBuilder {
 
 impl<Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type Consensus = Arc<dyn reth_consensus::Consensus>;
 

--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use reth_node_api::FullNodeComponents;
+use reth_node_api::{FullNodeComponents, NodeTypesWithEngine};
 use reth_node_core::node_config::NodeConfig;
 use reth_primitives::Head;
 use reth_tasks::TaskExecutor;
@@ -76,7 +76,10 @@ impl<Node: FullNodeComponents> ExExContext<Node> {
     }
 
     /// Returns the handle to the payload builder service.
-    pub fn payload_builder(&self) -> &reth_payload_builder::PayloadBuilderHandle<Node::Engine> {
+    pub fn payload_builder(
+        &self,
+    ) -> &reth_payload_builder::PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>
+    {
         self.components.payload_builder()
     }
 

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -18,7 +18,9 @@ use reth_evm::test_utils::MockExecutorProvider;
 use reth_execution_types::Chain;
 use reth_exex::{ExExContext, ExExEvent, ExExNotification};
 use reth_network::{config::SecretKey, NetworkConfigBuilder, NetworkManager};
-use reth_node_api::{FullNodeTypes, FullNodeTypesAdapter, NodeTypes, NodeTypesWithEngine};
+use reth_node_api::{
+    FullNodeTypes, FullNodeTypesAdapter, NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine,
+};
 use reth_node_builder::{
     components::{
         Components, ComponentsBuilder, ConsensusBuilder, ExecutorBuilder, NodeComponentsBuilder,
@@ -148,9 +150,9 @@ pub type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
 /// boot the testing environment
 pub type Adapter = NodeAdapter<
     RethFullAdapter<TmpDB, TestNode>,
-    <<TestNode as Node<FullNodeTypesAdapter<TestNode, TmpDB, BlockchainProvider<TmpDB>>>>::ComponentsBuilder as NodeComponentsBuilder<
-        RethFullAdapter<TmpDB, TestNode>,
-    >>::Components,
+    <<TestNode as Node<
+        FullNodeTypesAdapter<NodeTypesWithDBAdapter<TestNode, TmpDB>, BlockchainProvider<TmpDB>>,
+    >>::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<TmpDB, TestNode>>>::Components,
 >;
 /// An [`ExExContext`] using the [`Adapter`] type.
 pub type TestExExContext = ExExContext<Adapter>;
@@ -251,7 +253,7 @@ pub async fn test_exex_context_with_chain_spec(
     let tasks = TaskManager::current();
     let task_executor = tasks.executor();
 
-    let components = NodeAdapter::<FullNodeTypesAdapter<TestNode, _, _>, _> {
+    let components = NodeAdapter::<FullNodeTypesAdapter<NodeTypesWithDBAdapter<TestNode, _>, _>, _> {
         components: Components {
             transaction_pool,
             evm_config,

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -121,7 +121,7 @@ impl NodeTypesWithEngine for TestNode {
 
 impl<N> Node<N> for TestNode
 where
-    N: FullNodeTypes<Engine = EthEngineTypes, ChainSpec = ChainSpec>,
+    N: FullNodeTypes<Types: NodeTypesWithEngine<Engine = EthEngineTypes, ChainSpec = ChainSpec>>,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,

--- a/crates/node/api/Cargo.toml
+++ b/crates/node/api/Cargo.toml
@@ -23,3 +23,4 @@ reth-payload-primitives.workspace = true
 reth-tasks.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-network-api.workspace = true
+reth-node-types.workspace = true

--- a/crates/node/api/src/lib.rs
+++ b/crates/node/api/src/lib.rs
@@ -19,12 +19,11 @@ pub use reth_payload_primitives::*;
 /// Traits and helper types used to abstract over EVM methods and types.
 pub use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 
-pub mod primitives;
-
 pub mod node;
 pub use node::*;
 
 // re-export for convenience
+pub use reth_node_types::*;
 pub use reth_provider::FullProvider;
 
 pub use reth_rpc_eth_api::EthApiTypes;

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -159,50 +159,6 @@ pub struct FullNodeTypesAdapter<Types, Provider> {
     pub provider: PhantomData<Provider>,
 }
 
-impl<Types, Provider> FullNodeTypesAdapter<Types, Provider> {
-    /// Create a new adapter with the configured types.
-    pub fn new() -> Self {
-        Self { types: Default::default(), provider: Default::default() }
-    }
-}
-
-impl<Types, Provider> Default for FullNodeTypesAdapter<Types, Provider> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<Types, Provider> Clone for FullNodeTypesAdapter<Types, Provider> {
-    fn clone(&self) -> Self {
-        Self { types: self.types, provider: self.provider }
-    }
-}
-
-impl<Types, Provider> NodeTypes for FullNodeTypesAdapter<Types, Provider>
-where
-    Types: NodeTypes,
-    Provider: Send + Sync + Unpin + 'static,
-{
-    type Primitives = Types::Primitives;
-    type ChainSpec = Types::ChainSpec;
-}
-
-impl<Types, Provider> NodeTypesWithEngine for FullNodeTypesAdapter<Types, Provider>
-where
-    Types: NodeTypesWithEngine,
-    Provider: Send + Sync + Unpin + 'static,
-{
-    type Engine = Types::Engine;
-}
-
-impl<Types, Provider> NodeTypesWithDB for FullNodeTypesAdapter<Types, Provider>
-where
-    Types: NodeTypesWithDB,
-    Provider: Send + Sync + Unpin + 'static,
-{
-    type DB = Types::DB;
-}
-
 impl<Types, Provider> FullNodeTypes for FullNodeTypesAdapter<Types, Provider>
 where
     Types: NodeTypesWithDB,

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -92,9 +92,11 @@ where
 /// components to the node.
 ///
 /// Its types are configured by node internally and are not intended to be user configurable.
-pub trait FullNodeTypes: NodeTypesWithDB + Sized + 'static {
+pub trait FullNodeTypes: Send + Sync + Unpin + 'static {
+    /// Node's types with the database.
+    type Types: NodeTypesWithDB;
     /// The provider type used to interact with the node.
-    type Provider: FullProvider<Self>;
+    type Provider: FullProvider<Self::Types>;
 }
 
 /// An adapter type combining [`NodeTypes`] and db into [`NodeTypesWithDB`].
@@ -206,6 +208,7 @@ where
     Types: NodeTypesWithDB,
     Provider: FullProvider<Types>,
 {
+    type Types = Types;
     type Provider = Provider;
 }
 
@@ -239,7 +242,9 @@ pub trait FullNodeComponents: FullNodeTypes + Clone + 'static {
     fn network(&self) -> &Self::Network;
 
     /// Returns the handle to the payload builder service.
-    fn payload_builder(&self) -> &PayloadBuilderHandle<Self::Engine>;
+    fn payload_builder(
+        &self,
+    ) -> &PayloadBuilderHandle<<Self::Types as NodeTypesWithEngine>::Engine>;
 
     /// Returns handle to runtime.
     fn task_executor(&self) -> &TaskExecutor;

--- a/crates/node/api/src/primitives.rs
+++ b/crates/node/api/src/primitives.rs
@@ -1,8 +1,0 @@
-//! Type abstraction for node primitive types.
-
-/// Configures all the primitive types of the node.
-// TODO(mattsse): this is currently a placeholder
-pub trait NodePrimitives {}
-
-// TODO(mattsse): Placeholder
-impl NodePrimitives for () {}

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -22,7 +22,8 @@ use reth_network::{
     NetworkBuilder, NetworkConfig, NetworkConfigBuilder, NetworkHandle, NetworkManager,
 };
 use reth_node_api::{
-    FullNodeTypes, FullNodeTypesAdapter, NodeAddOns, NodeTypesWithDBAdapter, NodeTypesWithEngine,
+    FullNodeTypes, FullNodeTypesAdapter, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter,
+    NodeTypesWithEngine,
 };
 use reth_node_core::{
     cli::config::{PayloadBuilderConfig, RethTransactionPoolConfig},
@@ -554,7 +555,7 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     }
 
     /// Returns the chain spec of the node.
-    pub fn chain_spec(&self) -> Arc<Node::ChainSpec> {
+    pub fn chain_spec(&self) -> Arc<<Node::Types as NodeTypes>::ChainSpec> {
         self.provider().chain_spec()
     }
 

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -21,7 +21,9 @@ use reth_exex::ExExContext;
 use reth_network::{
     NetworkBuilder, NetworkConfig, NetworkConfigBuilder, NetworkHandle, NetworkManager,
 };
-use reth_node_api::{FullNodeTypes, FullNodeTypesAdapter, NodeAddOns, NodeTypesWithEngine};
+use reth_node_api::{
+    FullNodeTypes, FullNodeTypesAdapter, NodeAddOns, NodeTypesWithDBAdapter, NodeTypesWithEngine,
+};
 use reth_node_core::{
     cli::config::{PayloadBuilderConfig, RethTransactionPoolConfig},
     dirs::{ChainPath, DataDirPath},
@@ -46,7 +48,8 @@ use crate::{
 
 /// The adapter type for a reth node with the builtin provider type
 // Note: we need to hardcode this because custom components might depend on it in associated types.
-pub type RethFullAdapter<DB, Types> = FullNodeTypesAdapter<Types, DB, BlockchainProvider<DB>>;
+pub type RethFullAdapter<DB, Types> =
+    FullNodeTypesAdapter<NodeTypesWithDBAdapter<Types, DB>, BlockchainProvider<DB>>;
 
 #[allow(clippy::doc_markdown)]
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -216,10 +219,10 @@ where
     /// Configures the types of the node and the provider type that will be used by the node.
     pub fn with_types_and_provider<T, P>(
         self,
-    ) -> NodeBuilderWithTypes<FullNodeTypesAdapter<T, DB, P>>
+    ) -> NodeBuilderWithTypes<FullNodeTypesAdapter<NodeTypesWithDBAdapter<T, DB>, P>>
     where
         T: NodeTypesWithEngine<ChainSpec = ChainSpec>,
-        P: FullProvider<FullNodeTypesAdapter<T, DB, P>>,
+        P: FullProvider<NodeTypesWithDBAdapter<T, DB>>,
     {
         NodeBuilderWithTypes::new(self.config, self.database)
     }
@@ -274,10 +277,12 @@ where
     /// Configures the types of the node and the provider type that will be used by the node.
     pub fn with_types_and_provider<T, P>(
         self,
-    ) -> WithLaunchContext<NodeBuilderWithTypes<FullNodeTypesAdapter<T, DB, P>>>
+    ) -> WithLaunchContext<
+        NodeBuilderWithTypes<FullNodeTypesAdapter<NodeTypesWithDBAdapter<T, DB>, P>>,
+    >
     where
         T: NodeTypesWithEngine<ChainSpec = ChainSpec>,
-        P: FullProvider<FullNodeTypesAdapter<T, DB, P>>,
+        P: FullProvider<NodeTypesWithDBAdapter<T, DB>>,
     {
         WithLaunchContext {
             builder: self.builder.with_types_and_provider(),

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -219,7 +219,7 @@ where
     ) -> NodeBuilderWithTypes<FullNodeTypesAdapter<T, DB, P>>
     where
         T: NodeTypesWithEngine<ChainSpec = ChainSpec>,
-        P: FullProvider<DB, T::ChainSpec>,
+        P: FullProvider<FullNodeTypesAdapter<T, DB, P>>,
     {
         NodeBuilderWithTypes::new(self.config, self.database)
     }
@@ -277,7 +277,7 @@ where
     ) -> WithLaunchContext<NodeBuilderWithTypes<FullNodeTypesAdapter<T, DB, P>>>
     where
         T: NodeTypesWithEngine<ChainSpec = ChainSpec>,
-        P: FullProvider<DB, T::ChainSpec>,
+        P: FullProvider<FullNodeTypesAdapter<T, DB, P>>,
     {
         WithLaunchContext {
             builder: self.builder.with_types_and_provider(),

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -9,7 +9,7 @@ use std::{fmt, future::Future, marker::PhantomData};
 
 use reth_exex::ExExContext;
 use reth_node_api::{
-    FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes, NodeTypesWithEngine,
+    FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes, NodeTypesWithDB, NodeTypesWithEngine,
 };
 use reth_node_core::{
     node_config::NodeConfig,
@@ -99,8 +99,11 @@ impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypesWithEngine for NodeAdapter
     type Engine = T::Engine;
 }
 
-impl<T: FullNodeTypes, C: NodeComponents<T>> FullNodeTypes for NodeAdapter<T, C> {
+impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypesWithDB for NodeAdapter<T, C> {
     type DB = T::DB;
+}
+
+impl<T: FullNodeTypes, C: NodeComponents<T>> FullNodeTypes for NodeAdapter<T, C> {
     type Provider = T::Provider;
 }
 

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -36,7 +36,7 @@ pub struct NodeBuilderWithTypes<T: FullNodeTypes> {
 
 impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
     /// Creates a new instance of the node builder with the given configuration and types.
-    pub const fn new(config: NodeConfig, database: T::DB) -> Self {
+    pub const fn new(config: NodeConfig, database: <T::Types as NodeTypesWithDB>::DB) -> Self {
         Self { config, adapter: NodeTypesAdapter::new(database) }
     }
 
@@ -63,12 +63,12 @@ impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
 /// Container for the node's types and the database the node uses.
 pub struct NodeTypesAdapter<T: FullNodeTypes> {
     /// The database type used by the node.
-    pub database: T::DB,
+    pub database: <T::Types as NodeTypesWithDB>::DB,
 }
 
 impl<T: FullNodeTypes> NodeTypesAdapter<T> {
     /// Create a new adapter from the given node types.
-    pub(crate) const fn new(database: T::DB) -> Self {
+    pub(crate) const fn new(database: <T::Types as NodeTypesWithDB>::DB) -> Self {
         Self { database }
     }
 }
@@ -91,19 +91,20 @@ pub struct NodeAdapter<T: FullNodeTypes, C: NodeComponents<T>> {
 }
 
 impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypes for NodeAdapter<T, C> {
-    type Primitives = T::Primitives;
-    type ChainSpec = T::ChainSpec;
+    type Primitives = <T::Types as NodeTypes>::Primitives;
+    type ChainSpec = <T::Types as NodeTypes>::ChainSpec;
 }
 
 impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypesWithEngine for NodeAdapter<T, C> {
-    type Engine = T::Engine;
+    type Engine = <T::Types as NodeTypesWithEngine>::Engine;
 }
 
 impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypesWithDB for NodeAdapter<T, C> {
-    type DB = T::DB;
+    type DB = <T::Types as NodeTypesWithDB>::DB;
 }
 
 impl<T: FullNodeTypes, C: NodeComponents<T>> FullNodeTypes for NodeAdapter<T, C> {
+    type Types = T::Types;
     type Provider = T::Provider;
 }
 
@@ -133,7 +134,7 @@ impl<T: FullNodeTypes, C: NodeComponents<T>> FullNodeComponents for NodeAdapter<
         self.components.network()
     }
 
-    fn payload_builder(&self) -> &PayloadBuilderHandle<T::Engine> {
+    fn payload_builder(&self) -> &PayloadBuilderHandle<<T::Types as NodeTypesWithEngine>::Engine> {
         self.components.payload_builder()
     }
 

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -9,7 +9,7 @@ use std::{fmt, future::Future, marker::PhantomData};
 
 use reth_exex::ExExContext;
 use reth_node_api::{
-    FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes, NodeTypesWithDB, NodeTypesWithEngine,
+    FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypesWithDB, NodeTypesWithEngine,
 };
 use reth_node_core::{
     node_config::NodeConfig,
@@ -88,19 +88,6 @@ pub struct NodeAdapter<T: FullNodeTypes, C: NodeComponents<T>> {
     pub task_executor: TaskExecutor,
     /// The provider of the node.
     pub provider: T::Provider,
-}
-
-impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypes for NodeAdapter<T, C> {
-    type Primitives = <T::Types as NodeTypes>::Primitives;
-    type ChainSpec = <T::Types as NodeTypes>::ChainSpec;
-}
-
-impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypesWithEngine for NodeAdapter<T, C> {
-    type Engine = <T::Types as NodeTypesWithEngine>::Engine;
-}
-
-impl<T: FullNodeTypes, C: NodeComponents<T>> NodeTypesWithDB for NodeAdapter<T, C> {
-    type DB = <T::Types as NodeTypesWithDB>::DB;
 }
 
 impl<T: FullNodeTypes, C: NodeComponents<T>> FullNodeTypes for NodeAdapter<T, C> {

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -25,6 +25,7 @@ use reth_consensus::Consensus;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network::NetworkHandle;
 use reth_network_api::FullNetwork;
+use reth_node_api::NodeTypesWithEngine;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_transaction_pool::TransactionPool;
 
@@ -35,9 +36,7 @@ use crate::{ConfigureEvm, FullNodeTypes};
 ///  - transaction pool
 ///  - network
 ///  - payload builder.
-pub trait NodeComponents<NodeTypesWithEngine: FullNodeTypes>:
-    Clone + Unpin + Send + Sync + 'static
-{
+pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'static {
     /// The transaction pool of the node.
     type Pool: TransactionPool + Unpin;
 
@@ -69,7 +68,7 @@ pub trait NodeComponents<NodeTypesWithEngine: FullNodeTypes>:
     fn network(&self) -> &Self::Network;
 
     /// Returns the handle to the payload builder service.
-    fn payload_builder(&self) -> &PayloadBuilderHandle<NodeTypesWithEngine::Engine>;
+    fn payload_builder(&self) -> &PayloadBuilderHandle<<T::Types as NodeTypesWithEngine>::Engine>;
 }
 
 /// All the components of the node.
@@ -88,7 +87,7 @@ pub struct Components<Node: FullNodeTypes, Pool, EVM, Executor, Consensus> {
     /// The network implementation of the node.
     pub network: NetworkHandle,
     /// The handle to the payload builder service.
-    pub payload_builder: PayloadBuilderHandle<Node::Engine>,
+    pub payload_builder: PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>,
 }
 
 impl<Node, Pool, EVM, Executor, Cons> NodeComponents<Node>
@@ -126,7 +125,9 @@ where
         &self.network
     }
 
-    fn payload_builder(&self) -> &PayloadBuilderHandle<Node::Engine> {
+    fn payload_builder(
+        &self,
+    ) -> &PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine> {
         &self.payload_builder
     }
 }

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -2,6 +2,7 @@
 
 use std::future::Future;
 
+use reth_node_api::NodeTypesWithEngine;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_transaction_pool::TransactionPool;
 
@@ -16,7 +17,9 @@ pub trait PayloadServiceBuilder<Node: FullNodeTypes, Pool: TransactionPool>: Sen
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> impl Future<Output = eyre::Result<PayloadBuilderHandle<Node::Engine>>> + Send;
+    ) -> impl Future<
+        Output = eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>>,
+    > + Send;
 }
 
 impl<Node, F, Fut, Pool> PayloadServiceBuilder<Node, Pool> for F
@@ -24,13 +27,19 @@ where
     Node: FullNodeTypes,
     Pool: TransactionPool,
     F: Fn(&BuilderContext<Node>, Pool) -> Fut + Send,
-    Fut: Future<Output = eyre::Result<PayloadBuilderHandle<Node::Engine>>> + Send,
+    Fut: Future<
+            Output = eyre::Result<
+                PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>,
+            >,
+        > + Send,
 {
     fn spawn_payload_service(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> impl Future<Output = eyre::Result<PayloadBuilderHandle<Node::Engine>>> + Send {
+    ) -> impl Future<
+        Output = eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>>,
+    > + Send {
         self(ctx, pool)
     }
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -34,7 +34,7 @@ use reth_node_metrics::{
 use reth_primitives::{BlockNumber, Head, B256};
 use reth_provider::{
     providers::{BlockchainProvider, BlockchainProvider2, StaticFileProvider},
-    BlockHashReader, CanonStateNotificationSender, FullProvider, ProviderFactory, ProviderResult,
+    BlockHashReader, CanonStateNotificationSender, ProviderFactory, ProviderResult,
     StageCheckpointReader, StaticFileProviderFactory, TreeViewer,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
@@ -569,7 +569,6 @@ where
     ) -> eyre::Result<LaunchContextWith<Attached<WithConfigs, WithMeteredProviders<DB, T>>>>
     where
         T: FullNodeTypes,
-        T::Provider: FullProvider<DB, T::ChainSpec>,
         F: FnOnce(ProviderFactory<DB>) -> eyre::Result<T::Provider>,
     {
         let blockchain_db = create_blockchain_provider(self.provider_factory().clone())?;
@@ -598,7 +597,7 @@ where
 impl<DB, T> LaunchContextWith<Attached<WithConfigs, WithMeteredProviders<DB, T>>>
 where
     DB: Database + DatabaseMetrics + Send + Sync + Clone + 'static,
-    T: FullNodeTypes<Provider: FullProvider<DB, T::ChainSpec> + WithTree>,
+    T: FullNodeTypes<Provider: WithTree>,
 {
     /// Returns access to the underlying database.
     pub fn database(&self) -> &DB {
@@ -717,7 +716,7 @@ where
 impl<DB, T, CB> LaunchContextWith<Attached<WithConfigs, WithComponents<DB, T, CB>>>
 where
     DB: Database + DatabaseMetrics + Send + Sync + Clone + 'static,
-    T: FullNodeTypes<Provider: FullProvider<DB, T::ChainSpec> + WithTree>,
+    T: FullNodeTypes<Provider: WithTree>,
     CB: NodeComponentsBuilder<T>,
 {
     /// Returns the configured `ProviderFactory`.
@@ -915,7 +914,7 @@ pub struct WithMeteredProvider<DB> {
 pub struct WithMeteredProviders<DB, T>
 where
     DB: Database,
-    T: FullNodeTypes<Provider: FullProvider<DB, T::ChainSpec>>,
+    T: FullNodeTypes,
 {
     db_provider_container: WithMeteredProvider<DB>,
     blockchain_db: T::Provider,
@@ -931,7 +930,7 @@ where
 pub struct WithComponents<DB, T, CB>
 where
     DB: Database,
-    T: FullNodeTypes<Provider: FullProvider<DB, T::ChainSpec>>,
+    T: FullNodeTypes,
     CB: NodeComponentsBuilder<T>,
 {
     db_provider_container: WithMeteredProvider<DB>,

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -56,12 +56,10 @@ impl EngineNodeLauncher {
     }
 }
 
-impl<T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
+impl<Types, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
 where
-    T: FullNodeTypes<
-        Provider = BlockchainProvider2<<T as NodeTypesWithDB>::DB>,
-        ChainSpec = ChainSpec,
-    >,
+    Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
+    T: FullNodeTypes<Types = Types, Provider = BlockchainProvider2<Types::DB>>,
     CB: NodeComponentsBuilder<T>,
     AO: NodeAddOns<
         NodeAdapter<T, CB::Components>,

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -16,7 +16,7 @@ use reth_engine_util::EngineMessageStreamExt;
 use reth_exex::ExExManagerHandle;
 use reth_network::{NetworkSyncUpdater, SyncState};
 use reth_network_api::{BlockDownloaderProvider, NetworkEventListenerProvider};
-use reth_node_api::{BuiltPayload, FullNodeTypes, NodeAddOns};
+use reth_node_api::{BuiltPayload, FullNodeTypes, NodeAddOns, NodeTypesWithDB};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
@@ -59,7 +59,7 @@ impl EngineNodeLauncher {
 impl<T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
 where
     T: FullNodeTypes<
-        Provider = BlockchainProvider2<<T as FullNodeTypes>::DB>,
+        Provider = BlockchainProvider2<<T as NodeTypesWithDB>::DB>,
         ChainSpec = ChainSpec,
     >,
     CB: NodeComponentsBuilder<T>,

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -56,10 +56,12 @@ impl EngineNodeLauncher {
     }
 }
 
-impl<Types, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
+impl<T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
 where
-    Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
-    T: FullNodeTypes<Types = Types, Provider = BlockchainProvider2<Types::DB>>,
+    T: FullNodeTypes<
+        Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
+        Provider = BlockchainProvider2<Types::DB>,
+    >,
     CB: NodeComponentsBuilder<T>,
     AO: NodeAddOns<
         NodeAdapter<T, CB::Components>,

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -56,12 +56,10 @@ impl EngineNodeLauncher {
     }
 }
 
-impl<T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
+impl<Types, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
 where
-    T: FullNodeTypes<
-        Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
-        Provider = BlockchainProvider2<Types::DB>,
-    >,
+    Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
+    T: FullNodeTypes<Types = Types, Provider = BlockchainProvider2<Types::DB>>,
     CB: NodeComponentsBuilder<T>,
     AO: NodeAddOns<
         NodeAdapter<T, CB::Components>,

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -21,7 +21,7 @@ use reth_consensus_debug_client::{DebugConsensusClient, EtherscanBlockProvider, 
 use reth_engine_util::EngineMessageStreamExt;
 use reth_exex::ExExManagerHandle;
 use reth_network::{BlockDownloaderProvider, NetworkEventListenerProvider};
-use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns};
+use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypesWithDB};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
@@ -103,7 +103,7 @@ impl DefaultNodeLauncher {
 impl<T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for DefaultNodeLauncher
 where
     T: FullNodeTypes<
-        Provider = BlockchainProvider<<T as FullNodeTypes>::DB>,
+        Provider = BlockchainProvider<<T as NodeTypesWithDB>::DB>,
         ChainSpec = ChainSpec,
     >,
     CB: NodeComponentsBuilder<T>,

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -100,12 +100,10 @@ impl DefaultNodeLauncher {
     }
 }
 
-impl<T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for DefaultNodeLauncher
+impl<Types, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for DefaultNodeLauncher
 where
-    T: FullNodeTypes<
-        Provider = BlockchainProvider<<T as NodeTypesWithDB>::DB>,
-        ChainSpec = ChainSpec,
-    >,
+    Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
+    T: FullNodeTypes<Provider = BlockchainProvider<Types::DB>, Types = Types>,
     CB: NodeComponentsBuilder<T>,
     AO: NodeAddOns<
         NodeAdapter<T, CB::Components>,
@@ -409,7 +407,7 @@ where
                 Arc::new(block_provider),
             );
             ctx.task_executor().spawn_critical("etherscan consensus client", async move {
-                rpc_consensus_client.run::<T::Engine>().await
+                rpc_consensus_client.run::<Types::Engine>().await
             });
         }
 
@@ -422,7 +420,7 @@ where
                 Arc::new(block_provider),
             );
             ctx.task_executor().spawn_critical("rpc consensus client", async move {
-                rpc_consensus_client.run::<T::Engine>().await
+                rpc_consensus_client.run::<Types::Engine>().await
             });
         }
 

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -3,7 +3,7 @@ pub use reth_node_api::{FullNodeTypes, NodeTypes, NodeTypesWithEngine};
 
 use std::{marker::PhantomData, sync::Arc};
 
-use reth_node_api::FullNodeComponents;
+use reth_node_api::{EngineTypes, FullNodeComponents};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     node_config::NodeConfig,
@@ -58,9 +58,9 @@ where
     C: Send + Sync + Unpin + 'static,
     AO: Send + Sync + Unpin + Clone + 'static,
 {
-    type Primitives = N::Primitives;
+    type Primitives = <N::Types as NodeTypes>::Primitives;
 
-    type ChainSpec = N::ChainSpec;
+    type ChainSpec = <N::Types as NodeTypes>::ChainSpec;
 }
 
 impl<N, C, AO> NodeTypesWithEngine for AnyNode<N, C, AO>
@@ -69,7 +69,7 @@ where
     C: Send + Sync + Unpin + 'static,
     AO: Send + Sync + Unpin + Clone + 'static,
 {
-    type Engine = N::Engine;
+    type Engine = <N::Types as NodeTypesWithEngine>::Engine;
 }
 
 impl<N, C, AO> Node<N> for AnyNode<N, C, AO>
@@ -89,7 +89,7 @@ where
 /// The launched node with all components including RPC handlers.
 ///
 /// This can be used to interact with the launched node.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FullNode<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     /// The evm configuration.
     pub evm_config: Node::Evm,
@@ -102,7 +102,7 @@ pub struct FullNode<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     /// Provider to interact with the node's database
     pub provider: Node::Provider,
     /// Handle to the node's payload builder service.
-    pub payload_builder: PayloadBuilderHandle<Node::Engine>,
+    pub payload_builder: PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>,
     /// Task executor for the node.
     pub task_executor: TaskExecutor,
     /// Handles to the node's rpc servers
@@ -115,13 +115,32 @@ pub struct FullNode<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     pub data_dir: ChainPath<DataDirPath>,
 }
 
-impl<Node, AddOns> FullNode<Node, AddOns>
+impl<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> Clone for FullNode<Node, AddOns> {
+    fn clone(&self) -> Self {
+        Self {
+            evm_config: self.evm_config.clone(),
+            block_executor: self.block_executor.clone(),
+            pool: self.pool.clone(),
+            network: self.network.clone(),
+            provider: self.provider.clone(),
+            payload_builder: self.payload_builder.clone(),
+            task_executor: self.task_executor.clone(),
+            rpc_server_handles: self.rpc_server_handles.clone(),
+            rpc_registry: self.rpc_registry.clone(),
+            config: self.config.clone(),
+            data_dir: self.data_dir.clone(),
+        }
+    }
+}
+
+impl<Engine, Node, AddOns> FullNode<Node, AddOns>
 where
-    Node: FullNodeComponents,
+    Engine: EngineTypes,
+    Node: FullNodeComponents<Types: NodeTypesWithEngine<Engine = Engine>>,
     AddOns: NodeAddOns<Node>,
 {
     /// Returns the chain spec of the node.
-    pub fn chain_spec(&self) -> Arc<Node::ChainSpec> {
+    pub fn chain_spec(&self) -> Arc<<Node::Types as NodeTypes>::ChainSpec> {
         self.provider.chain_spec()
     }
 
@@ -138,14 +157,14 @@ where
     /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
     ///
     /// This will send authenticated http requests to the node's auth server.
-    pub fn engine_http_client(&self) -> impl EngineApiClient<Node::Engine> {
+    pub fn engine_http_client(&self) -> impl EngineApiClient<Engine> {
         self.auth_server_handle().http_client()
     }
 
     /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
     ///
     /// This will send authenticated ws requests to the node's auth server.
-    pub async fn engine_ws_client(&self) -> impl EngineApiClient<Node::Engine> {
+    pub async fn engine_ws_client(&self) -> impl EngineApiClient<Engine> {
         self.auth_server_handle().ws_client().await
     }
 
@@ -153,7 +172,7 @@ where
     ///
     /// This will send not authenticated IPC requests to the node's auth server.
     #[cfg(unix)]
-    pub async fn engine_ipc_client(&self) -> Option<impl EngineApiClient<Node::Engine>> {
+    pub async fn engine_ipc_client(&self) -> Option<impl EngineApiClient<Engine>> {
         self.auth_server_handle().ipc_client().await
     }
 }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -7,7 +7,7 @@ use std::{
 
 use futures::TryFutureExt;
 use reth_chainspec::ChainSpec;
-use reth_node_api::{BuilderProvider, FullNodeComponents};
+use reth_node_api::{BuilderProvider, FullNodeComponents, NodeTypesWithDB, NodeTypesWithEngine};
 use reth_node_core::{
     node_config::NodeConfig,
     rpc::{
@@ -284,7 +284,9 @@ where
     }
 
     /// Returns the handle to the payload builder service
-    pub fn payload_builder(&self) -> &PayloadBuilderHandle<Node::Engine> {
+    pub fn payload_builder(
+        &self,
+    ) -> &PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine> {
         self.node.payload_builder()
     }
 }
@@ -298,8 +300,8 @@ pub async fn launch_rpc_servers<Node, Engine, EthApi>(
     add_ons: RpcAddOns<Node, EthApi>,
 ) -> eyre::Result<(RethRpcServerHandles, RpcRegistry<Node, EthApi>)>
 where
-    Node: FullNodeComponents<ChainSpec = ChainSpec> + Clone,
-    Engine: EngineApiServer<Node::Engine>,
+    Node: FullNodeComponents<Types: NodeTypesWithDB<ChainSpec = ChainSpec>> + Clone,
+    Engine: EngineApiServer<<Node::Types as NodeTypesWithEngine>::Engine>,
     EthApi: EthApiBuilderProvider<Node>
         + FullEthApiServer<
             NetworkTypes: alloy_network::Network<

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use futures::TryFutureExt;
+use reth_chainspec::ChainSpec;
 use reth_node_api::{BuilderProvider, FullNodeComponents};
 use reth_node_core::{
     node_config::NodeConfig,
@@ -297,7 +298,7 @@ pub async fn launch_rpc_servers<Node, Engine, EthApi>(
     add_ons: RpcAddOns<Node, EthApi>,
 ) -> eyre::Result<(RethRpcServerHandles, RpcRegistry<Node, EthApi>)>
 where
-    Node: FullNodeComponents + Clone,
+    Node: FullNodeComponents<ChainSpec = ChainSpec> + Clone,
     Engine: EngineApiServer<Node::Engine>,
     EthApi: EthApiBuilderProvider<Node>
         + FullEthApiServer<

--- a/crates/node/types/Cargo.toml
+++ b/crates/node/types/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reth-node-types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-chainspec.workspace = true
+reth-db-api.workspace = true
+reth-engine-primitives.workspace = true

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -1,0 +1,50 @@
+//! Standalone crate for Reth configuration traits and builder types.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+use reth_chainspec::EthChainSpec;
+use reth_db_api::{
+    database_metrics::{DatabaseMetadata, DatabaseMetrics},
+    Database,
+};
+use reth_engine_primitives::EngineTypes;
+
+/// Configures all the primitive types of the node.
+// TODO(mattsse): this is currently a placeholder
+pub trait NodePrimitives {}
+
+// TODO(mattsse): Placeholder
+impl NodePrimitives for () {}
+
+/// The type that configures the essential types of an Ethereum-like node.
+///
+/// This includes the primitive types of a node and chain specification.
+///
+/// This trait is intended to be stateless and only define the types of the node.
+pub trait NodeTypes: Send + Sync + Unpin + 'static {
+    /// The node's primitive types, defining basic operations and structures.
+    type Primitives: NodePrimitives;
+    /// The type used for configuration of the EVM.
+    type ChainSpec: EthChainSpec;
+}
+
+/// The type that configures an Ethereum-like node with an engine for consensus.
+pub trait NodeTypesWithEngine: NodeTypes {
+    /// The node's engine types, defining the interaction with the consensus engine.
+    type Engine: EngineTypes;
+}
+
+/// A helper trait that is downstream of the [`NodeTypesWithEngine`] trait and adds database to the
+/// node.
+///
+/// Its types are configured by node internally and are not intended to be user configurable.
+pub trait NodeTypesWithDB: NodeTypesWithEngine {
+    /// Underlying database type used by the node to store and retrieve data.
+    type DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static;
+}

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -122,7 +122,7 @@ pub struct OptimismExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for OptimismExecutorBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type EVM = OptimismEvmConfig;
     type Executor = OpExecutorProvider<Self::EVM>;
@@ -149,7 +149,7 @@ pub struct OptimismPoolBuilder;
 
 impl<Node> PoolBuilder<Node> for OptimismPoolBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type Pool = OpTransactionPool<Node::Provider, DiskFileBlobStore>;
 
@@ -293,7 +293,7 @@ pub struct OptimismNetworkBuilder {
 
 impl<Node, Pool> NetworkBuilder<Node, Pool> for OptimismNetworkBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
     Pool: TransactionPool + Unpin + 'static,
 {
     async fn build_network(
@@ -350,7 +350,7 @@ pub struct OptimismConsensusBuilder;
 
 impl<Node> ConsensusBuilder<Node> for OptimismConsensusBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type Consensus = Arc<dyn reth_consensus::Consensus>;
 

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -58,7 +58,9 @@ impl OptimismNode {
         OptimismConsensusBuilder,
     >
     where
-        Node: FullNodeTypes<Engine = OptimismEngineTypes, ChainSpec = ChainSpec>,
+        Node: FullNodeTypes<
+            Types: NodeTypesWithEngine<Engine = OptimismEngineTypes, ChainSpec = ChainSpec>,
+        >,
     {
         let RollupArgs { disable_txpool_gossip, compute_pending_block, discovery_v4, .. } = args;
         ComponentsBuilder::default()
@@ -79,7 +81,9 @@ impl OptimismNode {
 
 impl<N> Node<N> for OptimismNode
 where
-    N: FullNodeTypes<Engine = OptimismEngineTypes, ChainSpec = ChainSpec>,
+    N: FullNodeTypes<
+        Types: NodeTypesWithEngine<Engine = OptimismEngineTypes, ChainSpec = ChainSpec>,
+    >,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -122,7 +126,7 @@ pub struct OptimismExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for OptimismExecutorBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type EVM = OptimismEvmConfig;
     type Executor = OpExecutorProvider<Self::EVM>;
@@ -149,7 +153,7 @@ pub struct OptimismPoolBuilder;
 
 impl<Node> PoolBuilder<Node> for OptimismPoolBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type Pool = OpTransactionPool<Node::Provider, DiskFileBlobStore>;
 
@@ -244,7 +248,9 @@ impl<EVM> OptimismPayloadBuilder<EVM> {
 
 impl<Node, EVM, Pool> PayloadServiceBuilder<Node, Pool> for OptimismPayloadBuilder<EVM>
 where
-    Node: FullNodeTypes<Engine = OptimismEngineTypes, ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<
+        Types: NodeTypesWithEngine<Engine = OptimismEngineTypes, ChainSpec = ChainSpec>,
+    >,
     Pool: TransactionPool + Unpin + 'static,
     EVM: ConfigureEvm,
 {
@@ -252,7 +258,7 @@ where
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> eyre::Result<PayloadBuilderHandle<Node::Engine>> {
+    ) -> eyre::Result<PayloadBuilderHandle<OptimismEngineTypes>> {
         let payload_builder =
             reth_optimism_payload_builder::OptimismPayloadBuilder::new(self.evm_config)
                 .set_compute_pending_block(self.compute_pending_block);
@@ -293,7 +299,7 @@ pub struct OptimismNetworkBuilder {
 
 impl<Node, Pool> NetworkBuilder<Node, Pool> for OptimismNetworkBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
     Pool: TransactionPool + Unpin + 'static,
 {
     async fn build_network(
@@ -350,7 +356,7 @@ pub struct OptimismConsensusBuilder;
 
 impl<Node> ConsensusBuilder<Node> for OptimismConsensusBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type Consensus = Arc<dyn reth_consensus::Consensus>;
 

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,3 +1,4 @@
+use reth_chainspec::ChainSpec;
 use reth_evm::ConfigureEvm;
 use reth_node_api::FullNodeComponents;
 use reth_primitives::{
@@ -16,7 +17,7 @@ use crate::{OpEthApi, OpEthApiError};
 impl<N> EthCall for OpEthApi<N>
 where
     Self: Call,
-    N: FullNodeComponents,
+    N: FullNodeComponents<ChainSpec = ChainSpec>,
 {
 }
 

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,6 +1,6 @@
 use reth_chainspec::ChainSpec;
 use reth_evm::ConfigureEvm;
-use reth_node_api::FullNodeComponents;
+use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives::{
     revm_primitives::{BlockEnv, OptimismFields, TxEnv},
     Bytes, TxKind, U256,
@@ -17,7 +17,7 @@ use crate::{OpEthApi, OpEthApiError};
 impl<N> EthCall for OpEthApi<N>
 where
     Self: Call,
-    N: FullNodeComponents<ChainSpec = ChainSpec>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
 }
 

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -16,7 +16,7 @@ use op_alloy_network::AnyNetwork;
 use reth_chainspec::ChainSpec;
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
-use reth_node_api::{BuilderProvider, FullNodeComponents, FullNodeTypes};
+use reth_node_api::{BuilderProvider, FullNodeComponents, FullNodeTypes, NodeTypes};
 use reth_node_builder::EthApiBuilderCtx;
 use reth_provider::{
     BlockIdReader, BlockNumReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider,
@@ -101,7 +101,7 @@ where
 impl<N> EthApiSpec for OpEthApi<N>
 where
     Self: Send + Sync,
-    N: FullNodeComponents<ChainSpec = ChainSpec>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     #[inline]
     fn provider(
@@ -151,7 +151,7 @@ where
 impl<N> LoadFee for OpEthApi<N>
 where
     Self: LoadBlock,
-    N: FullNodeComponents<ChainSpec = ChainSpec>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     #[inline]
     fn provider(
@@ -179,7 +179,7 @@ where
 impl<N> LoadState for OpEthApi<N>
 where
     Self: Send + Sync,
-    N: FullNodeComponents<ChainSpec = ChainSpec>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     #[inline]
     fn provider(&self) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> {
@@ -226,7 +226,7 @@ where
     }
 }
 
-impl<N: FullNodeComponents<ChainSpec = ChainSpec>> AddDevSigners for OpEthApi<N> {
+impl<N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>> AddDevSigners for OpEthApi<N> {
     fn with_dev_accounts(&self) {
         *self.signers().write() = DevSigner::random_signers(20)
     }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -101,7 +101,7 @@ where
 impl<N> EthApiSpec for OpEthApi<N>
 where
     Self: Send + Sync,
-    N: FullNodeComponents,
+    N: FullNodeComponents<ChainSpec = ChainSpec>,
 {
     #[inline]
     fn provider(
@@ -151,7 +151,7 @@ where
 impl<N> LoadFee for OpEthApi<N>
 where
     Self: LoadBlock,
-    N: FullNodeComponents,
+    N: FullNodeComponents<ChainSpec = ChainSpec>,
 {
     #[inline]
     fn provider(
@@ -179,7 +179,7 @@ where
 impl<N> LoadState for OpEthApi<N>
 where
     Self: Send + Sync,
-    N: FullNodeComponents,
+    N: FullNodeComponents<ChainSpec = ChainSpec>,
 {
     #[inline]
     fn provider(&self) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> {
@@ -226,7 +226,7 @@ where
     }
 }
 
-impl<N: FullNodeComponents> AddDevSigners for OpEthApi<N> {
+impl<N: FullNodeComponents<ChainSpec = ChainSpec>> AddDevSigners for OpEthApi<N> {
     fn with_dev_accounts(&self) {
         *self.signers().write() = DevSigner::random_signers(20)
     }

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -22,7 +22,7 @@ use crate::OpEthApi;
 impl<N> LoadPendingBlock for OpEthApi<N>
 where
     Self: SpawnBlocking,
-    N: FullNodeComponents,
+    N: FullNodeComponents<ChainSpec = ChainSpec>,
 {
     #[inline]
     fn provider(

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -2,7 +2,7 @@
 
 use reth_chainspec::ChainSpec;
 use reth_evm::ConfigureEvm;
-use reth_node_api::FullNodeComponents;
+use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives::{
     revm_primitives::BlockEnv, BlockNumber, Receipt, SealedBlockWithSenders, B256,
 };
@@ -22,7 +22,7 @@ use crate::OpEthApi;
 impl<N> LoadPendingBlock for OpEthApi<N>
 where
     Self: SpawnBlocking,
-    N: FullNodeComponents<ChainSpec = ChainSpec>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     #[inline]
     fn provider(

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -32,6 +32,7 @@ reth-nippy-jar.workspace = true
 reth-codecs.workspace = true
 reth-evm.workspace = true
 reth-chain-state.workspace = true
+reth-node-types.workspace = true
 
 # ethereum
 alloy-rpc-types-engine.workspace = true

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -6,18 +6,18 @@ use crate::{
     StaticFileProviderFactory, TransactionsProvider,
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
-use reth_chainspec::{ChainSpec, EthChainSpec};
-use reth_db_api::database::Database;
+use reth_chainspec::ChainSpec;
+use reth_node_types::NodeTypesWithDB;
 
 /// Helper trait to unify all provider traits for simplicity.
-pub trait FullProvider<DB: Database, ChainSpec: EthChainSpec>:
-    DatabaseProviderFactory<DB>
+pub trait FullProvider<N: NodeTypesWithDB>:
+    DatabaseProviderFactory<N::DB>
     + StaticFileProviderFactory
     + BlockReaderIdExt
     + AccountReader
     + StateProviderFactory
     + EvmEnvProvider
-    + ChainSpecProvider<ChainSpec = ChainSpec>
+    + ChainSpecProvider<ChainSpec = N::ChainSpec>
     + ChangeSetReader
     + CanonStateSubscriptions
     + ForkChoiceSubscriptions
@@ -28,14 +28,14 @@ pub trait FullProvider<DB: Database, ChainSpec: EthChainSpec>:
 {
 }
 
-impl<T, DB: Database, ChainSpec: EthChainSpec> FullProvider<DB, ChainSpec> for T where
-    T: DatabaseProviderFactory<DB>
+impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
+    T: DatabaseProviderFactory<N::DB>
         + StaticFileProviderFactory
         + BlockReaderIdExt
         + AccountReader
         + StateProviderFactory
         + EvmEnvProvider
-        + ChainSpecProvider<ChainSpec = ChainSpec>
+        + ChainSpecProvider<ChainSpec = N::ChainSpec>
         + ChangeSetReader
         + CanonStateSubscriptions
         + ForkChoiceSubscriptions

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -207,7 +207,7 @@ impl NodeTypesWithEngine for MyCustomNode {
 /// This provides a preset configuration for the node
 impl<N> Node<N> for MyCustomNode
 where
-    N: FullNodeTypes<Engine = CustomEngineTypes, ChainSpec = ChainSpec>,
+    N: FullNodeTypes<Types: NodeTypesWithEngine<Engine = CustomEngineTypes, ChainSpec = ChainSpec>>,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -237,14 +237,16 @@ pub struct CustomPayloadServiceBuilder;
 
 impl<Node, Pool> PayloadServiceBuilder<Node, Pool> for CustomPayloadServiceBuilder
 where
-    Node: FullNodeTypes<Engine = CustomEngineTypes, ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<
+        Types: NodeTypesWithEngine<Engine = CustomEngineTypes, ChainSpec = ChainSpec>,
+    >,
     Pool: TransactionPool + Unpin + 'static,
 {
     async fn spawn_payload_service(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> eyre::Result<PayloadBuilderHandle<Node::Engine>> {
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>> {
         let payload_builder = CustomPayloadBuilder::default();
         let conf = ctx.payload_builder_config();
 

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -144,7 +144,7 @@ pub struct MyExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for MyExecutorBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type EVM = MyEvmConfig;
     type Executor = EthExecutorProvider<Self::EVM>;

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -20,7 +20,7 @@ use reth::{
 };
 use reth_chainspec::{Chain, ChainSpec, Head};
 use reth_evm_ethereum::EthEvmConfig;
-use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes};
+use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{
     node::{EthereumAddOns, EthereumPayloadBuilder},
@@ -144,7 +144,7 @@ pub struct MyExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for MyExecutorBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type EVM = MyEvmConfig;
     type Executor = EthExecutorProvider<Self::EVM>;

--- a/examples/custom-node-components/src/main.rs
+++ b/examples/custom-node-components/src/main.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use reth::{
+    api::NodeTypes,
     builder::{components::PoolBuilder, BuilderContext, FullNodeTypes},
     chainspec::ChainSpec,
     cli::Cli,
@@ -46,7 +47,7 @@ pub struct CustomPoolBuilder {
 /// This will be used to build the transaction pool and its maintenance tasks during launch.
 impl<Node> PoolBuilder<Node> for CustomPoolBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type Pool = EthTransactionPool<Node::Provider, InMemoryBlobStore>;
 

--- a/examples/custom-node-components/src/main.rs
+++ b/examples/custom-node-components/src/main.rs
@@ -4,6 +4,7 @@
 
 use reth::{
     builder::{components::PoolBuilder, BuilderContext, FullNodeTypes},
+    chainspec::ChainSpec,
     cli::Cli,
     providers::CanonStateSubscriptions,
     transaction_pool::{
@@ -45,7 +46,7 @@ pub struct CustomPoolBuilder {
 /// This will be used to build the transaction pool and its maintenance tasks during launch.
 impl<Node> PoolBuilder<Node> for CustomPoolBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type Pool = EthTransactionPool<Node::Provider, InMemoryBlobStore>;
 

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -21,6 +21,7 @@ use reth::{
 };
 use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
 use reth_chainspec::ChainSpec;
+use reth_node_api::NodeTypesWithEngine;
 use reth_node_ethereum::{node::EthereumAddOns, EthEngineTypes, EthereumNode};
 use reth_payload_builder::PayloadBuilderService;
 
@@ -33,14 +34,14 @@ pub struct CustomPayloadBuilder;
 
 impl<Node, Pool> PayloadServiceBuilder<Node, Pool> for CustomPayloadBuilder
 where
-    Node: FullNodeTypes<Engine = EthEngineTypes, ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypesWithEngine<Engine = EthEngineTypes, ChainSpec = ChainSpec>>,
     Pool: TransactionPool + Unpin + 'static,
 {
     async fn spawn_payload_service(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> eyre::Result<PayloadBuilderHandle<Node::Engine>> {
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>> {
         tracing::info!("Spawning a custom payload builder");
         let conf = ctx.payload_builder_config();
 

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -207,7 +207,7 @@ pub struct MyExecutorBuilder {
 
 impl<Node> ExecutorBuilder<Node> for MyExecutorBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<ChainSpec = ChainSpec>,
 {
     type EVM = MyEvmConfig;
     type Executor = EthExecutorProvider<Self::EVM>;

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -19,7 +19,7 @@ use reth::{
     tasks::TaskManager,
 };
 use reth_chainspec::{Chain, ChainSpec};
-use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes};
+use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{node::EthereumAddOns, EthEvmConfig, EthExecutorProvider, EthereumNode};
 use reth_primitives::{
@@ -207,7 +207,7 @@ pub struct MyExecutorBuilder {
 
 impl<Node> ExecutorBuilder<Node> for MyExecutorBuilder
 where
-    Node: FullNodeTypes<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type EVM = MyEvmConfig;
     type Executor = EthExecutorProvider<Self::EVM>;


### PR DESCRIPTION
This PR extracts `DB` AT from `FullNodeTypes` into separate trait `NodeTypesWithDB`. This trait is moved to new crate `reth-node-types` along with `NodePrimitives`, `NodeTypes` and `NodeTypesWithEngine` This is needed to allow `reth-provider` depend on `NodeTypesWithDB`

`FullProvider` is now generic over `NodeTypesWithDB` and `FullNodeTypes` is changed to the following form:
https://github.com/paradigmxyz/reth/blob/416fc6bdadbb3953ef943d3ed99444e25ee08ef2/crates/node/api/src/node.rs#L95-L100

As it no more depends on `NodeTypes` I had to change the way we access some of the ATs (`Node::Engine` -> `<Node::Types as NodeTypesWithEngine>::Engine`)

This should allow usage of `NodeTypesWithDB` in provider traits
