### PR TITLE
perf(db): cache `ProcessUID::own` in memory

### DIFF
--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -7,7 +7,7 @@ use reth_tracing::tracing::error;
 use std::{
     path::{Path, PathBuf},
     process,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 use sysinfo::{ProcessRefreshKind, RefreshKind, System};
 
@@ -91,7 +91,7 @@ impl StorageLockInner {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ProcessUID {
     /// OS process identifier
     pid: usize,
@@ -109,7 +109,8 @@ impl ProcessUID {
 
     /// Creates [`Self`] from own process.
     fn own() -> Self {
-        Self::new(process::id() as usize).expect("own process")
+        static CACHE: OnceLock<ProcessUID> = OnceLock::new();
+        CACHE.get_or_init(|| Self::new(process::id() as usize).expect("own process")).clone()
     }
 
     /// Parses [`Self`] from a file.

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -102,9 +102,10 @@ struct ProcessUID {
 impl ProcessUID {
     /// Creates [`Self`] for the provided PID.
     fn new(pid: usize) -> Option<Self> {
-        System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()))
-            .process(pid.into())
-            .map(|process| Self { pid, start_time: process.start_time() })
+        let mut system = System::new();
+        let pid2 = sysinfo::Pid::from(pid);
+        system.refresh_process_specifics(pid2, ProcessRefreshKind::new());
+        system.process(pid2).map(|process| Self { pid, start_time: process.start_time() })
     }
 
     /// Creates [`Self`] from own process.


### PR DESCRIPTION
`System::new_with_specifics` is fairly expensive since it will read and parse all of `/proc`, on my machine it takes ~350ms.

I think caching our own PID is valid since we only use `start_time`.

After opening this PR I realized we can filter the parsing step to only parse `/proc/<id>`, and this takes it down to a few microseconds (I can't even see it with samply anymore); I think caching is still worth it just to not deal with any files after parsing it once

(This is called at least twice, in `DatabaseEnv::open` and `StaticFileProvider::new`)