### PR TITLE
test(rpc): filter test is taking too long

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -698,28 +698,28 @@ impl Iterator for BlockRangeInclusiveIter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{thread_rng, Rng};
+    use rand::Rng;
+    use reth_testing_utils::generators;
 
     #[test]
     fn test_block_range_iter() {
-        for _ in 0..100 {
-            let mut rng = thread_rng();
-            let start = rng.gen::<u32>() as u64;
-            let end = start.saturating_add(rng.gen::<u32>() as u64);
-            let step = rng.gen::<u16>() as u64;
-            let range = start..=end;
-            let mut iter = BlockRangeInclusiveIter::new(range.clone(), step);
-            let (from, mut end) = iter.next().unwrap();
-            assert_eq!(from, start);
-            assert_eq!(end, (from + step).min(*range.end()));
+        let mut rng = generators::rng();
 
-            for (next_from, next_end) in iter {
-                // ensure range starts with previous end + 1
-                assert_eq!(next_from, end + 1);
-                end = next_end;
-            }
+        let start = rng.gen::<u32>() as u64;
+        let end = start.saturating_add(rng.gen::<u32>() as u64);
+        let step = rng.gen::<u16>() as u64;
+        let range = start..=end;
+        let mut iter = BlockRangeInclusiveIter::new(range.clone(), step);
+        let (from, mut end) = iter.next().unwrap();
+        assert_eq!(from, start);
+        assert_eq!(end, (from + step).min(*range.end()));
 
-            assert_eq!(end, *range.end());
+        for (next_from, next_end) in iter {
+            // ensure range starts with previous end + 1
+            assert_eq!(next_from, end + 1);
+            end = next_end;
         }
+
+        assert_eq!(end, *range.end());
     }
 }


### PR DESCRIPTION
Sometimes this test takes too long https://github.com/paradigmxyz/reth/actions/runs/11071472230/job/30763405952, there should be no need to do a hundred iterations of it.

```console
  TRY 1 SLOW [> 30.000s] reth-rpc eth::filter::tests::test_block_range_iter
  TRY 1 SLOW [> 60.000s] reth-rpc eth::filter::tests::test_block_range_iter
  TRY 1 SLOW [> 90.000s] reth-rpc eth::filter::tests::test_block_range_iter
TRY 1 TRMNTG [>120.000s] reth-rpc eth::filter::tests::test_block_range_iter
   TRY 1 TMT [ 120.008s] reth-rpc eth::filter::tests::test_block_range_iter

--- TRY 1 STDOUT:        reth-rpc eth::filter::tests::test_block_range_iter ---

running 1 test
test eth::filter::tests::test_block_range_iter has been running for over 60 seconds

   DELAY 2/3 by   1.656s reth-rpc eth::filter::tests::test_block_range_iter
   RETRY 2/3 [         ] reth-rpc eth::filter::tests::test_block_range_iter
  TRY 2 PASS [   0.345s] reth-rpc eth::filter::tests::test_block_range_iter
------------
     Summary [ 145.657s] 786 tests run: 786 passed (1 flaky), 791 skipped
   FLAKY 2/3 [   0.345s] reth-rpc eth::filter::tests::test_block_range_iter
```