### PR TITLE
fix(cli): handle case when first transaction range is `None` on `reth db stats`

### DIFF
--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -264,9 +264,11 @@ impl Command {
                 let block_range =
                     SegmentRangeInclusive::new(first_ranges.0.start(), last_ranges.0.end());
 
+                // Transaction ranges can be empty, so we need to find the first and last which are not.
                 let tx_range = {
                     let start = ranges.iter().find_map(|(_, tx_range)|  tx_range.map(|r| r.start())).unwrap_or_default();
-                    last_ranges.1.map(|last| SegmentRangeInclusive::new(start, last.end()))
+                    let end = ranges.iter().rev().find_map(|(_, tx_range)|  tx_range.map(|r| r.end()));
+                    end.map(|end| SegmentRangeInclusive::new(start, end))
                 };
 
                 let mut row = Row::new();

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -264,10 +264,15 @@ impl Command {
                 let block_range =
                     SegmentRangeInclusive::new(first_ranges.0.start(), last_ranges.0.end());
 
-                // Transaction ranges can be empty, so we need to find the first and last which are not.
+                // Transaction ranges can be empty, so we need to find the first and last which are
+                // not.
                 let tx_range = {
-                    let start = ranges.iter().find_map(|(_, tx_range)|  tx_range.map(|r| r.start())).unwrap_or_default();
-                    let end = ranges.iter().rev().find_map(|(_, tx_range)|  tx_range.map(|r| r.end()));
+                    let start = ranges
+                        .iter()
+                        .find_map(|(_, tx_range)| tx_range.map(|r| r.start()))
+                        .unwrap_or_default();
+                    let end =
+                        ranges.iter().rev().find_map(|(_, tx_range)| tx_range.map(|r| r.end()));
                     end.map(|end| SegmentRangeInclusive::new(start, end))
                 };
 

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -266,8 +266,9 @@ impl Command {
                 let tx_range = first_ranges
                     .1
                     .zip(last_ranges.1)
-                    .map(|(first, last)| SegmentRangeInclusive::new(first.start(), last.end()));
-
+                    .map(|(first, last)| SegmentRangeInclusive::new(first.start(), last.end()))
+                    .or_else(|| last_ranges.1.map(|last| SegmentRangeInclusive::new(0, last.end())));
+                    
                 let mut row = Row::new();
                 row.add_cell(Cell::new(segment))
                     .add_cell(Cell::new(format!("{block_range}")))

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -263,13 +263,11 @@ impl Command {
 
                 let block_range =
                     SegmentRangeInclusive::new(first_ranges.0.start(), last_ranges.0.end());
-                let tx_range = first_ranges
-                    .1
-                    .zip(last_ranges.1)
-                    .map(|(first, last)| SegmentRangeInclusive::new(first.start(), last.end()))
-                    .or_else(|| {
-                        last_ranges.1.map(|last| SegmentRangeInclusive::new(0, last.end()))
-                    });
+
+                let tx_range = {
+                    let start = ranges.iter().find_map(|(_, tx_range)|  tx_range.map(|r| r.start())).unwrap_or_default();
+                    last_ranges.1.map(|last| SegmentRangeInclusive::new(start, last.end()))
+                };
 
                 let mut row = Row::new();
                 row.add_cell(Cell::new(segment))

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -267,8 +267,10 @@ impl Command {
                     .1
                     .zip(last_ranges.1)
                     .map(|(first, last)| SegmentRangeInclusive::new(first.start(), last.end()))
-                    .or_else(|| last_ranges.1.map(|last| SegmentRangeInclusive::new(0, last.end())));
-                    
+                    .or_else(|| {
+                        last_ranges.1.map(|last| SegmentRangeInclusive::new(0, last.end()))
+                    });
+
                 let mut row = Row::new();
                 row.add_cell(Cell::new(segment))
                     .add_cell(Cell::new(format!("{block_range}")))


### PR DESCRIPTION
If there are no transactions from block 0 to 500k,  it would show the whole collapsed range as empty as well

from

<img width="642" alt="image" src="https://github.com/user-attachments/assets/c1df935e-aae4-491f-bbd8-7464bc297a2d">

to

<img width="642" alt="image" src="https://github.com/user-attachments/assets/7104e4f5-3150-49aa-9fa5-d4ac14c86289">
