### PR TITLE
chore(trie): early return EMPTY_ROOT_HASH

### DIFF
--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -4,8 +4,7 @@
 use alloy_primitives::{B256, U256};
 use reth_primitives::{
     constants::{EMPTY_OMMER_ROOT_HASH, MAXIMUM_EXTRA_DATA_SIZE},
-    proofs::{self},
-    Block, Header, Request, SealedBlock, TransactionSigned, UintTryTo, Withdrawals,
+    proofs, Block, Header, Request, SealedBlock, TransactionSigned, Withdrawals,
 };
 use reth_rpc_types::engine::{
     payload::{ExecutionPayloadBodyV1, ExecutionPayloadFieldV2, ExecutionPayloadInputV2},
@@ -25,7 +24,7 @@ pub fn try_payload_v1_to_block(payload: ExecutionPayloadV1) -> Result<Block, Pay
 
     let transactions = payload
         .transactions
-        .into_iter()
+        .iter()
         .map(|tx| TransactionSigned::decode_enveloped(&mut tx.as_ref()))
         .collect::<Result<Vec<_>, _>>()?;
     let transactions_root = proofs::calculate_transaction_root(&transactions);
@@ -50,7 +49,7 @@ pub fn try_payload_v1_to_block(payload: ExecutionPayloadV1) -> Result<Block, Pay
         base_fee_per_gas: Some(
             payload
                 .base_fee_per_gas
-                .uint_try_to()
+                .try_into()
                 .map_err(|_| PayloadError::BaseFee(payload.base_fee_per_gas))?,
         ),
         blob_gas_used: None,

--- a/crates/trie/common/src/root.rs
+++ b/crates/trie/common/src/root.rs
@@ -28,6 +28,10 @@ pub fn ordered_trie_root_with_encoder<T, F>(items: &[T], mut encode: F) -> B256
 where
     F: FnMut(&T, &mut Vec<u8>),
 {
+    if items.is_empty() {
+        return alloy_trie::EMPTY_ROOT_HASH;
+    }
+
     let mut value_buffer = Vec::new();
 
     let mut hb = HashBuilder::default();


### PR DESCRIPTION
Smol fast path for empty input when calculating any root