### PR TITLE
chore: move eip2935 impl

### DIFF
--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -1,0 +1,150 @@
+//! [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) system call implementation.
+
+use alloc::{boxed::Box, string::ToString};
+use alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS;
+
+use crate::ConfigureEvm;
+use core::fmt::Display;
+use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_execution_errors::{BlockExecutionError, BlockValidationError};
+use revm::{interpreter::Host, Database, DatabaseCommit, Evm};
+use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ResultAndState, B256};
+
+/// Apply the [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) pre block contract call.
+///
+/// This constructs a new [`Evm`] with the given database and environment ([`CfgEnvWithHandlerCfg`]
+/// and [`BlockEnv`]) to execute the pre block contract call.
+///
+/// This uses [`apply_blockhashes_contract_call`] to ultimately apply the
+/// blockhash contract state change.
+pub fn pre_block_blockhashes_contract_call<EvmConfig, DB>(
+    db: &mut DB,
+    evm_config: &EvmConfig,
+    chain_spec: &ChainSpec,
+    initialized_cfg: &CfgEnvWithHandlerCfg,
+    initialized_block_env: &BlockEnv,
+    parent_block_hash: B256,
+) -> Result<(), BlockExecutionError>
+where
+    DB: Database + DatabaseCommit,
+    DB::Error: Display,
+    EvmConfig: ConfigureEvm,
+{
+    // Apply the pre-block EIP-2935 contract call
+    let mut evm_pre_block = Evm::builder()
+        .with_db(db)
+        .with_env_with_handler_cfg(EnvWithHandlerCfg::new_with_cfg_env(
+            initialized_cfg.clone(),
+            initialized_block_env.clone(),
+            Default::default(),
+        ))
+        .build();
+
+    apply_blockhashes_contract_call(
+        evm_config,
+        chain_spec,
+        initialized_block_env.timestamp.to(),
+        initialized_block_env.number.to(),
+        parent_block_hash,
+        &mut evm_pre_block,
+    )
+}
+
+/// Applies the pre-block call to the [EIP-2935] blockhashes contract, using the given block,
+/// [`ChainSpec`], and EVM.
+///
+/// If Prague is not activated, or the block is the genesis block, then this is a no-op, and no
+/// state changes are made.
+///
+/// Note: this does not commit the state changes to the database, it only transact the call.
+///
+/// Returns `None` if Prague is not active or the block is the genesis block, otherwise returns the
+/// result of the call.
+///
+/// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
+#[inline]
+pub fn transact_blockhashes_contract_call<EvmConfig, EXT, DB>(
+    evm_config: &EvmConfig,
+    chain_spec: &ChainSpec,
+    block_timestamp: u64,
+    block_number: u64,
+    parent_block_hash: B256,
+    evm: &mut Evm<'_, EXT, DB>,
+) -> Result<Option<ResultAndState>, BlockExecutionError>
+where
+    DB: Database + DatabaseCommit,
+    DB::Error: core::fmt::Display,
+    EvmConfig: ConfigureEvm,
+{
+    if !chain_spec.is_prague_active_at_timestamp(block_timestamp) {
+        return Ok(None)
+    }
+
+    // if the block number is zero (genesis block) then no system transaction may occur as per
+    // EIP-2935
+    if block_number == 0 {
+        return Ok(None)
+    }
+
+    // get previous env
+    let previous_env = Box::new(evm.context.env().clone());
+
+    // modify env for pre block call
+    evm_config.fill_tx_env_system_contract_call(
+        &mut evm.context.evm.env,
+        alloy_eips::eip4788::SYSTEM_ADDRESS,
+        HISTORY_STORAGE_ADDRESS,
+        parent_block_hash.0.into(),
+    );
+
+    let mut res = match evm.transact() {
+        Ok(res) => res,
+        Err(e) => {
+            evm.context.evm.env = previous_env;
+            return Err(BlockValidationError::BlockHashContractCall { message: e.to_string() }.into())
+        }
+    };
+
+    res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
+    res.state.remove(&evm.block().coinbase);
+
+    // re-set the previous env
+    evm.context.evm.env = previous_env;
+
+    Ok(Some(res))
+}
+
+/// Applies the pre-block call to the [EIP-2935] blockhashes contract, using the given block,
+/// [`ChainSpec`], and EVM and commits the relevant state changes.
+///
+/// If Prague is not activated, or the block is the genesis block, then this is a no-op, and no
+/// state changes are made.
+///
+/// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
+#[inline]
+pub fn apply_blockhashes_contract_call<EvmConfig, EXT, DB>(
+    evm_config: &EvmConfig,
+    chain_spec: &ChainSpec,
+    block_timestamp: u64,
+    block_number: u64,
+    parent_block_hash: B256,
+    evm: &mut Evm<'_, EXT, DB>,
+) -> Result<(), BlockExecutionError>
+where
+    DB: Database + DatabaseCommit,
+    DB::Error: core::fmt::Display,
+    EvmConfig: ConfigureEvm,
+{
+    if let Some(res) = transact_blockhashes_contract_call(
+        evm_config,
+        chain_spec,
+        block_timestamp,
+        block_number,
+        parent_block_hash,
+        evm,
+    )? {
+        evm.context.evm.db.commit(res.state);
+    }
+
+    Ok(())
+}

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -5,7 +5,6 @@ use core::fmt::Display;
 
 use crate::ConfigureEvm;
 use alloy_eips::{
-    eip2935::HISTORY_STORAGE_ADDRESS,
     eip4788::BEACON_ROOTS_ADDRESS,
     eip7002::{WithdrawalRequest, WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS},
     eip7251::{ConsolidationRequest, CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS},
@@ -19,106 +18,8 @@ use revm_primitives::{
     ResultAndState, B256,
 };
 
-/// Apply the [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) pre block contract call.
-///
-/// This constructs a new [`Evm`] with the given database and environment ([`CfgEnvWithHandlerCfg`]
-/// and [`BlockEnv`]) to execute the pre block contract call.
-///
-/// This uses [`apply_blockhashes_contract_call`] to ultimately apply the blockhash contract state
-/// change.
-pub fn pre_block_blockhashes_contract_call<EvmConfig, DB>(
-    db: &mut DB,
-    evm_config: &EvmConfig,
-    chain_spec: &ChainSpec,
-    initialized_cfg: &CfgEnvWithHandlerCfg,
-    initialized_block_env: &BlockEnv,
-    parent_block_hash: B256,
-) -> Result<(), BlockExecutionError>
-where
-    DB: Database + DatabaseCommit,
-    DB::Error: Display,
-    EvmConfig: ConfigureEvm,
-{
-    // Apply the pre-block EIP-2935 contract call
-    let mut evm_pre_block = Evm::builder()
-        .with_db(db)
-        .with_env_with_handler_cfg(EnvWithHandlerCfg::new_with_cfg_env(
-            initialized_cfg.clone(),
-            initialized_block_env.clone(),
-            Default::default(),
-        ))
-        .build();
-
-    apply_blockhashes_contract_call(
-        evm_config,
-        chain_spec,
-        initialized_block_env.timestamp.to(),
-        initialized_block_env.number.to(),
-        parent_block_hash,
-        &mut evm_pre_block,
-    )
-}
-
-/// Applies the pre-block call to the [EIP-2935] blockhashes contract, using the given block,
-/// [`ChainSpec`], and EVM.
-///
-/// If Prague is not activated, or the block is the genesis block, then this is a no-op, and no
-/// state changes are made.
-///
-/// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
-#[inline]
-pub fn apply_blockhashes_contract_call<EvmConfig, EXT, DB>(
-    evm_config: &EvmConfig,
-    chain_spec: &ChainSpec,
-    block_timestamp: u64,
-    block_number: u64,
-    parent_block_hash: B256,
-    evm: &mut Evm<'_, EXT, DB>,
-) -> Result<(), BlockExecutionError>
-where
-    DB: Database + DatabaseCommit,
-    DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm,
-{
-    if !chain_spec.is_prague_active_at_timestamp(block_timestamp) {
-        return Ok(())
-    }
-
-    // if the block number is zero (genesis block) then no system transaction may occur as per
-    // EIP-2935
-    if block_number == 0 {
-        return Ok(())
-    }
-
-    // get previous env
-    let previous_env = Box::new(evm.context.env().clone());
-
-    // modify env for pre block call
-    evm_config.fill_tx_env_system_contract_call(
-        &mut evm.context.evm.env,
-        alloy_eips::eip4788::SYSTEM_ADDRESS,
-        HISTORY_STORAGE_ADDRESS,
-        parent_block_hash.0.into(),
-    );
-
-    let mut state = match evm.transact() {
-        Ok(res) => res.state,
-        Err(e) => {
-            evm.context.evm.env = previous_env;
-            return Err(BlockValidationError::BlockHashContractCall { message: e.to_string() }.into())
-        }
-    };
-
-    state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
-    state.remove(&evm.block().coinbase);
-
-    evm.context.evm.db.commit(state);
-
-    // re-set the previous env
-    evm.context.evm.env = previous_env;
-
-    Ok(())
-}
+mod eip2935;
+pub use eip2935::*;
 
 /// Apply the [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) pre block contract call.
 ///


### PR DESCRIPTION
towards #10953

moves eip2935 to its own module and splits transact and apply.
we need this if we want to get access to evmstate before we commit

ref #10877