### PR TITLE
Handle non-default cargo target dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MDBX_PATH = "crates/storage/libmdbx-rs/mdbx-sys/libmdbx"
 DB_TOOLS_DIR = "db-tools"
 FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 
-BUILD_PATH = "target"
+CARGO_TARGET_DIR ?= target
 
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
@@ -125,7 +125,7 @@ op-build-aarch64-apple-darwin:
 
 # Create a `.tar.gz` containing a binary for a specific target.
 define tarball_release_binary
-	cp $(BUILD_PATH)/$(1)/$(PROFILE)/$(2) $(BIN_DIR)/$(2)
+	cp $(CARGO_TARGET_DIR)/$(1)/$(PROFILE)/$(2) $(BIN_DIR)/$(2)
 	cd $(BIN_DIR) && \
 		tar -czf reth-$(GIT_TAG)-$(1)$(3).tar.gz $(2) && \
 		rm $(2)
@@ -219,11 +219,11 @@ docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with
 define docker_build_push
 	$(MAKE) build-x86_64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/amd64
-	cp $(BUILD_PATH)/x86_64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/amd64/reth
+	cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/amd64/reth
 
 	$(MAKE) build-aarch64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/arm64
-	cp $(BUILD_PATH)/aarch64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/arm64/reth
+	cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/arm64/reth
 
 	docker buildx build --file ./Dockerfile.cross . \
 		--platform linux/amd64,linux/arm64 \
@@ -263,11 +263,11 @@ op-docker-build-push-nightly: ## Build and push cross-arch Docker image tagged w
 define op_docker_build_push
 	$(MAKE) op-build-x86_64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/amd64
-	cp $(BUILD_PATH)/x86_64-unknown-linux-gnu/$(PROFILE)/op-reth $(BIN_DIR)/amd64/op-reth
+	cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/op-reth $(BIN_DIR)/amd64/op-reth
 
 	$(MAKE) op-build-aarch64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/arm64
-	cp $(BUILD_PATH)/aarch64-unknown-linux-gnu/$(PROFILE)/op-reth $(BIN_DIR)/arm64/op-reth
+	cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/op-reth $(BIN_DIR)/arm64/op-reth
 
 	docker buildx build --file ./DockerfileOp.cross . \
 		--platform linux/amd64,linux/arm64 \
@@ -306,7 +306,7 @@ db-tools: ## Compile MDBX debugging tools.
 .PHONY: update-book-cli
 update-book-cli: build-debug ## Update book cli documentation.
 	@echo "Updating book cli doc..."
-	@./book/cli/update.sh $(BUILD_PATH)/debug/reth
+	@./book/cli/update.sh $(CARGO_TARGET_DIR)/debug/reth
 
 .PHONY: maxperf
 maxperf: ## Builds `reth` with the most aggressive optimisations.


### PR DESCRIPTION
Currently working from a Mac Mini with not so much internal storage, so using an external m.2 NVMe to store generated artifacts.

On main:
```
❯ make update-book-cli
cargo build --bin reth --features "jemalloc asm-keccak"
   Compiling reth-node-core v1.0.6 (/Users/estensen/Developer/reth/crates/node/core)
   Compiling reth-exex v1.0.6 (/Users/estensen/Developer/reth/crates/exex/exex)
   Compiling reth-rpc-builder v1.0.6 (/Users/estensen/Developer/reth/crates/rpc/rpc-builder)
   Compiling reth-stages v1.0.6 (/Users/estensen/Developer/reth/crates/stages/stages)
   Compiling reth-consensus-debug-client v1.0.6 (/Users/estensen/Developer/reth/crates/consensus/debug-client)
   Compiling reth-node-events v1.0.6 (/Users/estensen/Developer/reth/crates/node/events)
   Compiling reth-node-builder v1.0.6 (/Users/estensen/Developer/reth/crates/node/builder)
   Compiling reth-cli-commands v1.0.6 (/Users/estensen/Developer/reth/crates/cli/commands)
   Compiling reth-node-ethereum v1.0.6 (/Users/estensen/Developer/reth/crates/ethereum/node)
   Compiling reth v1.0.6 (/Users/estensen/Developer/reth/bin/reth)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 58.58s
Updating book cli doc...
Running: $ ./book/cli/help.rs --root-dir ./book/ --root-indentation 2 --root-summary --out-dir ./book/cli/ target/debug/reth
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `/Volumes/WD_BLACK_SN750_2TB/target/debug/help --root-dir ./book/ --root-indentation 2 --root-summary --out-dir ./book/cli/ target/debug/reth`
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
make: *** [update-book-cli] Error 1
```

this pr:
```
❯ make update-book-cli
cargo build --bin reth --features "jemalloc asm-keccak"
   Compiling reth-node-core v1.0.6 (/Users/estensen/Developer/reth/crates/node/core)
   Compiling reth-exex v1.0.6 (/Users/estensen/Developer/reth/crates/exex/exex)
   Compiling reth-rpc-builder v1.0.6 (/Users/estensen/Developer/reth/crates/rpc/rpc-builder)
   Compiling reth-stages v1.0.6 (/Users/estensen/Developer/reth/crates/stages/stages)
   Compiling reth-consensus-debug-client v1.0.6 (/Users/estensen/Developer/reth/crates/consensus/debug-client)
   Compiling reth-node-events v1.0.6 (/Users/estensen/Developer/reth/crates/node/events)
   Compiling reth-node-builder v1.0.6 (/Users/estensen/Developer/reth/crates/node/builder)
   Compiling reth-cli-commands v1.0.6 (/Users/estensen/Developer/reth/crates/cli/commands)
   Compiling reth-node-ethereum v1.0.6 (/Users/estensen/Developer/reth/crates/ethereum/node)
   Compiling reth v1.0.6 (/Users/estensen/Developer/reth/bin/reth)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.56s
Updating book cli doc...
Running: $ ./book/cli/help.rs --root-dir ./book/ --root-indentation 2 --root-summary --out-dir ./book/cli/ /Volumes/WD_BLACK_SN750_2TB/target/debug/reth
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `/Volumes/WD_BLACK_SN750_2TB/target/debug/help --root-dir ./book/ --root-indentation 2 --root-summary --out-dir ./book/cli/ /Volumes/WD_BLACK_SN750_2TB/target/debug/reth`
```