### PR TITLE
fix: an empty static file should be kept unless its related blocks are all unwound

### DIFF
--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -387,7 +387,7 @@ impl StaticFileProviderRW {
                 }
             };
 
-            if remaining_rows >= len {
+            if remaining_rows > len {
                 // If there's more rows to delete than this static file contains, then just
                 // delete the whole file and go to the next static file
                 let block_start = self.writer.user_header().expected_block_start();


### PR DESCRIPTION
In the scenario where we have a static file `static_file_receipts_500000_999999`, block `500000` contains no transaction receipts, while block  `500001` has one transaction. When we trigger an unwind to block `500000`, the static file is deleted even though the range of blocks has not been fully pruned yet.

When attempting to restart or unwind further, encounter the following error:

> Error: nippy jar error: failed to open file "./datadir/static_files/static_file_receipts_500000_999999.conf": No such file or directory (os error 2)

 This fix allows a static file to exist even if it contains no transactions.
