### PR TITLE
chore: make error msg conform to normal usage

### DIFF
--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -314,7 +314,7 @@ enum SenderRecoveryStageError {
     FailedRecovery(#[from] FailedSenderRecoveryError),
 
     /// Number of recovered senders does not match
-    #[error("failed to recover all senders from the batch: {_0}")]
+    #[error("mismatched sender count during recovery: {_0}")]
     RecoveredSendersMismatch(GotExpected<u64>),
 
     /// A different type of stage error occurred


### PR DESCRIPTION
Was reading: https://github.com/paradigmxyz/reth/issues/10835 and preceding PR to attempt it and saw that generally `GotExpected` messages have the format of using a message of the form: `*mismatch*` so conforming to that format on this one as well