### PR TITLE
chore: limit tracing logs to debug by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ CARGO_TARGET_DIR ?= target
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
-    FEATURES ?= asm-keccak
+    FEATURES ?= asm-keccak min-debug-logs
 else
-    FEATURES ?= jemalloc asm-keccak
+    FEATURES ?= jemalloc asm-keccak min-debug-logs
 endif
 
 # Cargo profile for builds. Default is for local builds, CI uses an override.


### PR DESCRIPTION
Trace level logs are way too verbose and in most cases just degrade performance.

Does not affect debug builds.