### PR TITLE
feat: extend pool configuration

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -440,6 +440,16 @@ TxPool:
 
           [default: 10]
 
+      --txpool.minimal-protocol-fee <MINIMAL_PROTOCOL_BASEFEE>
+          Minimum base fee required by the protocol
+
+          [default: 7]
+
+      --txpool.block-gas-limit <BLOCK_GAS_LIMIT>
+          The max gas limit of the block
+
+          [default: 30000000]
+
       --blobpool.pricebump <BLOB_TRANSACTION_PRICE_BUMP>
           Price bump percentage to replace an already existing blob transaction
 

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -445,8 +445,8 @@ TxPool:
 
           [default: 7]
 
-      --txpool.block-gas-limit <BLOCK_GAS_LIMIT>
-          The max gas limit of the block
+      --txpool.gas-limit <GAS_LIMIT>
+          The default enforced gas limit for transactions entering the pool
 
           [default: 30000000]
 

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -3,6 +3,7 @@
 use crate::cli::config::RethTransactionPoolConfig;
 use alloy_primitives::Address;
 use clap::Args;
+use reth_primitives::constants::{ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE};
 use reth_transaction_pool::{
     blobstore::disk::DEFAULT_MAX_CACHED_BLOBS,
     pool::{NEW_TX_LISTENER_BUFFER_SIZE, PENDING_TX_LISTENER_BUFFER_SIZE},
@@ -44,6 +45,14 @@ pub struct TxPoolArgs {
     /// Price bump (in %) for the transaction pool underpriced check.
     #[arg(long = "txpool.pricebump", default_value_t = DEFAULT_PRICE_BUMP)]
     pub price_bump: u128,
+
+    /// Minimum base fee required by the protocol.
+    #[arg(long = "txpool.minimal-protocol-fee", default_value_t = MIN_PROTOCOL_BASE_FEE)]
+    pub minimal_protocol_basefee: u64,
+
+    /// The max gas limit of the block
+    #[arg(long = "txpool.block-gas-limit", default_value_t = ETHEREUM_BLOCK_GAS_LIMIT)]
+    pub block_gas_limit: u64,
 
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
@@ -90,6 +99,8 @@ impl Default for TxPoolArgs {
             queued_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,
+            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
             max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             max_cached_entries: DEFAULT_MAX_CACHED_BLOBS,
@@ -133,6 +144,8 @@ impl RethTransactionPoolConfig for TxPoolArgs {
                 default_price_bump: self.price_bump,
                 replace_blob_tx_price_bump: self.blob_transaction_price_bump,
             },
+            minimal_protocol_basefee: self.minimal_protocol_basefee,
+            block_gas_limit: self.block_gas_limit,
             pending_tx_listener_buffer_size: self.pending_tx_listener_buffer_size,
             new_tx_listener_buffer_size: self.new_tx_listener_buffer_size,
         }

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -50,9 +50,9 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.minimal-protocol-fee", default_value_t = MIN_PROTOCOL_BASE_FEE)]
     pub minimal_protocol_basefee: u64,
 
-    /// The max gas limit of the block
-    #[arg(long = "txpool.block-gas-limit", default_value_t = ETHEREUM_BLOCK_GAS_LIMIT)]
-    pub block_gas_limit: u64,
+    /// The default enforced gas limit for transactions entering the pool
+    #[arg(long = "txpool.gas-limit", default_value_t = ETHEREUM_BLOCK_GAS_LIMIT)]
+    pub gas_limit: u64,
 
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
@@ -100,7 +100,7 @@ impl Default for TxPoolArgs {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
-            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
             max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             max_cached_entries: DEFAULT_MAX_CACHED_BLOBS,
@@ -145,7 +145,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
                 replace_blob_tx_price_bump: self.blob_transaction_price_bump,
             },
             minimal_protocol_basefee: self.minimal_protocol_basefee,
-            block_gas_limit: self.block_gas_limit,
+            gas_limit: self.gas_limit,
             pending_tx_listener_buffer_size: self.pending_tx_listener_buffer_size,
             new_tx_listener_buffer_size: self.new_tx_listener_buffer_size,
         }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -3,7 +3,10 @@ use crate::{
     PoolSize, TransactionOrigin,
 };
 use alloy_primitives::Address;
-use reth_primitives::EIP4844_TX_TYPE_ID;
+use reth_primitives::{
+    constants::{ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE},
+    EIP4844_TX_TYPE_ID,
+};
 use std::collections::HashSet;
 /// Guarantees max transactions for one sender, compatible with geth/erigon
 pub const TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;
@@ -40,8 +43,12 @@ pub struct PoolConfig {
     pub max_account_slots: usize,
     /// Price bump (in %) for the transaction pool underpriced check.
     pub price_bumps: PriceBumpConfig,
+    /// Minimum base fee required by the protocol.
+    pub minimal_protocol_basefee: u64,
+    /// The max gas limit of the block
+    pub block_gas_limit: u64,
     /// How to handle locally received transactions:
-    /// [`TransactionOrigin::Local`](crate::TransactionOrigin).
+    /// [`TransactionOrigin::Local`](TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
     /// Bound on number of pending transactions from `reth_network::TransactionsManager` to buffer.
     pub pending_tx_listener_buffer_size: usize,
@@ -50,7 +57,7 @@ pub struct PoolConfig {
 }
 
 impl PoolConfig {
-    /// Returns whether or not the size and amount constraints in any sub-pools are exceeded.
+    /// Returns whether the size and amount constraints in any sub-pools are exceeded.
     #[inline]
     pub const fn is_exceeded(&self, pool_size: PoolSize) -> bool {
         self.blob_limit.is_exceeded(pool_size.blob, pool_size.blob_size) ||
@@ -69,6 +76,8 @@ impl Default for PoolConfig {
             blob_limit: Default::default(),
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
+            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             local_transactions_config: Default::default(),
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,
@@ -138,7 +147,7 @@ impl Default for PriceBumpConfig {
 }
 
 /// Configuration options for the locally received transactions:
-/// [`TransactionOrigin::Local`](crate::TransactionOrigin)
+/// [`TransactionOrigin::Local`](TransactionOrigin)
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LocalTransactionConfig {
     /// Apply no exemptions to the locally received transactions.

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -45,8 +45,8 @@ pub struct PoolConfig {
     pub price_bumps: PriceBumpConfig,
     /// Minimum base fee required by the protocol.
     pub minimal_protocol_basefee: u64,
-    /// The max gas limit of the block
-    pub block_gas_limit: u64,
+    /// The max gas limit for transactions in the pool
+    pub gas_limit: u64,
     /// How to handle locally received transactions:
     /// [`TransactionOrigin::Local`](TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
@@ -77,7 +77,7 @@ impl Default for PoolConfig {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
-            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             local_transactions_config: Default::default(),
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -949,7 +949,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             price_bumps: config.price_bumps,
             local_transactions_config: config.local_transactions_config.clone(),
             minimal_protocol_basefee: config.minimal_protocol_basefee,
-            block_gas_limit: config.block_gas_limit,
+            block_gas_limit: config.gas_limit,
             ..Default::default()
         }
     }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -948,6 +948,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
             max_account_slots: config.max_account_slots,
             price_bumps: config.price_bumps,
             local_transactions_config: config.local_transactions_config.clone(),
+            minimal_protocol_basefee: config.minimal_protocol_basefee,
+            block_gas_limit: config.block_gas_limit,
             ..Default::default()
         }
     }


### PR DESCRIPTION
Adds a configurable minimal base fee and block gas limit for the pool, which up to now defaulted to `MIN_PROTOCOL_BASE_FEE` and `ETHEREUM_BLOCK_GAS_LIMIT`.