### PR TITLE
fix(docs): fix error message for missing jwtsecret flag

### DIFF
--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -51,9 +51,10 @@ impl BenchContext {
         let mut benchmark_mode = BenchMode::new(bench_args.from, bench_args.to)?;
 
         // construct the authenticated provider
-        let auth_jwt = bench_args.auth_jwtsecret.clone().ok_or_else(|| {
-            eyre::eyre!("--auth-jwtsecret must be provided for authenticated RPC")
-        })?;
+        let auth_jwt = bench_args
+            .auth_jwtsecret
+            .clone()
+            .ok_or_else(|| eyre::eyre!("--jwtsecret must be provided for authenticated RPC"))?;
 
         // fetch jwt from file
         //


### PR DESCRIPTION
This flag is called `--jwtsecret`, not `--auth-jwtsecret`