### PR TITLE
feat(witness): use block executor to execute block inside debug_execution_witness

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -379,10 +379,11 @@ where
         let EthExecuteOutput { receipts, requests, gas_used } =
             self.execute_without_verification(block, total_difficulty)?;
 
-        let cache = core::mem::take(&mut self.state.cache);
+        self.state.merge_transitions(BundleRetention::Reverts);
+
         Ok(BlockExecutionOutput {
             state: self.state.take_bundle(),
-            cache,
+            cache: core::mem::take(&mut self.state.cache),
             receipts,
             requests,
             gas_used,

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -379,6 +379,7 @@ where
         let EthExecuteOutput { receipts, requests, gas_used } =
             self.execute_without_verification(block, total_difficulty)?;
 
+        // NOTE: we need to merge keep the reverts for the bundle retention
         self.state.merge_transitions(BundleRetention::Reverts);
 
         Ok(BlockExecutionOutput {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -31,7 +31,7 @@ use reth_revm::{
         BundleAccount, State,
     },
     state_change::post_block_balance_increments,
-    Evm,
+    Evm, State
 };
 use revm_primitives::{
     db::{Database, DatabaseCommit},
@@ -379,10 +379,14 @@ where
         let EthExecuteOutput { receipts, requests, gas_used } =
             self.execute_without_verification(block, total_difficulty)?;
 
-        // NOTE: we need to merge keep the reverts for the bundle retention
-        self.state.merge_transitions(BundleRetention::Reverts);
-
-        Ok(BlockExecutionOutput { state: self.state.take_bundle(), receipts, requests, gas_used })
+        let cache = core::mem::take(&mut self.state.cache);
+        Ok(BlockExecutionOutput {
+            state: self.state.take_bundle(),
+            cache,
+            receipts,
+            requests,
+            gas_used,
+        })
     }
 }
 

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,5 +1,5 @@
 use reth_primitives::{Request, U256};
-use revm::db::BundleState;
+use revm::{db::BundleState, CacheState};
 
 /// A helper type for ethereum block inputs that consists of a block and the total difficulty.
 #[derive(Debug)]
@@ -30,6 +30,8 @@ impl<'a, Block> From<(&'a Block, U256)> for BlockExecutionInput<'a, Block> {
 pub struct BlockExecutionOutput<T> {
     /// The changed state of the block after execution.
     pub state: BundleState,
+    /// cache state of the block after execution.
+    pub cache: CacheState,
     /// All the receipts of the transactions in the block.
     pub receipts: Vec<T>,
     /// All the EIP-7685 requests of the transactions in the block.

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -55,6 +55,7 @@ impl<DB> Executor<DB> for MockExecutorProvider {
             self.exec_results.lock().pop().unwrap();
         Ok(BlockExecutionOutput {
             state: bundle,
+            cache: Default::default(),
             receipts: receipts.into_iter().flatten().flatten().collect(),
             requests: requests.into_iter().flatten().collect(),
             gas_used: 0,

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -192,6 +192,7 @@ pub struct RpcRegistry<Node: FullNodeComponents, EthApi: EthApiTypes> {
         TaskExecutor,
         Node::Provider,
         EthApi,
+        Node::Executor,
     >,
 }
 
@@ -207,6 +208,7 @@ where
         TaskExecutor,
         Node::Provider,
         EthApi,
+        Node::Executor,
     >;
 
     fn deref(&self) -> &Self::Target {
@@ -322,6 +324,7 @@ where
         .with_events(node.provider().clone())
         .with_executor(node.task_executor().clone())
         .with_evm_config(node.evm_config().clone())
+        .with_block_executor(node.block_executor().clone())
         .build_with_auth_server(module_config, engine_api, EthApi::eth_api_builder());
 
     let mut registry = RpcRegistry { registry };

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -362,10 +362,9 @@ where
         // NOTE: we need to merge keep the reverts for the bundle retention
         self.state.merge_transitions(BundleRetention::Reverts);
 
-        let cache = core::mem::take(&mut self.state.cache);
         Ok(BlockExecutionOutput {
             state: self.state.take_bundle(),
-            cache,
+            cache: core::mem::take(&mut self.state.cache),
             receipts,
             requests: vec![],
             gas_used,

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -160,12 +160,12 @@ where
                     transaction_gas_limit: transaction.gas_limit(),
                     block_available_gas,
                 }
-                .into());
+                .into())
             }
 
             // An optimism block should never contain blob transactions.
             if matches!(transaction.tx_type(), TxType::Eip4844) {
-                return Err(OptimismBlockExecutionError::BlobTransactionRejected.into());
+                return Err(OptimismBlockExecutionError::BlobTransactionRejected.into())
             }
 
             // Cache the depositor account prior to the state transition for the deposit nonce.

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -160,12 +160,12 @@ where
                     transaction_gas_limit: transaction.gas_limit(),
                     block_available_gas,
                 }
-                .into())
+                .into());
             }
 
             // An optimism block should never contain blob transactions.
             if matches!(transaction.tx_type(), TxType::Eip4844) {
-                return Err(OptimismBlockExecutionError::BlobTransactionRejected.into())
+                return Err(OptimismBlockExecutionError::BlobTransactionRejected.into());
             }
 
             // Cache the depositor account prior to the state transition for the deposit nonce.
@@ -362,8 +362,10 @@ where
         // NOTE: we need to merge keep the reverts for the bundle retention
         self.state.merge_transitions(BundleRetention::Reverts);
 
