### PR TITLE
dev: remove unused dev-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6647,15 +6647,11 @@ name = "reth-db-api"
 version = "1.0.6"
 dependencies = [
  "arbitrary",
- "assert_matches",
  "bytes",
- "criterion",
  "derive_more",
- "iai-callgrind",
  "metrics",
  "modular-bitfield",
  "parity-scale-codec",
- "pprof",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
@@ -6911,7 +6907,6 @@ dependencies = [
  "futures",
  "pin-project",
  "reth-beacon-consensus",
- "reth-blockchain-tree",
  "reth-chainspec",
  "reth-consensus",
  "reth-engine-tree",
@@ -6926,7 +6921,6 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-prune",
- "reth-prune-types",
  "reth-stages-api",
  "reth-tasks",
  "thiserror",
@@ -8812,16 +8806,13 @@ dependencies = [
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives",
- "reth-provider",
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
  "serde",
  "serde_json",
- "similar-asserts",
  "tokio",
- "tokio-stream",
  "tracing",
  "triehash",
 ]
@@ -8848,8 +8839,6 @@ dependencies = [
  "reth-primitives-traits",
  "revm-primitives",
  "serde",
- "test-fuzz",
- "toml",
 ]
 
 [[package]]
@@ -8858,7 +8847,6 @@ version = "1.0.6"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
- "criterion",
  "derive_more",
  "itertools 0.13.0",
  "metrics",

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -33,14 +33,11 @@ pin-project.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-reth-blockchain-tree.workspace = true
-reth-consensus.workspace = true
 reth-engine-tree = { workspace = true, features = ["test-utils"] }
 reth-ethereum-engine-primitives.workspace = true
 reth-evm-ethereum.workspace = true
 reth-exex-types.workspace = true
 reth-primitives.workspace = true
-reth-prune-types.workspace = true
 reth-chainspec.workspace = true
 
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -47,20 +47,9 @@ rand.workspace = true
 
 test-fuzz.workspace = true
 
-pprof = { workspace = true, features = [
-    "flamegraph",
-    "frame-pointer",
-    "criterion",
-] }
-criterion.workspace = true
-iai-callgrind.workspace = true
-
 arbitrary = { workspace = true, features = ["derive"] }
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
-
-
-assert_matches.workspace = true
 
 [features]
 test-utils = ["arbitrary"]

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -37,8 +37,6 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 arbitrary = { workspace = true, features = ["derive"] }
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
-test-fuzz.workspace = true
-toml.workspace = true
 hash-db = "=0.15.2"
 plain_hasher = "0.2"
 

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -71,7 +71,6 @@ tokio = { workspace = true, default-features = false, features = [
 tokio-stream.workspace = true
 serde_json.workspace = true
 similar-asserts.workspace = true
-criterion.workspace = true
 
 [features]
 metrics = ["reth-metrics", "reth-trie/metrics", "dep:metrics"]

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -48,7 +48,6 @@ serde = { workspace = true, optional = true }
 # reth
 reth-chainspec.workspace = true
 reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
-reth-provider = { workspace = true, features = ["test-utils"] }
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 
 # trie
@@ -62,9 +61,7 @@ tokio = { workspace = true, default-features = false, features = [
     "rt",
     "macros",
 ] }
-tokio-stream.workspace = true
 serde_json.workspace = true
-similar-asserts.workspace = true
 criterion.workspace = true
 
 [features]


### PR DESCRIPTION
Remove a coupe of unused deps in multiple crates' `[dev-dependencies]`.

Maybe warrants a run to `cargo udeps --all --all-features --tests --benches --workspace --locked` in the CI?