### PR TITLE
chore: update default payload builder logs

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -180,7 +180,7 @@ where
         warn!(target: "payload_builder",
             parent_hash=%parent_block.hash(),
             %err,
-            "failed to apply beacon root contract call for empty payload"
+            "failed to apply beacon root contract call for payload"
         );
         PayloadBuilderError::Internal(err.into())
     })?;
@@ -195,7 +195,7 @@ where
         parent_block.hash(),
     )
     .map_err(|err| {
-        warn!(target: "payload_builder", parent_hash=%parent_block.hash(), %err, "failed to update blockhashes for empty payload");
+        warn!(target: "payload_builder", parent_hash=%parent_block.hash(), %err, "failed to update blockhashes for payload");
         PayloadBuilderError::Internal(err.into())
     })?;
 
@@ -367,7 +367,7 @@ where
             warn!(target: "payload_builder",
                 parent_hash=%parent_block.hash(),
                 %err,
-                "failed to calculate state root for empty payload"
+                "failed to calculate state root for payload"
             );
         })?
     };

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -216,7 +216,7 @@ where
         warn!(target: "payload_builder",
             parent_hash=%parent_block.hash(),
             %err,
-            "failed to apply beacon root contract call for empty payload"
+            "failed to apply beacon root contract call for payload"
         );
         PayloadBuilderError::Internal(err.into())
     })?;
@@ -459,7 +459,7 @@ where
             warn!(target: "payload_builder",
                 parent_hash=%parent_block.hash(),
                 %err,
-                "failed to calculate state root for empty payload"
+                "failed to calculate state root for payload"
             );
         })?
     };


### PR DESCRIPTION
These logs are no longer exclusive for empty payloads, so the logs are updated.