### PR TITLE
feat(chain-state): notify about new safe/finalized only if modified

### DIFF
--- a/crates/chain-state/src/chain_info.rs
+++ b/crates/chain-state/src/chain_info.rs
@@ -113,7 +113,7 @@ impl ChainInfoTracker {
     /// Sets the safe header of the chain.
     pub fn set_safe(&self, header: SealedHeader) {
         self.inner.safe_block.send_if_modified(|current_header| {
-            if current_header.as_ref() != Some(&header) {
+            if current_header.as_ref().map(SealedHeader::hash) != Some(header.hash()) {
                 let _ = current_header.replace(header);
                 return true
             }
@@ -125,7 +125,7 @@ impl ChainInfoTracker {
     /// Sets the finalized header of the chain.
     pub fn set_finalized(&self, header: SealedHeader) {
         self.inner.finalized_block.send_if_modified(|current_header| {
-            if current_header.as_ref() != Some(&header) {
+            if current_header.as_ref().map(SealedHeader::hash) != Some(header.hash()) {
                 let _ = current_header.replace(header);
                 return true
             }

--- a/crates/chain-state/src/chain_info.rs
+++ b/crates/chain-state/src/chain_info.rs
@@ -112,15 +112,25 @@ impl ChainInfoTracker {
 
     /// Sets the safe header of the chain.
     pub fn set_safe(&self, header: SealedHeader) {
-        self.inner.safe_block.send_modify(|h| {
-            let _ = h.replace(header);
+        self.inner.safe_block.send_if_modified(|current_header| {
+            if current_header.as_ref() != Some(&header) {
+                let _ = current_header.replace(header);
+                return true
+            }
+
+            false
         });
     }
 
     /// Sets the finalized header of the chain.
     pub fn set_finalized(&self, header: SealedHeader) {
-        self.inner.finalized_block.send_modify(|h| {
-            let _ = h.replace(header);
+        self.inner.finalized_block.send_if_modified(|current_header| {
+            if current_header.as_ref() != Some(&header) {
+                let _ = current_header.replace(header);
+                return true
+            }
+
+            false
         });
     }
 


### PR DESCRIPTION
`ForkChoiceSubscriptions` is expected to be triggered only on new safe/finalized headers, but we in fact notify the subscribers every time we get an FCU, even if it's the same safe/finalized hash.

https://github.com/paradigmxyz/reth/blob/86f12b7f535b649b4b78e4881db106c96d0d6114/crates/chain-state/src/notifications.rs#L145-L163