### PR TITLE
Remove `optimism` feature from optimism crates

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
         name: Run tests
         run: |
           cargo nextest run \
-            --locked -p reth-optimism-node --features "optimism"
+            --locked -p reth-optimism-node
 
   integration-success:
     name: integration success

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -30,8 +30,6 @@ tracy-allocator = ["reth-cli-util/tracy-allocator"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-optimism-node/asm-keccak"]
 
-optimism = ["reth-optimism-cli/optimism", "reth-optimism-node/optimism"]
-
 [[bin]]
 name = "op-reth"
 path = "src/main.rs"

--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![allow(missing_docs, rustdoc::missing_crate_level_docs)]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 use clap::Parser;
 use reth_node_builder::{engine_tree_config::TreeConfig, EngineNodeLauncher};

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -18,14 +18,14 @@ reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true
 reth-db-common.workspace = true
 reth-downloaders.workspace = true
-reth-provider.workspace = true
+reth-provider = { workspace = true, features = ["optimism"] }
 reth-prune.workspace = true
 reth-stages.workspace = true
 reth-static-file.workspace = true
 reth-execution-types.workspace = true
-reth-node-core.workspace = true
+reth-node-core = { workspace = true, features = ["optimism"] }
 reth-optimism-node.workspace = true
-reth-primitives.workspace = true
+reth-primitives = { workspace = true, features = ["optimism"] }
 
 ## optimism
 reth-optimism-primitives.workspace = true
@@ -69,13 +69,6 @@ reth-db-common.workspace = true
 reth-cli-commands.workspace = true
 
 [features]
-optimism = [
-    "reth-primitives/optimism",
-    "reth-optimism-evm/optimism",
-    "reth-provider/optimism",
-    "reth-node-core/optimism",
-    "reth-optimism-node/optimism",
-]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "reth-node-core/asm-keccak",

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -5,10 +5,8 @@
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
-#![cfg_attr(all(not(test), feature = "optimism"), warn(unused_crate_dependencies))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 /// Optimism chain specification parser.
 pub mod chainspec;

--- a/crates/optimism/consensus/Cargo.toml
+++ b/crates/optimism/consensus/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 reth-chainspec.workspace = true
 reth-consensus-common.workspace = true
 reth-consensus.workspace = true
-reth-primitives.workspace = true
+reth-primitives = { workspace = true, features = ["optimism"] }
 reth-trie-common.workspace = true
 
 # op-reth
@@ -31,6 +31,3 @@ tracing.workspace = true
 [dev-dependencies]
 alloy-primitives.workspace = true
 reth-optimism-chainspec.workspace = true
-
-[features]
-optimism = ["reth-primitives/optimism"]

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -6,8 +6,6 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 use alloy_primitives::{B64, U256};
 use reth_chainspec::EthereumHardforks;

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -16,9 +16,9 @@ reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
-reth-revm.workspace = true
+reth-revm = { workspace = true, features = ["optimism"] }
 reth-execution-errors.workspace = true
-reth-execution-types.workspace = true
+reth-execution-types = { workspace = true, features = ["optimism"] }
 reth-prune-types.workspace = true
 
 # ethereum
@@ -31,7 +31,7 @@ reth-optimism-forks.workspace = true
 
 # revm
 revm.workspace = true
-revm-primitives.workspace = true
+revm-primitives = { workspace = true, features = ["optimism"] }
 
 # misc
 thiserror.workspace = true
@@ -42,11 +42,3 @@ reth-revm = { workspace = true, features = ["test-utils"] }
 reth-optimism-chainspec.workspace = true
 alloy-genesis.workspace = true
 alloy-consensus.workspace = true
-
-[features]
-optimism = [
-    "reth-primitives/optimism",
-    "reth-execution-types/optimism",
-    "reth-optimism-consensus/optimism",
-    "reth-revm/optimism",
-]

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -6,8 +6,6 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 use alloy_primitives::{Address, U256};
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv, NextBlockEnvAttributes};

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -12,10 +12,10 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec.workspace = true
-reth-primitives.workspace = true
+reth-chainspec = { workspace = true, features = ["optimism"] }
+reth-primitives = { workspace = true, features = ["optimism"] }
 reth-payload-builder.workspace = true
-reth-auto-seal-consensus.workspace = true
+reth-auto-seal-consensus = { workspace = true, features = ["optimism"] }
 reth-basic-payload-builder.workspace = true
 reth-consensus.workspace = true
 reth-rpc-types.workspace = true
@@ -23,12 +23,12 @@ reth-rpc-types-compat.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
 reth-tracing.workspace = true
-reth-provider.workspace = true
+reth-provider = { workspace = true, features = ["optimism"] }
 reth-transaction-pool.workspace = true
 reth-network.workspace = true
 reth-evm.workspace = true
-reth-revm.workspace = true
-reth-beacon-consensus.workspace = true
+reth-revm = { workspace = true, features = ["optimism"] }
+reth-beacon-consensus = { workspace = true, features = ["optimism"] }
 reth-discv5.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-rpc-eth-api.workspace = true
@@ -76,17 +76,5 @@ alloy-primitives.workspace = true
 alloy-genesis.workspace = true
 
 [features]
