### PR TITLE
ci: pin clippy to working version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2024-09-25
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Latest nightly is failing like here https://github.com/paradigmxyz/reth/actions/runs/11047704269/job/30689456904?pr=11213