### PR TITLE
refactor: relax bound on `NodeTypesWithDB`

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -10,7 +10,7 @@ use reth_network_p2p::{
     sync::{NetworkSyncUpdater, SyncState},
     BlockClient,
 };
-use reth_node_types::NodeTypesWithDB;
+use reth_node_types::NodeTypesWithEngine;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{PayloadAttributes, PayloadBuilderAttributes};
 use reth_payload_validator::ExecutionPayloadValidator;
@@ -86,6 +86,11 @@ const MAX_INVALID_HEADERS: u32 = 512u32;
 /// This is the default threshold, the distance to the head that the tree will be used for sync.
 /// If the distance exceeds this threshold, the pipeline will be used for sync.
 pub const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = EPOCH_SLOTS;
+
+/// Helper trait expressing requirements for node types to be used in engine.
+pub trait EngineNodeTypes: ProviderNodeTypes + NodeTypesWithEngine {}
+
+impl<T> EngineNodeTypes for T where T: ProviderNodeTypes + NodeTypesWithEngine {}
 
 /// Represents a pending forkchoice update.
 ///
@@ -169,7 +174,7 @@ type PendingForkchoiceUpdate<PayloadAttributes> =
 #[allow(missing_debug_implementations)]
 pub struct BeaconConsensusEngine<N, BT, Client>
 where
-    N: NodeTypesWithDB,
+    N: EngineNodeTypes,
     Client: BlockClient,
     BT: BlockchainTreeEngine
         + BlockReader
@@ -225,7 +230,7 @@ where
 
 impl<N, BT, Client> BeaconConsensusEngine<N, BT, Client>
 where
-    N: ProviderNodeTypes,
+    N: EngineNodeTypes,
     BT: BlockchainTreeEngine
         + BlockReader
         + BlockIdReader
@@ -1789,7 +1794,7 @@ where
 /// receiver and forwarding them to the blockchain tree.
 impl<N, BT, Client> Future for BeaconConsensusEngine<N, BT, Client>
 where
-    N: ProviderNodeTypes,
+    N: EngineNodeTypes,
     Client: BlockClient + 'static,
     BT: BlockchainTreeEngine
         + BlockReader

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -1,6 +1,6 @@
 use futures::{Stream, StreamExt};
 use pin_project::pin_project;
