### PR TITLE
chore: remove generics from Decode and Decompress

### DIFF
--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -134,7 +134,7 @@ where
                     B256::from_slice(&addr_key[..32]),
                     StorageEntry {
                         key: B256::from_slice(&addr_key[32..]),
-                        value: CompactU256::decompress(value)?.into(),
+                        value: CompactU256::decompress_owned(value)?.into(),
                     },
                 )?;
             }

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -118,7 +118,7 @@ where
             collector,
             first_sync,
             ShardedKey::new,
-            ShardedKey::<Address>::decode,
+            ShardedKey::<Address>::decode_owned,
             |key| key.key,
         )?;
 

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -124,7 +124,7 @@ where
             |AddressStorageKey((address, storage_key)), highest_block_number| {
                 StorageShardedKey::new(address, storage_key, highest_block_number)
             },
-            StorageShardedKey::decode,
+            StorageShardedKey::decode_owned,
             |key| AddressStorageKey((key.address, key.sharded_key.key)),
         )?;
 

--- a/crates/storage/db-api/src/models/accounts.rs
+++ b/crates/storage/db-api/src/models/accounts.rs
@@ -64,11 +64,9 @@ impl Encode for BlockNumberAddress {
 }
 
 impl Decode for BlockNumberAddress {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let value = value.as_ref();
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
         let num = u64::from_be_bytes(value[..8].try_into().map_err(|_| DatabaseError::Decode)?);
         let hash = Address::from_slice(&value[8..]);
-
         Ok(Self((num, hash)))
     }
 }
@@ -97,11 +95,9 @@ impl Encode for AddressStorageKey {
 }
 
 impl Decode for AddressStorageKey {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let value = value.as_ref();
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
         let address = Address::from_slice(&value[..20]);
         let storage_key = StorageKey::from_slice(&value[20..]);
-
         Ok(Self((address, storage_key)))
     }
 }
@@ -127,7 +123,7 @@ mod tests {
         let encoded = Encode::encode(key);
         assert_eq!(encoded, bytes);
 
-        let decoded: BlockNumberAddress = Decode::decode(encoded).unwrap();
+        let decoded: BlockNumberAddress = Decode::decode(&encoded).unwrap();
         assert_eq!(decoded, key);
     }
 
@@ -152,7 +148,7 @@ mod tests {
         let encoded = Encode::encode(key);
         assert_eq!(encoded, bytes);
 
-        let decoded: AddressStorageKey = Decode::decode(encoded).unwrap();
+        let decoded: AddressStorageKey = Decode::decode(&encoded).unwrap();
         assert_eq!(decoded, key);
     }
 

--- a/crates/storage/db-api/src/models/blocks.rs
+++ b/crates/storage/db-api/src/models/blocks.rs
@@ -29,9 +29,6 @@ mod tests {
         let mut ommer = StoredBlockOmmers::default();
         ommer.ommers.push(Header::default());
         ommer.ommers.push(Header::default());
-        assert_eq!(
-            ommer.clone(),
-            StoredBlockOmmers::decompress::<Vec<_>>(ommer.compress()).unwrap()
-        );
+        assert_eq!(ommer.clone(), StoredBlockOmmers::decompress(&ommer.compress()).unwrap());
     }
 }

