### PR TITLE
chore(builder): reorder revm `State` import

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -42,9 +42,9 @@ use reth_transaction_pool::{
 };
 use reth_trie::HashedPostState;
 use revm::{
-    db::states::bundle_state::BundleRetention,
+    db::{states::bundle_state::BundleRetention, State},
     primitives::{EVMError, EnvWithHandlerCfg, InvalidTransaction, ResultAndState},
-    DatabaseCommit, State,
+    DatabaseCommit,
 };
 use revm_primitives::calc_excess_blob_gas;
 use std::sync::Arc;

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -28,9 +28,9 @@ use reth_transaction_pool::{
 };
 use reth_trie::HashedPostState;
 use revm::{
-    db::states::bundle_state::BundleRetention,
+    db::{states::bundle_state::BundleRetention, State},
     primitives::{EVMError, EnvWithHandlerCfg, InvalidTransaction, ResultAndState},
-    DatabaseCommit, State,
+    DatabaseCommit,
 };
 use revm_primitives::calc_excess_blob_gas;
 use tracing::{debug, trace, warn};


### PR DESCRIPTION
My LSP does not find the correct `State` in revm if it's included as `revm::State` instead of `revm::db::State`