### PR TITLE
feat(grafana): add stacked block processing latency graph

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -129,7 +129,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -199,7 +200,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -269,7 +271,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -287,7 +290,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -337,7 +342,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -355,7 +361,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -405,7 +413,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -423,7 +432,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -473,7 +484,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -491,7 +503,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -541,7 +555,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -559,7 +574,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -623,7 +640,8 @@
                 "value": 30
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -639,7 +657,9 @@
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -688,7 +708,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -707,7 +728,9 @@
         "namePlacement": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
@@ -789,7 +812,8 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "bytes",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -807,7 +831,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -926,7 +952,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1020,7 +1047,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1128,7 +1156,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1188,7 +1217,8 @@
             "scaleDistribution": {
               "type": "linear"
             }
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1315,7 +1345,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1411,7 +1442,8 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1502,7 +1534,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1602,7 +1635,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1686,16 +1720,22 @@
       },
       "id": 48,
       "options": {
-        "displayLabels": ["name"],
+        "displayLabels": [
+          "name"
+        ],
         "legend": {
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "values": ["value"]
+          "values": [
+            "value"
+          ]
         },
         "pieType": "pie",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1770,7 +1810,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1854,11 +1895,15 @@
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "values": ["value"]
+          "values": [
+            "value"
+          ]
         },
         "pieType": "pie",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1905,7 +1950,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2018,12 +2064,14 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
       },
-      "pluginVersion": "10.3.3",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -2091,7 +2139,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2184,16 +2233,22 @@
       },
       "id": 202,
       "options": {
-        "displayLabels": ["name"],
+        "displayLabels": [
+          "name"
+        ],
         "legend": {
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "values": ["value"]
+          "values": [
+            "value"
+          ]
         },
         "pieType": "pie",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -2242,7 +2297,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2343,12 +2399,14 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
       },
-      "pluginVersion": "10.3.3",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -2390,7 +2448,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2491,12 +2550,14 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
       },
-      "pluginVersion": "10.3.3",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -2564,7 +2625,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2660,7 +2722,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2776,7 +2839,8 @@
               }
             ]
           },
-          "unit": "si: gas/s"
+          "unit": "si: gas/s",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -2816,12 +2880,131 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 95
+      },
+      "id": 242,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_state_root_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "State Root Duration",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_execution_execution_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Execution Duration",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Block Processing Latency",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 95
+        "y": 106
       },
       "id": 24,
       "panels": [],
@@ -2877,7 +3060,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2918,7 +3102,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 96
+        "y": 107
       },
       "id": 26,
       "options": {
@@ -3034,7 +3218,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3051,7 +3236,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 96
+        "y": 107
       },
       "id": 33,
       "options": {
@@ -3154,7 +3339,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3170,7 +3356,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 104
+        "y": 115
       },
       "id": 36,
       "options": {
@@ -3219,7 +3405,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 112
+        "y": 123
       },
       "id": 32,
       "panels": [],
@@ -3276,7 +3462,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3326,7 +3513,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 113
+        "y": 124
       },
       "id": 30,
       "options": {
@@ -3478,7 +3665,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -3491,7 +3679,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 113
+        "y": 124
       },
       "id": 28,
       "options": {
@@ -3594,7 +3782,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3610,7 +3799,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 121
+        "y": 132
       },
       "id": 35,
       "options": {
@@ -3701,7 +3890,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3735,7 +3925,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 121
+        "y": 132
       },
       "id": 73,
       "options": {
@@ -3827,7 +4017,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3861,7 +4052,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 129
+        "y": 140
       },
       "id": 102,
       "options": {
@@ -3924,7 +4115,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 137
+        "y": 148
       },
       "id": 79,
       "panels": [],
@@ -3981,7 +4172,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3997,7 +4189,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 138
+        "y": 149
       },
       "id": 74,
       "options": {
@@ -4077,7 +4269,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4093,7 +4286,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 138
+        "y": 149
       },
       "id": 80,
       "options": {
@@ -4173,7 +4366,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4189,7 +4383,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 146
+        "y": 157
       },
       "id": 81,
       "options": {
@@ -4268,7 +4462,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4285,7 +4480,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 146
+        "y": 157
       },
       "id": 114,
       "options": {
@@ -4364,7 +4559,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4381,7 +4577,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 154
+        "y": 165
       },
       "id": 190,
       "options": {
@@ -4419,7 +4615,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 162
+        "y": 173
       },
       "id": 87,
       "panels": [],
@@ -4476,7 +4672,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4492,7 +4689,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 163
+        "y": 174
       },
       "id": 83,
       "options": {
@@ -4571,7 +4768,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4587,7 +4785,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 163
+        "y": 174
       },
       "id": 84,
       "options": {
@@ -4678,7 +4876,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4694,7 +4893,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 171
+        "y": 182
       },
       "id": 85,
       "options": {
@@ -4773,7 +4972,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -4790,7 +4990,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 171
+        "y": 182
       },
       "id": 210,
       "options": {
@@ -5097,7 +5297,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5114,7 +5315,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 179
+        "y": 190
       },
       "id": 211,
       "options": {
@@ -5421,7 +5622,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5438,7 +5640,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 179
+        "y": 190
       },
       "id": 212,
       "options": {
@@ -5624,7 +5826,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 187
+        "y": 198
       },
       "id": 214,
       "panels": [],
