### PR TITLE
Update function visibility for `cfg_and_block_env()`

### DIFF
--- a/crates/optimism/node/src/lib.rs
+++ b/crates/optimism/node/src/lib.rs
@@ -23,8 +23,7 @@ pub use node::OptimismNode;
 pub mod txpool;
 
 pub use reth_optimism_payload_builder::{
-    OptimismBlockAttributes, OptimismBuiltPayload, OptimismPayloadBuilder,
-    OptimismPayloadBuilderAttributes,
+    OptimismBuiltPayload, OptimismPayloadBuilder, OptimismPayloadBuilderAttributes,
 };
 
 pub use reth_evm_optimism::*;

--- a/crates/optimism/node/src/lib.rs
+++ b/crates/optimism/node/src/lib.rs
@@ -23,7 +23,8 @@ pub use node::OptimismNode;
 pub mod txpool;
 
 pub use reth_optimism_payload_builder::{
-    OptimismBuiltPayload, OptimismPayloadBuilder, OptimismPayloadBuilderAttributes,
+    OptimismBlockAttributes, OptimismBuiltPayload, OptimismPayloadBuilder,
+    OptimismPayloadBuilderAttributes,
 };
 
 pub use reth_evm_optimism::*;

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -413,7 +413,7 @@ where
 
     /// Returns the configured [`CfgEnvWithHandlerCfg`] and [`BlockEnv`] for the targeted payload
     /// (that has the `parent` as its parent).
-    fn cfg_and_block_env(
+    pub fn cfg_and_block_env(
         &self,
         config: &PayloadConfig<OptimismPayloadBuilderAttributes>,
     ) -> (CfgEnvWithHandlerCfg, BlockEnv) {

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg(feature = "optimism")]
 
 pub mod builder;
-pub use builder::OptimismPayloadBuilder;
+pub use builder::{OptimismBlockAttributes, OptimismPayloadBuilder};
 pub mod error;
 pub mod payload;
 

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -17,5 +17,6 @@ pub mod error;
 pub mod payload;
 
 pub use payload::{
-    OptimismBuiltPayload, OptimismPayloadAttributes, OptimismPayloadBuilderAttributes,
+    OptimismBlockAttributes, OptimismBuiltPayload, OptimismPayloadAttributes,
+    OptimismPayloadBuilderAttributes,
 };

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -17,6 +17,5 @@ pub mod error;
 pub mod payload;
 
 pub use payload::{
-    OptimismBlockAttributes, OptimismBuiltPayload, OptimismPayloadAttributes,
-    OptimismPayloadBuilderAttributes,
+    OptimismBuiltPayload, OptimismPayloadAttributes, OptimismPayloadBuilderAttributes,
 };


### PR DESCRIPTION
This PR updates the function visibility for `cfg_and_block_env()` so that it can be used by custom OP Stack payload builders. This PR also re-exports `OptimismBlockAttributes`, similar to other optimism payload builder types.