### PR TITLE
chore: relax txpool client trait bounds

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -79,12 +79,12 @@
 //! Listen for new transactions and print them:
 //!
 //! ```
-//! use reth_chainspec::{MAINNET, ChainSpecProvider};
-//! use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+//! use reth_chainspec::MAINNET;
+//! use reth_storage_api::StateProviderFactory;
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::{TransactionValidationTaskExecutor, Pool, TransactionPool};
 //! use reth_transaction_pool::blobstore::InMemoryBlobStore;
-//! async fn t<C>(client: C)  where C: StateProviderFactory + BlockReaderIdExt + ChainSpecProvider + Clone + 'static{
+//! async fn t<C>(client: C)  where C: StateProviderFactory + Clone + 'static{
 //!     let blob_store = InMemoryBlobStore::default();
 //!     let pool = Pool::eth_pool(
 //!         TransactionValidationTaskExecutor::eth(client, MAINNET.clone(), blob_store.clone(), TokioTaskExecutor::default()),
@@ -278,7 +278,7 @@ where
 
 impl<Client, S> EthTransactionPool<Client, S>
 where
-    Client: StateProviderFactory + reth_storage_api::BlockReaderIdExt + Clone + 'static,
+    Client: StateProviderFactory + Clone + 'static,
     S: BlobStore,
 {
     /// Returns a new [`Pool`] that uses the default [`TransactionValidationTaskExecutor`] when
@@ -288,12 +288,12 @@ where
     ///
     /// ```
     /// use reth_chainspec::MAINNET;
-    /// use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+    /// use reth_storage_api::StateProviderFactory;
     /// use reth_tasks::TokioTaskExecutor;
     /// use reth_transaction_pool::{
     ///     blobstore::InMemoryBlobStore, Pool, TransactionValidationTaskExecutor,
     /// };
-    /// # fn t<C>(client: C)  where C: StateProviderFactory + BlockReaderIdExt + Clone + 'static {
+    /// # fn t<C>(client: C)  where C: StateProviderFactory + Clone + 'static {
     /// let blob_store = InMemoryBlobStore::default();
     /// let pool = Pool::eth_pool(
     ///     TransactionValidationTaskExecutor::eth(

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -15,7 +15,7 @@ use reth_primitives::{
     EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
     LEGACY_TX_TYPE_ID,
 };
-use reth_storage_api::{AccountReader, BlockReaderIdExt, StateProviderFactory};
+use reth_storage_api::{AccountReader, StateProviderFactory};
 use reth_tasks::TaskSpawner;
 use revm::{
     interpreter::gas::validate_initial_tx_gas,
@@ -48,7 +48,7 @@ impl<Client, Tx> EthTransactionValidator<Client, Tx> {
 
 impl<Client, Tx> EthTransactionValidator<Client, Tx>
 where
-    Client: StateProviderFactory + BlockReaderIdExt,
+    Client: StateProviderFactory,
     Tx: EthPoolTransaction,
 {
     /// Validates a single transaction.
@@ -77,7 +77,7 @@ where
 
 impl<Client, Tx> TransactionValidator for EthTransactionValidator<Client, Tx>
 where
-    Client: StateProviderFactory + BlockReaderIdExt,
+    Client: StateProviderFactory,
     Tx: EthPoolTransaction,
 {
     type Transaction = Tx;
@@ -146,7 +146,7 @@ impl<Client, Tx> EthTransactionValidatorInner<Client, Tx> {
 
 impl<Client, Tx> EthTransactionValidatorInner<Client, Tx>
 where
-    Client: StateProviderFactory + BlockReaderIdExt,
+    Client: StateProviderFactory,
     Tx: EthPoolTransaction,
 {
     /// Validates a single transaction.

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -9,7 +9,6 @@ use crate::{
 use futures_util::{lock::Mutex, StreamExt};
 use reth_chainspec::ChainSpec;
 use reth_primitives::SealedBlock;
-use reth_storage_api::BlockReaderIdExt;
 use reth_tasks::TaskSpawner;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::{
@@ -111,10 +110,7 @@ impl<V> TransactionValidationTaskExecutor<V> {
     }
 }
 
-impl<Client, Tx> TransactionValidationTaskExecutor<EthTransactionValidator<Client, Tx>>
-where
-    Client: BlockReaderIdExt,
-{
+impl<Client, Tx> TransactionValidationTaskExecutor<EthTransactionValidator<Client, Tx>> {
     /// Creates a new instance for the given [`ChainSpec`]
     ///
     /// This will spawn a single validation tasks that performs the actual validation.


### PR DESCRIPTION
this is no longer required,
this was previously used to lookup new blocks but with:

https://github.com/paradigmxyz/reth/blob/7258bcbf87b84b4c2ce0d11ec6a2ce79277698ef/crates/transaction-pool/src/validate/mod.rs#L213-L213

this is no longer necessary