### PR TITLE
feat: add `blocks_per_file` field to `StaticFileProvider`

### DIFF
--- a/crates/cli/commands/src/db/clear.rs
+++ b/crates/cli/commands/src/db/clear.rs
@@ -7,7 +7,7 @@ use reth_db_api::{
 };
 use reth_node_builder::NodeTypesWithDB;
 use reth_provider::{ProviderFactory, StaticFileProviderFactory};
-use reth_static_file_types::{find_fixed_range, StaticFileSegment};
+use reth_static_file_types::StaticFileSegment;
 
 /// The arguments for the `reth db clear` command
 #[derive(Parser, Debug)]
@@ -32,8 +32,7 @@ impl Command {
 
                 if let Some(segment_static_files) = static_files.get(&segment) {
                     for (block_range, _) in segment_static_files {
-                        static_file_provider
-                            .delete_jar(segment, find_fixed_range(block_range.start()))?;
+                        static_file_provider.delete_jar(segment, block_range.start())?;
                     }
                 }
             }

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -12,7 +12,7 @@ use reth_fs_util as fs;
 use reth_node_builder::{NodeTypesWithDB, NodeTypesWithDBAdapter, NodeTypesWithEngine};
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::providers::StaticFileProvider;
-use reth_static_file_types::{find_fixed_range, SegmentRangeInclusive};
+use reth_static_file_types::SegmentRangeInclusive;
 use std::{sync::Arc, time::Duration};
 
 #[derive(Parser, Debug)]
