### PR TITLE
fix(libmdbx): renew tx on timeout when dropping cursor

### DIFF
--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -486,8 +486,11 @@ where
     K: TransactionKind,
 {
     fn drop(&mut self) {
-        // Ignore the error, because we're dropping the cursor anyway.
-        let _ = self.txn.txn_execute(|_| unsafe { ffi::mdbx_cursor_close(self.cursor) });
+        // To be able to close a cursor of a timed out transaction, we need to renew it first.
+        // Hence the usage of `txn_execute_renew_on_timeout` here.
+        self.txn
+            .txn_execute_renew_on_timeout(|_| unsafe { ffi::mdbx_cursor_close(self.cursor) })
+            .unwrap();
     }
 }
 

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -488,9 +488,9 @@ where
     fn drop(&mut self) {
         // To be able to close a cursor of a timed out transaction, we need to renew it first.
         // Hence the usage of `txn_execute_renew_on_timeout` here.
-        self.txn
-            .txn_execute_renew_on_timeout(|_| unsafe { ffi::mdbx_cursor_close(self.cursor) })
-            .unwrap();
+        let _ = self
+            .txn
+            .txn_execute_renew_on_timeout(|_| unsafe { ffi::mdbx_cursor_close(self.cursor) });
     }
 }
 

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -112,6 +112,18 @@ where
         self.inner.txn_execute(f)
     }
 
+    /// Executes the given closure once the lock on the transaction is acquired. If the transaction
+    /// is timed out, it will be renewed first.
+    ///
+    /// Returns the result of the closure or an error if the transaction renewal fails.
+    #[inline]
+    pub(crate) fn txn_execute_renew_on_timeout<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(*mut ffi::MDBX_txn) -> T,
+    {
+        self.inner.txn_execute_renew_on_timeout(f)
+    }
+
     /// Returns a copy of the raw pointer to the underlying MDBX transaction.
     #[doc(hidden)]
     #[cfg(test)]
@@ -320,6 +332,14 @@ where
         F: FnOnce(*mut ffi::MDBX_txn) -> T,
     {
         self.txn.txn_execute_fail_on_timeout(f)
+    }
+
+    #[inline]
+    fn txn_execute_renew_on_timeout<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(*mut ffi::MDBX_txn) -> T,
+    {
+        self.txn.txn_execute_renew_on_timeout(f)
     }
 }
 
@@ -596,7 +616,7 @@ impl TransactionPtr {
     ///
     /// Returns the result of the closure or an error if the transaction renewal fails.
     #[inline]
-    fn txn_execute_renew_on_timeout<F, T>(&self, f: F) -> Result<T>
+    pub(crate) fn txn_execute_renew_on_timeout<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(*mut ffi::MDBX_txn) -> T,
     {


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/pull/10838 was incorrect, thanks @rkrasiuk for pointing out