### PR TITLE
fix(lint): lint for derive `Compat`

### DIFF
--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -60,6 +60,7 @@ pub fn generate_from_to(
             }
 
             #[test]
+            #[allow(missing_docs)]
             pub fn #test() {
                 #fuzz(#ident::default())
             }

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -287,6 +287,7 @@ mod tests {
                 assert_eq!(obj, same_obj);
             }
             #[test]
+            #[allow(missing_docs)]
             pub fn fuzz_test_struct() {
                 fuzz_test_test_struct(TestStruct::default())
             }


### PR DESCRIPTION
Fixes lint for derive `Compat`