### PR TITLE
chore(ci): unpin nightly version in lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-09-09
+          toolchain: nightly
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Unpins nightly version in lint job, since lint bugs were fixed