### PR TITLE
fix(storage): dont skip consistency checks for `op-mainnet` if using minimal bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8291,6 +8291,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-nippy-jar",
  "reth-node-types",
+ "reth-optimism-primitives",
  "reth-primitives",
  "reth-prune-types",
  "reth-stages-types",

--- a/book/run/sync-op-mainnet.md
+++ b/book/run/sync-op-mainnet.md
@@ -18,6 +18,8 @@ $ op-reth node --chain optimism --datadir op-mainnet --debug.tip 0x098f87b75c8b8
 
 ## Full bootstrap (not recommended)
 
+**Not recommended for now**: [storage consistency issue](https://github.com/paradigmxyz/reth/pull/11099) tldr: sudden crash may break the node.
+
 ### Import state 
 
 To sync OP mainnet, the Bedrock datadir needs to be imported to use as starting point.

--- a/book/run/sync-op-mainnet.md
+++ b/book/run/sync-op-mainnet.md
@@ -2,10 +2,10 @@
 
 To sync OP mainnet, bedrock state needs to be imported as a starting point. There are currently two ways:
 
-* Minimal bootstrap: only state snapshot at Bedrock block is imported without any OVM historical data.
-* Full bootstrap: state, blocks and receipts are imported.
+* Minimal bootstrap **(recommended)**: only state snapshot at Bedrock block is imported without any OVM historical data.
+* Full bootstrap **(not recommended)**: state, blocks and receipts are imported. *Not recommended for now: [storage consistency issue](https://github.com/paradigmxyz/reth/pull/11099) tldr: sudden crash may break the node
 
-## Minimal bootstrap
+## Minimal bootstrap (recommended)
 
 **The state snapshot at Bedrock block is required.** It can be exported from [op-geth](https://github.com/testinprod-io/op-erigon/blob/pcw109550/bedrock-db-migration/bedrock-migration.md#export-state) (**.jsonl**) or downloaded directly from [here](https://mega.nz/file/GdZ1xbAT#a9cBv3AqzsTGXYgX7nZc_3fl--tcBmOAIwIA5ND6kwc).
 
@@ -16,7 +16,7 @@ $ op-reth node --chain optimism --datadir op-mainnet --debug.tip 0x098f87b75c8b8
 ```
 
 
-## Full bootstrap
+## Full bootstrap (not recommended)
 
 ### Import state 
 

--- a/crates/optimism/primitives/src/bedrock.rs
+++ b/crates/optimism/primitives/src/bedrock.rs
@@ -55,6 +55,11 @@ pub fn is_dup_tx(block_number: u64) -> bool {
     false
 }
 
+/// OVM Header #1 hash.
+pub const OVM_HEADER_1_HASH: B256 = b256!(
+    "bee7192e575af30420cae0c7776304ac196077ee72b048970549e4f08e875453"
+);
+
 /// Bedrock hash on Optimism Mainnet.
 pub const BEDROCK_HEADER_HASH: B256 =
     b256!("dbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3");

--- a/crates/optimism/primitives/src/bedrock.rs
+++ b/crates/optimism/primitives/src/bedrock.rs
@@ -56,9 +56,8 @@ pub fn is_dup_tx(block_number: u64) -> bool {
 }
 
 /// OVM Header #1 hash.
-pub const OVM_HEADER_1_HASH: B256 = b256!(
-    "bee7192e575af30420cae0c7776304ac196077ee72b048970549e4f08e875453"
-);
+pub const OVM_HEADER_1_HASH: B256 =
+    b256!("bee7192e575af30420cae0c7776304ac196077ee72b048970549e4f08e875453");
 
 /// Bedrock hash on Optimism Mainnet.
 pub const BEDROCK_HEADER_HASH: B256 =

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -40,6 +40,9 @@ alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 revm.workspace = true
 
+# optimism
+reth-optimism-primitives = { workspace = true, optional = true }
+
 # async
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
@@ -79,7 +82,7 @@ once_cell.workspace = true
 eyre.workspace = true
 
 [features]
-optimism = ["reth-primitives/optimism", "reth-execution-types/optimism"]
+optimism = ["reth-primitives/optimism", "reth-execution-types/optimism", "reth-optimism-primitives"]
 serde = ["reth-execution-types/serde"]
 test-utils = [
     "reth-db/test-utils",

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -26,7 +26,6 @@ use reth_db_api::{
 };
 use reth_nippy_jar::{NippyJar, NippyJarChecker, CONFIG_FILE_EXTENSION};
 use reth_primitives::{
-    b256,
     static_file::{
         find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive,
         DEFAULT_BLOCKS_PER_STATIC_FILE,

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{keccak256, Address, BlockHash, BlockNumber, TxHash, TxNum
 use dashmap::DashMap;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::RwLock;
-use reth_chainspec::{Chain, ChainInfo, ChainSpecProvider, EthChainSpec};
+use reth_chainspec::{ChainInfo, ChainSpecProvider};
 use reth_db::{
     lockfile::StorageLock,
     static_file::{iter_static_files, HeaderMask, ReceiptMask, StaticFileCursor, TransactionMask},

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -639,11 +639,10 @@ impl StaticFileProvider {
         //
         // If we detect an OVM import was done (block #1 <https://optimistic.etherscan.io/block/1>), skip it.
         // More on [#11099](https://github.com/paradigmxyz/reth/pull/11099).
+        #[cfg(feature = "optimism")]
         if provider.chain_spec().chain() == Chain::optimism_mainnet() &&
             provider
-                .block_number(b256!(
-                    "bee7192e575af30420cae0c7776304ac196077ee72b048970549e4f08e875453"
-                ))?
+                .block_number(reth_optimism_primitives::bedrock::OVM_HEADER_1_HASH)?
                 .is_some()
         {
             info!(target: "reth::cli",

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{keccak256, Address, BlockHash, BlockNumber, TxHash, TxNum
 use dashmap::DashMap;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::RwLock;
-use reth_chainspec::{Chain, ChainInfo, ChainSpecProvider, EthChainSpec};
+use reth_chainspec::{ChainInfo, ChainSpecProvider};
 use reth_db::{
     lockfile::StorageLock,
     static_file::{iter_static_files, HeaderMask, ReceiptMask, StaticFileCursor, TransactionMask},
@@ -639,7 +639,8 @@ impl StaticFileProvider {
         // If we detect an OVM import was done (block #1 <https://optimistic.etherscan.io/block/1>), skip it.
         // More on [#11099](https://github.com/paradigmxyz/reth/pull/11099).
         #[cfg(feature = "optimism")]
-        if provider.chain_spec().chain() == Chain::optimism_mainnet() &&
+        if reth_chainspec::EthChainSpec::chain(&provider.chain_spec()) ==
+            reth_chainspec::Chain::optimism_mainnet() &&
             provider
                 .block_number(reth_optimism_primitives::bedrock::OVM_HEADER_1_HASH)?
                 .is_some()

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -638,6 +638,7 @@ impl StaticFileProvider {
         // range.
         //
         // If we detect an OVM import was done (block #1 <https://optimistic.etherscan.io/block/1>), skip it.
+        // More on [#11099](https://github.com/paradigmxyz/reth/pull/11099).
         if provider.chain_spec().chain() == Chain::optimism_mainnet() &&
             provider
                 .block_number(b256!(

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -632,16 +632,6 @@ impl StaticFileProvider {
     where
         Provider: DBProvider + BlockReader + StageCheckpointReader + ChainSpecProvider,
     {
-        // OVM chain contains duplicate transactions, so is inconsistent by default since reth db
-        // not designed for duplicate transactions (see <https://github.com/paradigmxyz/reth/blob/v1.0.3/crates/optimism/primitives/src/bedrock_import.rs>). Undefined behaviour for queries
-        // to OVM chain is also in op-erigon.
-        if provider.chain_spec().chain() == Chain::optimism_mainnet() {
-            info!(target: "reth::cli",
-                "Skipping storage verification for OP mainnet, expected inconsistency in OVM chain"
-            );
-            return Ok(None);
-        }
-
         info!(target: "reth::cli", "Verifying storage consistency.");
 
         let mut unwind_target: Option<BlockNumber> = None;


### PR DESCRIPTION
reverting https://github.com/paradigmxyz/reth/pull/9737

Storage consistency ensures that:
* The number of receipts/headers/transactions that the DB expects to exist are the same number as existing on static files.
* Transaction and block ranges in static files match the number of rows.

Currently, OVM import of receipts seems to be broken  (https://github.com/paradigmxyz/reth/issues/10580, https://github.com/paradigmxyz/reth/issues/9739) (https://github.com/paradigmxyz/reth/issues/9725).

Any node that synced to the tip after https://github.com/paradigmxyz/reth/pull/9737 may be inconsistent (from a historical storage pov), and disabling this skip entirely would break them. Static files are not a database, so a migration may be possible, but more complex.

For now, leaving this check disabled for nodes which imported the ovm historical data (use [minimal bootstrap](https://reth.rs/run/sync-op-mainnet.html#minimal-bootstrap) instead). **But it's important to understand that a sudden crash of the node MAY break it.**

