### PR TITLE
fix(exex): do not advance backfill range twice

### DIFF
--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -114,9 +114,6 @@ where
             let start = range.next();
             let range_bounds = start.zip(range.last().or(start));
 
-            // Advance the range by `batch_size` blocks
-            this.range.nth(this.batch_size);
-
             // If we have range bounds, then we can spawn a new task for that range
             if let Some((first, last)) = range_bounds {
                 let range = first..=last;


### PR DESCRIPTION
`this.range.by_ref().take(this.batch_size)` in fact advances the original iterator -.-

Will add tests in the subsequent PR, for now this fix works as expected.

## Before

```console
2024-09-16T19:56:55.256356Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=0 last=9999
2024-09-16T19:56:55.556711Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=20001 last=30000
2024-09-16T19:56:55.569177Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=40002 last=50001
2024-09-16T19:56:55.578051Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=60003 last=70002
```

## After

```console
2024-09-16T20:00:04.281247Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=0 last=9999
2024-09-16T20:00:04.618367Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=10000 last=19999
2024-09-16T20:00:04.630539Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=20000 last=29999
2024-09-16T20:00:04.648388Z  INFO exex{id="MyExEx"}: alex88_repro: Processing range of blocks first=30000 last=3999
```