### PR TITLE
fix(chain-state): fork choice stream should return only when changed

### DIFF
--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -153,14 +153,12 @@ pub trait ForkChoiceSubscriptions: Send + Sync {
 
     /// Convenience method to get a stream of the new safe blocks of the chain.
     fn safe_block_stream(&self) -> ForkChoiceStream<SealedHeader> {
-        ForkChoiceStream::<SealedHeader> { st: WatchStream::new(self.subscribe_safe_block().0) }
+        ForkChoiceStream::new(self.subscribe_safe_block().0)
     }
 
     /// Convenience method to get a stream of the new finalized blocks of the chain.
     fn finalized_block_stream(&self) -> ForkChoiceStream<SealedHeader> {
-        ForkChoiceStream::<SealedHeader> {
-            st: WatchStream::new(self.subscribe_finalized_block().0),
-        }
+        ForkChoiceStream::new(self.subscribe_finalized_block().0)
     }
 }
 
@@ -175,7 +173,7 @@ pub struct ForkChoiceStream<T> {
 impl<T: Clone + Sync + Send + 'static> ForkChoiceStream<T> {
     /// Creates a new `ForkChoiceStream`
     pub fn new(rx: watch::Receiver<Option<T>>) -> Self {
-        Self { st: WatchStream::new(rx) }
+        Self { st: WatchStream::from_changes(rx) }
     }
 }
 


### PR DESCRIPTION
> This stream will start by yielding the current value when the WatchStream is polled, regardless of whether it was the initial value or sent afterwards, unless you use [WatchStream<T>::from_changes](https://docs.rs/tokio-stream/latest/tokio_stream/wrappers/struct.WatchStream.html#method.from_changes).

https://docs.rs/tokio-stream/latest/tokio_stream/wrappers/struct.WatchStream.html

Using the stream with `WatchChanges::new` would lead to a future that never returns `Poll::Pending` and the drain will loop indefinitely https://github.com/paradigmxyz/reth/blob/56a643b53759d18c92de7c9e9196eff920111e01/crates/exex/exex/src/manager.rs#L642-L646