### PR TITLE
chore: clear reth rpc types from reth binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6175,6 +6175,7 @@ name = "reth"
 version = "1.0.7"
 dependencies = [
  "alloy-rlp",
+ "alloy-rpc-types",
  "aquamarine",
  "backon",
  "clap",
@@ -6223,7 +6224,6 @@ dependencies = [
  "reth-rpc-builder",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types",
  "reth-rpc-types-compat",
  "reth-stages",
  "reth-static-file",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -37,7 +37,6 @@ reth-consensus-common.workspace = true
 reth-blockchain-tree.workspace = true
 reth-rpc-builder.workspace = true
 reth-rpc.workspace = true
-reth-rpc-types.workspace = true
 reth-rpc-types-compat.workspace = true
 reth-rpc-api = { workspace = true, features = ["client"] }
 reth-rpc-eth-types.workspace = true
@@ -68,6 +67,7 @@ reth-prune.workspace = true
 
 # crypto
 alloy-rlp.workspace = true
+alloy-rpc-types = { workspace = true, features = ["engine"] }
 
 # tracing
 tracing.workspace = true

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -1,5 +1,6 @@
 //! Command for debugging block building.
 use alloy_rlp::Decodable;
+use alloy_rpc_types::engine::{BlobsBundleV1, PayloadAttributes};
 use clap::Parser;
 use eyre::Context;
 use reth_basic_payload_builder::{
@@ -31,7 +32,6 @@ use reth_provider::{
     ProviderFactory, StageCheckpointReader, StateProviderFactory,
 };
 use reth_revm::{database::StateProviderDatabase, primitives::EnvKzgSettings};
-use reth_rpc_types::engine::{BlobsBundleV1, PayloadAttributes};
 use reth_stages::StageId;
 use reth_transaction_pool::{
     blobstore::InMemoryBlobStore, BlobStore, EthPooledTransaction, PoolConfig, TransactionOrigin,

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -153,8 +153,6 @@ pub mod rpc {
 
     /// Re-exported from `alloy_rpc_types`.
     pub mod types {
-        /// Alias for a peer identifier
-        pub type PeerId = reth_primitives::B512;
         pub use alloy_rpc_types::*;
     }
 

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -151,9 +151,11 @@ pub mod rpc {
         pub use reth_rpc_builder::*;
     }
 
-    /// Re-exported from `reth_rpc_types`.
+    /// Re-exported from `alloy_rpc_types`.
     pub mod types {
-        pub use reth_rpc_types::*;
+        /// Alias for a peer identifier
+        pub type PeerId = reth_primitives::B512;
+        pub use alloy_rpc_types::*;
     }
 
     /// Re-exported from `reth_rpc_server_types`.

--- a/crates/e2e-test-utils/src/network.rs
+++ b/crates/e2e-test-utils/src/network.rs
@@ -1,9 +1,6 @@
 use futures_util::StreamExt;
-use reth::{
-    network::{NetworkEvent, NetworkEventListenerProvider, PeersHandleProvider, PeersInfo},
-    rpc::types::PeerId,
-};
-use reth_network_peers::NodeRecord;
+use reth::network::{NetworkEvent, NetworkEventListenerProvider, PeersHandleProvider, PeersInfo};
+use reth_network_peers::{NodeRecord, PeerId};
 use reth_tokio_util::EventStream;
 use reth_tracing::tracing::info;
 

--- a/crates/e2e-test-utils/src/traits.rs
+++ b/crates/e2e-test-utils/src/traits.rs
@@ -1,5 +1,5 @@
 use op_alloy_rpc_types_engine::OptimismExecutionPayloadEnvelopeV3;
-use reth::rpc::types::{engine::ExecutionPayloadEnvelopeV3, ExecutionPayloadV3};
+use reth::rpc::types::engine::{ExecutionPayloadEnvelopeV3, ExecutionPayloadV3};
 
 /// The execution payload envelope type.
 pub trait PayloadEnvelopeExt: Send + Sync + std::fmt::Debug {

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -12,9 +12,6 @@
 #[allow(hidden_glob_reexports)]
 mod eth;
 
-/// Alias for a peer identifier
-pub type PeerId = alloy_primitives::B512;
-
 // Ethereum specific rpc types related to typed transaction requests and the engine API.
 #[cfg(feature = "jsonrpsee-types")]
 pub use eth::error::ToRpcError;

--- a/examples/custom-rlpx-subprotocol/src/subprotocol/connection/handler.rs
+++ b/examples/custom-rlpx-subprotocol/src/subprotocol/connection/handler.rs
@@ -2,12 +2,11 @@ use super::CustomRlpxConnection;
 use crate::subprotocol::protocol::{
     event::ProtocolEvent, handler::ProtocolState, proto::CustomRlpxProtoMessage,
 };
-use reth::rpc::types::PeerId;
 use reth_eth_wire::{
     capability::SharedCapabilities, multiplex::ProtocolConnection, protocol::Protocol,
 };
 use reth_network::protocol::{ConnectionHandler, OnNotSupported};
-use reth_network_api::Direction;
+use reth_network_api::{Direction, PeerId};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 

--- a/examples/custom-rlpx-subprotocol/src/subprotocol/connection/handler.rs
+++ b/examples/custom-rlpx-subprotocol/src/subprotocol/connection/handler.rs
@@ -2,12 +2,12 @@ use super::CustomRlpxConnection;
 use crate::subprotocol::protocol::{
     event::ProtocolEvent, handler::ProtocolState, proto::CustomRlpxProtoMessage,
 };
+use reth::rpc::types::PeerId;
 use reth_eth_wire::{
     capability::SharedCapabilities, multiplex::ProtocolConnection, protocol::Protocol,
 };
 use reth_network::protocol::{ConnectionHandler, OnNotSupported};
 use reth_network_api::Direction;
-use reth_rpc_types::PeerId;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 


### PR DESCRIPTION
Removes `reth-rpc-types` from `reth` binary.

Linked to #11067. 