### PR TITLE
fix: don't filter out hardforks

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -680,9 +680,12 @@ impl From<Genesis> for ChainSpec {
         let mut ordered_hardforks = Vec::with_capacity(hardforks.len());
         for (hardfork, _) in mainnet_order {
             if let Some(pos) = hardforks.iter().position(|(e, _)| **e == *hardfork) {
-                ordered_hardforks.push(hardforks[pos].clone());
+                ordered_hardforks.push(hardforks.remove(pos));
             }
         }
+
+        // append the remaining unknown hardforks to ensure we don't filter any out
+        ordered_hardforks.extend(hardforks);
 
         // NOTE: in full node, we prune all receipts except the deposit contract's. We do not
         // have the deployment block in the genesis file, so we use block zero. We use the same


### PR DESCRIPTION
Currently if a hardfork is not activated on e.g. mainnet for Ethereum, the hardfork would be filtered out when specified in the genesis, because we try to sort the hardforks by activation order.

For now, we just add the "unknown" forks at the end of the list