### PR TITLE
     ci: pin clippy to working version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
+        with:
+          toolchain: nightly-2024-09-25
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true


### PR DESCRIPTION
Latest nightly is failing like here https://github.com/paradigmxyz/reth/actions/runs/11136420742/job/30948166901?pr=11341.
ref https://github.com/paradigmxyz/reth/pull/11237