### PR TITLE
chore(grafana): display empty string if no cargo features are available

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -598,7 +598,7 @@
           "exemplar": false,
           "expr": "reth_info{instance=~\"$instance\"}",
           "instant": true,
-          "legendFormat": "{{cargo_features}}",
+          "legendFormat": "{{cargo_features}} ",
           "range": false,
           "refId": "A"
         }
@@ -8911,6 +8911,6 @@
   "timezone": "",
   "title": "Reth",
   "uid": "2k8BXz24x",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
Sigh https://github.com/grafana/grafana/issues/5970

## Before

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/10ccfbf8-b51b-4e27-bf80-bb81fd302636">

## After

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/1344e7c3-ee9c-4ee5-97d4-40c176b3c08c">

