### PR TITLE
chore(rpc): `LoadReceipt::build_transaction_receipt` default impl to impl for `EthApi`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -3,10 +3,10 @@
 
 use futures::Future;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
-use reth_rpc_eth_types::{EthApiError, EthStateCache, ReceiptBuilder};
+use reth_rpc_eth_types::EthStateCache;
 use reth_rpc_types::AnyTransactionReceipt;
 
-use crate::{EthApiTypes, FromEthApiError};
+use crate::EthApiTypes;
 
 /// Assembles transaction receipt data w.r.t to network.
 ///
@@ -23,18 +23,5 @@ pub trait LoadReceipt: EthApiTypes + Send + Sync {
         tx: TransactionSigned,
         meta: TransactionMeta,
         receipt: Receipt,
-    ) -> impl Future<Output = Result<AnyTransactionReceipt, Self::Error>> + Send {
-        async move {
-            let hash = meta.block_hash;
-            // get all receipts for the block
-            let all_receipts = self
-                .cache()
-                .get_receipts(hash)
-                .await
-                .map_err(Self::Error::from_eth_err)?
-                .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
-
-            Ok(ReceiptBuilder::new(&tx, meta, &receipt, &all_receipts)?.build())
-        }
-    }
+    ) -> impl Future<Output = Result<AnyTransactionReceipt, Self::Error>> + Send;
 }

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,7 +1,9 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
-use reth_rpc_eth_api::helpers::LoadReceipt;
-use reth_rpc_eth_types::EthStateCache;
+use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
+use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError};
+use reth_rpc_eth_types::{EthApiError, EthStateCache, ReceiptBuilder};
+use reth_rpc_types::AnyTransactionReceipt;
 
 use crate::EthApi;
 
@@ -12,5 +14,23 @@ where
     #[inline]
     fn cache(&self) -> &EthStateCache {
         self.inner.cache()
+    }
+
+    async fn build_transaction_receipt(
+        &self,
+        tx: TransactionSigned,
+        meta: TransactionMeta,
+        receipt: Receipt,
+    ) -> Result<AnyTransactionReceipt, Self::Error> {
+        let hash = meta.block_hash;
+        // get all receipts for the block
+        let all_receipts = self
+            .cache()
+            .get_receipts(hash)
+            .await
+            .map_err(Self::Error::from_eth_err)?
+            .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
+
+        Ok(ReceiptBuilder::new(&tx, meta, &receipt, &all_receipts)?.build())
     }
 }


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/10632

`LoadReceipt::build_transaction_receipt` default impl to impl for `EthApi`. This prepares `EthApi` for returning network specific transaction type as opposed to `AnyTransactionReceipt`.