### PR TITLE
Remove feature gate for alloc, use extern crate alloc directly

### DIFF
--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
+
 extern crate alloc;
 
 /// Chain specific constants

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1,8 +1,9 @@
 pub use alloy_eips::eip1559::BaseFeeParams;
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-#[cfg(feature = "std")]
+extern crate alloc;
+
+use alloc::{boxed::Box,  vec::Vec};
+
 use std::sync::Arc;
 
 use alloy_chains::{Chain, ChainKind, NamedChain};


### PR DESCRIPTION

### Title: Remove Feature Gate for `alloc` and Use `extern crate alloc` Directly

#10853 

### Description:
This PR removes the feature gate for `alloc` and replaces it with an unconditional use of `extern crate alloc`. The update simplifies the codebase and ensures consistent usage of `alloc` types across the project.

**Changes made:**
- Removed the feature gate for `alloc`.
- Replaced feature-gated `alloc` usage in `lib.rs` and `spec.rs` with direct usage of `alloc::vec::Vec` and `alloc::boxed::Box`.
- Replaced `alloc::sync::Arc` with `std::sync::Arc` for consistency and standard library usage.

**Benefits:**
- Simplifies the code by removing conditional compilation.
- Ensures consistent usage of allocation types.
- Leverages the standard library `Arc` where applicable.

**Testing:**
- Verified that the project builds and passes tests with the updated code.

Please review the changes and merge if they meet the requirements.

