### PR TITLE
chore: rm ToRpcError usage from engine crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8635,7 +8635,6 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-rpc-api",
- "reth-rpc-types",
  "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-rpc-api.workspace = true
-reth-rpc-types.workspace = true
 reth-storage-api.workspace = true
 reth-beacon-consensus.workspace = true
 reth-payload-builder.workspace = true

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -4,7 +4,6 @@ use jsonrpsee_types::error::{
 };
 use reth_beacon_consensus::{BeaconForkChoiceUpdateError, BeaconOnNewPayloadError};
 use reth_payload_primitives::{EngineObjectValidationError, PayloadBuilderError};
-use reth_rpc_types::ToRpcError;
 use thiserror::Error;
 
 /// The Engine API result type
@@ -92,15 +91,15 @@ pub enum EngineApiError {
     /// The payload or attributes are known to be malformed before processing.
     #[error(transparent)]
     EngineObjectValidationError(#[from] EngineObjectValidationError),
-    /// Any other error
+    /// Any other rpc error
     #[error("{0}")]
-    Other(Box<dyn ToRpcError>),
+    Other(jsonrpsee_types::ErrorObject<'static>),
 }
 
 impl EngineApiError {
     /// Crates a new [`EngineApiError::Other`] variant.
-    pub fn other<E: ToRpcError>(err: E) -> Self {
-        Self::Other(Box::new(err))
+    pub const fn other(err: jsonrpsee_types::ErrorObject<'static>) -> Self {
+        Self::Other(err)
     }
 }
 
@@ -187,7 +186,7 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                 SERVER_ERROR_MSG,
                 Some(ErrorData::new(error)),
             ),
-            EngineApiError::Other(err) => err.to_rpc_error(),
+            EngineApiError::Other(err) => err,
         }
     }
 }


### PR DESCRIPTION
this is the last blocker to remove the rpc-types crate.

this now requires errorobject instead of boxing the trait.