-use reth_beacon_consensus::{BeaconConsensusEngineEvent, BeaconEngineMessage};
+use reth_beacon_consensus::{BeaconConsensusEngineEvent, BeaconEngineMessage, EngineNodeTypes};
 use reth_consensus::Consensus;
 use reth_engine_tree::{
     backfill::PipelineSync,
@@ -18,10 +18,7 @@ use reth_network_p2p::BlockClient;
 use reth_node_types::NodeTypesWithEngine;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_validator::ExecutionPayloadValidator;
-use reth_provider::{
-    providers::{BlockchainProvider2, ProviderNodeTypes},
-    ProviderFactory,
-};
+use reth_provider::{providers::BlockchainProvider2, ProviderFactory};
 use reth_prune::Pruner;
 use reth_stages_api::Pipeline;
 use reth_tasks::TaskSpawner;
@@ -50,7 +47,7 @@ type EngineServiceType<N, Client> = ChainOrchestrator<
 #[allow(missing_debug_implementations)]
 pub struct EngineService<N, Client, E>
 where
-    N: ProviderNodeTypes,
+    N: EngineNodeTypes,
     Client: BlockClient + 'static,
     E: BlockExecutorProvider + 'static,
 {
@@ -60,7 +57,7 @@ where
 
 impl<N, Client, E> EngineService<N, Client, E>
 where
-    N: ProviderNodeTypes,
+    N: EngineNodeTypes,
     Client: BlockClient + 'static,
     E: BlockExecutorProvider + 'static,
 {
@@ -119,7 +116,7 @@ where
 
 impl<N, Client, E> Stream for EngineService<N, Client, E>
 where
-    N: ProviderNodeTypes,
+    N: EngineNodeTypes,
     Client: BlockClient + 'static,
     E: BlockExecutorProvider + 'static,
 {

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -19,7 +19,7 @@ use crate::ConfigureEvm;
 /// Its types are configured by node internally and are not intended to be user configurable.
 pub trait FullNodeTypes: Send + Sync + Unpin + 'static {
     /// Node's types with the database.
-    type Types: NodeTypesWithDB;
+    type Types: NodeTypesWithDB + NodeTypesWithEngine;
     /// The provider type used to interact with the node.
     type Provider: FullProvider<Self::Types>;
 }
@@ -35,7 +35,7 @@ pub struct FullNodeTypesAdapter<Types, Provider> {
 
 impl<Types, Provider> FullNodeTypes for FullNodeTypesAdapter<Types, Provider>
 where
-    Types: NodeTypesWithDB,
+    Types: NodeTypesWithDB + NodeTypesWithEngine,
     Provider: FullProvider<Types>,
 {
     type Types = Types;

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -16,7 +16,9 @@ use reth_engine_util::EngineMessageStreamExt;
 use reth_exex::ExExManagerHandle;
 use reth_network::{NetworkSyncUpdater, SyncState};
 use reth_network_api::{BlockDownloaderProvider, NetworkEventListenerProvider};
-use reth_node_api::{BuiltPayload, FullNodeTypes, NodeAddOns, NodeTypesWithDB};
+use reth_node_api::{
+    BuiltPayload, FullNodeTypes, NodeAddOns, NodeTypesWithDB, NodeTypesWithEngine,
+};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
@@ -58,7 +60,7 @@ impl EngineNodeLauncher {
 
 impl<Types, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for EngineNodeLauncher
 where
-    Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
+    Types: NodeTypesWithDB<ChainSpec = ChainSpec> + NodeTypesWithEngine,
     T: FullNodeTypes<Types = Types, Provider = BlockchainProvider2<Types>>,
     CB: NodeComponentsBuilder<T>,
     AO: NodeAddOns<

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -21,7 +21,9 @@ use reth_consensus_debug_client::{DebugConsensusClient, EtherscanBlockProvider, 
 use reth_engine_util::EngineMessageStreamExt;
 use reth_exex::ExExManagerHandle;
 use reth_network::{BlockDownloaderProvider, NetworkEventListenerProvider};
-use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypesWithDB};
+use reth_node_api::{
+    FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypesWithDB, NodeTypesWithEngine,
+};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
@@ -102,7 +104,7 @@ impl DefaultNodeLauncher {
 
 impl<Types, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for DefaultNodeLauncher
 where
-    Types: NodeTypesWithDB<ChainSpec = ChainSpec>,
+    Types: NodeTypesWithDB<ChainSpec = ChainSpec> + NodeTypesWithEngine,
     T: FullNodeTypes<Provider = BlockchainProvider<Types>, Types = Types>,
     CB: NodeComponentsBuilder<T>,
     AO: NodeAddOns<

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -46,7 +46,7 @@ pub trait NodeTypesWithEngine: NodeTypes {
 /// node.
 ///
 /// Its types are configured by node internally and are not intended to be user configurable.
-pub trait NodeTypesWithDB: NodeTypesWithEngine {
+pub trait NodeTypesWithDB: NodeTypes {
     /// Underlying database type used by the node to store and retrieve data.
     type DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static;
 }
@@ -96,7 +96,7 @@ where
 
 impl<Types, DB> NodeTypesWithDB for NodeTypesWithDBAdapter<Types, DB>
 where
-    Types: NodeTypesWithEngine,
+    Types: NodeTypes,
     DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
 {
     type DB = DB;


### PR DESCRIPTION
Removes `NodeTypesWithDB: NodeTypesWithEngine` bound to allow using providers without engine types