### PR TITLE
chore: reth payload without reth rpc types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8163,13 +8163,14 @@ name = "reth-payload-primitives"
 version = "1.0.7"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types",
  "async-trait",
+ "op-alloy-rpc-types-engine",
  "pin-project",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-primitives",
- "reth-rpc-types",
  "reth-transaction-pool",
  "serde",
  "thiserror",
@@ -8182,9 +8183,9 @@ dependencies = [
 name = "reth-payload-validator"
 version = "1.0.7"
 dependencies = [
+ "alloy-rpc-types",
  "reth-chainspec",
  "reth-primitives",
- "reth-rpc-types",
  "reth-rpc-types-compat",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8142,6 +8142,7 @@ name = "reth-payload-builder"
 version = "1.0.7"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types",
  "async-trait",
  "futures-util",
  "metrics",
@@ -8151,7 +8152,6 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives",
  "reth-provider",
- "reth-rpc-types",
  "revm",
  "tokio",
  "tokio-stream",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -14,13 +14,13 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives.workspace = true
-reth-rpc-types.workspace = true
 reth-provider.workspace = true
 reth-payload-primitives.workspace = true
 reth-ethereum-engine-primitives.workspace = true
 reth-chain-state = { workspace = true, optional = true }
 
 # alloy
+alloy-rpc-types = { workspace = true, features = ["engine"] }
 alloy-primitives.workspace = true
 
 # async

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -110,8 +110,8 @@ pub mod noop;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
+pub use alloy_rpc_types::engine::PayloadId;
 pub use reth_payload_primitives::PayloadBuilderError;
-pub use reth_rpc_types::engine::PayloadId;
 pub use service::{
     PayloadBuilderHandle, PayloadBuilderService, PayloadServiceCommand, PayloadStore,
 };

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate defines abstractions to create and update payloads (blocks):
 //! - [`PayloadJobGenerator`]: a type that knows how to create new jobs for creating payloads based
-//!   on [`PayloadAttributes`](reth_rpc_types::engine::PayloadAttributes).
+//!   on [`PayloadAttributes`](alloy_rpc_types::engine::PayloadAttributes).
 //! - [`PayloadJob`]: a type that yields (better) payloads over time.
 //!
 //! This crate comes with the generic [`PayloadBuilderService`] responsible for managing payload

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -7,13 +7,13 @@ use crate::{
     metrics::PayloadBuilderServiceMetrics, traits::PayloadJobGenerator, KeepPayloadJobAlive,
     PayloadJob,
 };
+use alloy_rpc_types::engine::PayloadId;
 use futures_util::{future::FutureExt, Stream, StreamExt};
 use reth_payload_primitives::{
     BuiltPayload, Events, PayloadBuilder, PayloadBuilderAttributes, PayloadBuilderError,
     PayloadEvents, PayloadTypes,
 };
 use reth_provider::CanonStateNotification;
-use reth_rpc_types::engine::PayloadId;
 use std::{
     fmt,
     future::Future,

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -17,11 +17,12 @@ reth-chainspec.workspace = true
 reth-errors.workspace = true
 reth-primitives.workspace = true
 reth-transaction-pool.workspace = true
-reth-rpc-types.workspace = true
 reth-chain-state.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
+alloy-rpc-types = { workspace = true, features = ["engine"] }
+op-alloy-rpc-types-engine.workspace = true
 
 # async
 async-trait.workspace = true

--- a/crates/payload/primitives/src/payload.rs
+++ b/crates/payload/primitives/src/payload.rs
@@ -1,6 +1,6 @@
 use crate::{MessageValidationKind, PayloadAttributes};
 use alloy_primitives::B256;
-use reth_rpc_types::engine::ExecutionPayload;
+use alloy_rpc_types::engine::ExecutionPayload;
 
 /// Either an [`ExecutionPayload`] or a types that implements the [`PayloadAttributes`] trait.
 #[derive(Debug)]
@@ -30,7 +30,7 @@ where
     }
 
     /// Return the withdrawals for the payload or attributes.
-    pub fn withdrawals(&self) -> Option<&Vec<reth_rpc_types::Withdrawal>> {
+    pub fn withdrawals(&self) -> Option<&Vec<alloy_rpc_types::Withdrawal>> {
         match self {
             Self::ExecutionPayload { payload, .. } => payload.withdrawals(),
             Self::PayloadAttributes(attributes) => attributes.withdrawals(),

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -3,14 +3,14 @@ use crate::{
     PayloadBuilderError, PayloadEvents, PayloadTypes,
 };
 use alloy_primitives::{Address, B256, U256};
+use alloy_rpc_types::{
+    engine::{PayloadAttributes as EthPayloadAttributes, PayloadId},
+    Withdrawal,
+};
+use op_alloy_rpc_types_engine::OptimismPayloadAttributes;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::ChainSpec;
 use reth_primitives::{SealedBlock, Withdrawals};
-use reth_rpc_types::{
-    engine::{PayloadAttributes as EthPayloadAttributes, PayloadId},
-    optimism::OptimismPayloadAttributes,
-    Withdrawal,
-};
 use std::{future::Future, pin::Pin};
 use tokio::sync::oneshot;
 

--- a/crates/payload/validator/Cargo.toml
+++ b/crates/payload/validator/Cargo.toml
@@ -15,5 +15,7 @@ workspace = true
 # reth
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
-reth-rpc-types.workspace = true
 reth-rpc-types-compat.workspace = true
+
+# alloy
+alloy-rpc-types = { workspace = true, features = ["engine"] }

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -102,7 +102,7 @@ impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
     ///
     /// If the cancun fields are provided this also validates that the versioned hashes in the block
     /// match the versioned hashes passed in the
-    /// [`CancunPayloadFields`](reth_rpc_types::engine::CancunPayloadFields), if the cancun payload
+    /// [`CancunPayloadFields`](alloy_rpc_types::engine::CancunPayloadFields), if the cancun payload
     /// fields are provided. If the payload fields are not provided, but versioned hashes exist
     /// in the block, this is considered an error: [`PayloadError::InvalidVersionedHashes`].
     ///

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -8,9 +8,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use alloy_rpc_types::engine::{ExecutionPayload, MaybeCancunPayloadFields, PayloadError};
 use reth_chainspec::EthereumHardforks;
 use reth_primitives::SealedBlock;
-use reth_rpc_types::{engine::MaybeCancunPayloadFields, ExecutionPayload, PayloadError};
 use reth_rpc_types_compat::engine::payload::try_into_block;
 use std::sync::Arc;
 


### PR DESCRIPTION
Removes `reth-rpc-types` from `reth-payload-*`.

Linked to #11067. 