### PR TITLE
chore(reth-primitives): use derive_more::From when possible

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -75,7 +75,7 @@ pub(crate) static PARALLEL_SENDER_RECOVERY_THRESHOLD: Lazy<usize> =
 /// A raw transaction.
 ///
 /// Transaction types were introduced in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, derive_more::From)]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub enum Transaction {
     /// Legacy transaction (type `0x0`).
@@ -687,36 +687,6 @@ impl Transaction {
             Self::Eip7702(tx) => Some(tx),
             _ => None,
         }
-    }
-}
-
-impl From<TxLegacy> for Transaction {
-    fn from(tx: TxLegacy) -> Self {
-        Self::Legacy(tx)
-    }
-}
-
-impl From<TxEip2930> for Transaction {
-    fn from(tx: TxEip2930) -> Self {
-        Self::Eip2930(tx)
-    }
-}
-
-impl From<TxEip1559> for Transaction {
-    fn from(tx: TxEip1559) -> Self {
-        Self::Eip1559(tx)
-    }
-}
-
-impl From<TxEip4844> for Transaction {
-    fn from(tx: TxEip4844) -> Self {
-        Self::Eip4844(tx)
-    }
-}
-
-impl From<TxEip7702> for Transaction {
-    fn from(tx: TxEip7702) -> Self {
-        Self::Eip7702(tx)
     }
 }
 

--- a/crates/primitives/src/transaction/variant.rs
+++ b/crates/primitives/src/transaction/variant.rs
@@ -11,7 +11,7 @@ use core::ops::Deref;
 ///
 /// All variants are based on a the raw [Transaction] data and can contain additional information
 /// extracted (expensive) from that transaction, like the hash and the signer.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub enum TransactionSignedVariant {
     /// A signed transaction without a hash.
     SignedNoHash(TransactionSignedNoHash),
@@ -127,24 +127,6 @@ impl TransactionSignedVariant {
             Self::Signed(tx) => tx.try_into_ecrecovered(),
             Self::SignedNoHash(tx) => tx.with_hash().try_into_ecrecovered(),
         }
-    }
-}
-
-impl From<TransactionSignedNoHash> for TransactionSignedVariant {
-    fn from(tx: TransactionSignedNoHash) -> Self {
-        Self::SignedNoHash(tx)
-    }
-}
-
-impl From<TransactionSigned> for TransactionSignedVariant {
-    fn from(tx: TransactionSigned) -> Self {
-        Self::Signed(tx)
-    }
-}
-
-impl From<TransactionSignedEcRecovered> for TransactionSignedVariant {
-    fn from(tx: TransactionSignedEcRecovered) -> Self {
-        Self::SignedEcRecovered(tx)
     }
 }
 


### PR DESCRIPTION
It has a dependency. so we can use derive_more::from