### PR TITLE
chore(rpc): remove redundant trait bound

### DIFF
--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -66,7 +66,7 @@ where
             RpcTransaction<Eth::NetworkTypes>,
             RpcBlock<Eth::NetworkTypes>,
             RpcReceipt<Eth::NetworkTypes>,
-        > + EthTransactions<TransactionCompat: TransactionCompat>
+        > + EthTransactions
         + TraceExt
         + 'static,
 {


### PR DESCRIPTION
Remove redundant trait bound in `OttsercanServer` impl