### PR TITLE
fix: update pool gas limit

### DIFF
--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -48,7 +48,7 @@ fn custom_chain() -> Arc<ChainSpec> {
     "nonce": "0x42",
     "timestamp": "0x0",
     "extraData": "0x5343",
-    "gasLimit": "0x1388",
+    "gasLimit": "0x13880",
     "difficulty": "0x400000000",
     "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "coinbase": "0x0000000000000000000000000000000000000000",

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -505,6 +505,14 @@ where
         self.pool.get_transactions_by_origin(origin)
     }
 
+    /// Returns all pending transactions filtered by [`TransactionOrigin`]
+    fn get_pending_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.get_pending_transactions_by_origin(origin)
+    }
+
     fn unique_senders(&self) -> HashSet<Address> {
         self.pool.unique_senders()
     }
@@ -532,14 +540,6 @@ where
         versioned_hashes: &[B256],
     ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
         self.pool.blob_store().get_by_versioned_hashes(versioned_hashes)
-    }
-
-    /// Returns all pending transactions filtered by [`TransactionOrigin`]
-    fn get_pending_transactions_by_origin(
-        &self,
-        origin: TransactionOrigin,
-    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        self.pool.get_pending_transactions_by_origin(origin)
     }
 }
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -117,6 +117,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
         let latest = latest.seal_slow();
         let chain_spec = client.chain_spec();
         let info = BlockInfo {
+            block_gas_limit: latest.gas_limit,
             last_seen_block_hash: latest.hash(),
             last_seen_block_number: latest.number,
             pending_basefee: latest
@@ -403,6 +404,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                     maintained_state = MaintainedPoolState::Drifted;
                     debug!(target: "txpool", ?depth, "skipping deep canonical update");
                     let info = BlockInfo {
+                        block_gas_limit: tip.gas_limit,
                         last_seen_block_hash: tip.hash(),
                         last_seen_block_number: tip.number,
                         pending_basefee: pending_block_base_fee,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -40,6 +40,7 @@ impl TransactionPool for NoopTransactionPool {
 
     fn block_info(&self) -> BlockInfo {
         BlockInfo {
+            block_gas_limit: 0,
             last_seen_block_hash: Default::default(),
             last_seen_block_number: 0,
             pending_basefee: 0,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -19,7 +19,7 @@ use crate::{
 use alloy_eips::eip4844::BlobAndProofV1;
 use alloy_primitives::{Address, TxHash, B256, U256};
 use reth_eth_wire_types::HandleMempoolData;
-use reth_primitives::BlobTransactionSidecar;
+use reth_primitives::{constants::ETHEREUM_BLOCK_GAS_LIMIT, BlobTransactionSidecar};
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 use tokio::sync::{mpsc, mpsc::Receiver};
 
@@ -40,7 +40,7 @@ impl TransactionPool for NoopTransactionPool {
 
     fn block_info(&self) -> BlockInfo {
         BlockInfo {
-            block_gas_limit: 0,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             last_seen_block_hash: Default::default(),
             last_seen_block_number: 0,
             pending_basefee: 0,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -132,6 +132,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// Returns the currently tracked block values
     pub const fn block_info(&self) -> BlockInfo {
         BlockInfo {
+            block_gas_limit: self.all_transactions.block_gas_limit,
             last_seen_block_hash: self.all_transactions.last_seen_block_hash,
             last_seen_block_number: self.all_transactions.last_seen_block_number,
             pending_basefee: self.all_transactions.pending_fees.base_fee,
@@ -236,6 +237,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// This will also apply updates to the pool based on the new base fee
     pub fn set_block_info(&mut self, info: BlockInfo) {
         let BlockInfo {
+            block_gas_limit,
             last_seen_block_hash,
             last_seen_block_number,
             pending_basefee,
@@ -244,6 +246,8 @@ impl<T: TransactionOrdering> TxPool<T> {
         self.all_transactions.last_seen_block_hash = last_seen_block_hash;
         self.all_transactions.last_seen_block_number = last_seen_block_number;
         let basefee_ordering = self.update_basefee(pending_basefee);
+
+        self.all_transactions.block_gas_limit = block_gas_limit;
 
         if let Some(blob_fee) = pending_blob_fee {
             self.update_blob_fee(blob_fee, basefee_ordering)
@@ -1001,6 +1005,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
     /// Updates the block specific info
     fn set_block_info(&mut self, block_info: BlockInfo) {
         let BlockInfo {
+            block_gas_limit,
             last_seen_block_hash,
             last_seen_block_number,
             pending_basefee,
@@ -1011,6 +1016,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
         self.pending_fees.base_fee = pending_basefee;
         self.metrics.base_fee.set(pending_basefee as f64);
+
+        self.block_gas_limit = block_gas_limit;
 
         if let Some(pending_blob_fee) = pending_blob_fee {
             self.pending_fees.blob_fee = pending_blob_fee;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1302,7 +1302,7 @@ impl PoolSize {
 pub struct BlockInfo {
     /// Hash for the currently tracked block.
     pub last_seen_block_hash: B256,
-    /// Current the currently tracked block.
+    /// Currently tracked block.
     pub last_seen_block_number: u64,
     /// Currently enforced base fee: the threshold for the basefee sub-pool.
     ///

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -666,6 +666,7 @@ impl<'a> CanonicalStateUpdate<'a> {
     /// Returns the block info for the tip block.
     pub fn block_info(&self) -> BlockInfo {
         BlockInfo {
+            block_gas_limit: self.new_tip.gas_limit,
             last_seen_block_hash: self.hash(),
             last_seen_block_number: self.number(),
             pending_basefee: self.pending_block_base_fee,
@@ -1304,6 +1305,8 @@ pub struct BlockInfo {
     pub last_seen_block_hash: B256,
     /// Currently tracked block.
     pub last_seen_block_number: u64,
+    /// Current block gas limit for the latest block.
+    pub block_gas_limit: u64,
     /// Currently enforced base fee: the threshold for the basefee sub-pool.
     ///
     /// Note: this is the derived base fee of the _next_ block that builds on the block the pool is

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, B256};
 use rand::distributions::Uniform;
-use reth_primitives::constants::MIN_PROTOCOL_BASE_FEE;
+use reth_primitives::constants::{ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE};
 use reth_transaction_pool::{
     error::PoolErrorKind,
     test_utils::{
@@ -27,6 +27,7 @@ async fn only_blobs_eviction() {
 
     let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
     let block_info = BlockInfo {
+        block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
         last_seen_block_hash: B256::ZERO,
         last_seen_block_number: 0,
         pending_basefee: 10,
@@ -139,6 +140,7 @@ async fn mixed_eviction() {
 
     let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
     let block_info = BlockInfo {
+        block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
         last_seen_block_hash: B256::ZERO,
         last_seen_block_number: 0,
         pending_basefee: 10,
@@ -240,6 +242,7 @@ async fn nonce_gaps_eviction() {
 
     let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
     let block_info = BlockInfo {
+        block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
         last_seen_block_hash: B256::ZERO,
         last_seen_block_number: 0,
         pending_basefee: 10,


### PR DESCRIPTION
Updates the pool gas limit in the call to `on_canonical_update` for `AllTransactions`. Also slightly reorders trait implementation in order to match the order of the trait and fixes a small typo.

Resolves #10987 