### PR TITLE
feat: add support for wrapping the allocator with tracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "generator"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb949699c3e4df3a183b1d2142cb24277057055ed23c68ed58894f76c517223"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4549,6 +4562,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5160,7 +5186,6 @@ dependencies = [
  "reth-optimism-cli",
  "reth-optimism-rpc",
  "reth-provider",
- "tikv-jemallocator",
 ]
 
 [[package]]
@@ -6188,7 +6213,6 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "tempfile",
- "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -6314,9 +6338,9 @@ dependencies = [
  "csv",
  "eyre",
  "futures",
- "libc",
  "reqwest",
  "reth-cli-runner",
+ "reth-cli-util",
  "reth-db",
  "reth-node-api",
  "reth-node-core",
@@ -6328,7 +6352,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tower 0.4.13",
@@ -6512,12 +6535,15 @@ version = "1.0.6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
+ "cfg-if",
  "eyre",
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
  "secp256k1",
  "thiserror",
+ "tikv-jemallocator",
+ "tracy-client",
 ]
 
 [[package]]
@@ -9351,6 +9377,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10152,9 +10184,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619bfed27d807b54f7f776b9430d4f8060e66ee138a28632ca898584d462c31c"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
 dependencies = [
  "libc",
  "paste",
@@ -10163,9 +10195,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
 dependencies = [
  "cc",
  "libc",
@@ -10173,9 +10205,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -10572,6 +10604,26 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373db47331c3407b343538df77eea2516884a0b126cdfb4b135acfd400015dd7"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cf0064dcb31c99aa1244c1b93439359e53f72ed217eef5db50abd442241e9a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -11055,6 +11107,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11069,9 +11131,22 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -11087,10 +11162,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10604,7 +10604,8 @@ dependencies = [
 [[package]]
 name = "tracy-client"
 version = "0.17.3"
-source = "git+https://github.com/danipopes/rust_tracy_client?branch=custom-demangler#36655950b6a68d40e8b946bd0cdfb55efcd4d701"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373db47331c3407b343538df77eea2516884a0b126cdfb4b135acfd400015dd7"
 dependencies = [
  "loom",
  "once_cell",
@@ -10615,7 +10616,8 @@ dependencies = [
 [[package]]
 name = "tracy-client-sys"
 version = "0.24.0"
-source = "git+https://github.com/danipopes/rust_tracy_client?branch=custom-demangler#36655950b6a68d40e8b946bd0cdfb55efcd4d701"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cf0064dcb31c99aa1244c1b93439359e53f72ed217eef5db50abd442241e9a"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6322,7 +6322,6 @@ dependencies = [
 name = "reth-bench"
 version = "1.0.6"
 dependencies = [
- "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-provider",
@@ -6341,19 +6340,15 @@ dependencies = [
  "reqwest",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-db",
  "reth-node-api",
  "reth-node-core",
  "reth-primitives",
- "reth-provider",
  "reth-rpc-types",
  "reth-rpc-types-compat",
  "reth-tracing",
  "serde",
- "serde_json",
  "thiserror",
  "tokio",
- "tokio-util",
  "tower 0.4.13",
  "tracing",
 ]
@@ -10609,19 +10604,18 @@ dependencies = [
 [[package]]
 name = "tracy-client"
 version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373db47331c3407b343538df77eea2516884a0b126cdfb4b135acfd400015dd7"
+source = "git+https://github.com/danipopes/rust_tracy_client?branch=custom-demangler#36655950b6a68d40e8b946bd0cdfb55efcd4d701"
 dependencies = [
  "loom",
  "once_cell",
+ "rustc-demangle",
  "tracy-client-sys",
 ]
 
 [[package]]
 name = "tracy-client-sys"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cf0064dcb31c99aa1244c1b93439359e53f72ed217eef5db50abd442241e9a"
+source = "git+https://github.com/danipopes/rust_tracy_client?branch=custom-demangler#36655950b6a68d40e8b946bd0cdfb55efcd4d701"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -470,6 +470,7 @@ bitflags = "2.4"
 boyer-moore-magiclen = "0.2.16"
 bytes = "1.5"
 clap = "4"
+cfg-if = "1.0"
 const_format = { version = "0.2.32", features = ["rust_1_64"] }
 dashmap = "6.0"
 derive_more = { version = "1", features = ["full"] }
@@ -482,7 +483,9 @@ humantime-serde = "1.1"
 itertools = "0.13"
 linked_hash_set = "0.1"
 modular-bitfield = "0.11.2"
-notify = { version = "6.1.1", default-features = false, features = ["macos_fsevent"] }
+notify = { version = "6.1.1", default-features = false, features = [
+    "macos_fsevent",
+] }
 nybbles = "0.2.1"
 once_cell = "1.19"
 parking_lot = "0.12"
@@ -576,4 +579,7 @@ serial_test = "3"
 similar-asserts = "1.5.0"
 tempfile = "3.8"
 test-fuzz = "5"
-tikv-jemallocator = { version = "0.5.0" }
+
+tikv-jemalloc-ctl = "0.6"
+tikv-jemallocator = "0.6"
+tracy-client = "0.17.3"

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 # reth
 reth-provider = { workspace = true }
 reth-cli-runner.workspace = true
+reth-cli-util.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-node-core.workspace = true
 reth-node-api.workspace = true
@@ -25,7 +26,10 @@ reth-primitives = { workspace = true, features = ["alloy-compat"] }
 reth-tracing.workspace = true
 
 # alloy
-alloy-provider = { workspace = true, features = ["engine-api", "reqwest-rustls-tls"], default-features = false }
+alloy-provider = { workspace = true, features = [
+    "engine-api",
+    "reqwest-rustls-tls",
+], default-features = false }
 alloy-rpc-types-engine.workspace = true
 alloy-transport.workspace = true
 alloy-transport-http.workspace = true
@@ -71,10 +75,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 # for writing data
 csv = "1.3.0"
 
-[target.'cfg(unix)'.dependencies]
-tikv-jemallocator = { workspace = true, optional = true }
-libc = "0.2"
-
 [dev-dependencies]
 reth-tracing.workspace = true
 
@@ -83,8 +83,8 @@ default = ["jemalloc"]
 
 asm-keccak = ["reth-primitives/asm-keccak"]
 
-jemalloc = ["dep:tikv-jemallocator"]
-jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
+jemalloc = ["reth-cli-util/jemalloc"]
+jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
 
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -14,10 +14,8 @@ workspace = true
 
 [dependencies]
 # reth
-reth-provider = { workspace = true }
 reth-cli-runner.workspace = true
 reth-cli-util.workspace = true
-reth-db = { workspace = true, features = ["mdbx"] }
 reth-node-core.workspace = true
 reth-node-api.workspace = true
 reth-rpc-types.workspace = true
@@ -38,7 +36,6 @@ alloy-transport-ipc.workspace = true
 alloy-pubsub.workspace = true
 alloy-json-rpc.workspace = true
 alloy-rpc-client.workspace = true
-alloy-consensus.workspace = true
 alloy-eips.workspace = true
 
 # reqwest
@@ -54,7 +51,6 @@ tracing.workspace = true
 
 # io
 serde.workspace = true
-serde_json.workspace = true
 
 # async
 tokio = { workspace = true, features = [
@@ -63,7 +59,6 @@ tokio = { workspace = true, features = [
     "time",
     "rt-multi-thread",
 ] }
-tokio-util.workspace = true
 futures.workspace = true
 async-trait.workspace = true
 
@@ -93,11 +88,7 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
-optimism = [
-    "reth-primitives/optimism",
-    "reth-provider/optimism",
-    "reth-node-core/optimism",
-]
+optimism = ["reth-primitives/optimism", "reth-node-core/optimism"]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices
 ethereum = []

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -85,6 +85,7 @@ asm-keccak = ["reth-primitives/asm-keccak"]
 
 jemalloc = ["reth-cli-util/jemalloc"]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
+tracy-allocator = ["reth-cli-util/tracy-allocator"]
 
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]

--- a/bin/reth-bench/src/main.rs
+++ b/bin/reth-bench/src/main.rs
@@ -3,10 +3,16 @@
 //! This is a tool that converts existing blocks into a stream of blocks for benchmarking purposes.
 //! These blocks are then fed into reth as a stream of execution payloads.
 
-// We use jemalloc for performance reasons.
-#[cfg(all(feature = "jemalloc", unix))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
 pub mod authenticated_transport;
 pub mod bench;

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -91,9 +91,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 backon.workspace = true
 similar-asserts.workspace = true
 
-[target.'cfg(unix)'.dependencies]
-tikv-jemallocator = { workspace = true, optional = true }
-
 [dev-dependencies]
 reth-discv4.workspace = true
 tempfile.workspace = true
@@ -105,8 +102,12 @@ dev = ["reth-cli-commands/dev"]
 
 asm-keccak = ["reth-node-core/asm-keccak", "reth-primitives/asm-keccak"]
 
-jemalloc = ["dep:tikv-jemallocator", "reth-node-core/jemalloc", "reth-node-metrics/jemalloc"]
-jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
+jemalloc = [
+    "reth-cli-util/jemalloc",
+    "reth-node-core/jemalloc",
+    "reth-node-metrics/jemalloc",
+]
+jemalloc-prof = ["reth-cli-util/jemalloc"]
 
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -108,6 +108,7 @@ jemalloc = [
     "reth-node-metrics/jemalloc",
 ]
 jemalloc-prof = ["reth-cli-util/jemalloc"]
+tracy-allocator = ["reth-cli-util/tracy-allocator"]
 
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -146,7 +146,6 @@ pub mod transaction_pool {
 
 /// Re-export of `reth_rpc_*` crates.
 pub mod rpc {
-
     /// Re-exported from `reth_rpc_builder`.
     pub mod builder {
         pub use reth_rpc_builder::*;
@@ -189,9 +188,6 @@ pub mod rpc {
 // re-export for convenience
 #[doc(inline)]
 pub use reth_cli_runner::{tokio_runtime, CliContext, CliRunner};
-
-#[cfg(all(feature = "jemalloc", unix))]
-use tikv_jemallocator as _;
 
 // for rendering diagrams
 use aquamarine as _;

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -1,12 +1,13 @@
 #![allow(missing_docs)]
 
-// We use jemalloc for performance reasons.
-#[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
-/// clap [Args] for Engine related arguments.
-use clap::Args;
+use clap::{Args, Parser};
+use reth::{args::utils::DefaultChainSpecParser, cli::Cli};
+use reth_node_builder::EngineNodeLauncher;
+use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_provider::providers::BlockchainProvider2;
 
 /// Parameters for configuring the engine
 #[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
@@ -18,12 +19,6 @@ pub struct EngineArgs {
 }
 
 fn main() {
-    use clap::Parser;
-    use reth::{args::utils::DefaultChainSpecParser, cli::Cli};
-    use reth_node_builder::EngineNodeLauncher;
-    use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
-    use reth_provider::providers::BlockchainProvider2;
-
     reth_cli_util::sigsegv_handler::install();
 
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -18,12 +18,21 @@ reth-fs-util.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
 
-secp256k1 = { workspace = true, features = ["rand"] }
-rand.workspace = true
-
 # misc
-thiserror.workspace = true
+cfg-if.workspace = true
 eyre.workspace = true
+rand.workspace = true
+secp256k1 = { workspace = true, features = ["rand"] }
+thiserror.workspace = true
+
+tracy-client = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
 libc = "0.2"
+
+[features]
+jemalloc = ["dep:tikv-jemallocator"]
+jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
+
+tracy-allocator = ["dep:tracy-client"]

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -25,7 +25,7 @@ rand.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
 thiserror.workspace = true
 
-tracy-client = { workspace = true, optional = true }
+tracy-client = { workspace = true, optional = true, features = ["demangle"] }
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/crates/cli/util/src/allocator.rs
+++ b/crates/cli/util/src/allocator.rs
@@ -1,0 +1,32 @@
+//! Custom allocator implementation.
+
+// We use jemalloc for performance reasons.
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "jemalloc", unix))] {
+        type AllocatorInner = tikv_jemallocator::Jemalloc;
+    } else {
+        type AllocatorInner = std::alloc::System;
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "tracy-allocator")] {
+        type AllocatorWrapper = tracing_tracy::client::ProfiledAllocator<AllocatorInner>;
+        const fn new_allocator_wrapper() -> AllocatorWrapper {
+            AllocatorWrapper::new(AllocatorInner {}, 100)
+        }
+    } else {
+        type AllocatorWrapper = AllocatorInner;
+        const fn new_allocator_wrapper() -> AllocatorWrapper {
+            AllocatorInner {}
+        }
+    }
+}
+
+/// Custom allocator.
+pub type Allocator = AllocatorWrapper;
+
+/// Creates a new [custom allocator][Allocator].
+pub const fn new_allocator() -> Allocator {
+    new_allocator_wrapper()
+}

--- a/crates/cli/util/src/allocator.rs
+++ b/crates/cli/util/src/allocator.rs
@@ -23,6 +23,9 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(feature = "tracy-allocator")]
+tracy_client::register_demangler!();
+
 /// Custom allocator.
 pub type Allocator = AllocatorWrapper;
 

--- a/crates/cli/util/src/allocator.rs
+++ b/crates/cli/util/src/allocator.rs
@@ -11,7 +11,7 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "tracy-allocator")] {
-        type AllocatorWrapper = tracing_tracy::client::ProfiledAllocator<AllocatorInner>;
+        type AllocatorWrapper = tracy_client::ProfiledAllocator<AllocatorInner>;
         const fn new_allocator_wrapper() -> AllocatorWrapper {
             AllocatorWrapper::new(AllocatorInner {}, 100)
         }

--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -8,6 +8,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+pub mod allocator;
+
 /// Helper function to load a secret key from a file.
 pub mod load_secret_key;
 pub use load_secret_key::get_secret_key;

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -28,7 +28,7 @@ tracing.workspace = true
 eyre.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true, features = ["stats"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.16.0"
@@ -44,7 +44,6 @@ workspace = true
 
 [features]
 jemalloc = ["dep:tikv-jemalloc-ctl"]
-
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -26,6 +26,7 @@ default = ["jemalloc"]
 
 jemalloc = ["reth-cli-util/jemalloc"]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
+tracy-allocator = ["reth-cli-util/tracy-allocator"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-node-optimism/asm-keccak"]
 

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -18,17 +18,14 @@ reth-node-optimism.workspace = true
 
 clap = { workspace = true, features = ["derive", "env"] }
 
-[target.'cfg(unix)'.dependencies]
-tikv-jemallocator = { workspace = true, optional = true }
-
 [lints]
 workspace = true
 
 [features]
 default = ["jemalloc"]
 
-jemalloc = ["dep:tikv-jemallocator"]
-jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
+jemalloc = ["reth-cli-util/jemalloc"]
+jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-node-optimism/asm-keccak"]
 

--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -10,10 +10,8 @@ use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
 use reth_optimism_rpc::eth::rpc::SequencerClient;
 use reth_provider::providers::BlockchainProvider2;
 
-// We use jemalloc for performance reasons
-#[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
 fn main() {
     reth_cli_util::sigsegv_handler::install();


### PR DESCRIPTION
Useful for profiling memory usage w/ backtraces at allocation and deallocation of every object.

New deps in Cargo.lock are unreachable because of `cfg(loom)`.