### PR TITLE
fix(storage): add `FileDataReader` & `MmapDataReader` to `NippyJar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8559,6 +8559,7 @@ dependencies = [
  "reth-exex",
  "reth-network-p2p",
  "reth-network-peers",
+ "reth-nippy-jar",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -61,6 +61,7 @@ reth-execution-errors.workspace = true
 reth-consensus = { workspace = true, features = ["test-utils"] }
 reth-network-p2p = { workspace = true, features = ["test-utils"] }
 reth-downloaders.workspace = true
+reth-nippy-jar = { workspace = true, features = ["test-utils"] }
 reth-revm.workspace = true
 reth-static-file.workspace = true
 reth-testing-utils.workspace = true

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -48,6 +48,7 @@ mod tests {
         mdbx::{cursor::Cursor, RW},
         tables, AccountsHistory,
     };
+    use reth_nippy_jar::DataReader;
     use reth_db_api::{
         cursor::{DbCursorRO, DbCursorRW},
         table::Table,

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -48,7 +48,6 @@ mod tests {
         mdbx::{cursor::Cursor, RW},
         tables, AccountsHistory,
     };
-    use reth_nippy_jar::DataReader;
     use reth_db_api::{
         cursor::{DbCursorRO, DbCursorRW},
         table::Table,
@@ -56,6 +55,7 @@ mod tests {
     };
     use reth_evm_ethereum::execute::EthExecutorProvider;
     use reth_exex::ExExManagerHandle;
+    use reth_nippy_jar::DataReader;
     use reth_primitives::{
         address, hex_literal::hex, keccak256, Account, BlockNumber, Bytecode, SealedBlock,
         StaticFileSegment, B256, U256,

--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -1,7 +1,7 @@
 use super::mask::{ColumnSelectorOne, ColumnSelectorThree, ColumnSelectorTwo};
 use derive_more::{Deref, DerefMut};
 use reth_db_api::table::Decompress;
-use reth_nippy_jar::{DataReader, NippyJar, NippyJarCursor};
+use reth_nippy_jar::{MmapDataReader, NippyJar, NippyJarCursor};
 use reth_primitives::{static_file::SegmentHeader, B256};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::sync::Arc;
@@ -15,7 +15,7 @@ type ColumnResult<T> = ProviderResult<Option<T>>;
 
 impl<'a> StaticFileCursor<'a> {
     /// Returns a new [`StaticFileCursor`].
-    pub fn new(jar: &'a NippyJar<SegmentHeader>, reader: Arc<DataReader>) -> ProviderResult<Self> {
+    pub fn new(jar: &'a NippyJar<SegmentHeader>, reader: Arc<MmapDataReader>) -> ProviderResult<Self> {
         Ok(Self(
             NippyJarCursor::with_reader(jar, reader)
                 .map_err(|err| ProviderError::NippyJar(err.to_string()))?,

--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -1,7 +1,7 @@
 use super::mask::{ColumnSelectorOne, ColumnSelectorThree, ColumnSelectorTwo};
 use derive_more::{Deref, DerefMut};
 use reth_db_api::table::Decompress;
-use reth_nippy_jar::{MmapDataReader, NippyJar, NippyJarCursor};
+use reth_nippy_jar::{DefaultDataReader, NippyJar, NippyJarCursor};
 use reth_primitives::{static_file::SegmentHeader, B256};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::sync::Arc;
@@ -15,7 +15,10 @@ type ColumnResult<T> = ProviderResult<Option<T>>;
 
 impl<'a> StaticFileCursor<'a> {
     /// Returns a new [`StaticFileCursor`].
-    pub fn new(jar: &'a NippyJar<SegmentHeader>, reader: Arc<MmapDataReader>) -> ProviderResult<Self> {
+    pub fn new(
+        jar: &'a NippyJar<SegmentHeader>,
+        reader: Arc<DefaultDataReader>,
+    ) -> ProviderResult<Self> {
         Ok(Self(
             NippyJarCursor::with_reader(jar, reader)
                 .map_err(|err| ProviderError::NippyJar(err.to_string()))?,

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -1,4 +1,6 @@
-use crate::{writer::OFFSET_SIZE_BYTES, NippyJar, NippyJarError, NippyJarHeader};
+use crate::{
+    reader::DataReader, writer::OFFSET_SIZE_BYTES, NippyJar, NippyJarError, NippyJarHeader,
+};
 use std::{
     cmp::Ordering,
     fs::{File, OpenOptions},

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -200,9 +200,14 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
             row.push(ValueRange::Internal(from..to));
         } else {
             // Not compressed
+            //
+            // ! Only MmapReader allows reading directly from memory by using `reader.data_ref`.
+            // Otherwise we need to copy the data to a buffer by using `reader.data`.
             if self.reader.allows_data_ref() {
+                // MmapReader
                 row.push(ValueRange::Mmap(column_offset_range));
             } else {
+                // FileReader
                 let len = column_offset_range.end - column_offset_range.start;
 
                 // It's safe to use internal_buffer, since there's no partial compression. Either

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -1,6 +1,6 @@
 use crate::{
     compression::{Compression, Compressors, Zstd},
-    DataReader, NippyJar, NippyJarError, NippyJarHeader, RefRow,
+    MmapDataReader, NippyJar, NippyJarError, NippyJarHeader, RefRow,
 };
 use std::{ops::Range, sync::Arc};
 use zstd::bulk::Decompressor;
@@ -11,7 +11,7 @@ pub struct NippyJarCursor<'a, H = ()> {
     /// [`NippyJar`] which holds most of the required configuration to read from the file.
     jar: &'a NippyJar<H>,
     /// Data and offset reader.
-    reader: Arc<DataReader>,
+    reader: Arc<MmapDataReader>,
     /// Internal buffer to unload data to without reallocating memory on each retrieval.
     internal_buffer: Vec<u8>,
     /// Cursor row position.
@@ -38,7 +38,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
 
     pub fn with_reader(
         jar: &'a NippyJar<H>,
-        reader: Arc<DataReader>,
+        reader: Arc<MmapDataReader>,
     ) -> Result<Self, NippyJarError> {
         let max_row_size = jar.max_row_size;
         Ok(NippyJarCursor {

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -13,12 +13,10 @@
 #![allow(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use memmap2::Mmap;
 use serde::{Deserialize, Serialize};
 use std::{
     error::Error as StdError,
     fs::{File, OpenOptions},
-    ops::Range,
     path::{Path, PathBuf},
 };
 
@@ -32,6 +30,9 @@ pub mod compression;
 #[cfg(test)]
 use compression::Compression;
 use compression::Compressors;
+
+mod reader;
+pub use reader::DataReader;
 
 /// empty enum for backwards compatibility
 #[derive(Debug, Serialize, Deserialize)]
@@ -337,106 +338,6 @@ impl<H: NippyJarHeader> NippyJar<H> {
         }
 
         Ok(())
-    }
-}
-
-/// Manages the reading of static file data using memory-mapped files.
-///
-/// Holds file and mmap descriptors of the data and offsets files of a `static_file`.
-#[derive(Debug)]
-pub struct DataReader {
-    /// Data file descriptor. Needs to be kept alive as long as `data_mmap` handle.
-    #[allow(dead_code)]
-    data_file: File,
-    /// Mmap handle for data.
-    data_mmap: Mmap,
-    /// Offset file descriptor. Needs to be kept alive as long as `offset_mmap` handle.
-    #[allow(dead_code)]
-    offset_file: File,
-    /// Mmap handle for offsets.
-    offset_mmap: Mmap,
-    /// Number of bytes that represent one offset.
-    offset_size: u8,
-}
-
-impl DataReader {
-    /// Reads the respective data and offsets file and returns [`DataReader`].
-    pub fn new(path: impl AsRef<Path>) -> Result<Self, NippyJarError> {
-        let data_file = File::open(path.as_ref())?;
-        // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
-        let data_mmap = unsafe { Mmap::map(&data_file)? };
-
-        let offset_file = File::open(path.as_ref().with_extension(OFFSETS_FILE_EXTENSION))?;
-        // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
-        let offset_mmap = unsafe { Mmap::map(&offset_file)? };
-
-        // First byte is the size of one offset in bytes
-        let offset_size = offset_mmap[0];
-
-        // Ensure that the size of an offset is at most 8 bytes.
-        if offset_size > 8 {
-            return Err(NippyJarError::OffsetSizeTooBig { offset_size })
-        } else if offset_size == 0 {
-            return Err(NippyJarError::OffsetSizeTooSmall { offset_size })
-        }
-
-        Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
-    }
-
-    /// Returns the offset for the requested data index
-    pub fn offset(&self, index: usize) -> Result<u64, NippyJarError> {
-        // + 1 represents the offset_len u8 which is in the beginning of the file
-        let from = index * self.offset_size as usize + 1;
-
-        self.offset_at(from)
-    }
-
-    /// Returns the offset for the requested data index starting from the end
-    pub fn reverse_offset(&self, index: usize) -> Result<u64, NippyJarError> {
-        let offsets_file_size = self.offset_file.metadata()?.len() as usize;
-
-        if offsets_file_size > 1 {
-            let from = offsets_file_size - self.offset_size as usize * (index + 1);
-
-            self.offset_at(from)
-        } else {
-            Ok(0)
-        }
-    }
-
-    /// Returns total number of offsets in the file.
-    /// The size of one offset is determined by the file itself.
-    pub fn offsets_count(&self) -> Result<usize, NippyJarError> {
-        Ok((self.offset_file.metadata()?.len().saturating_sub(1) / self.offset_size as u64)
-            as usize)
-    }
-
-    /// Reads one offset-sized (determined by the offset file) u64 at the provided index.
-    fn offset_at(&self, index: usize) -> Result<u64, NippyJarError> {
-        let mut buffer: [u8; 8] = [0; 8];
-
-        let offset_end = index.saturating_add(self.offset_size as usize);
-        if offset_end > self.offset_mmap.len() {
-            return Err(NippyJarError::OffsetOutOfBounds { index })
-        }
-
-        buffer[..self.offset_size as usize].copy_from_slice(&self.offset_mmap[index..offset_end]);
-        Ok(u64::from_le_bytes(buffer))
-    }
-
-    /// Returns number of bytes that represent one offset.
-    pub const fn offset_size(&self) -> u8 {
-        self.offset_size
-    }
-
-    /// Returns the underlying data as a slice of bytes for the provided range.
-    pub fn data(&self, range: Range<usize>) -> &[u8] {
-        &self.data_mmap[range]
-    }
-
-    /// Returns total size of data
-    pub fn size(&self) -> usize {
-        self.data_mmap.len()
     }
 }
 

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -32,7 +32,7 @@ use compression::Compression;
 use compression::Compressors;
 
 mod reader;
-pub use reader::DataReader;
+pub use reader::MmapDataReader;
 
 /// empty enum for backwards compatibility
 #[derive(Debug, Serialize, Deserialize)]
@@ -245,8 +245,8 @@ impl<H: NippyJarHeader> NippyJar<H> {
     }
 
     /// Returns a [`DataReader`] of the data and offset file
-    pub fn open_data_reader(&self) -> Result<DataReader, NippyJarError> {
-        DataReader::new(self.data_path())
+    pub fn open_data_reader(&self) -> Result<MmapDataReader, NippyJarError> {
+        MmapDataReader::new(self.data_path())
     }
 
     /// Writes all necessary configuration to file.

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -32,7 +32,7 @@ use compression::Compression;
 use compression::Compressors;
 
 mod reader;
-pub use reader::MmapDataReader;
+pub use reader::{DataReader, DefaultDataReader, FileDataReader, MmapDataReader};
 
 /// empty enum for backwards compatibility
 #[derive(Debug, Serialize, Deserialize)]
@@ -245,8 +245,8 @@ impl<H: NippyJarHeader> NippyJar<H> {
     }
 
     /// Returns a [`DataReader`] of the data and offset file
-    pub fn open_data_reader(&self) -> Result<MmapDataReader, NippyJarError> {
-        MmapDataReader::new(self.data_path())
+    pub fn open_data_reader(&self) -> Result<DefaultDataReader, NippyJarError> {
+        DefaultDataReader::new(self.data_path())
     }
 
     /// Writes all necessary configuration to file.

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -221,6 +221,9 @@ impl DataReader for FileDataReader {
         false
     }
 
+    /// Not supported by [`FileDataReader`] and **will PANIC**.
+    /// 
+    /// Use [`Self::data`] instead.
     fn data_ref(&self, _: Range<usize>) -> &[u8] {
         unimplemented!()
     }

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -7,9 +7,11 @@ use std::{
     path::Path,
 };
 
+/// Uses [`FileDataReader`] due to Windows-specific issues with mmap, such as file access locks and poor handling of file changes.
 #[cfg(windows)]
 pub type DefaultDataReader = FileDataReader;
 
+/// Uses [`MmapDataReader`] for efficient zero-copy read access.
 #[cfg(not(windows))]
 pub type DefaultDataReader = MmapDataReader;
 
@@ -153,7 +155,7 @@ impl DataReader for MmapDataReader {
     }
 }
 
-/// Manages the reading of static file data using direct file access.
+/// Manages the reading of static file data using standard file I/O.
 #[derive(Debug)]
 pub struct FileDataReader {
     /// Data file descriptor.

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -1,0 +1,105 @@
+use std::ops::Range;
+use std::{fs::File, path::Path};
+use memmap2::Mmap;
+use crate::{NippyJarError, OFFSETS_FILE_EXTENSION};
+
+
+/// Manages the reading of static file data using memory-mapped files.
+///
+/// Holds file and mmap descriptors of the data and offsets files of a `static_file`.
+#[derive(Debug)]
+pub struct DataReader {
+    /// Data file descriptor. Needs to be kept alive as long as `data_mmap` handle.
+    #[allow(dead_code)]
+    data_file: File,
+    /// Mmap handle for data.
+    data_mmap: Mmap,
+    /// Offset file descriptor. Needs to be kept alive as long as `offset_mmap` handle.
+    #[allow(dead_code)]
+    offset_file: File,
+    /// Mmap handle for offsets.
+    offset_mmap: Mmap,
+    /// Number of bytes that represent one offset.
+    offset_size: u8,
+}
+
+impl DataReader {
+    /// Reads the respective data and offsets file and returns [`DataReader`].
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, NippyJarError> {
+        let data_file = File::open(path.as_ref())?;
+        // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
+        let data_mmap = unsafe { Mmap::map(&data_file)? };
+
+        let offset_file = File::open(path.as_ref().with_extension(OFFSETS_FILE_EXTENSION))?;
+        // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
+        let offset_mmap = unsafe { Mmap::map(&offset_file)? };
+
+        // First byte is the size of one offset in bytes
+        let offset_size = offset_mmap[0];
+
+        // Ensure that the size of an offset is at most 8 bytes.
+        if offset_size > 8 {
+            return Err(NippyJarError::OffsetSizeTooBig { offset_size })
+        } else if offset_size == 0 {
+            return Err(NippyJarError::OffsetSizeTooSmall { offset_size })
+        }
+
+        Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
+    }
+
+    /// Returns the offset for the requested data index
+    pub fn offset(&self, index: usize) -> Result<u64, NippyJarError> {
+        // + 1 represents the offset_len u8 which is in the beginning of the file
+        let from = index * self.offset_size as usize + 1;
+
+        self.offset_at(from)
+    }
+
+    /// Returns the offset for the requested data index starting from the end
+    pub fn reverse_offset(&self, index: usize) -> Result<u64, NippyJarError> {
+        let offsets_file_size = self.offset_file.metadata()?.len() as usize;
+
+        if offsets_file_size > 1 {
+            let from = offsets_file_size - self.offset_size as usize * (index + 1);
+
+            self.offset_at(from)
+        } else {
+            Ok(0)
+        }
+    }
+
+    /// Returns total number of offsets in the file.
+    /// The size of one offset is determined by the file itself.
+    pub fn offsets_count(&self) -> Result<usize, NippyJarError> {
+        Ok((self.offset_file.metadata()?.len().saturating_sub(1) / self.offset_size as u64)
+            as usize)
+    }
+
+    /// Reads one offset-sized (determined by the offset file) u64 at the provided index.
+    fn offset_at(&self, index: usize) -> Result<u64, NippyJarError> {
+        let mut buffer: [u8; 8] = [0; 8];
+
+        let offset_end = index.saturating_add(self.offset_size as usize);
+        if offset_end > self.offset_mmap.len() {
+            return Err(NippyJarError::OffsetOutOfBounds { index })
+        }
+
+        buffer[..self.offset_size as usize].copy_from_slice(&self.offset_mmap[index..offset_end]);
+        Ok(u64::from_le_bytes(buffer))
+    }
+
+    /// Returns number of bytes that represent one offset.
+    pub const fn offset_size(&self) -> u8 {
+        self.offset_size
+    }
+
+    /// Returns the underlying data as a slice of bytes for the provided range.
+    pub fn data(&self, range: Range<usize>) -> &[u8] {
+        &self.data_mmap[range]
+    }
+
+    /// Returns total size of data
+    pub fn size(&self) -> usize {
+        self.data_mmap.len()
+    }
+}

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -41,6 +41,9 @@ pub trait DataReader {
     fn allows_data_ref(&self) -> bool;
 
     /// Returns the underlying data range as a slice of bytes.
+    ///
+    /// # Panics
+    /// If the reader does not support returning the data range as a slice of bytes.
     fn data_ref(&self, range: Range<usize>) -> &[u8];
 
     /// Copies the underlying data range to a given mutable slice.

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -7,7 +7,8 @@ use std::{
     path::Path,
 };
 
-/// Uses [`FileDataReader`] due to Windows-specific issues with mmap, such as file access locks and poor handling of file changes.
+/// Uses [`FileDataReader`] due to Windows-specific issues with mmap, such as file access locks and
+/// poor handling of file changes.
 #[cfg(windows)]
 pub type DefaultDataReader = FileDataReader;
 
@@ -222,7 +223,7 @@ impl DataReader for FileDataReader {
     }
 
     /// Not supported by [`FileDataReader`] and **will PANIC**.
-    /// 
+    ///
     /// Use [`Self::data`] instead.
     fn data_ref(&self, _: Range<usize>) -> &[u8] {
         unimplemented!()

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -8,7 +8,7 @@ use crate::{NippyJarError, OFFSETS_FILE_EXTENSION};
 ///
 /// Holds file and mmap descriptors of the data and offsets files of a `static_file`.
 #[derive(Debug)]
-pub struct DataReader {
+pub struct MmapDataReader {
     /// Data file descriptor. Needs to be kept alive as long as `data_mmap` handle.
     #[allow(dead_code)]
     data_file: File,
@@ -23,7 +23,7 @@ pub struct DataReader {
     offset_size: u8,
 }
 
-impl DataReader {
+impl MmapDataReader {
     /// Reads the respective data and offsets file and returns [`DataReader`].
     pub fn new(path: impl AsRef<Path>) -> Result<Self, NippyJarError> {
         let data_file = File::open(path.as_ref())?;

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -45,6 +45,9 @@ pub trait DataReader {
 
     /// Returns the underlying data range as a slice of bytes.
     ///
+    /// # Safety
+    /// The caller must ensure that [`Self::allows_data_ref`] returns `true` before calling this function.
+    /// 
     /// # Panics
     /// If the reader does not support returning the data range as a slice of bytes.
     fn data_ref(&self, range: Range<usize>) -> &[u8];
@@ -226,7 +229,7 @@ impl DataReader for FileDataReader {
     ///
     /// Use [`Self::data`] instead.
     fn data_ref(&self, _: Range<usize>) -> &[u8] {
-        unimplemented!()
+        panic!("FileDataReader does not support returning data as a slice. Use reader.data() instead")
     }
 
     fn data(&self, range: Range<usize>, buffer: &mut [u8]) -> Result<(), NippyJarError> {

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -1,8 +1,54 @@
-use std::ops::Range;
-use std::{fs::File, path::Path};
-use memmap2::Mmap;
 use crate::{NippyJarError, OFFSETS_FILE_EXTENSION};
+use memmap2::Mmap;
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    ops::Range,
+    path::Path,
+};
 
+#[cfg(windows)]
+pub type DefaultDataReader = FileDataReader;
+
+#[cfg(not(windows))]
+pub type DefaultDataReader = MmapDataReader;
+
+/// Trait defining shared methods for reading data.
+pub trait DataReader {
+    /// Reads the respective data and offsets file and returns [`DataReader`].
+    fn new(path: impl AsRef<Path>) -> Result<Self, NippyJarError>
+    where
+        Self: Sized;
+
+    /// Returns the offset for the requested data index.
+    fn offset(&self, index: usize) -> Result<u64, NippyJarError>;
+
+    /// Returns the offset for the requested data index starting from the end.
+    fn reverse_offset(&self, index: usize) -> Result<u64, NippyJarError>;
+
+    /// Returns the total number of offsets in the file.
+    ///
+    /// The size of one offset is determined by the file itself.
+    fn offsets_count(&self) -> Result<usize, NippyJarError>;
+
+    /// Reads one offset-sized (determined by the offset file) `u64` at the provided index.
+    fn offset_at(&self, index: usize) -> Result<u64, NippyJarError>;
+
+    /// Returns number of bytes that represent one offset.
+    fn offset_size(&self) -> u8;
+
+    /// Whether this data reader supports [`Self::data_ref`]
+    fn allows_data_ref(&self) -> bool;
+
+    /// Returns the underlying data range as a slice of bytes.
+    fn data_ref(&self, range: Range<usize>) -> &[u8];
+
+    /// Copies the underlying data range to a given mutable slice.
+    fn data(&self, range: Range<usize>, buffer: &mut [u8]) -> Result<(), NippyJarError>;
+
+    /// Returns the total size of the data.
+    fn size(&self) -> Result<usize, NippyJarError>;
+}
 
 /// Manages the reading of static file data using memory-mapped files.
 ///
@@ -23,9 +69,8 @@ pub struct MmapDataReader {
     offset_size: u8,
 }
 
-impl MmapDataReader {
-    /// Reads the respective data and offsets file and returns [`DataReader`].
-    pub fn new(path: impl AsRef<Path>) -> Result<Self, NippyJarError> {
+impl DataReader for MmapDataReader {
+    fn new(path: impl AsRef<Path>) -> Result<Self, NippyJarError> {
         let data_file = File::open(path.as_ref())?;
         // SAFETY: File is read-only and its descriptor is kept alive as long as the mmap handle.
         let data_mmap = unsafe { Mmap::map(&data_file)? };
@@ -47,16 +92,14 @@ impl MmapDataReader {
         Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
     }
 
-    /// Returns the offset for the requested data index
-    pub fn offset(&self, index: usize) -> Result<u64, NippyJarError> {
+    fn offset(&self, index: usize) -> Result<u64, NippyJarError> {
         // + 1 represents the offset_len u8 which is in the beginning of the file
         let from = index * self.offset_size as usize + 1;
 
         self.offset_at(from)
     }
 
-    /// Returns the offset for the requested data index starting from the end
-    pub fn reverse_offset(&self, index: usize) -> Result<u64, NippyJarError> {
+    fn reverse_offset(&self, index: usize) -> Result<u64, NippyJarError> {
         let offsets_file_size = self.offset_file.metadata()?.len() as usize;
 
         if offsets_file_size > 1 {
@@ -68,14 +111,11 @@ impl MmapDataReader {
         }
     }
 
-    /// Returns total number of offsets in the file.
-    /// The size of one offset is determined by the file itself.
-    pub fn offsets_count(&self) -> Result<usize, NippyJarError> {
+    fn offsets_count(&self) -> Result<usize, NippyJarError> {
         Ok((self.offset_file.metadata()?.len().saturating_sub(1) / self.offset_size as u64)
             as usize)
     }
 
-    /// Reads one offset-sized (determined by the offset file) u64 at the provided index.
     fn offset_at(&self, index: usize) -> Result<u64, NippyJarError> {
         let mut buffer: [u8; 8] = [0; 8];
 
@@ -88,18 +128,108 @@ impl MmapDataReader {
         Ok(u64::from_le_bytes(buffer))
     }
 
-    /// Returns number of bytes that represent one offset.
-    pub const fn offset_size(&self) -> u8 {
+    fn offset_size(&self) -> u8 {
         self.offset_size
     }
 
-    /// Returns the underlying data as a slice of bytes for the provided range.
-    pub fn data(&self, range: Range<usize>) -> &[u8] {
+    fn allows_data_ref(&self) -> bool {
+        true
+    }
+
+    fn data_ref(&self, range: Range<usize>) -> &[u8] {
         &self.data_mmap[range]
     }
 
-    /// Returns total size of data
-    pub fn size(&self) -> usize {
-        self.data_mmap.len()
+    fn data(&self, range: Range<usize>, buffer: &mut [u8]) -> Result<(), NippyJarError> {
+        buffer.copy_from_slice(&self.data_mmap[range]);
+        Ok(())
+    }
+
+    fn size(&self) -> Result<usize, NippyJarError> {
+        Ok(self.data_mmap.len())
+    }
+}
+
+/// Manages the reading of static file data using direct file access.
+#[derive(Debug)]
+pub struct FileDataReader {
+    /// Data file descriptor.
+    data_file: File,
+    /// Offset file descriptor.
+    offset_file: File,
+    /// Number of bytes that represent one offset.
+    offset_size: u8,
+}
+
+impl DataReader for FileDataReader {
+    fn new(path: impl AsRef<Path>) -> Result<Self, NippyJarError> {
+        let data_file = File::open(path.as_ref())?;
+        let mut offset_file = File::open(path.as_ref().with_extension(OFFSETS_FILE_EXTENSION))?;
+
+        // First byte is the size of one offset in bytes
+        let mut offset_size_buf = [0u8; 1];
+        offset_file.read_exact(&mut offset_size_buf)?;
+        let offset_size = offset_size_buf[0];
+
+        if offset_size > 8 {
+            return Err(NippyJarError::OffsetSizeTooBig { offset_size });
+        } else if offset_size == 0 {
+            return Err(NippyJarError::OffsetSizeTooSmall { offset_size });
+        }
+
+        Ok(Self { data_file, offset_file, offset_size })
+    }
+
+    fn offset(&self, index: usize) -> Result<u64, NippyJarError> {
+        let from = index * self.offset_size as usize + 1;
+        self.offset_at(from)
+    }
+
+    fn reverse_offset(&self, index: usize) -> Result<u64, NippyJarError> {
+        let offsets_file_size = self.offset_file.metadata()?.len() as usize;
+        if offsets_file_size > 1 {
+            let from = offsets_file_size - self.offset_size as usize * (index + 1);
+            self.offset_at(from)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn offsets_count(&self) -> Result<usize, NippyJarError> {
+        Ok((self.offset_file.metadata()?.len().saturating_sub(1) / self.offset_size as u64)
+            as usize)
+    }
+
+    fn offset_at(&self, index: usize) -> Result<u64, NippyJarError> {
+        let mut buffer: [u8; 8] = [0; 8];
+        let mut offset_file = &self.offset_file;
+        offset_file.seek(SeekFrom::Start(index as u64))?;
+        offset_file.read_exact(&mut buffer[..self.offset_size as usize])?;
+        Ok(u64::from_le_bytes(buffer))
+    }
+
+    fn offset_size(&self) -> u8 {
+        self.offset_size
+    }
+
+    fn allows_data_ref(&self) -> bool {
+        false
+    }
+
+    fn data_ref(&self, _: Range<usize>) -> &[u8] {
+        unimplemented!()
+    }
+
+    fn data(&self, range: Range<usize>, buffer: &mut [u8]) -> Result<(), NippyJarError> {
+        debug_assert!(range.len() == buffer.len());
+
+        let mut data_file = &self.offset_file;
+        data_file.seek(SeekFrom::Start(range.start as u64))?;
+        data_file.read_exact(buffer)?;
+        Ok(())
+    }
+
+    fn size(&self) -> Result<usize, NippyJarError> {
+        Ok(self.data_file.metadata()?.len() as usize)
     }
 }

--- a/crates/storage/nippy-jar/src/reader.rs
+++ b/crates/storage/nippy-jar/src/reader.rs
@@ -46,8 +46,9 @@ pub trait DataReader {
     /// Returns the underlying data range as a slice of bytes.
     ///
     /// # Safety
-    /// The caller must ensure that [`Self::allows_data_ref`] returns `true` before calling this function.
-    /// 
+    /// The caller must ensure that [`Self::allows_data_ref`] returns `true` before calling this
+    /// function.
+    ///
     /// # Panics
     /// If the reader does not support returning the data range as a slice of bytes.
     fn data_ref(&self, range: Range<usize>) -> &[u8];
@@ -229,7 +230,9 @@ impl DataReader for FileDataReader {
     ///
     /// Use [`Self::data`] instead.
     fn data_ref(&self, _: Range<usize>) -> &[u8] {
-        panic!("FileDataReader does not support returning data as a slice. Use reader.data() instead")
+        panic!(
+            "FileDataReader does not support returning data as a slice. Use reader.data() instead"
+        )
     }
 
     fn data(&self, range: Range<usize>, buffer: &mut [u8]) -> Result<(), NippyJarError> {

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -48,7 +48,7 @@ impl<'a> StaticFileJarProvider<'a> {
     where
         'b: 'a,
     {
-        let result = StaticFileCursor::new(self.value(), self.mmap_handle())?;
+        let result = StaticFileCursor::new(self.value(), self.reader_handle())?;
 
         if let Some(metrics) = &self.metrics {
             metrics.record_segment_operation(

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -23,23 +23,20 @@ type LoadedJarRef<'a> = dashmap::mapref::one::Ref<'a, (u64, StaticFileSegment), 
 #[derive(Debug)]
 pub struct LoadedJar {
     jar: NippyJar<SegmentHeader>,
-    mmap_handle: Arc<reth_nippy_jar::MmapDataReader>,
+    reader_handle: Arc<reth_nippy_jar::DefaultDataReader>,
 }
 
 impl LoadedJar {
     fn new(jar: NippyJar<SegmentHeader>) -> ProviderResult<Self> {
         match jar.open_data_reader() {
-            Ok(data_reader) => {
-                let mmap_handle = Arc::new(data_reader);
-                Ok(Self { jar, mmap_handle })
-            }
+            Ok(data_reader) => Ok(Self { jar, reader_handle: Arc::new(data_reader) }),
             Err(e) => Err(ProviderError::NippyJar(e.to_string())),
         }
     }
 
     /// Returns a clone of the mmap handle that can be used to instantiate a cursor.
-    fn mmap_handle(&self) -> Arc<reth_nippy_jar::MmapDataReader> {
-        self.mmap_handle.clone()
+    fn reader_handle(&self) -> Arc<reth_nippy_jar::DefaultDataReader> {
+        self.reader_handle.clone()
     }
 
     const fn segment(&self) -> StaticFileSegment {

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -23,7 +23,7 @@ type LoadedJarRef<'a> = dashmap::mapref::one::Ref<'a, (u64, StaticFileSegment), 
 #[derive(Debug)]
 pub struct LoadedJar {
     jar: NippyJar<SegmentHeader>,
-    mmap_handle: Arc<reth_nippy_jar::DataReader>,
+    mmap_handle: Arc<reth_nippy_jar::MmapDataReader>,
 }
 
 impl LoadedJar {
@@ -38,7 +38,7 @@ impl LoadedJar {
     }
 
     /// Returns a clone of the mmap handle that can be used to instantiate a cursor.
-    fn mmap_handle(&self) -> Arc<reth_nippy_jar::DataReader> {
+    fn mmap_handle(&self) -> Arc<reth_nippy_jar::MmapDataReader> {
         self.mmap_handle.clone()
     }
 


### PR DESCRIPTION
* Adds `FileDataReader` which as the name suggests, does not use mmap
* Adds `DefaultDataReader`: windows will be `FileDataReader`, others `MmapDataReader` 

Windows mmap behaviour differs from unix, and there have been issues in the past. Some I was able to repro (eg. trying to remove a file with a mmap handle open gives out an error), others not so much (eg. writing to a file while a mmap is open https://github.com/paradigmxyz/reth/issues/10689). I've also had unexpected behaviour where written data was not flushed/sync_all just because the mmap handle was open, but it wouldnt even panic.

So for now I think the safest is to disable mmap usage from windows.