### PR TITLE
fix(cli): remove static file providers from cache on `reth db stats`

### DIFF
--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -249,6 +249,12 @@ impl Command {
                 total_index_size += index_size;
                 total_offsets_size += offsets_size;
                 total_config_size += config_size;
+
+                // Manually drop provider, otherwise removal from cache will deadlock.
+                drop(jar_provider);
+
+                // Removes from cache, since if we have many files, it may hit ulimit limits
+                static_file_provider.remove_cached_provider(segment, fixed_block_range.end());
             }
 
             if !self.detailed_segments {

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -358,6 +358,8 @@ impl StaticFileProvider {
     }
 
     /// Given a segment and block range it removes the cached provider from the map.
+    ///
+    /// CAUTION: cached provider should be dropped before calling this or IT WILL deadlock.
     pub fn remove_cached_provider(
         &self,
         segment: StaticFileSegment,


### PR DESCRIPTION
During `reth db stats` op-mainnet may fail since  it will iterate over all static files, opening them and keeping their file handles open in cache. This can result in hitting the following error

```
Too many open files (os error 24)
```