### PR TITLE
fix: ensure that `SendersRecoveryStage` either recovers all senders or fails

### DIFF
--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -193,7 +193,7 @@ where
                     let is_err = res.is_err();
 
                     let _ = recovered_senders_tx.send(res);
-                    
+
                     // Finish early
                     if is_err {
                         break
@@ -232,7 +232,9 @@ where
                             })
                         }
                         SenderRecoveryStageError::StageError(err) => Err(err),
-                        SenderRecoveryStageError::FailedBatchRecovery => Err(StageError::Fatal(SenderRecoveryStageError::FailedBatchRecovery.into())),
+                        SenderRecoveryStageError::FailedBatchRecovery => Err(StageError::Fatal(
+                            SenderRecoveryStageError::FailedBatchRecovery.into(),
+                        )),
                     }
                 }
             };

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -159,7 +159,7 @@ where
     // additional blocking tasks. This would cause this function to return
     // `SenderRecoveryStageError::FailedBatchRecovery` at the end.
     //
-    // However, using `std::thread::spawn` allows us to utilize the timeout grace 
+    // However, using `std::thread::spawn` allows us to utilize the timeout grace
     // period to complete some work without throwing errors during the shutdown.
     std::thread::spawn(move || {
         for (chunk_range, recovered_senders_tx) in chunks {


### PR DESCRIPTION
There were two issues with `SendersRecoveryStage` that can result in advancing the checkpoint without actually committing any senders to DB. Hasn't been detected, since `ExecutionStage` uses `Provider::block_with_senders` which recovers any missing sender for its execution.

When we CTRL+C on the middle of the stage, there's a 5 second timeout to drop the tokio runtime. Any current running tokio blocking task (such `pipeline` & `recover_range`) is waited on and will eventually time out. **Any new blocking task won't be executed, and end immediately.** This causes the channel tx to be dropped early with no senders sent (1).

https://github.com/paradigmxyz/reth/blob/e4b532587587f24f68a1c401d02f81594797fe6c/crates/stages/stages/src/stages/sender_recovery.rs#L189-L190

Since we do not catch any error coming from the blocking task (apart from `recover_sender`), or from the blocking task itself, we go through all channels without appending anything(1). In the end, since no error was thrown, we just commit the stage checkpoint and proceed to the next stage run, which will behave the same.

And this will all happen during the drop timeout grace period 

So:
* Catch all possible errors inside the spawned task.
* Before leaving `recover_range`, ensure that we have recovered `N` senders, otherwise throw err
* Swap `tokio::task::spawn_blocking` for `std::thread::spawn`: it will allow the pipeline to proceed and maybe commit data before the timeout grace period runs out.


closes https://github.com/paradigmxyz/reth/issues/10808