### PR TITLE
ci: dev udeps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -211,6 +211,7 @@ jobs:
       - crate-checks
       - docs
       - fmt
+      - udeps
       - book
       - codespell
       - grafana

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -137,7 +137,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo install cargo-udeps --locked
+      - uses: cargo-bins/cargo-binstall@main
+      - run: cargo binstall cargo-udeps --no-confirm
       - run: cargo udeps --workspace --lib --examples --tests --benches --all-features --locked
 
   book:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [main]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -126,6 +126,14 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all --check
+
+  udeps:
+    name: udeps
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses:
 
   book:
     name: book

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -133,7 +133,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses:
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: cargo install cargo-udeps --locked
+      - run: cargo udeps --workspace --lib --examples --tests --benches --all-features --locked
 
   book:
     name: book


### PR DESCRIPTION
Adds an execution of `udeps` to the CI lint workflow in order to verify if we have any unused dependencies. 

This should normally only catch unused `dev-dependencies` because the `warn(unused_crate_dependencies)` lint is active for `cfg(not(test))`.

Resolves #10817.