--- a/crates/storage/db-api/src/models/integer_list.rs
+++ b/crates/storage/db-api/src/models/integer_list.rs
@@ -18,7 +18,7 @@ impl Compress for IntegerList {
 }
 
 impl Decompress for IntegerList {
-    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        Self::from_bytes(value.as_ref()).map_err(|_| DatabaseError::Decode)
+    fn decompress(value: &[u8]) -> Result<Self, DatabaseError> {
+        Self::from_bytes(value).map_err(|_| DatabaseError::Decode)
     }
 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -239,8 +239,7 @@ impl_compression_for_compact!(
 macro_rules! impl_compression_fixed_compact {
     ($($name:tt),+) => {
         $(
-            impl Compress for $name
-            {
+            impl Compress for $name {
                 type Compressed = Vec<u8>;
 
                 fn uncompressable_ref(&self) -> Option<&[u8]> {
@@ -252,10 +251,8 @@ macro_rules! impl_compression_fixed_compact {
                 }
             }
 
-            impl Decompress for $name
-            {
+            impl Decompress for $name {
                 fn decompress(value: &[u8]) -> Result<$name, $crate::DatabaseError> {
-                    let value = value;
                     let (obj, _) = Compact::from_compact(&value, value.len());
                     Ok(obj)
                 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -42,10 +42,10 @@ macro_rules! impl_uints {
             }
 
             impl Decode for $name {
-                fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, $crate::DatabaseError> {
+                fn decode(value: &[u8]) -> Result<Self, $crate::DatabaseError> {
                     Ok(
                         $name::from_be_bytes(
-                            value.as_ref().try_into().map_err(|_| $crate::DatabaseError::Decode)?
+                            value.try_into().map_err(|_| $crate::DatabaseError::Decode)?
                         )
                     )
                 }
@@ -65,8 +65,12 @@ impl Encode for Vec<u8> {
 }
 
 impl Decode for Vec<u8> {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        Ok(value.as_ref().to_vec())
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(value.to_vec())
+    }
+
+    fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
+        Ok(value)
     }
 }
 
@@ -79,8 +83,8 @@ impl Encode for Address {
 }
 
 impl Decode for Address {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        Ok(Self::from_slice(value.as_ref()))
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self::from_slice(value))
     }
 }
 
@@ -93,8 +97,8 @@ impl Encode for B256 {
 }
 
 impl Decode for B256 {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        Ok(Self::new(value.as_ref().try_into().map_err(|_| DatabaseError::Decode)?))
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self::new(value.try_into().map_err(|_| DatabaseError::Decode)?))
     }
 }
 
@@ -107,8 +111,12 @@ impl Encode for String {
 }
 
 impl Decode for String {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        Self::from_utf8(value.as_ref().to_vec()).map_err(|_| DatabaseError::Decode)
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Self::decode_owned(value.to_vec())
+    }
+
+    fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
+        Self::from_utf8(value).map_err(|_| DatabaseError::Decode)
     }
 }
 
@@ -124,9 +132,8 @@ impl Encode for StoredNibbles {
 }
 
 impl Decode for StoredNibbles {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let buf = value.as_ref();
-        Ok(Self::from_compact(buf, buf.len()).0)
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self::from_compact(value, value.len()).0)
     }
 }
 
@@ -142,9 +149,8 @@ impl Encode for StoredNibblesSubKey {
 }
 
 impl Decode for StoredNibblesSubKey {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let buf = value.as_ref();
-        Ok(Self::from_compact(buf, buf.len()).0)
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self::from_compact(value, value.len()).0)
     }
 }
 
@@ -159,9 +165,8 @@ impl Encode for PruneSegment {
 }
 
 impl Decode for PruneSegment {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let buf = value.as_ref();
-        Ok(Self::from_compact(buf, buf.len()).0)
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self::from_compact(value, value.len()).0)
     }
 }
 
@@ -177,9 +182,8 @@ impl Encode for ClientVersion {
 }
 
 impl Decode for ClientVersion {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let buf = value.as_ref();
-        Ok(Self::from_compact(buf, buf.len()).0)
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self::from_compact(value, value.len()).0)
     }
 }
 
