### PR TITLE
feat: make `NodeConfig` generic over `ChainSpec`

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -133,7 +133,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
     /// ````
     pub fn run<L, Fut>(mut self, launcher: L) -> eyre::Result<()>
     where
-        L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>>>, Ext) -> Fut,
+        L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
         // add network name to logs dir

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,6 +1,7 @@
-use crate::ChainSpec;
+use crate::{ChainSpec, DepositContract};
 use alloy_chains::Chain;
 use alloy_eips::eip1559::BaseFeeParams;
+use alloy_primitives::B256;
 use core::fmt::Debug;
 
 /// Trait representing type configuring a chain spec.
@@ -14,6 +15,15 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {
 
     /// Get the [`BaseFeeParams`] for the chain at the given timestamp.
     fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams;
+
+    /// Returns the deposit contract data for the chain, if it's present
+    fn deposit_contract(&self) -> Option<&DepositContract>;
+
+    /// The genesis hash.
+    fn genesis_hash(&self) -> B256;
+
+    /// The delete limit for pruner, per run.
+    fn prune_delete_limit(&self) -> usize;
 }
 
 impl EthChainSpec for ChainSpec {
@@ -23,5 +33,17 @@ impl EthChainSpec for ChainSpec {
 
     fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams {
         self.base_fee_params_at_timestamp(timestamp)
+    }
+
+    fn deposit_contract(&self) -> Option<&DepositContract> {
+        self.deposit_contract.as_ref()
+    }
+
+    fn genesis_hash(&self) -> B256 {
+        self.genesis_hash()
+    }
+
+    fn prune_delete_limit(&self) -> usize {
+        self.prune_delete_limit
     }
 }

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -135,7 +135,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> No
     /// closure.
     pub async fn execute<L, Fut>(self, ctx: CliContext, launcher: L) -> eyre::Result<()>
     where
-        L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>>>, Ext) -> Fut,
+        L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
         tracing::info!(target: "reth::cli", version = ?version::SHORT_VERSION, "Starting reth");

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -281,7 +281,7 @@ pub struct EthereumNetworkBuilder {
 
 impl<Node, Pool> NetworkBuilder<Node, Pool> for EthereumNetworkBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec>>,
     Pool: TransactionPool + Unpin + 'static,
 {
     async fn build_network(

--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use reth_node_api::{FullNodeComponents, NodeTypesWithEngine};
+use reth_node_api::{FullNodeComponents, NodeTypes, NodeTypesWithEngine};
 use reth_node_core::node_config::NodeConfig;
 use reth_primitives::Head;
 use reth_tasks::TaskExecutor;
@@ -13,7 +13,7 @@ pub struct ExExContext<Node: FullNodeComponents> {
     /// The current head of the blockchain at launch.
     pub head: Head,
     /// The config of the node
-    pub config: NodeConfig,
+    pub config: NodeConfig<<Node::Types as NodeTypes>::ChainSpec>,
     /// The loaded node config
     pub reth_config: reth_config::Config,
     /// Channel used to send [`ExExEvent`]s to the rest of the node.

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -9,7 +9,7 @@ use std::{fmt, future::Future, marker::PhantomData};
 
 use reth_exex::ExExContext;
 use reth_node_api::{
-    FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypesWithDB, NodeTypesWithEngine,
+    FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes, NodeTypesWithDB, NodeTypesWithEngine,
 };
 use reth_node_core::{
     node_config::NodeConfig,
@@ -29,14 +29,17 @@ use crate::{
 /// A node builder that also has the configured types.
 pub struct NodeBuilderWithTypes<T: FullNodeTypes> {
     /// All settings for how the node should be configured.
-    config: NodeConfig,
+    config: NodeConfig<<T::Types as NodeTypes>::ChainSpec>,
     /// The configured database for the node.
     adapter: NodeTypesAdapter<T>,
 }
 
 impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
     /// Creates a new instance of the node builder with the given configuration and types.
-    pub const fn new(config: NodeConfig, database: <T::Types as NodeTypesWithDB>::DB) -> Self {
+    pub const fn new(
+        config: NodeConfig<<T::Types as NodeTypes>::ChainSpec>,
+        database: <T::Types as NodeTypesWithDB>::DB,
+    ) -> Self {
         Self { config, adapter: NodeTypesAdapter::new(database) }
     }
 
@@ -149,7 +152,7 @@ pub struct NodeBuilderWithComponents<
     AO: NodeAddOns<NodeAdapter<T, CB::Components>>,
 > {
     /// All settings for how the node should be configured.
-    pub config: NodeConfig,
+    pub config: NodeConfig<<T::Types as NodeTypes>::ChainSpec>,
     /// Adapter for the underlying node types and database
     pub adapter: NodeTypesAdapter<T>,
     /// container for type specific components

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -42,6 +42,7 @@ use tokio::sync::{mpsc::unbounded_channel, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::{
+    common::{Attached, LaunchContextWith, WithConfigs},
     hooks::NodeHooks,
     rpc::{launch_rpc_servers, EthApiBuilderProvider},
     setup::build_networked_pipeline,
@@ -132,7 +133,7 @@ where
                 debug!(target: "reth::cli", chain=%this.chain_id(), genesis=?this.genesis_hash(), "Initializing genesis");
             })
             .with_genesis()?
-            .inspect(|this| {
+            .inspect(|this: &LaunchContextWith<Attached<WithConfigs<ChainSpec>, _>>| {
                 info!(target: "reth::cli", "\n{}", this.chain_spec().display_hardforks());
             })
             .with_metrics_task()

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -4,7 +4,7 @@ use std::{fmt, fmt::Debug};
 
 use futures::future;
 use reth_exex::{ExExContext, ExExHandle, ExExManager, ExExManagerHandle};
-use reth_node_api::FullNodeComponents;
+use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives::Head;
 use reth_provider::CanonStateSubscriptions;
 use reth_tracing::tracing::{debug, info};
@@ -17,7 +17,7 @@ pub struct ExExLauncher<Node: FullNodeComponents> {
     head: Head,
     extensions: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
     components: Node,
-    config_container: WithConfigs,
+    config_container: WithConfigs<<Node::Types as NodeTypes>::ChainSpec>,
 }
 
 impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
@@ -26,7 +26,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
         head: Head,
         components: Node,
         extensions: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
-        config_container: WithConfigs,
+        config_container: WithConfigs<<Node::Types as NodeTypes>::ChainSpec>,
     ) -> Self {
         Self { head, extensions, components, config_container }
     }

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -6,6 +6,7 @@ mod exex;
 pub(crate) mod engine;
 
 pub use common::LaunchContext;
+use common::{Attached, LaunchContextWith, WithConfigs};
 pub use exex::ExExLauncher;
 
 use std::{future::Future, sync::Arc};
@@ -170,7 +171,7 @@ where
                 debug!(target: "reth::cli", chain=%this.chain_id(), genesis=?this.genesis_hash(), "Initializing genesis");
             })
             .with_genesis()?
-            .inspect(|this| {
+            .inspect(|this: &LaunchContextWith<Attached<WithConfigs<ChainSpec>, _>>| {
                 info!(target: "reth::cli", "\n{}", this.chain_spec().display_hardforks());
             })
             .with_metrics_task()

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -110,7 +110,7 @@ pub struct FullNode<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     /// The configured rpc namespaces
     pub rpc_registry: RpcRegistry<Node, AddOns::EthApi>,
     /// The initial node config.
-    pub config: NodeConfig,
+    pub config: NodeConfig<<Node::Types as NodeTypes>::ChainSpec>,
     /// The data dir of the node.
     pub data_dir: ChainPath<DataDirPath>,
 }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -7,7 +7,9 @@ use std::{
 
 use futures::TryFutureExt;
 use reth_chainspec::ChainSpec;
-use reth_node_api::{BuilderProvider, FullNodeComponents, NodeTypesWithDB, NodeTypesWithEngine};
+use reth_node_api::{
+    BuilderProvider, FullNodeComponents, NodeTypes, NodeTypesWithDB, NodeTypesWithEngine,
+};
 use reth_node_core::{
     node_config::NodeConfig,
     rpc::{
@@ -237,7 +239,7 @@ pub struct RpcContext<'a, Node: FullNodeComponents, EthApi: EthApiTypes> {
     pub(crate) node: Node,
 
     /// Gives access to the node configuration.
-    pub(crate) config: &'a NodeConfig,
+    pub(crate) config: &'a NodeConfig<<Node::Types as NodeTypes>::ChainSpec>,
 
     /// A Helper type the holds instances of the configured modules.
     ///
@@ -260,7 +262,7 @@ where
     EthApi: EthApiTypes,
 {
     /// Returns the config of the node.
-    pub const fn config(&self) -> &NodeConfig {
+    pub const fn config(&self) -> &NodeConfig<<Node::Types as NodeTypes>::ChainSpec> {
         self.config
     }
 
@@ -296,7 +298,7 @@ where
 pub async fn launch_rpc_servers<Node, Engine, EthApi>(
     node: Node,
     engine_api: Engine,
-    config: &NodeConfig,
+    config: &NodeConfig<ChainSpec>,
     jwt_secret: JwtSecret,
     add_ons: RpcAddOns<Node, EthApi>,
 ) -> eyre::Result<(RethRpcServerHandles, RpcRegistry<Node, EthApi>)>

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -3,7 +3,7 @@
 use crate::args::error::ReceiptsLogError;
 use alloy_primitives::{Address, BlockNumber};
 use clap::Args;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::EthChainSpec;
 use reth_config::config::PruneConfig;
 use reth_prune_types::{PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_PRUNING_DISTANCE};
 use std::collections::BTreeMap;
@@ -92,7 +92,7 @@ pub struct PruningArgs {
 
 impl PruningArgs {
     /// Returns pruning configuration.
-    pub fn prune_config(&self, chain_spec: &ChainSpec) -> Option<PruneConfig> {
+    pub fn prune_config(&self, chain_spec: &impl EthChainSpec) -> Option<PruneConfig> {
         // Initialise with a default prune configuration.
         let mut config = PruneConfig::default();
 
@@ -106,16 +106,14 @@ impl PruningArgs {
                     // prune all receipts if chain doesn't have deposit contract specified in chain
                     // spec
                     receipts: chain_spec
-                        .deposit_contract
-                        .as_ref()
+                        .deposit_contract()
                         .map(|contract| PruneMode::Before(contract.block))
                         .or(Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE))),
                     account_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                     storage_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                     receipts_log_filter: ReceiptsLogPruneConfig(
                         chain_spec
-                            .deposit_contract
-                            .as_ref()
+                            .deposit_contract()
                             .map(|contract| (contract.address, PruneMode::Before(contract.block)))
                             .into_iter()
                             .collect(),

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -123,7 +123,7 @@ where
     /// [`NodeCommand`](reth_cli_commands::node::NodeCommand).
     pub fn run<L, Fut>(mut self, launcher: L) -> eyre::Result<()>
     where
-        L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>>>, Ext) -> Fut,
+        L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
         // add network name to logs dir


### PR DESCRIPTION
Depends on https://github.com/paradigmxyz/reth/pull/10978

Towards https://github.com/paradigmxyz/reth/issues/10909

Makes `NodeConfig` generic over chainspec, allowing us to forward custom chainspecs parsed from CLI into NodeBuilder.

For now still requires concrete `ChainSpec` in several places including RPC and networking configuration