### PR TITLE
fix: reject 7702 transactions with empty auth list

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -12,8 +12,8 @@ use reth_rpc_types::{
     error::EthRpcErrorCode, request::TransactionInputError, BlockError, ToRpcError,
 };
 use reth_transaction_pool::error::{
-    Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError, PoolErrorKind,
-    PoolTransactionError,
+    Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
+    PoolError, PoolErrorKind, PoolTransactionError,
 };
 use revm::primitives::{EVMError, ExecutionResult, HaltReason, OutOfGasError};
 use revm_inspectors::tracing::MuxError;
@@ -593,9 +593,12 @@ pub enum RpcPoolError {
     /// Custom pool error
     #[error(transparent)]
     PoolTransactionError(Box<dyn PoolTransactionError>),
-    /// Eip-4844 related error
+    /// EIP-4844 related error
     #[error(transparent)]
     Eip4844(#[from] Eip4844PoolTransactionError),
+    /// EIP-7702 related error
+    #[error(transparent)]
+    Eip7702(#[from] Eip7702PoolTransactionError),
     /// Thrown if a conflicting transaction type is already in the pool
     ///
     /// In other words, thrown if a transaction with the same sender that violates the exclusivity
@@ -647,6 +650,7 @@ impl From<InvalidPoolTransactionError> for RpcPoolError {
             InvalidPoolTransactionError::Underpriced => Self::Underpriced,
             InvalidPoolTransactionError::Other(err) => Self::PoolTransactionError(err),
             InvalidPoolTransactionError::Eip4844(err) => Self::Eip4844(err),
+            InvalidPoolTransactionError::Eip7702(err) => Self::Eip7702(err),
             InvalidPoolTransactionError::Overdraft => {
                 Self::Invalid(RpcInvalidTransactionError::InsufficientFunds)
             }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -168,6 +168,15 @@ pub enum Eip4844PoolTransactionError {
     Eip4844NonceGap,
 }
 
+/// Represents all errors that can happen when validating transactions for the pool for EIP-7702
+/// transactions
+#[derive(Debug, thiserror::Error)]
+pub enum Eip7702PoolTransactionError {
+    /// Thrown if the transaction has no items in its authorization list
+    #[error("no items in authorization list for EIP7702 transaction")]
+    MissingEip7702AuthorizationList,
+}
+
 /// Represents errors that can happen when validating transactions for the pool
 ///
 /// See [`TransactionValidator`](crate::TransactionValidator).
@@ -195,9 +204,12 @@ pub enum InvalidPoolTransactionError {
     /// Thrown if the transaction's would require an account to be overdrawn
     #[error("transaction overdraws from account")]
     Overdraft,
-    /// Eip-4844 related errors
+    /// EIP-4844 related errors
     #[error(transparent)]
     Eip4844(#[from] Eip4844PoolTransactionError),
+    /// EIP-7702 related errors
+    #[error(transparent)]
+    Eip7702(#[from] Eip7702PoolTransactionError),
     /// Any other error that occurred while inserting/validating that is transaction specific
     #[error(transparent)]
     Other(Box<dyn PoolTransactionError>),
@@ -289,6 +301,9 @@ impl InvalidPoolTransactionError {
                     }
                 }
             }
+            Self::Eip7702(eip7702_err) => match eip7702_err {
+                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => false,
+            },
         }
     }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -3,7 +3,9 @@
 use super::constants::DEFAULT_MAX_TX_INPUT_BYTES;
 use crate::{
     blobstore::BlobStore,
-    error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
+    error::{
+        Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
+    },
     traits::TransactionOrigin,
     validate::{ValidTransaction, ValidationTask, MAX_INIT_CODE_BYTE_SIZE},
     EthBlobTransactionSidecar, EthPoolTransaction, LocalTransactionConfig, PoolTransaction,
@@ -272,6 +274,13 @@ where
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
+                )
+            }
+
+            if transaction.authorization_count() == 0 {
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into(),
                 )
             }
         }


### PR DESCRIPTION
If an EIP-7702 transaction has no authorization list items it won't be included in a block, so we might as well reject it in the pool too.