### PR TITLE
fix(cli) Allow Pruning CLI Args to take precedence over TOML configuration 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6544,6 +6544,7 @@ dependencies = [
  "humantime-serde",
  "reth-network-peers",
  "reth-network-types",
+ "reth-primitives",
  "reth-prune-types",
  "reth-stages-types",
  "serde",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -27,3 +27,4 @@ eyre.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 reth-network-peers.workspace = true
+reth-primitives.workspace = true

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -392,6 +392,34 @@ impl PruneConfig {
     pub fn has_receipts_pruning(&self) -> bool {
         self.segments.receipts.is_some() || !self.segments.receipts_log_filter.is_empty()
     }
+
+    /// Merges another `PruneConfig` into this one, taking values from the other config iff the
+    /// corresponding value in this config is not set.
+    pub fn merge(&mut self, other: Option<Self>) {
+        let Some(other) = other else { return };
+
+        // Merge block_interval
+        if self.block_interval == 0 {
+            self.block_interval = other.block_interval;
+        }
+
+        // Merge the various segment prune modes
+        self.segments.sender_recovery =
+            self.segments.sender_recovery.or(other.segments.sender_recovery);
+        self.segments.transaction_lookup =
+            self.segments.transaction_lookup.or(other.segments.transaction_lookup);
+        self.segments.receipts = self.segments.receipts.or(other.segments.receipts);
+        self.segments.account_history =
+            self.segments.account_history.or(other.segments.account_history);
+        self.segments.storage_history =
+            self.segments.storage_history.or(other.segments.storage_history);
+
+        if self.segments.receipts_log_filter.0.is_empty() &&
+            !other.segments.receipts_log_filter.0.is_empty()
+        {
+            self.segments.receipts_log_filter = other.segments.receipts_log_filter;
+        }
+    }
 }
 
 /// Helper type to support older versions of Duration deserialization.
@@ -415,8 +443,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Config, EXTENSION};
+    use crate::PruneConfig;
     use reth_network_peers::TrustedPeer;
-    use std::{path::Path, str::FromStr, time::Duration};
+    use reth_primitives::Address;
+    use reth_prune_types::{PruneMode, PruneModes, ReceiptsLogPruneConfig};
+    use std::{collections::BTreeMap, path::Path, str::FromStr, time::Duration};
 
     fn with_tempdir(filename: &str, proc: fn(&std::path::Path)) {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -891,6 +922,52 @@ receipts = 'full'
 #";
         let err = toml::from_str::<Config>(s).unwrap_err().to_string();
         assert!(err.contains("invalid value: string \"full\""), "{}", err);
+    }
+
+    #[test]
+    fn test_prune_config_merge() {
+        let mut config1 = PruneConfig {
+            block_interval: 5,
+            segments: PruneModes {
+                sender_recovery: Some(PruneMode::Full),
+                transaction_lookup: None,
+                receipts: Some(PruneMode::Distance(1000)),
+                account_history: None,
+                storage_history: Some(PruneMode::Before(5000)),
+                receipts_log_filter: ReceiptsLogPruneConfig(BTreeMap::from([(
+                    Address::random(),
+                    PruneMode::Full,
+                )])),
+            },
+        };
+
+        let config2 = PruneConfig {
+            block_interval: 10,
+            segments: PruneModes {
+                sender_recovery: Some(PruneMode::Distance(500)),
+                transaction_lookup: Some(PruneMode::Full),
+                receipts: Some(PruneMode::Full),
+                account_history: Some(PruneMode::Distance(2000)),
+                storage_history: Some(PruneMode::Distance(3000)),
+                receipts_log_filter: ReceiptsLogPruneConfig(BTreeMap::from([
+                    (Address::random(), PruneMode::Distance(1000)),
+                    (Address::random(), PruneMode::Before(2000)),
+                ])),
+            },
+        };
+
+        let original_filter = config1.segments.receipts_log_filter.clone();
+        config1.merge(Some(config2));
+
+        // Check that the configuration has been merged. Any configuration present in config1
+        // should not be overwritten by config2
+        assert_eq!(config1.block_interval, 5);
+        assert_eq!(config1.segments.sender_recovery, Some(PruneMode::Full));
+        assert_eq!(config1.segments.transaction_lookup, Some(PruneMode::Full));
+        assert_eq!(config1.segments.receipts, Some(PruneMode::Distance(1000)));
+        assert_eq!(config1.segments.account_history, Some(PruneMode::Distance(2000)));
+        assert_eq!(config1.segments.storage_history, Some(PruneMode::Before(5000)));
+        assert_eq!(config1.segments.receipts_log_filter, original_filter);
     }
 
     #[test]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -393,8 +393,8 @@ impl PruneConfig {
         self.segments.receipts.is_some() || !self.segments.receipts_log_filter.is_empty()
     }
 
