### PR TITLE
chore(reth-execution-errors): use derive_more::From when possible

### DIFF
--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -16,7 +16,7 @@ use alloc::{boxed::Box, string::String};
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
-use derive_more::Display;
+use derive_more::{Display, From};
 use reth_consensus::ConsensusError;
 use reth_prune_types::PruneSegmentError;
 use reth_storage_errors::provider::ProviderError;
@@ -139,7 +139,7 @@ impl std::error::Error for BlockValidationError {
 }
 
 /// `BlockExecutor` Errors
-#[derive(Debug, Display)]
+#[derive(Debug, From, Display)]
 pub enum BlockExecutionError {
     /// Validation error, transparently wrapping [`BlockValidationError`]
     Validation(BlockValidationError),
@@ -181,24 +181,6 @@ impl BlockExecutionError {
     }
 }
 
-impl From<BlockValidationError> for BlockExecutionError {
-    fn from(error: BlockValidationError) -> Self {
-        Self::Validation(error)
-    }
-}
-
-impl From<ConsensusError> for BlockExecutionError {
-    fn from(error: ConsensusError) -> Self {
-        Self::Consensus(error)
-    }
-}
-
-impl From<InternalBlockExecutionError> for BlockExecutionError {
-    fn from(error: InternalBlockExecutionError) -> Self {
-        Self::Internal(error)
-    }
-}
-
 impl From<ProviderError> for BlockExecutionError {
     fn from(error: ProviderError) -> Self {
         InternalBlockExecutionError::from(error).into()
@@ -217,9 +199,10 @@ impl std::error::Error for BlockExecutionError {
 }
 
 /// Internal (i.e., not validation or consensus related) `BlockExecutor` Errors
-#[derive(Display, Debug)]
+#[derive(Display, Debug, From)]
 pub enum InternalBlockExecutionError {
     /// Pruning error, transparently wrapping [`PruneSegmentError`]
+    #[from]
     Pruning(PruneSegmentError),
     /// Error when appending chain on fork is not possible
     #[display(
@@ -232,6 +215,7 @@ pub enum InternalBlockExecutionError {
         other_chain_fork: Box<BlockNumHash>,
     },
     /// Error when fetching latest block state.
+    #[from]
     LatestBlock(ProviderError),
     /// Arbitrary Block Executor Errors
     #[cfg(feature = "std")]
@@ -252,18 +236,6 @@ impl InternalBlockExecutionError {
     #[cfg(feature = "std")]
     pub fn msg(msg: impl std::fmt::Display) -> Self {
         Self::Other(msg.to_string().into())
-    }
-}
-
-impl From<PruneSegmentError> for InternalBlockExecutionError {
-    fn from(error: PruneSegmentError) -> Self {
-        Self::Pruning(error)
-    }
-}
-
-impl From<ProviderError> for InternalBlockExecutionError {
-    fn from(error: ProviderError) -> Self {
-        Self::LatestBlock(error)
     }
 }
 

--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -1,7 +1,7 @@
 //! Errors when computing the state root.
 
 use alloy_primitives::B256;
-use derive_more::Display;
+use derive_more::{Display, From};
 use nybbles::Nibbles;
 use reth_storage_errors::{db::DatabaseError, provider::ProviderError};
 
@@ -9,24 +9,12 @@ use reth_storage_errors::{db::DatabaseError, provider::ProviderError};
 use alloc::string::ToString;
 
 /// State root errors.
-#[derive(Display, Debug, PartialEq, Eq, Clone)]
+#[derive(Display, Debug, From, PartialEq, Eq, Clone)]
 pub enum StateRootError {
     /// Internal database error.
     Database(DatabaseError),
     /// Storage root error.
     StorageRootError(StorageRootError),
-}
-
-impl From<DatabaseError> for StateRootError {
-    fn from(error: DatabaseError) -> Self {
-        Self::Database(error)
-    }
-}
-
-impl From<StorageRootError> for StateRootError {
-    fn from(error: StorageRootError) -> Self {
-        Self::StorageRootError(error)
-    }
 }
 
 #[cfg(feature = "std")]
@@ -49,16 +37,10 @@ impl From<StateRootError> for DatabaseError {
 }
 
 /// Storage root error.
-#[derive(Display, PartialEq, Eq, Clone, Debug)]
+#[derive(Display, From, PartialEq, Eq, Clone, Debug)]
 pub enum StorageRootError {
     /// Internal database error.
     Database(DatabaseError),
-}
-
-impl From<DatabaseError> for StorageRootError {
-    fn from(error: DatabaseError) -> Self {
-        Self::Database(error)
-    }
 }
 
 impl From<StorageRootError> for DatabaseError {
@@ -79,24 +61,12 @@ impl std::error::Error for StorageRootError {
 }
 
 /// State proof errors.
-#[derive(Display, Debug, PartialEq, Eq, Clone)]
+#[derive(Display, From, Debug, PartialEq, Eq, Clone)]
 pub enum StateProofError {
     /// Internal database error.
     Database(DatabaseError),
     /// RLP decoding error.
     Rlp(alloy_rlp::Error),
-}
-
-impl From<DatabaseError> for StateProofError {
-    fn from(error: DatabaseError) -> Self {
-        Self::Database(error)
-    }
-}
-
-impl From<alloy_rlp::Error> for StateProofError {
-    fn from(error: alloy_rlp::Error) -> Self {
-        Self::Rlp(error)
-    }
 }
 
 impl From<StateProofError> for ProviderError {
@@ -119,11 +89,13 @@ impl std::error::Error for StateProofError {
 }
 
 /// Trie witness errors.
-#[derive(Display, Debug, PartialEq, Eq, Clone)]
+#[derive(Display, From, Debug, PartialEq, Eq, Clone)]
 pub enum TrieWitnessError {
     /// Error gather proofs.
+    #[from]
     Proof(StateProofError),
     /// RLP decoding error.
+    #[from]
     Rlp(alloy_rlp::Error),
     /// Missing account.
     #[display("missing account {_0}")]
@@ -131,18 +103,6 @@ pub enum TrieWitnessError {
     /// Missing target node.
     #[display("target node missing from proof {_0:?}")]
     MissingTargetNode(Nibbles),
-}
-
-impl From<StateProofError> for TrieWitnessError {
-    fn from(error: StateProofError) -> Self {
-        Self::Proof(error)
-    }
-}
-
-impl From<alloy_rlp::Error> for TrieWitnessError {
-    fn from(error: alloy_rlp::Error) -> Self {
-        Self::Rlp(error)
-    }
 }
 
 impl From<TrieWitnessError> for ProviderError {


### PR DESCRIPTION
It has a dependency. so we can use derive_more::from