### PR TITLE
chore(sdk): move getters for `TransactionSigned` into trait

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -9,7 +9,7 @@ use reth_chainspec::ChainInfo;
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_metrics::{metrics::Gauge, Metrics};
 use reth_primitives::{
-    Header, Receipt, Receipts, SealedBlock, SealedBlockWithSenders, SealedHeader,
+    BlockWithSenders, Header, Receipt, Receipts, SealedBlock, SealedBlockWithSenders, SealedHeader,
     SignedTransaction, TransactionMeta, TransactionSigned,
 };
 use reth_storage_api::StateProviderBox;

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -1,9 +1,7 @@
 //! Types for tracking the canonical chain state in memory.
 
-use crate::{
-    CanonStateNotification, CanonStateNotificationSender, CanonStateNotifications,
-    ChainInfoTracker, MemoryOverlayStateProvider,
-};
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
+
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{map::HashMap, Address, TxHash, B256};
 use parking_lot::RwLock;
@@ -11,13 +9,17 @@ use reth_chainspec::ChainInfo;
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_metrics::{metrics::Gauge, Metrics};
 use reth_primitives::{
-    Header, Receipt, Receipts, SealedBlock, SealedBlockWithSenders, SealedHeader, TransactionMeta,
-    TransactionSigned,
+    Header, Receipt, Receipts, SealedBlock, SealedBlockWithSenders, SealedHeader,
+    SignedTransaction, TransactionMeta, TransactionSigned,
 };
 use reth_storage_api::StateProviderBox;
 use reth_trie::{updates::TrieUpdates, HashedPostState};
-use std::{collections::BTreeMap, sync::Arc, time::Instant};
 use tokio::sync::{broadcast, watch};