-    /// Merges another `PruneConfig` into this one, taking values from the other config iff the
-    /// corresponding value in this config is not set.
+    /// Merges another `PruneConfig` into this one, taking values from the other config if and only
+    /// if the corresponding value in this config is not set.
     pub fn merge(&mut self, other: Option<Self>) {
         let Some(other) = other else { return };
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -355,7 +355,7 @@ impl<R> LaunchContextWith<Attached<WithConfigs, R>> {
                 Some(node_prune_config)
             }
             None => {
-                // If CLI PruneConfig isn't set, use the one from toml 
+                // If CLI PruneConfig isn't set, use the one from toml
                 self.toml_config().prune.clone()
             }
         }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -349,16 +349,14 @@ impl<R> LaunchContextWith<Attached<WithConfigs, R>> {
     /// Returns the configured [`PruneConfig`]
     /// Any configuration set in CLI will take precedence over those set in toml
     pub fn prune_config(&self) -> Option<PruneConfig> {
-        match self.node_config().prune_config() {
-            Some(mut node_prune_config) => {
-                node_prune_config.merge(self.toml_config().prune.clone());
-                Some(node_prune_config)
-            }
-            None => {
-                // If CLI PruneConfig isn't set, use the one from toml
-                self.toml_config().prune.clone()
-            }
-        }
+        let Some(mut node_prune_config) = self.node_config().prune_config() else {
+            // No CLI config is set, use the toml config.
+            return self.toml_config().prune.clone();
+        };
+
+        // Otherwise, use the CLI configuration and merge with toml config.
+        node_prune_config.merge(self.toml_config().prune.clone());
+        Some(node_prune_config)
     }
 
     /// Returns the configured [`PruneModes`], returning the default if no config was available.

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -347,8 +347,18 @@ impl<R> LaunchContextWith<Attached<WithConfigs, R>> {
     }
 
     /// Returns the configured [`PruneConfig`]
+    /// Any configuration set in CLI will take precedence over those set in toml
     pub fn prune_config(&self) -> Option<PruneConfig> {
-        self.toml_config().prune.clone().or_else(|| self.node_config().prune_config())
+        match self.node_config().prune_config() {
+            Some(mut node_prune_config) => {
+                node_prune_config.merge(self.toml_config().prune.clone());
+                Some(node_prune_config)
+            }
+            None => {
+                // If CLI PruneConfig isn't set, use the one from toml 
+                self.toml_config().prune.clone()
+            }
+        }
     }
 
     /// Returns the configured [`PruneModes`], returning the default if no config was available.


### PR DESCRIPTION
Now that https://github.com/paradigmxyz/reth/pull/10639 is in, we expose all `PruneConfig` via CLI. Now that configuration can be set either via CLI or `reth.toml` we should allow CLI to clobber and take precedence over any file based configuration.  

This PR then addresses discussion in https://github.com/paradigmxyz/reth/issues/9808, superseding the approach in https://github.com/paradigmxyz/reth/pull/10409  