### PR TITLE
fix(provider): replace `block_state_by_tx_id` with `get_in_memory_or_storage_by_tx_id` 

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -217,7 +217,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
             return fetch_from_db(provider)
         }
 
-        for block_state in in_mem_chain {
+        for block_state in in_mem_chain.into_iter().rev() {
             let executed_block = block_state.block();
             let block = executed_block.block();
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -217,6 +217,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
             return fetch_from_db(provider)
         }
 
+        // Iterate from the lowest block to the highest
         for block_state in in_mem_chain.into_iter().rev() {
             let executed_block = block_state.block();
             let block = executed_block.block();

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -732,9 +732,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
         self.fetch_db_mem_by_tx_id(
             id,
             |provider| provider.transaction_block(id),
-            |_, block_state| {
-                Ok(Some(block_state.block().block().number))
-            },
+            |_, block_state| Ok(Some(block_state.block().block().number)),
         )
     }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -181,7 +181,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
     }
 
     /// Fetches data from either in-memory state or storage by [`TxNumber`].
-    fn fetch_db_mem_by_tx_id<S, M, R>(
+    fn get_in_memory_or_database_by_tx_id<S, M, R>(
         &self,
         id: TxNumber,
         fetch_from_db: S,
@@ -678,7 +678,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
     }
 
     fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
-        self.fetch_db_mem_by_tx_id(
+        self.get_in_memory_or_database_by_tx_id(
             id,
             |provider| provider.transaction_by_id(id),
             |tx_index, block_state| {
@@ -691,7 +691,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
         &self,
         id: TxNumber,
     ) -> ProviderResult<Option<TransactionSignedNoHash>> {
-        self.fetch_db_mem_by_tx_id(
+        self.get_in_memory_or_database_by_tx_id(
             id,
             |provider| provider.transaction_by_id_no_hash(id),
             |tx_index, block_state| {
@@ -729,7 +729,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
     }
 
     fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
-        self.fetch_db_mem_by_tx_id(
+        self.get_in_memory_or_database_by_tx_id(
             id,
             |provider| provider.transaction_block(id),
             |_, block_state| Ok(Some(block_state.block().block().number)),
@@ -805,7 +805,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
     }
 
     fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
-        self.fetch_db_mem_by_tx_id(
+        self.get_in_memory_or_database_by_tx_id(
             id,
             |provider| provider.transaction_sender(id),
             |tx_index, block_state| {
@@ -823,7 +823,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
 
 impl<N: ProviderNodeTypes> ReceiptProvider for BlockchainProvider2<N> {
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
-        self.fetch_db_mem_by_tx_id(
+        self.get_in_memory_or_database_by_tx_id(
             id,
             |provider| provider.receipt(id),
             |tx_index, block_state| {
@@ -3840,7 +3840,7 @@ mod tests {
         let result = provider.transaction_block(tx_id)?;
         assert!(
             result.is_none(),
-            "`fetch_db_mem_by_tx_id` should be None if the block is in database"
+            "`get_in_memory_or_database_by_tx_id` should be None if the block is in database"
         );
 
         // Ensure that invalid transaction ID returns None

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -181,7 +181,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
     }
 
     /// Fetches data from either in-memory state or storage by [`TxNumber`].
-    fn get_in_memory_or_database_by_tx_id<S, M, R>(
+    fn get_in_memory_or_storage_by_tx_id<S, M, R>(
         &self,
         id: TxNumber,
         fetch_from_db: S,
@@ -678,7 +678,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
     }
 
     fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
-        self.get_in_memory_or_database_by_tx_id(
+        self.get_in_memory_or_storage_by_tx_id(
             id,
             |provider| provider.transaction_by_id(id),
             |tx_index, block_state| {
@@ -691,7 +691,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
         &self,
         id: TxNumber,
     ) -> ProviderResult<Option<TransactionSignedNoHash>> {
-        self.get_in_memory_or_database_by_tx_id(
+        self.get_in_memory_or_storage_by_tx_id(
             id,
             |provider| provider.transaction_by_id_no_hash(id),
             |tx_index, block_state| {
@@ -729,7 +729,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
     }
 
     fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
-        self.get_in_memory_or_database_by_tx_id(
+        self.get_in_memory_or_storage_by_tx_id(
             id,
             |provider| provider.transaction_block(id),
             |_, block_state| Ok(Some(block_state.block().block().number)),
@@ -805,7 +805,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
     }
 
     fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
-        self.get_in_memory_or_database_by_tx_id(
+        self.get_in_memory_or_storage_by_tx_id(
             id,
             |provider| provider.transaction_sender(id),
             |tx_index, block_state| {
@@ -823,7 +823,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
 
 impl<N: ProviderNodeTypes> ReceiptProvider for BlockchainProvider2<N> {
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
-        self.get_in_memory_or_database_by_tx_id(
+        self.get_in_memory_or_storage_by_tx_id(
             id,
             |provider| provider.receipt(id),
             |tx_index, block_state| {
@@ -3840,7 +3840,7 @@ mod tests {
         let result = provider.transaction_block(tx_id)?;
         assert!(
             result.is_none(),
-            "`get_in_memory_or_database_by_tx_id` should be None if the block is in database"
+            "`get_in_memory_or_storage_by_tx_id` should be None if the block is in database"
         );
 
         // Ensure that invalid transaction ID returns None

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -3838,10 +3838,7 @@ mod tests {
 
         // Retrieve the block number for this transaction
         let result = provider.transaction_block(tx_id)?;
-        assert!(
-            result.is_none(),
-            "`get_in_memory_or_storage_by_tx_id` should be None if the block is in database"
-        );
+        assert_eq!(Some(0), result, "The block number should match the database block number");
 
         // Ensure that invalid transaction ID returns None
         let result = provider.transaction_block(67675657)?;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -224,7 +224,6 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
             for tx_index in 0..block.body.transactions.len() {
                 if id == in_memory_tx_num {
                     return fetch_from_block_state(tx_index, block_state)
-                    // return Ok((provider, Some((Some(block_state), tx_index))))
                 }
 
                 in_memory_tx_num += 1;


### PR DESCRIPTION
* `self.canonical_in_memory_state.state_by_number` should **not** be used inside a loop. Similar to https://github.com/paradigmxyz/reth/pull/11332 , it should use `canonical_chain` which provides a snapshot view.
* `block_state_by_tx_id` replaced by `get_in_memory_or_storage_by_tx_id `. User now passes two closures on how it fetches the data if it's on database or in-mem. Similar to `fetch_db_mem_range_while` or `get_with_static_file_or_database`

may close https://github.com/paradigmxyz/reth/issues/11053 https://github.com/paradigmxyz/reth/issues/11308