### PR TITLE
fix: use configured chainspec parser for commands

### DIFF
--- a/crates/optimism/cli/src/commands/mod.rs
+++ b/crates/optimism/cli/src/commands/mod.rs
@@ -2,6 +2,8 @@ use crate::chainspec::OpChainSpecParser;
 use clap::Subcommand;
 use import::ImportOpCommand;
 use import_receipts::ImportReceiptsOpCommand;
+use reth_chainspec::ChainSpec;
+use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     config_cmd, db, dump_genesis, init_cmd, init_state,
     node::{self, NoArgs},
@@ -16,40 +18,43 @@ pub mod import_receipts;
 
 /// Commands to be executed
 #[derive(Debug, Subcommand)]
-pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
+pub enum Commands<
+    Spec: ChainSpecParser<ChainSpec = ChainSpec> = OpChainSpecParser,
+    Ext: clap::Args + fmt::Debug = NoArgs,
+> {
     /// Start the node
     #[command(name = "node")]
-    Node(Box<node::NodeCommand<OpChainSpecParser, Ext>>),
+    Node(Box<node::NodeCommand<Spec, Ext>>),
     /// Initialize the database from a genesis file.
     #[command(name = "init")]
-    Init(init_cmd::InitCommand<OpChainSpecParser>),
+    Init(init_cmd::InitCommand<Spec>),
     /// Initialize the database from a state dump file.
     #[command(name = "init-state")]
-    InitState(init_state::InitStateCommand<OpChainSpecParser>),
+    InitState(init_state::InitStateCommand<Spec>),
     /// This syncs RLP encoded OP blocks below Bedrock from a file, without executing.
     #[command(name = "import-op")]
-    ImportOp(ImportOpCommand<OpChainSpecParser>),
+    ImportOp(ImportOpCommand<Spec>),
     /// This imports RLP encoded receipts from a file.
     #[command(name = "import-receipts-op")]
-    ImportReceiptsOp(ImportReceiptsOpCommand<OpChainSpecParser>),
+    ImportReceiptsOp(ImportReceiptsOpCommand<Spec>),
     /// Dumps genesis block JSON configuration to stdout.
-    DumpGenesis(dump_genesis::DumpGenesisCommand<OpChainSpecParser>),
+    DumpGenesis(dump_genesis::DumpGenesisCommand<Spec>),
     /// Database debugging utilities
     #[command(name = "db")]
-    Db(db::Command<OpChainSpecParser>),
+    Db(db::Command<Spec>),
     /// Manipulate individual stages.
     #[command(name = "stage")]
-    Stage(Box<stage::Command<OpChainSpecParser>>),
+    Stage(Box<stage::Command<Spec>>),
     /// P2P Debugging utilities
     #[command(name = "p2p")]
-    P2P(p2p::Command<OpChainSpecParser>),
+    P2P(p2p::Command<Spec>),
     /// Write config to stdout
     #[command(name = "config")]
     Config(config_cmd::Command),
     /// Scripts for node recovery
     #[command(name = "recover")]
-    Recover(recover::Command<OpChainSpecParser>),
+    Recover(recover::Command<Spec>),
     /// Prune according to the configuration without any limits
     #[command(name = "prune")]
-    Prune(prune::PruneCommand<OpChainSpecParser>),
+    Prune(prune::PruneCommand<Spec>),
 }

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -61,7 +61,7 @@ pub struct Cli<
 > {
     /// The command to run
     #[command(subcommand)]
-    command: Commands<Ext>,
+    command: Commands<Spec, Ext>,
 
     /// The chain this node is running.
     ///


### PR DESCRIPTION
we need propagate the chainspec parser generic down to the commands