### PR TITLE
feat(trie): use global thread pool in async state root calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9028,7 +9028,6 @@ dependencies = [
  "reth-metrics",
  "reth-primitives",
  "reth-provider",
- "reth-tasks",
  "reth-trie",
  "reth-trie-db",
  "thiserror",

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -33,7 +33,6 @@ thiserror.workspace = true
 derive_more.workspace = true
 
 # `async` feature
-reth-tasks = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, default-features = false }
 itertools = { workspace = true, optional = true }
 
@@ -61,7 +60,7 @@ proptest-arbitrary-interop.workspace = true
 [features]
 default = ["metrics", "async", "parallel"]
 metrics = ["reth-metrics", "dep:metrics", "reth-trie/metrics"]
-async = ["reth-tasks/rayon", "tokio/sync", "itertools"]
+async = ["tokio/sync", "itertools"]
 parallel = ["rayon"]
 
 [[bench]]

--- a/crates/trie/parallel/benches/root.rs
+++ b/crates/trie/parallel/benches/root.rs
@@ -3,13 +3,11 @@ use alloy_primitives::{B256, U256};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
 use proptest_arbitrary_interop::arb;
-use rayon::ThreadPoolBuilder;
 use reth_primitives::Account;
 use reth_provider::{
     providers::ConsistentDbView, test_utils::create_test_provider_factory, StateChangeWriter,
     TrieWriter,
 };
-use reth_tasks::pool::BlockingTaskPool;
 use reth_trie::{
     hashed_cursor::HashedPostStateCursorFactory, HashedPostState, HashedStorage, StateRoot,
     TrieInput,
@@ -23,7 +21,6 @@ pub fn calculate_state_root(c: &mut Criterion) {
     group.sample_size(20);
 
     let runtime = tokio::runtime::Runtime::new().unwrap();
-    let blocking_pool = BlockingTaskPool::new(ThreadPoolBuilder::default().build().unwrap());
 
     for size in [1_000, 3_000, 5_000, 10_000] {
         let (db_state, updated_state) = generate_test_data(size);
@@ -77,13 +74,7 @@ pub fn calculate_state_root(c: &mut Criterion) {
         // async root
         group.bench_function(BenchmarkId::new("async root", size), |b| {
             b.to_async(&runtime).iter_with_setup(
-                || {
-                    AsyncStateRoot::new(
-                        view.clone(),
-                        blocking_pool.clone(),
-                        TrieInput::from_state(updated_state.clone()),
-                    )
-                },
+                || AsyncStateRoot::new(view.clone(), TrieInput::from_state(updated_state.clone())),
                 |calculator| calculator.incremental_root(),
             );
         });

--- a/crates/trie/parallel/src/async_root.rs
+++ b/crates/trie/parallel/src/async_root.rs
@@ -90,8 +90,7 @@ where
         // Pre-calculate storage roots async for accounts which were changed.
         tracker.set_precomputed_storage_roots(storage_root_targets.len() as u64);
         debug!(target: "trie::async_state_root", len = storage_root_targets.len(), "pre-calculating storage roots");
-        let mut storage_roots: HashMap<B256, oneshot::Receiver<Result<_, AsyncStateRootError>>> =
-            HashMap::with_capacity(storage_root_targets.len());
+        let mut storage_roots = HashMap::with_capacity(storage_root_targets.len());
         for (hashed_address, prefix_set) in
             storage_root_targets.into_iter().sorted_unstable_by_key(|(address, _)| *address)
         {
@@ -128,6 +127,7 @@ where
             });
             storage_roots.insert(hashed_address, rx);
         }
+
         trace!(target: "trie::async_state_root", "calculating state root");
         let mut trie_updates = TrieUpdates::default();
 

--- a/crates/trie/parallel/src/async_root.rs
+++ b/crates/trie/parallel/src/async_root.rs
@@ -90,47 +90,45 @@ where
         tracker.set_precomputed_storage_roots(storage_root_targets.len() as u64);
         debug!(target: "trie::async_state_root", len = storage_root_targets.len(), "pre-calculating storage roots");
 
-        let mut storage_roots_receivers: HashMap<
-            B256,
-            oneshot::Receiver<Result<_, AsyncStateRootError>>,
-        > = storage_root_targets
-            .into_iter()
-            .map(|(hashed_address, prefix_set)| {
-                let view = self.view.clone();
-                let hashed_state_sorted = hashed_state_sorted.clone();
-                let trie_nodes_sorted = trie_nodes_sorted.clone();
-                #[cfg(feature = "metrics")]
-                let metrics = self.metrics.storage_trie.clone();
+        let mut storage_roots: HashMap<B256, oneshot::Receiver<Result<_, AsyncStateRootError>>> =
+            storage_root_targets
+                .into_iter()
+                .map(|(hashed_address, prefix_set)| {
+                    let view = self.view.clone();
+                    let hashed_state_sorted = hashed_state_sorted.clone();
+                    let trie_nodes_sorted = trie_nodes_sorted.clone();
+                    #[cfg(feature = "metrics")]
+                    let metrics = self.metrics.storage_trie.clone();
 
-                let (tx, rx) = oneshot::channel();
+                    let (tx, rx) = oneshot::channel();
 
-                rayon::spawn_fifo(move || {
-                    let result = (|| -> Result<_, AsyncStateRootError> {
-                        let provider_ro = view.provider_ro()?;
-                        let trie_cursor_factory = InMemoryTrieCursorFactory::new(
-                            DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-                            &trie_nodes_sorted,
-                        );
-                        let hashed_state = HashedPostStateCursorFactory::new(
-                            DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-                            &hashed_state_sorted,
-                        );
-                        Ok(StorageRoot::new_hashed(
-                            trie_cursor_factory,
-                            hashed_state,
-                            hashed_address,
-                            #[cfg(feature = "metrics")]
-                            metrics,
-                        )
-                        .with_prefix_set(prefix_set)
-                        .calculate(retain_updates)?)
-                    })();
-                    let _ = tx.send(result);
-                });
+                    rayon::spawn_fifo(move || {
+                        let result = (|| -> Result<_, AsyncStateRootError> {
+                            let provider_ro = view.provider_ro()?;
+                            let trie_cursor_factory = InMemoryTrieCursorFactory::new(
+                                DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
+                                &trie_nodes_sorted,
+                            );
+                            let hashed_state = HashedPostStateCursorFactory::new(
+                                DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
+                                &hashed_state_sorted,
+                            );
+                            Ok(StorageRoot::new_hashed(
+                                trie_cursor_factory,
+                                hashed_state,
+                                hashed_address,
+                                #[cfg(feature = "metrics")]
+                                metrics,
+                            )
+                            .with_prefix_set(prefix_set)
+                            .calculate(retain_updates)?)
+                        })();
+                        let _ = tx.send(result);
+                    });
 
-                (hashed_address, rx)
-            })
-            .collect();
+                    (hashed_address, rx)
+                })
+                .collect();
 
         trace!(target: "trie::async_state_root", "calculating state root");
         let mut trie_updates = TrieUpdates::default();
@@ -163,9 +161,7 @@ where
                     hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
                 }
                 TrieElement::Leaf(hashed_address, account) => {
-                    let (storage_root, _, updates) = match storage_roots_receivers
-                        .remove(&hashed_address)
-                    {
+                    let (storage_root, _, updates) = match storage_roots.remove(&hashed_address) {
                         Some(rx) => rx.await.map_err(|_| {
                             AsyncStateRootError::StorageRootChannelClosed { hashed_address }
                         })??,


### PR DESCRIPTION
Uses rayon's global thread pool in the async state root calculation. 