### PR TITLE
storage-api: update BlockReaderIdExt

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1229,7 +1229,7 @@ where
 
 impl<N: NodeTypesWithDB> BlockReaderIdExt for BlockchainProvider2<N>
 where
-    Self: BlockReader + BlockIdReader + ReceiptProviderIdExt,
+    Self: BlockReader + ReceiptProviderIdExt,
 {
     fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>> {
         match id {

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -798,7 +798,7 @@ where
 
 impl<N: ProviderNodeTypes> BlockReaderIdExt for BlockchainProvider<N>
 where
-    Self: BlockReader + BlockIdReader + ReceiptProviderIdExt,
+    Self: BlockReader + ReceiptProviderIdExt,
 {
     fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block>> {
         match id {

--- a/crates/storage/storage-api/src/block.rs
+++ b/crates/storage/storage-api/src/block.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BlockIdReader, BlockNumReader, HeaderProvider, ReceiptProvider, ReceiptProviderIdExt,
-    RequestsProvider, TransactionVariant, TransactionsProvider, WithdrawalsProvider,
+    BlockNumReader, HeaderProvider, ReceiptProvider, ReceiptProviderIdExt, RequestsProvider,
+    TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{BlockNumber, B256};
@@ -161,7 +161,7 @@ pub trait BlockReader:
 /// `BlockIdReader` methods should be used to resolve `BlockId`s to block numbers or hashes, and
 /// retrieving the block should be done using the type's `BlockReader` methods.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait BlockReaderIdExt: BlockReader + BlockIdReader + ReceiptProviderIdExt {
+pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     /// Returns the block with matching tag from the database
     ///
     /// Returns `None` if block is not found.


### PR DESCRIPTION
I don't know if it's right.  I see  ReceiptProviderIdExt has the trait BlockIdReader, so I think BlockReaderIdExt can remove BlockIdReader.
 https://github.com/paradigmxyz/reth/blob/52c72a3b1d61b9cffccdd79451c9c8773dca1721/crates/storage/storage-api/src/receipts.rs#L44. 
https://github.com/paradigmxyz/reth/blob/52c72a3b1d61b9cffccdd79451c9c8773dca1721/crates/storage/storage-api/src/block.rs#L164