-optimism = [
-    "reth-chainspec/optimism",
-    "reth-primitives/optimism",
-    "reth-provider/optimism",
-    "reth-rpc-types-compat/optimism",
-    "reth-optimism-evm/optimism",
-    "reth-optimism-payload-builder/optimism",
-    "reth-beacon-consensus/optimism",
-    "reth-revm/optimism",
-    "reth-auto-seal-consensus/optimism",
-    "reth-optimism-rpc/optimism"
-]
 asm-keccak = ["reth-primitives/asm-keccak"]
 test-utils = ["reth-node-builder/test-utils"]

--- a/crates/optimism/node/src/lib.rs
+++ b/crates/optimism/node/src/lib.rs
@@ -6,8 +6,6 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 /// CLI argument parsing for the optimism node.
 pub mod args;

--- a/crates/optimism/node/tests/e2e/main.rs
+++ b/crates/optimism/node/tests/e2e/main.rs
@@ -1,9 +1,7 @@
 #![allow(missing_docs)]
 
-#[cfg(feature = "optimism")]
 mod p2p;
 
-#[cfg(feature = "optimism")]
 mod utils;
 
 const fn main() {}

--- a/crates/optimism/node/tests/it/main.rs
+++ b/crates/optimism/node/tests/it/main.rs
@@ -1,6 +1,5 @@
 #![allow(missing_docs)]
 
-#[cfg(feature = "optimism")]
 mod builder;
 
 const fn main() {}

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -13,12 +13,12 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec.workspace = true
-reth-primitives.workspace = true
-reth-revm.workspace = true
+reth-chainspec = { workspace = true, features = ["optimism"] }
+reth-primitives = { workspace = true, features = ["optimism"] }
+reth-revm = { workspace = true, features = ["optimism"] }
 reth-transaction-pool.workspace = true
-reth-provider.workspace = true
-reth-rpc-types-compat.workspace = true
+reth-provider = { workspace = true, features = ["optimism"] }
+reth-rpc-types-compat = { workspace = true, features = ["optimism"] }
 reth-evm.workspace = true
 reth-execution-types.workspace = true
 reth-payload-builder.workspace = true
@@ -45,13 +45,3 @@ alloy-rpc-types-engine.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 sha2.workspace = true
-
-[features]
-optimism = [
-    "reth-chainspec/optimism",
-    "reth-primitives/optimism",
-    "reth-provider/optimism",
-    "reth-rpc-types-compat/optimism",
-    "reth-optimism-evm/optimism",
-    "reth-revm/optimism",
-]

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -5,11 +5,9 @@
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
-#![cfg_attr(all(not(test), feature = "optimism"), warn(unused_crate_dependencies))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![allow(clippy::useless_let_if_seq)]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 pub mod builder;
 pub use builder::OptimismPayloadBuilder;

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -14,9 +14,9 @@ workspace = true
 [dependencies]
 # reth
 reth-evm.workspace = true
-reth-primitives.workspace = true
-reth-provider.workspace = true
-reth-rpc-eth-api.workspace = true
+reth-primitives = { workspace = true, features = ["optimism"] }
+reth-provider = { workspace = true, features = ["optimism"] }
+reth-rpc-eth-api = { workspace = true, features = ["optimism"] }
 reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }
@@ -40,7 +40,7 @@ alloy-rpc-types.workspace = true
 op-alloy-network.workspace = true
 op-alloy-rpc-types.workspace = true
 op-alloy-consensus.workspace = true
-revm.workspace = true
+revm = { workspace = true, features = ["optimism"] }
 
 # async
 parking_lot.workspace = true
@@ -58,12 +58,3 @@ derive_more.workspace = true
 
 [dev-dependencies]
 reth-optimism-chainspec.workspace = true
-
-[features]
-optimism = [
-    "reth-optimism-evm/optimism",
-    "reth-primitives/optimism",
-    "reth-provider/optimism",
-    "reth-rpc-eth-api/optimism",
-    "revm/optimism",
-]

--- a/crates/optimism/rpc/src/lib.rs
+++ b/crates/optimism/rpc/src/lib.rs
@@ -5,10 +5,8 @@
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
-#![cfg_attr(all(not(test), feature = "optimism"), warn(unused_crate_dependencies))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 pub mod error;
 pub mod eth;

--- a/crates/optimism/storage/Cargo.toml
+++ b/crates/optimism/storage/Cargo.toml
@@ -11,13 +11,10 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-reth-primitives.workspace = true
+reth-primitives = { workspace = true, features = ["optimism"] }
 
 [dev-dependencies]
 reth-codecs.workspace = true
 reth-db-api.workspace = true
 reth-prune-types.workspace = true
 reth-stages-types.workspace = true
-
-[features]
-optimism = ["reth-primitives/optimism"]

--- a/crates/optimism/storage/src/lib.rs
+++ b/crates/optimism/storage/src/lib.rs
@@ -6,8 +6,6 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Since the optimism related code now lives in separate crates - the inclusion of each crate's code depends on being included as a dependency. So I thought there's no longer the need to conditionally not compile this code