### PR TITLE
feat(node): export `EngineArgs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7807,6 +7807,7 @@ dependencies = [
  "reth-db",
  "reth-discv4",
  "reth-discv5",
+ "reth-engine-primitives",
  "reth-fs-util",
  "reth-net-nat",
  "reth-network",

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -68,6 +68,58 @@ pub mod prometheus_exporter {
 /// change.
 pub mod args {
     pub use reth_node_core::args::*;
+
+    use clap::Args;
+    use reth_node_builder::engine_tree_config::{
+        DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD,
+    };
+
+    /// Parameters for configuring the engine
+    #[derive(Debug, Clone, Args, PartialEq, Eq)]
+    #[command(next_help_heading = "Engine")]
+    pub struct EngineArgs {
+        /// Enable the engine2 experimental features on reth binary
+        #[arg(long = "engine.experimental", default_value = "false")]
+        pub experimental: bool,
+
+        /// Configure persistence threshold for engine experimental.
+        #[arg(long = "engine.persistence-threshold", requires = "experimental", default_value_t = DEFAULT_PERSISTENCE_THRESHOLD)]
+        pub persistence_threshold: u64,
+
+        /// Configure the target number of blocks to keep in memory.
+        #[arg(long = "engine.memory-block-buffer-target", requires = "experimental", default_value_t = DEFAULT_MEMORY_BLOCK_BUFFER_TARGET)]
+        pub memory_block_buffer_target: u64,
+    }
+
+    impl Default for EngineArgs {
+        fn default() -> Self {
+            Self {
+                experimental: false,
+                persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
+                memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use clap::Parser;
+
+        /// A helper type to parse Args more easily
+        #[derive(Parser)]
+        struct CommandParser<T: Args> {
+            #[command(flatten)]
+            args: T,
+        }
+
+        #[test]
+        fn test_parse_engine_args() {
+            let default_args = EngineArgs::default();
+            let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
+            assert_eq!(args, default_args);
+        }
+    }
 }
 
 /// Re-exported from `reth_node_core`, also to prevent a breaking change. See the comment on

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -3,43 +3,14 @@
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
-use clap::{Args, Parser};
-use reth::{args::utils::DefaultChainSpecParser, cli::Cli};
-use reth_node_builder::{
-    engine_tree_config::{
-        TreeConfig, DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD,
-    },
-    EngineNodeLauncher,
+use clap::Parser;
+use reth::{
+    args::{utils::DefaultChainSpecParser, EngineArgs},
+    cli::Cli,
 };
+use reth_node_builder::{engine_tree_config::TreeConfig, EngineNodeLauncher};
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_provider::providers::BlockchainProvider2;
-
-/// Parameters for configuring the engine
-#[derive(Debug, Clone, Args, PartialEq, Eq)]
-#[command(next_help_heading = "Engine")]
-pub struct EngineArgs {
-    /// Enable the engine2 experimental features on reth binary
-    #[arg(long = "engine.experimental", default_value = "false")]
-    pub experimental: bool,
-
-    /// Configure persistence threshold for engine experimental.
-    #[arg(long = "engine.persistence-threshold", requires = "experimental", default_value_t = DEFAULT_PERSISTENCE_THRESHOLD)]
-    pub persistence_threshold: u64,
-
-    /// Configure the target number of blocks to keep in memory.
-    #[arg(long = "engine.memory-block-buffer-target", requires = "experimental", default_value_t = DEFAULT_MEMORY_BLOCK_BUFFER_TARGET)]
-    pub memory_block_buffer_target: u64,
-}
-
-impl Default for EngineArgs {
-    fn default() -> Self {
-        Self {
-            experimental: false,
-            persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
-            memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
-        }
-    }
-}
 
 fn main() {
     reth_cli_util::sigsegv_handler::install();
@@ -81,25 +52,5 @@ fn main() {
     {
         eprintln!("Error: {err:?}");
         std::process::exit(1);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::Parser;
-
-    /// A helper type to parse Args more easily
-    #[derive(Parser)]
-    struct CommandParser<T: Args> {
-        #[command(flatten)]
-        args: T,
-    }
-
-    #[test]
-    fn test_parse_engine_args() {
-        let default_args = EngineArgs::default();
-        let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
-        assert_eq!(args, default_args);
     }
 }

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -11,6 +11,9 @@
 mod invalid_block_hook;
 pub use invalid_block_hook::InvalidBlockHook;
 
+mod tree;
+pub use tree::{DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD};
+
 pub use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, EngineObjectValidationError, PayloadOrAttributes,
     PayloadTypes,

--- a/crates/engine/primitives/src/tree.rs
+++ b/crates/engine/primitives/src/tree.rs
@@ -1,0 +1,5 @@
+/// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
+pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
+
+/// How close to the canonical head we persist blocks.
+pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 2;

--- a/crates/engine/tree/src/tree/config.rs
+++ b/crates/engine/tree/src/tree/config.rs
@@ -1,10 +1,6 @@
 //! Engine tree configuration.
 
-/// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
-pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
-
-/// How close to the canonical head we persist blocks.
-pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 2;
+use reth_engine_primitives::{DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD};
 
 const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = 256;
 const DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH: u32 = 256;

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -33,6 +33,7 @@ reth-tracing.workspace = true
 reth-config.workspace = true
 reth-discv4.workspace = true
 reth-discv5.workspace = true
+reth-engine-primitives.workspace = true
 reth-net-nat.workspace = true
 reth-network-peers.workspace = true
 reth-consensus-common.workspace = true

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -1,0 +1,49 @@
+use clap::Args;
+use reth_engine_primitives::{DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD};
+
+/// Parameters for configuring the engine
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+#[command(next_help_heading = "Engine")]
+pub struct EngineArgs {
+    /// Enable the engine2 experimental features on reth binary
+    #[arg(long = "engine.experimental", default_value = "false")]
+    pub experimental: bool,
+
+    /// Configure persistence threshold for engine experimental.
+    #[arg(long = "engine.persistence-threshold", requires = "experimental", default_value_t = DEFAULT_PERSISTENCE_THRESHOLD)]
+    pub persistence_threshold: u64,
+
+    /// Configure the target number of blocks to keep in memory.
+    #[arg(long = "engine.memory-block-buffer-target", requires = "experimental", default_value_t = DEFAULT_MEMORY_BLOCK_BUFFER_TARGET)]
+    pub memory_block_buffer_target: u64,
+}
+
+impl Default for EngineArgs {
+    fn default() -> Self {
+        Self {
+            experimental: false,
+            persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
+            memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, Parser};
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_parse_engine_args() {
+        let default_args = EngineArgs::default();
+        let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
+    }
+}

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -56,7 +56,7 @@ pub use datadir_args::DatadirArgs;
 mod benchmark_args;
 pub use benchmark_args::BenchmarkArgs;
 
-/// EngineArgs struct for configuring the engine
+/// Struct for configuring the engine
 mod engine;
 pub use engine::EngineArgs;
 

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -56,6 +56,10 @@ pub use datadir_args::DatadirArgs;
 mod benchmark_args;
 pub use benchmark_args::BenchmarkArgs;
 
+/// EngineArgs struct for configuring the engine
+mod engine;
+pub use engine::EngineArgs;
+
 pub mod utils;
 
 mod error;


### PR DESCRIPTION
Otherwise we can't test ExExes with the new engine toggle, as there's no way to use the `EngineArgs` defined in `main.rs`