### PR TITLE
fix: prevent panic during enr conversion

### DIFF
--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -148,9 +148,11 @@ impl Discv5 {
     /// Returns the [`NodeRecord`] of the local node.
     ///
     /// This includes the currently tracked external IP address of the node.
-    pub fn node_record(&self) -> NodeRecord {
+    ///
+    /// Returns `None` if the local ENR does not contain the required fields.
+    pub fn node_record(&self) -> Option<NodeRecord> {
         let enr: Enr<_> = EnrCombinedKeyWrapper(self.discv5.local_enr()).into();
-        (&enr).try_into().unwrap()
+        enr.try_into().ok()
     }
 
     /// Spawns [`discv5::Discv5`]. Returns [`discv5::Discv5`] handle in reth compatible wrapper type

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -212,8 +212,8 @@ impl PeersInfo for NetworkHandle {
     fn local_node_record(&self) -> NodeRecord {
         if let Some(discv4) = &self.inner.discv4 {
             discv4.node_record()
-        } else if let Some(discv5) = &self.inner.discv5 {
-            discv5.node_record()
+        } else if let Some(record) = self.inner.discv5.as_ref().and_then(|d| d.node_record()) {
+            record
         } else {
             let id = *self.peer_id();
             let mut socket_addr = *self.inner.listener_address.lock();

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -197,6 +197,15 @@ impl FromStr for NodeRecord {
 }
 
 #[cfg(feature = "secp256k1")]
+impl TryFrom<Enr<secp256k1::SecretKey>> for NodeRecord {
+    type Error = NodeRecordParseError;
+
+    fn try_from(enr: Enr<secp256k1::SecretKey>) -> Result<Self, Self::Error> {
+        (&enr).try_into()
+    }
+}
+
+#[cfg(feature = "secp256k1")]
 impl TryFrom<&Enr<secp256k1::SecretKey>> for NodeRecord {
     type Error = NodeRecordParseError;
 

--- a/crates/rpc/rpc-testing-util/tests/it/trace.rs
+++ b/crates/rpc/rpc-testing-util/tests/it/trace.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Instant};
+//! Integration tests for the trace API.
 
 use futures::StreamExt;
 use jsonrpsee::http_client::HttpClientBuilder;
@@ -10,6 +10,7 @@ use reth_rpc_types::{
     trace::{filter::TraceFilter, parity::TraceType, tracerequest::TraceCallRequest},
     Block, Transaction,
 };
+use std::{collections::HashSet, time::Instant};
 
 /// This is intended to be run locally against a running node.
 ///


### PR DESCRIPTION
this can panic if the enr doesn't include the required fields, such as ip