### PR TITLE
feat(engine): compare invalid block witness against a healthy node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7347,6 +7347,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
+ "futures",
  "jsonrpsee",
  "pretty_assertions",
  "reth-chainspec",
@@ -7359,7 +7360,6 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "serde_json",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7347,6 +7347,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
+ "jsonrpsee",
  "pretty_assertions",
  "reth-chainspec",
  "reth-engine-primitives",
@@ -7354,9 +7355,11 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-revm",
+ "reth-rpc-api",
  "reth-tracing",
  "reth-trie",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -7623,6 +7626,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "futures",
+ "jsonrpsee",
  "rayon",
  "reth-auto-seal-consensus",
  "reth-beacon-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7660,6 +7660,7 @@ dependencies = [
  "reth-provider",
  "reth-prune",
  "reth-rpc",
+ "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-engine-api",
  "reth-rpc-eth-types",

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -548,7 +548,7 @@ Debug:
           [possible values: witness, pre-state, opcode]
 
       --debug.healthy-node-rpc-url <URL>
-          The RPC URL of a healthy node.
+          The RPC URL of a healthy node to use for comparing invalid block hook results against.
 
 Database:
       --db.log-level <LOG_LEVEL>

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -547,6 +547,9 @@ Debug:
 
           [possible values: witness, pre-state, opcode]
 
+      --debug.healthy-node-rpc-url <URL>
+          The URL of the healthy node RPC.
+
 Database:
       --db.log-level <LOG_LEVEL>
           Database logging level. Levels higher than "notice" require a debug build

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -548,7 +548,7 @@ Debug:
           [possible values: witness, pre-state, opcode]
 
       --debug.healthy-node-rpc-url <URL>
-          The URL of the healthy node RPC.
+          The RPC URL of a healthy node.
 
 Database:
       --db.log-level <LOG_LEVEL>

--- a/crates/engine/invalid-block-hooks/Cargo.toml
+++ b/crates/engine/invalid-block-hooks/Cargo.toml
@@ -18,6 +18,7 @@ reth-evm.workspace = true
 reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-revm.workspace = true
+reth-rpc-api = { workspace = true, features = ["client"] }
 reth-tracing.workspace = true
 reth-trie = { workspace = true, features = ["serde"] }
 
@@ -25,7 +26,11 @@ reth-trie = { workspace = true, features = ["serde"] }
 alloy-rlp.workspace = true
 alloy-rpc-types-debug.workspace = true
 
+# async
+tokio.workspace = true
+
 # misc
 eyre.workspace = true
+jsonrpsee.workspace = true
 pretty_assertions = "1.4"
 serde_json.workspace = true

--- a/crates/engine/invalid-block-hooks/Cargo.toml
+++ b/crates/engine/invalid-block-hooks/Cargo.toml
@@ -27,7 +27,7 @@ alloy-rlp.workspace = true
 alloy-rpc-types-debug.workspace = true
 
 # async
-tokio.workspace = true
+futures.workspace = true
 
 # misc
 eyre.workspace = true

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -163,11 +163,12 @@ where
 
         // Write the witness to the output directory.
         let response = ExecutionWitness { witness, state_preimages: Some(state_preimages) };
-        File::options()
-            .write(true)
-            .create_new(true)
-            .open(self.output_directory.join(format!("{}_{}.json", block.number, block.hash())))?
-            .write_all(serde_json::to_string(&response)?.as_bytes())?;
+        File::create_new(self.output_directory.join(format!(
+            "{}_{}.json",
+            block.number,
+            block.hash()
+        )))?
+        .write_all(serde_json::to_string(&response)?.as_bytes())?;
 
         // The bundle state after re-execution should match the original one.
         if bundle_state != output.state {
@@ -205,15 +206,12 @@ where
             })?;
 
             // Write the healthy node witness to the output directory.
