### PR TITLE
transaction-pool: replace reth-primitive imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8730,6 +8730,7 @@ dependencies = [
 name = "reth-transaction-pool"
 version = "1.0.6"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
  "assert_matches",

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -25,6 +25,7 @@ revm.workspace = true
 
 # ethereum
 alloy-rlp.workspace = true
+alloy-primitives.workspace = true
 
 # async/futures
 futures-util.workspace = true

--- a/crates/transaction-pool/benches/truncate.rs
+++ b/crates/transaction-pool/benches/truncate.rs
@@ -8,7 +8,7 @@ use proptest::{
     strategy::ValueTree,
     test_runner::{RngAlgorithm, TestRng, TestRunner},
 };
-use reth_primitives::{hex_literal::hex, Address};
+use alloy_primitives::{hex_literal::hex, Address};
 use reth_transaction_pool::{
     pool::{BasefeeOrd, ParkedPool, PendingPool, QueuedOrd},
     test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},

--- a/crates/transaction-pool/benches/truncate.rs
+++ b/crates/transaction-pool/benches/truncate.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+use alloy_primitives::{hex_literal::hex, Address};
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
 };
@@ -8,7 +9,6 @@ use proptest::{
     strategy::ValueTree,
     test_runner::{RngAlgorithm, TestRng, TestRunner},
 };
-use alloy_primitives::{hex_literal::hex, Address};
 use reth_transaction_pool::{
     pool::{BasefeeOrd, ParkedPool, PendingPool, QueuedOrd},
     test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -1,9 +1,10 @@
 //! A simple diskstore for blobs
 
 use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobStoreSize};
+use alloy_primitives::{TxHash, B256};
 use alloy_rlp::{Decodable, Encodable};
 use parking_lot::{Mutex, RwLock};
-use reth_primitives::{BlobTransactionSidecar, TxHash, B256};
+use reth_primitives::BlobTransactionSidecar;
 use schnellru::{ByLength, LruMap};
 use std::{collections::HashSet, fmt, fs, io, path::PathBuf, sync::Arc};
 use tracing::{debug, trace};

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -1,8 +1,8 @@
 use crate::blobstore::{
     BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobStoreSize, BlobTransactionSidecar,
 };
+use alloy_primitives::B256;
 use parking_lot::RwLock;
-use reth_primitives::B256;
 use std::{collections::HashMap, sync::Arc};
 
 /// An in-memory blob store.

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -1,9 +1,10 @@
 //! Storage for blob data of EIP4844 transactions.
 
+use alloy_primitives::B256;
 pub use disk::{DiskFileBlobStore, DiskFileBlobStoreConfig, OpenDiskFileBlobStore};
 pub use mem::InMemoryBlobStore;
 pub use noop::NoopBlobStore;
-use reth_primitives::{BlobTransactionSidecar, B256};
+use reth_primitives::BlobTransactionSidecar;
 use std::{
     fmt,
     sync::atomic::{AtomicUsize, Ordering},

--- a/crates/transaction-pool/src/blobstore/noop.rs
+++ b/crates/transaction-pool/src/blobstore/noop.rs
@@ -1,5 +1,5 @@
 use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobTransactionSidecar};
-use reth_primitives::B256;
+use alloy_primitives::B256;
 
 /// A blobstore implementation that does nothing
 #[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Default)]

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -1,7 +1,7 @@
 //! Support for maintaining the blob pool.
 
-use reth_execution_types::ChainBlocks;
 use alloy_primitives::{BlockNumber, B256};
+use reth_execution_types::ChainBlocks;
 use std::collections::BTreeMap;
 
 /// The type that is used to track canonical blob transactions.

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -1,7 +1,7 @@
 //! Support for maintaining the blob pool.
 
 use reth_execution_types::ChainBlocks;
-use reth_primitives::{BlockNumber, B256};
+use alloy_primitives::{BlockNumber, B256};
 use std::collections::BTreeMap;
 
 /// The type that is used to track canonical blob transactions.

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -2,7 +2,8 @@ use crate::{
     pool::{NEW_TX_LISTENER_BUFFER_SIZE, PENDING_TX_LISTENER_BUFFER_SIZE},
     PoolSize, TransactionOrigin,
 };
-use reth_primitives::{Address, EIP4844_TX_TYPE_ID};
+use alloy_primitives::Address;
+use reth_primitives::EIP4844_TX_TYPE_ID;
 use std::collections::HashSet;
 /// Guarantees max transactions for one sender, compatible with geth/erigon
 pub const TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -1,6 +1,7 @@
 //! Transaction pool errors
 
