### PR TITLE
ci(hive): update expected rpc-compat failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -20,7 +20,24 @@ rpc-compat:
   - eth_getBlockByNumber/get-latest (reth)
   - eth_getBlockByNumber/get-safe (reth)
 
-# https://github.com/paradigmxyz/reth/issues/8732
+  - eth_createAccessList/create-al-contract-eip1559 (reth)
+  - eth_createAccessList/create-al-contract (reth)
+  - eth_getProof/get-account-proof-blockhash (reth)
+  - eth_getProof/get-account-proof-latest (reth)
+  - eth_getProof/get-account-proof-with-storage (reth)
+  - eth_getTransactionByBlockHashAndIndex/get-block-n (reth)
+  - eth_getTransactionByBlockNumberAndIndex/get-block-n (reth)
+  - eth_getTransactionByHash/get-access-list (reth)
+  - eth_getTransactionByHash/get-blob-tx (reth)
+  - eth_getTransactionByHash/get-dynamic-fee (reth)
+  - eth_getTransactionByHash/get-legacy-create (reth)
+  - eth_getTransactionByHash/get-legacy-input (reth)
+  - eth_getTransactionByHash/get-legacy-tx (reth)
+  - eth_getTransactionReceipt/get-legacy-contract (reth)
+  - eth_getTransactionReceipt/get-legacy-input (reth)
+  - eth_getTransactionReceipt/get-legacy-receipt (reth)'
+
+  # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:
   - Withdrawals Fork On Genesis (Paris) (reth)
   - Withdrawals Fork on Block 1 (Paris) (reth)

--- a/.github/assets/hive/expected_failures_experimental.yaml
+++ b/.github/assets/hive/expected_failures_experimental.yaml
@@ -20,6 +20,23 @@ rpc-compat:
   - eth_getBlockByNumber/get-latest (reth)
   - eth_getBlockByNumber/get-safe (reth)
 
+  - eth_createAccessList/create-al-contract-eip1559 (reth)
+  - eth_createAccessList/create-al-contract (reth)
+  - eth_getProof/get-account-proof-blockhash (reth)
+  - eth_getProof/get-account-proof-latest (reth)
+  - eth_getProof/get-account-proof-with-storage (reth)
+  - eth_getTransactionByBlockHashAndIndex/get-block-n (reth)
+  - eth_getTransactionByBlockNumberAndIndex/get-block-n (reth)
+  - eth_getTransactionByHash/get-access-list (reth)
+  - eth_getTransactionByHash/get-blob-tx (reth)
+  - eth_getTransactionByHash/get-dynamic-fee (reth)
+  - eth_getTransactionByHash/get-legacy-create (reth)
+  - eth_getTransactionByHash/get-legacy-input (reth)
+  - eth_getTransactionByHash/get-legacy-tx (reth)
+  - eth_getTransactionReceipt/get-legacy-contract (reth)
+  - eth_getTransactionReceipt/get-legacy-input (reth)
+  - eth_getTransactionReceipt/get-legacy-receipt (reth)'
+
 # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:
   - Withdrawals Fork On Genesis (Paris) (reth)


### PR DESCRIPTION
These tests expect non-checksummed versions of addresses in the RPC responses and we now return checksummed addresses:
```
>>  {"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByHash","params":["0xbdb37c763e721bf1a0e94e0bc72db704110b2ccc6720713708744422a2cc95d6"]}
<<  {"jsonrpc":"2.0","id":1,"result":{"hash":"0xbdb37c763e721bf1a0e94e0bc72db704110b2ccc6720713708744422a2cc95d6","nonce":"0x0","blockHash":"0xac5c61edb087a51279674fe01d5c1f65eac3fd8597f9bea215058e745df8088e","blockNumber":"0x1","transactionIndex":"0x0","from":"0x7435ed30A8b4AEb0877CEf0c6E8cFFe834eb865f","to":null,"value":"0x0","gasPrice":"0x342770c1","gas":"0x131ec","input":"0x600d380380600d6000396000f360004381526020014681526020014181526020014881526020014481526020013281526020013481526020016000f3","r":"0xdf95c12446d276292221a19cca4f3e678f113a412bf3845bd85dc5bb5bd87def","s":"0x523b1712e2f5a7b421f5740d32f51fd33a525026a21fd89770a55480ad28732","v":"0x18e5bb3abd10a0","chainId":"0xc72dd9d5e883e","type":"0x0"}}
response differs from expected (-- client, ++ test):
 {
   "id": 1,
   "jsonrpc": "2.0",
   "result": {
     "blockHash": "0xac5c61edb087a51279674fe01d5c1f65eac3fd8597f9bea215058e745df8088e",
     "blockNumber": "0x1",
     "chainId": "0xc72dd9d5e883e",
-    "from": "0x7435ed30A8b4AEb0877CEf0c6E8cFFe834eb865f",
+    "from": "0x7435ed30a8b4aeb0877cef0c6e8cffe834eb865f",
     "gas": "0x131ec",
     "gasPrice": "0x342770c1",
     "hash": "0xbdb37c763e721bf1a0e94e0bc72db704110b2ccc6720713708744422a2cc95d6",
     "input": "0x600d380380600d6000396000f360004381526020014681526020014181526020014881526020014481526020013281526020013481526020016000f3",
     "nonce": "0x0",
     "r": "0xdf95c12446d276292221a19cca4f3e678f113a412bf3845bd85dc5bb5bd87def",
     "s": "0x523b1712e2f5a7b421f5740d32f51fd33a525026a21fd89770a55480ad28732",
     "to": null,
     "transactionIndex": "0x0",
     "type": "0x0",
     "v": "0x18e5bb3abd10a0",
     "value": "0x0"
   }
 }
```