@@ -196,9 +200,8 @@ macro_rules! impl_compression_for_compact {
             }
 
             impl Decompress for $name {
-                fn decompress<B: AsRef<[u8]>>(value: B) -> Result<$name, $crate::DatabaseError> {
-                    let value = value.as_ref();
-                    let (obj, _) = Compact::from_compact(&value, value.len());
+                fn decompress(value: &[u8]) -> Result<$name, $crate::DatabaseError> {
+                    let (obj, _) = Compact::from_compact(value, value.len());
                     Ok(obj)
                 }
             }
@@ -240,19 +243,19 @@ macro_rules! impl_compression_fixed_compact {
             {
                 type Compressed = Vec<u8>;
 
-                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
-                    let _  = Compact::to_compact(&self, buf);
-                }
-
                 fn uncompressable_ref(&self) -> Option<&[u8]> {
                     Some(self.as_ref())
+                }
+
+                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+                    let _  = Compact::to_compact(&self, buf);
                 }
             }
 
             impl Decompress for $name
             {
-                fn decompress<B: AsRef<[u8]>>(value: B) -> Result<$name, $crate::DatabaseError> {
-                    let value = value.as_ref();
+                fn decompress(value: &[u8]) -> Result<$name, $crate::DatabaseError> {
+                    let value = value;
                     let (obj, _) = Compact::from_compact(&value, value.len());
                     Ok(obj)
                 }

--- a/crates/storage/db-api/src/models/sharded_key.rs
+++ b/crates/storage/db-api/src/models/sharded_key.rs
@@ -16,7 +16,7 @@ pub const NUM_OF_INDICES_IN_SHARD: usize = 2_000;
 /// `Address | 200` -> data is from block 0 to 200.
 ///
 /// `Address | 300` -> data is from block 201 to 300.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct ShardedKey<T> {
     /// The key for this type.
     pub key: T,
@@ -43,11 +43,7 @@ impl<T> ShardedKey<T> {
     }
 }
 
-impl<T> Encode for ShardedKey<T>
-where
-    T: Encode,
-    Vec<u8>: From<<T as Encode>::Encoded>,
-{
+impl<T: Encode> Encode for ShardedKey<T> {
     type Encoded = Vec<u8>;
 
     fn encode(self) -> Self::Encoded {
@@ -57,30 +53,11 @@ where
     }
 }
 
-impl<T> Decode for ShardedKey<T>
-where
-    T: Decode,
-{
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let value = value.as_ref();
-
-        let tx_num_index = value.len() - 8;
-
-        let highest_tx_number = u64::from_be_bytes(
-            value[tx_num_index..].try_into().map_err(|_| DatabaseError::Decode)?,
-        );
-        let key = T::decode(&value[..tx_num_index])?;
-
+impl<T: Decode> Decode for ShardedKey<T> {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let (key, highest_tx_number) = value.split_last_chunk().unwrap();
+        let key = T::decode(key)?;
+        let highest_tx_number = u64::from_be_bytes(*highest_tx_number);
         Ok(Self::new(key, highest_tx_number))
-    }
-}
-
-impl<T> Hash for ShardedKey<T>
-where
-    T: Hash,
-{
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.key.hash(state);
-        self.highest_block_number.hash(state);
     }
 }

--- a/crates/storage/db-api/src/models/storage_sharded_key.rs
+++ b/crates/storage/db-api/src/models/storage_sharded_key.rs
@@ -61,8 +61,7 @@ impl Encode for StorageShardedKey {
 }
 
 impl Decode for StorageShardedKey {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        let value = value.as_ref();
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
         let tx_num_index = value.len() - 8;
 
         let highest_tx_number = u64::from_be_bytes(

--- a/crates/storage/db-api/src/scale.rs
+++ b/crates/storage/db-api/src/scale.rs
@@ -30,8 +30,8 @@ impl<T> Decompress for T
 where
     T: ScaleValue + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
 {
-    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<T, DatabaseError> {
-        parity_scale_codec::Decode::decode(&mut value.as_ref()).map_err(|_| DatabaseError::Decode)
+    fn decompress(mut value: &[u8]) -> Result<T, DatabaseError> {
+        parity_scale_codec::Decode::decode(&mut value).map_err(|_| DatabaseError::Decode)
     }
 }
 

--- a/crates/storage/db-api/src/table.rs
+++ b/crates/storage/db-api/src/table.rs
@@ -38,11 +38,11 @@ pub trait Compress: Send + Sync + Sized + Debug {
 /// Trait that will transform the data to be read from the DB.
 pub trait Decompress: Send + Sync + Sized + Debug {
     /// Decompresses data coming from the database.
-    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError>;
+    fn decompress(value: &[u8]) -> Result<Self, DatabaseError>;
 
     /// Decompresses owned data coming from the database.
     fn decompress_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
-        Self::decompress(value)
+        Self::decompress(&value)
     }
 }
 
@@ -58,7 +58,12 @@ pub trait Encode: Send + Sync + Sized + Debug {
 /// Trait that will transform the data to be read from the DB.
 pub trait Decode: Send + Sync + Sized + Debug {
     /// Decodes data coming from the database.
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError>;
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError>;
+
+    /// Decodes owned data coming from the database.
+    fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
+        Self::decode(&value)
+    }
 }
 
 /// Generic trait that enforces the database key to implement [`Encode`] and [`Decode`].

--- a/crates/storage/db-api/src/utils.rs
+++ b/crates/storage/db-api/src/utils.rs
@@ -10,8 +10,7 @@ macro_rules! impl_fixed_arbitrary {
                 fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
                     let mut buffer = vec![0; $size];
                     u.fill_buffer(buffer.as_mut_slice())?;
-
-                    Decode::decode(buffer).map_err(|_| arbitrary::Error::IncorrectFormat)
+                    Decode::decode_owned(buffer).map_err(|_| arbitrary::Error::IncorrectFormat)
                 }
             }
 
@@ -26,7 +25,7 @@ macro_rules! impl_fixed_arbitrary {
                 fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
                     use proptest::strategy::Strategy;
                     proptest::collection::vec(proptest::arbitrary::any_with::<u8>(args), $size)
-                        .prop_map(move |vec| Decode::decode(vec).unwrap())
+                        .prop_map(move |vec| Decode::decode_owned(vec).unwrap())
                 }
             }
         )+

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -87,7 +87,7 @@ where
             |input| {
                 {
                     for (_, k, _, _) in input {
-                        let _ = <T as Table>::Key::decode(k);
+                        let _ = <T as Table>::Key::decode(&k);
                     }
                 };
                 black_box(());
@@ -115,7 +115,7 @@ where
             |input| {
                 {
                     for (_, _, _, v) in input {
-                        let _ = <T as Table>::Value::decompress(v);
+                        let _ = <T as Table>::Value::decompress(&v);
                     }
                 };
                 black_box(());

--- a/crates/storage/db/benches/iai.rs
+++ b/crates/storage/db/benches/iai.rs
@@ -25,7 +25,7 @@ macro_rules! impl_iai_callgrind_inner {
                 #[library_benchmark]
                 pub fn $decompress() {
                     for (_, _, _, comp) in black_box(load_vectors::<reth_db::tables::$name>()) {
-                        let _ = black_box(<reth_db::tables::$name as Table>::Value::decompress(comp));
+                        let _ = black_box(<reth_db::tables::$name as Table>::Value::decompress(&comp));
                     }
                 }
 
@@ -39,7 +39,7 @@ macro_rules! impl_iai_callgrind_inner {
                 #[library_benchmark]
                 pub fn $decode() {
                     for (_, enc, _, _) in black_box(load_vectors::<reth_db::tables::$name>()) {
-                        let _ = black_box(<reth_db::tables::$name as Table>::Key::decode(enc));
+                        let _ = black_box(<reth_db::tables::$name as Table>::Key::decode(&enc));
                     }
                 }
 

--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -1,7 +1,5 @@
-#![cfg(feature = "test-utils")]
 #![allow(missing_docs)]
-
-use std::{path::Path, sync::Arc};
+#![cfg(feature = "test-utils")]
 
 use alloy_primitives::Bytes;
 use reth_db::{test_utils::create_test_rw_db_with_path, DatabaseEnv};
@@ -11,6 +9,7 @@ use reth_db_api::{
     Database,
 };
 use reth_fs_util as fs;
+use std::{path::Path, sync::Arc};
 
 /// Path where the DB is initialized for benchmarks.
 #[allow(dead_code)]

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -81,7 +81,7 @@ macro_rules! compress_to_buf_or_ref {
         if let Some(value) = $value.uncompressable_ref() {
             Some(value)
         } else {
-            $self.buf.truncate(0);
+            $self.buf.clear();
             $value.compress_to_buf(&mut $self.buf);
             None
         }

--- a/crates/storage/db/src/tables/codecs/fuzz/mod.rs
+++ b/crates/storage/db/src/tables/codecs/fuzz/mod.rs
@@ -30,13 +30,12 @@ macro_rules! impl_fuzzer_with_input {
 
                 /// Encodes and decodes table types returning its encoded size and the decoded object.
                 /// This method is used for benchmarking, so its parameter should be the actual type that is being tested.
-                pub fn encode_and_decode(obj: $name) -> (usize, $name)
-                {
+                pub fn encode_and_decode(obj: $name) -> (usize, $name) {
                     let data = table::$encode::$encode_method(obj);
                     let size = data.len();
 
                     // Some `data` might be a fixed array.
-                    (size, table::$decode::$decode_method(data.to_vec()).expect("failed to decode"))
+                    (size, table::$decode::$decode_method(&data).expect("failed to decode"))
                 }
 
                 #[cfg(test)]

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -429,8 +429,8 @@ impl Encode for ChainStateKey {
 }
 
 impl Decode for ChainStateKey {
-    fn decode<B: AsRef<[u8]>>(value: B) -> Result<Self, reth_db_api::DatabaseError> {
-        if value.as_ref() == [0] {
+    fn decode(value: &[u8]) -> Result<Self, reth_db_api::DatabaseError> {
+        if value == [0] {
             Ok(Self::LastFinalizedBlock)
         } else {
             Err(reth_db_api::DatabaseError::Decode)

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -96,8 +96,12 @@ impl<K: Key> Encode for RawKey<K> {
 
 // Decode
 impl<K: Key> Decode for RawKey<K> {
-    fn decode<B: AsRef<[u8]>>(key: B) -> Result<Self, DatabaseError> {
-        Ok(Self { key: key.as_ref().to_vec(), _phantom: std::marker::PhantomData })
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self { key: value.to_vec(), _phantom: std::marker::PhantomData })
+    }
+
+    fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
+        Ok(Self { key: value, _phantom: std::marker::PhantomData })
     }
 }
 
@@ -168,8 +172,8 @@ impl<V: Value> Compress for RawValue<V> {
 }
 
 impl<V: Value> Decompress for RawValue<V> {
-    fn decompress<B: AsRef<[u8]>>(value: B) -> Result<Self, DatabaseError> {
-        Ok(Self { value: value.as_ref().to_vec(), _phantom: std::marker::PhantomData })
+    fn decompress(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self { value: value.to_vec(), _phantom: std::marker::PhantomData })
     }
 
     fn decompress_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {

--- a/crates/storage/db/src/tables/utils.rs
+++ b/crates/storage/db/src/tables/utils.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 /// Helper function to decode a `(key, value)` pair.
 pub(crate) fn decoder<'a, T>(
-    kv: (Cow<'a, [u8]>, Cow<'a, [u8]>),
+    (k, v): (Cow<'a, [u8]>, Cow<'a, [u8]>),
 ) -> Result<TableRow<T>, DatabaseError>
 where
     T: Table,
@@ -14,11 +14,11 @@ where
     T::Value: Decompress,
 {
     Ok((
-        match kv.0 {
+        match k {
             Cow::Borrowed(k) => Decode::decode(k)?,
-            Cow::Owned(k) => Decode::decode(k)?,
+            Cow::Owned(k) => Decode::decode_owned(k)?,
         },
-        match kv.1 {
+        match v {
             Cow::Borrowed(v) => Decompress::decompress(v)?,
             Cow::Owned(v) => Decompress::decompress_owned(v)?,
         },


### PR DESCRIPTION
And add `decode_owned` to match `decompress_owned`.

There is no benefit of accepting `AsRef<[u8]>` rather than `&[u8]` directly, and instead only makes code size and compilation times worse.