### PR TITLE
chore(reth-ethereum-consensus): use const GAS_LIMIT_BOUND_DIVISOR

### DIFF
--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_invalid_gas_limit_decrease_exceeding_limit() {
-        let parent = header_with_gas_limit(1024 * 10);
+        let parent = header_with_gas_limit(GAS_LIMIT_BOUND_DIVISOR * 10);
         let child = header_with_gas_limit(
             parent.gas_limit - parent.gas_limit / GAS_LIMIT_BOUND_DIVISOR - 1,
         );

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -46,7 +46,7 @@ impl EthBeaconConsensus {
     /// Checks the gas limit for consistency between parent and self headers.
     ///
     /// The maximum allowable difference between self and parent gas limits is determined by the
-    /// parent's gas limit divided by the ['GAS_LIMIT_BOUND_DIVISOR'].
+    /// parent's gas limit divided by the [`GAS_LIMIT_BOUND_DIVISOR`].
     fn validate_against_parent_gas_limit(
         &self,
         header: &SealedHeader,

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -22,6 +22,9 @@ use reth_primitives::{
 };
 use std::{sync::Arc, time::SystemTime};
 
+/// The bound divisor of the gas limit, used in update calculations.
+const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
+
 mod validation;
 pub use validation::validate_block_post_execution;
 
@@ -43,7 +46,7 @@ impl EthBeaconConsensus {
     /// Checks the gas limit for consistency between parent and self headers.
     ///
     /// The maximum allowable difference between self and parent gas limits is determined by the
-    /// parent's gas limit divided by the elasticity multiplier (1024).
+    /// parent's gas limit divided by the ['GAS_LIMIT_BOUND_DIVISOR'].
     fn validate_against_parent_gas_limit(
         &self,
         header: &SealedHeader,
@@ -62,7 +65,7 @@ impl EthBeaconConsensus {
 
         // Check for an increase in gas limit beyond the allowed threshold.
         if header.gas_limit > parent_gas_limit {
-            if header.gas_limit - parent_gas_limit >= parent_gas_limit / 1024 {
+            if header.gas_limit - parent_gas_limit >= parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR {
                 return Err(ConsensusError::GasLimitInvalidIncrease {
                     parent_gas_limit,
                     child_gas_limit: header.gas_limit,
@@ -70,7 +73,8 @@ impl EthBeaconConsensus {
             }
         }
         // Check for a decrease in gas limit beyond the allowed threshold.
-        else if parent_gas_limit - header.gas_limit >= parent_gas_limit / 1024 {
+        else if parent_gas_limit - header.gas_limit >= parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR
+        {
             return Err(ConsensusError::GasLimitInvalidDecrease {
                 parent_gas_limit,
                 child_gas_limit: header.gas_limit,
@@ -230,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_valid_gas_limit_increase() {
-        let parent = header_with_gas_limit(1024 * 10);
+        let parent = header_with_gas_limit(GAS_LIMIT_BOUND_DIVISOR * 10);
         let child = header_with_gas_limit(parent.gas_limit + 5);
 
         assert_eq!(
@@ -254,8 +258,10 @@ mod tests {
 
     #[test]
     fn test_invalid_gas_limit_increase_exceeding_limit() {
-        let parent = header_with_gas_limit(1024 * 10);
-        let child = header_with_gas_limit(parent.gas_limit + parent.gas_limit / 1024 + 1);
+        let parent = header_with_gas_limit(GAS_LIMIT_BOUND_DIVISOR * 10);
+        let child = header_with_gas_limit(
+            parent.gas_limit + parent.gas_limit / GAS_LIMIT_BOUND_DIVISOR + 1,
+        );
 
         assert_eq!(
             EthBeaconConsensus::new(Arc::new(ChainSpec::default()))
@@ -269,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_valid_gas_limit_decrease_within_limit() {
-        let parent = header_with_gas_limit(1024 * 10);
+        let parent = header_with_gas_limit(GAS_LIMIT_BOUND_DIVISOR * 10);
         let child = header_with_gas_limit(parent.gas_limit - 5);
 
         assert_eq!(
@@ -282,7 +288,9 @@ mod tests {
     #[test]
     fn test_invalid_gas_limit_decrease_exceeding_limit() {
         let parent = header_with_gas_limit(1024 * 10);
-        let child = header_with_gas_limit(parent.gas_limit - parent.gas_limit / 1024 - 1);
+        let child = header_with_gas_limit(
+            parent.gas_limit - parent.gas_limit / GAS_LIMIT_BOUND_DIVISOR - 1,
+        );
 
         assert_eq!(
             EthBeaconConsensus::new(Arc::new(ChainSpec::default()))


### PR DESCRIPTION
ref erigon and geth https://github.com/erigontech/erigon/blob/293503e853057472fe3d6c14cbeb651c2b31ebf6/params/protocol_params.go#L29-L29, use const GAS_LIMIT_BOUND_DIVISOR