### PR TITLE
fix: unwind_to should be exclusive

### DIFF
--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -317,8 +317,9 @@ where
 
         // First unwind the db tables, until the unwind_to block number. use the walker to unwind
         // HeaderNumbers based on the index in CanonicalHeaders
+        // unwind from the next block number since the unwind_to block is exclusive
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
-            input.unwind_to..,
+            (input.unwind_to + 1)..,
         )?;
         provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
         provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to)?;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1500,7 +1500,9 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         Ok(deleted)
     }
 
-    /// Unwind a table forward by a [`Walker`][reth_db_api::cursor::Walker] on another table
+    /// Unwind a table forward by a [`Walker`][reth_db_api::cursor::Walker] on another table.
+    ///
+    /// Note: Range is inclusive and first key in the range is removed.
     pub fn unwind_table_by_walker<T1, T2>(
         &self,
         range: impl RangeBounds<T1::Key>,


### PR DESCRIPTION
While unwinding with `unwind_table_by_walker`, the range passed is inclusive. To ensure the `unwind_to` block is preserved, we adjust the range to start from` unwind_to + 1 `

