### PR TITLE
chore: remove dead_code on InMemoryAccountTrieCursor

### DIFF
--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -49,7 +49,6 @@ impl<'a, CF: TrieCursorFactory> TrieCursorFactory for InMemoryTrieCursorFactory<
 /// The cursor to iterate over account trie updates and corresponding database entries.
 /// It will always give precedence to the data from the trie updates.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct InMemoryAccountTrieCursor<'a, C> {
     /// The database cursor.
     cursor: C,


### PR DESCRIPTION
This no longer has dead code, and is used