### PR TITLE
chore: update genesis to chain spec conversion

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -2440,4 +2440,140 @@ Post-merge hard forks (timestamp based):
             MAINNET.latest_fork_id()
         )
     }
+
+    #[test]
+    #[cfg(not(feature = "optimism"))]
+    fn test_fork_order_ethereum_mainnet() {
+        let genesis = Genesis {
+            config: ChainConfig {
+                chain_id: 0,
+                homestead_block: Some(0),
+                dao_fork_block: Some(0),
+                dao_fork_support: false,
+                eip150_block: Some(0),
+                eip155_block: Some(0),
+                eip158_block: Some(0),
+                byzantium_block: Some(0),
+                constantinople_block: Some(0),
+                petersburg_block: Some(0),
+                istanbul_block: Some(0),
+                muir_glacier_block: Some(0),
+                berlin_block: Some(0),
+                london_block: Some(0),
+                arrow_glacier_block: Some(0),
+                gray_glacier_block: Some(0),
+                merge_netsplit_block: Some(0),
+                shanghai_time: Some(0),
+                cancun_time: Some(0),
+                terminal_total_difficulty: Some(U256::ZERO),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let chain_spec = into_ethereum_chain_spec(genesis);
+
+        let hardforks: Vec<_> = chain_spec.hardforks.forks_iter().map(|(h, _)| h).collect();
+        let expected_hardforks = vec![
+            EthereumHardfork::Homestead.boxed(),
+            EthereumHardfork::Dao.boxed(),
+            EthereumHardfork::Tangerine.boxed(),
+            EthereumHardfork::SpuriousDragon.boxed(),
+            EthereumHardfork::Byzantium.boxed(),
+            EthereumHardfork::Constantinople.boxed(),
+            EthereumHardfork::Petersburg.boxed(),
+            EthereumHardfork::Istanbul.boxed(),
+            EthereumHardfork::MuirGlacier.boxed(),
+            EthereumHardfork::Berlin.boxed(),
+            EthereumHardfork::London.boxed(),
+            EthereumHardfork::ArrowGlacier.boxed(),
+            EthereumHardfork::GrayGlacier.boxed(),
+            EthereumHardfork::Paris.boxed(),
+            EthereumHardfork::Shanghai.boxed(),
+            EthereumHardfork::Cancun.boxed(),
+        ];
+
+        assert!(expected_hardforks
+            .iter()
+            .zip(hardforks.iter())
+            .all(|(expected, actual)| &**expected == *actual));
+        assert_eq!(expected_hardforks.len(), hardforks.len());
+    }
+
+    #[test]
+    #[cfg(feature = "optimism")]
+    fn test_fork_order_optimism_mainnet() {
+        use crate::OptimismHardfork;
+
+        let genesis = Genesis {
+            config: ChainConfig {
+                chain_id: 0,
+                homestead_block: Some(0),
+                dao_fork_block: Some(0),
+                dao_fork_support: false,
+                eip150_block: Some(0),
+                eip155_block: Some(0),
+                eip158_block: Some(0),
+                byzantium_block: Some(0),
+                constantinople_block: Some(0),
+                petersburg_block: Some(0),
+                istanbul_block: Some(0),
+                muir_glacier_block: Some(0),
+                berlin_block: Some(0),
+                london_block: Some(0),
+                arrow_glacier_block: Some(0),
+                gray_glacier_block: Some(0),
+                merge_netsplit_block: Some(0),
+                shanghai_time: Some(0),
+                cancun_time: Some(0),
+                terminal_total_difficulty: Some(U256::ZERO),
+                extra_fields: [
+                    (String::from("bedrockBlock"), 0.into()),
+                    (String::from("regolithTime"), 0.into()),
+                    (String::from("canyonTime"), 0.into()),
+                    (String::from("ecotoneTime"), 0.into()),
+                    (String::from("fjordTime"), 0.into()),
+                    (String::from("graniteTime"), 0.into()),
+                ]
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let chain_spec: ChainSpec = into_optimism_chain_spec(genesis);
+
+        let hardforks: Vec<_> = chain_spec.hardforks.forks_iter().map(|(h, _)| h).collect();
+        let expected_hardforks = vec![
+            EthereumHardfork::Homestead.boxed(),
+            EthereumHardfork::Dao.boxed(),
+            EthereumHardfork::Tangerine.boxed(),
+            EthereumHardfork::SpuriousDragon.boxed(),
+            EthereumHardfork::Byzantium.boxed(),
+            EthereumHardfork::Constantinople.boxed(),
+            EthereumHardfork::Petersburg.boxed(),
+            EthereumHardfork::Istanbul.boxed(),
+            EthereumHardfork::MuirGlacier.boxed(),
+            EthereumHardfork::Berlin.boxed(),
+            EthereumHardfork::London.boxed(),
+            EthereumHardfork::ArrowGlacier.boxed(),
+            EthereumHardfork::GrayGlacier.boxed(),
+            EthereumHardfork::Paris.boxed(),
+            OptimismHardfork::Bedrock.boxed(),
+            OptimismHardfork::Regolith.boxed(),
+            EthereumHardfork::Shanghai.boxed(),
+            OptimismHardfork::Canyon.boxed(),
+            EthereumHardfork::Cancun.boxed(),
+            OptimismHardfork::Ecotone.boxed(),
+            OptimismHardfork::Fjord.boxed(),
+            OptimismHardfork::Granite.boxed(),
+        ];
+
+        assert!(expected_hardforks
+            .iter()
+            .zip(hardforks.iter())
+            .all(|(expected, actual)| &**expected == *actual));
+        assert_eq!(expected_hardforks.len(), hardforks.len());
+    }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -706,8 +706,8 @@ where
     })
 }
 
-/// Convert the given [`Genesis`] into an ethereum [`ChainSpec`].
-#[cfg_attr(feature = "optimism", allow(dead_code))]
+/// Convert the given [`Genesis`] into an Ethereum [`ChainSpec`].
+#[cfg(not(feature = "optimism"))]
 fn into_ethereum_chain_spec(
     genesis: Genesis,
     hardfork_opts: Vec<(Box<dyn Hardfork>, ForkCondition)>,
@@ -730,7 +730,7 @@ fn into_ethereum_chain_spec(
 }
 
 #[cfg(feature = "optimism")]
-/// Convert the given [`Genesis`] into an optimism [`ChainSpec`].
+/// Convert the given [`Genesis`] into an Optimism [`ChainSpec`].
 fn into_optimism_chain_spec(
     genesis: Genesis,
     mut hardforks: Vec<(Box<dyn Hardfork>, ForkCondition)>,

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -706,7 +706,6 @@ fn into_optimism_chain_spec(genesis: Genesis) -> ChainSpec {
     // Block-based hardforks
     let hardfork_opts = [
         (EthereumHardfork::Homestead.boxed(), genesis.config.homestead_block),
-        (EthereumHardfork::Dao.boxed(), genesis.config.dao_fork_block),
         (EthereumHardfork::Tangerine.boxed(), genesis.config.eip150_block),
         (EthereumHardfork::SpuriousDragon.boxed(), genesis.config.eip155_block),
         (EthereumHardfork::Byzantium.boxed(), genesis.config.byzantium_block),
@@ -2547,7 +2546,6 @@ Post-merge hard forks (timestamp based):
         let hardforks: Vec<_> = chain_spec.hardforks.forks_iter().map(|(h, _)| h).collect();
         let expected_hardforks = vec![
             EthereumHardfork::Homestead.boxed(),
-            EthereumHardfork::Dao.boxed(),
             EthereumHardfork::Tangerine.boxed(),
             EthereumHardfork::SpuriousDragon.boxed(),
             EthereumHardfork::Byzantium.boxed(),

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -199,7 +199,6 @@ impl OptimismHardfork {
         ChainHardforks::new(vec![
             (EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::Homestead.boxed(), ForkCondition::Block(0)),
-            (EthereumHardfork::Dao.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::Tangerine.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::SpuriousDragon.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::Byzantium.boxed(), ForkCondition::Block(0)),

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -199,6 +199,7 @@ impl OptimismHardfork {
         ChainHardforks::new(vec![
             (EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::Homestead.boxed(), ForkCondition::Block(0)),
+            (EthereumHardfork::Dao.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::Tangerine.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::SpuriousDragon.boxed(), ForkCondition::Block(0)),
             (EthereumHardfork::Byzantium.boxed(), ForkCondition::Block(0)),


### PR DESCRIPTION
This PR updates the `From<Genesis>` implementation for `ChainSpec` and splits it into two functions: `into_optimism_chain_spec` and `into_ethereum_chain_spec`. 

Linked to #10725. 

Follow up PR to add more tests to it.