### PR TITLE
reth-stages: remove duplicate buf clear

### DIFF
--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -191,8 +191,6 @@ where
             rayon::spawn(move || {
                 let mut rlp_buf = Vec::with_capacity(128);
                 for (number, tx) in chunk {
-                    rlp_buf.clear();
-
                     let res = tx
                         .value()
                         .map_err(|err| Box::new(SenderRecoveryStageError::StageError(err.into())))


### PR DESCRIPTION
This place has clear. https://github.com/paradigmxyz/reth/blob/ddb79ef08b1a335ac1b4d18a363bf43d6eb23cb2/crates/primitives/src/transaction/mod.rs#L881-L882. Maybe we can remove the outside clear.