### PR TITLE
feat(tree): add block validation metrics

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -11,6 +11,8 @@ pub(crate) struct EngineApiMetrics {
     pub(crate) engine: EngineMetrics,
     /// Block executor metrics.
     pub(crate) executor: ExecutorMetrics,
+    /// Metrics for block validation
+    pub(crate) block_validation: BlockValidationMetrics,
 }
 
 /// Metrics for the `EngineApi`.
@@ -28,4 +30,22 @@ pub(crate) struct EngineMetrics {
     /// Histogram of persistence operation durations (in seconds)
     pub(crate) persistence_duration: Histogram,
     // TODO add latency metrics
+}
+
+/// Metrics for non-execution related block validation.
+#[derive(Metrics)]
+#[metrics(scope = "sync.block_validation")]
+pub(crate) struct BlockValidationMetrics {
+    /// Histogram of state root duration
+    pub(crate) state_root_histogram: Histogram,
+    /// Latest state root duration
+    pub(crate) state_root_duration: Gauge,
+}
+
+impl BlockValidationMetrics {
+    /// Records a new state root time, updating both the histogram and state root gauge
+    pub(crate) fn record_state_root(&self, elapsed_as_secs: f64) {
+        self.state_root_duration.set(elapsed_as_secs);
+        self.state_root_histogram.record(elapsed_as_secs);
+    }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2179,7 +2179,9 @@ where
             .into())
         }
 
-        debug!(target: "engine", elapsed=?root_time.elapsed(), ?block_number, "Calculated state root");
+        let root_elapsed = root_time.elapsed();
+        self.metrics.block_validation.record_state_root(root_elapsed.as_secs_f64());
+        debug!(target: "engine", ?root_elapsed, ?block_number, "Calculated state root");
 
         let executed = ExecutedBlock {
             block: sealed_block.clone(),

--- a/crates/evm/src/metrics.rs
+++ b/crates/evm/src/metrics.rs
@@ -4,7 +4,7 @@
 //! [`ExecutorMetrics::metered`].
 use std::time::Instant;
 
-use metrics::{Counter, Gauge};
+use metrics::{Counter, Gauge, Histogram};
 use reth_execution_types::BlockExecutionInput;
 use reth_metrics::Metrics;
 use reth_primitives::BlockWithSenders;
@@ -18,6 +18,10 @@ pub struct ExecutorMetrics {
     pub gas_processed_total: Counter,
     /// The instantaneous amount of gas processed per second.
     pub gas_per_second: Gauge,
+    /// The Histogram for amount of time taken to execute blocks.
+    pub execution_histogram: Histogram,
+    /// The total amount of time it took to execute the latest block.
+    pub execution_duration: Gauge,
 }
 
 impl ExecutorMetrics {
@@ -36,6 +40,8 @@ impl ExecutorMetrics {
         // Update gas metrics.
         self.gas_processed_total.increment(gas_used);
         self.gas_per_second.set(gas_used as f64 / execution_duration);
+        self.execution_histogram.record(execution_duration);
+        self.execution_duration.set(execution_duration);
 
         output
     }


### PR DESCRIPTION
This adds a block validation metrics struct for the new engine, now recording the state root duration and a histogram for state root duration. `execution_duration` / `execution_histogram` is also added for execution