### PR TITLE
refactor: make `reth-prune` independent of concrete `DatabaseProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,7 +8209,6 @@ dependencies = [
  "reth-errors",
  "reth-exex-types",
  "reth-metrics",
- "reth-node-types",
  "reth-provider",
  "reth-prune-types",
  "reth-stages",

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -24,7 +24,7 @@ use reth_payload_builder::test_utils::spawn_test_payload_service;
 use reth_provider::{
     providers::BlockchainProvider,
     test_utils::{create_test_provider_factory_with_chain_spec, MockNodeTypesWithDB},
-    ExecutionOutcome, ProviderFactory,
+    ExecutionOutcome,
 };
 use reth_prune::Pruner;
 use reth_prune_types::PruneModes;
@@ -397,7 +397,7 @@ where
         let blockchain_provider =
             BlockchainProvider::with_blocks(provider_factory.clone(), tree, genesis_block, None);
 
-        let pruner = Pruner::<_, ProviderFactory<_>>::new(
+        let pruner = Pruner::new_with_factory(
             provider_factory.clone(),
             vec![],
             5,

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -19,7 +19,7 @@ use reth_node_types::NodeTypesWithEngine;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_validator::ExecutionPayloadValidator;
 use reth_provider::{providers::BlockchainProvider2, ProviderFactory};
-use reth_prune::Pruner;
+use reth_prune::PrunerWithFactory;
 use reth_stages_api::{MetricEventsSender, Pipeline};
 use reth_tasks::TaskSpawner;
 use std::{
@@ -73,7 +73,7 @@ where
         pipeline_task_spawner: Box<dyn TaskSpawner>,
         provider: ProviderFactory<N>,
         blockchain_db: BlockchainProvider2<N>,
-        pruner: Pruner<N::DB, ProviderFactory<N>>,
+        pruner: PrunerWithFactory<ProviderFactory<N>>,
         payload_builder: PayloadBuilderHandle<N::Engine>,
         tree_config: TreeConfig,
         invalid_block_hook: Box<dyn InvalidBlockHook>,
@@ -147,6 +147,7 @@ mod tests {
     use reth_network_p2p::test_utils::TestFullBlockClient;
     use reth_primitives::SealedHeader;
     use reth_provider::test_utils::create_test_provider_factory_with_chain_spec;
+    use reth_prune::Pruner;
     use reth_tasks::TokioTaskExecutor;
     use std::sync::Arc;
     use tokio::sync::{mpsc::unbounded_channel, watch};
@@ -178,8 +179,7 @@ mod tests {
                 .unwrap();
 
         let (_tx, rx) = watch::channel(FinishedExExHeight::NoExExs);
-        let pruner =
-            Pruner::<_, ProviderFactory<_>>::new(provider_factory.clone(), vec![], 0, 0, None, rx);
+        let pruner = Pruner::new_with_factory(provider_factory.clone(), vec![], 0, 0, None, rx);
 
         let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
         let (tx, _rx) = unbounded_channel();

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -1,13 +1,12 @@
 use crate::metrics::PersistenceMetrics;
 use reth_chain_state::ExecutedBlock;
 use reth_errors::ProviderError;
-use reth_node_types::NodeTypesWithDB;
 use reth_primitives::BlockNumHash;
 use reth_provider::{
     providers::ProviderNodeTypes, writer::UnifiedStorageWriter, BlockHashReader, ProviderFactory,
     StaticFileProviderFactory,
 };
-use reth_prune::{Pruner, PrunerError, PrunerOutput};
+use reth_prune::{PrunerError, PrunerOutput, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};
 use std::{
     sync::mpsc::{Receiver, SendError, Sender},
@@ -25,13 +24,13 @@ use tracing::{debug, error};
 /// This should be spawned in its own thread with [`std::thread::spawn`], since this performs
 /// blocking I/O operations in an endless loop.
 #[derive(Debug)]
-pub struct PersistenceService<N: NodeTypesWithDB> {
+pub struct PersistenceService<N: ProviderNodeTypes> {
     /// The provider factory to use
     provider: ProviderFactory<N>,
     /// Incoming requests
     incoming: Receiver<PersistenceAction>,
     /// The pruner
-    pruner: Pruner<N::DB, ProviderFactory<N>>,
+    pruner: PrunerWithFactory<ProviderFactory<N>>,
     /// metrics
     metrics: PersistenceMetrics,
     /// Sender for sync metrics - we only submit sync metrics for persisted blocks
@@ -43,7 +42,7 @@ impl<N: ProviderNodeTypes> PersistenceService<N> {
     pub fn new(
         provider: ProviderFactory<N>,
         incoming: Receiver<PersistenceAction>,
-        pruner: Pruner<N::DB, ProviderFactory<N>>,
+        pruner: PrunerWithFactory<ProviderFactory<N>>,
         sync_metrics_tx: MetricEventsSender,
     ) -> Self {
         Self { provider, incoming, pruner, metrics: PersistenceMetrics::default(), sync_metrics_tx }
@@ -187,7 +186,7 @@ impl PersistenceHandle {
     /// Create a new [`PersistenceHandle`], and spawn the persistence service.
     pub fn spawn_service<N: ProviderNodeTypes>(
         provider_factory: ProviderFactory<N>,
-        pruner: Pruner<N::DB, ProviderFactory<N>>,
+        pruner: PrunerWithFactory<ProviderFactory<N>>,
         sync_metrics_tx: MetricEventsSender,
     ) -> Self {
         // create the initial channels
@@ -268,7 +267,7 @@ mod tests {
     use reth_chain_state::test_utils::TestBlockBuilder;
     use reth_exex_types::FinishedExExHeight;
     use reth_primitives::B256;
-    use reth_provider::{test_utils::create_test_provider_factory, ProviderFactory};
+    use reth_provider::test_utils::create_test_provider_factory;
     use reth_prune::Pruner;
     use tokio::sync::mpsc::unbounded_channel;
 
@@ -278,14 +277,8 @@ mod tests {
         let (_finished_exex_height_tx, finished_exex_height_rx) =
             tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
 
-        let pruner = Pruner::<_, ProviderFactory<_>>::new(
-            provider.clone(),
-            vec![],
-            5,
-            0,
-            None,
-            finished_exex_height_rx,
-        );
+        let pruner =
+            Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
 
         let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
         PersistenceHandle::spawn_service(provider, pruner, sync_metrics_tx)

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -23,7 +23,6 @@ reth-tokio-util.workspace = true
 reth-config.workspace = true
 reth-prune-types.workspace = true
 reth-static-file-types.workspace = true
-reth-node-types.workspace = true
 
 # metrics
 reth-metrics.workspace = true

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -1,10 +1,14 @@
 use crate::{segments::SegmentSet, Pruner};
 use reth_chainspec::MAINNET;
 use reth_config::PruneConfig;
+use reth_db::transaction::DbTxMut;
 use reth_db_api::database::Database;
 use reth_exex_types::FinishedExExHeight;
 use reth_node_types::NodeTypesWithDB;
-use reth_provider::{providers::StaticFileProvider, ProviderFactory, StaticFileProviderFactory};
+use reth_provider::{
+    providers::StaticFileProvider, BlockReader, DBProvider, DatabaseProviderFactory,
+    ProviderFactory, PruneCheckpointWriter, StaticFileProviderFactory, TransactionsProvider,
+};
 use reth_prune_types::PruneModes;
 use std::time::Duration;
 use tokio::sync::watch;
@@ -72,14 +76,15 @@ impl PrunerBuilder {
     }
 
     /// Builds a [Pruner] from the current configuration with the given provider factory.
-    pub fn build_with_provider_factory<N: NodeTypesWithDB>(
-        self,
-        provider_factory: ProviderFactory<N>,
-    ) -> Pruner<N::DB, ProviderFactory<N>> {
+    pub fn build_with_provider_factory<PF>(self, provider_factory: PF) -> Pruner<PF::ProviderRW, PF>
+    where
+        PF: DatabaseProviderFactory<ProviderRW: PruneCheckpointWriter + BlockReader>
+            + StaticFileProviderFactory,
+    {
         let segments =
             SegmentSet::from_components(provider_factory.static_file_provider(), self.segments);
 
-        Pruner::<_, ProviderFactory<N>>::new(
+        Pruner::<_, PF>::new(
             provider_factory,
             segments.into_vec(),
             self.block_interval,
@@ -90,10 +95,15 @@ impl PrunerBuilder {
     }
 
     /// Builds a [Pruner] from the current configuration with the given static file provider.
-    pub fn build<DB: Database>(self, static_file_provider: StaticFileProvider) -> Pruner<DB, ()> {
-        let segments = SegmentSet::<DB>::from_components(static_file_provider, self.segments);
+    pub fn build<Provider>(self, static_file_provider: StaticFileProvider) -> Pruner<Provider, ()>
+    where
+        Provider:
+            DBProvider<Tx: DbTxMut> + BlockReader + PruneCheckpointWriter + TransactionsProvider,
+    {
+        let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);
 
-        Pruner::<_, ()>::new(
+        Pruner::new(
+            (),
             segments.into_vec(),
             self.block_interval,
             self.delete_limit,

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -2,12 +2,10 @@ use crate::{segments::SegmentSet, Pruner};
 use reth_chainspec::MAINNET;
 use reth_config::PruneConfig;
 use reth_db::transaction::DbTxMut;
-use reth_db_api::database::Database;
 use reth_exex_types::FinishedExExHeight;
-use reth_node_types::NodeTypesWithDB;
 use reth_provider::{
     providers::StaticFileProvider, BlockReader, DBProvider, DatabaseProviderFactory,
-    ProviderFactory, PruneCheckpointWriter, StaticFileProviderFactory, TransactionsProvider,
+    PruneCheckpointWriter, StaticFileProviderFactory, TransactionsProvider,
 };
 use reth_prune_types::PruneModes;
 use std::time::Duration;
@@ -84,7 +82,7 @@ impl PrunerBuilder {
         let segments =
             SegmentSet::from_components(provider_factory.static_file_provider(), self.segments);
 
-        Pruner::<_, PF>::new(
+        Pruner::new_with_factory(
             provider_factory,
             segments.into_vec(),
             self.block_interval,
@@ -103,7 +101,6 @@ impl PrunerBuilder {
         let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);
 
         Pruner::new(
-            (),
             segments.into_vec(),
             self.block_interval,
             self.delete_limit,

--- a/crates/prune/prune/src/db_ext.rs
+++ b/crates/prune/prune/src/db_ext.rs
@@ -1,0 +1,127 @@
+use std::{fmt::Debug, ops::RangeBounds};
+
+use reth_db::{
+    cursor::{DbCursorRO, DbCursorRW, RangeWalker},
+    table::{Table, TableRow},
+    transaction::DbTxMut,
+    DatabaseError,
+};
+use reth_prune_types::PruneLimiter;
+use tracing::debug;
+
+pub trait DbTxPruneExt: DbTxMut {
+    /// Prune the table for the specified pre-sorted key iterator.
+    ///
+    /// Returns number of rows pruned.
+    fn prune_table_with_iterator<T: Table>(
+        &self,
+        keys: impl IntoIterator<Item = T::Key>,
+        limiter: &mut PruneLimiter,
+        mut delete_callback: impl FnMut(TableRow<T>),
+    ) -> Result<(usize, bool), DatabaseError> {
+        let mut cursor = self.cursor_write::<T>()?;
+        let mut keys = keys.into_iter();
+
+        let mut deleted_entries = 0;
+
+        for key in &mut keys {
+            if limiter.is_limit_reached() {
+                debug!(
+                    target: "providers::db",
+                    ?limiter,
+                    deleted_entries_limit = %limiter.is_deleted_entries_limit_reached(),
+                    time_limit = %limiter.is_time_limit_reached(),
+                    table = %T::NAME,
+                    "Pruning limit reached"
+                );
+                break
+            }
+
+            let row = cursor.seek_exact(key)?;
+            if let Some(row) = row {
+                cursor.delete_current()?;
+                limiter.increment_deleted_entries_count();
+                deleted_entries += 1;
+                delete_callback(row);
+            }
+        }
+
+        let done = keys.next().is_none();
+        Ok((deleted_entries, done))
+    }
+
+    /// Prune the table for the specified key range.
+    ///
+    /// Returns number of rows pruned.
+    fn prune_table_with_range<T: Table>(
+        &self,
+        keys: impl RangeBounds<T::Key> + Clone + Debug,
+        limiter: &mut PruneLimiter,
+        mut skip_filter: impl FnMut(&TableRow<T>) -> bool,
+        mut delete_callback: impl FnMut(TableRow<T>),
+    ) -> Result<(usize, bool), DatabaseError> {
+        let mut cursor = self.cursor_write::<T>()?;
+        let mut walker = cursor.walk_range(keys)?;
+
+        let mut deleted_entries = 0;
+
+        let done = loop {
+            // check for time out must be done in this scope since it's not done in
+            // `prune_table_with_range_step`
+            if limiter.is_limit_reached() {
+                debug!(
+                    target: "providers::db",
+                    ?limiter,
+                    deleted_entries_limit = %limiter.is_deleted_entries_limit_reached(),
+                    time_limit = %limiter.is_time_limit_reached(),
+                    table = %T::NAME,
+                    "Pruning limit reached"
+                );
+                break false
+            }
+
+            let done = self.prune_table_with_range_step(
+                &mut walker,
+                limiter,
+                &mut skip_filter,
+                &mut delete_callback,
+            )?;
+
+            if done {
+                break true
+            }
+            deleted_entries += 1;
+        };
+
+        Ok((deleted_entries, done))
+    }
+
+    /// Steps once with the given walker and prunes the entry in the table.
+    ///
+    /// Returns `true` if the walker is finished, `false` if it may have more data to prune.
+    ///
+    /// CAUTION: Pruner limits are not checked. This allows for a clean exit of a prune run that's
+    /// pruning different tables concurrently, by letting them step to the same height before
+    /// timing out.
+    fn prune_table_with_range_step<T: Table>(
+        &self,
+        walker: &mut RangeWalker<'_, T, Self::CursorMut<T>>,
+        limiter: &mut PruneLimiter,
+        skip_filter: &mut impl FnMut(&TableRow<T>) -> bool,
+        delete_callback: &mut impl FnMut(TableRow<T>),
+    ) -> Result<bool, DatabaseError> {
+        let Some(res) = walker.next() else { return Ok(true) };
+
+        let row = res?;
+
+        if !skip_filter(&row) {
+            walker.delete_current()?;
+            limiter.increment_deleted_entries_count();
+            delete_callback(row);
+        }
+
+        Ok(false)
+    }
+}
+
+impl<Tx> DbTxPruneExt for Tx where Tx: DbTxMut {}

--- a/crates/prune/prune/src/db_ext.rs
+++ b/crates/prune/prune/src/db_ext.rs
@@ -9,7 +9,7 @@ use reth_db::{
 use reth_prune_types::PruneLimiter;
 use tracing::debug;
 
-pub trait DbTxPruneExt: DbTxMut {
+pub(crate) trait DbTxPruneExt: DbTxMut {
     /// Prune the table for the specified pre-sorted key iterator.
     ///
     /// Returns number of rows pruned.

--- a/crates/prune/prune/src/lib.rs
+++ b/crates/prune/prune/src/lib.rs
@@ -21,7 +21,7 @@ use crate::metrics::Metrics;
 pub use builder::PrunerBuilder;
 pub use error::PrunerError;
 pub use event::PrunerEvent;
-pub use pruner::{Pruner, PrunerResult, PrunerWithResult};
+pub use pruner::{Pruner, PrunerResult, PrunerWithFactory, PrunerWithResult};
 
 // Re-export prune types
 #[doc(inline)]

--- a/crates/prune/prune/src/lib.rs
+++ b/crates/prune/prune/src/lib.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod builder;
+mod db_ext;
 mod error;
 mod event;
 mod metrics;

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -5,10 +5,7 @@ mod user;
 
 use crate::PrunerError;
 use alloy_primitives::{BlockNumber, TxNumber};
-use reth_db_api::database::Database;
-use reth_provider::{
-    errors::provider::ProviderResult, BlockReader, DatabaseProviderRW, PruneCheckpointWriter,
-};
+use reth_provider::{errors::provider::ProviderResult, BlockReader, PruneCheckpointWriter};
 use reth_prune_types::{
     PruneCheckpoint, PruneLimiter, PruneMode, PrunePurpose, PruneSegment, SegmentOutput,
 };

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -31,7 +31,7 @@ pub use user::{
 /// 2. If [`Segment::prune`] returned a [Some] in `checkpoint` of [`SegmentOutput`], call
 ///    [`Segment::save_checkpoint`].
 /// 3. Subtract `pruned` of [`SegmentOutput`] from `delete_limit` of next [`PruneInput`].
-pub trait Segment<DB: Database>: Debug + Send + Sync {
+pub trait Segment<Provider>: Debug + Send + Sync {
     /// Segment of data that's pruned.
     fn segment(&self) -> PruneSegment;
 
@@ -42,18 +42,17 @@ pub trait Segment<DB: Database>: Debug + Send + Sync {
     fn purpose(&self) -> PrunePurpose;
 
     /// Prune data for [`Self::segment`] using the provided input.
-    fn prune(
-        &self,
-        provider: &DatabaseProviderRW<DB>,
-        input: PruneInput,
-    ) -> Result<SegmentOutput, PrunerError>;
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError>;
 
     /// Save checkpoint for [`Self::segment`] to the database.
     fn save_checkpoint(
         &self,
-        provider: &DatabaseProviderRW<DB>,
+        provider: &Provider,
         checkpoint: PruneCheckpoint,
-    ) -> ProviderResult<()> {
+    ) -> ProviderResult<()>
+    where
+        Provider: PruneCheckpointWriter,
+    {
         provider.save_prune_checkpoint(self.segment(), checkpoint)
     }
 }
@@ -78,9 +77,9 @@ impl PruneInput {
     /// 2. If checkpoint doesn't exist, return 0.
     ///
     /// To get the range end: get last tx number for `to_block`.
-    pub(crate) fn get_next_tx_num_range<DB: Database>(
+    pub(crate) fn get_next_tx_num_range<Provider: BlockReader>(
         &self,
-        provider: &DatabaseProviderRW<DB>,
+        provider: &Provider,
     ) -> ProviderResult<Option<RangeInclusive<TxNumber>>> {
         let from_tx_number = self.previous_checkpoint
             // Checkpoint exists, prune from the next transaction after the highest pruned one

--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -7,10 +7,9 @@
 
 use crate::{db_ext::DbTxPruneExt, segments::PruneInput, PrunerError};
 use reth_db::{tables, transaction::DbTxMut};
-use reth_db_api::database::Database;
 use reth_provider::{
-    errors::provider::ProviderResult, BlockReader, DBProvider, DatabaseProviderRW,
-    PruneCheckpointWriter, TransactionsProvider,
+    errors::provider::ProviderResult, BlockReader, DBProvider, PruneCheckpointWriter,
+    TransactionsProvider,
 };
 use reth_prune_types::{
     PruneCheckpoint, PruneProgress, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
@@ -86,7 +85,7 @@ mod tests {
         Itertools,
     };
     use reth_db::tables;
-    use reth_provider::PruneCheckpointReader;
+    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader};
     use reth_prune_types::{
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
@@ -161,7 +160,7 @@ mod tests {
                 )
                 .sub(1);
 
-            let provider = db.factory.provider_rw().unwrap();
+            let provider = db.factory.database_provider_rw().unwrap();
             let result = super::prune(&provider, input).unwrap();
             limiter.increment_deleted_entries_count_by(result.pruned);
 

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -3,7 +3,6 @@ use crate::segments::{
     UserReceipts,
 };
 use reth_db::transaction::DbTxMut;
-use reth_db_api::database::Database;
 use reth_provider::{
     providers::StaticFileProvider, BlockReader, DBProvider, PruneCheckpointWriter,
     TransactionsProvider,

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -2,32 +2,36 @@ use crate::segments::{
     AccountHistory, ReceiptsByLogs, Segment, SenderRecovery, StorageHistory, TransactionLookup,
     UserReceipts,
 };
+use reth_db::transaction::DbTxMut;
 use reth_db_api::database::Database;
-use reth_provider::providers::StaticFileProvider;
+use reth_provider::{
+    providers::StaticFileProvider, BlockReader, DBProvider, PruneCheckpointWriter,
+    TransactionsProvider,
+};
 use reth_prune_types::PruneModes;
 
 use super::{StaticFileHeaders, StaticFileReceipts, StaticFileTransactions};
 
 /// Collection of [Segment]. Thread-safe, allocated on the heap.
 #[derive(Debug)]
-pub struct SegmentSet<DB: Database> {
-    inner: Vec<Box<dyn Segment<DB>>>,
+pub struct SegmentSet<Provider> {
+    inner: Vec<Box<dyn Segment<Provider>>>,
 }
 
-impl<DB: Database> SegmentSet<DB> {
+impl<Provider> SegmentSet<Provider> {
     /// Returns empty [`SegmentSet`] collection.
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Adds new [Segment] to collection.
-    pub fn segment<S: Segment<DB> + 'static>(mut self, segment: S) -> Self {
+    pub fn segment<S: Segment<Provider> + 'static>(mut self, segment: S) -> Self {
         self.inner.push(Box::new(segment));
         self
     }
 
     /// Adds new [Segment] to collection if it's [Some].
-    pub fn segment_opt<S: Segment<DB> + 'static>(self, segment: Option<S>) -> Self {
+    pub fn segment_opt<S: Segment<Provider> + 'static>(self, segment: Option<S>) -> Self {
         if let Some(segment) = segment {
             return self.segment(segment)
         }
@@ -35,10 +39,15 @@ impl<DB: Database> SegmentSet<DB> {
     }
 
     /// Consumes [`SegmentSet`] and returns a [Vec].
-    pub fn into_vec(self) -> Vec<Box<dyn Segment<DB>>> {
+    pub fn into_vec(self) -> Vec<Box<dyn Segment<Provider>>> {
         self.inner
     }
+}
 
+impl<Provider> SegmentSet<Provider>
+where
+    Provider: DBProvider<Tx: DbTxMut> + TransactionsProvider + PruneCheckpointWriter + BlockReader,
+{
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and
     /// [`PruneModes`].
     pub fn from_components(
@@ -79,7 +88,7 @@ impl<DB: Database> SegmentSet<DB> {
     }
 }
 
-impl<DB: Database> Default for SegmentSet<DB> {
+impl<Provider> Default for SegmentSet<Provider> {
     fn default() -> Self {
         Self { inner: Vec::new() }
     }

--- a/crates/prune/prune/src/segments/static_file/receipts.rs
+++ b/crates/prune/prune/src/segments/static_file/receipts.rs
@@ -2,9 +2,11 @@ use crate::{
     segments::{PruneInput, Segment},
     PrunerError,
 };
+use reth_db::transaction::DbTxMut;
 use reth_db_api::database::Database;
 use reth_provider::{
-    errors::provider::ProviderResult, providers::StaticFileProvider, DatabaseProviderRW,
+    errors::provider::ProviderResult, providers::StaticFileProvider, BlockReader, DBProvider,
+    DatabaseProviderRW, PruneCheckpointWriter, TransactionsProvider,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 use reth_static_file_types::StaticFileSegment;
@@ -20,7 +22,10 @@ impl Receipts {
     }
 }
 
-impl<DB: Database> Segment<DB> for Receipts {
+impl<Provider> Segment<Provider> for Receipts
+where
+    Provider: DBProvider<Tx: DbTxMut> + PruneCheckpointWriter + TransactionsProvider + BlockReader,
+{
     fn segment(&self) -> PruneSegment {
         PruneSegment::Receipts
     }
@@ -35,17 +40,13 @@ impl<DB: Database> Segment<DB> for Receipts {
         PrunePurpose::StaticFile
     }
 
-    fn prune(
-        &self,
-        provider: &DatabaseProviderRW<DB>,
-        input: PruneInput,
-    ) -> Result<SegmentOutput, PrunerError> {
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         crate::segments::receipts::prune(provider, input)
     }
 
     fn save_checkpoint(
         &self,
-        provider: &DatabaseProviderRW<DB>,
+        provider: &Provider,
         checkpoint: PruneCheckpoint,
     ) -> ProviderResult<()> {
         crate::segments::receipts::save_checkpoint(provider, checkpoint)

--- a/crates/prune/prune/src/segments/static_file/receipts.rs
+++ b/crates/prune/prune/src/segments/static_file/receipts.rs
@@ -3,10 +3,9 @@ use crate::{
     PrunerError,
 };
 use reth_db::transaction::DbTxMut;
-use reth_db_api::database::Database;
 use reth_provider::{
     errors::provider::ProviderResult, providers::StaticFileProvider, BlockReader, DBProvider,
-    DatabaseProviderRW, PruneCheckpointWriter, TransactionsProvider,
+    PruneCheckpointWriter, TransactionsProvider,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 use reth_static_file_types::StaticFileSegment;

--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -1,10 +1,14 @@
 use crate::{
+    db_ext::DbTxPruneExt,
     segments::{PruneInput, Segment},
     PrunerError,
 };
-use reth_db::tables;
+use reth_db::{tables, transaction::DbTxMut};
 use reth_db_api::database::Database;
-use reth_provider::{providers::StaticFileProvider, DatabaseProviderRW, TransactionsProvider};
+use reth_provider::{
+    providers::StaticFileProvider, BlockReader, DBProvider, DatabaseProviderRW,
+    TransactionsProvider,
+};
 use reth_prune_types::{
     PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
 };
@@ -22,7 +26,10 @@ impl Transactions {
     }
 }
 
-impl<DB: Database> Segment<DB> for Transactions {
+impl<Provider> Segment<Provider> for Transactions
+where
+    Provider: DBProvider<Tx: DbTxMut> + TransactionsProvider + BlockReader,
+{
     fn segment(&self) -> PruneSegment {
         PruneSegment::Transactions
     }
@@ -37,11 +44,7 @@ impl<DB: Database> Segment<DB> for Transactions {
         PrunePurpose::StaticFile
     }
 
-    fn prune(
-        &self,
-        provider: &DatabaseProviderRW<DB>,
-        input: PruneInput,
-    ) -> Result<SegmentOutput, PrunerError> {
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         let tx_range = match input.get_next_tx_num_range(provider)? {
             Some(range) => range,
             None => {
@@ -53,7 +56,7 @@ impl<DB: Database> Segment<DB> for Transactions {
         let mut limiter = input.limiter;
 
         let mut last_pruned_transaction = *tx_range.end();
-        let (pruned, done) = provider.prune_table_with_range::<tables::Transactions>(
+        let (pruned, done) = provider.tx_ref().prune_table_with_range::<tables::Transactions>(
             tx_range,
             &mut limiter,
             |_| false,

--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -4,11 +4,7 @@ use crate::{
     PrunerError,
 };
 use reth_db::{tables, transaction::DbTxMut};
-use reth_db_api::database::Database;
-use reth_provider::{
-    providers::StaticFileProvider, BlockReader, DBProvider, DatabaseProviderRW,
-    TransactionsProvider,
-};
+use reth_provider::{providers::StaticFileProvider, BlockReader, DBProvider, TransactionsProvider};
 use reth_prune_types::{
     PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
 };
@@ -94,7 +90,10 @@ mod tests {
         Itertools,
     };
     use reth_db::tables;
-    use reth_provider::{PruneCheckpointReader, PruneCheckpointWriter, StaticFileProviderFactory};
+    use reth_provider::{
+        DatabaseProviderFactory, PruneCheckpointReader, PruneCheckpointWriter,
+        StaticFileProviderFactory,
+    };
     use reth_prune_types::{
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress,
         PruneSegment, SegmentOutput,
@@ -144,7 +143,7 @@ mod tests {
                 .map(|tx_number| tx_number + 1)
                 .unwrap_or_default();
 
-            let provider = db.factory.provider_rw().unwrap();
+            let provider = db.factory.database_provider_rw().unwrap();
             let result = segment.prune(&provider, input.clone()).unwrap();
             limiter.increment_deleted_entries_count_by(result.pruned);
 

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use itertools::Itertools;
 use reth_db::{tables, transaction::DbTxMut};
-use reth_db_api::{database::Database, models::ShardedKey};
-use reth_provider::{DBProvider, DatabaseProviderRW};
+use reth_db_api::models::ShardedKey;
+use reth_provider::DBProvider;
 use reth_prune_types::{
     PruneInterruptReason, PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput,
     SegmentOutputCheckpoint,
@@ -135,7 +135,7 @@ mod tests {
     use alloy_primitives::{BlockNumber, B256};
     use assert_matches::assert_matches;
     use reth_db::{tables, BlockNumberList};
-    use reth_provider::PruneCheckpointReader;
+    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader};
     use reth_prune_types::{
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
@@ -203,7 +203,7 @@ mod tests {
                 };
                 let segment = AccountHistory::new(prune_mode);
 
-                let provider = db.factory.provider_rw().unwrap();
+                let provider = db.factory.database_provider_rw().unwrap();
                 let result = segment.prune(&provider, input).unwrap();
                 limiter.increment_deleted_entries_count_by(result.pruned);
 

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -8,7 +8,7 @@ use reth_db_api::{
     transaction::DbTxMut,
     DatabaseError,
 };
-use reth_provider::DatabaseProviderRW;
+use reth_provider::{DBProvider, DatabaseProviderRW};
 
 enum PruneShardOutcome {
     Deleted,
@@ -26,13 +26,13 @@ pub(crate) struct PrunedIndices {
 /// Prune history indices according to the provided list of highest sharded keys.
 ///
 /// Returns total number of deleted, updated and unchanged entities.
-pub(crate) fn prune_history_indices<DB, T, SK>(
-    provider: &DatabaseProviderRW<DB>,
+pub(crate) fn prune_history_indices<Provider, T, SK>(
+    provider: &Provider,
     highest_sharded_keys: impl IntoIterator<Item = T::Key>,
     key_matches: impl Fn(&T::Key, &T::Key) -> bool,
 ) -> Result<PrunedIndices, DatabaseError>
 where
-    DB: Database,
+    Provider: DBProvider<Tx: DbTxMut>,
     T: Table<Value = BlockNumberList>,
     T::Key: AsRef<ShardedKey<SK>>,
 {

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -2,13 +2,12 @@ use alloy_primitives::BlockNumber;
 use reth_db::{BlockNumberList, RawKey, RawTable, RawValue};
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
-    database::Database,
     models::ShardedKey,
     table::Table,
     transaction::DbTxMut,
     DatabaseError,
 };
-use reth_provider::{DBProvider, DatabaseProviderRW};
+use reth_provider::DBProvider;
 
 enum PruneShardOutcome {
     Deleted,

--- a/crates/prune/prune/src/segments/user/receipts.rs
+++ b/crates/prune/prune/src/segments/user/receipts.rs
@@ -2,8 +2,12 @@ use crate::{
     segments::{PruneInput, Segment},
     PrunerError,
 };
+use reth_db::transaction::DbTxMut;
 use reth_db_api::database::Database;
-use reth_provider::{errors::provider::ProviderResult, DatabaseProviderRW};
+use reth_provider::{
+    errors::provider::ProviderResult, BlockReader, DBProvider, DatabaseProviderRW,
+    PruneCheckpointWriter, TransactionsProvider,
+};
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 use tracing::instrument;
 
@@ -18,7 +22,10 @@ impl Receipts {
     }
 }
 
-impl<DB: Database> Segment<DB> for Receipts {
+impl<Provider> Segment<Provider> for Receipts
+where
+    Provider: DBProvider<Tx: DbTxMut> + PruneCheckpointWriter + TransactionsProvider + BlockReader,
+{
     fn segment(&self) -> PruneSegment {
         PruneSegment::Receipts
     }
@@ -32,17 +39,13 @@ impl<DB: Database> Segment<DB> for Receipts {
     }
 
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
-    fn prune(
-        &self,
-        provider: &DatabaseProviderRW<DB>,
-        input: PruneInput,
-    ) -> Result<SegmentOutput, PrunerError> {
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         crate::segments::receipts::prune(provider, input)
     }
 
     fn save_checkpoint(
         &self,
-        provider: &DatabaseProviderRW<DB>,
+        provider: &Provider,
         checkpoint: PruneCheckpoint,
     ) -> ProviderResult<()> {
         crate::segments::receipts::save_checkpoint(provider, checkpoint)

--- a/crates/prune/prune/src/segments/user/receipts.rs
+++ b/crates/prune/prune/src/segments/user/receipts.rs
@@ -3,10 +3,9 @@ use crate::{
     PrunerError,
 };
 use reth_db::transaction::DbTxMut;
-use reth_db_api::database::Database;
 use reth_provider::{
-    errors::provider::ProviderResult, BlockReader, DBProvider, DatabaseProviderRW,
-    PruneCheckpointWriter, TransactionsProvider,
+    errors::provider::ProviderResult, BlockReader, DBProvider, PruneCheckpointWriter,
+    TransactionsProvider,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 use tracing::instrument;

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -4,10 +4,7 @@ use crate::{
     PrunerError,
 };
 use reth_db::{tables, transaction::DbTxMut};
-use reth_db_api::database::Database;
-use reth_provider::{
-    BlockReader, DBProvider, DatabaseProviderRW, PruneCheckpointWriter, TransactionsProvider,
-};
+use reth_provider::{BlockReader, DBProvider, PruneCheckpointWriter, TransactionsProvider};
 use reth_prune_types::{
     PruneCheckpoint, PruneMode, PruneProgress, PrunePurpose, PruneSegment, ReceiptsLogPruneConfig,
     SegmentOutput, MINIMUM_PRUNING_DISTANCE,
@@ -226,7 +223,7 @@ mod tests {
     use assert_matches::assert_matches;
     use reth_db::tables;
     use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
-    use reth_provider::{PruneCheckpointReader, TransactionsProvider};
+    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader, TransactionsProvider};
     use reth_prune_types::{PruneLimiter, PruneMode, PruneSegment, ReceiptsLogPruneConfig};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_testing_utils::generators::{
@@ -288,7 +285,7 @@ mod tests {
         );
 
         let run_prune = || {
-            let provider = db.factory.provider_rw().unwrap();
+            let provider = db.factory.database_provider_rw().unwrap();
 
             let prune_before_block: usize = 20;
             let prune_mode = PruneMode::Before(prune_before_block as u64);

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -4,8 +4,7 @@ use crate::{
     PrunerError,
 };
 use reth_db::{tables, transaction::DbTxMut};
-use reth_db_api::database::Database;
-use reth_provider::{BlockReader, DBProvider, DatabaseProviderRW, TransactionsProvider};
+use reth_provider::{BlockReader, DBProvider, TransactionsProvider};
 use reth_prune_types::{
     PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
 };
@@ -91,7 +90,7 @@ mod tests {
         Itertools,
     };
     use reth_db::tables;
-    use reth_provider::PruneCheckpointReader;
+    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader};
     use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneMode, PruneProgress, PruneSegment};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
@@ -180,7 +179,7 @@ mod tests {
                 .into_inner()
                 .0;
 
-            let provider = db.factory.provider_rw().unwrap();
+            let provider = db.factory.database_provider_rw().unwrap();
             let result = segment.prune(&provider, input).unwrap();
             limiter.increment_deleted_entries_count_by(result.pruned);
 

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -1,14 +1,15 @@
 use crate::{
+    db_ext::DbTxPruneExt,
     segments::{user::history::prune_history_indices, PruneInput, Segment, SegmentOutput},
     PrunerError,
 };
 use itertools::Itertools;
-use reth_db::tables;
+use reth_db::{tables, transaction::DbTxMut};
 use reth_db_api::{
     database::Database,
     models::{storage_sharded_key::StorageShardedKey, BlockNumberAddress},
 };
-use reth_provider::DatabaseProviderRW;
+use reth_provider::{DBProvider, DatabaseProviderRW};
 use reth_prune_types::{
     PruneInterruptReason, PruneMode, PruneProgress, PrunePurpose, PruneSegment,
     SegmentOutputCheckpoint,
@@ -33,7 +34,10 @@ impl StorageHistory {
     }
 }
 
-impl<DB: Database> Segment<DB> for StorageHistory {
+impl<Provider> Segment<Provider> for StorageHistory
+where
+    Provider: DBProvider<Tx: DbTxMut>,
+{
     fn segment(&self) -> PruneSegment {
         PruneSegment::StorageHistory
     }
@@ -47,11 +51,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
     }
 
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
-    fn prune(
-        &self,
-        provider: &DatabaseProviderRW<DB>,
-        input: PruneInput,
-    ) -> Result<SegmentOutput, PrunerError> {
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         let range = match input.get_next_block_range() {
             Some(range) => range,
             None => {
@@ -83,8 +83,8 @@ impl<DB: Database> Segment<DB> for StorageHistory {
         // size should be up to 0.5MB + some hashmap overhead. `blocks_since_last_run` is
         // additionally limited by the `max_reorg_depth`, so no OOM is expected here.
         let mut highest_deleted_storages = FxHashMap::default();
-        let (pruned_changesets, done) = provider
-            .prune_table_with_range::<tables::StorageChangeSets>(
+        let (pruned_changesets, done) =
+            provider.tx_ref().prune_table_with_range::<tables::StorageChangeSets>(
                 BlockNumberAddress::range(range),
                 &mut limiter,
                 |_| false,
@@ -114,7 +114,7 @@ impl<DB: Database> Segment<DB> for StorageHistory {
                     block_number.min(last_changeset_pruned_block),
                 )
             });
-        let outcomes = prune_history_indices::<DB, tables::StoragesHistory, _>(
+        let outcomes = prune_history_indices::<Provider, tables::StoragesHistory, _>(
             provider,
             highest_sharded_keys,
             |a, b| a.address == b.address && a.sharded_key.key == b.sharded_key.key,

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -5,11 +5,8 @@ use crate::{
 };
 use itertools::Itertools;
 use reth_db::{tables, transaction::DbTxMut};
-use reth_db_api::{
-    database::Database,
-    models::{storage_sharded_key::StorageShardedKey, BlockNumberAddress},
-};
-use reth_provider::{DBProvider, DatabaseProviderRW};
+use reth_db_api::models::{storage_sharded_key::StorageShardedKey, BlockNumberAddress};
+use reth_provider::DBProvider;
 use reth_prune_types::{
     PruneInterruptReason, PruneMode, PruneProgress, PrunePurpose, PruneSegment,
     SegmentOutputCheckpoint,
@@ -143,7 +140,7 @@ mod tests {
     use alloy_primitives::{BlockNumber, B256};
     use assert_matches::assert_matches;
     use reth_db::{tables, BlockNumberList};
-    use reth_provider::PruneCheckpointReader;
+    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader};
     use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneMode, PruneProgress, PruneSegment};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_testing_utils::generators::{
@@ -210,7 +207,7 @@ mod tests {
             };
             let segment = StorageHistory::new(prune_mode);
 
-            let provider = db.factory.provider_rw().unwrap();
+            let provider = db.factory.database_provider_rw().unwrap();
             let result = segment.prune(&provider, input).unwrap();
             limiter.increment_deleted_entries_count_by(result.pruned);
 

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -5,8 +5,7 @@ use crate::{
 };
 use rayon::prelude::*;
 use reth_db::{tables, transaction::DbTxMut};
-use reth_db_api::database::Database;
-use reth_provider::{BlockReader, DBProvider, DatabaseProviderRW, TransactionsProvider};
+use reth_provider::{BlockReader, DBProvider, TransactionsProvider};
 use reth_prune_types::{
     PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutputCheckpoint,
 };
@@ -119,7 +118,7 @@ mod tests {
         Itertools,
     };
     use reth_db::tables;
-    use reth_provider::PruneCheckpointReader;
+    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader};
     use reth_prune_types::{
         PruneCheckpoint, PruneInterruptReason, PruneLimiter, PruneMode, PruneProgress, PruneSegment,
     };
@@ -206,7 +205,7 @@ mod tests {
                 .into_inner()
                 .0;
 
-            let provider = db.factory.provider_rw().unwrap();
+            let provider = db.factory.database_provider_rw().unwrap();
             let result = segment.prune(&provider, input).unwrap();
             limiter.increment_deleted_entries_count_by(result.pruned);
 

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -1,11 +1,12 @@
 use crate::{
+    db_ext::DbTxPruneExt,
     segments::{PruneInput, Segment, SegmentOutput},
     PrunerError,
 };
 use rayon::prelude::*;
-use reth_db::tables;
+use reth_db::{tables, transaction::DbTxMut};
 use reth_db_api::database::Database;
-use reth_provider::{DatabaseProviderRW, TransactionsProvider};
+use reth_provider::{BlockReader, DBProvider, DatabaseProviderRW, TransactionsProvider};
 use reth_prune_types::{
     PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutputCheckpoint,
 };
@@ -22,7 +23,10 @@ impl TransactionLookup {
     }
 }
 
-impl<DB: Database> Segment<DB> for TransactionLookup {
+impl<Provider> Segment<Provider> for TransactionLookup
+where
+    Provider: DBProvider<Tx: DbTxMut> + TransactionsProvider + BlockReader,
+{
     fn segment(&self) -> PruneSegment {
         PruneSegment::TransactionLookup
     }
@@ -36,11 +40,7 @@ impl<DB: Database> Segment<DB> for TransactionLookup {
     }
 
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
-    fn prune(
-        &self,
-        provider: &DatabaseProviderRW<DB>,
-        input: PruneInput,
-    ) -> Result<SegmentOutput, PrunerError> {
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         let (start, end) = match input.get_next_tx_num_range(provider)? {
             Some(range) => range,
             None => {
@@ -73,13 +73,15 @@ impl<DB: Database> Segment<DB> for TransactionLookup {
         let mut limiter = input.limiter;
 
         let mut last_pruned_transaction = None;
-        let (pruned, done) = provider.prune_table_with_iterator::<tables::TransactionHashNumbers>(
-            hashes,
-            &mut limiter,
-            |row| {
-                last_pruned_transaction = Some(last_pruned_transaction.unwrap_or(row.1).max(row.1))
-            },
-        )?;
+        let (pruned, done) =
+            provider.tx_ref().prune_table_with_iterator::<tables::TransactionHashNumbers>(
+                hashes,
+                &mut limiter,
+                |row| {
+                    last_pruned_transaction =
+                        Some(last_pruned_transaction.unwrap_or(row.1).max(row.1))
+                },
+            )?;
 
         let done = done && tx_range_end == end;
         trace!(target: "pruner", %pruned, %done, "Pruned transaction lookup");

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -47,7 +47,7 @@ impl<DB: Database> Stage<DB> for PruneStage {
             .delete_limit(self.commit_threshold)
             .build(provider.static_file_provider().clone());
 
-        let result = pruner.run(provider, input.target())?;
+        let result = pruner.run_with_provider(&provider.0, input.target())?;
         if result.progress.is_finished() {
             Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
         } else {

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -159,8 +159,7 @@ where
 
             // Create a new database transaction on every segment to prevent long-lived read-only
             // transactions
-            let mut provider = self.provider.database_provider_ro()?;
-            provider.disable_long_read_transaction_safety();
+            let provider = self.provider.database_provider_ro()?.disable_long_read_transaction_safety();
             segment.copy_to_static_files(provider, self.provider.static_file_provider(), block_range.clone())?;
 
             let elapsed = start.elapsed(); // TODO(alexey): track in metrics

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -13,6 +13,7 @@ use reth_chain_state::{
     MemoryOverlayStateProvider,
 };
 use reth_chainspec::ChainInfo;
+use reth_db::Database;
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_execution_types::ExecutionOutcome;
@@ -34,7 +35,7 @@ use std::{
 };
 use tracing::trace;
 
-use super::ProviderNodeTypes;
+use super::{DatabaseProvider, ProviderNodeTypes};
 
 /// The main type for interacting with the blockchain.
 ///
@@ -263,10 +264,15 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
 
 impl<N: ProviderNodeTypes> DatabaseProviderFactory for BlockchainProvider2<N> {
     type DB = N::DB;
-    type Provider = DatabaseProviderRO<N::DB>;
+    type Provider = DatabaseProvider<<N::DB as Database>::TX>;
+    type ProviderRW = DatabaseProvider<<N::DB as Database>::TXMut>;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
-        self.database.provider()
+        self.database.database_provider_ro()
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
+        self.database.database_provider_rw()
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -186,9 +186,14 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
 impl<N: ProviderNodeTypes> DatabaseProviderFactory for ProviderFactory<N> {
     type DB = N::DB;
     type Provider = DatabaseProviderRO<N::DB>;
+    type ProviderRW = DatabaseProvider<<N::DB as Database>::TXMut>;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
         self.provider()
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
+        self.provider_rw().map(|provider| provider.0)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -23,13 +23,13 @@ use reth_db::{
 };
 use reth_db_api::{
     common::KeyValue,
-    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, RangeWalker},
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     database::Database,
     models::{
         sharded_key, storage_sharded_key::StorageShardedKey, AccountBeforeTx, BlockNumberAddress,
         ShardedKey, StoredBlockBodyIndices, StoredBlockOmmers, StoredBlockWithdrawals,
     },
-    table::{Table, TableRow},
+    table::Table,
     transaction::{DbTx, DbTxMut},
     DatabaseError,
 };
@@ -43,7 +43,7 @@ use reth_primitives::{
     TransactionSigned, TransactionSignedEcRecovered, TransactionSignedNoHash, TxHash, TxNumber,
     Withdrawal, Withdrawals, B256, U256,
 };
-use reth_prune_types::{PruneCheckpoint, PruneLimiter, PruneModes, PruneSegment};
+use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::TryIntoHistoricalStateProvider;
 use reth_storage_errors::provider::{ProviderResult, RootMismatch};
@@ -3577,7 +3577,7 @@ impl<TX: DbTxMut> FinalizedBlockWriter for DatabaseProvider<TX> {
     }
 }
 
-impl<TX: DbTx> DBProvider for DatabaseProvider<TX> {
+impl<TX: DbTx + 'static> DBProvider for DatabaseProvider<TX> {
     type Tx = TX;
 
     fn tx_ref(&self) -> &Self::Tx {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1519,119 +1519,6 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         Ok(())
     }
 
-    /// Prune the table for the specified pre-sorted key iterator.
-    ///
-    /// Returns number of rows pruned.
-    pub fn prune_table_with_iterator<T: Table>(
-        &self,
-        keys: impl IntoIterator<Item = T::Key>,
-        limiter: &mut PruneLimiter,
-        mut delete_callback: impl FnMut(TableRow<T>),
-    ) -> Result<(usize, bool), DatabaseError> {
-        let mut cursor = self.tx.cursor_write::<T>()?;
-        let mut keys = keys.into_iter();
-
-        let mut deleted_entries = 0;
-
-        for key in &mut keys {
-            if limiter.is_limit_reached() {
-                debug!(
-                    target: "providers::db",
-                    ?limiter,
-                    deleted_entries_limit = %limiter.is_deleted_entries_limit_reached(),
-                    time_limit = %limiter.is_time_limit_reached(),
-                    table = %T::NAME,
-                    "Pruning limit reached"
-                );
-                break
-            }
-
-            let row = cursor.seek_exact(key)?;
-            if let Some(row) = row {
-                cursor.delete_current()?;
-                limiter.increment_deleted_entries_count();
-                deleted_entries += 1;
-                delete_callback(row);
-            }
-        }
-
-        let done = keys.next().is_none();
-        Ok((deleted_entries, done))
-    }
-
-    /// Prune the table for the specified key range.
-    ///
-    /// Returns number of rows pruned.
-    pub fn prune_table_with_range<T: Table>(
-        &self,
-        keys: impl RangeBounds<T::Key> + Clone + Debug,
-        limiter: &mut PruneLimiter,
-        mut skip_filter: impl FnMut(&TableRow<T>) -> bool,
-        mut delete_callback: impl FnMut(TableRow<T>),
-    ) -> Result<(usize, bool), DatabaseError> {
-        let mut cursor = self.tx.cursor_write::<T>()?;
-        let mut walker = cursor.walk_range(keys)?;
-
-        let mut deleted_entries = 0;
-
-        let done = loop {
-            // check for time out must be done in this scope since it's not done in
-            // `prune_table_with_range_step`
-            if limiter.is_limit_reached() {
-                debug!(
-                    target: "providers::db",
-                    ?limiter,
-                    deleted_entries_limit = %limiter.is_deleted_entries_limit_reached(),
-                    time_limit = %limiter.is_time_limit_reached(),
-                    table = %T::NAME,
-                    "Pruning limit reached"
-                );
-                break false
-            }
-
-            let done = self.prune_table_with_range_step(
-                &mut walker,
-                limiter,
-                &mut skip_filter,
-                &mut delete_callback,
-            )?;
-
-            if done {
-                break true
-            }
-            deleted_entries += 1;
-        };
-
-        Ok((deleted_entries, done))
-    }
-
-    /// Steps once with the given walker and prunes the entry in the table.
-    ///
-    /// Returns `true` if the walker is finished, `false` if it may have more data to prune.
-    ///
-    /// CAUTION: Pruner limits are not checked. This allows for a clean exit of a prune run that's
-    /// pruning different tables concurrently, by letting them step to the same height before
-    /// timing out.
-    pub fn prune_table_with_range_step<T: Table>(
-        &self,
-        walker: &mut RangeWalker<'_, T, <TX as DbTxMut>::CursorMut<T>>,
-        limiter: &mut PruneLimiter,
-        skip_filter: &mut impl FnMut(&TableRow<T>) -> bool,
-        delete_callback: &mut impl FnMut(TableRow<T>),
-    ) -> Result<bool, DatabaseError> {
-        let Some(res) = walker.next() else { return Ok(true) };
-
-        let row = res?;
-
-        if !skip_filter(&row) {
-            walker.delete_current()?;
-            limiter.increment_deleted_entries_count();
-            delete_callback(row);
-        }
-
-        Ok(false)
-    }
-
     /// Load shard and remove it. If list is empty, last shard was full or
     /// there are no shards at all.
     fn take_shard<T>(&self, key: T::Key) -> ProviderResult<Vec<u64>>
@@ -3699,6 +3586,10 @@ impl<TX: DbTx> DBProvider for DatabaseProvider<TX> {
 
     fn tx_mut(&mut self) -> &mut Self::Tx {
         &mut self.tx
+    }
+
+    fn into_tx(self) -> Self::Tx {
+        self.tx
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -14,6 +14,7 @@ use reth_blockchain_tree_api::{
 };
 use reth_chain_state::{ChainInfoTracker, ForkChoiceNotifications, ForkChoiceSubscriptions};
 use reth_chainspec::{ChainInfo, ChainSpec};
+use reth_db::Database;
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_node_types::NodeTypesWithDB;
@@ -171,10 +172,15 @@ where
 
 impl<N: ProviderNodeTypes> DatabaseProviderFactory for BlockchainProvider<N> {
     type DB = N::DB;
-    type Provider = DatabaseProviderRO<N::DB>;
+    type Provider = DatabaseProvider<<N::DB as Database>::TX>;
+    type ProviderRW = DatabaseProvider<<N::DB as Database>::TXMut>;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
         self.database.provider()
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
+        self.database.provider_rw().map(|p| p.0)
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -147,8 +147,13 @@ impl MockEthProvider {
 impl DatabaseProviderFactory for MockEthProvider {
     type DB = DatabaseMock;
     type Provider = DatabaseProvider<TxMock>;
+    type ProviderRW = DatabaseProvider<TxMock>;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+    }
+
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
         Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
     }
 }

--- a/crates/storage/storage-api/src/database_provider.rs
+++ b/crates/storage/storage-api/src/database_provider.rs
@@ -1,8 +1,17 @@
-use reth_db_api::{database::Database, transaction::DbTx};
+use std::{fmt::Debug, ops::RangeBounds};
+
+use reth_db_api::{
+    cursor::{DbCursorRO, DbCursorRW, RangeWalker},
+    database::Database,
+    table::{Table, TableRow},
+    transaction::{DbTx, DbTxMut},
+    DatabaseError,
+};
+use reth_prune_types::PruneLimiter;
 use reth_storage_errors::provider::ProviderResult;
 
 /// Database provider.
-pub trait DBProvider: Send + Sync {
+pub trait DBProvider: Send + Sync + Sized {
     /// Underlying database transaction held by the provider.
     type Tx: DbTx;
 
@@ -12,18 +21,28 @@ pub trait DBProvider: Send + Sync {
     /// Returns a mutable reference to the underlying transaction.
     fn tx_mut(&mut self) -> &mut Self::Tx;
 
+    /// Consumes the provider and returns the underlying transaction.
+    fn into_tx(self) -> Self::Tx;
+
     /// Disables long-lived read transaction safety guarantees for leaks prevention and
     /// observability improvements.
     ///
     /// CAUTION: In most of the cases, you want the safety guarantees for long read transactions
     /// enabled. Use this only if you're sure that no write transaction is open in parallel, meaning
     /// that Reth as a node is offline and not progressing.
-    fn disable_long_read_transaction_safety(&mut self) {
+    fn disable_long_read_transaction_safety(mut self) -> Self {
         self.tx_mut().disable_long_read_transaction_safety();
+        self
+    }
+
+    /// Commit database transaction
+    fn commit(self) -> ProviderResult<bool> {
+        Ok(self.into_tx().commit()?)
     }
 }
 
 /// Database provider factory.
+#[auto_impl::auto_impl(&, Arc)]
 pub trait DatabaseProviderFactory: Send + Sync {
     /// Database this factory produces providers for.
     type DB: Database;
@@ -31,6 +50,12 @@ pub trait DatabaseProviderFactory: Send + Sync {
     /// Provider type returned by the factory.
     type Provider: DBProvider<Tx = <Self::DB as Database>::TX>;
 
+    /// Read-write provider type returned by the factory.
+    type ProviderRW: DBProvider<Tx = <Self::DB as Database>::TXMut>;
+
     /// Create new read-only database provider.
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider>;
+
+    /// Create new read-write database provider.
+    fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW>;
 }

--- a/crates/storage/storage-api/src/database_provider.rs
+++ b/crates/storage/storage-api/src/database_provider.rs
@@ -1,17 +1,8 @@
-use std::{fmt::Debug, ops::RangeBounds};
-
-use reth_db_api::{
-    cursor::{DbCursorRO, DbCursorRW, RangeWalker},
-    database::Database,
-    table::{Table, TableRow},
-    transaction::{DbTx, DbTxMut},
-    DatabaseError,
-};
-use reth_prune_types::PruneLimiter;
+use reth_db_api::{database::Database, transaction::DbTx};
 use reth_storage_errors::provider::ProviderResult;
 
 /// Database provider.
-pub trait DBProvider: Send + Sync + Sized {
+pub trait DBProvider: Send + Sync + Sized + 'static {
     /// Underlying database transaction held by the provider.
     type Tx: DbTx;
 


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/10797 https://github.com/paradigmxyz/reth/issues/10909

- Extends `DatabaseProviderFactory` trait with methods for obtaining rw provider
- Moves pruning methods from `DatabaseProvider` to extension trait for `DbTxMut` defined in `reth-prune`
- Makes prune `Segment`s generic over provider instead of database
- Makes `Pruner` generic over provider factory.

With this PR, `reth-prune` only depends on `reth-provider` for `StaticFileProvider`

Follow-up would be to remove usage of `DatabaseProviderRW` from `reth-stages` in a similar way. After that it would be much easier to integrate and use chainspec generic in `DatabaseProvider`

