### PR TITLE
fix(tree): use in-memory data first to query total difficulty

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -362,17 +362,20 @@ impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider2<N> {
     }
 
     fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        // If the TD is recorded on disk, we can just return that
-        if let Some(td) = self.database.header_td_by_number(number)? {
-            Ok(Some(td))
-        } else if self.canonical_in_memory_state.hash_by_number(number).is_some() {
-            // Otherwise, if the block exists in memory, we should return a TD for it.
+        if self.canonical_in_memory_state.hash_by_number(number).is_some() {
+            // If the block exists in memory, we should return a TD for it.
             //
             // The canonical in memory state should only store post-merge blocks. Post-merge blocks
             // have zero difficulty. This means we can use the total difficulty for the last
-            // persisted block number.
-            let last_persisted_block_number = self.database.last_block_number()?;
-            self.database.header_td_by_number(last_persisted_block_number)
+            // finalized block number, so that we are not affected by reorgs.
+            let last_finalized_num_hash = self
+                .canonical_in_memory_state
+                .get_finalized_num_hash()
+                .unwrap_or(BlockNumHash::new(0, B256::default()));
+            self.database.header_td_by_number(last_finalized_num_hash.number)
+        } else if let Some(td) = self.database.header_td_by_number(number)? {
+            // Otherwise, if the TD is recorded on disk, we can just return that
+            Ok(Some(td))
         } else {
             // If the block does not exist in memory, and does not exist on-disk, we should not
             // return a TD for it.

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2689,6 +2689,10 @@ mod tests {
 
         let database_block = database_blocks.first().unwrap().clone();
         let in_memory_block = in_memory_blocks.last().unwrap().clone();
+        // make sure that the finalized block is on db
+        let finalized_block = database_blocks.get(database_blocks.len() - 3).unwrap();
+        provider.set_finalized(finalized_block.header.clone());
+
         let blocks = [database_blocks, in_memory_blocks].concat();
 
         assert_eq!(provider.header(&database_block.hash())?, Some(database_block.header().clone()));

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -371,7 +371,7 @@ impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider2<N> {
             let last_finalized_num_hash = self
                 .canonical_in_memory_state
                 .get_finalized_num_hash()
-                .unwrap_or(BlockNumHash::new(0, B256::default()));
+                .unwrap_or_else(|| BlockNumHash::new(0, B256::default()));
             self.database.header_td_by_number(last_finalized_num_hash.number)
         } else if let Some(td) = self.database.header_td_by_number(number)? {
             // Otherwise, if the TD is recorded on disk, we can just return that

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -373,13 +373,9 @@ impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider2<N> {
                 .get_finalized_num_hash()
                 .unwrap_or_else(|| BlockNumHash::new(0, B256::default()));
             self.database.header_td_by_number(last_finalized_num_hash.number)
-        } else if let Some(td) = self.database.header_td_by_number(number)? {
-            // Otherwise, if the TD is recorded on disk, we can just return that
-            Ok(Some(td))
         } else {
-            // If the block does not exist in memory, and does not exist on-disk, we should not
-            // return a TD for it.
-            Ok(None)
+            // Otherwise, return what we have on disk
+            self.database.header_td_by_number(number)
         }
     }
 


### PR DESCRIPTION
Flips the order of data retrieval in `header_td_by_number`, first in-memory, then db. 

Additionally, to prevent races with the persistence task in cases of reorgs, when the required block is found in memory it uses the last finalized block to get the total difficulty, if none is found we will use the last block number found in memory (in this case we are still exposed to reorgs)

ref https://github.com/paradigmxyz/reth/issues/10941