### PR TITLE
fix: actually use `RevmBytecode::new_raw_checked`

### DIFF
--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -65,7 +65,7 @@ impl Bytecode {
     /// Returns an error on incorrect Bytecode format.
     #[inline]
     pub fn new_raw_checked(bytecode: Bytes) -> Result<Self, BytecodeDecodeError> {
-        Ok(Self(RevmBytecode::new_raw(bytecode)))
+        RevmBytecode::new_raw_checked(bytecode).map(Self)
     }
 }
 


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/pull/10584 added `Bytecode::new_raw_checked`, but it is still uses `new_raw` which panics.