### PR TITLE
Print the exact unknown error code in `libmdbx` error message

### DIFF
--- a/crates/storage/libmdbx-rs/src/error.rs
+++ b/crates/storage/libmdbx-rs/src/error.rs
@@ -120,7 +120,7 @@ pub enum Error {
     #[error("read transaction has been timed out")]
     ReadTransactionTimeout,
     /// Unknown error code.
-    #[error("unknown error code")]
+    #[error("unknown error code: {0}")]
     Other(i32),
 }
 


### PR DESCRIPTION
As a title, this prints the exact error code returned by `libmdbx`, which is helpful for debugging purposes.