### PR TITLE
fix (reth-consensus): use derive_more::Error replace std::error::Error

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -151,40 +151,40 @@ pub enum ConsensusError {
 
     /// Error when the hash of block ommer is different from the expected hash.
     #[display("mismatched block ommer hash: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BodyOmmersHashDiff(GotExpectedBoxed<B256>),
 
     /// Error when the state root in the block is different from the expected state root.
     #[display("mismatched block state root: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BodyStateRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when the transaction root in the block is different from the expected transaction
     /// root.
     #[display("mismatched block transaction root: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BodyTransactionRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when the receipt root in the block is different from the expected receipt root.
     #[display("receipt root mismatch: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BodyReceiptRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when header bloom filter is different from the expected bloom filter.
     #[display("header bloom filter mismatch: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BodyBloomLogDiff(GotExpectedBoxed<Bloom>),
 
     /// Error when the withdrawals root in the block is different from the expected withdrawals
     /// root.
     #[display("mismatched block withdrawals root: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BodyWithdrawalsRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when the requests root in the block is different from the expected requests
     /// root.
     #[display("mismatched block requests root: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BodyRequestsRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when a block with a specific hash and number is already known.
@@ -216,7 +216,7 @@ pub enum ConsensusError {
 
     /// Error when the parent hash does not match the expected parent hash.
     #[display("mismatched parent hash: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     ParentHashMismatch(GotExpectedBoxed<B256>),
 
     /// Error when the block timestamp is in the future compared to our clock time.
@@ -338,7 +338,7 @@ pub enum ConsensusError {
 
     /// Error when the blob gas used in the header does not match the expected blob gas used.
     #[display("blob gas used mismatch: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BlobGasUsedDiff(GotExpected<u64>),
 
     /// Error for a transaction that violates consensus.
@@ -346,7 +346,7 @@ pub enum ConsensusError {
 
     /// Error when the block's base fee is different from the expected base fee.
     #[display("block base fee mismatch: {_0}")]
-    #[error(not(source))]
+    #[error(ignore)]
     BaseFeeDiff(GotExpected<u64>),
 
     /// Error when there is an invalid excess blob gas.

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -151,33 +151,40 @@ pub enum ConsensusError {
 
     /// Error when the hash of block ommer is different from the expected hash.
     #[display("mismatched block ommer hash: {_0}")]
+    #[error(not(source))]
     BodyOmmersHashDiff(GotExpectedBoxed<B256>),
 
     /// Error when the state root in the block is different from the expected state root.
     #[display("mismatched block state root: {_0}")]
+    #[error(not(source))]
     BodyStateRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when the transaction root in the block is different from the expected transaction
     /// root.
     #[display("mismatched block transaction root: {_0}")]
+    #[error(not(source))]
     BodyTransactionRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when the receipt root in the block is different from the expected receipt root.
     #[display("receipt root mismatch: {_0}")]
+    #[error(not(source))]
     BodyReceiptRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when header bloom filter is different from the expected bloom filter.
     #[display("header bloom filter mismatch: {_0}")]
+    #[error(not(source))]
     BodyBloomLogDiff(GotExpectedBoxed<Bloom>),
 
     /// Error when the withdrawals root in the block is different from the expected withdrawals
     /// root.
     #[display("mismatched block withdrawals root: {_0}")]
+    #[error(not(source))]
     BodyWithdrawalsRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when the requests root in the block is different from the expected requests
     /// root.
     #[display("mismatched block requests root: {_0}")]
+    #[error(not(source))]
     BodyRequestsRootDiff(GotExpectedBoxed<B256>),
 
     /// Error when a block with a specific hash and number is already known.
@@ -209,6 +216,7 @@ pub enum ConsensusError {
 
     /// Error when the parent hash does not match the expected parent hash.
     #[display("mismatched parent hash: {_0}")]
+    #[error(not(source))]
     ParentHashMismatch(GotExpectedBoxed<B256>),
 
     /// Error when the block timestamp is in the future compared to our clock time.
@@ -330,6 +338,7 @@ pub enum ConsensusError {
 
     /// Error when the blob gas used in the header does not match the expected blob gas used.
     #[display("blob gas used mismatch: {_0}")]
+    #[error(not(source))]
     BlobGasUsedDiff(GotExpected<u64>),
 
     /// Error for a transaction that violates consensus.
@@ -337,6 +346,7 @@ pub enum ConsensusError {
 
     /// Error when the block's base fee is different from the expected base fee.
     #[display("block base fee mismatch: {_0}")]
+    #[error(not(source))]
     BaseFeeDiff(GotExpected<u64>),
 
     /// Error when there is an invalid excess blob gas.


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/10828, fix https://github.com/paradigmxyz/reth/pull/10831.

after https://github.com/paradigmxyz/reth/pull/10831, use cargo expand
the code is
```rust
#[automatically_derived]
impl derive_more::Error for ConsensusError {
    fn source(&self) -> Option<&(dyn derive_more::Error + 'static)> {
        use derive_more::__private::AsDynError;
        match self {
            ConsensusError::BodyOmmersHashDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::BodyStateRootDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::BodyTransactionRootDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::BodyReceiptRootDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::BodyBloomLogDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::BodyWithdrawalsRootDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::BodyRequestsRootDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::ParentHashMismatch(source) => Some(source.as_dyn_error()),
            ConsensusError::BlobGasUsedDiff(source) => Some(source.as_dyn_error()),
            ConsensusError::InvalidTransaction(source) => Some(source.as_dyn_error()),
            ConsensusError::BaseFeeDiff(source) => Some(source.as_dyn_error()),
            _ => None,
        }
    }
}
```
but the original code is https://github.com/paradigmxyz/reth/blob/57fb2d26bbd1c16ca04888e26cd24644977a25cc/crates/consensus/consensus/src/lib.rs#L399-L406

