### PR TITLE
dev: swap_remove

### DIFF
--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -383,7 +383,7 @@ where
                     .into())
                 }
 
-                let sealed_target = headers.remove(0).seal_slow();
+                let sealed_target = headers.swap_remove(0).seal_slow();
                 let (header, seal) = sealed_target.into_parts();
                 let target = SealedHeader::new(header, seal);
 

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -106,7 +106,7 @@ where
     /// # Panics
     /// If the index is out of bounds.
     pub fn remove_peer(&mut self, index: usize) -> Peer<C, Pool> {
-        self.peers.swap_remove(index)
+        self.peers.remove(index)
     }
 
     /// Return a mutable iterator over all peers.

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -106,7 +106,7 @@ where
     /// # Panics
     /// If the index is out of bounds.
     pub fn remove_peer(&mut self, index: usize) -> Peer<C, Pool> {
-        self.peers.remove(index)
+        self.peers.swap_remove(index)
     }
 
     /// Return a mutable iterator over all peers.

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -303,7 +303,7 @@ where
         let (fut, keep_alive) = self.payload_jobs[job].0.resolve();
 
         if keep_alive == KeepPayloadJobAlive::No {
-            let (_, id) = self.payload_jobs.remove(job);
+            let (_, id) = self.payload_jobs.swap_remove(job);
             trace!(%id, "terminated resolved job");
         }
 


### PR DESCRIPTION
Replaces remove with swap_remove for optimized removal of items in a Vec where preservation of order of the items isn't needed.