### PR TITLE
perf(db): use smallvec for mdbx table names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7543,6 +7543,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_xorshift",
  "reth-mdbx-sys",
+ "smallvec",
  "tempfile",
  "thiserror",
  "tracing",

--- a/crates/cli/util/src/allocator.rs
+++ b/crates/cli/util/src/allocator.rs
@@ -12,6 +12,7 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(feature = "tracy-allocator")] {
         type AllocatorWrapper = tracy_client::ProfiledAllocator<AllocatorInner>;
+        tracy_client::register_demangler!();
         const fn new_allocator_wrapper() -> AllocatorWrapper {
             AllocatorWrapper::new(AllocatorInner {}, 100)
         }
@@ -22,9 +23,6 @@ cfg_if::cfg_if! {
         }
     }
 }
-
-#[cfg(feature = "tracy-allocator")]
-tracy_client::register_demangler!();
 
 /// Custom allocator.
 pub type Allocator = AllocatorWrapper;

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -19,14 +19,16 @@ byteorder = "1"
 derive_more.workspace = true
 indexmap = "2"
 parking_lot.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
-dashmap = { workspace = true, features = ["inline"], optional = true }
 tracing.workspace = true
+
+dashmap = { workspace = true, features = ["inline"], optional = true }
 
 [features]
 default = []
 return-borrowed = []
-read-tx-timeouts = ["dashmap", "dashmap/inline"]
+read-tx-timeouts = ["dep:dashmap"]
 
 [dev-dependencies]
 pprof = { workspace = true, features = [


### PR DESCRIPTION
`Database::new` is called on every `tx.new_cursor`, `tx.get`, `tx.put`... (a lot). This function allocates a `CString` for the table name to pass it through FFI to mdbx. Use smallvec to create the `CStr` on the stack to avoid this allocation.