### PR TITLE
db-api: trait Compress and Encode use reference self

### DIFF
--- a/crates/storage/db-api/src/models/accounts.rs
+++ b/crates/storage/db-api/src/models/accounts.rs
@@ -51,7 +51,7 @@ impl From<(BlockNumber, Address)> for BlockNumberAddress {
 impl Encode for BlockNumberAddress {
     type Encoded = [u8; 28];
 
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         let block_number = self.0 .0;
         let address = self.0 .1;
 
@@ -84,7 +84,7 @@ pub struct AddressStorageKey(pub (Address, StorageKey));
 impl Encode for AddressStorageKey {
     type Encoded = [u8; 52];
 
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         let address = self.0 .0;
         let storage_key = self.0 .1;
 
@@ -124,7 +124,7 @@ mod tests {
         bytes[..8].copy_from_slice(&num.to_be_bytes());
         bytes[8..].copy_from_slice(hash.as_slice());
 
-        let encoded = Encode::encode(key);
+        let encoded = Encode::encode(&key);
         assert_eq!(encoded, bytes);
 
         let decoded: BlockNumberAddress = Decode::decode(encoded).unwrap();
@@ -136,7 +136,7 @@ mod tests {
         let mut bytes = [0u8; 28];
         thread_rng().fill(bytes.as_mut_slice());
         let key = BlockNumberAddress::arbitrary(&mut Unstructured::new(&bytes)).unwrap();
-        assert_eq!(bytes, Encode::encode(key));
+        assert_eq!(bytes, Encode::encode(&key));
     }
 
     #[test]
@@ -149,7 +149,7 @@ mod tests {
         bytes[..20].copy_from_slice(address.as_slice());
         bytes[20..].copy_from_slice(storage_key.as_slice());
 
-        let encoded = Encode::encode(key);
+        let encoded = Encode::encode(&key);
         assert_eq!(encoded, bytes);
 
         let decoded: AddressStorageKey = Decode::decode(encoded).unwrap();
@@ -161,6 +161,6 @@ mod tests {
         let mut bytes = [0u8; 52];
         thread_rng().fill(bytes.as_mut_slice());
         let key = AddressStorageKey::arbitrary(&mut Unstructured::new(&bytes)).unwrap();
-        assert_eq!(bytes, Encode::encode(key));
+        assert_eq!(bytes, Encode::encode(&key));
     }
 }

--- a/crates/storage/db-api/src/models/integer_list.rs
+++ b/crates/storage/db-api/src/models/integer_list.rs
@@ -9,10 +9,10 @@ use reth_primitives_traits::IntegerList;
 impl Compress for IntegerList {
     type Compressed = Vec<u8>;
 
-    fn compress(self) -> Self::Compressed {
+    fn compress(&self) -> Self::Compressed {
         self.to_bytes()
     }
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         self.to_mut_bytes(buf)
     }
 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -36,7 +36,7 @@ macro_rules! impl_uints {
             impl Encode for $name {
                 type Encoded = [u8; std::mem::size_of::<$name>()];
 
-                fn encode(self) -> Self::Encoded {
+                fn encode(&self) -> Self::Encoded {
                     self.to_be_bytes()
                 }
             }
@@ -59,8 +59,8 @@ impl_uints!(u64, u32, u16, u8);
 impl Encode for Vec<u8> {
     type Encoded = Self;
 
-    fn encode(self) -> Self::Encoded {
-        self
+    fn encode(&self) -> Self::Encoded {
+        self.clone()
     }
 }
 
@@ -73,7 +73,7 @@ impl Decode for Vec<u8> {
 impl Encode for Address {
     type Encoded = [u8; 20];
 
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         self.0 .0
     }
 }
@@ -87,7 +87,7 @@ impl Decode for Address {
 impl Encode for B256 {
     type Encoded = [u8; 32];
 
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         self.0
     }
 }
@@ -101,8 +101,8 @@ impl Decode for B256 {
 impl Encode for String {
     type Encoded = Vec<u8>;
 
-    fn encode(self) -> Self::Encoded {
-        self.into_bytes()
+    fn encode(&self) -> Self::Encoded {
+        self.clone().into_bytes()
     }
 }
 
@@ -116,7 +116,7 @@ impl Encode for StoredNibbles {
     type Encoded = Vec<u8>;
 
     // Delegate to the Compact implementation
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         let mut buf = Vec::with_capacity(self.0.len());
         self.to_compact(&mut buf);
         buf
@@ -134,7 +134,7 @@ impl Encode for StoredNibblesSubKey {
     type Encoded = Vec<u8>;
 
     // Delegate to the Compact implementation
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         let mut buf = Vec::with_capacity(65);
         self.to_compact(&mut buf);
         buf
@@ -151,7 +151,7 @@ impl Decode for StoredNibblesSubKey {
 impl Encode for PruneSegment {
     type Encoded = [u8; 1];
 
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         let mut buf = [0u8];
         self.to_compact(&mut buf.as_mut());
         buf
@@ -169,7 +169,7 @@ impl Encode for ClientVersion {
     type Encoded = Vec<u8>;
 
     // Delegate to the Compact implementation
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         let mut buf = vec![];
         self.to_compact(&mut buf);
         buf
@@ -190,7 +190,7 @@ macro_rules! impl_compression_for_compact {
             impl Compress for $name {
                 type Compressed = Vec<u8>;
 
-                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
                     let _ = Compact::to_compact(&self, buf);
                 }
             }
@@ -240,7 +240,7 @@ macro_rules! impl_compression_fixed_compact {
             {
                 type Compressed = Vec<u8>;
 
-                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
                     let _  = Compact::to_compact(&self, buf);
                 }
 

--- a/crates/storage/db-api/src/models/sharded_key.rs
+++ b/crates/storage/db-api/src/models/sharded_key.rs
@@ -50,8 +50,8 @@ where
 {
     type Encoded = Vec<u8>;
 
-    fn encode(self) -> Self::Encoded {
-        let mut buf: Vec<u8> = Encode::encode(self.key).into();
+    fn encode(&self) -> Self::Encoded {
+        let mut buf: Vec<u8> = Encode::encode(&self.key).into();
         buf.extend_from_slice(&self.highest_block_number.to_be_bytes());
         buf
     }

--- a/crates/storage/db-api/src/models/storage_sharded_key.rs
+++ b/crates/storage/db-api/src/models/storage_sharded_key.rs
@@ -52,9 +52,9 @@ impl StorageShardedKey {
 impl Encode for StorageShardedKey {
     type Encoded = Vec<u8>;
 
-    fn encode(self) -> Self::Encoded {
-        let mut buf: Vec<u8> = Encode::encode(self.address).into();
-        buf.extend_from_slice(&Encode::encode(self.sharded_key.key));
+    fn encode(&self) -> Self::Encoded {
+        let mut buf: Vec<u8> = Encode::encode(&self.address).into();
+        buf.extend_from_slice(&Encode::encode(&self.sharded_key.key));
         buf.extend_from_slice(&self.sharded_key.highest_block_number.to_be_bytes());
         buf
     }

--- a/crates/storage/db-api/src/scale.rs
+++ b/crates/storage/db-api/src/scale.rs
@@ -17,11 +17,11 @@ where
 {
     type Compressed = Vec<u8>;
 
-    fn compress(self) -> Self::Compressed {
+    fn compress(&self) -> Self::Compressed {
         parity_scale_codec::Encode::encode(&self)
     }
 
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         buf.put_slice(&parity_scale_codec::Encode::encode(&self))
     }
 }

--- a/crates/storage/db-api/src/table.rs
+++ b/crates/storage/db-api/src/table.rs
@@ -25,14 +25,14 @@ pub trait Compress: Send + Sync + Sized + Debug {
     }
 
     /// Compresses data going into the database.
-    fn compress(self) -> Self::Compressed {
+    fn compress(&self) -> Self::Compressed {
         let mut buf = Self::Compressed::default();
         self.compress_to_buf(&mut buf);
         buf
     }
 
     /// Compresses data to a given buffer.
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B);
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B);
 }
 
 /// Trait that will transform the data to be read from the DB.
@@ -52,7 +52,7 @@ pub trait Encode: Send + Sync + Sized + Debug {
     type Encoded: AsRef<[u8]> + Into<Vec<u8>> + Send + Sync + Ord + Debug;
 
     /// Encodes data going into the database.
-    fn encode(self) -> Self::Encoded;
+    fn encode(&self) -> Self::Encoded;
 }
 
 /// Trait that will transform the data to be read from the DB.

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -349,7 +349,7 @@ impl DbTxMut for Tx<RW> {
     ) -> Result<bool, DatabaseError> {
         let mut data = None;
 
-        let value = value.map(Compress::compress);
+        let value = value.map(|val| val.compress());
         if let Some(value) = &value {
             data = Some(value.as_ref());
         };

--- a/crates/storage/db/src/tables/codecs/fuzz/mod.rs
+++ b/crates/storage/db/src/tables/codecs/fuzz/mod.rs
@@ -32,7 +32,7 @@ macro_rules! impl_fuzzer_with_input {
                 /// This method is used for benchmarking, so its parameter should be the actual type that is being tested.
                 pub fn encode_and_decode(obj: $name) -> (usize, $name)
                 {
-                    let data = table::$encode::$encode_method(obj);
+                    let data = table::$encode::$encode_method(&obj);
                     let size = data.len();
 
                     // Some `data` might be a fixed array.

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -421,7 +421,7 @@ pub enum ChainStateKey {
 impl Encode for ChainStateKey {
     type Encoded = [u8; 1];
 
-    fn encode(self) -> Self::Encoded {
+    fn encode(&self) -> Self::Encoded {
         match self {
             Self::LastFinalizedBlock => [0],
         }

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -48,7 +48,7 @@ pub struct RawKey<K: Key> {
 impl<K: Key> RawKey<K> {
     /// Create new raw key.
     pub fn new(key: K) -> Self {
-        Self { key: K::encode(key).into(), _phantom: std::marker::PhantomData }
+        Self { key: K::encode(&key).into(), _phantom: std::marker::PhantomData }
     }
 
     /// Creates a raw key from an existing `Vec`. Useful when we already have the encoded
@@ -89,8 +89,8 @@ impl AsRef<[u8]> for RawKey<Vec<u8>> {
 impl<K: Key> Encode for RawKey<K> {
     type Encoded = Vec<u8>;
 
-    fn encode(self) -> Self::Encoded {
-        self.key
+    fn encode(&self) -> Self::Encoded {
+        self.key.clone()
     }
 }
 
@@ -113,7 +113,7 @@ pub struct RawValue<V: Value> {
 impl<V: Value> RawValue<V> {
     /// Create new raw value.
     pub fn new(value: V) -> Self {
-        Self { value: V::compress(value).into(), _phantom: std::marker::PhantomData }
+        Self { value: V::compress(&value).into(), _phantom: std::marker::PhantomData }
     }
 
     /// Creates a raw value from an existing `Vec`. Useful when we already have the encoded
@@ -158,11 +158,11 @@ impl<V: Value> Compress for RawValue<V> {
         Some(&self.value)
     }
 
-    fn compress(self) -> Self::Compressed {
-        self.value
+    fn compress(&self) -> Self::Compressed {
+        self.value.clone()
     }
 
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         buf.put_slice(self.value.as_slice())
     }
 }


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/11185.

Trait Encode fn encodes use self. It's a bit weird.

 I see many crate use &self, like

This is alloyed rlp  Encode trait.
https://github.com/alloy-rs/rlp/blob/9aef28e6da7c2769460dd6bf22eeacd53adf0ffc/crates/rlp/src/encode.rs#L15

```rust
/// A type that can be encoded via RLP.
pub trait Encodable {
    /// Encodes the type into the `out` buffer.
    fn encode(&self, out: &mut dyn BufMut);

    /// Returns the length of the encoding of this type in bytes.
    ///
    /// The default implementation computes this by encoding the type.
    /// When possible, we recommender implementers override this with a
    /// specialized implementation.
    #[inline]
    fn length(&self) -> usize {
        let mut out = Vec::new();
        self.encode(&mut out);
        out.len()
    }
}
```
And then maybe we can remove some clone. I think some db fn like put also can use reference