### PR TITLE
chore: Replace map types with `alloy_primitives::map` in primitives crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411aff151f2a73124ee473708e82ed51b2535f68928b6a1caa8bc1246ae6f7cd"
+checksum = "260d3ff3bff0bb84599f032a2f2c6828180b0ea0cd41fdaf44f39cef3ba41861"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -289,15 +289,20 @@ dependencies = [
  "derive_arbitrary",
  "derive_more",
  "getrandom 0.2.15",
+ "hashbrown 0.14.5",
  "hex-literal",
+ "indexmap 2.5.0",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
  "ruint",
+ "rustc-hash 2.0.0",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -3923,6 +3928,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
+ "arbitrary",
  "equivalent",
  "hashbrown 0.14.5",
  "serde",
@@ -5917,6 +5923,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -9348,6 +9355,9 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rustc-hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -421,7 +421,7 @@ revm-primitives = { version = "9.0.2", features = [
 # eth
 alloy-chains = "0.1.32"
 alloy-dyn-abi = "0.8.0"
-alloy-primitives = { version = "0.8.3", default-features = false }
+alloy-primitives = { version = "0.8.4", default-features = false }
 alloy-rlp = "0.3.4"
 alloy-sol-types = "0.8.0"
 alloy-trie = { version = "0.5", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -70,6 +70,7 @@ reth-chainspec.workspace = true
 reth-codecs.workspace = true
 alloy-eips = { workspace = true, features = ["arbitrary"] }
 alloy-genesis.workspace = true
+alloy-primitives = { workspace = true, features = ["map"] }
 
 assert_matches.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -107,11 +107,10 @@ mod tests {
     use super::*;
     use crate::{constants::EMPTY_ROOT_HASH, hex_literal::hex, Block, U256};
     use alloy_genesis::GenesisAccount;
-    use alloy_primitives::{b256, Address};
+    use alloy_primitives::{b256, map::HashMap, Address};
     use alloy_rlp::Decodable;
     use reth_chainspec::{HOLESKY, MAINNET, SEPOLIA};
     use reth_trie_common::root::{state_root_ref_unhashed, state_root_unhashed};
-    use std::collections::HashMap;
 
     #[cfg(not(feature = "optimism"))]
     use crate::TxType;


### PR DESCRIPTION
Bumps `alloy_primitives` version and replaces the map type with `alloy_primitives::map` in primitives crate.
Related: #11220