### PR TITLE
chore(lint): fix lint warnings `reth-net-nat`

### DIFF
--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -238,7 +238,7 @@ mod tests {
     async fn get_external_ip() {
         reth_tracing::init_test_tracing();
         let ip = external_ip().await;
-        dbg!(ip);
+        dbg!(ip)
     }
 
     #[tokio::test]
@@ -250,7 +250,7 @@ mod tests {
         let ip = interval.tick().await;
         dbg!(ip);
         let ip = interval.tick().await;
-        dbg!(ip);
+        dbg!(ip)
     }
 
     #[test]

--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -238,7 +238,7 @@ mod tests {
     async fn get_external_ip() {
         reth_tracing::init_test_tracing();
         let ip = external_ip().await;
-        dbg!(ip)
+        _ = dbg!(ip)
     }
 
     #[tokio::test]
@@ -250,7 +250,7 @@ mod tests {
         let ip = interval.tick().await;
         dbg!(ip);
         let ip = interval.tick().await;
-        dbg!(ip)
+        _ = dbg!(ip)
     }
 
     #[test]

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -117,7 +117,7 @@ pub enum AnyNode {
 
 impl AnyNode {
     /// Returns the peer id of the node.
-    pub fn peer_id(&self) -> PeerId {
+    pub const fn peer_id(&self) -> PeerId {
         match self {
             Self::NodeRecord(record) => record.id,
             #[cfg(feature = "secp256k1")]
@@ -127,7 +127,7 @@ impl AnyNode {
     }
 
     /// Returns the full node record if available.
-    pub fn node_record(&self) -> Option<NodeRecord> {
+    pub const fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),
             #[cfg(feature = "secp256k1")]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,9 +1,7 @@
 //! Transaction types.
 
-use crate::BlockHashOrNumber;
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_primitives::{keccak256, Address, TxKind, B256, U256};
-
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
@@ -18,6 +16,8 @@ use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use signature::{decode_with_eip155_chain_id, with_eip155_parity};
 
+use crate::BlockHashOrNumber;
+
 pub use error::{
     InvalidTransactionError, TransactionConversionError, TryFromRecoveredTransactionError,
 };
@@ -28,7 +28,6 @@ pub use sidecar::generate_blob_sidecar;
 #[cfg(feature = "c-kzg")]
 pub use sidecar::BlobTransactionValidationError;
 pub use sidecar::{BlobTransaction, BlobTransactionSidecar};
-
 pub use compat::FillTxEnv;
 pub use signature::{
     extract_chain_id, legacy_parity, recover_signer, recover_signer_unchecked, Signature,


### PR DESCRIPTION
Fixes lint warnings in `reth-net-nat`