+
+use crate::{
+    CanonStateNotification, CanonStateNotificationSender, CanonStateNotifications,
+    ChainInfoTracker, MemoryOverlayStateProvider,
+};
 
 /// Size of the broadcast channel used to notify canonical state events.
 const CANON_STATE_NOTIFICATION_CHANNEL_SIZE: usize = 256;

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -1,14 +1,3 @@
-use crate::{mode::MiningMode, Storage};
-use alloy_rpc_types_engine::ForkchoiceState;
-use futures_util::{future::BoxFuture, FutureExt};
-use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_engine_primitives::EngineTypes;
-use reth_evm::execute::BlockExecutorProvider;
-use reth_provider::{CanonChainTracker, StateProviderFactory};
-use reth_stages_api::PipelineEvent;
-use reth_tokio_util::EventStream;
-use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
 use std::{
     collections::VecDeque,
     future::Future,
@@ -16,8 +5,22 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+use alloy_rpc_types_engine::ForkchoiceState;
+use futures_util::{future::BoxFuture, FutureExt};
+use reth_beacon_consensus::{BeaconEngineMessage, ForkchoiceStatus};
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_engine_primitives::EngineTypes;
+use reth_evm::execute::BlockExecutorProvider;
+use reth_primitives::SignedTransaction;
+use reth_provider::{CanonChainTracker, StateProviderFactory};
+use reth_stages_api::PipelineEvent;
+use reth_tokio_util::EventStream;
+use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use tracing::{debug, error, warn};
+
+use crate::{mode::MiningMode, Storage};
 
 /// A Future that listens for new ready transactions and puts new blocks into storage
 pub struct MiningTask<Client, Pool: TransactionPool, Executor, Engine: EngineTypes, ChainSpec> {

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -1,5 +1,12 @@
 //! Stream wrapper that simulates reorgs.
 
+use std::{
+    collections::VecDeque,
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
 use alloy_primitives::U256;
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayload, ForkchoiceState, PayloadStatus,
@@ -12,7 +19,7 @@ use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResu
 use reth_ethereum_forks::EthereumHardforks;
 use reth_evm::{system_calls::SystemCaller, ConfigureEvm};
 use reth_payload_validator::ExecutionPayloadValidator;
-use reth_primitives::{proofs, Block, BlockBody, Header, Receipt, Receipts};
+use reth_primitives::{proofs, Block, BlockBody, Header, Receipt, Receipts, SignedTransaction};
 use reth_provider::{BlockReader, ExecutionOutcome, ProviderError, StateProviderFactory};
 use reth_revm::{
     database::StateProviderDatabase,
@@ -24,12 +31,6 @@ use reth_rpc_types_compat::engine::payload::block_to_payload;
 use reth_trie::HashedPostState;
 use revm_primitives::{
     calc_excess_blob_gas, BlockEnv, CfgEnvWithHandlerCfg, EVMError, EnvWithHandlerCfg,
-};
-use std::{
-    collections::VecDeque,
-    future::Future,
-    pin::Pin,
-    task::{ready, Context, Poll},
 };
 use tokio::sync::oneshot;
 use tracing::*;

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -1,17 +1,19 @@
 //! Contains [Chain], a chain of blocks and their final state.
 
-use crate::ExecutionOutcome;
 use alloc::{borrow::Cow, collections::BTreeMap};
+use core::{fmt, ops::RangeInclusive};
+
 use alloy_eips::{eip1898::ForkBlock, BlockNumHash};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash};
-use core::{fmt, ops::RangeInclusive};
 use reth_execution_errors::{BlockExecutionError, InternalBlockExecutionError};
 use reth_primitives::{
-    Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader, TransactionSigned,
-    TransactionSignedEcRecovered,
+    Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader, SignedTransaction,
+    TransactionSigned, TransactionSignedEcRecovered,
 };
 use reth_trie::updates::TrieUpdates;
 use revm::db::BundleState;
+
+use crate::ExecutionOutcome;
 
 /// A chain of blocks and their final state.
 ///

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -48,7 +48,9 @@ use reth_network_p2p::{
 };
 use reth_network_peers::PeerId;
 use reth_network_types::ReputationChangeKind;
-use reth_primitives::{PooledTransactionsElement, TransactionSigned, TransactionSignedEcRecovered};
+use reth_primitives::{
+    PooledTransactionsElement, SignedTransaction, TransactionSigned, TransactionSignedEcRecovered,
+};
 use reth_tokio_util::EventStream;
 use reth_transaction_pool::{
     error::{PoolError, PoolResult},

--- a/crates/optimism/primitives/src/signed_transaction.rs
+++ b/crates/optimism/primitives/src/signed_transaction.rs
@@ -26,6 +26,18 @@ pub struct OpTransactionSigned {
 }
 
 impl SignedTransaction for OpTransactionSigned {
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn hash(&self) -> TxHash {
+        self.hash
+    }
+
+    fn hash_ref(&self) -> &TxHash {
+        &self.hash
+    }
+
     fn recover_signer(&self) -> Option<Address> {
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1066,21 +1066,6 @@ impl AsRef<Self> for TransactionSigned {
 // === impl TransactionSigned ===
 
 impl TransactionSigned {
-    /// Transaction signature.
-    pub const fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    /// Transaction hash. Used to identify transaction.
-    pub const fn hash(&self) -> TxHash {
-        self.hash
-    }
-
-    /// Reference to transaction hash. Used to identify transaction.
-    pub const fn hash_ref(&self) -> &TxHash {
-        &self.hash
-    }
-
     /// Recovers a list of signers from a transaction list iterator.
     ///
     /// Returns `None`, if some transaction's signature is invalid, see also
@@ -1440,6 +1425,18 @@ impl Decodable2718 for TransactionSigned {
 }
 
 impl SignedTransaction for TransactionSigned {
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn hash(&self) -> TxHash {
+        self.hash
+    }
+
+    fn hash_ref(&self) -> &TxHash {
+        &self.hash
+    }
+
     fn recover_signer(&self) -> Option<Address> {
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.

--- a/crates/primitives/src/transaction/signed.rs
+++ b/crates/primitives/src/transaction/signed.rs
@@ -1,9 +1,18 @@
 //! API of a signed transaction, w.r.t. network stack.
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, Signature, TxHash};
 
 /// A signed transaction.
 pub trait SignedTransaction: Sized {
+    /// Transaction signature.
+    fn signature(&self) -> &Signature;
+
+    /// Transaction hash. Used to identify transaction.
+    fn hash(&self) -> TxHash;
+
+    /// Reference to transaction hash. Used to identify transaction.
+    fn hash_ref(&self) -> &TxHash;
+
     /// Recover signer from signature and hash.
     ///
     /// Returns `None` if the transaction's signature is invalid following [EIP-2](https://eips.ethereum.org/EIPS/eip-2), see also [`recover_signer`].

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -1,9 +1,6 @@
 //! Loads a pending block from database. Helper trait for `eth_` transaction, call and trace RPC
 //! methods.
 
-use crate::{
-    AsEthApiError, FromEthApiError, FromEvmError, FullEthApiTypes, IntoEthApiError, RpcBlock,
-};
 use alloy_eips::{eip1559::calc_next_block_base_fee, eip2930::AccessListResult};
 use alloy_primitives::{Bytes, TxKind, B256, U256};
 use alloy_rpc_types::{
@@ -20,7 +17,7 @@ use reth_primitives::{
         BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ExecutionResult, HaltReason,
         ResultAndState, TransactTo, TxEnv,
     },
-    Header, TransactionSignedEcRecovered,
+    Header, SignedTransaction, TransactionSignedEcRecovered,
 };
 use reth_provider::{ChainSpecProvider, HeaderProvider, StateProvider};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB, DatabaseRef};
@@ -38,6 +35,10 @@ use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GA
 use revm::{Database, DatabaseCommit, GetInspector};
 use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use tracing::trace;
+
+use crate::{
+    AsEthApiError, FromEthApiError, FromEvmError, FullEthApiTypes, IntoEthApiError, RpcBlock,
+};
 
 use super::{LoadBlock, LoadPendingBlock, LoadState, LoadTransaction, SpawnBlocking, Trace};
 

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -4,7 +4,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types::{BlockId, TransactionInfo};
 use futures::Future;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
-use reth_primitives::Header;
+use reth_primitives::{Header, SignedTransaction};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDb, StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types::{BlockNumberOrTag, TransactionInfo};
 use alloy_rpc_types_eth::transaction::TransactionRequest;
 use futures::Future;
 use reth_primitives::{
-    BlockId, Receipt, SealedBlockWithSenders, TransactionMeta, TransactionSigned,
+    BlockId, Receipt, SealedBlockWithSenders, SignedTransaction, TransactionMeta, TransactionSigned,
 };
 use reth_provider::{BlockNumReader, BlockReaderIdExt, ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_types::{

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -6,7 +6,7 @@ use alloy_primitives::TxHash;
 use alloy_rpc_types::{FilterId, FilteredParams, Log};
 use reth_chainspec::ChainInfo;
 use reth_errors::ProviderError;
-use reth_primitives::{BlockNumHash, Receipt};
+use reth_primitives::{BlockNumHash, Receipt, SignedTransaction};
 use reth_rpc_server_types::result::rpc_error_with_code;
 use reth_storage_api::BlockReader;
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -11,8 +11,8 @@ use jsonrpsee_types::ErrorObject;
 use reth_primitives::{
     logs_bloom,
     proofs::{calculate_receipt_root, calculate_transaction_root},
-    BlockBody, BlockWithSenders, Receipt, Signature, Transaction, TransactionSigned,
-    TransactionSignedNoHash,
+    BlockBody, BlockWithSenders, Receipt, Signature, SignedTransaction, Transaction,
+    TransactionSigned, TransactionSignedNoHash,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_server_types::result::rpc_err;

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -4,7 +4,7 @@
 
 use alloy_primitives::B256;
 use alloy_rpc_types::TransactionInfo;
-use reth_primitives::TransactionSignedEcRecovered;
+use reth_primitives::{SignedTransaction, TransactionSignedEcRecovered};
 use reth_rpc_types_compat::{
     transaction::{from_recovered, from_recovered_with_block_context},
     TransactionCompat,

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -6,7 +6,8 @@ use alloy_rpc_types::{
     Block, BlockError, BlockTransactions, BlockTransactionsKind, Header, TransactionInfo,
 };
 use reth_primitives::{
-    Block as PrimitiveBlock, BlockWithSenders, Header as PrimitiveHeader, SealedHeader, Withdrawals,
+    Block as PrimitiveBlock, BlockWithSenders, Header as PrimitiveHeader, SealedHeader,
+    SignedTransaction, Withdrawals,
 };
 
 use crate::{transaction::from_recovered_with_block_context, TransactionCompat};

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -9,7 +9,7 @@ use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{
     revm_primitives::db::{DatabaseCommit, DatabaseRef},
-    PooledTransactionsElement,
+    PooledTransactionsElement, SignedTransaction,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_api::{FromEthApiError, FromEvmError};

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -4,7 +4,7 @@ use alloy_network::{AnyNetwork, Network};
 use alloy_primitives::{Address, TxKind};
 use alloy_rpc_types::{Transaction, TransactionInfo};
 use alloy_serde::WithOtherFields;
-use reth_primitives::TransactionSignedEcRecovered;
+use reth_primitives::{SignedTransaction, TransactionSignedEcRecovered};
 use reth_rpc_types_compat::{
     transaction::{from_primitive_signature, GasPrice},
     TransactionCompat,

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -7,6 +7,7 @@ use reth_db_api::{
     transaction::{DbTx, DbTxMut},
 };
 use reth_etl::Collector;
+use reth_primitives::SignedTransaction;
 use reth_provider::{
     BlockReader, DBProvider, PruneCheckpointReader, PruneCheckpointWriter,
     StaticFileProviderFactory, StatsReader, TransactionsProvider, TransactionsProviderExt,

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1,12 +1,7 @@
 //! Mock types.
 
-use crate::{
-    identifier::{SenderIdentifiers, TransactionId},
-    pool::txpool::TxPool,
-    traits::TransactionOrigin,
-    CoinbaseTipOrdering, EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction,
-    ValidPoolTransaction,
-};
+use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
+
 use alloy_consensus::{TxEip1559, TxEip2930, TxEip4844, TxLegacy};
 use alloy_eips::eip2930::AccessList;
 use alloy_primitives::{Address, Bytes, ChainId, TxHash, TxKind, B256, U256};
@@ -19,11 +14,17 @@ use reth_primitives::{
     constants::{eip4844::DATA_GAS_PER_BLOB, MIN_PROTOCOL_BASE_FEE},
     transaction::TryFromRecoveredTransactionError,
     BlobTransactionSidecar, BlobTransactionValidationError, PooledTransactionsElementEcRecovered,
-    Signature, Transaction, TransactionSigned, TransactionSignedEcRecovered, TxType,
-    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
+    Signature, SignedTransaction, Transaction, TransactionSigned, TransactionSignedEcRecovered,
+    TxType, EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
 };
 
-use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
+use crate::{
+    identifier::{SenderIdentifiers, TransactionId},
+    pool::txpool::TxPool,
+    traits::TransactionOrigin,
+    CoinbaseTipOrdering, EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction,
+    ValidPoolTransaction,
+};
 
 /// A transaction pool implementation using [`MockOrdering`] for transaction ordering.
 ///

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -17,8 +17,8 @@ use reth_execution_types::ChangedAccount;
 use reth_primitives::{
     kzg::KzgSettings, transaction::TryFromRecoveredTransactionError, BlobTransactionSidecar,
     BlobTransactionValidationError, PooledTransactionsElement,
-    PooledTransactionsElementEcRecovered, SealedBlock, Transaction, TransactionSignedEcRecovered,
-    EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+    PooledTransactionsElementEcRecovered, SealedBlock, SignedTransaction, Transaction,
+    TransactionSignedEcRecovered, EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/11253

Moves getters from `TransactionSigned` fields into trait methods of `SignedTransaction`