### PR TITLE
fix: map header not found error for op

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -425,6 +425,7 @@ where
         full: bool,
     ) -> RpcResult<Option<RpcBlock<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?number, ?full, "Serving eth_getBlockByNumber");
+        // TODO: map error here?
         Ok(EthBlocks::rpc_block(self, number.into(), full).await?)
     }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/error.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/error.rs
@@ -56,7 +56,6 @@ pub trait AsEthApiError {
         if let Some(err) = self.as_err() {
             return err.is_gas_too_high()
         }
-
         false
     }
 }

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -141,6 +141,10 @@ impl EthApiError {
     pub const fn is_gas_too_high(&self) -> bool {
         matches!(self, Self::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh))
     }
+    /// Returns `true` if error is a header/block not found error.
+    pub const fn is_header_not_found(&self) -> bool {
+        matches!(self, Self::HeaderNotFound(_))
+    }
 }
 
 impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {


### PR DESCRIPTION
until there's a new op node release we need to map the header not found error to something op-node currently recognises as notfound error, such as "block not found"

@emhane where the best place to do that?

ref https://github.com/ethereum-optimism/optimism/pull/11759