### PR TITLE
chore: propagate std feature to alloy-trie

### DIFF
--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -49,15 +49,13 @@ op-alloy-rpc-types.workspace = true
 
 [features]
 default = ["std"]
-optimism = [
-    "serde",
-    "dep:op-alloy-rpc-types",
-    "reth-optimism-forks",
+optimism = ["serde", "dep:op-alloy-rpc-types", "reth-optimism-forks"]
+std = [
+    "alloy-chains/std",
+    "alloy-eips/std",
+    "alloy-genesis/std",
+    "alloy-primitives/std",
+    "alloy-trie/std",
 ]
-std = []
-arbitrary = [
-    "alloy-chains/arbitrary"
-]
+arbitrary = ["alloy-chains/arbitrary"]
 test-utils = []
-
-


### PR DESCRIPTION
There's likely many more dependencies that never enable std because it's not propagated, even if obviously we're building the reth binary with std