### PR TITLE
dev: test vectors seed

### DIFF
--- a/crates/cli/commands/src/test_vectors/tables.rs
+++ b/crates/cli/commands/src/test_vectors/tables.rs
@@ -21,6 +21,7 @@ pub(crate) fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
     // Prepare random seed for test (same method as used by proptest)
     let mut seed = [0u8; 32];
     getrandom(&mut seed)?;
+    println!("Seed for test vectors: {:?}", seed);
 
     // Start the runner with the seed
     let config = ProptestConfig::default();
@@ -46,7 +47,6 @@ pub(crate) fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
                 tables = all_tables;
             }
 
-            println!("Seed for test vectors: {:?}", seed);
             for table in tables {
                 match table.as_str() {
                     $(

--- a/crates/cli/commands/src/test_vectors/tables.rs
+++ b/crates/cli/commands/src/test_vectors/tables.rs
@@ -1,9 +1,10 @@
+use alloy_primitives::private::getrandom::getrandom;
 use arbitrary::Arbitrary;
 use eyre::Result;
 use proptest::{
     prelude::ProptestConfig,
     strategy::{Strategy, ValueTree},
-    test_runner::TestRunner,
+    test_runner::{TestRng, TestRunner},
 };
 use proptest_arbitrary_interop::arb;
 use reth_db::tables;
@@ -17,7 +18,15 @@ const PER_TABLE: usize = 1000;
 
 /// Generates test vectors for specified `tables`. If list is empty, then generate for all tables.
 pub(crate) fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
-    let mut runner = TestRunner::new(ProptestConfig::default());
+    // Prepare random seed for test (same method as used by proptest)
+    let mut seed = [0u8; 32];
+    getrandom(&mut seed)?;
+
+    // Start the runner with the seed
+    let config = ProptestConfig::default();
+    let rng = TestRng::from_seed(config.rng_algorithm, &seed);
+    let mut runner = TestRunner::new_with_rng(config, rng);
+
     fs::create_dir_all(VECTORS_FOLDER)?;
 
     macro_rules! generate_vector {
@@ -37,6 +46,7 @@ pub(crate) fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
                 tables = all_tables;
             }
 
+            println!("Seed for test vectors: {:?}", seed);
             for table in tables {
                 match table.as_str() {
                     $(


### PR DESCRIPTION
Adds a print of the seed for the `reth-db` test vectors used in the benches. 

Unfortunately `proptest` hides the seed in an internal struct which we don't have access to, so we create a seed ourselves (using `getrandom` as done in proptest) and use this seed for the test.

Resolves #10610 