### PR TITLE
chore(sdk): replace generics for builders, with generics for their output

### DIFF
--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -52,10 +52,7 @@ pub async fn setup<N>(
 ) -> eyre::Result<(Vec<NodeHelperType<N, N::AddOns>>, TaskManager, Wallet)>
 where
     N: Default + Node<TmpNodeAdapter<N>> + NodeTypesWithEngine<ChainSpec = ChainSpec>,
-    N::ComponentsBuilder: NodeComponentsBuilder<
-        TmpNodeAdapter<N>,
-        Components: NodeComponents<TmpNodeAdapter<N>, Network: PeersHandleProvider>,
-    >,
+    N::Components: NodeComponents<TmpNodeAdapter<N>, Network: PeersHandleProvider>,
     N::AddOns: NodeAddOns<
         Adapter<N>,
         EthApi: FullEthApiServer + AddDevSigners + EthApiBuilderProvider<Adapter<N>>,
@@ -116,12 +113,8 @@ type TmpNodeAdapter<N> = FullNodeTypesAdapter<
     BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>,
 >;
 
-type Adapter<N> = NodeAdapter<
-    RethFullAdapter<TmpDB, N>,
-    <<N as Node<TmpNodeAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
-        RethFullAdapter<TmpDB, N>,
-    >>::Components,
->;
+type Adapter<N> =
+    NodeAdapter<RethFullAdapter<TmpDB, N>, <N as Node<TmpNodeAdapter<N>>>::Components>;
 
 /// Type alias for a type of `NodeHelper`
 pub type NodeHelperType<N, AO> = NodeTestContext<Adapter<N>, AO>;

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -89,14 +89,14 @@ where
     Types: NodeTypesWithEngine<Engine = EthEngineTypes, ChainSpec = ChainSpec>,
     N: FullNodeTypes<Types = Types>,
 {
-    type ComponentsBuilder = ComponentsBuilder<
+    type Components = NodeComponents<
         N,
-        EthereumPoolBuilder,
-        EthereumPayloadBuilder,
-        EthereumNetworkBuilder,
-        EthereumExecutorBuilder,
-        EthereumConsensusBuilder,
-        EthereumEngineValidatorBuilder,
+        EthTransactionPool<N::Provider, DiskFileBlobStore>,
+        PayloadBuilderHandle<N::Engine>,
+        NetworkHandle,
+        EthExecutorProvider<EthEvmConfig>,
+        Arc<dyn reth_consensus::Consensus>,
+        EthereumEngineValidator,
     >;
 
     type AddOns = EthereumAddOns;

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -130,14 +130,14 @@ impl<N> Node<N> for TestNode
 where
     N: FullNodeTypes<Types: NodeTypesWithEngine<Engine = EthEngineTypes, ChainSpec = ChainSpec>>,
 {
-    type ComponentsBuilder = ComponentsBuilder<
+    type Components = NodeComponents<
         N,
-        TestPoolBuilder,
-        EthereumPayloadBuilder,
-        EthereumNetworkBuilder,
-        TestExecutorBuilder,
-        TestConsensusBuilder,
-        EthereumEngineValidatorBuilder,
+        TestPool,
+        PayloadBuilderHandle<N::Engine>,
+        NetworkHandle,
+        (EthEvmConfig, MockExecutorProvider),
+        Arc<TestConsensus>,
+        EthereumEngineValidator,
     >;
     type AddOns = EthereumAddOns;
 
@@ -159,12 +159,12 @@ pub type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
 /// boot the testing environment
 pub type Adapter = NodeAdapter<
     RethFullAdapter<TmpDB, TestNode>,
-    <<TestNode as Node<
+    <TestNode as Node<
         FullNodeTypesAdapter<
             NodeTypesWithDBAdapter<TestNode, TmpDB>,
             BlockchainProvider<NodeTypesWithDBAdapter<TestNode, TmpDB>>,
         >,
-    >>::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<TmpDB, TestNode>>>::Components,
+    >>::Components,
 >;
 /// An [`ExExContext`] using the [`Adapter`] type.
 pub type TestExExContext = ExExContext<Adapter>;

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -93,7 +93,7 @@ impl<N: FullNodeComponents> NodeAddOns<N> for () {
 }
 
 /// Returns the builder for type.
-pub trait BuilderProvider<N: FullNodeComponents>: Send {
+pub trait BuilderProvider<N>: Send {
     /// Context required to build type.
     type Ctx<'a>;
 
@@ -102,7 +102,7 @@ pub trait BuilderProvider<N: FullNodeComponents>: Send {
     fn builder() -> Box<dyn for<'a> Fn(Self::Ctx<'a>) -> Self + Send>;
 }
 
-impl<N: FullNodeComponents> BuilderProvider<N> for () {
+impl<N> BuilderProvider<N> for () {
     type Ctx<'a> = ();
 
     fn builder() -> Box<dyn for<'a> Fn(Self::Ctx<'a>) -> Self + Send> {

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -239,7 +239,11 @@ where
     pub fn node<N>(
         self,
         node: N,
-    ) -> NodeBuilderWithComponents<RethFullAdapter<DB, N>, N::ComponentsBuilder, N::AddOns>
+    ) -> NodeBuilderWithComponents<
+        RethFullAdapter<DB, N>,
+        Box<dyn NodeComponentsBuilder<RethFullAdapter<DB, N>>>,
+        N::AddOns,
+    >
     where
         N: Node<RethFullAdapter<DB, N>, ChainSpec = ChainSpec>,
     {
@@ -306,7 +310,11 @@ where
         self,
         node: N,
     ) -> WithLaunchContext<
-        NodeBuilderWithComponents<RethFullAdapter<DB, N>, N::ComponentsBuilder, N::AddOns>,
+        NodeBuilderWithComponents<
+            RethFullAdapter<DB, N>,
+            Box<dyn NodeComponentsBuilder<RethFullAdapter<DB, N>>>,
+            N::AddOns,
+        >,
     >
     where
         N: Node<RethFullAdapter<DB, N>, ChainSpec = ChainSpec>,
@@ -322,30 +330,14 @@ where
     pub async fn launch_node<N>(
         self,
         node: N,
-    ) -> eyre::Result<
-        NodeHandle<
-            NodeAdapter<
-                RethFullAdapter<DB, N>,
-                <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
-            >,
-            N::AddOns,
-        >,
-    >
+    ) -> eyre::Result<NodeHandle<NodeAdapter<RethFullAdapter<DB, N>, N::Components>, N::AddOns>>
     where
         N: Node<RethFullAdapter<DB, N>, ChainSpec = ChainSpec>,
         N::AddOns: NodeAddOns<
-            NodeAdapter<
-                RethFullAdapter<DB, N>,
-                <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
-            >,
-            EthApi: EthApiBuilderProvider<
-                        NodeAdapter<
-                            RethFullAdapter<DB, N>,
-                            <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
-                        >
-                    >
+            NodeAdapter<RethFullAdapter<DB, N>, N::Components>,
+            EthApi: EthApiBuilderProvider<NodeAdapter<RethFullAdapter<DB, N>, N::Components>>
                         + FullEthApiServer
-                        + AddDevSigners
+                        + AddDevSigners,
         >,
     {
         self.node(node).launch().await

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -39,13 +39,13 @@ use super::EngineValidatorBuilder;
 /// launched.
 #[derive(Debug)]
 pub struct ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, ExecB, ConsB, EVB> {
-    pool_builder: PoolB,
-    payload_builder: PayloadB,
-    network_builder: NetworkB,
-    executor_builder: ExecB,
-    consensus_builder: ConsB,
-    engine_validator_builder: EVB,
-    _marker: PhantomData<Node>,
+    pub pool_builder: PoolB,
+    pub payload_builder: PayloadB,
+    pub network_builder: NetworkB,
+    pub executor_builder: ExecB,
+    pub consensus_builder: ConsB,
+    pub engine_validator_builder: EVB,
+    pub _marker: PhantomData<Node>,
 }
 
 impl<Node, PoolB, PayloadB, NetworkB, ExecB, ConsB, EVB>
@@ -448,5 +448,20 @@ where
         ctx: &BuilderContext<Node>,
     ) -> impl Future<Output = eyre::Result<Self::Components>> + Send {
         self(ctx)
+    }
+}
+
+impl<N, T> NodeComponentsBuilder<N> for T
+where
+    N: FullNodeTypes,
+    T: BuilderProvider<Ctx = &BuilderContext<Node>>,
+{
+    type Components = Self;
+
+    fn build_components(
+        self,
+        ctx: &BuilderContext<N>,
+    ) -> impl Future<Output = eyre::Result<Self::Components>> + Send {
+        Self::builder(ctx)
     }
 }

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -104,23 +104,21 @@ impl DefaultNodeLauncher {
     }
 }
 
-impl<Types, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for DefaultNodeLauncher
+impl<Types, T, C, AO> LaunchNode<N> for DefaultNodeLauncher
 where
     Types: NodeTypesWithDB<ChainSpec: EthereumHardforks + EthChainSpec> + NodeTypesWithEngine,
     T: FullNodeTypes<Provider = BlockchainProvider<Types>, Types = Types>,
-    CB: NodeComponentsBuilder<T>,
+    C: NodeComponents<T>,
     AO: NodeAddOns<
-        NodeAdapter<T, CB::Components>,
-        EthApi: EthApiBuilderProvider<NodeAdapter<T, CB::Components>>
-                    + FullEthApiServer
-                    + AddDevSigners,
+        NodeAdapter<T, C>,
+        EthApi: EthApiBuilderProvider<NodeAdapter<T, C>> + FullEthApiServer + AddDevSigners,
     >,
 {
-    type Node = NodeHandle<NodeAdapter<T, CB::Components>, AO>;
+    type Node = NodeHandle<NodeAdapter<T, C>, AO>;
 
     async fn launch_node(
         self,
-        target: NodeBuilderWithComponents<T, CB, AO>,
+        target: NodeBuilderWithComponents<T, Box<dyn NodeComponentsBuilder<T, Components = C>>, AO>,
     ) -> eyre::Result<Self::Node> {
         let Self { ctx } = self;
         let NodeBuilderWithComponents {


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/9543, alternative to https://github.com/paradigmxyz/reth/pull/11204

POC: bijective relation builder-output<>builder, allows for output to provide its builder

The builders' output types that are used through out the program, whereas the builders are only used once and don't leave the node builder scope. It's more lightweight, if we access the builder via the output, output -> builder. rather than currently on main
```rust
<N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components
```
we should access
```rust
N::Components
```

Builders can definitely rather be used as trait objects than (long complex) generics for the reason that their build function is only called once, and only relevant where it's called. The builder generics aren't really helpful to read, but propagate nonetheless and quickly get overwhelmingly complex - unless we use the `BuilderProvider` pattern. We don't really care about what the builder type is, we just care about that 
(i) we can use it when we need to, and that
(ii) it builds the output type we wish to use through the rest of the program - we are more concerned about the output type.
Atm it feels like it's hard to find the actual output types in the node builder code, they are nested somewhere in associated types of the builders. The builder types are most of what we see reading that code, but we want to see the output types most. The builder types are just a means to an end, the components = reth's substance.

Generics are cumbersome, and should be reserved for types that are used often by the program. For example the consensus type or task spawner type in reth have no need to be dynamically dispatched, because they never change, i.e. we don't have a list of different types of consensus types in some struct field, and they are loaded often by the program, e.g. the `spawn` trait method on type that impl `TaskSpawner` is called many times during the program.