### PR TITLE
fix(libmdbx): Some options can only be set after `mdbx_env_open`

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -643,8 +643,6 @@ impl EnvironmentBuilder {
                 }
                 for (opt, v) in [
                     (ffi::MDBX_opt_max_db, self.max_dbs),
-                    (ffi::MDBX_opt_sync_bytes, self.sync_bytes),
-                    (ffi::MDBX_opt_sync_period, self.sync_period),
                     (ffi::MDBX_opt_rp_augment_limit, self.rp_augment_limit),
                     (ffi::MDBX_opt_loose_limit, self.loose_limit),
                     (ffi::MDBX_opt_dp_reserve_limit, self.dp_reserve_limit),
@@ -697,6 +695,15 @@ impl EnvironmentBuilder {
                     self.flags.make_flags() | self.kind.extra_flags(),
                     mode,
                 ))?;
+
+                for (opt, v) in [
+                    (ffi::MDBX_opt_sync_bytes, self.sync_bytes),
+                    (ffi::MDBX_opt_sync_period, self.sync_period),
+                ] {
+                    if let Some(v) = v {
+                        mdbx_result(ffi::mdbx_env_set_option(env, opt, v))?;
+                    }
+                }
 
                 Ok(())
             })() {

--- a/crates/storage/libmdbx-rs/src/error.rs
+++ b/crates/storage/libmdbx-rs/src/error.rs
@@ -119,8 +119,11 @@ pub enum Error {
     /// Read transaction has been timed out.
     #[error("read transaction has been timed out")]
     ReadTransactionTimeout,
+    /// Permission defined
+    #[error("permission denied to setup database")]
+    Permission,
     /// Unknown error code.
-    #[error("unknown error code")]
+    #[error("unknown error code: {0}")]
     Other(i32),
 }
 
@@ -157,6 +160,7 @@ impl Error {
             ffi::MDBX_EACCESS => Self::Access,
             ffi::MDBX_TOO_LARGE => Self::TooLarge,
             ffi::MDBX_EBADSIGN => Self::BadSignature,
+            ffi::MDBX_EPERM => Self::Permission,
             other => Self::Other(other),
         }
     }
@@ -196,6 +200,7 @@ impl Error {
             Self::WriteTransactionUnsupportedInReadOnlyMode |
             Self::NestedTransactionsUnsupportedWithWriteMap => ffi::MDBX_EACCESS,
             Self::ReadTransactionTimeout => -96000, // Custom non-MDBX error code
+            Self::Permission => ffi::MDBX_EPERM,
             Self::Other(err_code) => *err_code,
         }
     }


### PR DESCRIPTION
I'm building some application solely relying on reth libmdbx bindings because it's more actively maintained.

When trying to setup `MDBX_opt_sync_bytes` and `MDBX_opt_sync_period`, this returns `EPERM` which is confusing. After digging into the code, the two options are guarded by:

```c
  case MDBX_opt_sync_bytes:
    // ...
    if (unlikely(!(env->me_flags & MDBX_ENV_ACTIVE)))
      return MDBX_EPERM;
```

And the only place to set `MDBX_ENV_ACTIVE` is in `mdbx_env_open`:

```c
    env->me_flags = (flags & ~MDBX_FATAL_ERROR) | MDBX_ENV_ACTIVE;
```

Therefore, the two options should be set after `mdbx_env_open`.

I have checked other options and these two seem the only special ones. I also added `EPERM` error type to `libmdbx::Error`.
