### PR TITLE
refactor: remove `ChainSpec` from `ConfigureEvm`

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -19,7 +19,7 @@ use reth_evm::execute::{BlockExecutorProvider, Executor};
 use reth_execution_types::ExecutionOutcome;
 use reth_fs_util as fs;
 use reth_node_api::{NodeTypesWithDB, NodeTypesWithEngine, PayloadBuilderAttributes};
-use reth_node_ethereum::EthExecutorProvider;
+use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider};
 use reth_payload_builder::database::CachedReads;
 use reth_primitives::{
     revm_primitives::KzgSettings, Address, BlobTransaction, BlobTransactionSidecar, Bytes,
@@ -243,7 +243,9 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             None,
         );
 
-        let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::default();
+        let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
+            EthEvmConfig::new(provider_factory.chain_spec()),
+        );
 
         match payload_builder.try_build(args)? {
             BuildOutcome::Better { payload, .. } => {

--- a/bin/reth/src/commands/debug_cmd/replay_engine.rs
+++ b/bin/reth/src/commands/debug_cmd/replay_engine.rs
@@ -19,7 +19,7 @@ use reth_fs_util as fs;
 use reth_network::{BlockDownloaderProvider, NetworkHandle};
 use reth_network_api::NetworkInfo;
 use reth_node_api::{NodeTypesWithDB, NodeTypesWithDBAdapter, NodeTypesWithEngine};
-use reth_node_ethereum::{EthEngineTypes, EthExecutorProvider};
+use reth_node_ethereum::{EthEngineTypes, EthEvmConfig, EthExecutorProvider};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::{
     providers::BlockchainProvider, CanonStateSubscriptions, ChainSpecProvider, ProviderFactory,
@@ -117,7 +117,9 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             .await?;
 
         // Set up payload builder
-        let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::default();
+        let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
+            EthEvmConfig::new(provider_factory.chain_spec()),
+        );
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(
             blockchain_db.clone(),

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -64,13 +64,7 @@ where
         // Setup environment for the execution.
         let mut cfg = CfgEnvWithHandlerCfg::new(Default::default(), Default::default());
         let mut block_env = BlockEnv::default();
-        self.evm_config.fill_cfg_and_block_env(
-            &mut cfg,
-            &mut block_env,
-            &self.provider.chain_spec(),
-            block.header(),
-            U256::MAX,
-        );
+        self.evm_config.fill_cfg_and_block_env(&mut cfg, &mut block_env, block.header(), U256::MAX);
 
         // Setup EVM
         let mut evm = self.evm_config.evm_with_env(

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -279,13 +279,7 @@ where
     // Configure environments
     let mut cfg = CfgEnvWithHandlerCfg::new(Default::default(), Default::default());
     let mut block_env = BlockEnv::default();
-    evm_config.fill_cfg_and_block_env(
-        &mut cfg,
-        &mut block_env,
-        chain_spec,
-        &reorg_target.header,
-        U256::MAX,
-    );
+    evm_config.fill_cfg_and_block_env(&mut cfg, &mut block_env, &reorg_target.header, U256::MAX);
     let env = EnvWithHandlerCfg::new_with_cfg_env(cfg, block_env, Default::default());
     let mut evm = evm_config.evm_with_env(&mut state, env);
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -47,7 +47,7 @@ pub struct EthExecutorProvider<EvmConfig = EthEvmConfig> {
 impl EthExecutorProvider {
     /// Creates a new default ethereum executor provider.
     pub fn ethereum(chain_spec: Arc<ChainSpec>) -> Self {
-        Self::new(chain_spec, Default::default())
+        Self::new(chain_spec.clone(), EthEvmConfig::new(chain_spec))
     }
 
     /// Returns a new provider for the mainnet.
@@ -285,7 +285,6 @@ where
         self.executor.evm_config.fill_cfg_and_block_env(
             &mut cfg,
             &mut block_env,
-            self.chain_spec(),
             header,
             total_difficulty,
         );
@@ -522,7 +521,7 @@ mod tests {
     }
 
     fn executor_provider(chain_spec: Arc<ChainSpec>) -> EthExecutorProvider<EthEvmConfig> {
-        EthExecutorProvider { chain_spec, evm_config: Default::default() }
+        EthExecutorProvider { evm_config: EthEvmConfig::new(chain_spec.clone()), chain_spec }
     }
 
     #[test]

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -12,6 +12,8 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+use std::sync::Arc;
+
 use reth_chainspec::{ChainSpec, Head};
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{transaction::FillTxEnv, Address, Header, TransactionSigned, U256};
@@ -32,20 +34,28 @@ pub mod dao_fork;
 pub mod eip6110;
 
 /// Ethereum-related EVM configuration.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct EthEvmConfig;
+pub struct EthEvmConfig {
+    chain_spec: Arc<ChainSpec>,
+}
+
+impl EthEvmConfig {
+    /// Create a new `EthEvmConfig` with the given `chain_spec`.
+    pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
+        Self { chain_spec }
+    }
+}
 
 impl ConfigureEvmEnv for EthEvmConfig {
     fn fill_cfg_env(
         &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
-        chain_spec: &ChainSpec,
         header: &Header,
         total_difficulty: U256,
     ) {
         let spec_id = config::revm_spec(
-            chain_spec,
+            &self.chain_spec,
             &Head {
                 number: header.number,
                 timestamp: header.timestamp,
@@ -55,7 +65,7 @@ impl ConfigureEvmEnv for EthEvmConfig {
             },
         );
 
-        cfg_env.chain_id = chain_spec.chain().id();
+        cfg_env.chain_id = self.chain_spec.chain().id();
         cfg_env.perf_analyse_created_bytecodes = AnalysisKind::Analyse;
 
         cfg_env.handler_cfg.spec_id = spec_id;
@@ -115,7 +125,7 @@ impl ConfigureEvm for EthEvmConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_chainspec::{Chain, ChainSpec};
+    use reth_chainspec::{Chain, ChainSpec, MAINNET};
     use reth_evm::execute::ProviderError;
     use reth_primitives::{
         revm_primitives::{BlockEnv, CfgEnv, SpecId},
@@ -155,10 +165,9 @@ mod tests {
 
         // Use the `EthEvmConfig` to fill the `cfg_env` and `block_env` based on the ChainSpec,
         // Header, and total difficulty
-        EthEvmConfig::default().fill_cfg_and_block_env(
+        EthEvmConfig::new(Arc::new(chain_spec.clone())).fill_cfg_and_block_env(
             &mut cfg_env,
             &mut block_env,
-            &chain_spec,
             &header,
             total_difficulty,
         );
@@ -172,7 +181,7 @@ mod tests {
     #[allow(clippy::needless_update)]
     fn test_evm_configure() {
         // Create a default `EthEvmConfig`
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
         // Initialize an empty database wrapped in CacheDB
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
@@ -210,7 +219,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_env_default_spec() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -231,7 +240,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_env_custom_cfg() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -262,7 +271,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_env_custom_block_and_tx() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -296,7 +305,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_spec_id() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -319,7 +328,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_inspector() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -361,7 +370,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_env_and_default_inspector() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let env_with_handler = EnvWithHandlerCfg::default();
@@ -381,7 +390,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_env_inspector_and_custom_cfg() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let cfg = CfgEnv::default().with_chain_id(111);
@@ -406,7 +415,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_env_inspector_and_custom_block_tx() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         // Create custom block and tx environment
@@ -438,7 +447,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn test_evm_with_env_inspector_and_spec_id() {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let handler_cfg = HandlerCfg { spec_id: SpecId::CONSTANTINOPLE, ..Default::default() };

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -61,12 +61,6 @@ impl<EvmConfig> EthereumPayloadBuilder<EvmConfig> {
     }
 }
 
-impl Default for EthereumPayloadBuilder {
-    fn default() -> Self {
-        Self::new(EthEvmConfig::default())
-    }
-}
-
 // Default implementation of [PayloadBuilder] for unit type
 impl<EvmConfig, Pool, Client> PayloadBuilder<Pool, Client> for EthereumPayloadBuilder<EvmConfig>
 where

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -15,7 +15,6 @@ extern crate alloc;
 use core::ops::Deref;
 
 use crate::builder::RethEvmBuilder;
-use reth_chainspec::ChainSpec;
 use reth_primitives::{Address, Header, TransactionSigned, TransactionSignedEcRecovered, U256};
 use revm::{Database, Evm, GetInspector};
 use revm_primitives::{
@@ -133,7 +132,6 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
     fn fill_cfg_env(
         &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
-        chain_spec: &ChainSpec,
         header: &Header,
         total_difficulty: U256,
     );
@@ -165,11 +163,10 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
         &self,
         cfg: &mut CfgEnvWithHandlerCfg,
         block_env: &mut BlockEnv,
-        chain_spec: &ChainSpec,
         header: &Header,
         total_difficulty: U256,
     ) {
-        self.fill_cfg_env(cfg, chain_spec, header, total_difficulty);
+        self.fill_cfg_env(cfg, header, total_difficulty);
         let after_merge = cfg.handler_cfg.spec_id >= SpecId::MERGE;
         self.fill_block_env(block_env, header, after_merge);
     }

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -76,16 +76,16 @@ pub struct TestExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for TestExecutorBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
 {
     type EVM = EthEvmConfig;
     type Executor = MockExecutorProvider;
 
     async fn build_evm(
         self,
-        _ctx: &BuilderContext<Node>,
+        ctx: &BuilderContext<Node>,
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(ctx.chain_spec());
         let executor = MockExecutorProvider::default();
 
         Ok((evm_config, executor))
@@ -238,7 +238,7 @@ pub async fn test_exex_context_with_chain_spec(
     chain_spec: Arc<ChainSpec>,
 ) -> eyre::Result<(ExExContext<Adapter>, TestExExHandle)> {
     let transaction_pool = testing_pool();
-    let evm_config = EthEvmConfig::default();
+    let evm_config = EthEvmConfig::new(chain_spec.clone());
     let executor = MockExecutorProvider::default();
     let consensus = Arc::new(TestConsensus::default());
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -35,7 +35,7 @@ pub struct OpExecutorProvider<EvmConfig = OptimismEvmConfig> {
 impl OpExecutorProvider {
     /// Creates a new default optimism executor provider.
     pub fn optimism(chain_spec: Arc<ChainSpec>) -> Self {
-        Self::new(chain_spec, Default::default())
+        Self::new(chain_spec.clone(), OptimismEvmConfig::new(chain_spec))
     }
 }
 
@@ -269,7 +269,6 @@ where
         self.executor.evm_config.fill_cfg_and_block_env(
             &mut cfg,
             &mut block_env,
-            self.chain_spec(),
             header,
             total_difficulty,
         );

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -478,7 +478,7 @@ mod tests {
     }
 
     fn executor_provider(chain_spec: Arc<ChainSpec>) -> OpExecutorProvider<OptimismEvmConfig> {
-        OpExecutorProvider { chain_spec, evm_config: Default::default() }
+        OpExecutorProvider { evm_config: OptimismEvmConfig::new(chain_spec.clone()), chain_spec }
     }
 
     #[test]

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -32,7 +32,7 @@ pub use error::OptimismBlockExecutionError;
 use revm_primitives::{Bytes, Env, OptimismFields, TxKind};
 
 /// Optimism-related EVM configuration.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct OptimismEvmConfig {
     chain_spec: Arc<ChainSpec>,
@@ -150,7 +150,7 @@ mod tests {
     use reth_evm::execute::ProviderError;
     use reth_primitives::{
         revm_primitives::{BlockEnv, CfgEnv, SpecId},
-        Genesis, Header, B256, KECCAK_EMPTY, U256,
+        Genesis, Header, B256, BASE_MAINNET, KECCAK_EMPTY, U256,
     };
     use reth_revm::{
         db::{CacheDB, EmptyDBTyped},
@@ -159,6 +159,10 @@ mod tests {
     };
     use revm_primitives::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
     use std::collections::HashSet;
+
+    fn test_evm_config() -> OptimismEvmConfig {
+        OptimismEvmConfig::new(Arc::new(Arc::unwrap_or_clone(BASE_MAINNET.clone()).inner))
+    }
 
     #[test]
     fn test_fill_cfg_and_block_env() {
@@ -186,7 +190,7 @@ mod tests {
 
         // Use the `OptimismEvmConfig` to fill the `cfg_env` and `block_env` based on the ChainSpec,
         // Header, and total difficulty
-        OptimismEvmConfig::default().fill_cfg_and_block_env(
+        OptimismEvmConfig::new(Arc::new(chain_spec.clone())).fill_cfg_and_block_env(
             &mut cfg_env,
             &mut block_env,
             &header,
@@ -201,7 +205,7 @@ mod tests {
     #[test]
     fn test_evm_configure() {
         // Create a default `OptimismEvmConfig`
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
 
         // Initialize an empty database wrapped in CacheDB
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
@@ -241,7 +245,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_default_spec() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -261,7 +265,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_custom_cfg() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -291,7 +295,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_custom_block_and_tx() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -324,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_spec_id() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -343,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_inspector() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -387,7 +391,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_and_default_inspector() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let env_with_handler = EnvWithHandlerCfg::default();
@@ -406,7 +410,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_inspector_and_custom_cfg() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let cfg = CfgEnv::default().with_chain_id(111);
@@ -430,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_inspector_and_custom_block_tx() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         // Create custom block and tx environment
@@ -461,7 +465,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_inspector_and_spec_id() {
-        let evm_config = OptimismEvmConfig::default();
+        let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let handler_cfg = HandlerCfg { spec_id: SpecId::ECOTONE, ..Default::default() };

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -137,7 +137,7 @@ where
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
         let chain_spec = ctx.chain_spec();
         let evm_config = OptimismEvmConfig::default();
-        let executor = OpExecutorProvider::new(chain_spec, evm_config);
+        let executor = OpExecutorProvider::new(chain_spec, evm_config.clone());
 
         Ok((evm_config, executor))
     }

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -126,5 +126,5 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
         .with_network(NoopNetwork::default())
         .with_executor(TokioTaskExecutor::default())
         .with_events(TestCanonStateSubscriptions::default())
-        .with_evm_config(EthEvmConfig::default())
+        .with_evm_config(EthEvmConfig::new(MAINNET.clone()))
 }

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -350,7 +350,7 @@ impl<Provider, Pool, Network, EvmConfig> EthApiInner<Provider, Pool, Network, Ev
 #[cfg(test)]
 mod tests {
     use jsonrpsee_types::error::INVALID_PARAMS_CODE;
-    use reth_chainspec::{BaseFeeParams, ChainSpec};
+    use reth_chainspec::{BaseFeeParams, ChainSpec, MAINNET};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{Block, BlockNumberOrTag, Header, TransactionSigned, B256, U64};
@@ -382,8 +382,8 @@ mod tests {
     >(
         provider: P,
     ) -> EthApi<P, TestPool, NoopNetwork, EthEvmConfig> {
-        let evm_config = EthEvmConfig::default();
-        let cache = EthStateCache::spawn(provider.clone(), Default::default(), evm_config);
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let cache = EthStateCache::spawn(provider.clone(), Default::default(), evm_config.clone());
         let fee_history_cache =
             FeeHistoryCache::new(cache.clone(), FeeHistoryCacheConfig::default());
 

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -350,7 +350,7 @@ impl<Provider, Pool, Network, EvmConfig> EthApiInner<Provider, Pool, Network, Ev
 #[cfg(test)]
 mod tests {
     use jsonrpsee_types::error::INVALID_PARAMS_CODE;
-    use reth_chainspec::{BaseFeeParams, ChainSpec, MAINNET};
+    use reth_chainspec::{BaseFeeParams, ChainSpec};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{Block, BlockNumberOrTag, Header, TransactionSigned, B256, U64};
@@ -382,7 +382,7 @@ mod tests {
     >(
         provider: P,
     ) -> EthApi<P, TestPool, NoopNetwork, EthEvmConfig> {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::new(provider.chain_spec());
         let cache = EthStateCache::spawn(provider.clone(), Default::default(), evm_config.clone());
         let fee_history_cache =
             FeeHistoryCache::new(cache.clone(), FeeHistoryCacheConfig::default());

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -60,12 +60,12 @@ mod tests {
 
     fn noop_eth_api() -> EthApi<NoopProvider, TestPool, (), EthEvmConfig> {
         let pool = testing_pool();
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let provider = NoopProvider::default();
+        let evm_config = EthEvmConfig::new(provider.chain_spec());
 
-        let cache =
-            EthStateCache::spawn(NoopProvider::default(), Default::default(), evm_config.clone());
+        let cache = EthStateCache::spawn(provider, Default::default(), evm_config.clone());
         EthApi::new(
-            NoopProvider::default(),
+            provider,
             pool,
             (),
             cache.clone(),

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -43,6 +43,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_chainspec::MAINNET;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_primitives::{
         constants::ETHEREUM_BLOCK_GAS_LIMIT, Address, StorageKey, StorageValue, KECCAK_EMPTY, U256,
@@ -59,9 +60,10 @@ mod tests {
 
     fn noop_eth_api() -> EthApi<NoopProvider, TestPool, (), EthEvmConfig> {
         let pool = testing_pool();
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
-        let cache = EthStateCache::spawn(NoopProvider::default(), Default::default(), evm_config);
+        let cache =
+            EthStateCache::spawn(NoopProvider::default(), Default::default(), evm_config.clone());
         EthApi::new(
             NoopProvider::default(),
             pool,
@@ -81,12 +83,13 @@ mod tests {
         accounts: HashMap<Address, ExtendedAccount>,
     ) -> EthApi<MockEthProvider, TestPool, (), EthEvmConfig> {
         let pool = testing_pool();
-        let evm_config = EthEvmConfig::default();
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
 
         let mock_provider = MockEthProvider::default();
         mock_provider.extend_accounts(accounts);
 
-        let cache = EthStateCache::spawn(mock_provider.clone(), Default::default(), evm_config);
+        let cache =
+            EthStateCache::spawn(mock_provider.clone(), Default::default(), evm_config.clone());
         EthApi::new(
             mock_provider.clone(),
             pool,

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -52,6 +52,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use reth_chainspec::MAINNET;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, hex_literal::hex, Bytes};
@@ -73,8 +74,8 @@ mod tests {
 
         let pool = testing_pool();
 
-        let evm_config = EthEvmConfig::default();
-        let cache = EthStateCache::spawn(noop_provider, Default::default(), evm_config);
+        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let cache = EthStateCache::spawn(noop_provider, Default::default(), evm_config.clone());
         let fee_history_cache =
             FeeHistoryCache::new(cache.clone(), FeeHistoryCacheConfig::default());
         let eth_api = EthApi::new(

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -52,11 +52,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use reth_chainspec::MAINNET;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, hex_literal::hex, Bytes};
-    use reth_provider::test_utils::NoopProvider;
+    use reth_provider::{test_utils::NoopProvider, ChainSpecProvider};
     use reth_rpc_eth_api::helpers::EthTransactions;
     use reth_rpc_eth_types::{
         EthStateCache, FeeHistoryCache, FeeHistoryCacheConfig, GasPriceOracle,
@@ -74,7 +73,7 @@ mod tests {
 
         let pool = testing_pool();
 
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::new(noop_provider.chain_spec());
         let cache = EthStateCache::spawn(noop_provider, Default::default(), evm_config.clone());
         let fee_history_cache =
             FeeHistoryCache::new(cache.clone(), FeeHistoryCacheConfig::default());

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1011,13 +1011,7 @@ impl<N: ProviderNodeTypes> EvmEnvProvider for BlockchainProvider2<N> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
-        evm_config.fill_cfg_and_block_env(
-            cfg,
-            block_env,
-            &self.database.chain_spec(),
-            header,
-            total_difficulty,
-        );
+        evm_config.fill_cfg_and_block_env(cfg, block_env, header, total_difficulty);
         Ok(())
     }
 
@@ -1047,7 +1041,7 @@ impl<N: ProviderNodeTypes> EvmEnvProvider for BlockchainProvider2<N> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
-        evm_config.fill_cfg_env(cfg, &self.database.chain_spec(), header, total_difficulty);
+        evm_config.fill_cfg_env(cfg, header, total_difficulty);
         Ok(())
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2478,13 +2478,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
-        evm_config.fill_cfg_and_block_env(
-            cfg,
-            block_env,
-            &self.chain_spec,
-            header,
-            total_difficulty,
-        );
+        evm_config.fill_cfg_and_block_env(cfg, block_env, header, total_difficulty);
         Ok(())
     }
 
@@ -2514,7 +2508,7 @@ impl<TX: DbTx> EvmEnvProvider for DatabaseProvider<TX> {
         let total_difficulty = self
             .header_td_by_number(header.number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(header.number.into()))?;
-        evm_config.fill_cfg_env(cfg, &self.chain_spec, header, total_difficulty);
+        evm_config.fill_cfg_env(cfg, header, total_difficulty);
         Ok(())
     }
 }

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -45,9 +45,12 @@ use reth_node_api::{
     validate_version_specific_fields, EngineTypes, PayloadAttributes, PayloadBuilderAttributes,
 };
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
-use reth_node_ethereum::node::{
-    EthereumAddOns, EthereumConsensusBuilder, EthereumExecutorBuilder, EthereumNetworkBuilder,
-    EthereumPoolBuilder,
+use reth_node_ethereum::{
+    node::{
+        EthereumAddOns, EthereumConsensusBuilder, EthereumExecutorBuilder, EthereumNetworkBuilder,
+        EthereumPoolBuilder,
+    },
+    EthEvmConfig,
 };
 use reth_payload_builder::{
     error::PayloadBuilderError, EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderHandle,
@@ -302,7 +305,10 @@ where
 
         // This reuses the default EthereumPayloadBuilder to build the payload
         // but any custom logic can be implemented here
-        reth_ethereum_payload_builder::EthereumPayloadBuilder::default().try_build(BuildArguments {
+        reth_ethereum_payload_builder::EthereumPayloadBuilder::new(EthEvmConfig::new(
+            chain_spec.clone(),
+        ))
+        .try_build(BuildArguments {
             client,
             pool,
             cached_reads,
@@ -332,7 +338,7 @@ where
             attributes,
             chain_spec,
         } = config;
-        <reth_ethereum_payload_builder::EthereumPayloadBuilder as PayloadBuilder<Pool, Client>>::build_empty_payload(&reth_ethereum_payload_builder::EthereumPayloadBuilder::default(),client,
+        <reth_ethereum_payload_builder::EthereumPayloadBuilder as PayloadBuilder<Pool, Client>>::build_empty_payload(&reth_ethereum_payload_builder::EthereumPayloadBuilder::new(EthEvmConfig::new(chain_spec.clone())),client,
                                                                                                                      PayloadConfig { initialized_block_env, initialized_cfg, parent_block, extra_data, attributes: attributes.0, chain_spec })
     }
 }

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -4,7 +4,11 @@
 
 use alloy_genesis::Genesis;
 use reth::{
-    builder::{components::ExecutorBuilder, BuilderContext, NodeBuilder},
+    builder::{
+        components::{ExecutorBuilder, PayloadServiceBuilder},
+        BuilderContext, NodeBuilder,
+    },
+    payload::{EthBuiltPayload, EthPayloadBuilderAttributes},
     primitives::{
         address,
         revm_primitives::{Env, PrecompileResult},
@@ -16,27 +20,40 @@ use reth::{
         precompile::{Precompile, PrecompileOutput, PrecompileSpecId},
         ContextPrecompiles, Database, Evm, EvmBuilder, GetInspector,
     },
+    rpc::types::engine::PayloadAttributes,
     tasks::TaskManager,
+    transaction_pool::TransactionPool,
 };
-use reth_chainspec::{Chain, ChainSpec, Head};
+use reth_chainspec::{Chain, ChainSpec};
 use reth_evm_ethereum::EthEvmConfig;
-use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NodeTypes};
+use reth_node_api::{
+    ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NodeTypes, NodeTypesWithEngine, PayloadTypes,
+};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{
     node::{EthereumAddOns, EthereumPayloadBuilder},
     EthExecutorProvider, EthereumNode,
 };
 use reth_primitives::{
-    revm_primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
+    revm_primitives::{CfgEnvWithHandlerCfg, TxEnv},
     Address, Header, TransactionSigned, U256,
 };
 use reth_tracing::{RethTracer, Tracer};
 use std::sync::Arc;
 
 /// Custom EVM configuration
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct MyEvmConfig;
+pub struct MyEvmConfig {
+    /// Wrapper around mainnet configuration
+    inner: EthEvmConfig,
+}
+
+impl MyEvmConfig {
+    pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
+        Self { inner: EthEvmConfig::new(chain_spec) }
+    }
+}
 
 impl MyEvmConfig {
     /// Sets the precompiles to the EVM handler
@@ -73,29 +90,14 @@ impl ConfigureEvmEnv for MyEvmConfig {
     fn fill_cfg_env(
         &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
-        chain_spec: &ChainSpec,
         header: &Header,
         total_difficulty: U256,
     ) {
-        let spec_id = reth_evm_ethereum::revm_spec(
-            chain_spec,
-            &Head {
-                number: header.number,
-                timestamp: header.timestamp,
-                difficulty: header.difficulty,
-                total_difficulty,
-                hash: Default::default(),
-            },
-        );
-
-        cfg_env.chain_id = chain_spec.chain().id();
-        cfg_env.perf_analyse_created_bytecodes = AnalysisKind::Analyse;
-
-        cfg_env.handler_cfg.spec_id = spec_id;
+        self.inner.fill_cfg_env(cfg_env, header, total_difficulty);
     }
 
     fn fill_tx_env(&self, tx_env: &mut TxEnv, transaction: &TransactionSigned, sender: Address) {
-        EthEvmConfig::default().fill_tx_env(tx_env, transaction, sender)
+        self.inner.fill_tx_env(tx_env, transaction, sender);
     }
 
     fn fill_tx_env_system_contract_call(
@@ -105,7 +107,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
         contract: Address,
         data: Bytes,
     ) {
-        EthEvmConfig::default().fill_tx_env_system_contract_call(env, caller, contract, data)
+        self.inner.fill_tx_env_system_contract_call(env, caller, contract, data);
     }
 }
 
@@ -154,12 +156,38 @@ where
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
         Ok((
-            MyEvmConfig::default(),
-            EthExecutorProvider::new(ctx.chain_spec(), MyEvmConfig::default()),
+            MyEvmConfig::new(ctx.chain_spec()),
+            EthExecutorProvider::new(ctx.chain_spec(), MyEvmConfig::new(ctx.chain_spec())),
         ))
     }
 }
 
+/// Builds a regular ethereum block executor that uses the custom EVM.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct MyPayloadBuilder {
+    inner: EthereumPayloadBuilder,
+}
+
+impl<Types, Node, Pool> PayloadServiceBuilder<Node, Pool> for MyPayloadBuilder
+where
+    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    Node: FullNodeTypes<Types = Types>,
+    Pool: TransactionPool + Unpin + 'static,
+    Types::Engine: PayloadTypes<
+        BuiltPayload = EthBuiltPayload,
+        PayloadAttributes = PayloadAttributes,
+        PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+    >,
+{
+    async fn spawn_payload_service(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+    ) -> eyre::Result<reth::payload::PayloadBuilderHandle<Types::Engine>> {
+        self.inner.spawn(MyEvmConfig::new(ctx.chain_spec()), ctx, pool)
+    }
+}
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     let _guard = RethTracer::new().init()?;
@@ -187,7 +215,7 @@ async fn main() -> eyre::Result<()> {
         .with_components(
             EthereumNode::components()
                 .executor(MyExecutorBuilder::default())
-                .payload(EthereumPayloadBuilder::new(MyEvmConfig::default())),
+                .payload(MyPayloadBuilder::default()),
         )
         .with_add_ons::<EthereumAddOns>()
         .launch()

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -22,7 +22,7 @@ use reth::{
 use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
 use reth_chainspec::ChainSpec;
 use reth_node_api::NodeTypesWithEngine;
-use reth_node_ethereum::{node::EthereumAddOns, EthEngineTypes, EthereumNode};
+use reth_node_ethereum::{node::EthereumAddOns, EthEngineTypes, EthEvmConfig, EthereumNode};
 use reth_payload_builder::PayloadBuilderService;
 
 pub mod generator;
@@ -57,7 +57,9 @@ where
             ctx.task_executor().clone(),
             payload_job_config,
             ctx.chain_spec().clone(),
-            reth_ethereum_payload_builder::EthereumPayloadBuilder::default(),
+            reth_ethereum_payload_builder::EthereumPayloadBuilder::new(EthEvmConfig::new(
+                ctx.chain_spec(),
+            )),
         );
 
         let (payload_service, payload_builder) =

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> eyre::Result<()> {
         .with_noop_pool()
         .with_noop_network()
         .with_executor(TokioTaskExecutor::default())
-        .with_evm_config(EthEvmConfig::default())
+        .with_evm_config(EthEvmConfig::new(spec))
         .with_events(TestCanonStateSubscriptions::default());
 
     // Pick which namespaces to expose.


### PR DESCRIPTION
Removes `chain_spec` parameter from `ConfigureEvm` methods, requiring all `ConfigureEvm` implementations to hold their own copy of chainspec.

This allows us to avoid introducing `ChainSpec` generic on types that implement `EvmEnvProvider`, eg `DatabaseProvider`