+        let cache = core::mem::take(&mut self.state.cache);
         Ok(BlockExecutionOutput {
             state: self.state.take_bundle(),
+            cache,
             receipts,
             requests: vec![],
             gas_used,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -83,7 +83,16 @@
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::TransactionPool;
 //! use tokio::try_join;
-//! pub async fn launch<Provider, Pool, Network, Events, EngineApi, EngineT, EvmConfig, BlockExecutor>(
+//! pub async fn launch<
+//!     Provider,
+//!     Pool,
+//!     Network,
+//!     Events,
+//!     EngineApi,
+//!     EngineT,
+//!     EvmConfig,
+//!     BlockExecutor,
+//! >(
 //!     provider: Provider,
 //!     pool: Pool,
 //!     network: Network,
@@ -1403,9 +1412,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
     ///
     /// If no server is configured, no server will be launched on [`RpcServerConfig::start`].
     pub const fn has_server(&self) -> bool {
-        self.http_server_config.is_some()
-            || self.ws_server_config.is_some()
-            || self.ipc_server_config.is_some()
+        self.http_server_config.is_some() ||
+            self.ws_server_config.is_some() ||
+            self.ipc_server_config.is_some()
     }
 
     /// Returns the [`SocketAddr`] of the http server
@@ -1470,9 +1479,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
         }
 
         // If both are configured on the same port, we combine them into one server.
-        if self.http_addr == self.ws_addr
-            && self.http_server_config.is_some()
-            && self.ws_server_config.is_some()
+        if self.http_addr == self.ws_addr &&
+            self.http_server_config.is_some() &&
+            self.ws_server_config.is_some()
         {
             let cors = match (self.ws_cors_domains.as_ref(), self.http_cors_domains.as_ref()) {
                 (Some(ws_cors), Some(http_cors)) => {
@@ -1892,8 +1901,8 @@ impl RpcServerHandle {
                 "Bearer {}",
                 secret
                     .encode(&Claims {
-                        iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
-                            + Duration::from_secs(60))
+                        iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
+                            Duration::from_secs(60))
                         .as_secs(),
                         exp: None,
                     })

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -3,10 +3,13 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
 use reth_chainspec::MAINNET;
 use reth_ethereum_engine_primitives::EthEngineTypes;
-use reth_evm_ethereum::EthEvmConfig;
+use reth_evm_ethereum::{execute::EthExecutorProvider, EthEvmConfig};
 use reth_network_api::noop::NoopNetwork;
 use reth_payload_builder::test_utils::spawn_test_payload_service;
-use reth_provider::test_utils::{NoopProvider, TestCanonStateSubscriptions};
+use reth_provider::{
+    test_utils::{NoopProvider, TestCanonStateSubscriptions},
+    ChainSpecProvider,
+};
 use reth_rpc::EthApi;
 use reth_rpc_builder::{
     auth::{AuthRpcModule, AuthServerConfig, AuthServerHandle},
@@ -123,12 +126,15 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
     TokioTaskExecutor,
     TestCanonStateSubscriptions,
     EthEvmConfig,
+    EthExecutorProvider<EthEvmConfig>,
 > {
+    let provider = NoopProvider::default();
     RpcModuleBuilder::default()
-        .with_provider(NoopProvider::default())
+        .with_provider(provider)
         .with_pool(TestPoolBuilder::default().into())
         .with_network(NoopNetwork::default())
         .with_executor(TokioTaskExecutor::default())
         .with_events(TestCanonStateSubscriptions::default())
         .with_evm_config(EthEvmConfig::new(MAINNET.clone()))
+        .with_block_executor(EthExecutorProvider::ethereum(provider.chain_spec()))
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -580,7 +580,7 @@ where
             .eth_api
             .block_with_senders(block_id.into())
             .await?
-            .ok_or(EthApiError::UnknownBlockNumber)?;
+            .ok_or(EthApiError::HeaderNotFound(block_id.into()))?;
 
         let this = self.clone();
 

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -33,8 +33,8 @@ use reth::rpc::builder::{
 // Configuring the network parts, ideally also wouldn't need to think about this.
 use myrpc_ext::{MyRpcExt, MyRpcExtApiServer};
 use reth::{blockchain_tree::noop::NoopBlockchainTree, tasks::TokioTaskExecutor};
-use reth_node_ethereum::{EthEvmConfig, EthereumNode};
-use reth_provider::test_utils::TestCanonStateSubscriptions;
+use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider, EthereumNode};
+use reth_provider::{test_utils::TestCanonStateSubscriptions, ChainSpecProvider};
 
 // Custom rpc extension
 pub mod myrpc_ext;
@@ -67,7 +67,9 @@ async fn main() -> eyre::Result<()> {
         .with_noop_network()
         .with_executor(TokioTaskExecutor::default())
         .with_evm_config(EthEvmConfig::new(spec))
-        .with_events(TestCanonStateSubscriptions::default());
+        .with_events(TestCanonStateSubscriptions::default())
+        .with_block_executor(EthExecutorProvider::ethereum(provider.chain_spec()));
+>>>>>>> 7d9b7e746 (Add block_executor to debug_execution_witness to execute blocks)
 
     // Pick which namespaces to expose.
     let config = TransportRpcModuleConfig::default().with_http([RethRpcModule::Eth]);


### PR DESCRIPTION
## Description

The code does the following:
1. allow passing `BlockExecutorProvider` to `RpcModuleBuilder` and eventually passed down to `DebugApi` initialization
2. rework `debug_execution_witness` API to use block_executor to execute blocks.