@@ -5678,7 +5880,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5695,7 +5898,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 188
+        "y": 199
       },
       "id": 215,
       "options": {
@@ -5774,7 +5977,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5790,7 +5994,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 188
+        "y": 199
       },
       "id": 216,
       "options": {
@@ -5841,7 +6045,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 196
+        "y": 207
       },
       "id": 68,
       "panels": [],
@@ -5898,7 +6102,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -5914,7 +6119,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 197
+        "y": 208
       },
       "id": 60,
       "options": {
@@ -5993,7 +6198,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6009,7 +6215,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 197
+        "y": 208
       },
       "id": 62,
       "options": {
@@ -6088,7 +6294,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6104,7 +6311,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 205
+        "y": 216
       },
       "id": 64,
       "options": {
@@ -6141,7 +6348,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 213
+        "y": 224
       },
       "id": 97,
       "panels": [],
@@ -6195,7 +6402,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6225,7 +6433,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 214
+        "y": 225
       },
       "id": 98,
       "options": {
@@ -6370,7 +6578,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6387,7 +6596,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 214
+        "y": 225
       },
       "id": 101,
       "options": {
@@ -6467,7 +6676,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6484,7 +6694,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 222
+        "y": 233
       },
       "id": 99,
       "options": {
@@ -6564,7 +6774,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6581,7 +6792,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 222
+        "y": 233
       },
       "id": 100,
       "options": {
@@ -6619,7 +6830,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 230
+        "y": 241
       },
       "id": 105,
       "panels": [],
@@ -6674,7 +6885,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6691,7 +6903,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 231
+        "y": 242
       },
       "id": 106,
       "options": {
@@ -6771,7 +6983,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6788,7 +7001,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 231
+        "y": 242
       },
       "id": 107,
       "options": {
@@ -6867,7 +7080,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -6884,7 +7098,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 239
+        "y": 250
       },
       "id": 217,
       "options": {
@@ -6922,7 +7136,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 247
+        "y": 258
       },
       "id": 108,
       "panels": [],
@@ -6977,7 +7191,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7019,7 +7234,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 248
+        "y": 259
       },
       "id": 109,
       "options": {
@@ -7082,7 +7297,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 248
+        "y": 259
       },
       "id": 111,
       "maxDataPoints": 25,
@@ -7127,7 +7342,7 @@
           "unit": "percentunit"
         }
       },
-      "pluginVersion": "10.3.3",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -7194,7 +7409,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7211,7 +7427,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 256
+        "y": 267
       },
       "id": 120,
       "options": {
@@ -7270,7 +7486,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 256
+        "y": 267
       },
       "id": 112,
       "maxDataPoints": 25,
@@ -7315,7 +7531,7 @@
           "unit": "percentunit"
         }
       },
-      "pluginVersion": "10.3.3",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -7382,7 +7598,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7423,7 +7640,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 264
+        "y": 275
       },
       "id": 198,
       "options": {
@@ -7591,7 +7808,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7608,7 +7826,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 264
+        "y": 275
       },
       "id": 213,
       "options": {
@@ -7647,7 +7865,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 272
+        "y": 283
       },
       "id": 236,
       "panels": [],
@@ -7702,7 +7920,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7718,7 +7937,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 273
+        "y": 284
       },
       "id": 237,
       "options": {
@@ -7798,7 +8017,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7814,7 +8034,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 273
+        "y": 284
       },
       "id": 238,
       "options": {
@@ -7894,7 +8114,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7910,7 +8131,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 281
+        "y": 292
       },
       "id": 239,
       "options": {
@@ -8002,7 +8223,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8018,7 +8240,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 281
+        "y": 292
       },
       "id": 219,
       "options": {
@@ -8061,16 +8283,13 @@
           "color": {
             "mode": "palette-classic"
           },
-          "custom": {
-            "align": "auto",
-            "filterable": false
-          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8078,7 +8297,8 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "none",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -8086,7 +8306,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 289
+        "y": 300
       },
       "id": 220,
       "options": {
@@ -8095,13 +8315,17 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.6",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -8125,7 +8349,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 297
+        "y": 308
       },
       "id": 226,
       "panels": [],
@@ -8180,7 +8404,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8188,7 +8413,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -8221,7 +8447,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 298
+        "y": 309
       },
       "id": 225,
       "options": {
@@ -8307,7 +8533,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8315,7 +8542,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -8348,7 +8576,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 298
+        "y": 309
       },
       "id": 227,
       "options": {
@@ -8434,7 +8662,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8442,7 +8671,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -8475,7 +8705,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 306
+        "y": 317
       },
       "id": 235,
       "options": {
@@ -8561,7 +8791,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8569,7 +8800,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -8602,7 +8834,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 306
+        "y": 317
       },
       "id": 234,
       "options": {
@@ -8679,6 +8911,6 @@
   "timezone": "",
   "title": "Reth",
   "uid": "2k8BXz24x",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Adds a stacked chart for block processing latency, currently only showing execution and state root duration

Holesky example:
![Screenshot 2024-09-11 at 1 13 36 PM](https://github.com/user-attachments/assets/6f1978be-2f84-45b2-8e60-95845be65290)
