### PR TITLE
fix: genesis header override workaround for alphanet

### DIFF
--- a/crates/optimism/chainspec/src/base.rs
+++ b/crates/optimism/chainspec/src/base.rs
@@ -23,6 +23,7 @@ pub static BASE_MAINNET: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             genesis_hash: Some(b256!(
                 "f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
             )),
+            genesis_header: None,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks: OptimismHardfork::base_mainnet(),
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/optimism/chainspec/src/base_sepolia.rs
+++ b/crates/optimism/chainspec/src/base_sepolia.rs
@@ -23,6 +23,7 @@ pub static BASE_SEPOLIA: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             genesis_hash: Some(b256!(
                 "0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
             )),
+            genesis_header: None,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks: OptimismHardfork::base_sepolia(),
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -26,6 +26,7 @@ pub static OP_DEV: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
                 genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
                     .expect("Can't deserialize Dev testnet genesis json"),
                 genesis_hash: Some(DEV_GENESIS_HASH),
+                genesis_header: None,
                 paris_block_and_final_difficulty: Some((0, U256::from(0))),
                 hardforks: DEV_HARDFORKS.clone(),
                 base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),

--- a/crates/optimism/chainspec/src/op.rs
+++ b/crates/optimism/chainspec/src/op.rs
@@ -26,6 +26,7 @@ pub static OP_MAINNET: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             genesis_hash: Some(b256!(
                 "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
             )),
+            genesis_header: None,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks: OptimismHardfork::op_mainnet(),
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/optimism/chainspec/src/op_sepolia.rs
+++ b/crates/optimism/chainspec/src/op_sepolia.rs
@@ -24,6 +24,7 @@ pub static OP_SEPOLIA: Lazy<Arc<OpChainSpec>> = Lazy::new(|| {
             genesis_hash: Some(b256!(
                 "102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
             )),
+            genesis_header: None,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks: OptimismHardfork::op_sepolia(),
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -635,6 +635,7 @@ mod tests {
             },
             hardforks: Default::default(),
             genesis_hash: None,
+            genesis_header: None,
             paris_block_and_final_difficulty: None,
             deposit_contract: None,
             ..Default::default()

--- a/examples/bsc-p2p/src/chainspec.rs
+++ b/examples/bsc-p2p/src/chainspec.rs
@@ -15,6 +15,7 @@ pub(crate) fn bsc_chain_spec() -> Arc<ChainSpec> {
         chain: Chain::from_id(56),
         genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
         genesis_hash: Some(GENESIS),
+        genesis_header: None,
         paris_block_and_final_difficulty: None,
         hardforks: ChainHardforks::new(vec![(
             EthereumHardfork::Shanghai.boxed(),

--- a/examples/polygon-p2p/src/chain_cfg.rs
+++ b/examples/polygon-p2p/src/chain_cfg.rs
@@ -16,6 +16,7 @@ pub(crate) fn polygon_chain_spec() -> Arc<ChainSpec> {
         // <https://github.com/maticnetwork/bor/blob/d521b8e266b97efe9c8fdce8167e9dd77b04637d/builder/files/genesis-mainnet-v1.json>
         genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
         genesis_hash: Some(GENESIS),
+        genesis_header: None,
         paris_block_and_final_difficulty: None,
         hardforks: ChainHardforks::new(vec![
             (EthereumHardfork::Petersburg.boxed(), ForkCondition::Block(0)),


### PR DESCRIPTION
For alphanet we enable Prague, which makes reth add a `requests_root` to the genesis block, altering the genesis hash. The genesis hash of op stack must be fixed to what the optimism genesis generator sets, so we need to be able to override the genesis header in Alphanet to not include a requests root

This is a temporary (and ugly) workaround until the chainspec is more generic, or we find an alternative solution