### PR TITLE
fix: sequencer client must be arced

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -67,7 +67,7 @@ pub struct OpEthApi<N: FullNodeComponents> {
     inner: Arc<EthApiNodeBackend<N>>,
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
     /// network.
-    sequencer_client: OnceCell<SequencerClient>,
+    sequencer_client: Arc<OnceCell<SequencerClient>>,
 }
 
 impl<N: FullNodeComponents> OpEthApi<N> {
@@ -93,7 +93,7 @@ impl<N: FullNodeComponents> OpEthApi<N> {
             ctx.config.proof_permits,
         );
 
-        Self { inner: Arc::new(inner), sequencer_client: OnceCell::new() }
+        Self { inner: Arc::new(inner), sequencer_client: Arc::new(OnceCell::new()) }
     }
 }
 


### PR DESCRIPTION
on clone oncencell creates a new instance, but what we want here is to have the same instance across clones

otherwise this doesn't work:

https://github.com/paradigmxyz/reth/blob/883513ddf3af1f41549d6b58f520a02e3f2716da/crates/optimism/bin/src/main.rs#L42-L42