### PR TITLE
fix(providers): collect BlockState before constructing DB provider

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -498,6 +498,21 @@ impl CanonicalInMemoryState {
     ///
     /// This merges the state of all blocks that are part of the chain that the requested block is
     /// the head of. This includes all blocks that connect back to the canonical block on disk.
+    pub fn state_provider_from_state(
+        &self,
+        state: &BlockState,
+        historical: StateProviderBox,
+    ) -> MemoryOverlayStateProvider {
+        let in_memory: Vec<_> =
+            state.chain().into_iter().map(|block_state| block_state.block()).collect();
+
+        MemoryOverlayStateProvider::new(historical, in_memory)
+    }
+
+    /// Return state provider with reference to in-memory blocks that overlay database state.
+    ///
+    /// This merges the state of all blocks that are part of the chain that the requested block is
+    /// the head of. This includes all blocks that connect back to the canonical block on disk.
     pub fn state_provider(
         &self,
         hash: B256,

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -503,8 +503,7 @@ impl CanonicalInMemoryState {
         state: &BlockState,
         historical: StateProviderBox,
     ) -> MemoryOverlayStateProvider {
-        let in_memory: Vec<_> =
-            state.chain().into_iter().map(|block_state| block_state.block()).collect();
+        let in_memory = state.chain().into_iter().map(|block_state| block_state.block()).collect();
 
         MemoryOverlayStateProvider::new(historical, in_memory)
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -177,7 +177,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         let state = state.as_ref();
         let anchor_hash = state.anchor().hash;
         let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
-        Ok(self.canonical_in_memory_state.state_provider(state.hash(), latest_historical))
+        Ok(self.canonical_in_memory_state.state_provider_from_state(state, latest_historical))
     }
 
     /// Returns:


### PR DESCRIPTION
Changes from https://github.com/paradigmxyz/reth/pull/11265 that fix a race condition in the builder

The race condition is between the builder and tree, with the following order of events:
* The builder is trying to get a state provider for a block, with anchor = block `N`
* The persistence task finishes, and cleans up block `N+1` from the in memory state
* The builder fetches calls `CanonicalInmemoryState::state_provider`. In the current code this results in a DB provider for block `N`, and `BlockState` for `N+2, ...`, meaning there is a gap for block `N+1`, which no longer exists in `CanonicalInMemoryState`.

This happens because the anchor hash is determined before block `N+1` is persisted. The `BlockState` is still valid, but we should not be re-fetching the state.

This PR re-uses the `BlockState` that is used to determine the anchor hash, and introduces a new method `state_provider_from_state` that allows this reuse.