### PR TITLE
typo: fix typo in `help_message()` function name

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -45,7 +45,7 @@ pub struct Cli<C: ChainSpecParser = DefaultChainSpecParser, Ext: clap::Args + fm
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        long_help = C::help_messge(),
+        long_help = C::help_message(),
         default_value = C::SUPPORTED_CHAINS[0],
         value_parser = C::parser(),
         global = true,

--- a/crates/cli/cli/src/chainspec.rs
+++ b/crates/cli/cli/src/chainspec.rs
@@ -57,7 +57,7 @@ pub trait ChainSpecParser: Clone + Send + Sync + 'static {
     }
 
     /// Produces a help message for the chain spec argument.
-    fn help_messge() -> String {
+    fn help_message() -> String {
         format!("The chain this node is running.\nPossible values are either a built-in chain or the path to a chain specification file.\n\nBuilt-in chains:\n    {}", Self::SUPPORTED_CHAINS.join(", "))
     }
 }

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -39,7 +39,7 @@ pub struct EnvironmentArgs<C: ChainSpecParser> {
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        long_help = C::help_messge(),
+        long_help = C::help_message(),
         default_value = C::SUPPORTED_CHAINS[0],
         value_parser = C::parser()
     )]

--- a/crates/cli/commands/src/dump_genesis.rs
+++ b/crates/cli/commands/src/dump_genesis.rs
@@ -14,7 +14,7 @@ pub struct DumpGenesisCommand<C: ChainSpecParser> {
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        long_help = C::help_messge(),
+        long_help = C::help_message(),
         default_value = C::SUPPORTED_CHAINS[0],
         value_parser = C::parser()
     )]

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -34,7 +34,7 @@ pub struct NodeCommand<
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        long_help = C::help_messge(),
+        long_help = C::help_message(),
         default_value = C::SUPPORTED_CHAINS[0],
         default_value_if("dev", "true", "dev"),
         value_parser = C::parser(),

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -31,7 +31,7 @@ pub struct Command<C: ChainSpecParser> {
     #[arg(
         long,
         value_name = "CHAIN_OR_PATH",
-        long_help = C::help_messge(),
+        long_help = C::help_message(),
         default_value = C::SUPPORTED_CHAINS[0],
         value_parser = C::parser()
     )]


### PR DESCRIPTION
This PR corrects a typo in the function name help_message(). The incorrect spelling help_messge() has been fixed to help_message() in affected files. 