### PR TITLE
chore(sdk): replace `NodePrimitives` trait with `alloy_network::Network`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7919,6 +7919,7 @@ dependencies = [
 name = "reth-node-types"
 version = "1.0.7"
 dependencies = [
+ "alloy-network",
  "reth-chainspec",
  "reth-db-api",
  "reth-engine-primitives",

--- a/crates/node/types/Cargo.toml
+++ b/crates/node/types/Cargo.toml
@@ -15,3 +15,6 @@ workspace = true
 reth-chainspec.workspace = true
 reth-db-api.workspace = true
 reth-engine-primitives.workspace = true
+
+# ethereum
+alloy-network.workspace = true

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -10,19 +10,13 @@
 
 use std::marker::PhantomData;
 
+use alloy_network::Network;
 use reth_chainspec::EthChainSpec;
 use reth_db_api::{
     database_metrics::{DatabaseMetadata, DatabaseMetrics},
     Database,
 };
 use reth_engine_primitives::EngineTypes;
-
-/// Configures all the primitive types of the node.
-// TODO(mattsse): this is currently a placeholder
-pub trait NodePrimitives {}
-
-// TODO(mattsse): Placeholder
-impl NodePrimitives for () {}
 
 /// The type that configures the essential types of an Ethereum-like node.
 ///
@@ -31,7 +25,7 @@ impl NodePrimitives for () {}
 /// This trait is intended to be stateless and only define the types of the node.
 pub trait NodeTypes: Send + Sync + Unpin + 'static {
     /// The node's primitive types, defining basic operations and structures.
-    type Primitives: NodePrimitives;
+    type Primitives: Network;
     /// The type used for configuration of the EVM.
     type ChainSpec: EthChainSpec;
 }
@@ -120,7 +114,7 @@ impl<P, C> AnyNodeTypes<P, C> {
 
 impl<P, C> NodeTypes for AnyNodeTypes<P, C>
 where
-    P: NodePrimitives + Send + Sync + Unpin + 'static,
+    P: Network + Send + Sync + Unpin + 'static,
     C: EthChainSpec,
 {
     type Primitives = P;
@@ -155,7 +149,7 @@ impl<P, E, C> AnyNodeTypesWithEngine<P, E, C> {
 
 impl<P, E, C> NodeTypes for AnyNodeTypesWithEngine<P, E, C>
 where
-    P: NodePrimitives + Send + Sync + Unpin + 'static,
+    P: Network + Send + Sync + Unpin + 'static,
     E: EngineTypes + Send + Sync + Unpin,
     C: EthChainSpec,
 {
@@ -165,7 +159,7 @@ where
 
 impl<P, E, C> NodeTypesWithEngine for AnyNodeTypesWithEngine<P, E, C>
 where
-    P: NodePrimitives + Send + Sync + Unpin + 'static,
+    P: Network + Send + Sync + Unpin + 'static,
     E: EngineTypes + Send + Sync + Unpin,
     C: EthChainSpec,
 {


### PR DESCRIPTION
Replaces `NodePrimitives` trait with `alloy_network::Network`