### PR TITLE
perf(trie): use unstable sort when sorting for computing roots

### DIFF
--- a/crates/trie/common/src/root.rs
+++ b/crates/trie/common/src/root.rs
@@ -75,7 +75,7 @@ pub fn state_root_unhashed<A: Into<TrieAccount>>(
 pub fn state_root_unsorted<A: Into<TrieAccount>>(
     state: impl IntoIterator<Item = (B256, A)>,
 ) -> B256 {
-    state_root(state.into_iter().sorted_by_key(|(key, _)| *key))
+    state_root(state.into_iter().sorted_unstable_by_key(|(key, _)| *key))
 }
 
 /// Calculates the root hash of the state represented as MPT.
@@ -105,7 +105,7 @@ pub fn storage_root_unhashed(storage: impl IntoIterator<Item = (B256, U256)>) ->
 /// Sorts and calculates the root hash of account storage trie.
 /// See [`storage_root`] for more info.
 pub fn storage_root_unsorted(storage: impl IntoIterator<Item = (B256, U256)>) -> B256 {
-    storage_root(storage.into_iter().sorted_by_key(|(key, _)| *key))
+    storage_root(storage.into_iter().sorted_unstable_by_key(|(key, _)| *key))
 }
 
 /// Calculates the root hash of account storage trie.


### PR DESCRIPTION
[`slice::sort_unstable`](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_unstable)
> It is typically faster than stable sorting, except in a few special cases, e.g., when the slice is partially sorted.

We expect the iterator not to be sorted, even partially, and not to have any duplicate elements, since it's generally a list of 32-byte hashes in random order.

I've also measured it on a clean load of a 100mb genesis file (computes the state root on launch), which is 20-25% faster at sorting the huge genesis state, and overall 3-5% faster:
![image](https://github.com/user-attachments/assets/df0f87c3-d8db-47cd-bc2e-fda0b3862d1d)
