### PR TITLE
Make EngineType generic wrt Engine and payload types

### DIFF
--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -29,18 +29,41 @@ pub use reth_rpc_types::{
 #[non_exhaustive]
 pub struct EthEngineTypes;
 
-impl PayloadTypes for EthEngineTypes {
+pub trait GenericEngineTypes {
+    type ExecutionPayloadV1;
+    type ExecutionPayloadV2;
+    type ExecutionPayloadV3;
+    type ExecutionPayloadV4;
+}
+
+pub trait GenericPayloadTypes  {
+    type BuiltPayload ;
+    type PayloadAttributes ;
+    type PayloadBuilderAttributes ;
+}
+
+pub trait EngineTypes: GenericEngineTypes + GenricPayloadTypes {
+    fn validate_version_specific_fields(
+        chain_spec: &ChainSpec,
+        version: EngineApiMessageVersion,
+        payload_or_attrs: PayloadOrAttributes<'_, Self::PayloadAttributes>,
+    ) -> Result<(), EngineObjectValidationError>;
+}
+
+impl GenericEngineTypes for EthEngineTypes {
+    type ExecutionPayloadV1 = ExecutionPayloadV1;
+    type ExecutionPayloadV2 = ExecutionPayloadEnvelopeV2;
+    type ExecutionPayloadV3 = ExecutionPayloadEnvelopeV3;
+    type ExecutionPayloadV4 = ExecutionPayloadEnvelopeV4;
+}
+
+impl GenricPayloadTypes for EthEngineTypes {
     type BuiltPayload = EthBuiltPayload;
     type PayloadAttributes = EthPayloadAttributes;
     type PayloadBuilderAttributes = EthPayloadBuilderAttributes;
 }
 
 impl EngineTypes for EthEngineTypes {
-    type ExecutionPayloadV1 = ExecutionPayloadV1;
-    type ExecutionPayloadV2 = ExecutionPayloadEnvelopeV2;
-    type ExecutionPayloadV3 = ExecutionPayloadEnvelopeV3;
-    type ExecutionPayloadV4 = ExecutionPayloadEnvelopeV4;
-
     fn validate_version_specific_fields(
         chain_spec: &ChainSpec,
         version: EngineApiMessageVersion,


### PR DESCRIPTION
Trying to tackle https://github.com/paradigmxyz/reth/issues/8331

This is my first attempt to contribute to reth and i have created a draft pr before moving forward to gather feedback whether this is the right way to make the EngineTypes generic. 

I have added a trait for EngineTypes that requires any type which implements it to also implement it's extended traits that define its associated types.

Very grateful for any feedback regarding this so that i continue on this path!

 