### PR TITLE
chore(tree): add legacy tree metrics to new engine

### DIFF
--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -5,26 +5,6 @@ use reth_metrics::{
 };
 use std::time::{Duration, Instant};
 
-/// Metrics for the entire blockchain tree
-#[derive(Metrics)]
-#[metrics(scope = "blockchain_tree")]
-pub struct TreeMetrics {
-    /// Total number of sidechains (not including the canonical chain)
-    pub sidechains: Gauge,
-    /// The highest block number in the canonical chain
-    pub canonical_chain_height: Gauge,
-    /// The number of reorgs
-    pub reorgs: Counter,
-    /// The latest reorg depth
-    pub latest_reorg_depth: Gauge,
-    /// Longest sidechain height
-    pub longest_sidechain_height: Gauge,
-    /// The number of times cached trie updates were used for insert.
-    pub trie_updates_insert_cached: Counter,
-    /// The number of times trie updates were recomputed for insert.
-    pub trie_updates_insert_recomputed: Counter,
-}
-
 /// Metrics for the blockchain tree block buffer
 #[derive(Metrics)]
 #[metrics(scope = "blockchain_tree.block_buffer")]
@@ -63,6 +43,26 @@ impl MakeCanonicalDurationsRecorder {
         self.current_metrics.record(action, duration);
         self.latest = Some(elapsed);
     }
+}
+
+/// Metrics for the entire blockchain tree
+#[derive(Metrics)]
+#[metrics(scope = "blockchain_tree")]
+pub struct TreeMetrics {
+    /// Total number of sidechains (not including the canonical chain)
+    pub sidechains: Gauge,
+    /// The highest block number in the canonical chain
+    pub canonical_chain_height: Gauge,
+    /// The number of reorgs
+    pub reorgs: Counter,
+    /// The latest reorg depth
+    pub latest_reorg_depth: Gauge,
+    /// Longest sidechain height
+    pub longest_sidechain_height: Gauge,
+    /// The number of times cached trie updates were used for insert.
+    pub trie_updates_insert_cached: Counter,
+    /// The number of times trie updates were recomputed for insert.
+    pub trie_updates_insert_recomputed: Counter,
 }
 
 /// Represents actions for making a canonical chain.

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -1,3 +1,4 @@
+use reth_blockchain_tree::metrics::TreeMetrics;
 use reth_evm::metrics::ExecutorMetrics;
 use reth_metrics::{
     metrics::{Counter, Gauge, Histogram},
@@ -13,6 +14,8 @@ pub(crate) struct EngineApiMetrics {
     pub(crate) executor: ExecutorMetrics,
     /// Metrics for block validation
     pub(crate) block_validation: BlockValidationMetrics,
+    /// A copy of legacy blockchain tree metrics, to be replaced when we replace the old tree
+    pub(crate) tree: TreeMetrics,
 }
 
 /// Metrics for the `EngineApi`.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1291,6 +1291,7 @@ where
             backfill_num_hash,
         );
         self.metrics.engine.executed_blocks.set(self.state.tree_state.block_count() as f64);
+        self.metrics.tree.canonical_chain_height.set(backfill_height as f64);
 
         // remove all buffered blocks below the backfill height
         self.state.buffer.remove_old_blocks(backfill_height);
@@ -1955,6 +1956,9 @@ where
         // update the tracked in-memory state with the new chain
         self.canonical_in_memory_state.update_chain(chain_update);
         self.canonical_in_memory_state.set_canonical_head(tip.clone());
+
+        // Update metrics based on new tip
+        self.metrics.tree.canonical_chain_height.set(tip.number as f64);
 
         // sends an event to all active listeners about the new canonical chain
         self.canonical_in_memory_state.notify_canon_state(notification);


### PR DESCRIPTION
This will be removed once we make the new engine default, but some of the metrics are still relatively useful in the context of the new engine. So this puts a new `TreeMetrics` in the engine metrics.

This now makes `Canonical Chain Height` active. However, sidechain count metrics are nontrivial with the new design.

ref https://github.com/paradigmxyz/reth/issues/10521