### PR TITLE
Update `OptimismPayloadBuilder` field visibility

### DIFF
--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -41,9 +41,9 @@ use tracing::{debug, trace, warn};
 pub struct OptimismPayloadBuilder<EvmConfig> {
     /// The rollup's compute pending block configuration option.
     // TODO(clabby): Implement this feature.
-    compute_pending_block: bool,
+    pub compute_pending_block: bool,
     /// The type responsible for creating the evm.
-    evm_config: EvmConfig,
+    pub evm_config: EvmConfig,
 }
 
 impl<EvmConfig> OptimismPayloadBuilder<EvmConfig>


### PR DESCRIPTION
This PR updates the visibility of  `OptimismPayloadBuilder` fields to pub. This allows custom OP stack payload builders using the `OptimismPayloadBuilder` as an `inner` type to reference these variables.

```rust
pub struct OPStackBlockBuilder<EvmConfig> {
    inner: OptimismPayloadBuilder<EvmConfig>,
}

impl<EvmConfig> OPStackBlockBuilder<EvmConfig> {
    fn build_payload(&self) {
        // --snip--
        let config = &self.inner.evm_config;
    }
}
```