### PR TITLE
chore(sdk): `ChainSpec` generic over hardforks

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -6,8 +6,8 @@ use crate::ChainSpec;
 
 /// Trait representing type configuring a chain spec.
 pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {
-    // todo: make chain spec type generic over hardfork
-    //type Hardfork: Clone + Copy + 'static;
+    /// Hardfork type of network stack.
+    type Hardfork;
 
     /// Chain id.
     fn chain(&self) -> Chain;
@@ -17,6 +17,8 @@ impl<T> EthChainSpec for ChainSpec<T>
 where
     T: Send + Sync + Unpin + Debug + 'static,
 {
+    type Hardfork = T;
+
     fn chain(&self) -> Chain {
         self.chain
     }

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,6 +1,8 @@
-use crate::ChainSpec;
-use alloy_chains::Chain;
 use core::fmt::Debug;
+
+use alloy_chains::Chain;
+
+use crate::ChainSpec;
 
 /// Trait representing type configuring a chain spec.
 pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {
@@ -11,7 +13,10 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {
     fn chain(&self) -> Chain;
 }
 
-impl EthChainSpec for ChainSpec {
+impl<T> EthChainSpec for ChainSpec<T>
+where
+    T: Send + Sync + Unpin + Debug + 'static,
+{
     fn chain(&self) -> Chain {
         self.chain
     }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -615,7 +615,7 @@ impl ChainSpec<ChainHardforks> {
     }
 }
 
-impl From<Genesis> for ChainSpec<ChainHardforks> {
+impl From<Genesis> for ChainSpec {
     fn from(genesis: Genesis) -> Self {
         #[cfg(not(feature = "optimism"))]
         {
@@ -631,7 +631,7 @@ impl From<Genesis> for ChainSpec<ChainHardforks> {
 
 /// Convert the given [`Genesis`] into an Ethereum [`ChainSpec`].
 #[cfg(not(feature = "optimism"))]
-fn into_ethereum_chain_spec(genesis: Genesis) -> ChainSpec<ChainHardforks> {
+fn into_ethereum_chain_spec(genesis: Genesis) -> ChainSpec {
     // Block-based hardforks
     let hardfork_opts = [
         (EthereumHardfork::Homestead.boxed(), genesis.config.homestead_block),
@@ -720,7 +720,7 @@ fn into_ethereum_chain_spec(genesis: Genesis) -> ChainSpec<ChainHardforks> {
 
 #[cfg(feature = "optimism")]
 /// Convert the given [`Genesis`] into an Optimism [`ChainSpec`].
-fn into_optimism_chain_spec(genesis: Genesis) -> ChainSpec<ChainHardforks> {
+fn into_optimism_chain_spec(genesis: Genesis) -> ChainSpec {
     use reth_ethereum_forks::OptimismHardfork;
     let optimism_genesis_info = OptimismGenesisInfo::extract_from(&genesis);
     let genesis_info = optimism_genesis_info.optimism_chain_info.genesis_info.unwrap_or_default();
@@ -1060,8 +1060,8 @@ impl ChainSpecBuilder {
     }
 }
 
-impl From<&Arc<ChainSpec<ChainHardforks>>> for ChainSpecBuilder {
-    fn from(value: &Arc<ChainSpec<ChainHardforks>>) -> Self {
+impl From<&Arc<ChainSpec>> for ChainSpecBuilder {
+    fn from(value: &Arc<ChainSpec>) -> Self {
         Self {
             chain: Some(value.chain),
             genesis: Some(value.genesis.clone()),

--- a/crates/trie/db/tests/proof.rs
+++ b/crates/trie/db/tests/proof.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
-use reth_chainspec::{Chain, ChainSpec, HOLESKY, MAINNET};
+use reth_chainspec::{Chain, ChainHardforks, ChainSpec, HOLESKY, MAINNET};
 use reth_primitives::{constants::EMPTY_ROOT_HASH, Account};
 use reth_provider::test_utils::{create_test_provider_factory, insert_genesis};
 use reth_trie::{proof::Proof, Nibbles};
@@ -22,7 +22,7 @@ use std::{
     All expected testspec results were obtained from querying proof RPC on the running geth instance `geth init crates/trie/testdata/proof-genesis.json && geth --http`.
 */
 static TEST_SPEC: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
-    ChainSpec {
+    ChainSpec::<ChainHardforks> {
         chain: Chain::from_id(12345),
         genesis: serde_json::from_str(include_str!("../../trie/testdata/proof-genesis.json"))
             .expect("Can't deserialize test genesis json"),


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/10468

Makes `ChainSpec` generic over hard forks, leaving `ChainHardforks` as default generic.