### PR TITLE
fix(tree): prevent noisy canonical block debug logs

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -360,7 +360,7 @@ where
                     }
                     event =  eth_service.next() => {
                         let Some(event) = event else { break };
-                        debug!(target: "reth::cli", "Event: {event:?}");
+                        debug!(target: "reth::cli", "Event: {event}");
                         match event {
                             ChainEvent::BackfillSyncFinished => {
                                 network_handle.update_sync_state(SyncState::Idle);


### PR DESCRIPTION
Since we now have `Display` impls for `ChainEvent<BeaconConsensusEngineEvent>`, we can use `Display` to prevent logging the entire sealed header or block in these events.