### PR TITLE
feat: expose `ChainSpec` metrics

### DIFF
--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -28,6 +28,7 @@ use reth_node_core::{
     },
 };
 use reth_node_metrics::{
+    chain::ChainSpecInfo,
     hooks::Hooks,
     server::{MetricServer, MetricServerConfig},
     version::VersionInfo,
@@ -130,6 +131,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                     target_triple: VERGEN_CARGO_TARGET_TRIPLE,
                     build_profile: BUILD_PROFILE_NAME,
                 },
+                ChainSpecInfo { name: format!("{}", provider_factory.chain_spec().chain) },
                 ctx.task_executor,
                 Hooks::new(
                     provider_factory.db_ref().clone(),

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -131,7 +131,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                     target_triple: VERGEN_CARGO_TARGET_TRIPLE,
                     build_profile: BUILD_PROFILE_NAME,
                 },
-                ChainSpecInfo { name: format!("{}", provider_factory.chain_spec().chain) },
+                ChainSpecInfo { name: provider_factory.chain_spec().chain.to_string() },
                 ctx.task_executor,
                 Hooks::new(
                     provider_factory.db_ref().clone(),

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -28,6 +28,7 @@ use reth_node_core::{
     },
 };
 use reth_node_metrics::{
+    chain::ChainSpecInfo,
     hooks::Hooks,
     server::{MetricServer, MetricServerConfig},
     version::VersionInfo,
@@ -504,6 +505,7 @@ where
                     target_triple: VERGEN_CARGO_TARGET_TRIPLE,
                     build_profile: BUILD_PROFILE_NAME,
                 },
+                ChainSpecInfo { name: format!("{}", self.left().config.chain.chain) },
                 self.task_executor().clone(),
                 Hooks::new(self.database().clone(), self.static_file_provider()),
             );

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -505,7 +505,7 @@ where
                     target_triple: VERGEN_CARGO_TARGET_TRIPLE,
                     build_profile: BUILD_PROFILE_NAME,
                 },
-                ChainSpecInfo { name: format!("{}", self.left().config.chain.chain) },
+                ChainSpecInfo { name: self.left().config.chain.chain.to_string() },
                 self.task_executor().clone(),
                 Hooks::new(self.database().clone(), self.static_file_provider()),
             );

--- a/crates/node/metrics/src/chain.rs
+++ b/crates/node/metrics/src/chain.rs
@@ -1,0 +1,19 @@
+//! This exposes reth's chain information over prometheus.
+use metrics::{describe_gauge, gauge};
+
+/// Contains chain information for the application.
+#[derive(Debug, Clone)]
+pub struct ChainSpecInfo {
+    /// The name of the chain.
+    pub name: String,
+}
+
+impl ChainSpecInfo {
+    /// This exposes reth's chain information over prometheus.
+    pub fn register_chain_spec_metrics(&self) {
+        let labels: [(&str, String); 1] = [("name", self.name.clone())];
+
+        describe_gauge!("chain_spec", "Information about the chain");
+        let _gauge = gauge!("chain_spec", &labels);
+    }
+}

--- a/crates/node/metrics/src/lib.rs
+++ b/crates/node/metrics/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+pub mod chain;
 /// The metrics hooks for prometheus.
 pub mod hooks;
 pub mod recorder;

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -255,7 +255,6 @@ mod tests {
 
         // Check the response body
         let body = response.text().await.unwrap();
-        assert!(body.contains("reth_chain_spec"));
         assert!(body.contains("reth_db_table_size"));
         assert!(body.contains("reth_jemalloc_metadata"));
     }

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -1,4 +1,5 @@
 use crate::{
+    chain::ChainSpecInfo,
     hooks::{Hook, Hooks},
     recorder::install_prometheus_recorder,
     version::VersionInfo,
@@ -17,6 +18,7 @@ use tracing::info;
 pub struct MetricServerConfig {
     listen_addr: SocketAddr,
     version_info: VersionInfo,
+    chain_spec_info: ChainSpecInfo,
     task_executor: TaskExecutor,
     hooks: Hooks,
 }
@@ -26,10 +28,11 @@ impl MetricServerConfig {
     pub const fn new(
         listen_addr: SocketAddr,
         version_info: VersionInfo,
+        chain_spec_info: ChainSpecInfo,
         task_executor: TaskExecutor,
         hooks: Hooks,
     ) -> Self {
-        Self { listen_addr, hooks, task_executor, version_info }
+        Self { listen_addr, hooks, task_executor, version_info, chain_spec_info }
     }
 }
 
@@ -47,7 +50,8 @@ impl MetricServer {
 
     /// Spawns the metrics server
     pub async fn serve(&self) -> eyre::Result<()> {
-        let MetricServerConfig { listen_addr, hooks, task_executor, version_info } = &self.config;
+        let MetricServerConfig { listen_addr, hooks, task_executor, version_info, chain_spec_info } =
+            &self.config;
 
         info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
 
@@ -68,6 +72,7 @@ impl MetricServer {
         describe_io_stats();
 
         version_info.register_version_metrics();
+        chain_spec_info.register_chain_spec_metrics();
 
         Ok(())
     }
@@ -221,6 +226,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_metrics_endpoint() {
+        let chain_spec_info = ChainSpecInfo { name: "test".to_string() };
         let version_info = VersionInfo {
             version: "test",
             build_timestamp: "test",
@@ -237,7 +243,8 @@ mod tests {
         let hooks = Hooks::new(factory.db_ref().clone(), factory.static_file_provider());
 
         let listen_addr = get_random_available_addr();
-        let config = MetricServerConfig::new(listen_addr, version_info, executor, hooks);
+        let config =
+            MetricServerConfig::new(listen_addr, version_info, chain_spec_info, executor, hooks);
 
         MetricServer::new(config).serve().await.unwrap();
 
@@ -248,6 +255,7 @@ mod tests {
 
         // Check the response body
         let body = response.text().await.unwrap();
+        assert!(body.contains("reth_chain_spec"));
         assert!(body.contains("reth_db_table_size"));
         assert!(body.contains("reth_jemalloc_metadata"));
     }

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -147,7 +147,79 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 20
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "reth_chain_spec{instance=~\"$instance\"}",
+          "instant": true,
+          "legendFormat": "{{name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Chain",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 3,
+        "y": 1
+      },
+      "id": 240,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -203,8 +275,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 6,
-        "x": 3,
+        "w": 5,
+        "x": 5,
         "y": 1
       },
       "id": 192,
@@ -271,8 +343,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 3,
-        "x": 9,
+        "w": 2,
+        "x": 10,
         "y": 1
       },
       "id": 193,


### PR DESCRIPTION
This adds a new `ChainSpecInfo` struct that can be used to expose static `ChainSpec` metrics. The primary goal of this is to add the chain's name to the Grafana dashboard, but potentially other labels derived from `ChainSpec` could also be exported.