### PR TITLE
fix(metrics): set sync metrics when blocks are added

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -223,6 +223,7 @@ where
             ctx.components().payload_builder().clone(),
             TreeConfig::default(),
             ctx.invalid_block_hook()?,
+            ctx.sync_metrics_tx(),
         );
 
         let event_sender = EventSender::default();


### PR DESCRIPTION
This should send sync metric events when blocks are persisted as well as when blocks are removed, restoring some metrics which were missing during live sync in the new engine