-            File::options()
-                .write(true)
-                .create_new(true)
-                .open(self.output_directory.join(format!(
-                    "{}_{}.healthy_witness.json",
-                    block.number,
-                    block.hash()
-                )))?
-                .write_all(serde_json::to_string(&healthy_node_witness)?.as_bytes())?;
+            File::create_new(self.output_directory.join(format!(
+                "{}_{}.healthy_witness.json",
+                block.number,
+                block.hash()
+            )))?
+            .write_all(serde_json::to_string(&healthy_node_witness)?.as_bytes())?;
 
             // If the witnesses are different, write the diff to the output directory.
             if response != healthy_node_witness {
@@ -235,11 +233,7 @@ where
     ) -> eyre::Result<PathBuf> {
         let path = self.output_directory.join(filename);
         let diff = Comparison::new(original, new);
-        File::options()
-            .write(true)
-            .create_new(true)
-            .open(&path)?
-            .write_all(diff.to_string().as_bytes())?;
+        File::create_new(&path)?.write_all(diff.to_string().as_bytes())?;
 
         Ok(path)
     }

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -195,7 +195,7 @@ where
 
         if let Some(healthy_node_client) = &self.healthy_node_client {
             // Compare the witness against the healthy node.
-            let healthy_node_witness = tokio::runtime::Handle::current().block_on(async move {
+            let healthy_node_witness = futures::executor::block_on(async move {
                 DebugApiClient::debug_execution_witness(
                     healthy_node_client,
                     block.number.into(),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -558,7 +558,7 @@ where
         }
     }
 
-    /// Sets the bad block hook.
+    /// Sets the invalid block hook.
     fn set_invalid_block_hook(&mut self, invalid_block_hook: Box<dyn InvalidBlockHook>) {
         self.invalid_block_hook = invalid_block_hook;
     }

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -44,6 +44,7 @@ reth-payload-validator.workspace = true
 reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-prune.workspace = true
+reth-rpc-api.workspace = true
 reth-rpc-builder.workspace = true
 reth-rpc-engine-api.workspace = true
 reth-rpc-eth-types.workspace = true

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -82,6 +82,7 @@ secp256k1 = { workspace = true, features = [
 aquamarine.workspace = true
 eyre.workspace = true
 fdlimit.workspace = true
+jsonrpsee.workspace = true
 rayon.workspace = true
 
 # tracing

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -868,16 +868,15 @@ where
                 let client = jsonrpsee::http_client::HttpClientBuilder::default().build(url)?;
 
                 // Verify that the healthy node is running the same chain as the current node.
-                let chain_id = tokio::runtime::Handle::current()
-                    .block_on(async {
-                        EthApiClient::<
-                            reth_rpc_types::Transaction,
-                            reth_rpc_types::Block,
-                            reth_rpc_types::Receipt,
-                        >::chain_id(&client)
-                        .await
-                    })?
-                    .ok_or_eyre("healthy node rpc client didn't return a chain id")?;
+                let chain_id = futures::executor::block_on(async {
+                    EthApiClient::<
+                        reth_rpc_types::Transaction,
+                        reth_rpc_types::Block,
+                        reth_rpc_types::Receipt,
+                    >::chain_id(&client)
+                    .await
+                })?
+                .ok_or_eyre("healthy node rpc client didn't return a chain id")?;
                 if chain_id.to::<u64>() != self.chain_id().id() {
                     eyre::bail!("invalid chain id for healthy node: {chain_id}")
                 }

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -91,8 +91,8 @@ pub struct DebugArgs {
 /// Create a [`InvalidBlockSelection`] from a selection.
 ///
 /// ```
-/// use reth_node_core::args::{InvalidBlockHook, InvalidBlockSelection};
-/// let config: InvalidBlockSelection = vec![InvalidBlockHook::Witness].into();
+/// use reth_node_core::args::{InvalidBlockHookType, InvalidBlockSelection};
+/// let config: InvalidBlockSelection = vec![InvalidBlockHookType::Witness].into();
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Deref)]
 pub struct InvalidBlockSelection(HashSet<InvalidBlockHookType>);
@@ -106,34 +106,34 @@ impl InvalidBlockSelection {
     ///
     /// # Example
     ///
-    /// Create a selection from the [`InvalidBlockHook`] string identifiers
+    /// Create a selection from the [`InvalidBlockHookType`] string identifiers
     ///
     /// ```
-    /// use reth_node_core::args::{InvalidBlockHook, InvalidBlockSelection};
+    /// use reth_node_core::args::{InvalidBlockHookType, InvalidBlockSelection};
     /// let selection = vec!["witness", "prestate", "opcode"];
     /// let config = InvalidBlockSelection::try_from_selection(selection).unwrap();
     /// assert_eq!(
     ///     config,
     ///     InvalidBlockSelection::from([
-    ///         InvalidBlockHook::Witness,
-    ///         InvalidBlockHook::PreState,
-    ///         InvalidBlockHook::Opcode
+    ///         InvalidBlockHookType::Witness,
+    ///         InvalidBlockHookType::PreState,
+    ///         InvalidBlockHookType::Opcode
     ///     ])
     /// );
     /// ```
     ///
-    /// Create a unique selection from the [`InvalidBlockHook`] string identifiers
+    /// Create a unique selection from the [`InvalidBlockHookType`] string identifiers
     ///
     /// ```
-    /// use reth_node_core::args::{InvalidBlockHook, InvalidBlockSelection};
+    /// use reth_node_core::args::{InvalidBlockHookType, InvalidBlockSelection};
     /// let selection = vec!["witness", "prestate", "opcode", "witness", "prestate"];
     /// let config = InvalidBlockSelection::try_from_selection(selection).unwrap();
     /// assert_eq!(
     ///     config,
     ///     InvalidBlockSelection::from([
-    ///         InvalidBlockHook::Witness,
-    ///         InvalidBlockHook::PreState,
-    ///         InvalidBlockHook::Opcode
+    ///         InvalidBlockHookType::Witness,
+    ///         InvalidBlockHookType::PreState,
+    ///         InvalidBlockHookType::Opcode
     ///     ])
     /// );
     /// ```
@@ -145,7 +145,7 @@ impl InvalidBlockSelection {
         selection.into_iter().map(TryInto::try_into).collect()
     }
 
-    /// Clones the set of configured [`InvalidBlockHook`].
+    /// Clones the set of configured [`InvalidBlockHookType`].
     pub fn to_selection(&self) -> HashSet<InvalidBlockHookType> {
         self.0.clone()
     }

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -68,7 +68,7 @@ pub struct DebugArgs {
     #[arg(long = "debug.engine-api-store", help_heading = "Debug", value_name = "PATH")]
     pub engine_api_store: Option<PathBuf>,
 
-    /// Determines which type of bad block hook to install
+    /// Determines which type of invalid block hook to install
     ///
     /// Example: `witness,prestate`
     #[arg(long = "debug.invalid-block-hook", help_heading = "Debug", value_parser = InvalidBlockSelectionValueParser::default())]
@@ -95,7 +95,7 @@ pub struct DebugArgs {
 /// let config: InvalidBlockSelection = vec![InvalidBlockHook::Witness].into();
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Deref)]
-pub struct InvalidBlockSelection(HashSet<InvalidBlockHook>);
+pub struct InvalidBlockSelection(HashSet<InvalidBlockHookType>);
 
 impl InvalidBlockSelection {
     /// Creates a new _unique_ [`InvalidBlockSelection`] from the given items.
@@ -140,39 +140,39 @@ impl InvalidBlockSelection {
     pub fn try_from_selection<I, T>(selection: I) -> Result<Self, T::Error>
     where
         I: IntoIterator<Item = T>,
-        T: TryInto<InvalidBlockHook>,
+        T: TryInto<InvalidBlockHookType>,
     {
         selection.into_iter().map(TryInto::try_into).collect()
     }
 
     /// Clones the set of configured [`InvalidBlockHook`].
-    pub fn to_selection(&self) -> HashSet<InvalidBlockHook> {
+    pub fn to_selection(&self) -> HashSet<InvalidBlockHookType> {
         self.0.clone()
     }
 }
 
-impl From<&[InvalidBlockHook]> for InvalidBlockSelection {
-    fn from(s: &[InvalidBlockHook]) -> Self {
+impl From<&[InvalidBlockHookType]> for InvalidBlockSelection {
+    fn from(s: &[InvalidBlockHookType]) -> Self {
         Self(s.iter().copied().collect())
     }
 }
 
-impl From<Vec<InvalidBlockHook>> for InvalidBlockSelection {
-    fn from(s: Vec<InvalidBlockHook>) -> Self {
+impl From<Vec<InvalidBlockHookType>> for InvalidBlockSelection {
+    fn from(s: Vec<InvalidBlockHookType>) -> Self {
         Self(s.into_iter().collect())
     }
 }
 
-impl<const N: usize> From<[InvalidBlockHook; N]> for InvalidBlockSelection {
-    fn from(s: [InvalidBlockHook; N]) -> Self {
+impl<const N: usize> From<[InvalidBlockHookType; N]> for InvalidBlockSelection {
+    fn from(s: [InvalidBlockHookType; N]) -> Self {
         Self(s.iter().copied().collect())
     }
 }
 
-impl FromIterator<InvalidBlockHook> for InvalidBlockSelection {
+impl FromIterator<InvalidBlockHookType> for InvalidBlockSelection {
     fn from_iter<I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = InvalidBlockHook>,
+        I: IntoIterator<Item = InvalidBlockHookType>,
     {
         Self(iter.into_iter().collect())
     }
@@ -214,7 +214,7 @@ impl TypedValueParser for InvalidBlockSelectionValueParser {
             value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
         val.parse::<InvalidBlockSelection>().map_err(|err| {
             let arg = arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned());
-            let possible_values = InvalidBlockHook::all_variant_names().to_vec().join(",");
+            let possible_values = InvalidBlockHookType::all_variant_names().to_vec().join(",");
             let msg = format!(
                 "Invalid value '{val}' for {arg}: {err}.\n    [possible values: {possible_values}]"
             );
@@ -223,12 +223,12 @@ impl TypedValueParser for InvalidBlockSelectionValueParser {
     }
 
     fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
-        let values = InvalidBlockHook::all_variant_names().iter().map(PossibleValue::new);
+        let values = InvalidBlockHookType::all_variant_names().iter().map(PossibleValue::new);
         Some(Box::new(values))
     }
 }
 
-/// The type of bad block hook to install
+/// The type of invalid block hook to install
 #[derive(
     Debug,
     Clone,
@@ -243,7 +243,7 @@ impl TypedValueParser for InvalidBlockSelectionValueParser {
     EnumIter,
 )]
 #[strum(serialize_all = "kebab-case")]
-pub enum InvalidBlockHook {
+pub enum InvalidBlockHookType {
     /// A witness value enum
     Witness,
     /// A prestate trace value enum
@@ -252,7 +252,7 @@ pub enum InvalidBlockHook {
     Opcode,
 }
 
-impl FromStr for InvalidBlockHook {
+impl FromStr for InvalidBlockHookType {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -265,20 +265,20 @@ impl FromStr for InvalidBlockHook {
     }
 }
 
-impl TryFrom<&str> for InvalidBlockHook {
+impl TryFrom<&str> for InvalidBlockHookType {
     type Error = ParseError;
     fn try_from(s: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
         FromStr::from_str(s)
     }
 }
 
-impl fmt::Display for InvalidBlockHook {
+impl fmt::Display for InvalidBlockHookType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(self.as_ref())
     }
 }
 
-impl InvalidBlockHook {
+impl InvalidBlockHookType {
     /// Returns all variant names of the enum
     pub const fn all_variant_names() -> &'static [&'static str] {
         <Self as VariantNames>::VARIANTS
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_parse_invalid_block_args() {
         let expected_args = DebugArgs {
-            invalid_block_hook: Some(InvalidBlockSelection::from([InvalidBlockHook::Witness])),
+            invalid_block_hook: Some(InvalidBlockSelection::from([InvalidBlockHookType::Witness])),
             ..Default::default()
         };
         let args = CommandParser::<DebugArgs>::parse_from([
@@ -320,8 +320,8 @@ mod tests {
 
         let expected_args = DebugArgs {
             invalid_block_hook: Some(InvalidBlockSelection::from([
-                InvalidBlockHook::Witness,
-                InvalidBlockHook::PreState,
+                InvalidBlockHookType::Witness,
+                InvalidBlockHookType::PreState,
             ])),
             ..Default::default()
         };

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -74,7 +74,7 @@ pub struct DebugArgs {
     #[arg(long = "debug.invalid-block-hook", help_heading = "Debug", value_parser = InvalidBlockSelectionValueParser::default())]
     pub invalid_block_hook: Option<InvalidBlockSelection>,
 
-    /// The RPC URL of a healthy node.
+    /// The RPC URL of a healthy node to use for comparing invalid block hook results against.
     #[arg(
         long = "debug.healthy-node-rpc-url",
         help_heading = "Debug",

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -73,6 +73,15 @@ pub struct DebugArgs {
     /// Example: `witness,prestate`
     #[arg(long = "debug.invalid-block-hook", help_heading = "Debug", value_parser = InvalidBlockSelectionValueParser::default())]
     pub invalid_block_hook: Option<InvalidBlockSelection>,
+
+    /// The URL of the healthy node RPC.
+    #[arg(
+        long = "debug.healthy-node-rpc-url",
+        help_heading = "Debug",
+        value_name = "URL",
+        verbatim_doc_comment
+    )]
+    pub healthy_node_rpc_url: Option<String>,
 }
 
 /// Describes the invalid block hooks that should be installed.

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -74,7 +74,7 @@ pub struct DebugArgs {
     #[arg(long = "debug.invalid-block-hook", help_heading = "Debug", value_parser = InvalidBlockSelectionValueParser::default())]
     pub invalid_block_hook: Option<InvalidBlockSelection>,
 
-    /// The URL of the healthy node RPC.
+    /// The RPC URL of a healthy node.
     #[arg(
         long = "debug.healthy-node-rpc-url",
         help_heading = "Debug",

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -14,7 +14,7 @@ pub use rpc_state_cache::RpcStateCacheArgs;
 
 /// DebugArgs struct for debugging purposes
 mod debug;
-pub use debug::{DebugArgs, InvalidBlockHook, InvalidBlockSelection};
+pub use debug::{DebugArgs, InvalidBlockHookType, InvalidBlockSelection};
 
 /// DatabaseArgs struct for configuring the database
 mod database;


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/10549

Adds a `--debug.healthy-node-rpc-url` CLI argument that initializes an RPC client, checks if the chain ID matches, and passes the client to the witness invalid block hook.

Later, if the witness hook is triggered, we query the healthy node for the witness of the same block, save the output in a separate file and compare it against the original one.