### PR TITLE
rpc: replace reth-primitive imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8290,6 +8290,7 @@ name = "reth-rpc-api"
 version = "1.0.6"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-primitives",
  "jsonrpsee",
  "reth-engine-primitives",
  "reth-network-peers",
@@ -8303,6 +8304,7 @@ dependencies = [
 name = "reth-rpc-api-testing-util"
 version = "1.0.6"
 dependencies = [
+ "alloy-primitives",
  "futures",
  "jsonrpsee",
  "jsonrpsee-http-client",
@@ -8320,6 +8322,7 @@ name = "reth-rpc-builder"
 version = "1.0.6"
 dependencies = [
  "alloy-network",
+ "alloy-primitives",
  "clap",
  "http",
  "jsonrpsee",
@@ -8366,6 +8369,7 @@ dependencies = [
 name = "reth-rpc-engine-api"
 version = "1.0.6"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
  "async-trait",
@@ -8403,6 +8407,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-primitives",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -8436,6 +8441,7 @@ dependencies = [
 name = "reth-rpc-eth-types"
 version = "1.0.6"
 dependencies = [
+ "alloy-primitives",
  "alloy-sol-types",
  "derive_more",
  "futures",
@@ -8528,6 +8534,7 @@ dependencies = [
 name = "reth-rpc-types-compat"
 version = "1.0.6"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
  "reth-primitives",

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -21,6 +21,7 @@ reth-network-peers.workspace = true
 
 # ethereum
 alloy-json-rpc.workspace = true
+alloy-primitives.workspace = true
 
 # misc
 jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/rpc/rpc-api/src/anvil.rs
+++ b/crates/rpc/rpc-api/src/anvil.rs
@@ -1,6 +1,6 @@
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
-use reth_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_rpc_types::{
     anvil::{Forking, Metadata, MineOptions, NodeInfo},
     Block,

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,5 +1,6 @@
+use alloy_primitives::{Address, Bytes, B256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256};
+use reth_primitives::{BlockId, BlockNumberOrTag};
 use reth_rpc_types::{
     debug::ExecutionWitness,
     trace::geth::{

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -4,9 +4,10 @@
 //! the consensus client.
 
 use alloy_json_rpc::RpcObject;
+use alloy_primitives::{Address, BlockHash, Bytes, B256, U256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_engine_primitives::EngineTypes;
-use reth_primitives::{Address, BlockHash, BlockId, BlockNumberOrTag, Bytes, B256, U256, U64};
+use reth_primitives::{BlockId, BlockNumberOrTag};
 use reth_rpc_types::{
     engine::{
         ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadBodiesV2,

--- a/crates/rpc/rpc-api/src/ganache.rs
+++ b/crates/rpc/rpc-api/src/ganache.rs
@@ -1,5 +1,5 @@
+use alloy_primitives::U256;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::U256;
 use reth_rpc_types::anvil::MineOptions;
 
 /// Ganache rpc interface.

--- a/crates/rpc/rpc-api/src/hardhat.rs
+++ b/crates/rpc/rpc-api/src/hardhat.rs
@@ -1,5 +1,5 @@
+use alloy_primitives::{Address, Bytes, B256, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{Address, Bytes, B256, U256};
 use reth_rpc_types::anvil::{Forking, Metadata};
 
 /// Hardhat rpc interface.

--- a/crates/rpc/rpc-api/src/net.rs
+++ b/crates/rpc/rpc-api/src/net.rs
@@ -1,5 +1,5 @@
+use alloy_primitives::U64;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::U64;
 
 /// Net rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "net"))]

--- a/crates/rpc/rpc-api/src/otterscan.rs
+++ b/crates/rpc/rpc-api/src/otterscan.rs
@@ -1,5 +1,6 @@
+use alloy_primitives::{Address, Bytes, TxHash, B256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{Address, BlockId, Bytes, TxHash, B256};
+use reth_primitives::BlockId;
 use reth_rpc_types::{
     trace::otterscan::{
         BlockDetails, ContractCreator, InternalOperation, OtsBlockTransactions, TraceEntry,

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -1,5 +1,6 @@
+use alloy_primitives::{Address, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{Address, BlockId, U256};
+use reth_primitives::BlockId;
 use std::collections::HashMap;
 
 /// Reth API namespace for reth-specific methods

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -1,5 +1,6 @@
+use alloy_primitives::{Bytes, B256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{BlockId, Bytes, B256};
+use reth_primitives::BlockId;
 use reth_rpc_types::{
     state::StateOverride,
     trace::{

--- a/crates/rpc/rpc-api/src/txpool.rs
+++ b/crates/rpc/rpc-api/src/txpool.rs
@@ -1,5 +1,5 @@
+use alloy_primitives::Address;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::Address;
 use reth_rpc_types::{
     txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolStatus},
     Transaction, WithOtherFields,

--- a/crates/rpc/rpc-api/src/web3.rs
+++ b/crates/rpc/rpc-api/src/web3.rs
@@ -1,5 +1,5 @@
+use alloy_primitives::{Bytes, B256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{Bytes, B256};
 
 /// Web3 rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "web3"))]

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -68,6 +68,8 @@ reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-tokio-util.workspace = true
 reth-node-api.workspace = true
 
+alloy-primitives.workspace = true
+
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 serde_json.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/crates/rpc/rpc-builder/tests/it/auth.rs
+++ b/crates/rpc/rpc-builder/tests/it/auth.rs
@@ -1,9 +1,10 @@
 //! Auth server tests
 
 use crate::utils::launch_auth;
+use alloy_primitives::U64;
 use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
 use reth_ethereum_engine_primitives::EthEngineTypes;
-use reth_primitives::{Block, U64};
+use reth_primitives::Block;
 use reth_rpc_api::clients::EngineApiClient;
 use reth_rpc_layer::JwtSecret;
 use reth_rpc_types::engine::{ForkchoiceState, PayloadId, TransitionConfiguration};

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -2,6 +2,7 @@
 //! Standalone http tests
 
 use crate::utils::{launch_http, launch_http_ws, launch_ws};
+use alloy_primitives::{hex_literal::hex, Address, Bytes, TxHash, B256, B64, U256, U64};
 use jsonrpsee::{
     core::{
         client::{ClientT, SubscriptionClientT},
@@ -12,10 +13,7 @@ use jsonrpsee::{
     types::error::ErrorCode,
 };
 use reth_network_peers::NodeRecord;
-use reth_primitives::{
-    hex_literal::hex, Address, BlockId, BlockNumberOrTag, Bytes, Receipt, TxHash, B256, B64, U256,
-    U64,
-};
+use reth_primitives::{BlockId, BlockNumberOrTag, Receipt};
 use reth_rpc_api::{
     clients::{AdminApiClient, EthApiClient},
     DebugApiClient, EthFilterApiClient, NetApiClient, OtterscanClient, TraceApiClient,

--- a/crates/rpc/rpc-builder/tests/it/serde.rs
+++ b/crates/rpc/rpc-builder/tests/it/serde.rs
@@ -1,11 +1,11 @@
 //! various serde test
 
 use crate::utils::launch_http;
+use alloy_primitives::U256;
 use jsonrpsee::{
     core::{client::ClientT, traits::ToRpcParams},
     types::Request,
 };
-use reth_primitives::U256;
 use reth_rpc_server_types::RethRpcModule;
 use serde_json::value::RawValue;
 

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -27,6 +27,9 @@ reth-engine-primitives.workspace = true
 reth-evm.workspace = true
 reth-transaction-pool.workspace = true
 
+# ethereum
+alloy-primitives.workspace = true
+
 # async
 tokio = { workspace = true, features = ["sync"] }
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1,6 +1,7 @@
 use crate::{
     capabilities::EngineCapabilities, metrics::EngineApiMetrics, EngineApiError, EngineApiResult,
 };
+use alloy_primitives::{BlockHash, BlockNumber, B256, U64};
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
@@ -12,9 +13,7 @@ use reth_payload_primitives::{
     validate_payload_timestamp, EngineApiMessageVersion, PayloadAttributes,
     PayloadBuilderAttributes, PayloadOrAttributes,
 };
-use reth_primitives::{
-    Block, BlockHash, BlockHashOrNumber, BlockNumber, EthereumHardfork, B256, U64,
-};
+use reth_primitives::{Block, BlockHashOrNumber, EthereumHardfork};
 use reth_rpc_api::EngineApiServer;
 use reth_rpc_types::{
     engine::{
@@ -1147,7 +1146,7 @@ mod tests {
     // https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification-3
     mod exchange_transition_configuration {
         use super::*;
-        use reth_primitives::U256;
+        use alloy_primitives::U256;
         use reth_testing_utils::generators::{self, BlockParams};
 
         #[tokio::test]

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -1,10 +1,10 @@
+use alloy_primitives::{B256, U256};
 use jsonrpsee_types::error::{
     INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, INVALID_PARAMS_MSG, SERVER_ERROR_MSG,
 };
 use reth_beacon_consensus::{BeaconForkChoiceUpdateError, BeaconOnNewPayloadError};
 use reth_payload_builder::error::PayloadBuilderError;
 use reth_payload_primitives::EngineObjectValidationError;
-use reth_primitives::{B256, U256};
 use reth_rpc_types::ToRpcError;
 use thiserror::Error;
 

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -1,8 +1,9 @@
 //! Some payload tests
 
+use alloy_primitives::{Bytes, U256};
 use alloy_rlp::{Decodable, Error as RlpError};
 use assert_matches::assert_matches;
-use reth_primitives::{proofs, Block, Bytes, SealedBlock, TransactionSigned, Withdrawals, U256};
+use reth_primitives::{proofs, Block, SealedBlock, TransactionSigned, Withdrawals};
 use reth_rpc_types::engine::{
     ExecutionPayload, ExecutionPayloadBodyV1, ExecutionPayloadV1, PayloadError,
 };

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -34,8 +34,9 @@ reth-trie.workspace = true
 
 # ethereum
 alloy-dyn-abi = { workspace = true, features = ["eip712"] }
-alloy-network.workspace = true
 alloy-json-rpc.workspace = true
+alloy-network.workspace = true
+alloy-primitives.workspace = true
 
 # rpc
 jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/rpc/rpc-eth-api/src/bundle.rs
+++ b/crates/rpc/rpc-eth-api/src/bundle.rs
@@ -2,8 +2,8 @@
 //!
 //! See also <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint>
 
+use alloy_primitives::{Bytes, B256};
 use jsonrpsee::proc_macros::rpc;
-use reth_primitives::{Bytes, B256};
 use reth_rpc_types::mev::{
     CancelBundleRequest, CancelPrivateTransactionRequest, EthBundleHash, EthCallBundle,
     EthCallBundleResponse, EthSendBundle, PrivateTransactionRequest,

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -3,10 +3,9 @@
 use alloy_dyn_abi::TypedData;
 use alloy_json_rpc::RpcObject;
 use alloy_network::Network;
+use alloy_primitives::{Address, Bytes, B256, B64, U256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives::{
-    transaction::AccessListResult, Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64,
-};
+use reth_primitives::{transaction::AccessListResult, BlockId, BlockNumberOrTag};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_rpc_types::{
     serde_helpers::JsonStorageKey,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -2,6 +2,7 @@
 //! methods.
 
 use crate::{AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError};
+use alloy_primitives::{Bytes, TxKind, B256, U256};
 use futures::Future;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
@@ -10,7 +11,7 @@ use reth_primitives::{
         ResultAndState, TransactTo, TxEnv,
     },
     transaction::AccessListResult,
-    Bytes, TransactionSignedEcRecovered, TxKind, B256, U256,
+    TransactionSignedEcRecovered,
 };
 use reth_provider::{ChainSpecProvider, StateProvider};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB, DatabaseRef};

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -1,8 +1,8 @@
 //! Loads fee history from database. Helper trait for `eth_` fee and transaction RPC methods.
 
+use alloy_primitives::U256;
 use futures::Future;
 use reth_chainspec::ChainSpec;
-use reth_primitives::U256;
 use reth_provider::{BlockIdReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider};
 use reth_rpc_eth_types::{
     fee_history::calculate_reward_percentiles_for_block, EthApiError, EthStateCache,

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -4,6 +4,7 @@
 use std::time::{Duration, Instant};
 
 use crate::{EthApiTypes, FromEthApiError, FromEvmError};
+use alloy_primitives::{BlockNumber, B256, U256};
 use futures::Future;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_evm::{
@@ -18,9 +19,8 @@ use reth_primitives::{
         BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, EVMError, Env, ExecutionResult, InvalidTransaction,
         ResultAndState, SpecId,
     },
-    Block, BlockNumber, Header, IntoRecoveredTransaction, Receipt, Requests,
-    SealedBlockWithSenders, SealedHeader, TransactionSignedEcRecovered, B256,
-    EMPTY_OMMER_ROOT_HASH, U256,
+    Block, Header, IntoRecoveredTransaction, Receipt, Requests, SealedBlockWithSenders,
+    SealedHeader, TransactionSignedEcRecovered, EMPTY_OMMER_ROOT_HASH,
 };
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderError,

--- a/crates/rpc/rpc-eth-api/src/helpers/signer.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/signer.rs
@@ -3,8 +3,9 @@
 use std::result;
 
 use alloy_dyn_abi::TypedData;
+use alloy_primitives::Address;
 use dyn_clone::DynClone;
-use reth_primitives::{Address, Signature, TransactionSigned};
+use reth_primitives::{Signature, TransactionSigned};
 use reth_rpc_eth_types::SignError;
 use reth_rpc_types::TypedTransactionRequest;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -2,11 +2,11 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::{Address, U256, U64};
 use futures::Future;
 use reth_chainspec::{ChainInfo, ChainSpec};
 use reth_errors::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
-use reth_primitives::{Address, U256, U64};
 use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
 use reth_rpc_types::{Stage, SyncInfo, SyncStatus};
 

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -1,11 +1,12 @@
 //! Loads a pending block from database. Helper trait for `eth_` block, transaction, call and trace
 //! RPC methods.
 
+use alloy_primitives::{Address, Bytes, B256, U256};
 use futures::Future;
 use reth_chainspec::ChainSpec;
 use reth_errors::RethError;
 use reth_evm::ConfigureEvmEnv;
-use reth_primitives::{Address, BlockId, Bytes, Header, B256, KECCAK_EMPTY, U256};
+use reth_primitives::{BlockId, Header, KECCAK_EMPTY};
 use reth_provider::{
     BlockIdReader, ChainSpecProvider, StateProvider, StateProviderBox, StateProviderFactory,
 };

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -1,8 +1,8 @@
 //! Loads a pending block from database. Helper trait for `eth_` call and trace RPC methods.
 
+use alloy_primitives::B256;
 use futures::Future;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
-use reth_primitives::B256;
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDb, StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -2,10 +2,10 @@
 //! network.
 
 use alloy_dyn_abi::TypedData;
+use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, U256};
 use futures::Future;
 use reth_primitives::{
-    Address, BlockId, Bytes, Receipt, SealedBlockWithSenders, TransactionMeta, TransactionSigned,
-    TxHash, TxKind, B256, U256,
+    BlockId, Receipt, SealedBlockWithSenders, TransactionMeta, TransactionSigned,
 };
 use reth_provider::{BlockNumReader, BlockReaderIdExt, ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_types::{

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -29,6 +29,7 @@ reth-transaction-pool.workspace = true
 reth-trie.workspace = true
 
 # ethereum
+alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 revm.workspace = true
 revm-inspectors.workspace = true

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -2,8 +2,8 @@
 //! <https://github.com/rust-lang/rust/issues/100013> in default implementation of
 //! `reth_rpc_eth_api::helpers::Call`.
 
+use alloy_primitives::{Address, B256, U256};
 use reth_errors::ProviderResult;
-use reth_primitives::{Address, B256, U256};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB, DatabaseRef};
 use reth_storage_api::StateProvider;
 use reth_trie::HashedStorage;
@@ -75,7 +75,7 @@ impl<'a> reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'
         &self,
         overlay: reth_trie::HashedPostState,
         target: reth_trie::HashedPostState,
-    ) -> reth_errors::ProviderResult<std::collections::HashMap<B256, reth_primitives::Bytes>> {
+    ) -> reth_errors::ProviderResult<std::collections::HashMap<B256, alloy_primitives::Bytes>> {
         self.0.witness(overlay, target)
     }
 }
@@ -92,15 +92,15 @@ impl<'a> reth_storage_api::AccountReader for StateProviderTraitObjWrapper<'a> {
 impl<'a> reth_storage_api::BlockHashReader for StateProviderTraitObjWrapper<'a> {
     fn block_hash(
         &self,
-        block_number: reth_primitives::BlockNumber,
+        block_number: alloy_primitives::BlockNumber,
     ) -> reth_errors::ProviderResult<Option<B256>> {
         self.0.block_hash(block_number)
     }
 
     fn canonical_hashes_range(
         &self,
-        start: reth_primitives::BlockNumber,
-        end: reth_primitives::BlockNumber,
+        start: alloy_primitives::BlockNumber,
+        end: alloy_primitives::BlockNumber,
     ) -> reth_errors::ProviderResult<Vec<B256>> {
         self.0.canonical_hashes_range(start, end)
     }
@@ -145,8 +145,8 @@ impl<'a> StateProvider for StateProviderTraitObjWrapper<'a> {
     fn storage(
         &self,
         account: revm_primitives::Address,
-        storage_key: reth_primitives::StorageKey,
-    ) -> reth_errors::ProviderResult<Option<reth_primitives::StorageValue>> {
+        storage_key: alloy_primitives::StorageKey,
+    ) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>> {
         self.0.storage(account, storage_key)
     }
 }

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -1,5 +1,6 @@
 //! Async caching support for eth RPC
 
+use alloy_primitives::B256;
 use futures::{future::Either, Stream, StreamExt};
 use reth_chain_state::CanonStateNotification;
 use reth_errors::{ProviderError, ProviderResult};
@@ -7,7 +8,7 @@ use reth_evm::{provider::EvmEnvProvider, ConfigureEvm};
 use reth_execution_types::Chain;
 use reth_primitives::{
     Block, BlockHashOrNumber, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders,
-    TransactionSigned, TransactionSignedEcRecovered, B256,
+    TransactionSigned, TransactionSignedEcRecovered,
 };
 use reth_storage_api::{BlockReader, StateProviderFactory, TransactionVariant};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -2,9 +2,10 @@
 
 use std::time::Duration;
 
+use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::decode_revert_reason;
 use reth_errors::RethError;
-use reth_primitives::{revm_primitives::InvalidHeader, Address, BlockId, Bytes};
+use reth_primitives::{revm_primitives::InvalidHeader, BlockId};
 use reth_rpc_server_types::result::{
     block_id_to_str, internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code,
 };

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{atomic::Ordering::SeqCst, Arc},
 };
 
+use alloy_primitives::B256;
 use futures::{
     future::{Fuse, FusedFuture},
     FutureExt, Stream, StreamExt,
@@ -16,7 +17,7 @@ use reth_chainspec::{ChainSpec, ChainSpecProvider};
 use reth_primitives::{
     basefee::calc_next_block_base_fee,
     eip4844::{calc_blob_gasprice, calculate_excess_blob_gas},
-    Receipt, SealedBlock, TransactionSigned, B256,
+    Receipt, SealedBlock, TransactionSigned,
 };
 use reth_rpc_types::TxGasAndReward;
 use reth_storage_api::BlockReaderIdExt;

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -3,8 +3,9 @@
 
 use std::fmt::{self, Debug, Formatter};
 
+use alloy_primitives::{B256, U256};
 use derive_more::{Deref, DerefMut, From, Into};
-use reth_primitives::{constants::GWEI_TO_WEI, BlockNumberOrTag, B256, U256};
+use reth_primitives::{constants::GWEI_TO_WEI, BlockNumberOrTag};
 use reth_rpc_server_types::constants;
 use reth_rpc_types::BlockId;
 use reth_storage_api::BlockReaderIdExt;

--- a/crates/rpc/rpc-eth-types/src/id_provider.rs
+++ b/crates/rpc/rpc-eth-types/src/id_provider.rs
@@ -46,7 +46,7 @@ fn to_quantity(val: u128) -> SubscriptionId<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_primitives::U128;
+    use alloy_primitives::U128;
 
     #[test]
     fn test_id_provider_quantity() {

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -2,9 +2,10 @@
 //!
 //! Log parsing for building filter.
 
+use alloy_primitives::TxHash;
 use reth_chainspec::ChainInfo;
 use reth_errors::ProviderError;
-use reth_primitives::{BlockNumHash, Receipt, TxHash};
+use reth_primitives::{BlockNumHash, Receipt};
 use reth_rpc_server_types::result::rpc_error_with_code;
 use reth_rpc_types::{FilterId, FilteredParams, Log};
 use reth_storage_api::BlockReader;
@@ -167,7 +168,7 @@ pub fn append_matching_block_logs(
 /// Returns true if the log matches the filter and should be included
 pub fn log_matches_filter(
     block: BlockNumHash,
-    log: &reth_primitives::Log,
+    log: &alloy_primitives::Log,
     params: &FilteredParams,
 ) -> bool {
     if params.filter.is_some() &&

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -4,10 +4,9 @@
 
 use std::time::Instant;
 
+use alloy_primitives::B256;
 use derive_more::Constructor;
-use reth_primitives::{
-    BlockId, BlockNumberOrTag, Receipt, SealedBlockWithSenders, SealedHeader, B256,
-};
+use reth_primitives::{BlockId, BlockNumberOrTag, Receipt, SealedBlockWithSenders, SealedHeader};
 use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg};
 
 /// Configured [`BlockEnv`] and [`CfgEnvWithHandlerCfg`] for a pending block.

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -1,6 +1,7 @@
 //! RPC receipt response builder, extends a layer one receipt with layer two data.
 
-use reth_primitives::{Address, Receipt, TransactionMeta, TransactionSigned, TxKind};
+use alloy_primitives::{Address, TxKind};
+use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
 use reth_rpc_types::{
     AnyReceiptEnvelope, AnyTransactionReceipt, Log, OtherFields, ReceiptWithBloom,
     TransactionReceipt, WithOtherFields,

--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -1,6 +1,6 @@
 //! utilities for working with revm
 
-use reth_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use reth_rpc_types::{
     state::{AccountOverride, StateOverride},
     BlockOverrides,

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -1,7 +1,8 @@
 //! Helper types for `reth_rpc_eth_api::EthApiServer` implementation.
 //!
 //! Transaction wrapper that labels transaction with its origin.
-use reth_primitives::{TransactionSignedEcRecovered, B256};
+use alloy_primitives::B256;
+use reth_primitives::TransactionSignedEcRecovered;
 use reth_rpc_types::{Transaction, TransactionInfo, WithOtherFields};
 use reth_rpc_types_compat::transaction::from_recovered_with_block_context;
 

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -1,6 +1,7 @@
 //! Commonly used code snippets
 
-use reth_primitives::{Bytes, PooledTransactionsElement, PooledTransactionsElementEcRecovered};
+use alloy_primitives::Bytes;
+use reth_primitives::{PooledTransactionsElement, PooledTransactionsElementEcRecovered};
 use std::future::Future;
 
 use super::{EthApiError, EthResult};

--- a/crates/rpc/rpc-server-types/Cargo.toml
+++ b/crates/rpc/rpc-server-types/Cargo.toml
@@ -17,7 +17,6 @@ reth-network-api.workspace = true
 reth-primitives.workspace = true
 reth-rpc-types.workspace = true
 
-
 # ethereum
 alloy-primitives.workspace = true
 

--- a/crates/rpc/rpc-server-types/src/result.rs
+++ b/crates/rpc/rpc-server-types/src/result.rs
@@ -144,7 +144,7 @@ pub fn rpc_err(
         code,
         msg.into(),
         data.map(|data| {
-            jsonrpsee_core::to_json_raw_value(&reth_primitives::hex::encode_prefixed(data))
+            jsonrpsee_core::to_json_raw_value(&alloy_primitives::hex::encode_prefixed(data))
                 .expect("serializing String can't fail")
         }),
     )

--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -17,6 +17,9 @@ reth-primitives.workspace = true
 reth-rpc-types.workspace = true
 reth-rpc-api = { workspace = true, features = ["client"] }
 
+# ethereum
+alloy-primitives.workspace = true
+
 # async
 futures.workspace = true
 

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -6,9 +6,10 @@ use std::{
     task::{Context, Poll},
 };
 
+use alloy_primitives::{TxHash, B256};
 use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::Error as RpcError;
-use reth_primitives::{BlockId, Receipt, TxHash, B256};
+use reth_primitives::{BlockId, Receipt};
 use reth_rpc_api::{clients::DebugApiClient, EthApiClient};
 use reth_rpc_types::{
     trace::{

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -1,8 +1,9 @@
 //! Helpers for testing trace calls.
 
+use alloy_primitives::{Bytes, TxHash, B256};
 use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::Error as RpcError;
-use reth_primitives::{BlockId, Bytes, TxHash, B256};
+use reth_primitives::BlockId;
 use reth_rpc_api::clients::TraceApiClient;
 use reth_rpc_types::{
     trace::{

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -12,9 +12,13 @@ description = "Compatibility layer for reth-primitives and ethereum RPC types"
 workspace = true
 
 [dependencies]
+# reth
 reth-primitives.workspace = true
 reth-rpc-types.workspace = true
 reth-trie-common.workspace = true
+
+# ethereum
+alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-rpc-types.workspace = true
 

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -1,10 +1,11 @@
 //! Compatibility functions for rpc `Block` type.
 
 use crate::transaction::from_recovered_with_block_context;
+use alloy_primitives::{B256, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types::{Transaction, TransactionInfo};
 use reth_primitives::{
-    Block as PrimitiveBlock, BlockWithSenders, Header as PrimitiveHeader, Withdrawals, B256, U256,
+    Block as PrimitiveBlock, BlockWithSenders, Header as PrimitiveHeader, Withdrawals,
 };
 use reth_rpc_types::{
     Block, BlockError, BlockTransactions, BlockTransactionsKind, Header, WithOtherFields,

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -1,10 +1,11 @@
 //! Standalone Conversion Functions for Handling Different Versions of Execution Payloads in
 //! Ethereum's Engine
 
+use alloy_primitives::{B256, U256};
 use reth_primitives::{
     constants::{EMPTY_OMMER_ROOT_HASH, MAXIMUM_EXTRA_DATA_SIZE},
     proofs::{self},
-    Block, Header, Request, SealedBlock, TransactionSigned, UintTryTo, Withdrawals, B256, U256,
+    Block, Header, Request, SealedBlock, TransactionSigned, UintTryTo, Withdrawals,
 };
 use reth_rpc_types::engine::{
     payload::{ExecutionPayloadBodyV1, ExecutionPayloadFieldV2, ExecutionPayloadInputV2},
@@ -447,7 +448,7 @@ mod tests {
         block_to_payload_v3, try_into_block, try_payload_v3_to_block, try_payload_v4_to_block,
         validate_block_hash,
     };
-    use reth_primitives::{b256, hex, Bytes, U256};
+    use alloy_primitives::{b256, hex, Bytes, U256};
     use reth_rpc_types::{
         engine::{CancunPayloadFields, ExecutionPayloadV3, ExecutionPayloadV4},
         ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2,

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -1,10 +1,11 @@
 //! Compatibility functions for rpc `Transaction` type.
 
+use alloy_primitives::{Address, TxKind};
 use alloy_rpc_types::{
     request::{TransactionInput, TransactionRequest},
     TransactionInfo,
 };
-use reth_primitives::{Address, TransactionSignedEcRecovered, TxKind, TxType};
+use reth_primitives::{TransactionSignedEcRecovered, TxType};
 use reth_rpc_types::{Transaction, WithOtherFields};
 use signature::from_primitive_signature;
 pub use typed::*;

--- a/crates/rpc/rpc-types-compat/src/transaction/signature.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/signature.rs
@@ -1,4 +1,5 @@
-use reth_primitives::{Signature as PrimitiveSignature, TxType, U256};
+use alloy_primitives::U256;
+use reth_primitives::{Signature as PrimitiveSignature, TxType};
 use reth_rpc_types::{Parity, Signature};
 
 /// Creates a new rpc signature from a legacy [primitive

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -36,7 +36,7 @@ reth-node-api.workspace = true
 reth-network-types.workspace = true
 reth-trie.workspace = true
 
-# eth
+# ethereum
 alloy-dyn-abi.workspace = true
 alloy-rlp.workspace = true
 alloy-primitives.workspace = true

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -6,9 +7,7 @@ use reth_evm::{
     system_calls::{pre_block_beacon_root_contract_call, pre_block_blockhashes_contract_call},
     ConfigureEvmEnv,
 };
-use reth_primitives::{
-    Address, Block, BlockId, BlockNumberOrTag, Bytes, TransactionSignedEcRecovered, B256, U256,
-};
+use reth_primitives::{Block, BlockId, BlockNumberOrTag, TransactionSignedEcRecovered};
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, HeaderProvider, StateProofProvider,
     StateProviderFactory, TransactionVariant,

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -1,6 +1,7 @@
 use alloy_network::Network;
+use alloy_primitives::{Address, Bytes, B256, U256, U64};
 use jsonrpsee::core::RpcResult as Result;
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256, U256, U64};
+use reth_primitives::{BlockId, BlockNumberOrTag};
 use reth_rpc_api::{EngineEthApiServer, EthApiServer, EthFilterApiServer};
 /// Re-export for convenience
 pub use reth_rpc_engine_api::EngineApi;

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -2,12 +2,12 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::{keccak256, U256};
 use jsonrpsee::core::RpcResult;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
-    keccak256,
     revm_primitives::db::{DatabaseCommit, DatabaseRef},
-    PooledTransactionsElement, U256,
+    PooledTransactionsElement,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_api::{FromEthApiError, FromEvmError};

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -4,9 +4,10 @@
 use std::sync::Arc;
 
 use alloy_network::AnyNetwork;
+use alloy_primitives::U256;
 use derive_more::Deref;
 use reth_node_api::{BuilderProvider, FullNodeComponents};
-use reth_primitives::{BlockNumberOrTag, U256};
+use reth_primitives::BlockNumberOrTag;
 use reth_provider::{BlockReaderIdExt, CanonStateSubscriptions, ChainSpecProvider};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, SpawnBlocking},
@@ -349,11 +350,12 @@ impl<Provider, Pool, Network, EvmConfig> EthApiInner<Provider, Pool, Network, Ev
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{B256, U64};
     use jsonrpsee_types::error::INVALID_PARAMS_CODE;
     use reth_chainspec::{BaseFeeParams, ChainSpec};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
-    use reth_primitives::{Block, BlockNumberOrTag, Header, TransactionSigned, B256, U64};
+    use reth_primitives::{Block, BlockNumberOrTag, Header, TransactionSigned};
     use reth_provider::{
         test_utils::{MockEthProvider, NoopProvider},
         BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory,

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -9,10 +9,11 @@ use std::{
     time::{Duration, Instant},
 };
 
+use alloy_primitives::TxHash;
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
 use reth_chainspec::ChainInfo;
-use reth_primitives::{IntoRecoveredTransaction, TransactionSignedEcRecovered, TxHash};
+use reth_primitives::{IntoRecoveredTransaction, TransactionSignedEcRecovered};
 use reth_provider::{BlockIdReader, BlockReader, EvmEnvProvider, ProviderError};
 use reth_rpc_eth_api::EthFilterApiServer;
 use reth_rpc_eth_types::{

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -3,9 +3,8 @@
 use std::collections::HashMap;
 
 use alloy_dyn_abi::TypedData;
-use reth_primitives::{
-    eip191_hash_message, sign_message, Address, Signature, TransactionSigned, B256,
-};
+use alloy_primitives::{eip191_hash_message, Address, B256};
+use reth_primitives::{sign_message, Signature, TransactionSigned};
 use reth_rpc_eth_api::helpers::{signer::Result, AddDevSigners, EthSigner};
 use reth_rpc_eth_types::SignError;
 use reth_rpc_types::TypedTransactionRequest;
@@ -104,7 +103,7 @@ impl EthSigner for DevSigner {
 mod tests {
     use std::str::FromStr;
 
-    use reth_primitives::U256;
+    use alloy_primitives::U256;
 
     use super::*;
 

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,6 +1,6 @@
+use alloy_primitives::U256;
 use reth_chainspec::ChainSpec;
 use reth_network_api::NetworkInfo;
-use reth_primitives::U256;
 use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
 use reth_rpc_eth_api::helpers::EthApiSpec;
 use reth_transaction_pool::TransactionPool;

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -43,10 +43,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::{Address, StorageKey, StorageValue, U256};
     use reth_evm_ethereum::EthEvmConfig;
-    use reth_primitives::{
-        constants::ETHEREUM_BLOCK_GAS_LIMIT, Address, StorageKey, StorageValue, KECCAK_EMPTY, U256,
-    };
+    use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, KECCAK_EMPTY};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider, NoopProvider};
     use reth_rpc_eth_api::helpers::EthState;
     use reth_rpc_eth_types::{

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -52,9 +52,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{hex_literal::hex, Bytes};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
-    use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, hex_literal::hex, Bytes};
+    use reth_primitives::constants::ETHEREUM_BLOCK_GAS_LIMIT;
     use reth_provider::test_utils::NoopProvider;
     use reth_rpc_eth_api::helpers::EthTransactions;
     use reth_rpc_eth_types::{

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -2,12 +2,13 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::TxHash;
 use futures::StreamExt;
 use jsonrpsee::{
     server::SubscriptionMessage, types::ErrorObject, PendingSubscriptionSink, SubscriptionSink,
 };
 use reth_network_api::NetworkInfo;
-use reth_primitives::{IntoRecoveredTransaction, TxHash};
+use reth_primitives::IntoRecoveredTransaction;
 use reth_provider::{BlockReader, CanonStateSubscriptions, EvmEnvProvider};
 use reth_rpc_eth_api::pubsub::EthPubSubApiServer;
 use reth_rpc_eth_types::logs_utils;

--- a/crates/rpc/rpc/src/net.rs
+++ b/crates/rpc/rpc/src/net.rs
@@ -1,6 +1,6 @@
+use alloy_primitives::U64;
 use jsonrpsee::core::RpcResult as Result;
 use reth_network_api::PeersInfo;
-use reth_primitives::U64;
 use reth_rpc_api::NetApiServer;
 use reth_rpc_eth_api::helpers::EthApiSpec;
 

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -1,8 +1,8 @@
 use alloy_network::Network;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, TxHash, B256, U256};
+use reth_primitives::{BlockId, BlockNumberOrTag};
 use reth_rpc_api::{EthApiServer, OtterscanServer};
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -1,9 +1,10 @@
 use std::{collections::HashMap, future::Future, sync::Arc};
 
+use alloy_primitives::{Address, U256};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_errors::RethResult;
-use reth_primitives::{Address, BlockId, U256};
+use reth_primitives::BlockId;
 use reth_provider::{BlockReaderIdExt, ChangeSetReader, StateProviderFactory};
 use reth_rpc_api::RethApiServer;
 use reth_rpc_eth_types::{EthApiError, EthResult};

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, sync::Arc};
 
+use alloy_primitives::{Bytes, B256, U256};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
@@ -7,7 +8,7 @@ use reth_consensus_common::calc::{
     base_block_reward, base_block_reward_pre_merge, block_reward, ommer_reward,
 };
 use reth_evm::ConfigureEvmEnv;
-use reth_primitives::{BlockId, Bytes, Header, B256, U256};
+use reth_primitives::{BlockId, Header};
 use reth_provider::{BlockReader, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::TraceApiServer;

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -1,6 +1,7 @@
+use alloy_primitives::Address;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult as Result;
-use reth_primitives::{Address, TransactionSignedEcRecovered};
+use reth_primitives::TransactionSignedEcRecovered;
 use reth_rpc_api::TxPoolApiServer;
 use reth_rpc_types::{
     txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus},

--- a/crates/rpc/rpc/src/web3.rs
+++ b/crates/rpc/rpc/src/web3.rs
@@ -1,7 +1,7 @@
+use alloy_primitives::{keccak256, Bytes, B256};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_network_api::NetworkInfo;
-use reth_primitives::{keccak256, Bytes, B256};
 use reth_rpc_api::Web3ApiServer;
 use reth_rpc_server_types::ToRpcResult;
 


### PR DESCRIPTION
Progress on https://github.com/paradigmxyz/reth/issues/10749

Changed all where direct drop-in-replacement was possible