### PR TITLE
chore: ignore proc-macro-error 1.0.4 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,8 +2,11 @@
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-version = 2
 yanked = "warn"
+ignore = [
+    # proc-macro-error 1.0.4 unmaintained https://rustsec.org/advisories/RUSTSEC-2024-0370
+    "RUSTSEC-2024-0370"
+]
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:


### PR DESCRIPTION
error[unmaintained]: proc-macro-error is unmaintained
    ┌─ /Users/Matthias/git/rust/reth/Cargo.lock:160:1
    │
160 │ proc-macro-error 1.0.4 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0370
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0370
    ├ proc-macro-error's maintainer seems to be unreachable, with no commits for 2 years, no releases pushed for 4 years, and no activity on the GitLab repo or response to email.
      
      proc-macro-error also depends on `syn 1.x`, which may be bringing duplicate dependencies into dependant build trees.


can't get of it ourselves
├── aquamarine v0.5.0 (proc-macro)
│   ├── reth v1.0.6 (/Users/Matthias/git/rust/reth/bin/reth) (*)
│   ├── reth-blockchain-tree v1.0.6 (/Users/Matthias/git/rust/reth/crates/blockchain-tree) (*)
│   ├── reth-network v1.0.6 (/Users/Matthias/git/rust/reth/crates/net/network) (*)
│   ├── reth-node-builder v1.0.6 (/Users/Matthias/git/rust/reth/crates/node/builder) (*)
│   ├── reth-stages-api v1.0.6 (/Users/Matthias/git/rust/reth/crates/stages/api) (*)
│   └── reth-transaction-pool v1.0.6 (/Users/Matthias/git/rust/reth/crates/transaction-pool) (*)
└── iai-callgrind-macros v0.2.0 (proc-macro)
    └── iai-callgrind v0.11.1
        [dev-dependencies]
        ├── reth-db v1.0.6 (/Users/Matthias/git/rust/reth/crates/storage/db) (*)
        └── reth-db-api v1.0.6 (/Users/Matthias/git/rust/reth/crates/storage/db-api) (*)

