### PR TITLE
fix: reset pruned sender numbers on stage drop

### DIFF
--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use reth_chainspec::ChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_db::{static_file::iter_static_files, tables};
-use reth_db_api::transaction::DbTxMut;
+use reth_db_api::transaction::{DbTx, DbTxMut};
 use reth_db_common::{
     init::{insert_genesis_header, insert_genesis_history, insert_genesis_state},
     DbTool,
@@ -13,6 +13,7 @@ use reth_db_common::{
 use reth_node_builder::NodeTypesWithEngine;
 use reth_node_core::args::StageEnum;
 use reth_provider::{writer::UnifiedStorageWriter, StaticFileProviderFactory};
+use reth_prune::PruneSegment;
 use reth_stages::StageId;
 use reth_static_file_types::StaticFileSegment;
 
@@ -89,6 +90,17 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             }
             StageEnum::Senders => {
                 tx.clear::<tables::TransactionSenders>()?;
+                // Reset pruned numbers to not count them in the next rerun's stage progress
+                if let Some(mut prune_checkpoint) =
+                    tx.get::<tables::PruneCheckpoints>(PruneSegment::SenderRecovery)?
+                {
+                    prune_checkpoint.block_number = None;
+                    prune_checkpoint.tx_number = None;
+                    tx.put::<tables::PruneCheckpoints>(
+                        PruneSegment::SenderRecovery,
+                        prune_checkpoint,
+                    )?;
+                }
                 tx.put::<tables::StageCheckpoints>(
                     StageId::SenderRecovery.to_string(),
                     Default::default(),


### PR DESCRIPTION
We may get over 100% stage progress if we do:
1. Prune some senders
2. Drop the sender recovery stage
3. Rerun the sender recovery stage

```
INFO ... stage=SenderRecovery checkpoint=4889589 target=19426586 stage_progress=101.19%
...
INFO ... stage=SenderRecovery checkpoint=16606018 target=19426586 stage_progress=177.06%
```

This is because we count pruned transactions towards progress:
https://github.com/paradigmxyz/reth/blob/f9b8dc40354306c531f0b76693bb00a2381a73e6/crates/stages/stages/src/stages/sender_recovery.rs#L291-L303

This naive fix resets the pruned numbers when we drop the sender recovery stage. Hope it doesn't break something else :sweat_smile:. 