### PR TITLE
feat: relax chainspec bounds on `NodeBuilder` and rpc types

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,8 +1,10 @@
 use crate::{ChainSpec, DepositContract};
 use alloy_chains::Chain;
 use alloy_eips::eip1559::BaseFeeParams;
+use alloy_genesis::Genesis;
 use alloy_primitives::B256;
-use core::fmt::Debug;
+use core::fmt::{Debug, Display};
+use reth_primitives_traits::Header;
 
 /// Trait representing type configuring a chain spec.
 #[auto_impl::auto_impl(&, Arc)]
@@ -24,6 +26,18 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {
 
     /// The delete limit for pruner, per run.
     fn prune_delete_limit(&self) -> usize;
+
+    /// Returns a string representation of the hardforks.
+    fn display_hardforks(&self) -> impl Display;
+
+    /// The genesis header.
+    fn genesis_header(&self) -> &Header;
+
+    /// The genesis block specification.
+    fn genesis(&self) -> &Genesis;
+
+    /// The block gas limit.
+    fn max_gas_limit(&self) -> u64;
 }
 
 impl EthChainSpec for ChainSpec {
@@ -45,5 +59,21 @@ impl EthChainSpec for ChainSpec {
 
     fn prune_delete_limit(&self) -> usize {
         self.prune_delete_limit
+    }
+
+    fn display_hardforks(&self) -> impl Display {
+        self.display_hardforks()
+    }
+
+    fn genesis_header(&self) -> &Header {
+        self.genesis_header()
+    }
+
+    fn genesis(&self) -> &Genesis {
+        self.genesis()
+    }
+
+    fn max_gas_limit(&self) -> u64 {
+        self.max_gas_limit
     }
 }

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -15,6 +15,9 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {
     /// Chain id.
     fn chain(&self) -> Chain;
 
+    /// Get the [`BaseFeeParams`] for the chain at the given block.
+    fn base_fee_params_at_block(&self, block_number: u64) -> BaseFeeParams;
+
     /// Get the [`BaseFeeParams`] for the chain at the given timestamp.
     fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams;
 
@@ -43,6 +46,10 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug + 'static {
 impl EthChainSpec for ChainSpec {
     fn chain(&self) -> Chain {
         self.chain
+    }
+
+    fn base_fee_params_at_block(&self, block_number: u64) -> BaseFeeParams {
+        self.base_fee_params_at_block(block_number)
     }
 
     fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -616,6 +616,10 @@ impl Hardforks for ChainSpec {
 }
 
 impl EthereumHardforks for ChainSpec {
+    fn get_final_paris_total_difficulty(&self) -> Option<U256> {
+        self.get_final_paris_total_difficulty()
+    }
+
     fn final_paris_total_difficulty(&self, block_number: u64) -> Option<U256> {
         self.final_paris_total_difficulty(block_number)
     }

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -1,7 +1,7 @@
 use crate::{mode::MiningMode, Storage};
 use futures_util::{future::BoxFuture, FutureExt};
 use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::EngineTypes;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_primitives::IntoRecoveredTransaction;
@@ -21,7 +21,7 @@ use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use tracing::{debug, error, warn};
 
 /// A Future that listens for new ready transactions and puts new blocks into storage
-pub struct MiningTask<Client, Pool: TransactionPool, Executor, Engine: EngineTypes> {
+pub struct MiningTask<Client, Pool: TransactionPool, Executor, Engine: EngineTypes, ChainSpec> {
     /// The configured chain spec
     chain_spec: Arc<ChainSpec>,
     /// The client used to interact with the state
@@ -46,8 +46,8 @@ pub struct MiningTask<Client, Pool: TransactionPool, Executor, Engine: EngineTyp
 
 // === impl MiningTask ===
 
-impl<Executor, Client, Pool: TransactionPool, Engine: EngineTypes>
-    MiningTask<Client, Pool, Executor, Engine>
+impl<Executor, Client, Pool: TransactionPool, Engine: EngineTypes, ChainSpec>
+    MiningTask<Client, Pool, Executor, Engine, ChainSpec>
 {
     /// Creates a new instance of the task
     #[allow(clippy::too_many_arguments)]
@@ -80,12 +80,14 @@ impl<Executor, Client, Pool: TransactionPool, Engine: EngineTypes>
     }
 }
 
-impl<Executor, Client, Pool, Engine> Future for MiningTask<Client, Pool, Executor, Engine>
+impl<Executor, Client, Pool, Engine, ChainSpec> Future
+    for MiningTask<Client, Pool, Executor, Engine, ChainSpec>
 where
     Client: StateProviderFactory + CanonChainTracker + Clone + Unpin + 'static,
     Pool: TransactionPool + Unpin + 'static,
     Engine: EngineTypes,
     Executor: BlockExecutorProvider,
+    ChainSpec: EthChainSpec + EthereumHardforks,
 {
     type Output = ();
 
@@ -216,8 +218,8 @@ where
     }
 }
 
-impl<Client, Pool: TransactionPool, EvmConfig: std::fmt::Debug, Engine: EngineTypes> std::fmt::Debug
-    for MiningTask<Client, Pool, EvmConfig, Engine>
+impl<Client, Pool: TransactionPool, EvmConfig: std::fmt::Debug, Engine: EngineTypes, ChainSpec>
+    std::fmt::Debug for MiningTask<Client, Pool, EvmConfig, Engine, ChainSpec>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MiningTask").finish_non_exhaustive()

--- a/crates/consensus/common/src/calc.rs
+++ b/crates/consensus/common/src/calc.rs
@@ -66,7 +66,7 @@ pub fn base_block_reward_pre_merge(chain_spec: impl Hardforks, block_number: Blo
 /// let total_difficulty = U256::from(2_235_668_675_900usize);
 /// let number_of_ommers = 1;
 ///
-/// let reward = base_block_reward(&MAINNET, block_number, block_difficulty, total_difficulty)
+/// let reward = base_block_reward(&*MAINNET, block_number, block_difficulty, total_difficulty)
 ///     .map(|reward| block_reward(reward, 1));
 ///
 /// // The base block reward is 5 ETH, and the ommer inclusion reward is 1/32th of 5 ETH.

--- a/crates/consensus/common/src/calc.rs
+++ b/crates/consensus/common/src/calc.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{BlockNumber, U256};
-use reth_chainspec::{ChainSpec, EthereumHardfork};
+use reth_chainspec::{EthereumHardfork, Hardforks};
 use reth_primitives::constants::ETH_TO_WEI;
 
 /// Calculates the base block reward.
@@ -22,7 +22,7 @@ use reth_primitives::constants::ETH_TO_WEI;
 ///
 /// [yp]: https://ethereum.github.io/yellowpaper/paper.pdf
 pub fn base_block_reward(
-    chain_spec: &ChainSpec,
+    chain_spec: impl Hardforks,
     block_number: BlockNumber,
     block_difficulty: U256,
     total_difficulty: U256,
@@ -37,7 +37,7 @@ pub fn base_block_reward(
 /// Calculates the base block reward __before__ the merge (Paris hardfork).
 ///
 /// Caution: The caller must ensure that the block number is before the merge.
-pub fn base_block_reward_pre_merge(chain_spec: &ChainSpec, block_number: BlockNumber) -> u128 {
+pub fn base_block_reward_pre_merge(chain_spec: impl Hardforks, block_number: BlockNumber) -> u128 {
     if chain_spec.fork(EthereumHardfork::Constantinople).active_at_block(block_number) {
         ETH_TO_WEI * 2
     } else if chain_spec.fork(EthereumHardfork::Byzantium).active_at_block(block_number) {
@@ -130,7 +130,7 @@ mod tests {
         ];
 
         for ((block_number, td), expected_reward) in cases {
-            assert_eq!(base_block_reward(&MAINNET, block_number, U256::ZERO, td), expected_reward);
+            assert_eq!(base_block_reward(&*MAINNET, block_number, U256::ZERO, td), expected_reward);
         }
     }
 

--- a/crates/ethereum-forks/src/hardforks/ethereum.rs
+++ b/crates/ethereum-forks/src/hardforks/ethereum.rs
@@ -52,6 +52,9 @@ pub trait EthereumHardforks: Hardforks {
         }
     }
 
+    /// Returns the final total difficulty if the Paris hardfork is known.
+    fn get_final_paris_total_difficulty(&self) -> Option<U256>;
+
     /// Returns the final total difficulty if the given block number is after the Paris hardfork.
     ///
     /// Note: technically this would also be valid for the block before the paris upgrade, but this

--- a/crates/ethereum-forks/src/hardforks/mod.rs
+++ b/crates/ethereum-forks/src/hardforks/mod.rs
@@ -14,7 +14,7 @@ use alloc::{boxed::Box, vec::Vec};
 
 /// Generic trait over a set of ordered hardforks
 #[auto_impl::auto_impl(&, Arc)]
-pub trait Hardforks: Default + Clone {
+pub trait Hardforks: Clone {
     /// Retrieves [`ForkCondition`] from `fork`. If `fork` is not present, returns
     /// [`ForkCondition::Never`].
     fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition;

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -208,7 +208,7 @@ impl ExecutionOutcome {
     pub fn optimism_receipts_root_slow(
         &self,
         block_number: BlockNumber,
-        chain_spec: &reth_chainspec::ChainSpec,
+        chain_spec: impl reth_chainspec::Hardforks,
         timestamp: u64,
     ) -> Option<B256> {
         self.receipts.optimism_root_slow(

--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -5,7 +5,7 @@ use alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS;
 
 use crate::ConfigureEvm;
 use core::fmt::Display;
-use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 use reth_primitives::Header;
 use revm::{interpreter::Host, Database, DatabaseCommit, Evm};
@@ -21,7 +21,7 @@ use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ResultA
 pub fn pre_block_blockhashes_contract_call<EvmConfig, DB>(
     db: &mut DB,
     evm_config: &EvmConfig,
-    chain_spec: &ChainSpec,
+    chain_spec: impl EthereumHardforks,
     initialized_cfg: &CfgEnvWithHandlerCfg,
     initialized_block_env: &BlockEnv,
     parent_block_hash: B256,
@@ -66,7 +66,7 @@ where
 #[inline]
 pub fn transact_blockhashes_contract_call<EvmConfig, EXT, DB>(
     evm_config: &EvmConfig,
-    chain_spec: &ChainSpec,
+    chain_spec: impl EthereumHardforks,
     block_timestamp: u64,
     block_number: u64,
     parent_block_hash: B256,
@@ -125,7 +125,7 @@ where
 #[inline]
 pub fn apply_blockhashes_contract_call<EvmConfig, EXT, DB>(
     evm_config: &EvmConfig,
-    chain_spec: &ChainSpec,
+    chain_spec: impl EthereumHardforks,
     block_timestamp: u64,
     block_number: u64,
     parent_block_hash: B256,

--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -52,7 +52,7 @@ where
 }
 
 /// Applies the pre-block call to the [EIP-2935] blockhashes contract, using the given block,
-/// [`ChainSpec`], and EVM.
+/// chain specification, and EVM.
 ///
 /// If Prague is not activated, or the block is the genesis block, then this is a no-op, and no
 /// state changes are made.
@@ -116,7 +116,7 @@ where
 }
 
 /// Applies the pre-block call to the [EIP-2935] blockhashes contract, using the given block,
-/// [`ChainSpec`], and EVM and commits the relevant state changes.
+/// chain specification, and EVM and commits the relevant state changes.
 ///
 /// If Prague is not activated, or the block is the genesis block, then this is a no-op, and no
 /// state changes are made.

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -3,7 +3,7 @@ use alloc::{boxed::Box, string::ToString};
 
 use crate::ConfigureEvm;
 use alloy_eips::eip4788::BEACON_ROOTS_ADDRESS;
-use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 use reth_primitives::Header;
 use revm::{interpreter::Host, Database, DatabaseCommit, Evm};
@@ -19,7 +19,7 @@ use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ResultA
 pub fn pre_block_beacon_root_contract_call<EvmConfig, DB>(
     db: &mut DB,
     evm_config: &EvmConfig,
-    chain_spec: &ChainSpec,
+    chain_spec: impl EthereumHardforks,
     initialized_cfg: &CfgEnvWithHandlerCfg,
     initialized_block_env: &BlockEnv,
     parent_beacon_block_root: Option<B256>,
@@ -133,9 +133,9 @@ where
 ///
 /// [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788
 #[inline]
-pub fn apply_beacon_root_contract_call<EvmConfig, EXT, DB, Spec>(
+pub fn apply_beacon_root_contract_call<EvmConfig, EXT, DB>(
     evm_config: &EvmConfig,
-    chain_spec: &Spec,
+    chain_spec: impl EthereumHardforks,
     block_timestamp: u64,
     block_number: u64,
     parent_beacon_block_root: Option<B256>,
@@ -145,7 +145,6 @@ where
     DB: Database + DatabaseCommit,
     DB::Error: core::fmt::Display,
     EvmConfig: ConfigureEvm<Header = Header>,
-    Spec: EthereumHardforks,
 {
     if let Some(res) = transact_beacon_root_contract_call(
         evm_config,

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -51,7 +51,7 @@ where
 }
 
 /// Applies the pre-block call to the [EIP-4788] beacon block root contract, using the given block,
-/// [`ChainSpec`], EVM.
+/// chain spec, EVM.
 ///
 /// Note: this does not commit the state changes to the database, it only transact the call.
 ///
@@ -126,7 +126,7 @@ where
 }
 
 /// Applies the pre-block call to the [EIP-4788] beacon block root contract, using the given block,
-/// [`ChainSpec`], EVM.
+/// chain spec, EVM.
 ///
 /// If Cancun is not activated or the block is the genesis block, then this is a no-op, and no
 /// state changes are made.

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -148,7 +148,7 @@ where
 {
     if let Some(res) = transact_beacon_root_contract_call(
         evm_config,
-        chain_spec,
+        &chain_spec,
         block_timestamp,
         block_number,
         parent_beacon_block_root,

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -10,7 +10,7 @@ pub use states::*;
 use std::sync::Arc;
 
 use futures::Future;
-use reth_chainspec::{ChainSpec, EthChainSpec};
+use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks};
 use reth_cli_util::get_secret_key;
 use reth_db_api::{
     database::Database,
@@ -209,9 +209,10 @@ impl<DB, ChainSpec: EthChainSpec> NodeBuilder<DB, ChainSpec> {
     }
 }
 
-impl<DB> NodeBuilder<DB, ChainSpec>
+impl<DB, ChainSpec> NodeBuilder<DB, ChainSpec>
 where
     DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
+    ChainSpec: EthChainSpec + EthereumHardforks,
 {
     /// Configures the types of the node.
     pub fn with_types<T>(self) -> NodeBuilderWithTypes<RethFullAdapter<DB, T>>
@@ -269,9 +270,10 @@ impl<DB, ChainSpec> WithLaunchContext<NodeBuilder<DB, ChainSpec>> {
     }
 }
 
-impl<DB> WithLaunchContext<NodeBuilder<DB, ChainSpec>>
+impl<DB, ChainSpec> WithLaunchContext<NodeBuilder<DB, ChainSpec>>
 where
     DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
+    ChainSpec: EthChainSpec + EthereumHardforks,
 {
     /// Configures the types of the node.
     pub fn with_types<T>(self) -> WithLaunchContext<NodeBuilderWithTypes<RethFullAdapter<DB, T>>>
@@ -483,7 +485,7 @@ where
 impl<T, DB, CB, AO> WithLaunchContext<NodeBuilderWithComponents<RethFullAdapter<DB, T>, CB, AO>>
 where
     DB: Database + DatabaseMetrics + DatabaseMetadata + Clone + Unpin + 'static,
-    T: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    T: NodeTypesWithEngine<ChainSpec: EthereumHardforks + EthChainSpec>,
     CB: NodeComponentsBuilder<RethFullAdapter<DB, T>>,
     AO: NodeAddOns<
         NodeAdapter<RethFullAdapter<DB, T>, CB::Components>,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -39,7 +39,7 @@ use reth_node_metrics::{
 };
 use reth_primitives::Head;
 use reth_provider::{
-    providers::{BlockchainProvider, BlockchainProvider2, StaticFileProvider},
+    providers::{BlockchainProvider, BlockchainProvider2, ProviderNodeTypes, StaticFileProvider},
     BlockHashReader, CanonStateNotificationSender, ChainSpecProvider, ProviderFactory,
     ProviderResult, StageCheckpointReader, StateProviderFactory, StaticFileProviderFactory,
     TreeViewer,
@@ -483,7 +483,7 @@ where
 
 impl<T> LaunchContextWith<Attached<WithConfigs<T::ChainSpec>, ProviderFactory<T>>>
 where
-    T: NodeTypesWithDB<ChainSpec = ChainSpec>,
+    T: NodeTypesWithDB<ChainSpec: EthereumHardforks + EthChainSpec>,
 {
     /// Returns access to the underlying database.
     pub const fn database(&self) -> &T::DB {
@@ -523,7 +523,7 @@ where
                     target_triple: VERGEN_CARGO_TARGET_TRIPLE,
                     build_profile: BUILD_PROFILE_NAME,
                 },
-                ChainSpecInfo { name: self.left().config.chain.chain.to_string() },
+                ChainSpecInfo { name: self.left().config.chain.chain().to_string() },
                 self.task_executor().clone(),
                 Hooks::new(self.database().clone(), self.static_file_provider()),
             );
@@ -621,7 +621,7 @@ impl<T>
         Attached<WithConfigs<<T::Types as NodeTypes>::ChainSpec>, WithMeteredProviders<T>>,
     >
 where
-    T: FullNodeTypes<Types: NodeTypesWithDB<ChainSpec = ChainSpec>, Provider: WithTree>,
+    T: FullNodeTypes<Types: ProviderNodeTypes, Provider: WithTree>,
 {
     /// Returns access to the underlying database.
     pub const fn database(&self) -> &<T::Types as NodeTypesWithDB>::DB {
@@ -746,7 +746,10 @@ impl<T, CB>
         Attached<WithConfigs<<T::Types as NodeTypes>::ChainSpec>, WithComponents<T, CB>>,
     >
 where
-    T: FullNodeTypes<Provider: WithTree, Types: NodeTypes<ChainSpec = ChainSpec>>,
+    T: FullNodeTypes<
+        Provider: WithTree,
+        Types: NodeTypes<ChainSpec: EthChainSpec + EthereumHardforks>,
+    >,
     CB: NodeComponentsBuilder<T>,
 {
     /// Returns the configured `ProviderFactory`.

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -6,10 +6,7 @@ use std::{
 };
 
 use futures::TryFutureExt;
-use reth_chainspec::ChainSpec;
-use reth_node_api::{
-    BuilderProvider, FullNodeComponents, NodeTypes, NodeTypesWithDB, NodeTypesWithEngine,
-};
+use reth_node_api::{BuilderProvider, FullNodeComponents, NodeTypes, NodeTypesWithEngine};
 use reth_node_core::{
     node_config::NodeConfig,
     rpc::{
@@ -18,6 +15,7 @@ use reth_node_core::{
     },
 };
 use reth_payload_builder::PayloadBuilderHandle;
+use reth_provider::providers::ProviderNodeTypes;
 use reth_rpc_builder::{
     auth::{AuthRpcModule, AuthServerHandle},
     config::RethRpcServerConfig,
@@ -296,12 +294,12 @@ where
 pub async fn launch_rpc_servers<Node, Engine, EthApi>(
     node: Node,
     engine_api: Engine,
-    config: &NodeConfig<ChainSpec>,
+    config: &NodeConfig<<Node::Types as NodeTypes>::ChainSpec>,
     jwt_secret: JwtSecret,
     add_ons: RpcAddOns<Node, EthApi>,
 ) -> eyre::Result<(RethRpcServerHandles, RpcRegistry<Node, EthApi>)>
 where
-    Node: FullNodeComponents<Types: NodeTypesWithDB<ChainSpec = ChainSpec>> + Clone,
+    Node: FullNodeComponents<Types: ProviderNodeTypes> + Clone,
     Engine: EngineApiServer<<Node::Types as NodeTypesWithEngine>::Engine>,
     EthApi: EthApiBuilderProvider<Node> + FullEthApiServer,
 {

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -14,7 +14,7 @@ use std::{fmt, sync::Arc};
 use alloy_primitives::U256;
 use derive_more::Deref;
 use op_alloy_network::Optimism;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
 use reth_node_api::{BuilderProvider, FullNodeComponents, FullNodeTypes, NodeTypes};
@@ -110,12 +110,12 @@ where
 impl<N> EthApiSpec for OpEthApi<N>
 where
     Self: Send + Sync,
-    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
 {
     #[inline]
     fn provider(
         &self,
-    ) -> impl ChainSpecProvider<ChainSpec = ChainSpec> + BlockNumReader + StageCheckpointReader
+    ) -> impl ChainSpecProvider<ChainSpec: EthereumHardforks> + BlockNumReader + StageCheckpointReader
     {
         self.inner.provider()
     }
@@ -160,12 +160,12 @@ where
 impl<N> LoadFee for OpEthApi<N>
 where
     Self: LoadBlock,
-    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
 {
     #[inline]
     fn provider(
         &self,
-    ) -> impl BlockIdReader + HeaderProvider + ChainSpecProvider<ChainSpec = ChainSpec> {
+    ) -> impl BlockIdReader + HeaderProvider + ChainSpecProvider<ChainSpec: EthereumHardforks> {
         self.inner.provider()
     }
 
@@ -188,10 +188,12 @@ where
 impl<N> LoadState for OpEthApi<N>
 where
     Self: Send + Sync + Clone,
-    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
 {
     #[inline]
-    fn provider(&self) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> {
+    fn provider(
+        &self,
+    ) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks> {
         self.inner.provider()
     }
 

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -1,7 +1,7 @@
 //! Loads OP pending block for a RPC response.
 
 use alloy_primitives::{BlockNumber, B256};
-use reth_chainspec::ChainSpec;
+use reth_chainspec::EthereumHardforks;
 use reth_evm::ConfigureEvm;
 use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives::{
@@ -23,14 +23,14 @@ use crate::OpEthApi;
 impl<N> LoadPendingBlock for OpEthApi<N>
 where
     Self: SpawnBlocking,
-    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
 {
     #[inline]
     fn provider(
         &self,
     ) -> impl BlockReaderIdExt
            + EvmEnvProvider
-           + ChainSpecProvider<ChainSpec = ChainSpec>
+           + ChainSpecProvider<ChainSpec: EthereumHardforks>
            + StateProviderFactory {
         self.inner.provider()
     }

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -49,7 +49,7 @@ pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone + 'static
 ///
 /// Otherwise, this will return [`EngineObjectValidationError::UnsupportedFork`].
 pub fn validate_payload_timestamp(
-    chain_spec: &ChainSpec,
+    chain_spec: impl EthereumHardforks,
     version: EngineApiMessageVersion,
     timestamp: u64,
 ) -> Result<(), EngineObjectValidationError> {

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -55,7 +55,7 @@ pub fn calculate_receipt_root_no_memo(receipts: &[&Receipt]) -> B256 {
 #[cfg(feature = "optimism")]
 pub fn calculate_receipt_root_no_memo_optimism(
     receipts: &[&Receipt],
-    chain_spec: &reth_chainspec::ChainSpec,
+    chain_spec: impl reth_chainspec::Hardforks,
     timestamp: u64,
 ) -> B256 {
     // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
@@ -63,6 +63,7 @@ pub fn calculate_receipt_root_no_memo_optimism(
     // encoding. In the Regolith Hardfork, we must strip the deposit nonce from the
     // receipts before calculating the receipt root. This was corrected in the Canyon
     // hardfork.
+
     if chain_spec
         .is_fork_active_at_timestamp(reth_optimism_forks::OptimismHardfork::Regolith, timestamp) &&
         !chain_spec.is_fork_active_at_timestamp(

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -112,7 +112,7 @@ impl Receipts {
     pub fn optimism_root_slow(
         &self,
         index: usize,
-        chain_spec: &reth_chainspec::ChainSpec,
+        chain_spec: impl reth_chainspec::Hardforks,
         timestamp: u64,
     ) -> Option<B256> {
         Some(crate::proofs::calculate_receipt_root_no_memo_optimism(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -152,7 +152,7 @@ use jsonrpsee::{
     },
     Methods, RpcModule,
 };
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_engine_primitives::EngineTypes;
 use reth_evm::ConfigureEvm;
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
@@ -224,7 +224,7 @@ pub async fn launch<Provider, Pool, Network, Tasks, Events, EvmConfig, EthApi>(
     eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, EthApi>,
 ) -> Result<RpcServerHandle, RpcError>
 where
-    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
@@ -410,7 +410,7 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig>
 impl<Provider, Pool, Network, Tasks, Events, EvmConfig>
     RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, EvmConfig>
 where
-    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
@@ -751,7 +751,7 @@ where
     Provider: ChainSpecProvider<ChainSpec = ChainSpec>,
 {
     /// Instantiates `AdminApi`
-    pub fn admin_api(&self) -> AdminApi<Network>
+    pub fn admin_api(&self) -> AdminApi<Network, Provider::ChainSpec>
     where
         Network: Peers,
     {
@@ -784,7 +784,7 @@ where
 impl<Provider, Pool, Network, Tasks, Events, EthApi>
     RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi>
 where
-    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     EthApi: EthApiServer<
@@ -965,7 +965,7 @@ where
 impl<Provider, Pool, Network, Tasks, Events, EthApi>
     RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi>
 where
-    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -152,7 +152,7 @@ use jsonrpsee::{
     },
     Methods, RpcModule,
 };
-use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_chainspec::EthereumHardforks;
 use reth_engine_primitives::EngineTypes;
 use reth_evm::ConfigureEvm;
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
@@ -224,7 +224,7 @@ pub async fn launch<Provider, Pool, Network, Tasks, Events, EvmConfig, EthApi>(
     eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, EthApi>,
 ) -> Result<RpcServerHandle, RpcError>
 where
-    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
@@ -410,7 +410,7 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig>
 impl<Provider, Pool, Network, Tasks, Events, EvmConfig>
     RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, EvmConfig>
 where
-    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
@@ -748,7 +748,7 @@ impl<Provider, Pool, Network, Tasks, Events, EthApi>
 where
     Network: NetworkInfo + Clone + 'static,
     EthApi: EthApiTypes,
-    Provider: ChainSpecProvider<ChainSpec = ChainSpec>,
+    Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
 {
     /// Instantiates `AdminApi`
     pub fn admin_api(&self) -> AdminApi<Network, Provider::ChainSpec>
@@ -784,7 +784,7 @@ where
 impl<Provider, Pool, Network, Tasks, Events, EthApi>
     RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi>
 where
-    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     EthApi: EthApiServer<
@@ -965,7 +965,7 @@ where
 impl<Provider, Pool, Network, Tasks, Events, EthApi>
     RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi>
 where
-    Provider: FullRpcProvider<ChainSpec: EthereumHardforks> + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider + AccountReader + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types::{
 };
 use alloy_rpc_types_eth::transaction::TransactionRequest;
 use futures::Future;
-use reth_chainspec::MIN_TRANSACTION_GAS;
+use reth_chainspec::{EthChainSpec, MIN_TRANSACTION_GAS};
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
     basefee::calc_next_block_base_fee,
@@ -782,8 +782,9 @@ pub trait Call: LoadState + SpawnBlocking {
         }
 
         // We can now normalize the highest gas limit to a u64
-        let mut highest_gas_limit: u64 =
-            highest_gas_limit.try_into().unwrap_or(self.provider().chain_spec().max_gas_limit);
+        let mut highest_gas_limit: u64 = highest_gas_limit
+            .try_into()
+            .unwrap_or_else(|_| self.provider().chain_spec().max_gas_limit());
 
         // If the provided gas limit is less than computed cap, use that
         env.tx.gas_limit = env.tx.gas_limit.min(highest_gas_limit);

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::U256;
 use alloy_rpc_types::{BlockNumberOrTag, FeeHistory};
 use futures::Future;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_provider::{BlockIdReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider};
 use reth_rpc_eth_types::{
     fee_history::calculate_reward_percentiles_for_block, EthApiError, EthStateCache,
@@ -147,7 +147,7 @@ pub trait EthFees: LoadFee {
                 // Also need to include the `base_fee_per_gas` and `base_fee_per_blob_gas` for the
                 // next block
                 base_fee_per_gas
-                    .push(last_entry.next_block_base_fee(&LoadFee::provider(self).chain_spec())
+                    .push(last_entry.next_block_base_fee(LoadFee::provider(self).chain_spec())
                         as u128);
 
                 base_fee_per_blob_gas.push(last_entry.next_block_blob_fee().unwrap_or_default());
@@ -247,7 +247,7 @@ pub trait LoadFee: LoadBlock {
     /// Data access in default (L1) trait method implementations.
     fn provider(
         &self,
-    ) -> impl BlockIdReader + HeaderProvider + ChainSpecProvider<ChainSpec = ChainSpec>;
+    ) -> impl BlockIdReader + HeaderProvider + ChainSpecProvider<ChainSpec: EthereumHardforks>;
 
     /// Returns a handle for reading data from memory.
     ///

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -7,7 +7,7 @@ use crate::{EthApiTypes, FromEthApiError, FromEvmError};
 use alloy_primitives::{BlockNumber, B256, U256};
 use alloy_rpc_types::BlockNumberOrTag;
 use futures::Future;
-use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
     system_calls::{pre_block_beacon_root_contract_call, pre_block_blockhashes_contract_call},
     ConfigureEvm, ConfigureEvmEnv,
@@ -50,7 +50,7 @@ pub trait LoadPendingBlock: EthApiTypes {
         &self,
     ) -> impl BlockReaderIdExt
            + EvmEnvProvider
-           + ChainSpecProvider<ChainSpec = ChainSpec>
+           + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
            + StateProviderFactory;
 
     /// Returns a handle for reading data from transaction pool.

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -1,11 +1,9 @@
 //! Loads chain metadata.
 
-use std::sync::Arc;
-
 use alloy_primitives::{Address, U256, U64};
 use alloy_rpc_types::{Stage, SyncInfo, SyncStatus};
 use futures::Future;
-use reth_chainspec::{ChainInfo, ChainSpec};
+use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_errors::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
 use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
@@ -20,7 +18,7 @@ pub trait EthApiSpec: Send + Sync {
     /// Returns a handle for reading data from disk.
     fn provider(
         &self,
-    ) -> impl ChainSpecProvider<ChainSpec = ChainSpec> + BlockNumReader + StageCheckpointReader;
+    ) -> impl ChainSpecProvider<ChainSpec: EthereumHardforks> + BlockNumReader + StageCheckpointReader;
 
     /// Returns a handle for reading network data summary.
     fn network(&self) -> impl NetworkInfo;
@@ -86,10 +84,5 @@ pub trait EthApiSpec: Send + Sync {
             SyncStatus::None
         };
         Ok(status)
-    }
-
-    /// Returns the configured [`ChainSpec`].
-    fn chain_spec(&self) -> Arc<ChainSpec> {
-        self.provider().chain_spec()
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -4,7 +4,7 @@
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types::{serde_helpers::JsonStorageKey, Account, EIP1186AccountProofResponse};
 use futures::Future;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{BlockId, Header, KECCAK_EMPTY};
@@ -157,7 +157,9 @@ pub trait LoadState: EthApiTypes {
     /// Returns a handle for reading state from database.
     ///
     /// Data access in default trait method implementations.
-    fn provider(&self) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>;
+    fn provider(
+        &self,
+    ) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>;
 
     /// Returns a handle for reading data from memory.
     ///

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -14,7 +14,7 @@ use futures::{
 };
 use metrics::atomics::AtomicU64;
 use reth_chain_state::CanonStateNotification;
-use reth_chainspec::{ChainSpec, ChainSpecProvider};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives::{
     basefee::calc_next_block_base_fee,
     eip4844::{calc_blob_gasprice, calculate_excess_blob_gas},
@@ -377,7 +377,7 @@ impl FeeHistoryEntry {
     }
 
     /// Returns the base fee for the next block according to the EIP-1559 spec.
-    pub fn next_block_base_fee(&self, chain_spec: &ChainSpec) -> u64 {
+    pub fn next_block_base_fee(&self, chain_spec: impl EthChainSpec) -> u64 {
         calc_next_block_base_fee(
             self.gas_used as u128,
             self.gas_limit as u128,

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_admin::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{EthChainSpec, EthereumHardforks, ForkCondition};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::{id2pk, AnyNode, NodeRecord};
 use reth_network_types::PeerKind;
@@ -18,14 +18,14 @@ use reth_rpc_server_types::ToRpcResult;
 /// `admin` API implementation.
 ///
 /// This type provides the functionality for handling `admin` related requests.
-pub struct AdminApi<N> {
+pub struct AdminApi<N, ChainSpec> {
     /// An interface to interact with the network
     network: N,
     /// The specification of the blockchain's configuration.
     chain_spec: Arc<ChainSpec>,
 }
 
-impl<N> AdminApi<N> {
+impl<N, ChainSpec> AdminApi<N, ChainSpec> {
     /// Creates a new instance of `AdminApi`.
     pub const fn new(network: N, chain_spec: Arc<ChainSpec>) -> Self {
         Self { network, chain_spec }
@@ -33,9 +33,10 @@ impl<N> AdminApi<N> {
 }
 
 #[async_trait]
-impl<N> AdminApiServer for AdminApi<N>
+impl<N, ChainSpec> AdminApiServer for AdminApi<N, ChainSpec>
 where
     N: NetworkInfo + Peers + 'static,
+    ChainSpec: EthChainSpec + EthereumHardforks + Send + Sync + 'static,
 {
     /// Handler for `admin_addPeer`
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool> {
@@ -108,16 +109,12 @@ where
         let enode = self.network.local_node_record();
         let status = self.network.network_status().await.to_rpc_result()?;
         let mut config = ChainConfig {
-            chain_id: self.chain_spec.chain.id(),
+            chain_id: self.chain_spec.chain().id(),
             terminal_total_difficulty_passed: self
                 .chain_spec
                 .get_final_paris_total_difficulty()
                 .is_some(),
-            terminal_total_difficulty: self
-                .chain_spec
-                .hardforks
-                .fork(EthereumHardfork::Paris)
-                .ttd(),
+            terminal_total_difficulty: self.chain_spec.fork(EthereumHardfork::Paris).ttd(),
             ..self.chain_spec.genesis().config.clone()
         };
 
@@ -127,7 +124,12 @@ where
                 $(
                     // don't overwrite if already set
                     if $config.$field.is_none() {
-                        $config.$field = self.chain_spec.hardforks.fork_block(EthereumHardfork::$fork);
+                        $config.$field = match self.chain_spec.fork(EthereumHardfork::$fork) {
+                            ForkCondition::Block(block) => Some(block),
+                            ForkCondition::TTD { fork_block, .. } => fork_block,
+                            ForkCondition::Timestamp(ts) => Some(ts),
+                            ForkCondition::Never => None,
+                        };
                     }
                 )*
             };
@@ -185,7 +187,7 @@ where
     }
 }
 
-impl<N> std::fmt::Debug for AdminApi<N> {
+impl<N, ChainSpec> std::fmt::Debug for AdminApi<N, ChainSpec> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AdminApi").finish_non_exhaustive()
     }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_trace::geth::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_chainspec::EthereumHardforks;
 use reth_evm::{
     system_calls::{pre_block_beacon_root_contract_call, pre_block_blockhashes_contract_call},
     ConfigureEvmEnv,
@@ -72,7 +72,7 @@ impl<Provider, Eth> DebugApi<Provider, Eth>
 where
     Provider: BlockReaderIdExt
         + HeaderProvider
-        + ChainSpecProvider<ChainSpec = ChainSpec>
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + EvmEnvProvider
         + 'static,
@@ -856,7 +856,7 @@ impl<Provider, Eth> DebugApiServer for DebugApi<Provider, Eth>
 where
     Provider: BlockReaderIdExt
         + HeaderProvider
-        + ChainSpecProvider<ChainSpec = ChainSpec>
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + EvmEnvProvider
         + 'static,

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use alloy_primitives::{keccak256, U256};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use jsonrpsee::core::RpcResult;
+use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
     revm_primitives::db::{DatabaseCommit, DatabaseRef},

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -376,7 +376,7 @@ mod tests {
     use alloy_primitives::{B256, U64};
     use alloy_rpc_types::FeeHistory;
     use jsonrpsee_types::error::INVALID_PARAMS_CODE;
-    use reth_chainspec::{BaseFeeParams, ChainSpec};
+    use reth_chainspec::{BaseFeeParams, ChainSpec, EthChainSpec};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{Block, BlockBody, BlockNumberOrTag, Header, TransactionSigned};
@@ -414,7 +414,7 @@ mod tests {
         let fee_history_cache =
             FeeHistoryCache::new(cache.clone(), FeeHistoryCacheConfig::default());
 
-        let gas_cap = provider.chain_spec().max_gas_limit;
+        let gas_cap = provider.chain_spec().max_gas_limit();
         EthApi::new(
             provider.clone(),
             testing_pool(),

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,6 +1,6 @@
 //! Contains RPC handler implementations for fee history.
 
-use reth_chainspec::ChainSpec;
+use reth_chainspec::EthereumHardforks;
 use reth_provider::{BlockIdReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider};
 
 use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
@@ -16,12 +16,12 @@ impl<Provider, Pool, Network, EvmConfig> EthFees for EthApi<Provider, Pool, Netw
 impl<Provider, Pool, Network, EvmConfig> LoadFee for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: LoadBlock,
-    Provider: BlockReaderIdExt + HeaderProvider + ChainSpecProvider<ChainSpec = ChainSpec>,
+    Provider: BlockReaderIdExt + HeaderProvider + ChainSpecProvider<ChainSpec: EthereumHardforks>,
 {
     #[inline]
     fn provider(
         &self,
-    ) -> impl BlockIdReader + HeaderProvider + ChainSpecProvider<ChainSpec = ChainSpec> {
+    ) -> impl BlockIdReader + HeaderProvider + ChainSpecProvider<ChainSpec: EthereumHardforks> {
         self.inner.provider()
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -1,6 +1,6 @@
 //! Support for building a pending block with transactions from local view of mempool.
 
-use reth_chainspec::ChainSpec;
+use reth_chainspec::EthereumHardforks;
 use reth_evm::ConfigureEvm;
 use reth_primitives::Header;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
@@ -16,7 +16,7 @@ where
     Self: SpawnBlocking,
     Provider: BlockReaderIdExt
         + EvmEnvProvider
-        + ChainSpecProvider<ChainSpec = ChainSpec>
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory,
     Pool: TransactionPool,
     EvmConfig: ConfigureEvm<Header = Header>,
@@ -26,7 +26,7 @@ where
         &self,
     ) -> impl BlockReaderIdExt
            + EvmEnvProvider
-           + ChainSpecProvider<ChainSpec = ChainSpec>
+           + ChainSpecProvider<ChainSpec: EthereumHardforks>
            + StateProviderFactory {
         self.inner.provider()
     }

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::U256;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::EthereumHardforks;
 use reth_network_api::NetworkInfo;
 use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
 use reth_rpc_eth_api::helpers::EthApiSpec;
@@ -10,14 +10,16 @@ use crate::EthApi;
 impl<Provider, Pool, Network, EvmConfig> EthApiSpec for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Pool: TransactionPool + 'static,
-    Provider:
-        ChainSpecProvider<ChainSpec = ChainSpec> + BlockNumReader + StageCheckpointReader + 'static,
+    Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
+        + BlockNumReader
+        + StageCheckpointReader
+        + 'static,
     Network: NetworkInfo + 'static,
     EvmConfig: Send + Sync,
 {
     fn provider(
         &self,
-    ) -> impl ChainSpecProvider<ChainSpec = ChainSpec> + BlockNumReader + StageCheckpointReader
+    ) -> impl ChainSpecProvider<ChainSpec: EthereumHardforks> + BlockNumReader + StageCheckpointReader
     {
         self.inner.provider()
     }

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,6 +1,6 @@
 //! Contains RPC handler implementations specific to state.
 
-use reth_chainspec::ChainSpec;
+use reth_chainspec::EthereumHardforks;
 use reth_provider::{ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
@@ -21,11 +21,13 @@ where
 impl<Provider, Pool, Network, EvmConfig> LoadState for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: Send + Sync,
-    Provider: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
+    Provider: StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks>,
     Pool: TransactionPool,
 {
     #[inline]
-    fn provider(&self) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> {
+    fn provider(
+        &self,
+    ) -> impl StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks> {
         self.inner.provider()
     }
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -14,7 +14,7 @@ use alloy_rpc_types_trace::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_chainspec::EthereumHardforks;
 use reth_consensus_common::calc::{
     base_block_reward, base_block_reward_pre_merge, block_reward, ommer_reward,
 };
@@ -80,7 +80,7 @@ where
     Provider: BlockReader
         + StateProviderFactory
         + EvmEnvProvider
-        + ChainSpecProvider<ChainSpec = ChainSpec>
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + 'static,
     Eth: TraceExt + 'static,
 {
@@ -559,7 +559,7 @@ where
     Provider: BlockReader
         + StateProviderFactory
         + EvmEnvProvider
-        + ChainSpecProvider<ChainSpec = ChainSpec>
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + 'static,
     Eth: TraceExt + 'static,
 {

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -2,7 +2,7 @@
 
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, U256};
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{ChainSpec, EthChainSpec};
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
 use reth_db::tables;
@@ -71,10 +71,7 @@ impl From<DatabaseError> for InitDatabaseError {
 /// Write the genesis block if it has not already been written
 pub fn init_genesis<PF>(factory: &PF) -> Result<B256, InitDatabaseError>
 where
-    PF: DatabaseProviderFactory
-        + StaticFileProviderFactory
-        + ChainSpecProvider<ChainSpec = ChainSpec>
-        + BlockHashReader,
+    PF: DatabaseProviderFactory + StaticFileProviderFactory + ChainSpecProvider + BlockHashReader,
     PF::ProviderRW: StageCheckpointWriter
         + HistoryWriter
         + HeaderProvider
@@ -294,13 +291,14 @@ where
 }
 
 /// Inserts header for the genesis state.
-pub fn insert_genesis_header<Provider>(
+pub fn insert_genesis_header<Provider, Spec>(
     provider: &Provider,
     static_file_provider: &StaticFileProvider,
-    chain: &ChainSpec,
+    chain: &Spec,
 ) -> ProviderResult<()>
 where
     Provider: DBProvider<Tx: DbTxMut>,
+    Spec: EthChainSpec,
 {
     let (header, block_hash) = (chain.genesis_header(), chain.genesis_hash());
 

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -6,6 +6,7 @@ use crate::{
     StaticFileProviderFactory, TransactionsProvider,
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
+use reth_chainspec::EthereumHardforks;
 use reth_node_types::NodeTypesWithDB;
 
 /// Helper trait to unify all provider traits for simplicity.
@@ -50,7 +51,7 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
 pub trait FullRpcProvider:
     StateProviderFactory
     + EvmEnvProvider
-    + ChainSpecProvider
+    + ChainSpecProvider<ChainSpec: EthereumHardforks>
     + BlockReaderIdExt
     + HeaderProvider
     + TransactionsProvider
@@ -64,7 +65,7 @@ pub trait FullRpcProvider:
 impl<T> FullRpcProvider for T where
     T: StateProviderFactory
         + EvmEnvProvider
-        + ChainSpecProvider
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + BlockReaderIdExt
         + HeaderProvider
         + TransactionsProvider

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -6,7 +6,6 @@ use crate::{
     StaticFileProviderFactory, TransactionsProvider,
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
-use reth_chainspec::ChainSpec;
 use reth_node_types::NodeTypesWithDB;
 
 /// Helper trait to unify all provider traits for simplicity.
@@ -51,7 +50,7 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
 pub trait FullRpcProvider:
     StateProviderFactory
     + EvmEnvProvider
-    + ChainSpecProvider<ChainSpec = ChainSpec>
+    + ChainSpecProvider
     + BlockReaderIdExt
     + HeaderProvider
     + TransactionsProvider
@@ -65,7 +64,7 @@ pub trait FullRpcProvider:
 impl<T> FullRpcProvider for T where
     T: StateProviderFactory
         + EvmEnvProvider
-        + ChainSpecProvider<ChainSpec = ChainSpec>
+        + ChainSpecProvider
         + BlockReaderIdExt
         + HeaderProvider
         + TransactionsProvider


### PR DESCRIPTION
More steps towards getting rid of concrete `ChainSpec`. Introduces chainspec generic on some of the concrete types and prepares migration of optimism components to `OpChainSpec`