### PR TITLE
fix(trie): witness empty root node

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -2,7 +2,7 @@
 
 use crate::{Nibbles, TrieAccount};
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
-use alloy_rlp::{encode_fixed_size, Decodable};
+use alloy_rlp::{encode_fixed_size, Decodable, EMPTY_STRING_CODE};
 use alloy_trie::{
     nodes::TrieNode,
     proof::{verify_proof, ProofNodes, ProofVerificationError},
@@ -86,13 +86,18 @@ pub struct StorageMultiProof {
     pub subtree: ProofNodes,
 }
 
-impl Default for StorageMultiProof {
-    fn default() -> Self {
-        Self { root: EMPTY_ROOT_HASH, subtree: Default::default() }
-    }
-}
-
 impl StorageMultiProof {
+    /// Create new storage multiproof for empty trie.
+    pub fn empty() -> Self {
+        Self {
+            root: EMPTY_ROOT_HASH,
+            subtree: ProofNodes::from_iter([(
+                Nibbles::default(),
+                Bytes::from([EMPTY_STRING_CODE]),
+            )]),
+        }
+    }
+
     /// Return storage proofs for the target storage slot (unhashed).
     pub fn storage_proof(&self, slot: B256) -> Result<StorageProof, alloy_rlp::Error> {
         let nibbles = Nibbles::unpack(keccak256(slot));
@@ -207,6 +212,12 @@ impl StorageProof {
     /// Create new storage proof from the storage slot and its pre-hashed image.
     pub fn new_with_nibbles(key: B256, nibbles: Nibbles) -> Self {
         Self { key, nibbles, ..Default::default() }
+    }
+
+    /// Set proof nodes on storage proof.
+    pub fn with_proof(mut self, proof: Vec<Bytes>) -> Self {
+        self.proof = proof;
+        self
     }
 
     /// Verify the proof against the provided storage root.

--- a/crates/trie/db/tests/proof.rs
+++ b/crates/trie/db/tests/proof.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_rlp::EMPTY_STRING_CODE;
 use reth_chainspec::{Chain, ChainSpec, HOLESKY, MAINNET};
 use reth_primitives::{constants::EMPTY_ROOT_HASH, Account};
 use reth_provider::test_utils::{create_test_provider_factory, insert_genesis};
@@ -111,7 +112,10 @@ fn testspec_empty_storage_proof() {
     assert_eq!(slots.len(), account_proof.storage_proofs.len());
     for (idx, slot) in slots.into_iter().enumerate() {
         let proof = account_proof.storage_proofs.get(idx).unwrap();
-        assert_eq!(proof, &StorageProof::new(slot));
+        assert_eq!(
+            proof,
+            &StorageProof::new(slot).with_proof(vec![Bytes::from([EMPTY_STRING_CODE])])
+        );
         assert_eq!(proof.verify(account_proof.storage_root), Ok(()));
     }
     assert_eq!(account_proof.verify(root), Ok(()));

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -1,0 +1,57 @@
+#![allow(missing_docs)]
+
+use alloy_primitives::{
+    keccak256,
+    map::{HashMap, HashSet},
+    Address, Bytes, B256, U256,
+};
+use alloy_rlp::EMPTY_STRING_CODE;
+use reth_primitives::{constants::EMPTY_ROOT_HASH, Account};
+use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
+use reth_trie::{proof::Proof, witness::TrieWitness, HashedPostState, HashedStorage, StateRoot};
+use reth_trie_db::{DatabaseProof, DatabaseStateRoot, DatabaseTrieWitness};
+
+#[test]
+fn includes_empty_node_preimage() {
+    let factory = create_test_provider_factory();
+    let provider = factory.provider_rw().unwrap();
+
+    let address = Address::random();
+    let hashed_address = keccak256(address);
+    let hashed_slot = B256::random();
+
+    // witness includes empty state trie root node
+    assert_eq!(
+        TrieWitness::from_tx(provider.tx_ref())
+            .compute(HashedPostState {
+                accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
+                storages: HashMap::default(),
+            })
+            .unwrap(),
+        HashMap::from_iter([(EMPTY_ROOT_HASH, Bytes::from([EMPTY_STRING_CODE]))])
+    );
+
+    // Insert account into database
+    provider.insert_account_for_hashing([(address, Some(Account::default()))]).unwrap();
+
+    let state_root = StateRoot::from_tx(provider.tx_ref()).root().unwrap();
+    let multiproof = Proof::from_tx(provider.tx_ref())
+        .multiproof(HashMap::from_iter([(hashed_address, HashSet::from_iter([hashed_slot]))]))
+        .unwrap();
+
+    let witness = TrieWitness::from_tx(provider.tx_ref())
+        .compute(HashedPostState {
+            accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::from([(
+                hashed_address,
+                HashedStorage::from_iter(false, [(hashed_slot, U256::from(1))]),
+            )]),
+        })
+        .unwrap();
+    assert!(witness.contains_key(&state_root));
+    for node in multiproof.account_subtree.values() {
+        assert_eq!(witness.get(&keccak256(node)), Some(node));
+    }
+    // witness includes empty state trie root node
+    assert_eq!(witness.get(&EMPTY_ROOT_HASH), Some(&Bytes::from([EMPTY_STRING_CODE])));
+}

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -192,7 +192,7 @@ where
 
         // short circuit on empty storage
         if hashed_storage_cursor.is_storage_empty()? {
-            return Ok(StorageMultiProof::default())
+            return Ok(StorageMultiProof::empty())
         }
 
         let target_nibbles = targets.into_iter().map(Nibbles::unpack).collect::<Vec<_>>();


### PR DESCRIPTION
## Description

Add test for empty root nodes included in the witness.
~~Blocked by next `alloy-trie` release with https://github.com/alloy-rs/trie/pull/36.~~