### PR TITLE
fix(lint): lint warnings in `reth-eth-wire`

### DIFF
--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -1,5 +1,7 @@
 //! Utilities for testing p2p protocol.
 
+#![allow(missing_docs)]
+
 use crate::{
     hello::DEFAULT_TCP_PORT, EthVersion, HelloMessageWithProtocols, P2PStream, ProtocolVersion,
     Status, UnauthedP2PStream,

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -46,6 +46,7 @@ macro_rules! fuzz_type_and_name {
 }
 
 #[cfg(test)]
+#[allow(missing_docs)]
 pub mod fuzz_rlp {
     use crate::roundtrip_encoding;
     use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};


### PR DESCRIPTION
Fixes lint warnings in `reth-eth-wire`