### PR TITLE
chore: relax trait bounds on transact fns

### DIFF
--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -74,7 +74,7 @@ pub fn transact_blockhashes_contract_call<EvmConfig, EXT, DB>(
     evm: &mut Evm<'_, EXT, DB>,
 ) -> Result<Option<ResultAndState>, BlockExecutionError>
 where
-    DB: Database + DatabaseCommit,
+    DB: Database,
     DB::Error: core::fmt::Display,
     EvmConfig: ConfigureEvm<Header = Header>,
 {

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -70,7 +70,7 @@ pub fn transact_beacon_root_contract_call<EvmConfig, EXT, DB, Spec>(
     evm: &mut Evm<'_, EXT, DB>,
 ) -> Result<Option<ResultAndState>, BlockExecutionError>
 where
-    DB: Database + DatabaseCommit,
+    DB: Database,
     DB::Error: core::fmt::Display,
     EvmConfig: ConfigureEvm<Header = Header>,
     Spec: EthereumHardforks,

--- a/crates/evm/src/system_calls/eip7002.rs
+++ b/crates/evm/src/system_calls/eip7002.rs
@@ -55,7 +55,7 @@ pub fn transact_withdrawal_requests_contract_call<EvmConfig, EXT, DB>(
     evm: &mut Evm<'_, EXT, DB>,
 ) -> Result<ResultAndState, BlockExecutionError>
 where
-    DB: Database + DatabaseCommit,
+    DB: Database,
     DB::Error: core::fmt::Display,
     EvmConfig: ConfigureEvm<Header = Header>,
 {

--- a/crates/evm/src/system_calls/eip7251.rs
+++ b/crates/evm/src/system_calls/eip7251.rs
@@ -56,7 +56,7 @@ pub fn transact_consolidation_requests_contract_call<EvmConfig, EXT, DB>(
     evm: &mut Evm<'_, EXT, DB>,
 ) -> Result<ResultAndState, BlockExecutionError>
 where
-    DB: Database + DatabaseCommit,
+    DB: Database,
     DB::Error: core::fmt::Display,
     EvmConfig: ConfigureEvm<Header = Header>,
 {


### PR DESCRIPTION
we can relax these since this does not commit