### PR TITLE
feat(exex): WAL handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,6 +7400,7 @@ dependencies = [
  "eyre",
  "futures",
  "metrics",
+ "parking_lot 0.12.3",
  "reth-blockchain-tree",
  "reth-chain-state",
  "reth-chainspec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,6 +7397,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
+ "dashmap 6.1.0",
  "eyre",
  "futures",
  "metrics",

--- a/crates/exex/exex/Cargo.toml
+++ b/crates/exex/exex/Cargo.toml
@@ -44,6 +44,7 @@ tokio.workspace = true
 dashmap.workspace = true
 eyre.workspace = true
 metrics.workspace = true
+parking_lot.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 

--- a/crates/exex/exex/Cargo.toml
+++ b/crates/exex/exex/Cargo.toml
@@ -41,6 +41,7 @@ tokio-util.workspace = true
 tokio.workspace = true
 
 ## misc
+dashmap.workspace = true
 eyre.workspace = true
 metrics.workspace = true
 serde_json.workspace = true

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
 
 use dashmap::DashMap;
 use reth_exex_types::ExExNotification;
@@ -8,14 +11,14 @@ use reth_primitives::{BlockNumHash, B256};
 ///
 /// This cache is needed to avoid walking the WAL directory every time we want to find a
 /// notification corresponding to a block or a block corresponding to a hash.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockCache {
     /// A mapping of `File ID -> List of Blocks`.
     ///
     /// For each notification written to the WAL, there will be an entry per block written to
     /// the cache with the same file ID. I.e. for each notification, there may be multiple blocks
     /// in the cache.
-    files: BTreeMap<u64, VecDeque<CachedBlock>>,
+    files: Arc<RwLock<BTreeMap<u64, VecDeque<CachedBlock>>>>,
     /// A mapping of `Block Hash -> Block`.
     ///
     /// For each [`ExExNotification::ChainCommitted`] notification, there will be an entry per
@@ -26,45 +29,59 @@ pub struct BlockCache {
 impl BlockCache {
     /// Creates a new instance of [`BlockCache`].
     pub(super) fn new() -> Self {
-        Self { files: BTreeMap::new(), blocks: DashMap::new() }
+        Self { files: Arc::new(RwLock::new(BTreeMap::new())), blocks: DashMap::new() }
+    }
+
+    fn read_files(&self) -> RwLockReadGuard<'_, BTreeMap<u64, VecDeque<CachedBlock>>> {
+        self.files.read().unwrap()
+    }
+
+    fn write_files(&self) -> RwLockWriteGuard<'_, BTreeMap<u64, VecDeque<CachedBlock>>> {
+        self.files.write().unwrap()
     }
 
     /// Returns `true` if the cache is empty.
     pub(super) fn is_empty(&self) -> bool {
-        self.files.is_empty()
+        self.read_files().is_empty()
     }
 
     /// Returns a front-to-back iterator.
     pub(super) fn iter(&self) -> impl Iterator<Item = (u64, CachedBlock)> + '_ {
-        self.files.iter().flat_map(|(k, v)| v.iter().map(move |b| (*k, *b)))
+        self.read_files()
+            .iter()
+            .flat_map(|(k, v)| v.iter().map(move |b| (*k, *b)))
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 
     /// Provides a reference to the first block from the cache, or `None` if the cache is
     /// empty.
     pub(super) fn front(&self) -> Option<(u64, CachedBlock)> {
-        self.files.first_key_value().and_then(|(k, v)| v.front().map(|b| (*k, *b)))
+        self.read_files().first_key_value().and_then(|(k, v)| v.front().map(|b| (*k, *b)))
     }
 
     /// Provides a reference to the last block from the cache, or `None` if the cache is
     /// empty.
     pub(super) fn back(&self) -> Option<(u64, CachedBlock)> {
-        self.files.last_key_value().and_then(|(k, v)| v.back().map(|b| (*k, *b)))
+        self.read_files().last_key_value().and_then(|(k, v)| v.back().map(|b| (*k, *b)))
     }
 
     /// Removes the notification with the given file ID.
-    pub(super) fn remove_notification(&mut self, key: u64) -> Option<VecDeque<CachedBlock>> {
-        self.files.remove(&key)
+    pub(super) fn remove_notification(&self, key: u64) -> Option<VecDeque<CachedBlock>> {
+        self.write_files().remove(&key)
     }
 
     /// Pops the first block from the cache. If it resulted in the whole file entry being empty,
     /// it will also remove the file entry.
-    pub(super) fn pop_front(&mut self) -> Option<(u64, CachedBlock)> {
-        let first_entry = self.files.first_entry()?;
+    pub(super) fn pop_front(&self) -> Option<(u64, CachedBlock)> {
+        let mut files = self.write_files();
+
+        let first_entry = files.first_entry()?;
         let key = *first_entry.key();
         let blocks = first_entry.into_mut();
         let first_block = blocks.pop_front().unwrap();
         if blocks.is_empty() {
-            self.files.remove(&key);
+            files.remove(&key);
         }
 
         Some((key, first_block))
@@ -72,44 +89,40 @@ impl BlockCache {
 
     /// Pops the last block from the cache. If it resulted in the whole file entry being empty,
     /// it will also remove the file entry.
-    pub(super) fn pop_back(&mut self) -> Option<(u64, CachedBlock)> {
-        let last_entry = self.files.last_entry()?;
+    pub(super) fn pop_back(&self) -> Option<(u64, CachedBlock)> {
+        let mut files = self.write_files();
+
+        let last_entry = files.last_entry()?;
         let key = *last_entry.key();
         let blocks = last_entry.into_mut();
         let last_block = blocks.pop_back().unwrap();
         if blocks.is_empty() {
-            self.files.remove(&key);
+            files.remove(&key);
         }
 
         Some((key, last_block))
-    }
-
-    /// Appends a block to the back of the specified file entry.
-    pub(super) fn insert(&mut self, file_id: u64, block: CachedBlock) {
-        self.files.entry(file_id).or_default().push_back(block);
     }
 
     /// Inserts the blocks from the notification into the cache with the given file ID.
     ///
     /// First, inserts the reverted blocks (if any), then the committed blocks (if any).
     pub(super) fn insert_notification_blocks_with_file_id(
-        &mut self,
+        &self,
         file_id: u64,
         notification: &ExExNotification,
     ) {
+        let mut files = self.write_files();
+
         let reverted_chain = notification.reverted_chain();
         let committed_chain = notification.committed_chain();
 
         if let Some(reverted_chain) = reverted_chain {
             for block in reverted_chain.blocks().values() {
-                self.insert(
-                    file_id,
-                    CachedBlock {
-                        action: CachedBlockAction::Revert,
-                        block: (block.number, block.hash()).into(),
-                        parent_hash: block.parent_hash,
-                    },
-                );
+                files.entry(file_id).or_default().push_back(CachedBlock {
+                    action: CachedBlockAction::Revert,
+                    block: (block.number, block.hash()).into(),
+                    parent_hash: block.parent_hash,
+                });
             }
         }
 
@@ -120,7 +133,7 @@ impl BlockCache {
                     block: (block.number, block.hash()).into(),
                     parent_hash: block.parent_hash,
                 };
-                self.insert(file_id, cached_block);
+                files.entry(file_id).or_default().push_back(cached_block);
                 self.blocks.insert(block.hash(), cached_block);
             }
         }

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -132,6 +132,7 @@ pub(super) struct CachedBlock {
     pub(super) action: CachedBlockAction,
     /// The block number and hash of the block.
     pub(super) block: BlockNumHash,
+    /// The hash of the parent block.
     pub(super) parent_hash: B256,
 }
 

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -4,17 +4,22 @@ use dashmap::DashMap;
 use reth_exex_types::ExExNotification;
 use reth_primitives::{BlockNumHash, B256};
 
-/// The block cache of the WAL. Acts as a mapping of `File ID -> List of Blocks`.
-///
-/// For each notification written to the WAL, there will be an entry per block written to
-/// the cache with the same file ID. I.e. for each notification, there may be multiple blocks in the
-/// cache.
+/// The block cache of the WAL.
 ///
 /// This cache is needed to avoid walking the WAL directory every time we want to find a
-/// notification corresponding to a block.
+/// notification corresponding to a block or a block corresponding to a hash.
 #[derive(Debug)]
 pub struct BlockCache {
+    /// A mapping of `File ID -> List of Blocks`.
+    ///
+    /// For each notification written to the WAL, there will be an entry per block written to
+    /// the cache with the same file ID. I.e. for each notification, there may be multiple blocks
+    /// in the cache.
     files: BTreeMap<u64, VecDeque<CachedBlock>>,
+    /// A mapping of `Block Hash -> Block`.
+    ///
+    /// For each [`ExExNotification::ChainCommitted`] notification, there will be an entry per
+    /// block.
     blocks: DashMap<B256, CachedBlock>,
 }
 

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, VecDeque};
 
+use dashmap::DashMap;
 use reth_exex_types::ExExNotification;
-use reth_primitives::BlockNumHash;
+use reth_primitives::{BlockNumHash, B256};
 
 /// The block cache of the WAL. Acts as a mapping of `File ID -> List of Blocks`.
 ///
@@ -12,50 +13,53 @@ use reth_primitives::BlockNumHash;
 /// This cache is needed to avoid walking the WAL directory every time we want to find a
 /// notification corresponding to a block.
 #[derive(Debug)]
-pub struct BlockCache(BTreeMap<u64, VecDeque<CachedBlock>>);
+pub struct BlockCache {
+    files: BTreeMap<u64, VecDeque<CachedBlock>>,
+    blocks: DashMap<B256, CachedBlock>,
+}
 
 impl BlockCache {
     /// Creates a new instance of [`BlockCache`].
-    pub(super) const fn new() -> Self {
-        Self(BTreeMap::new())
+    pub(super) fn new() -> Self {
+        Self { files: BTreeMap::new(), blocks: DashMap::new() }
     }
 
     /// Returns `true` if the cache is empty.
     pub(super) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.files.is_empty()
     }
 
     /// Returns a front-to-back iterator.
     pub(super) fn iter(&self) -> impl Iterator<Item = (u64, CachedBlock)> + '_ {
-        self.0.iter().flat_map(|(k, v)| v.iter().map(move |b| (*k, *b)))
+        self.files.iter().flat_map(|(k, v)| v.iter().map(move |b| (*k, *b)))
     }
 
     /// Provides a reference to the first block from the cache, or `None` if the cache is
     /// empty.
     pub(super) fn front(&self) -> Option<(u64, CachedBlock)> {
-        self.0.first_key_value().and_then(|(k, v)| v.front().map(|b| (*k, *b)))
+        self.files.first_key_value().and_then(|(k, v)| v.front().map(|b| (*k, *b)))
     }
 
     /// Provides a reference to the last block from the cache, or `None` if the cache is
     /// empty.
     pub(super) fn back(&self) -> Option<(u64, CachedBlock)> {
-        self.0.last_key_value().and_then(|(k, v)| v.back().map(|b| (*k, *b)))
+        self.files.last_key_value().and_then(|(k, v)| v.back().map(|b| (*k, *b)))
     }
 
     /// Removes the notification with the given file ID.
     pub(super) fn remove_notification(&mut self, key: u64) -> Option<VecDeque<CachedBlock>> {
-        self.0.remove(&key)
+        self.files.remove(&key)
     }
 
     /// Pops the first block from the cache. If it resulted in the whole file entry being empty,
     /// it will also remove the file entry.
     pub(super) fn pop_front(&mut self) -> Option<(u64, CachedBlock)> {
-        let first_entry = self.0.first_entry()?;
+        let first_entry = self.files.first_entry()?;
         let key = *first_entry.key();
         let blocks = first_entry.into_mut();
         let first_block = blocks.pop_front().unwrap();
         if blocks.is_empty() {
-            self.0.remove(&key);
+            self.files.remove(&key);
         }
 
         Some((key, first_block))
@@ -64,12 +68,12 @@ impl BlockCache {
     /// Pops the last block from the cache. If it resulted in the whole file entry being empty,
     /// it will also remove the file entry.
     pub(super) fn pop_back(&mut self) -> Option<(u64, CachedBlock)> {
-        let last_entry = self.0.last_entry()?;
+        let last_entry = self.files.last_entry()?;
         let key = *last_entry.key();
         let blocks = last_entry.into_mut();
         let last_block = blocks.pop_back().unwrap();
         if blocks.is_empty() {
-            self.0.remove(&key);
+            self.files.remove(&key);
         }
 
         Some((key, last_block))
@@ -77,7 +81,7 @@ impl BlockCache {
 
     /// Appends a block to the back of the specified file entry.
     pub(super) fn insert(&mut self, file_id: u64, block: CachedBlock) {
-        self.0.entry(file_id).or_default().push_back(block);
+        self.files.entry(file_id).or_default().push_back(block);
     }
 
     /// Inserts the blocks from the notification into the cache with the given file ID.
@@ -98,6 +102,7 @@ impl BlockCache {
                     CachedBlock {
                         action: CachedBlockAction::Revert,
                         block: (block.number, block.hash()).into(),
+                        parent_hash: block.parent_hash,
                     },
                 );
             }
@@ -105,13 +110,13 @@ impl BlockCache {
 
         if let Some(committed_chain) = committed_chain {
             for block in committed_chain.blocks().values() {
-                self.insert(
-                    file_id,
-                    CachedBlock {
-                        action: CachedBlockAction::Commit,
-                        block: (block.number, block.hash()).into(),
-                    },
-                );
+                let cached_block = CachedBlock {
+                    action: CachedBlockAction::Commit,
+                    block: (block.number, block.hash()).into(),
+                    parent_hash: block.parent_hash,
+                };
+                self.insert(file_id, cached_block);
+                self.blocks.insert(block.hash(), cached_block);
             }
         }
     }
@@ -122,6 +127,7 @@ pub(super) struct CachedBlock {
     pub(super) action: CachedBlockAction,
     /// The block number and hash of the block.
     pub(super) block: BlockNumHash,
+    pub(super) parent_hash: B256,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -25,7 +25,7 @@ use reth_tracing::tracing::{debug, instrument};
 ///    with [`Wal::commit`].
 /// 3. When the chain is finalized, call [`Wal::finalize`] to prevent the infinite growth of the
 ///    WAL.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Wal {
     /// The underlying WAL storage backed by a file.
     storage: Storage,
@@ -64,6 +64,11 @@ impl Wal {
         }
 
         Ok(())
+    }
+
+    /// Returns a read-only handle to the WAL.
+    pub fn handle(&self) -> WalHandle {
+        WalHandle { wal: self.clone() }
     }
 
     /// Commits the notification to WAL.
@@ -238,6 +243,12 @@ impl Wal {
 
         Ok(Box::new(self.storage.iter_notifications(range).map(|entry| Ok(entry?.1))))
     }
+}
+
+/// A read-only handle to the WAL that can be shared.
+#[derive(Debug)]
+pub struct WalHandle {
+    wal: Wal,
 }
 
 #[cfg(test)]

--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -339,6 +339,7 @@ mod tests {
                 CachedBlock {
                     action: CachedBlockAction::Commit,
                     block: (blocks[0].number, blocks[0].hash()).into(),
+                    parent_hash: blocks[0].parent_hash,
                 },
             ),
             (
@@ -346,6 +347,7 @@ mod tests {
                 CachedBlock {
                     action: CachedBlockAction::Commit,
                     block: (blocks[1].number, blocks[1].hash()).into(),
+                    parent_hash: blocks[1].parent_hash,
                 },
             ),
         ];
@@ -361,6 +363,7 @@ mod tests {
             CachedBlock {
                 action: CachedBlockAction::Revert,
                 block: (blocks[1].number, blocks[1].hash()).into(),
+                parent_hash: blocks[1].parent_hash,
             },
         )];
         assert_eq!(
@@ -414,6 +417,7 @@ mod tests {
                 CachedBlock {
                     action: CachedBlockAction::Commit,
                     block: (block_1_reorged.number, block_1_reorged.hash()).into(),
+                    parent_hash: block_1_reorged.parent_hash,
                 },
             ),
             (
@@ -421,6 +425,7 @@ mod tests {
                 CachedBlock {
                     action: CachedBlockAction::Commit,
                     block: (blocks[2].number, blocks[2].hash()).into(),
+                    parent_hash: blocks[2].parent_hash,
                 },
             ),
         ];
@@ -451,6 +456,7 @@ mod tests {
                 CachedBlock {
                     action: CachedBlockAction::Revert,
                     block: (blocks[2].number, blocks[2].hash()).into(),
+                    parent_hash: blocks[2].parent_hash,
                 },
             ),
             (
@@ -458,6 +464,7 @@ mod tests {
                 CachedBlock {
                     action: CachedBlockAction::Commit,
                     block: (block_2_reorged.number, block_2_reorged.hash()).into(),
+                    parent_hash: block_2_reorged.parent_hash,
                 },
             ),
             (
@@ -465,6 +472,7 @@ mod tests {
                 CachedBlock {
                     action: CachedBlockAction::Commit,
                     block: (blocks[3].number, blocks[3].hash()).into(),
+                    parent_hash: blocks[3].parent_hash,
                 },
             ),
         ];

--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -15,7 +15,7 @@ use reth_tracing::tracing::{debug, instrument};
 ///
 /// WAL is backed by a directory of binary files represented by [`Storage`] and a block cache
 /// represented by [`BlockCache`]. The role of the block cache is to avoid walking the WAL directory
-/// and decoding notifications every time we want to rollback/finalize the WAL.
+/// and decoding notifications every time we want to iterate or finalize the WAL.
 ///
 /// The expected mode of operation is as follows:
 /// 1. On every new canonical chain notification, call [`Wal::commit`].
@@ -60,6 +60,7 @@ impl Wal {
     }
 }
 
+/// Inner type for the WAL.
 #[derive(Debug)]
 struct WalInner {
     /// The underlying WAL storage backed by a file.

--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -14,7 +14,7 @@ use tracing::instrument;
 ///
 /// Each notification is represented by a single file that contains a MessagePack-encoded
 /// notification.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Storage {
     /// The path to the WAL file.
     path: PathBuf,

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -20,7 +20,7 @@ use reth_db_common::init::init_genesis;
 use reth_ethereum_engine_primitives::EthereumEngineValidator;
 use reth_evm::test_utils::MockExecutorProvider;
 use reth_execution_types::Chain;
-use reth_exex::{ExExContext, ExExEvent, ExExNotification, ExExNotifications};
+use reth_exex::{ExExContext, ExExEvent, ExExNotification, ExExNotifications, Wal};
 use reth_network::{config::SecretKey, NetworkConfigBuilder, NetworkManager};
 use reth_node_api::{
     FullNodeTypes, FullNodeTypesAdapter, NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine,
@@ -49,6 +49,7 @@ use reth_provider::{
 use reth_tasks::TaskManager;
 use reth_transaction_pool::test_utils::{testing_pool, TestPool};
 use std::{
+    env::temp_dir,
     fmt::Debug,
     future::{poll_fn, Future},
     sync::Arc,
@@ -310,6 +311,8 @@ pub async fn test_exex_context_with_chain_spec(
         components.provider.clone(),
         components.components.executor.clone(),
         notifications_rx,
+        // TODO(alexey): do we want to expose WAL to the user?
+        Wal::new(temp_dir())?.handle(),
     );
 
     let ctx = ExExContext {

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -45,6 +45,15 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
             return Ok(None)
         }
 
+        let exex_wal = Wal::new(
+            config_container
+                .config
+                .datadir
+                .clone()
+                .resolve_datadir(config_container.config.chain.chain())
+                .exex_wal(),
+        )?;
+
         let mut exex_handles = Vec::with_capacity(extensions.len());
         let mut exexes = Vec::with_capacity(extensions.len());
 
@@ -55,6 +64,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
                 head,
                 components.provider().clone(),
                 components.block_executor().clone(),
+                exex_wal.handle(),
             );
             exex_handles.push(handle);
 
@@ -96,14 +106,6 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
         // spawn exex manager
         debug!(target: "reth::cli", "spawning exex manager");
         // todo(onbjerg): rm magic number
-        let exex_wal = Wal::new(
-            config_container
-                .config
-                .datadir
-                .clone()
-                .resolve_datadir(config_container.config.chain.chain())
-                .exex_wal(),
-        )?;
         let exex_manager = ExExManager::new(
             exex_handles,
             1024,


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/11261

`WalHandle` doesn't have any methods yet, this PR just makes it clonable and passes it to the notifications structs