### PR TITLE
fix(tree): make state methods work for historical blocks

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -191,7 +191,6 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         let (state, reverts) =
             self.populate_bundle_state(account_changeset, storage_changeset, end_block_number)?;
 
-        // iterate over block body and create ExecutionResult
         let mut receipt_iter =
             self.receipts_by_tx_range(from_transaction_num..=to_transaction_num)?.into_iter();
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -162,7 +162,9 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         // We are not removing block meta as it is used to get block changesets.
         let mut block_bodies = Vec::new();
         for block_num in range.clone() {
-            let Some(block_body) = self.block_body_indices(block_num)? else { break };
+            let block_body = self
+                .block_body_indices(block_num)?
+                .ok_or(ProviderError::BlockBodyIndicesNotFound(block_num))?;
             block_bodies.push((block_num, block_body))
         }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -167,11 +167,11 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         }
 
         // get transaction receipts
-        let Some(from_transaction_num) = block_bodies.first().map(|bodies| bodies.1.first_tx_num())
+        let Some(from_transaction_num) = block_bodies.first().map(|body| body.1.first_tx_num())
         else {
             return Ok(None)
         };
-        let Some(to_transaction_num) = block_bodies.last().map(|bodies| bodies.1.last_tx_num())
+        let Some(to_transaction_num) = block_bodies.last().map(|body| body.1.last_tx_num())
         else {
             return Ok(None)
         };