@@ -191,7 +191,7 @@ impl Command {
             ) = (0, 0, 0, 0, 0, 0);
 
             for (block_range, tx_range) in &ranges {
-                let fixed_block_range = find_fixed_range(block_range.start());
+                let fixed_block_range = static_file_provider.find_fixed_range(block_range.start());
                 let jar_provider = static_file_provider
                     .get_segment_provider(segment, || Some(fixed_block_range), None)?
                     .ok_or_else(|| {

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -14,7 +14,7 @@ use reth_node_builder::NodeTypesWithEngine;
 use reth_node_core::args::StageEnum;
 use reth_provider::{writer::UnifiedStorageWriter, StaticFileProviderFactory};
 use reth_stages::StageId;
-use reth_static_file_types::{find_fixed_range, StaticFileSegment};
+use reth_static_file_types::StaticFileSegment;
 
 /// `reth drop-stage` command
 #[derive(Debug, Parser)]
@@ -54,8 +54,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                     .sorted_by_key(|(block_range, _)| block_range.start())
                     .rev()
                 {
-                    static_file_provider
-                        .delete_jar(static_file_segment, find_fixed_range(block_range.start()))?;
+                    static_file_provider.delete_jar(static_file_segment, block_range.start())?;
                 }
             }
         }

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -64,7 +64,10 @@ impl HighestStaticFiles {
 
 /// Each static file has a fixed number of blocks. This gives out the range where the requested
 /// block is positioned. Used for segment filename.
-pub const fn find_fixed_range(block: BlockNumber) -> SegmentRangeInclusive {
-    let start = (block / DEFAULT_BLOCKS_PER_STATIC_FILE) * DEFAULT_BLOCKS_PER_STATIC_FILE;
-    SegmentRangeInclusive::new(start, start + DEFAULT_BLOCKS_PER_STATIC_FILE - 1)
+pub const fn find_fixed_range(
+    block: BlockNumber,
+    blocks_per_static_file: u64,
+) -> SegmentRangeInclusive {
+    let start = (block / blocks_per_static_file) * blocks_per_static_file;
+    SegmentRangeInclusive::new(start, start + blocks_per_static_file - 1)
 }

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -16,7 +16,7 @@ pub use compression::Compression;
 pub use segment::{SegmentConfig, SegmentHeader, SegmentRangeInclusive, StaticFileSegment};
 
 /// Default static file block count.
-pub const BLOCKS_PER_STATIC_FILE: u64 = 500_000;
+pub const DEFAULT_BLOCKS_PER_STATIC_FILE: u64 = 500_000;
 
 /// Highest static file block numbers, per data segment.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
@@ -65,6 +65,6 @@ impl HighestStaticFiles {
 /// Each static file has a fixed number of blocks. This gives out the range where the requested
 /// block is positioned. Used for segment filename.
 pub const fn find_fixed_range(block: BlockNumber) -> SegmentRangeInclusive {
-    let start = (block / BLOCKS_PER_STATIC_FILE) * BLOCKS_PER_STATIC_FILE;
-    SegmentRangeInclusive::new(start, start + BLOCKS_PER_STATIC_FILE - 1)
+    let start = (block / DEFAULT_BLOCKS_PER_STATIC_FILE) * DEFAULT_BLOCKS_PER_STATIC_FILE;
+    SegmentRangeInclusive::new(start, start + DEFAULT_BLOCKS_PER_STATIC_FILE - 1)
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -254,6 +254,7 @@ impl StaticFileProviderInner {
 
 impl StaticFileProvider {
     /// Set a custom number of blocks per file.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn with_custom_blocks_per_file(self, blocks_per_file: u64) -> Self {
         let mut provider =
             Arc::try_unwrap(self.0).expect("should be called when initializing only");

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -909,8 +909,8 @@ impl StaticFileProvider {
                     return Ok(Some(res))
                 }
                 range = SegmentRangeInclusive::new(
-                    range.start().saturating_sub(DEFAULT_BLOCKS_PER_STATIC_FILE),
-                    range.end().saturating_sub(DEFAULT_BLOCKS_PER_STATIC_FILE),
+                    range.start().saturating_sub(self.blocks_per_file),
+                    range.end().saturating_sub(self.blocks_per_file),
                 );
             }
         }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1,7 +1,6 @@
 use super::{
     metrics::StaticFileProviderMetrics, writer::StaticFileWriters, LoadedJar,
     StaticFileJarProvider, StaticFileProviderRW, StaticFileProviderRWRefMut,
-    BLOCKS_PER_STATIC_FILE,
 };
 use crate::{
     to_range, BlockHashReader, BlockNumReader, BlockReader, BlockSource, DatabaseProvider,
@@ -27,7 +26,10 @@ use reth_db_api::{
 };
 use reth_nippy_jar::{NippyJar, NippyJarChecker, CONFIG_FILE_EXTENSION};
 use reth_primitives::{
-    static_file::{find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive},
+    static_file::{
+        find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive,
+        DEFAULT_BLOCKS_PER_STATIC_FILE,
+    },
     Block, BlockWithSenders, Header, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
     StaticFileSegment, TransactionMeta, TransactionSigned, TransactionSignedNoHash, Withdrawal,
     Withdrawals,
@@ -893,8 +895,8 @@ impl StaticFileProvider {
                     return Ok(Some(res))
                 }
                 range = SegmentRangeInclusive::new(
-                    range.start().saturating_sub(BLOCKS_PER_STATIC_FILE),
-                    range.end().saturating_sub(BLOCKS_PER_STATIC_FILE),
+                    range.start().saturating_sub(DEFAULT_BLOCKS_PER_STATIC_FILE),
+                    range.end().saturating_sub(DEFAULT_BLOCKS_PER_STATIC_FILE),
                 );
             }
         }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -73,7 +73,7 @@ impl StaticFileAccess {
 }
 
 /// [`StaticFileProvider`] manages all existing [`StaticFileJarProvider`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct StaticFileProvider(pub(crate) Arc<StaticFileProviderInner>);
 
 impl StaticFileProvider {
@@ -195,7 +195,7 @@ impl Deref for StaticFileProvider {
 }
 
 /// [`StaticFileProviderInner`] manages all existing [`StaticFileJarProvider`].
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct StaticFileProviderInner {
     /// Maintains a map which allows for concurrent access to different `NippyJars`, over different
     /// segments and ranges.

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -14,8 +14,6 @@ use reth_primitives::{static_file::SegmentHeader, StaticFileSegment};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::{ops::Deref, sync::Arc};
 
-const BLOCKS_PER_STATIC_FILE: u64 = 500_000;
-
 /// Alias type for each specific `NippyJar`.
 type LoadedJarRef<'a> = dashmap::mapref::one::Ref<'a, (u64, StaticFileSegment), LoadedJar>;
 

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -60,7 +60,7 @@ mod tests {
     use rand::seq::SliceRandom;
     use reth_db::{CanonicalHeaders, HeaderNumbers, HeaderTerminalDifficulties, Headers};
     use reth_db_api::transaction::DbTxMut;
-    use reth_primitives::static_file::find_fixed_range;
+    use reth_primitives::static_file::{find_fixed_range, DEFAULT_BLOCKS_PER_STATIC_FILE};
     use reth_testing_utils::generators::{self, random_header_range};
 
     #[test]
@@ -72,9 +72,10 @@ mod tests {
         // Data sources
         let factory = create_test_provider_factory();
         let static_files_path = tempfile::tempdir().unwrap();
-        let static_file = static_files_path
-            .path()
-            .join(StaticFileSegment::Headers.filename(&find_fixed_range(*range.end())));
+        let static_file = static_files_path.path().join(
+            StaticFileSegment::Headers
+                .filename(&find_fixed_range(*range.end(), DEFAULT_BLOCKS_PER_STATIC_FILE)),
+        );
 
         // Setup data
         let mut headers = random_header_range(

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -8,7 +8,7 @@ use reth_codecs::Compact;
 use reth_db_api::models::CompactU256;
 use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
 use reth_primitives::{
-    static_file::{find_fixed_range, SegmentHeader, SegmentRangeInclusive},
+    static_file::{SegmentHeader, SegmentRangeInclusive},
     Header, Receipt, StaticFileSegment, TransactionSignedNoHash,
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
@@ -139,7 +139,7 @@ impl StaticFileProviderRW {
 
         let static_file_provider = Self::upgrade_provider_to_strong_reference(&reader);
 
-        let block_range = find_fixed_range(block);
+        let block_range = static_file_provider.find_fixed_range(block);
         let (jar, path) = match static_file_provider.get_segment_provider_from_block(
             segment,
             block_range.start(),
@@ -328,8 +328,12 @@ impl StaticFileProviderRW {
                 self.writer = writer;
                 self.data_path = data_path;
 
-                *self.writer.user_header_mut() =
-                    SegmentHeader::new(find_fixed_range(last_block + 1), None, None, segment);
+                *self.writer.user_header_mut() = SegmentHeader::new(
+                    self.reader().find_fixed_range(last_block + 1),
+                    None,
+                    None,
+                    segment,
+                );
             }
         }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     ops::{RangeBounds, RangeInclusive},
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -554,7 +555,7 @@ impl PruneCheckpointReader for NoopProvider {
 
 impl StaticFileProviderFactory for NoopProvider {
     fn static_file_provider(&self) -> StaticFileProvider {
-        StaticFileProvider::default()
+        StaticFileProvider::read_only(PathBuf::default(), false).unwrap()
     }
 }
 


### PR DESCRIPTION
The number of blocks per file has been a const. This PR makes it configurable so it's easier to create test scenarios that cover https://github.com/paradigmxyz/reth/pull/11021 https://github.com/paradigmxyz/reth/pull/11029 without creating 500k chains