### PR TITLE
chore: allow static mut ref

### DIFF
--- a/crates/cli/util/src/sigsegv_handler.rs
+++ b/crates/cli/util/src/sigsegv_handler.rs
@@ -47,6 +47,8 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
     // Reserve data segment so we don't have to malloc in a signal handler, which might fail
     // in incredibly undesirable and unexpected ways due to e.g. the allocator deadlocking
     static mut STACK_TRACE: [*mut libc::c_void; MAX_FRAMES] = [ptr::null_mut(); MAX_FRAMES];
+    #[allow(static_mut_refs)]
+    // TODO: remove static mut; this will become a hard error in edition 2024
     let stack = unsafe {
         // Collect return addresses
         let depth = libc::backtrace(STACK_TRACE.as_mut_ptr(), MAX_FRAMES as i32);


### PR DESCRIPTION
allow for now to make ci pass

this will become a hard error in the future: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html

fyi @DaniPopes 