### PR TITLE
fix(provider): use `canonical_chain` on range lookups

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2247,19 +2247,22 @@ mod tests {
         // Check for partial in-memory ranges
         let blocks = provider.block_range(start_block_number + 1..=end_block_number)?;
         assert_eq!(blocks.len(), in_memory_blocks.len() - 1);
-        for (retrieved_block, expected_block) in blocks.iter().zip(in_memory_blocks.iter().skip(1)) {
+        for (retrieved_block, expected_block) in blocks.iter().zip(in_memory_blocks.iter().skip(1))
+        {
             assert_eq!(retrieved_block, &expected_block.clone().unseal());
         }
 
         let blocks = provider.block_range(start_block_number + 1..=end_block_number - 1)?;
         assert_eq!(blocks.len(), in_memory_blocks.len() - 2);
-        for (retrieved_block, expected_block) in blocks.iter().zip(in_memory_blocks.iter().skip(1)) {
+        for (retrieved_block, expected_block) in blocks.iter().zip(in_memory_blocks.iter().skip(1))
+        {
             assert_eq!(retrieved_block, &expected_block.clone().unseal());
         }
 
         let blocks = provider.block_range(start_block_number + 1..=end_block_number + 1)?;
         assert_eq!(blocks.len(), in_memory_blocks.len() - 1);
-        for (retrieved_block, expected_block) in blocks.iter().zip(in_memory_blocks.iter().skip(1)) {
+        for (retrieved_block, expected_block) in blocks.iter().zip(in_memory_blocks.iter().skip(1))
+        {
             assert_eq!(retrieved_block, &expected_block.clone().unseal());
         }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -129,9 +129,9 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
     /// recent in-memory blocks in case of overlaps.
     ///
     /// * `fetch_db_range` function (`F`) provides access to the database provider, allowing the
-    /// user to retrieve the required range of items from the database.
-    /// * `map_block_state_item` function (`G`) provides each block of the range in the in-memory state,
-    /// allowing for selection or filtering for the desired data.
+    ///   user to retrieve the required range of items from the database.
+    /// * `map_block_state_item` function (`G`) provides each block of the range in the in-memory
+    ///   state, allowing for selection or filtering for the desired data.
     fn fetch_db_mem_range_while<T, F, G, P>(
         &self,
         range: impl RangeBounds<BlockNumber>,


### PR DESCRIPTION
alternative to https://github.com/paradigmxyz/reth/pull/10068

closes https://github.com/paradigmxyz/reth/issues/10037

may close https://github.com/paradigmxyz/reth/issues/11053 https://github.com/paradigmxyz/reth/issues/11308

* use `canonical_chain` on `fetch_db_mem_range_while` to lookup in-mem range atomically
* takes priority of in-mem blocks on overlaps