### PR TITLE
perf: change zstd compression level to 1

### DIFF
--- a/crates/primitives/src/compression/mod.rs
+++ b/crates/primitives/src/compression/mod.rs
@@ -13,7 +13,7 @@ pub static TRANSACTION_DICTIONARY: &[u8] = include_bytes!("./transaction_diction
 thread_local! {
     /// Thread Transaction compressor.
     pub static TRANSACTION_COMPRESSOR: RefCell<Compressor<'static>> = RefCell::new(
-        Compressor::with_dictionary(0, TRANSACTION_DICTIONARY)
+        Compressor::with_dictionary(1, TRANSACTION_DICTIONARY)
             .expect("failed to initialize transaction compressor"),
     );
 
@@ -26,7 +26,7 @@ thread_local! {
 
     /// Thread receipt compressor.
     pub static RECEIPT_COMPRESSOR: RefCell<Compressor<'static>> = RefCell::new(
-        Compressor::with_dictionary(0, RECEIPT_DICTIONARY)
+        Compressor::with_dictionary(1, RECEIPT_DICTIONARY)
             .expect("failed to initialize receipt compressor"),
     );
 


### PR DESCRIPTION
Hi. I've noticed you're using compression level of 0 for zstd compressors.

I've put together this benchmark: https://github.com/pawurb/zstd-tx-bench . I've tried to recreate the way you use compression in the reth codebase. 

It shows that compression level `1` is ~40% faster than `0` while producing (at least for the sample tx) only ~2% larger payloads: 

<img width="978" alt="Screenshot 2024-09-23 at 14 58 54" src="https://github.com/user-attachments/assets/c89e5bfc-cc80-4e67-ba73-f47db3a760cf">

[The official docs](https://facebook.github.io/zstd/zstd_manual.html) mention that level 0 is in practice equal to 3 (default value). But given the significant speed increase maybe it's worth changing? 