### PR TITLE
perf: improve IntegerList API to avoid allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,6 @@ dependencies = [
  "futures-util",
  "reth",
  "reth-node-ethereum",
- "reth-rpc-types",
 ]
 
 [[package]]

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -21,7 +21,7 @@ pub mod account;
 pub use account::{Account, Bytecode};
 
 mod integer_list;
-pub use integer_list::{IntegerList, RoaringBitmapError};
+pub use integer_list::{IntegerList, IntegerListError};
 
 pub mod request;
 pub use request::{Request, Requests};

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -275,10 +275,8 @@ mod tests {
                     .iter()
                     .filter(|(key, _)| key.highest_block_number > last_pruned_block_number)
                     .map(|(key, blocks)| {
-                        let new_blocks = blocks
-                            .iter()
-                            .skip_while(|block| *block <= last_pruned_block_number)
-                            .collect::<Vec<_>>();
+                        let new_blocks =
+                            blocks.iter().skip_while(|block| *block <= last_pruned_block_number);
                         (key.clone(), BlockNumberList::new_pre_sorted(new_blocks))
                     })
                     .collect::<Vec<_>>();

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -281,10 +281,8 @@ mod tests {
                 .iter()
                 .filter(|(key, _)| key.sharded_key.highest_block_number > last_pruned_block_number)
                 .map(|(key, blocks)| {
-                    let new_blocks = blocks
-                        .iter()
-                        .skip_while(|block| *block <= last_pruned_block_number)
-                        .collect::<Vec<_>>();
+                    let new_blocks =
+                        blocks.iter().skip_while(|block| *block <= last_pruned_block_number);
                     (key.clone(), BlockNumberList::new_pre_sorted(new_blocks))
                 })
                 .collect::<Vec<_>>();

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     fn list(list: &[u64]) -> BlockNumberList {
-        BlockNumberList::new(list).unwrap()
+        BlockNumberList::new(list.iter().copied()).unwrap()
     }
 
     fn cast(

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -197,7 +197,7 @@ mod tests {
     }
 
     fn list(list: &[u64]) -> BlockNumberList {
-        BlockNumberList::new(list).unwrap()
+        BlockNumberList::new(list.iter().copied()).unwrap()
     }
 
     fn cast(

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -54,11 +54,11 @@ where
     let mut cache: HashMap<P, Vec<u64>> = HashMap::default();
 
     let mut collect = |cache: &HashMap<P, Vec<u64>>| {
-        for (key, indice_list) in cache {
-            let last = indice_list.last().expect("qed");
+        for (key, indices) in cache {
+            let last = indices.last().expect("qed");
             collector.insert(
                 sharded_key_factory(*key, *last),
-                BlockNumberList::new_pre_sorted(indice_list),
+                BlockNumberList::new_pre_sorted(indices.iter().copied()),
             )?;
         }
         Ok::<(), StageError>(())

--- a/crates/storage/db-api/src/models/integer_list.rs
+++ b/crates/storage/db-api/src/models/integer_list.rs
@@ -12,6 +12,7 @@ impl Compress for IntegerList {
     fn compress(self) -> Self::Compressed {
         self.to_bytes()
     }
+
     fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
         self.to_mut_bytes(buf)
     }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -1319,7 +1319,7 @@ mod tests {
 
         for i in 1..5 {
             let key = ShardedKey::new(real_key, i * 100);
-            let list: IntegerList = vec![i * 100u64].into();
+            let list = IntegerList::new_pre_sorted([i * 100u64]);
 
             db.update(|tx| tx.put::<AccountsHistory>(key.clone(), list.clone()).expect(""))
                 .unwrap();
@@ -1340,7 +1340,7 @@ mod tests {
                 .expect("should be able to retrieve it.");
 
             assert_eq!(ShardedKey::new(real_key, 200), key);
-            let list200: IntegerList = vec![200u64].into();
+            let list200 = IntegerList::new_pre_sorted([200u64]);
             assert_eq!(list200, list);
         }
         // Seek greatest index
@@ -1357,7 +1357,7 @@ mod tests {
                 .expect("should be able to retrieve it.");
 
             assert_eq!(ShardedKey::new(real_key, 400), key);
-            let list400: IntegerList = vec![400u64].into();
+            let list400 = IntegerList::new_pre_sorted([400u64]);
             assert_eq!(list400, list);
         }
     }

--- a/crates/storage/db/src/tables/codecs/fuzz/inputs.rs
+++ b/crates/storage/db/src/tables/codecs/fuzz/inputs.rs
@@ -10,13 +10,7 @@ pub struct IntegerListInput(pub Vec<u64>);
 impl From<IntegerListInput> for IntegerList {
     fn from(list: IntegerListInput) -> Self {
         let mut v = list.0;
-        // Empty lists are not supported by `IntegerList`, so we want to skip these cases.
-        let list = if v.is_empty() {
-            &[1u64][..]
-        } else {
-            v.sort_unstable();
-            &v
-        };
-        IntegerList::new_pre_sorted(list.iter().copied())
+        v.sort_unstable();
+        Self::new_pre_sorted(v)
     }
 }

--- a/crates/storage/db/src/tables/codecs/fuzz/inputs.rs
+++ b/crates/storage/db/src/tables/codecs/fuzz/inputs.rs
@@ -10,12 +10,13 @@ pub struct IntegerListInput(pub Vec<u64>);
 impl From<IntegerListInput> for IntegerList {
     fn from(list: IntegerListInput) -> Self {
         let mut v = list.0;
-
         // Empty lists are not supported by `IntegerList`, so we want to skip these cases.
-        if v.is_empty() {
-            return vec![1u64].into()
-        }
-        v.sort();
-        v.into()
+        let list = if v.is_empty() {
+            &[1u64][..]
+        } else {
+            v.sort_unstable();
+            &v
+        };
+        IntegerList::new_pre_sorted(list.iter().copied())
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1356,7 +1356,7 @@ impl<TX: DbTxMut + DbTx, Spec: Send + Sync> DatabaseProvider<TX, Spec> {
                 };
                 self.tx.put::<T>(
                     sharded_key_factory(partial_key, highest_block_number),
-                    BlockNumberList::new_pre_sorted(list),
+                    BlockNumberList::new_pre_sorted(list.iter().copied()),
                 )?;
             }
         }

--- a/examples/custom-inspector/Cargo.toml
+++ b/examples/custom-inspector/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 [dependencies]
 reth.workspace = true
 reth-node-ethereum.workspace = true
-reth-rpc-types.workspace = true
 alloy-rpc-types.workspace = true
 clap = { workspace = true, features = ["derive"] }
 futures-util.workspace = true


### PR DESCRIPTION
`RoaringBitmap` is constructed using iterators, don't force callers to construct `IntegerList` using slices.