### PR TITLE
chore(hive): update expected failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -19,7 +19,6 @@ rpc-compat:
   - eth_getBlockByNumber/get-genesis (reth)
   - eth_getBlockByNumber/get-latest (reth)
   - eth_getBlockByNumber/get-safe (reth)
-  - eth_sendRawTransaction/send-blob-tx (reth)
 
 # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:

--- a/.github/assets/hive/expected_failures_experimental.yaml
+++ b/.github/assets/hive/expected_failures_experimental.yaml
@@ -19,7 +19,6 @@ rpc-compat:
   - eth_getBlockByNumber/get-genesis (reth)
   - eth_getBlockByNumber/get-latest (reth)
   - eth_getBlockByNumber/get-safe (reth)
-  - eth_sendRawTransaction/send-blob-tx (reth)
 
 # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:


### PR DESCRIPTION
The `eth_sendRawTransaction/send-blob-tx` test in rpc-compat hive's suite was fixed here #11031, we re getting unexpected passes now https://github.com/paradigmxyz/reth/actions/runs/10985465285/job/30497780719. This PR removes it from expected failures. 