@@ -211,6 +211,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         Ok(Some(ExecutionOutcome::new_init(
             state,
             reverts,
+            // We skip new contracts since we never delete them from the database
             Vec::new(),
             receipts.into(),
             start_block_number,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -226,9 +226,6 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         storage_changeset: Vec<(BlockNumberAddress, StorageEntry)>,
         block_range_end: BlockNumber,
     ) -> ProviderResult<(BundleStateInit, RevertsInit)> {
-        // iterate previous value and get plain state value to create changeset
-        // Double option around Account represent if Account state is know (first option) and
-        // account is removed (Second Option)
         let mut state: BundleStateInit = HashMap::new();
         let mut reverts: RevertsInit = HashMap::new();
         let state_provider = self.state_by_block_number_or_tag(block_range_end.into())?;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -130,10 +130,10 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
 
     /// Return the last N blocks of state, recreating the [`ExecutionOutcome`].
     ///
-    /// 1. Iterate over the [`BlockBodyIndices`][tables::BlockBodyIndices] table to get all the
+    /// 1. Iterate over the [`BlockBodyIndices`][reth_db::BlockBodyIndices] table to get all the
     ///    transaction ids.
-    /// 2. Iterate over the [`StorageChangeSets`][tables::StorageChangeSets] table and the
-    ///    [`AccountChangeSets`][tables::AccountChangeSets] tables in reverse order to reconstruct
+    /// 2. Iterate over the [`StorageChangeSets`][reth_db::StorageChangeSets] table and the
+    ///    [`AccountChangeSets`][reth_db::AccountChangeSets] tables in reverse order to reconstruct
     ///    the changesets.
     ///    - In order to have both the old and new values in the changesets, we also access the
     ///      plain state tables.
@@ -219,8 +219,8 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
     }
 
     /// Populate a [`BundleStateInit`] and [`RevertsInit`] using cursors over the
-    /// [`PlainAccountState`] and [`PlainStorageState`] tables, based on the given storage and
-    /// account changesets.
+    /// [`reth_db::PlainAccountState`] and [`reth_db::PlainStorageState`] tables, based on the given
+    /// storage and account changesets.
     fn populate_bundle_state(
         &self,
         account_changeset: Vec<(u64, AccountBeforeTx)>,
@@ -1663,7 +1663,7 @@ impl<N: ProviderNodeTypes> StateReader for BlockchainProvider2<N> {
             let state = state.block_ref().execution_outcome().clone();
             Ok(Some(state))
         } else {
-            self.database.provider()?.get_state(block..=block)
+            self.get_state(block..=block)
         }
     }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -171,8 +171,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         else {
             return Ok(None)
         };
-        let Some(to_transaction_num) = block_bodies.last().map(|body| body.1.last_tx_num())
-        else {
+        let Some(to_transaction_num) = block_bodies.last().map(|body| body.1.last_tx_num()) else {
             return Ok(None)
         };
 
@@ -200,10 +199,10 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         // loop break if we are at the end of the blocks.
         for (_, block_body) in block_bodies {
             let mut block_receipts = Vec::with_capacity(block_body.tx_count as usize);
-            for _ in block_body.tx_num_range() {
-                if let Some(receipt) = receipt_iter.next() {
-                    block_receipts.push(Some(receipt));
-                }
+            for tx_num in block_body.tx_num_range() {
+                let receipt =
+                    receipt_iter.next().ok_or(ProviderError::ReceiptNotFound(tx_num.into()))?;
+                block_receipts.push(Some(receipt));
             }
             receipts.push(block_receipts);
         }
@@ -232,12 +231,6 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         // Double option around Account represent if Account state is know (first option) and
         // account is removed (Second Option)
         let mut state: BundleStateInit = HashMap::new();
-
-        // This is not working for blocks that are not at tip. as plain state is not the last
-        // state of end range. We should rename the functions or add support to access
-        // History state. Accessing history state can be tricky but we are not gaining
-        // anything.
-
         let mut reverts: RevertsInit = HashMap::new();
         let state_provider = self.state_by_block_number_or_tag(block_range_end.into())?;
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1420,7 +1420,7 @@ impl<TX: DbTx, Spec: Send + Sync> StorageChangeSetReader for DatabaseProvider<TX
         block_number: BlockNumber,
     ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
         let range = block_number..=block_number;
-        let storage_range = BlockNumberAddress::range(range.clone());
+        let storage_range = BlockNumberAddress::range(range);
         self.tx
             .cursor_dup_read::<tables::StorageChangeSets>()?
             .walk_range(storage_range)?

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -46,7 +46,7 @@ use reth_primitives::{
 };
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
-use reth_storage_api::TryIntoHistoricalStateProvider;
+use reth_storage_api::{StorageChangeSetReader, TryIntoHistoricalStateProvider};
 use reth_storage_errors::provider::{ProviderResult, RootMismatch};
 use reth_trie::{
     prefix_set::{PrefixSet, PrefixSetMut, TriePrefixSets},
@@ -1411,6 +1411,21 @@ impl<TX: DbTx, Spec: Send + Sync> AccountExtReader for DatabaseProvider<TX, Spec
         )?;
 
         Ok(account_transitions)
+    }
+}
+
+impl<TX: DbTx, Spec: Send + Sync> StorageChangeSetReader for DatabaseProvider<TX, Spec> {
+    fn storage_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+        let range = block_number..=block_number;
+        let storage_range = BlockNumberAddress::range(range.clone());
+        self.tx
+            .cursor_dup_read::<tables::StorageChangeSets>()?
+            .walk_range(storage_range)?
+            .map(|result| -> ProviderResult<_> { Ok(result?) })
+            .collect()
     }
 }
 

--- a/crates/storage/storage-api/src/storage.rs
+++ b/crates/storage/storage-api/src/storage.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::{Address, BlockNumber, B256};
+use reth_db_api::models::BlockNumberAddress;
 use reth_primitives::StorageEntry;
 use reth_storage_errors::provider::ProviderResult;
 use std::{
@@ -29,4 +30,14 @@ pub trait StorageReader: Send + Sync {
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<BTreeMap<(Address, B256), Vec<u64>>>;
+}
+
+/// Storage ChangeSet reader
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait StorageChangeSetReader: Send + Sync {
+    /// Iterate over storage changesets and return the storage state from before this block.
+    fn storage_changeset(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>>;
 }


### PR DESCRIPTION
This fixes https://github.com/paradigmxyz/reth/issues/11251 by allowing fetching state from disk OR from in-memory state.

Closes: #10875
Closes: #8305