### PR TITLE
Move `EthBlocks::block_receipts` default impl to impl for `EthApi`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -3,9 +3,9 @@
 use std::sync::Arc;
 
 use futures::Future;
-use reth_primitives::{BlockId, Receipt, SealedBlock, SealedBlockWithSenders, TransactionMeta};
+use reth_primitives::{BlockId, Receipt, SealedBlock, SealedBlockWithSenders};
 use reth_provider::{BlockIdReader, BlockReader, BlockReaderIdExt, HeaderProvider};
-use reth_rpc_eth_types::{EthApiError, EthStateCache, ReceiptBuilder};
+use reth_rpc_eth_types::{EthApiError, EthStateCache};
 use reth_rpc_types::{AnyTransactionReceipt, Header, Index};
 use reth_rpc_types_compat::block::{from_block, uncle_block_from_header};
 
@@ -93,44 +93,7 @@ pub trait EthBlocks: LoadBlock {
         block_id: BlockId,
     ) -> impl Future<Output = Result<Option<Vec<AnyTransactionReceipt>>, Self::Error>> + Send
     where
-        Self: LoadReceipt,
-    {
-        async move {
-            if let Some((block, receipts)) = self.load_block_and_receipts(block_id).await? {
-                let block_number = block.number;
-                let base_fee = block.base_fee_per_gas;
-                let block_hash = block.hash();
-                let excess_blob_gas = block.excess_blob_gas;
-                let timestamp = block.timestamp;
-                let block = block.unseal();
-
-                let receipts = block
-                    .body
-                    .into_iter()
-                    .zip(receipts.iter())
-                    .enumerate()
-                    .map(|(idx, (tx, receipt))| {
-                        let meta = TransactionMeta {
-                            tx_hash: tx.hash,
-                            index: idx as u64,
-                            block_hash,
-                            block_number,
-                            base_fee,
-                            excess_blob_gas,
-                            timestamp,
-                        };
-
-                        ReceiptBuilder::new(&tx, meta, receipt, &receipts)
-                            .map(|builder| builder.build())
-                            .map_err(Self::Error::from_eth_err)
-                    })
-                    .collect::<Result<Vec<_>, Self::Error>>();
-                return receipts.map(Some)
-            }
-
-            Ok(None)
-        }
-    }
+        Self: LoadReceipt;
 
     /// Helper method that loads a bock and all its receipts.
     fn load_block_and_receipts(

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -1,8 +1,13 @@
 //! Contains RPC handler implementations specific to blocks.
 
+use reth_primitives::{BlockId, TransactionMeta};
 use reth_provider::{BlockReaderIdExt, HeaderProvider};
-use reth_rpc_eth_api::helpers::{EthBlocks, LoadBlock, LoadPendingBlock, SpawnBlocking};
-use reth_rpc_eth_types::EthStateCache;
+use reth_rpc_eth_api::{
+    helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
+    FromEthApiError,
+};
+use reth_rpc_eth_types::{EthStateCache, ReceiptBuilder};
+use reth_rpc_types::AnyTransactionReceipt;
 
 use crate::EthApi;
 
@@ -14,6 +19,48 @@ where
     #[inline]
     fn provider(&self) -> impl HeaderProvider {
         self.inner.provider()
+    }
+
+    async fn block_receipts(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<Vec<AnyTransactionReceipt>>, Self::Error>
+    where
+        Self: LoadReceipt,
+    {
+        if let Some((block, receipts)) = self.load_block_and_receipts(block_id).await? {
+            let block_number = block.number;
+            let base_fee = block.base_fee_per_gas;
+            let block_hash = block.hash();
+            let excess_blob_gas = block.excess_blob_gas;
+            let timestamp = block.timestamp;
+            let block = block.unseal();
+
+            let receipts = block
+                .body
+                .into_iter()
+                .zip(receipts.iter())
+                .enumerate()
+                .map(|(idx, (tx, receipt))| {
+                    let meta = TransactionMeta {
+                        tx_hash: tx.hash,
+                        index: idx as u64,
+                        block_hash,
+                        block_number,
+                        base_fee,
+                        excess_blob_gas,
+                        timestamp,
+                    };
+
+                    ReceiptBuilder::new(&tx, meta, receipt, &receipts)
+                        .map(|builder| builder.build())
+                        .map_err(Self::Error::from_eth_err)
+                })
+                .collect::<Result<Vec<_>, Self::Error>>();
+            return receipts.map(Some)
+        }
+
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/10632

`EthBlocks::block_receipts` default impl to impl for `EthApi`. This prepares `EthApi` for returning network specific transaction type as opposed to `AnyTransactionReceipt`.