### PR TITLE
fix(op): add min-logs tracing features to optimism bin

### DIFF
--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -32,6 +32,12 @@ asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-optimism-node/asm-keccak"]
 
 optimism = ["reth-optimism-cli/optimism", "reth-optimism-node/optimism"]
 
+min-error-logs = ["reth-optimism-cli/min-error-logs"]
+min-warn-logs = ["reth-optimism-cli/min-warn-logs"]
+min-info-logs = ["reth-optimism-cli/min-info-logs"]
+min-debug-logs = ["reth-optimism-cli/min-debug-logs"]
+min-trace-logs = ["reth-optimism-cli/min-trace-logs"]
+
 [[bin]]
 name = "op-reth"
 path = "src/main.rs"

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -82,3 +82,9 @@ asm-keccak = [
     "reth-optimism-node/asm-keccak",
     "reth-primitives/asm-keccak",
 ]
+
+min-error-logs = ["tracing/release_max_level_error"]
+min-warn-logs = ["tracing/release_max_level_warn"]
+min-info-logs = ["tracing/release_max_level_info"]
+min-debug-logs = ["tracing/release_max_level_debug"]
+min-trace-logs = ["tracing/release_max_level_trace"]


### PR DESCRIPTION
Fixes the CI failure on main due to lack of `min-debug-logs` feature in the optimism bin