### PR TITLE
fix(ci): use `taiki-e/install-action` instead for `cargo-udeps`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -137,8 +137,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - uses: cargo-bins/cargo-binstall@main
-      - run: cargo binstall cargo-udeps --no-confirm
+      - uses: taiki-e/install-action@cargo-udeps
       - run: cargo udeps --workspace --lib --examples --tests --benches --all-features --locked
 
   book:


### PR DESCRIPTION
PRs are having issues with cargo-udeps. 

we usually use taiki-e for cargo installs, lets see

edit: seems to have worked at least for this PR