### PR TITLE
chore: Move optimism root checks into crates/optimism 

### DIFF
--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -23,6 +23,8 @@ use std::{sync::Arc, time::SystemTime};
 
 mod proof;
 mod validation;
+mod receipt;
+
 pub use validation::validate_block_post_execution;
 
 /// Optimism consensus implementation.

--- a/crates/optimism/consensus/src/proof.rs
+++ b/crates/optimism/consensus/src/proof.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::B256;
 use reth_chainspec::{ChainSpec, OptimismHardfork};
-use reth_primitives::ReceiptWithBloom;
+use reth_primitives::{Receipt, ReceiptWithBloom, ReceiptWithBloomRef};
 use reth_trie_common::root::ordered_trie_root_with_encoder;
 
 /// Calculates the receipt root for a header.
@@ -34,6 +34,42 @@ pub(crate) fn calculate_receipt_root_optimism(
     }
 
     ordered_trie_root_with_encoder(receipts, |r, buf| r.encode_inner(buf, false))
+}
+
+/// Calculates the receipt root for a header for the reference type of [Receipt].
+///
+/// NOTE: Prefer calculate receipt root optimism if you have log blooms memoized.
+pub fn calculate_receipt_root_no_memo_optimism(
+    receipts: &[&Receipt],
+    chain_spec: &reth_chainspec::ChainSpec,
+    timestamp: u64,
+) -> B256 {
+    // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
+    // the receipt root calculation does not include the deposit nonce in the receipt
+    // encoding. In the Regolith Hardfork, we must strip the deposit nonce from the
+    // receipts before calculating the receipt root. This was corrected in the Canyon
+    // hardfork.
+    if chain_spec.is_fork_active_at_timestamp(reth_chainspec::OptimismHardfork::Regolith, timestamp) &&
+        !chain_spec
+            .is_fork_active_at_timestamp(reth_chainspec::OptimismHardfork::Canyon, timestamp)
+    {
+        let receipts = receipts
+            .iter()
+            .map(|r| {
+                let mut r = (*r).clone();
+                r.deposit_nonce = None;
+                r
+            })
+            .collect::<Vec<_>>();
+
+        return ordered_trie_root_with_encoder(&receipts, |r, buf| {
+            ReceiptWithBloomRef::from(r).encode_inner(buf, false)
+        })
+    }
+
+    ordered_trie_root_with_encoder(receipts, |r, buf| {
+        ReceiptWithBloomRef::from(*r).encode_inner(buf, false)
+    })
 }
 
 #[cfg(test)]

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -51,43 +51,6 @@ pub fn calculate_receipt_root_no_memo(receipts: &[&Receipt]) -> B256 {
     })
 }
 
-/// Calculates the receipt root for a header for the reference type of [Receipt].
-///
-/// NOTE: Prefer calculate receipt root optimism if you have log blooms memoized.
-#[cfg(feature = "optimism")]
-pub fn calculate_receipt_root_no_memo_optimism(
-    receipts: &[&Receipt],
-    chain_spec: &reth_chainspec::ChainSpec,
-    timestamp: u64,
-) -> B256 {
-    // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
-    // the receipt root calculation does not include the deposit nonce in the receipt
-    // encoding. In the Regolith Hardfork, we must strip the deposit nonce from the
-    // receipts before calculating the receipt root. This was corrected in the Canyon
-    // hardfork.
-    if chain_spec.is_fork_active_at_timestamp(reth_chainspec::OptimismHardfork::Regolith, timestamp) &&
-        !chain_spec
-            .is_fork_active_at_timestamp(reth_chainspec::OptimismHardfork::Canyon, timestamp)
-    {
-        let receipts = receipts
-            .iter()
-            .map(|r| {
-                let mut r = (*r).clone();
-                r.deposit_nonce = None;
-                r
-            })
-            .collect::<Vec<_>>();
-
-        return ordered_trie_root_with_encoder(&receipts, |r, buf| {
-            ReceiptWithBloomRef::from(r).encode_inner(buf, false)
-        })
-    }
-
-    ordered_trie_root_with_encoder(receipts, |r, buf| {
-        ReceiptWithBloomRef::from(*r).encode_inner(buf, false)
-    })
-}
-
 /// Calculates the root hash for ommer/uncle headers.
 pub fn calculate_ommers_root(ommers: &[Header]) -> B256 {
     // Check if `ommers` list is empty

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -117,7 +117,7 @@ impl Receipts {
         chain_spec: &reth_chainspec::ChainSpec,
         timestamp: u64,
     ) -> Option<B256> {
-        Some(crate::proofs::calculate_receipt_root_no_memo_optimism(
+        Some(calculate_receipt_root_no_memo_optimism(
             &self.receipt_vec[index].iter().map(Option::as_ref).collect::<Option<Vec<_>>>()?,
             chain_spec,
             timestamp,


### PR DESCRIPTION
WIP for https://github.com/paradigmxyz/reth/issues/10713

Moves `calculate_receipt_root_no_memo_optimism` and associated usages from `crates/primitive` to `crates/optimism` 