### PR TITLE
perf: improve genesis handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -482,7 +482,9 @@ humantime-serde = "1.1"
 itertools = "0.13"
 linked_hash_set = "0.1"
 modular-bitfield = "0.11.2"
-notify = { version = "6.1.1", default-features = false, features = ["macos_fsevent"] }
+notify = { version = "6.1.1", default-features = false, features = [
+    "macos_fsevent",
+] }
 nybbles = "0.2.1"
 once_cell = "1.19"
 parking_lot = "0.12"

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,7 +1,6 @@
-use core::fmt::Debug;
-
 use crate::ChainSpec;
 use alloy_chains::Chain;
+use core::fmt::Debug;
 
 /// Trait representing type configuring a chain spec.
 pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -34,6 +34,13 @@ pub use spec::{
     DepositContract, ForkBaseFeeParams, DEV, HOLESKY, MAINNET, SEPOLIA,
 };
 
+/// Simple utility to create a `OnceLock` with a value set.
+pub fn once_lock_set<T>(value: T) -> std::sync::OnceLock<T> {
+    let once = std::sync::OnceLock::new();
+    let _ = once.set(value);
+    once
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -9,7 +9,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 /// Chain specific constants
@@ -35,8 +34,8 @@ pub use spec::{
 };
 
 /// Simple utility to create a `OnceLock` with a value set.
-pub fn once_lock_set<T>(value: T) -> std::sync::OnceLock<T> {
-    let once = std::sync::OnceLock::new();
+pub fn once_lock_set<T>(value: T) -> once_cell::sync::OnceCell<T> {
+    let once = once_cell::sync::OnceCell::new();
     let _ = once.set(value);
     once
 }

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -33,8 +33,8 @@ pub use spec::{
     DepositContract, ForkBaseFeeParams, DEV, HOLESKY, MAINNET, SEPOLIA,
 };
 
-/// Simple utility to create a `OnceLock` with a value set.
-pub fn once_lock_set<T>(value: T) -> once_cell::sync::OnceCell<T> {
+/// Simple utility to create a `OnceCell` with a value set.
+pub fn once_cell_set<T>(value: T) -> once_cell::sync::OnceCell<T> {
     let once = once_cell::sync::OnceCell::new();
     let _ = once.set(value);
     once

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1,4 +1,4 @@
-use crate::{constants::MAINNET_DEPOSIT_CONTRACT, once_lock_set, EthChainSpec};
+use crate::{constants::MAINNET_DEPOSIT_CONTRACT, once_cell_set, EthChainSpec};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_chains::{Chain, ChainKind, NamedChain};
 use alloy_genesis::Genesis;
@@ -33,7 +33,7 @@ pub static MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         chain: Chain::mainnet(),
         genesis: serde_json::from_str(include_str!("../res/genesis/mainnet.json"))
             .expect("Can't deserialize Mainnet genesis json"),
-        genesis_hash: once_lock_set(MAINNET_GENESIS_HASH),
+        genesis_hash: once_cell_set(MAINNET_GENESIS_HASH),
         genesis_header: Default::default(),
         // <https://etherscan.io/block/15537394>
         paris_block_and_final_difficulty: Some((
@@ -61,7 +61,7 @@ pub static SEPOLIA: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         chain: Chain::sepolia(),
         genesis: serde_json::from_str(include_str!("../res/genesis/sepolia.json"))
             .expect("Can't deserialize Sepolia genesis json"),
-        genesis_hash: once_lock_set(SEPOLIA_GENESIS_HASH),
+        genesis_hash: once_cell_set(SEPOLIA_GENESIS_HASH),
         genesis_header: Default::default(),
         // <https://sepolia.etherscan.io/block/1450409>
         paris_block_and_final_difficulty: Some((1450409, U256::from(17_000_018_015_853_232u128))),
@@ -86,7 +86,7 @@ pub static HOLESKY: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         chain: Chain::holesky(),
         genesis: serde_json::from_str(include_str!("../res/genesis/holesky.json"))
             .expect("Can't deserialize Holesky genesis json"),
-        genesis_hash: once_lock_set(HOLESKY_GENESIS_HASH),
+        genesis_hash: once_cell_set(HOLESKY_GENESIS_HASH),
         genesis_header: Default::default(),
         paris_block_and_final_difficulty: Some((0, U256::from(1))),
         hardforks: EthereumHardfork::holesky().into(),
@@ -112,7 +112,7 @@ pub static DEV: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
         chain: Chain::dev(),
         genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
             .expect("Can't deserialize Dev testnet genesis json"),
-        genesis_hash: once_lock_set(DEV_GENESIS_HASH),
+        genesis_hash: once_cell_set(DEV_GENESIS_HASH),
         paris_block_and_final_difficulty: Some((0, U256::from(0))),
         hardforks: DEV_HARDFORKS.clone(),
         base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
@@ -176,16 +176,19 @@ pub struct ChainSpec {
     /// The chain ID
     pub chain: Chain,
 
-    /// The hash of the genesis block.
-    ///
-    /// This acts as a small cache for known chains. If the chain is known, then the genesis hash
-    /// is also known ahead of time, and this will be `Some`.
-    pub genesis_hash: OnceCell<B256>,
-
     /// The genesis block.
     pub genesis: Genesis,
 
+    /// The hash of the genesis block.
+    ///
+    /// This is either stored at construction time if it is known using [`once_cell_set`], or
+    /// computed once on the first access.
+    pub genesis_hash: OnceCell<B256>,
+
     /// The header corresponding to the genesis block.
+    ///
+    /// This is either stored at construction time if it is known using [`once_cell_set`], or
+    /// computed once on the first access.
     pub genesis_header: OnceCell<Header>,
 
     /// The block at which [`EthereumHardfork::Paris`] was activated and the final difficulty at

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -94,7 +94,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> EnvironmentArgs<C> {
         let provider_factory = self.create_provider_factory(&config, db, sfp)?;
         if access.is_read_write() {
             debug!(target: "reth::cli", chain=%self.chain.chain, genesis=?self.chain.genesis_hash(), "Initializing genesis");
-            init_genesis(provider_factory.clone())?;
+            init_genesis(&provider_factory)?;
         }
 
         Ok(Environment { config, provider_factory, data_dir })

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -73,7 +73,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                     StageId::Headers.to_string(),
                     Default::default(),
                 )?;
-                insert_genesis_header(&provider_rw, &static_file_provider, self.env.chain)?;
+                insert_genesis_header(&provider_rw, &static_file_provider, &self.env.chain)?;
             }
             StageEnum::Bodies => {
                 tx.clear::<tables::BlockBodyIndices>()?;
@@ -86,7 +86,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                     StageId::Bodies.to_string(),
                     Default::default(),
                 )?;
-                insert_genesis_header(&provider_rw, &static_file_provider, self.env.chain)?;
+                insert_genesis_header(&provider_rw, &static_file_provider, &self.env.chain)?;
             }
             StageEnum::Senders => {
                 tx.clear::<tables::TransactionSenders>()?;
@@ -173,7 +173,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                     StageId::TransactionLookup.to_string(),
                     Default::default(),
                 )?;
-                insert_genesis_header(&provider_rw, &static_file_provider, self.env.chain)?;
+                insert_genesis_header(&provider_rw, &static_file_provider, &self.env.chain)?;
             }
         }
 

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -392,7 +392,7 @@ where
             BlockchainTree::new(externals, BlockchainTreeConfig::new(1, 2, 3, 2))
                 .expect("failed to create tree"),
         ));
-        let genesis_block = self.base_config.chain_spec.genesis_header().seal_slow();
+        let genesis_block = self.base_config.chain_spec.genesis_header().clone().seal_slow();
 
         let blockchain_provider =
             BlockchainProvider::with_blocks(provider_factory.clone(), tree, genesis_block, None);

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2691,7 +2691,7 @@ mod tests {
 
             let (from_tree_tx, from_tree_rx) = unbounded_channel();
 
-            let header = chain_spec.genesis_header().seal_slow();
+            let header = chain_spec.genesis_header().clone().seal_slow();
             let engine_api_tree_state = EngineApiTreeState::new(10, 10, header.num_hash());
             let canonical_in_memory_state = CanonicalInMemoryState::with_head(header, None);
 

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -417,7 +417,7 @@ mod tests {
 
         // use cfg_and_block_env
         let cfg_and_block_env =
-            payload_builder_attributes.cfg_and_block_env(&chainspec, &chainspec.genesis_header());
+            payload_builder_attributes.cfg_and_block_env(&chainspec, chainspec.genesis_header());
 
         // ensure the base fee is non zero
         assert_eq!(cfg_and_block_env.1.basefee, U256::from(EIP1559_INITIAL_BASE_FEE));

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -730,7 +730,7 @@ mod tests {
                 .build(),
         );
 
-        let mut header = chain_spec.genesis_header();
+        let mut header = chain_spec.genesis_header().clone();
         let provider = executor_provider(chain_spec);
         let mut executor = provider.batch_executor(StateProviderDatabase::new(&db));
 
@@ -952,7 +952,7 @@ mod tests {
                 .build(),
         );
 
-        let header = chain_spec.genesis_header();
+        let header = chain_spec.genesis_header().clone();
         let provider = executor_provider(chain_spec);
         let mut executor = provider.batch_executor(StateProviderDatabase::new(&db));
 
@@ -1123,7 +1123,7 @@ mod tests {
                 .build(),
         );
 
-        let mut header = chain_spec.genesis_header();
+        let mut header = chain_spec.genesis_header().clone();
         header.requests_root = Some(EMPTY_ROOT_HASH);
         let header_hash = header.hash_slow();
 
@@ -1281,7 +1281,7 @@ mod tests {
         let input: Bytes = [&validator_public_key[..], &withdrawal_amount[..]].concat().into();
         assert_eq!(input.len(), 56);
 
-        let mut header = chain_spec.genesis_header();
+        let mut header = chain_spec.genesis_header().clone();
         header.gas_limit = 1_500_000;
         header.gas_used = 134_807;
         header.receipts_root =
@@ -1370,7 +1370,7 @@ mod tests {
         assert_eq!(input.len(), 56);
 
         // Create a genesis block header with a specified gas limit and gas used
-        let mut header = chain_spec.genesis_header();
+        let mut header = chain_spec.genesis_header().clone();
         header.gas_limit = 1_500_000;
         header.gas_used = 134_807;
         header.receipts_root =

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -252,7 +252,7 @@ mod tests {
 
         let executor = EthExecutorProvider::ethereum(chain_spec.clone());
         let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
-        init_genesis(provider_factory.clone())?;
+        init_genesis(&provider_factory)?;
         let blockchain_db = BlockchainProvider::new(
             provider_factory.clone(),
             Arc::new(NoopBlockchainTree::default()),
@@ -291,7 +291,7 @@ mod tests {
 
         let executor = EthExecutorProvider::ethereum(chain_spec.clone());
         let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
-        init_genesis(provider_factory.clone())?;
+        init_genesis(&provider_factory)?;
         let blockchain_db = BlockchainProvider::new(
             provider_factory.clone(),
             Arc::new(NoopBlockchainTree::default()),

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -202,7 +202,7 @@ mod tests {
 
         let executor = EthExecutorProvider::ethereum(chain_spec.clone());
         let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
-        init_genesis(provider_factory.clone())?;
+        init_genesis(&provider_factory)?;
         let blockchain_db = BlockchainProvider::new(
             provider_factory.clone(),
             Arc::new(NoopBlockchainTree::default()),
@@ -243,7 +243,7 @@ mod tests {
 
         let executor = EthExecutorProvider::ethereum(chain_spec.clone());
         let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
-        init_genesis(provider_factory.clone())?;
+        init_genesis(&provider_factory)?;
         let blockchain_db = BlockchainProvider::new(
             provider_factory.clone(),
             Arc::new(NoopBlockchainTree::default()),

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -250,7 +250,7 @@ pub async fn test_exex_context_with_chain_spec(
         StaticFileProvider::read_write(static_dir.into_path()).expect("static file provider"),
     );
 
-    let genesis_hash = init_genesis(provider_factory.clone())?;
+    let genesis_hash = init_genesis(&provider_factory)?;
     let provider =
         BlockchainProvider::new(provider_factory.clone(), Arc::new(NoopBlockchainTree::default()))?;
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -522,13 +522,13 @@ where
 
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitDatabaseError> {
-        init_genesis(self.provider_factory().clone())?;
+        init_genesis(self.provider_factory())?;
         Ok(self)
     }
 
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitDatabaseError> {
-        init_genesis(self.provider_factory().clone())
+        init_genesis(self.provider_factory())
     }
 
     /// Creates a new `WithMeteredProvider` container and attaches it to the

--- a/crates/optimism/chainspec/src/base.rs
+++ b/crates/optimism/chainspec/src/base.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 
 use crate::OpChainSpec;
@@ -20,7 +20,7 @@ pub static BASE_MAINNET: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             chain: Chain::base_mainnet(),
             genesis: serde_json::from_str(include_str!("../res/genesis/base.json"))
                 .expect("Can't deserialize Base genesis json"),
-            genesis_hash: Some(b256!(
+            genesis_hash: once_lock_set(b256!(
                 "f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/chainspec/src/base.rs
+++ b/crates/optimism/chainspec/src/base.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 
 use crate::OpChainSpec;
@@ -20,7 +20,7 @@ pub static BASE_MAINNET: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             chain: Chain::base_mainnet(),
             genesis: serde_json::from_str(include_str!("../res/genesis/base.json"))
                 .expect("Can't deserialize Base genesis json"),
-            genesis_hash: once_lock_set(b256!(
+            genesis_hash: once_cell_set(b256!(
                 "f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/chainspec/src/base_sepolia.rs
+++ b/crates/optimism/chainspec/src/base_sepolia.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 
 use crate::OpChainSpec;
@@ -20,7 +20,7 @@ pub static BASE_SEPOLIA: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             chain: Chain::base_sepolia(),
             genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_base.json"))
                 .expect("Can't deserialize Base Sepolia genesis json"),
-            genesis_hash: once_lock_set(b256!(
+            genesis_hash: once_cell_set(b256!(
                 "0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/chainspec/src/base_sepolia.rs
+++ b/crates/optimism/chainspec/src/base_sepolia.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 
 use crate::OpChainSpec;
@@ -20,7 +20,7 @@ pub static BASE_SEPOLIA: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             chain: Chain::base_sepolia(),
             genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_base.json"))
                 .expect("Can't deserialize Base Sepolia genesis json"),
-            genesis_hash: Some(b256!(
+            genesis_hash: once_lock_set(b256!(
                 "0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::U256;
 use once_cell::sync::Lazy;
-use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::DEV_HARDFORKS;
 use reth_primitives_traits::constants::DEV_GENESIS_HASH;
 
@@ -24,7 +24,7 @@ pub static OP_DEV: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             chain: Chain::dev(),
             genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
                 .expect("Can't deserialize Dev testnet genesis json"),
-            genesis_hash: once_lock_set(DEV_GENESIS_HASH),
+            genesis_hash: once_cell_set(DEV_GENESIS_HASH),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks: DEV_HARDFORKS.clone(),
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),

--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::U256;
 use once_cell::sync::Lazy;
-use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::DEV_HARDFORKS;
 use reth_primitives_traits::constants::DEV_GENESIS_HASH;
 
@@ -19,20 +19,18 @@ use crate::OpChainSpec;
 /// Includes 20 prefunded accounts with `10_000` ETH each derived from mnemonic "test test test test
 /// test test test test test test test junk".
 pub static OP_DEV: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
-    {
-        OpChainSpec {
-            inner: ChainSpec {
-                chain: Chain::dev(),
-                genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
-                    .expect("Can't deserialize Dev testnet genesis json"),
-                genesis_hash: Some(DEV_GENESIS_HASH),
-                paris_block_and_final_difficulty: Some((0, U256::from(0))),
-                hardforks: DEV_HARDFORKS.clone(),
-                base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
-                deposit_contract: None, // TODO: do we even have?
-                ..Default::default()
-            },
-        }
+    OpChainSpec {
+        inner: ChainSpec {
+            chain: Chain::dev(),
+            genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
+                .expect("Can't deserialize Dev testnet genesis json"),
+            genesis_hash: once_lock_set(DEV_GENESIS_HASH),
+            paris_block_and_final_difficulty: Some((0, U256::from(0))),
+            hardforks: DEV_HARDFORKS.clone(),
+            base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
+            deposit_contract: None, // TODO: do we even have?
+            ..Default::default()
+        },
     }
     .into()
 });

--- a/crates/optimism/chainspec/src/op.rs
+++ b/crates/optimism/chainspec/src/op.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 use reth_primitives_traits::constants::ETHEREUM_BLOCK_GAS_LIMIT;
 
@@ -23,7 +23,7 @@ pub static OP_MAINNET: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             // manually from trusted source
             genesis: serde_json::from_str(include_str!("../res/genesis/optimism.json"))
                 .expect("Can't deserialize Optimism Mainnet genesis json"),
-            genesis_hash: once_lock_set(b256!(
+            genesis_hash: once_cell_set(b256!(
                 "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/chainspec/src/op.rs
+++ b/crates/optimism/chainspec/src/op.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 use reth_primitives_traits::constants::ETHEREUM_BLOCK_GAS_LIMIT;
 
@@ -23,7 +23,7 @@ pub static OP_MAINNET: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             // manually from trusted source
             genesis: serde_json::from_str(include_str!("../res/genesis/optimism.json"))
                 .expect("Can't deserialize Optimism Mainnet genesis json"),
-            genesis_hash: Some(b256!(
+            genesis_hash: once_lock_set(b256!(
                 "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/chainspec/src/op_sepolia.rs
+++ b/crates/optimism/chainspec/src/op_sepolia.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::{Chain, NamedChain};
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 use reth_primitives_traits::constants::ETHEREUM_BLOCK_GAS_LIMIT;
 
@@ -21,7 +21,7 @@ pub static OP_SEPOLIA: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             chain: Chain::from_named(NamedChain::OptimismSepolia),
             genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_op.json"))
                 .expect("Can't deserialize OP Sepolia genesis json"),
-            genesis_hash: once_lock_set(b256!(
+            genesis_hash: once_cell_set(b256!(
                 "102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/chainspec/src/op_sepolia.rs
+++ b/crates/optimism/chainspec/src/op_sepolia.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use alloy_chains::{Chain, NamedChain};
 use alloy_primitives::{b256, U256};
 use once_cell::sync::Lazy;
-use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_lock_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, OptimismHardfork};
 use reth_primitives_traits::constants::ETHEREUM_BLOCK_GAS_LIMIT;
 
@@ -21,7 +21,7 @@ pub static OP_SEPOLIA: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             chain: Chain::from_named(NamedChain::OptimismSepolia),
             genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_op.json"))
                 .expect("Can't deserialize OP Sepolia genesis json"),
-            genesis_hash: Some(b256!(
+            genesis_hash: once_lock_set(b256!(
                 "102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
             )),
             paris_block_and_final_difficulty: Some((0, U256::from(0))),

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -285,7 +285,7 @@ mod test {
             ChunkedFileReader::from_file(f, DEFAULT_BYTE_LEN_CHUNK_CHAIN_FILE).await.unwrap();
 
         let db = TestStageDB::default();
-        init_genesis(db.factory.clone()).unwrap();
+        init_genesis(&db.factory).unwrap();
 
         // todo: where does import command init receipts ? probably somewhere in pipeline
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -78,7 +78,7 @@ impl From<DatabaseError> for InitDatabaseError {
 
 /// Write the genesis block if it has not already been written
 pub fn init_genesis<N: NodeTypesWithDB<ChainSpec = ChainSpec>>(
-    factory: ProviderFactory<N>,
+    factory: &ProviderFactory<N>,
 ) -> Result<B256, InitDatabaseError> {
     let chain = factory.chain_spec();
 
@@ -559,7 +559,7 @@ mod tests {
     #[test]
     fn success_init_genesis_mainnet() {
         let genesis_hash =
-            init_genesis(create_test_provider_factory_with_chain_spec(MAINNET.clone())).unwrap();
+            init_genesis(&create_test_provider_factory_with_chain_spec(MAINNET.clone())).unwrap();
 
         // actual, expected
         assert_eq!(genesis_hash, MAINNET_GENESIS_HASH);
@@ -568,7 +568,7 @@ mod tests {
     #[test]
     fn success_init_genesis_sepolia() {
         let genesis_hash =
-            init_genesis(create_test_provider_factory_with_chain_spec(SEPOLIA.clone())).unwrap();
+            init_genesis(&create_test_provider_factory_with_chain_spec(SEPOLIA.clone())).unwrap();
 
         // actual, expected
         assert_eq!(genesis_hash, SEPOLIA_GENESIS_HASH);
@@ -577,7 +577,7 @@ mod tests {
     #[test]
     fn success_init_genesis_holesky() {
         let genesis_hash =
-            init_genesis(create_test_provider_factory_with_chain_spec(HOLESKY.clone())).unwrap();
+            init_genesis(&create_test_provider_factory_with_chain_spec(HOLESKY.clone())).unwrap();
 
         // actual, expected
         assert_eq!(genesis_hash, HOLESKY_GENESIS_HASH);
@@ -587,7 +587,7 @@ mod tests {
     fn fail_init_inconsistent_db() {
         let factory = create_test_provider_factory_with_chain_spec(SEPOLIA.clone());
         let static_file_provider = factory.static_file_provider();
-        init_genesis(factory.clone()).unwrap();
+        init_genesis(&factory).unwrap();
 
         // Try to init db with a different genesis block
         let genesis_hash = init_genesis(ProviderFactory::<MockNodeTypesWithDB>::new(
@@ -636,7 +636,7 @@ mod tests {
         });
 
         let factory = create_test_provider_factory_with_chain_spec(chain_spec);
-        init_genesis(factory.clone()).unwrap();
+        init_genesis(&factory).unwrap();
 
         let provider = factory.provider().unwrap();
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -238,13 +238,7 @@ pub fn insert_genesis_hashes<'a, 'b, DB: Database>(
     let alloc_storage = alloc.filter_map(|(addr, account)| {
         // only return Some if there is storage
         account.storage.as_ref().map(|storage| {
-            (
-                *addr,
-                storage
-                    .clone()
-                    .into_iter()
-                    .map(|(key, value)| StorageEntry { key, value: value.into() }),
-            )
+            (*addr, storage.iter().map(|(&key, &value)| StorageEntry { key, value: value.into() }))
         })
     });
     provider.insert_storage_for_hashing(alloc_storage)?;

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -544,7 +544,7 @@ mod tests {
     use reth_provider::test_utils::{
         create_test_provider_factory_with_chain_spec, MockNodeTypesWithDB,
     };
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, sync::Arc};
 
     fn collect_table_entries<DB, T>(
         tx: &<DB as Database>::TX,
@@ -590,7 +590,7 @@ mod tests {
         init_genesis(&factory).unwrap();
 
         // Try to init db with a different genesis block
-        let genesis_hash = init_genesis(ProviderFactory::<MockNodeTypesWithDB>::new(
+        let genesis_hash = init_genesis(&ProviderFactory::<MockNodeTypesWithDB>::new(
             factory.into_db(),
             MAINNET.clone(),
             static_file_provider,

--- a/crates/storage/provider/src/traits/history.rs
+++ b/crates/storage/provider/src/traits/history.rs
@@ -2,10 +2,7 @@ use auto_impl::auto_impl;
 use reth_db_api::models::BlockNumberAddress;
 use reth_primitives::{Address, BlockNumber, B256};
 use reth_storage_errors::provider::ProviderResult;
-use std::{
-    collections::BTreeMap,
-    ops::{Range, RangeInclusive},
-};
+use std::ops::{Range, RangeInclusive};
 
 /// History Writer
 #[auto_impl(&, Arc, Box)]
@@ -21,7 +18,7 @@ pub trait HistoryWriter: Send + Sync {
     /// Insert account change index to database. Used inside AccountHistoryIndex stage
     fn insert_account_history_index(
         &self,
-        account_transitions: BTreeMap<Address, Vec<u64>>,
+        index_updates: impl IntoIterator<Item = (Address, impl IntoIterator<Item = u64>)>,
     ) -> ProviderResult<()>;
 
     /// Unwind and clear storage history indices.
@@ -35,7 +32,7 @@ pub trait HistoryWriter: Send + Sync {
     /// Insert storage change index to database. Used inside StorageHistoryIndex stage
     fn insert_storage_history_index(
         &self,
-        storage_transitions: BTreeMap<(Address, B256), Vec<u64>>,
+        storage_transitions: impl IntoIterator<Item = ((Address, B256), impl IntoIterator<Item = u64>)>,
     ) -> ProviderResult<()>;
 
     /// Read account/storage changesets and update account/storage history indices.

--- a/examples/bsc-p2p/src/chainspec.rs
+++ b/examples/bsc-p2p/src/chainspec.rs
@@ -1,5 +1,5 @@
 use reth_chainspec::{
-    once_lock_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
+    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
 };
 use reth_network_peers::NodeRecord;
 use reth_primitives::{b256, B256};
@@ -14,7 +14,7 @@ pub(crate) fn bsc_chain_spec() -> Arc<ChainSpec> {
     ChainSpec {
         chain: Chain::from_id(56),
         genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
-        genesis_hash: once_lock_set(GENESIS),
+        genesis_hash: once_cell_set(GENESIS),
         genesis_header: Default::default(),
         paris_block_and_final_difficulty: None,
         hardforks: ChainHardforks::new(vec![(

--- a/examples/bsc-p2p/src/chainspec.rs
+++ b/examples/bsc-p2p/src/chainspec.rs
@@ -1,5 +1,5 @@
 use reth_chainspec::{
-    BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
+    once_lock_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
 };
 use reth_network_peers::NodeRecord;
 use reth_primitives::{b256, B256};
@@ -14,7 +14,8 @@ pub(crate) fn bsc_chain_spec() -> Arc<ChainSpec> {
     ChainSpec {
         chain: Chain::from_id(56),
         genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
-        genesis_hash: Some(GENESIS),
+        genesis_hash: once_lock_set(GENESIS),
+        genesis_header: Default::default(),
         paris_block_and_final_difficulty: None,
         hardforks: ChainHardforks::new(vec![(
             EthereumHardfork::Shanghai.boxed(),

--- a/examples/polygon-p2p/src/chain_cfg.rs
+++ b/examples/polygon-p2p/src/chain_cfg.rs
@@ -1,5 +1,5 @@
 use reth_chainspec::{
-    BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
+    once_lock_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
 };
 use reth_discv4::NodeRecord;
 use reth_primitives::{b256, Head, B256};
@@ -15,7 +15,8 @@ pub(crate) fn polygon_chain_spec() -> Arc<ChainSpec> {
         chain: Chain::from_id(137),
         // <https://github.com/maticnetwork/bor/blob/d521b8e266b97efe9c8fdce8167e9dd77b04637d/builder/files/genesis-mainnet-v1.json>
         genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
-        genesis_hash: Some(GENESIS),
+        genesis_hash: once_lock_set(GENESIS),
+        genesis_header: Default::default(),
         paris_block_and_final_difficulty: None,
         hardforks: ChainHardforks::new(vec![
             (EthereumHardfork::Petersburg.boxed(), ForkCondition::Block(0)),

--- a/examples/polygon-p2p/src/chain_cfg.rs
+++ b/examples/polygon-p2p/src/chain_cfg.rs
@@ -1,5 +1,5 @@
 use reth_chainspec::{
-    once_lock_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
+    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
 };
 use reth_discv4::NodeRecord;
 use reth_primitives::{b256, Head, B256};
@@ -15,7 +15,7 @@ pub(crate) fn polygon_chain_spec() -> Arc<ChainSpec> {
         chain: Chain::from_id(137),
         // <https://github.com/maticnetwork/bor/blob/d521b8e266b97efe9c8fdce8167e9dd77b04637d/builder/files/genesis-mainnet-v1.json>
         genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
-        genesis_hash: once_lock_set(GENESIS),
+        genesis_hash: once_cell_set(GENESIS),
         genesis_header: Default::default(),
         paris_block_and_final_difficulty: None,
         hardforks: ChainHardforks::new(vec![


### PR DESCRIPTION
- cache genesis hash and header (which includes state root) with `OnceLock` fields; these are currently computed at least 2 times each on each reth invocation, if not more (`sealed_genesis_header` computes header and hash which itself computes header again if not set)
- remove a ton of clones and btreemap collections in `impl HistoryWriter for DatabaseProvider` by passing required values in `impl IntoIterator`s
- pass state provider by reference in `init_genesis`; it's not really "cheap" to clone (5 arcs + `PruneModes` which could allocate)