### PR TITLE
chore: rename default chainspec parser

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -16,7 +16,7 @@ use reth_cli_commands::{
 use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
-use reth_node_core::args::utils::DefaultChainSpecParser;
+use reth_node_core::args::utils::EthereumChainSpecParser;
 use reth_node_ethereum::{EthExecutorProvider, EthereumNode};
 use reth_tracing::FileWorkerGuard;
 use std::{ffi::OsString, fmt, future::Future, sync::Arc};
@@ -34,7 +34,8 @@ pub use crate::core::cli::*;
 /// This is the entrypoint to the executable.
 #[derive(Debug, Parser)]
 #[command(author, version = SHORT_VERSION, long_version = LONG_VERSION, about = "Reth", long_about = None)]
-pub struct Cli<C: ChainSpecParser = DefaultChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs> {
+pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs>
+{
     /// The command to run
     #[command(subcommand)]
     command: Commands<C, Ext>,
@@ -116,14 +117,14 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
     ///
     /// ```no_run
     /// use clap::Parser;
-    /// use reth::{args::utils::DefaultChainSpecParser, cli::Cli};
+    /// use reth::{args::utils::EthereumChainSpecParser, cli::Cli};
     ///
     /// #[derive(Debug, Parser)]
     /// pub struct MyArgs {
     ///     pub enable: bool,
     /// }
     ///
-    /// Cli::<DefaultChainSpecParser, MyArgs>::parse()
+    /// Cli::<EthereumChainSpecParser, MyArgs>::parse()
     ///     .run(|builder, my_args: MyArgs| async move {
     ///         // launch the node
     ///
@@ -250,7 +251,7 @@ mod tests {
     /// runtime
     #[test]
     fn test_parse_help_all_subcommands() {
-        let reth = Cli::<DefaultChainSpecParser, NoArgs>::command();
+        let reth = Cli::<EthereumChainSpecParser, NoArgs>::command();
         for sub_command in reth.get_subcommands() {
             let err = Cli::try_parse_args_from(["reth", sub_command.get_name(), "--help"])
                 .err()

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -4,7 +4,7 @@
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
 use clap::{Args, Parser};
-use reth::{args::utils::DefaultChainSpecParser, cli::Cli};
+use reth::{args::utils::EthereumChainSpecParser, cli::Cli};
 use reth_node_builder::{
     engine_tree_config::{
         TreeConfig, DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD,
@@ -50,7 +50,7 @@ fn main() {
     }
 
     if let Err(err) =
-        Cli::<DefaultChainSpecParser, EngineArgs>::parse().run(|builder, engine_args| async move {
+        Cli::<EthereumChainSpecParser, EngineArgs>::parse().run(|builder, engine_args| async move {
             let enable_engine2 = engine_args.experimental;
             match enable_engine2 {
                 true => {

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -160,13 +160,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_node_core::args::utils::{DefaultChainSpecParser, SUPPORTED_CHAINS};
+    use reth_node_core::args::utils::{EthereumChainSpecParser, SUPPORTED_CHAINS};
     use std::path::Path;
 
     #[test]
     fn parse_stats_globals() {
         let path = format!("../{}", SUPPORTED_CHAINS[0]);
-        let cmd = Command::<DefaultChainSpecParser>::try_parse_from([
+        let cmd = Command::<EthereumChainSpecParser>::try_parse_from([
             "reth",
             "--datadir",
             &path,

--- a/crates/cli/commands/src/dump_genesis.rs
+++ b/crates/cli/commands/src/dump_genesis.rs
@@ -32,12 +32,12 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> DumpGenesisCommand<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_node_core::args::utils::{DefaultChainSpecParser, SUPPORTED_CHAINS};
+    use reth_node_core::args::utils::{EthereumChainSpecParser, SUPPORTED_CHAINS};
 
     #[test]
     fn parse_dump_genesis_command_chain_args() {
         for chain in SUPPORTED_CHAINS {
-            let args: DumpGenesisCommand<DefaultChainSpecParser> =
+            let args: DumpGenesisCommand<EthereumChainSpecParser> =
                 DumpGenesisCommand::parse_from(["reth", "--chain", chain]);
             assert_eq!(
                 Ok(args.chain.chain),

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -231,12 +231,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reth_node_core::args::utils::{DefaultChainSpecParser, SUPPORTED_CHAINS};
+    use reth_node_core::args::utils::{EthereumChainSpecParser, SUPPORTED_CHAINS};
 
     #[test]
     fn parse_common_import_command_chain_args() {
         for chain in SUPPORTED_CHAINS {
-            let args: ImportCommand<DefaultChainSpecParser> =
+            let args: ImportCommand<EthereumChainSpecParser> =
                 ImportCommand::parse_from(["reth", "--chain", chain, "."]);
             assert_eq!(
                 Ok(args.env.chain.chain),

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -9,7 +9,7 @@ use reth_db::{init_db, DatabaseEnv};
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_node_core::{
     args::{
-        utils::DefaultChainSpecParser, DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, NetworkArgs,
+        utils::EthereumChainSpecParser, DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, NetworkArgs,
         PayloadBuilderArgs, PruningArgs, RpcServerArgs, TxPoolArgs,
     },
     node_config::NodeConfig,
@@ -21,7 +21,7 @@ use std::{ffi::OsString, fmt, future::Future, net::SocketAddr, path::PathBuf, sy
 /// Start the node
 #[derive(Debug, Parser)]
 pub struct NodeCommand<
-    C: ChainSpecParser = DefaultChainSpecParser,
+    C: ChainSpecParser = EthereumChainSpecParser,
     Ext: clap::Args + fmt::Debug = NoArgs,
 > {
     /// The path to the configuration file to use.
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn parse_help_node_command() {
-        let err = NodeCommand::<DefaultChainSpecParser>::try_parse_args_from(["reth", "--help"])
+        let err = NodeCommand::<EthereumChainSpecParser>::try_parse_args_from(["reth", "--help"])
             .unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
     }
@@ -359,7 +359,7 @@ mod tests {
 
     #[test]
     fn with_unused_ports_conflicts_with_instance() {
-        let err = NodeCommand::<DefaultChainSpecParser>::try_parse_args_from([
+        let err = NodeCommand::<EthereumChainSpecParser>::try_parse_args_from([
             "reth",
             "--with-unused-ports",
             "--instance",

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -213,13 +213,13 @@ impl Subcommands {
 
 #[cfg(test)]
 mod tests {
-    use reth_node_core::args::utils::DefaultChainSpecParser;
+    use reth_node_core::args::utils::EthereumChainSpecParser;
 
     use super::*;
 
     #[test]
     fn parse_unwind() {
-        let cmd = Command::<DefaultChainSpecParser>::parse_from([
+        let cmd = Command::<EthereumChainSpecParser>::parse_from([
             "reth",
             "--datadir",
             "dir",
@@ -228,7 +228,7 @@ mod tests {
         ]);
         assert_eq!(cmd.command, Subcommands::ToBlock { target: BlockHashOrNumber::Number(100) });
 
-        let cmd = Command::<DefaultChainSpecParser>::parse_from([
+        let cmd = Command::<EthereumChainSpecParser>::parse_from([
             "reth",
             "--datadir",
             "dir",

--- a/crates/node/core/src/args/utils.rs
+++ b/crates/node/core/src/args/utils.rs
@@ -71,11 +71,12 @@ pub fn parse_custom_chain_spec(s: &str) -> eyre::Result<ChainSpec, eyre::Error> 
     Ok(genesis.into())
 }
 
-/// Default chain specification parser.
-#[derive(Debug, Clone, Default)]
-pub struct DefaultChainSpecParser;
+/// A chain specification parser for ethereum chains.
+#[derive(Debug, Copy, Clone, Default)]
+#[non_exhaustive]
+pub struct EthereumChainSpecParser;
 
-impl ChainSpecParser for DefaultChainSpecParser {
+impl ChainSpecParser for EthereumChainSpecParser {
     type ChainSpec = ChainSpec;
 
     const SUPPORTED_CHAINS: &'static [&'static str] = SUPPORTED_CHAINS;

--- a/examples/beacon-api-sidecar-fetcher/src/main.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/main.rs
@@ -23,7 +23,7 @@ use clap::Parser;
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use mined_sidecar::MinedSidecarStream;
 use reth::{
-    args::utils::DefaultChainSpecParser, builder::NodeHandle, cli::Cli,
+    args::utils::EthereumChainSpecParser, builder::NodeHandle, cli::Cli,
     providers::CanonStateSubscriptions,
 };
 use reth_node_ethereum::EthereumNode;
@@ -31,7 +31,7 @@ use reth_node_ethereum::EthereumNode;
 pub mod mined_sidecar;
 
 fn main() {
-    Cli::<DefaultChainSpecParser, BeaconSidecarConfig>::parse()
+    Cli::<EthereumChainSpecParser, BeaconSidecarConfig>::parse()
         .run(|builder, beacon_config| async move {
             // launch the node
             let NodeHandle { node, node_exit_future } =

--- a/examples/beacon-api-sse/src/main.rs
+++ b/examples/beacon-api-sse/src/main.rs
@@ -21,13 +21,13 @@ use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use clap::Parser;
 use futures_util::stream::StreamExt;
 use mev_share_sse::{client::EventStream, EventClient};
-use reth::{args::utils::DefaultChainSpecParser, cli::Cli};
+use reth::{args::utils::EthereumChainSpecParser, cli::Cli};
 use reth_node_ethereum::EthereumNode;
 use std::net::{IpAddr, Ipv4Addr};
 use tracing::{info, warn};
 
 fn main() {
-    Cli::<DefaultChainSpecParser, BeaconEventsConfig>::parse()
+    Cli::<EthereumChainSpecParser, BeaconEventsConfig>::parse()
         .run(|builder, args| async move {
             let handle = builder.node(EthereumNode::default()).launch().await?;
 

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types::state::EvmOverrides;
 use clap::Parser;
 use futures_util::StreamExt;
 use reth::{
-    args::utils::DefaultChainSpecParser,
+    args::utils::EthereumChainSpecParser,
     builder::NodeHandle,
     cli::Cli,
     primitives::BlockNumberOrTag,
@@ -30,7 +30,7 @@ use reth::{
 use reth_node_ethereum::node::EthereumNode;
 
 fn main() {
-    Cli::<DefaultChainSpecParser, RethCliTxpoolExt>::parse()
+    Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
         .run(|builder, args| async move {
             // launch the node
             let NodeHandle { node, node_exit_future } =

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -14,12 +14,12 @@
 
 use clap::Parser;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth::{args::utils::DefaultChainSpecParser, cli::Cli};
+use reth::{args::utils::EthereumChainSpecParser, cli::Cli};
 use reth_node_ethereum::EthereumNode;
 use reth_transaction_pool::TransactionPool;
 
 fn main() {
-    Cli::<DefaultChainSpecParser, RethCliTxpoolExt>::parse()
+    Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
         .run(|builder, args| async move {
             let handle = builder
                 .node(EthereumNode::default())

--- a/examples/txpool-tracing/src/main.rs
+++ b/examples/txpool-tracing/src/main.rs
@@ -15,13 +15,13 @@ use alloy_rpc_types_trace::{parity::TraceType, tracerequest::TraceCallRequest};
 use clap::Parser;
 use futures_util::StreamExt;
 use reth::{
-    args::utils::DefaultChainSpecParser, builder::NodeHandle, cli::Cli,
+    args::utils::EthereumChainSpecParser, builder::NodeHandle, cli::Cli,
     rpc::compat::transaction::transaction_to_call_request, transaction_pool::TransactionPool,
 };
 use reth_node_ethereum::node::EthereumNode;
 
 fn main() {
-    Cli::<DefaultChainSpecParser, RethCliTxpoolExt>::parse()
+    Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
         .run(|builder, args| async move {
             // launch the node
             let NodeHandle { node, node_exit_future } =


### PR DESCRIPTION
towards #11397

we now have separate chainspec parsers for op and eth, we can rename this