### PR TITLE
fix: include reverts in execution outcome when building payload

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -13,6 +13,13 @@ rpc-compat:
   - eth_getTransactionReceipt/get-access-list (reth)
   - eth_getTransactionReceipt/get-blob-tx (reth)
   - eth_getTransactionReceipt/get-dynamic-fee (reth)
+  - eth_getBlockByHash/get-block-by-hash (reth)
+  - eth_getBlockByNumber/get-block-n (reth)
+  - eth_getBlockByNumber/get-finalized (reth)
+  - eth_getBlockByNumber/get-genesis (reth)
+  - eth_getBlockByNumber/get-latest (reth)
+  - eth_getBlockByNumber/get-safe (reth)
+  - eth_sendRawTransaction/send-blob-tx (reth)
 
 # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:

--- a/.github/assets/hive/expected_failures_experimental.yaml
+++ b/.github/assets/hive/expected_failures_experimental.yaml
@@ -13,6 +13,13 @@ rpc-compat:
   - eth_getTransactionReceipt/get-access-list (reth)
   - eth_getTransactionReceipt/get-blob-tx (reth)
   - eth_getTransactionReceipt/get-dynamic-fee (reth)
+  - eth_getBlockByHash/get-block-by-hash (reth)
+  - eth_getBlockByNumber/get-block-n (reth)
+  - eth_getBlockByNumber/get-finalized (reth)
+  - eth_getBlockByNumber/get-genesis (reth)
+  - eth_getBlockByNumber/get-latest (reth)
+  - eth_getBlockByNumber/get-safe (reth)
+  - eth_sendRawTransaction/send-blob-tx (reth)
 
 # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:
@@ -37,11 +44,7 @@ engine-withdrawals:
 
 # https://github.com/paradigmxyz/reth/issues/8305
 # https://github.com/paradigmxyz/reth/issues/6217
-engine-api:
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Paris) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P9 (Paris) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P10 (Paris) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P10 (Paris) (reth)
+engine-api: []
 
 # https://github.com/paradigmxyz/reth/issues/8305
 # https://github.com/paradigmxyz/reth/issues/6217
@@ -51,10 +54,10 @@ engine-cancun:
   - Blob Transaction Ordering, Multiple Clients (Cancun) (reth)
   - Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun) (reth)
   - Invalid NewPayload, ExcessBlobGas, Syncing=True, EmptyTxs=False, DynFeeTxs=False (Cancun) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P9 (Cancun) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P10 (Cancun) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P10 (Cancun) (reth)
+  - Invalid NewPayload, VersionedHashes, Syncing=False, EmptyTxs=False, DynFeeTxs=False (Cancun) (reth)
+  - Invalid NewPayload, VersionedHashes Version, Syncing=False, EmptyTxs=False, DynFeeTxs=False (Cancun) (reth)
+  - Invalid NewPayload, Incomplete VersionedHashes, Syncing=False, EmptyTxs=False, DynFeeTxs=False (Cancun) (reth)
+  - Invalid NewPayload, Extra VersionedHashes, Syncing=False, EmptyTxs=False, DynFeeTxs=False (Cancun) (reth)
 
 # https://github.com/paradigmxyz/reth/issues/8579
 sync:

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -330,7 +330,7 @@ where
 
     // merge all transitions into bundle state, this would apply the withdrawal balance changes
     // and 4788 contract call
-    db.merge_transitions(BundleRetention::PlainState);
+    db.merge_transitions(BundleRetention::Reverts);
 
     let execution_outcome = ExecutionOutcome::new(
         db.take_bundle(),


### PR DESCRIPTION
Fixes hive failures introduced in #10717, the execution outcome calculated during payload build and inserted later in the in-memory tree state was missing reverts.

Also updates hive expected failures to match the current state.