-use reth_primitives::{Address, BlobTransactionValidationError, InvalidTransactionError, TxHash};
+use alloy_primitives::{Address, TxHash};
+use reth_primitives::{BlobTransactionValidationError, InvalidTransactionError};
 
 /// Transaction pool result type.
 pub type PoolResult<T> = Result<T, PoolError>;
@@ -104,7 +105,7 @@ impl PoolError {
             }
             PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => {
                 // fee cap of the tx below the technical minimum determined by the protocol, see
-                // [MINIMUM_PROTOCOL_FEE_CAP](reth_primitives::constants::MIN_PROTOCOL_BASE_FEE)
+                // [MINIMUM_PROTOCOL_FEE_CAP](alloy_primitives::constants::MIN_PROTOCOL_BASE_FEE)
                 // although this transaction will always be invalid, we do not want to penalize the
                 // sender because this check simply could not be implemented by the client
                 false

--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -1,5 +1,5 @@
 //! Identifier types for transactions and senders.
-use reth_primitives::Address;
+use alloy_primitives::Address;
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -151,10 +151,11 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use crate::{identifier::TransactionId, pool::PoolInner};
+use alloy_primitives::{Address, TxHash, U256};
 use aquamarine as _;
 use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
-use reth_primitives::{Address, BlobTransactionSidecar, PooledTransactionsElement, TxHash, U256};
+use reth_primitives::{BlobTransactionSidecar, PooledTransactionsElement};
 use reth_storage_api::StateProviderFactory;
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::mpsc::Receiver;

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -7,6 +7,7 @@ use crate::{
     traits::{CanonicalStateUpdate, TransactionPool, TransactionPoolExt},
     BlockInfo, PoolTransaction,
 };
+use alloy_primitives::{Address, BlockHash, BlockNumber};
 use futures_util::{
     future::{BoxFuture, Fuse, FusedFuture},
     FutureExt, Stream, StreamExt,
@@ -16,8 +17,8 @@ use reth_chainspec::{ChainSpec, ChainSpecProvider};
 use reth_execution_types::ChangedAccount;
 use reth_fs_util::FsPathError;
 use reth_primitives::{
-    Address, BlockHash, BlockNumber, BlockNumberOrTag, IntoRecoveredTransaction,
-    PooledTransactionsElementEcRecovered, TransactionSigned,
+    BlockNumberOrTag, IntoRecoveredTransaction, PooledTransactionsElementEcRecovered,
+    TransactionSigned,
 };
 use reth_storage_api::{errors::provider::ProviderError, BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::TaskSpawner;
@@ -678,9 +679,10 @@ mod tests {
         blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
         CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionOrigin,
     };
+    use alloy_primitives::{hex, U256};
     use reth_chainspec::MAINNET;
     use reth_fs_util as fs;
-    use reth_primitives::{hex, PooledTransactionsElement, U256};
+    use reth_primitives::PooledTransactionsElement;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_tasks::TaskManager;
 

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -16,8 +16,9 @@ use crate::{
     PooledTransactionsElement, PropagatedTransactions, TransactionEvents, TransactionOrigin,
     TransactionPool, TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
 };
+use alloy_primitives::{Address, TxHash, U256};
 use reth_eth_wire_types::HandleMempoolData;
-use reth_primitives::{Address, BlobTransactionSidecar, TxHash, U256};
+use reth_primitives::BlobTransactionSidecar;
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 use tokio::sync::{mpsc, mpsc::Receiver};
 

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -1,5 +1,6 @@
 use crate::traits::PoolTransaction;
-use reth_primitives::{PooledTransactionsElementEcRecovered, TransactionSignedEcRecovered, U256};
+use alloy_primitives::U256;
+use reth_primitives::{PooledTransactionsElementEcRecovered, TransactionSignedEcRecovered};
 use std::{fmt, marker::PhantomData};
 
 /// Priority of the transaction that can be missing.

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -2,8 +2,8 @@ use crate::{
     identifier::TransactionId, pool::pending::PendingTransaction, PoolTransaction,
     TransactionOrdering, ValidPoolTransaction,
 };
+use alloy_primitives::B256 as TxHash;
 use core::fmt;
-use reth_primitives::B256 as TxHash;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
@@ -268,7 +268,7 @@ mod tests {
         test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},
         Priority,
     };
-    use reth_primitives::U256;
+    use alloy_primitives::U256;
 
     #[test]
     fn test_best_iter() {

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -1,5 +1,5 @@
 use crate::{traits::PropagateKind, PoolTransaction, ValidPoolTransaction};
-use reth_primitives::{TxHash, B256};
+use alloy_primitives::{TxHash, B256};
 use std::sync::Arc;
 
 #[cfg(feature = "serde")]

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -6,7 +6,7 @@ use crate::{
     PoolTransaction, ValidPoolTransaction,
 };
 use futures_util::Stream;
-use reth_primitives::{TxHash, B256};
+use alloy_primitives::{TxHash, B256};
 use std::{
     collections::{hash_map::Entry, HashMap},
     pin::Pin,

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -5,8 +5,8 @@ use crate::{
     traits::PropagateKind,
     PoolTransaction, ValidPoolTransaction,
 };
-use futures_util::Stream;
 use alloy_primitives::{TxHash, B256};
+use futures_util::Stream;
 use std::{
     collections::{hash_map::Entry, HashMap},
     pin::Pin,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -80,13 +80,15 @@ use crate::{
     validate::{TransactionValidationOutcome, ValidPoolTransaction},
     CanonicalStateUpdate, PoolConfig, TransactionOrdering, TransactionValidator,
 };
+use alloy_primitives::{Address, TxHash, B256};
 use best::BestTransactions;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
 use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
+
 use reth_primitives::{
-    Address, BlobTransaction, BlobTransactionSidecar, IntoRecoveredTransaction,
-    PooledTransactionsElement, TransactionSigned, TxHash, B256,
+    BlobTransaction, BlobTransactionSidecar, IntoRecoveredTransaction, PooledTransactionsElement,
+    TransactionSigned,
 };
 use std::{
     collections::{HashMap, HashSet},

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -520,7 +520,8 @@ impl<T: PoolTransaction> Ord for QueuedOrd<T> {
 mod tests {
     use super::*;
     use crate::test_utils::{MockTransaction, MockTransactionFactory, MockTransactionSet};
-    use reth_primitives::{address, TxType};
+    use alloy_primitives::address;
+    use reth_primitives::TxType;
     use std::collections::HashSet;
 
     #[test]

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -597,7 +597,8 @@ mod tests {
         test_utils::{MockOrdering, MockTransaction, MockTransactionFactory, MockTransactionSet},
         PoolTransaction,
     };
-    use reth_primitives::{address, TxType};
+    use alloy_primitives::address;
+    use reth_primitives::TxType;
     use std::collections::HashSet;
 
     #[test]

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -18,11 +18,9 @@ use crate::{
     PoolConfig, PoolResult, PoolTransaction, PriceBumpConfig, TransactionOrdering,
     ValidPoolTransaction, U256,
 };
-use reth_primitives::{
-    constants::{
-        eip4844::BLOB_TX_MIN_BLOB_GASPRICE, ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE,
-    },
-    Address, TxHash, B256,
+use alloy_primitives::{Address, TxHash, B256};
+use reth_primitives::constants::{
+    eip4844::BLOB_TX_MIN_BLOB_GASPRICE, ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE,
 };
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -1848,7 +1846,8 @@ impl SenderInfo {
 
 #[cfg(test)]
 mod tests {
-    use reth_primitives::{address, TxType};
+    use alloy_primitives::address;
+    use reth_primitives::TxType;
 
     use super::*;
     use crate::{

--- a/crates/transaction-pool/src/pool/update.rs
+++ b/crates/transaction-pool/src/pool/update.rs
@@ -1,7 +1,7 @@
 //! Support types for updating the pool.
 
 use crate::{identifier::TransactionId, pool::state::SubPool};
-use reth_primitives::TxHash;
+use alloy_primitives::TxHash;
 
 /// A change of the transaction's location
 ///

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -1,9 +1,10 @@
 use crate::EthPooledTransaction;
+use alloy_primitives::{Address, B256, U256};
 use rand::Rng;
 use reth_chainspec::MAINNET;
 use reth_primitives::{
-    constants::MIN_PROTOCOL_BASE_FEE, sign_message, AccessList, Address, Bytes, Transaction,
-    TransactionSigned, TxEip1559, TxEip4844, TxKind, TxLegacy, B256, U256,
+    constants::MIN_PROTOCOL_BASE_FEE, sign_message, AccessList, Bytes, Transaction,
+    TransactionSigned, TxEip1559, TxEip4844, TxKind, TxLegacy,
 };
 
 /// A generator for transactions for testing purposes.

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -7,6 +7,7 @@ use crate::{
     CoinbaseTipOrdering, EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction,
     ValidPoolTransaction,
 };
+use alloy_primitives::{Address, Bytes, ChainId, TxHash, TxKind, B256, U256};
 use paste::paste;
 use rand::{
     distributions::{Uniform, WeightedIndex},
@@ -15,12 +16,12 @@ use rand::{
 use reth_primitives::{
     constants::{eip4844::DATA_GAS_PER_BLOB, MIN_PROTOCOL_BASE_FEE},
     transaction::TryFromRecoveredTransactionError,
-    AccessList, Address, BlobTransactionSidecar, BlobTransactionValidationError, Bytes, ChainId,
+    AccessList, BlobTransactionSidecar, BlobTransactionValidationError,
     PooledTransactionsElementEcRecovered, Signature, Transaction, TransactionSigned,
-    TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844, TxHash, TxKind, TxLegacy,
-    TxType, B256, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
-    U256,
+    TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844, TxLegacy, TxType,
+    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
 };
+
 use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
 
 /// A transaction pool implementation using [`MockOrdering`] for transaction ordering.

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -8,7 +8,7 @@ use crate::{
     TransactionOrdering,
 };
 use rand::Rng;
-use reth_primitives::{Address, U256};
+use alloy_primitives::{Address, U256};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -7,8 +7,8 @@ use crate::{
     test_utils::{MockOrdering, MockTransactionDistribution, MockTransactionFactory},
     TransactionOrdering,
 };
-use rand::Rng;
 use alloy_primitives::{Address, U256};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -7,14 +7,15 @@ use crate::{
     validate::ValidPoolTransaction,
     AllTransactionsEvents,
 };
+use alloy_primitives::{Address, TxHash, TxKind, B256, U256};
 use futures_util::{ready, Stream};
 use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
 use reth_primitives::{
-    kzg::KzgSettings, transaction::TryFromRecoveredTransactionError, AccessList, Address,
+    kzg::KzgSettings, transaction::TryFromRecoveredTransactionError, AccessList,
     BlobTransactionSidecar, BlobTransactionValidationError, PooledTransactionsElement,
     PooledTransactionsElementEcRecovered, SealedBlock, Transaction, TransactionSignedEcRecovered,
-    TxHash, TxKind, B256, EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID, U256,
+    EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -29,7 +30,7 @@ use std::{
 use tokio::sync::mpsc::Receiver;
 
 /// The `PeerId` type.
-pub type PeerId = reth_primitives::B512;
+pub type PeerId = alloy_primitives::B512;
 
 /// General purpose abstraction of a transaction-pool.
 ///

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -833,8 +833,9 @@ mod tests {
         blobstore::InMemoryBlobStore, error::PoolErrorKind, CoinbaseTipOrdering,
         EthPooledTransaction, Pool, TransactionPool,
     };
+    use alloy_primitives::{hex, U256};
     use reth_chainspec::MAINNET;
-    use reth_primitives::{hex, PooledTransactionsElement, U256};
+    use reth_primitives::PooledTransactionsElement;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 
     fn get_transaction() -> EthPooledTransaction {

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -174,7 +174,7 @@ pub trait TransactionValidator: Send + Sync {
     ///    * nonce >= next nonce of the sender
     ///    * ...
     ///
-    /// See [`InvalidTransactionError`](alloy_primitives::InvalidTransactionError) for common errors
+    /// See [`InvalidTransactionError`](reth_primitives::InvalidTransactionError) for common errors
     /// variants.
     ///
     /// The transaction pool makes no additional assumptions about the validity of the transaction

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -5,11 +5,11 @@ use crate::{
     identifier::{SenderId, TransactionId},
     traits::{PoolTransaction, TransactionOrigin},
 };
+use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
 use reth_primitives::{
-    Address, BlobTransactionSidecar, IntoRecoveredTransaction,
-    PooledTransactionsElementEcRecovered, SealedBlock, TransactionSignedEcRecovered, TxHash, B256,
-    U256,
+    BlobTransactionSidecar, IntoRecoveredTransaction, PooledTransactionsElementEcRecovered,
+    SealedBlock, TransactionSignedEcRecovered,
 };
 use std::{fmt, future::Future, time::Instant};
 
@@ -174,7 +174,7 @@ pub trait TransactionValidator: Send + Sync {
     ///    * nonce >= next nonce of the sender
     ///    * ...
     ///
-    /// See [`InvalidTransactionError`](reth_primitives::InvalidTransactionError) for common errors
+    /// See [`InvalidTransactionError`](alloy_primitives::InvalidTransactionError) for common errors
     /// variants.
     ///
     /// The transaction pool makes no additional assumptions about the validity of the transaction

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -1,7 +1,8 @@
 //! Transaction pool eviction tests.
 
+use alloy_primitives::{Address, B256};
 use rand::distributions::Uniform;
-use reth_primitives::{constants::MIN_PROTOCOL_BASE_FEE, Address, B256};
+use reth_primitives::constants::MIN_PROTOCOL_BASE_FEE;
 use reth_transaction_pool::{
     error::PoolErrorKind,
     test_utils::{


### PR DESCRIPTION
Progress on https://github.com/paradigmxyz/reth/issues/10749

Changed all where direct drop-in-replacement was possible