### PR TITLE
fix(tree): avoid holding two locks simultaneously

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -103,10 +103,8 @@ impl InMemoryState {
 
     /// Returns the current chain head state.
     pub(crate) fn head_state(&self) -> Option<Arc<BlockState>> {
-        self.numbers
-            .read()
-            .last_key_value()
-            .and_then(|(_, hash)| self.blocks.read().get(hash).cloned())
+        let hash = *self.numbers.read().last_key_value()?.1;
+        self.blocks.read().get(&hash).cloned()
     }
 
     /// Returns the pending state corresponding to the current head plus one,

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -104,7 +104,7 @@ impl InMemoryState {
     /// Returns the current chain head state.
     pub(crate) fn head_state(&self) -> Option<Arc<BlockState>> {
         let hash = *self.numbers.read().last_key_value()?.1;
-        self.blocks.read().get(&hash).cloned()
+        self.state_by_hash(hash)
     }
 
     /// Returns the pending state corresponding to the current head plus one,


### PR DESCRIPTION
## Description

Follow up to https://github.com/paradigmxyz/reth/pull/10842. Avoid holding two locks simultaneously. Then order does not matter :) 