### PR TITLE
chore(op): Use `tokio::sync::OnceCell` to set `SequencerClient`

### DIFF
--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
                             if let Some(sequencer_http) = sequencer_http_arg {
                                 ctx.registry
                                     .eth_api()
-                                    .set_sequencer_client(SequencerClient::new(sequencer_http));
+                                    .set_sequencer_client(SequencerClient::new(sequencer_http))?;
                             }
 
                             Ok(())
@@ -62,7 +62,7 @@ fn main() {
                             if let Some(sequencer_http) = sequencer_http_arg {
                                 ctx.registry
                                     .eth_api()
-                                    .set_sequencer_client(SequencerClient::new(sequencer_http));
+                                    .set_sequencer_client(SequencerClient::new(sequencer_http))?;
                             }
 
                             Ok(())

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -36,6 +36,7 @@ use reth_tasks::{
     TaskSpawner,
 };
 use reth_transaction_pool::TransactionPool;
+use tokio::sync::OnceCell;
 
 use crate::{OpEthApiError, SequencerClient};
 
@@ -59,8 +60,11 @@ pub type EthApiNodeBackend<N> = EthApiInner<
 /// all the `Eth` helper traits and prerequisite traits.
 #[derive(Clone)]
 pub struct OpEthApi<N: FullNodeComponents> {
+    /// Gateway to node's core components.
     inner: Arc<EthApiNodeBackend<N>>,
-    sequencer_client: Arc<parking_lot::RwLock<Option<SequencerClient>>>,
+    /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
+    /// network.
+    sequencer_client: OnceCell<SequencerClient>,
 }
 
 impl<N> OpEthApi<N>
@@ -90,7 +94,7 @@ where
             ctx.config.proof_permits,
         );
 
-        Self { inner: Arc::new(inner), sequencer_client: Arc::new(parking_lot::RwLock::new(None)) }
+        Self { inner: Arc::new(inner), sequencer_client: OnceCell::new() }
     }
 }
 

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -76,13 +76,16 @@ impl<N> OpEthApi<N>
 where
     N: FullNodeComponents,
 {
-    /// Sets a `SequencerClient` for `eth_sendRawTransaction` to forward transactions to.
-    pub fn set_sequencer_client(&self, sequencer_client: SequencerClient) {
-        *self.sequencer_client.write() = Some(sequencer_client);
+    /// Sets a [`SequencerClient`] for `eth_sendRawTransaction` to forward transactions to.
+    pub fn set_sequencer_client(
+        &self,
+        sequencer_client: SequencerClient,
+    ) -> Result<(), tokio::sync::SetError<SequencerClient>> {
+        self.sequencer_client.set(sequencer_client)
     }
 
-    /// Returns the `SequencerClient` if one is set.
+    /// Returns the [`SequencerClient`] if one is set.
     pub fn raw_tx_forwarder(&self) -> Option<SequencerClient> {
-        self.sequencer_client.read().clone()
+        self.sequencer_client.get().cloned()
     }
 }


### PR DESCRIPTION
Replaces use of `Arc<RwLock<_>>` with `tokio::sync::OnceCell<_>` in `OpEthApi`