### PR TITLE
chore: add metric and trace for already executed blocks

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -24,6 +24,8 @@ pub(crate) struct EngineApiMetrics {
 pub(crate) struct EngineMetrics {
     /// How many executed blocks are currently stored.
     pub(crate) executed_blocks: Gauge,
+    /// How many already executed blocks were directly inserted into the tree.
+    pub(crate) inserted_already_executed_blocks: Counter,
     /// The number of times the pipeline was run.
     pub(crate) pipeline_runs: Counter,
     /// The total count of forkchoice updated messages received.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1191,7 +1191,9 @@ where
             FromEngine::Request(request) => {
                 match request {
                     EngineApiRequest::InsertExecutedBlock(block) => {
+                        debug!(target: "engine::tree", block=?block.block().num_hash(), "inserting already executed block");
                         self.state.tree_state.insert_executed(block);
+                        self.metrics.engine.inserted_already_executed_blocks.increment(1);
                     }
                     EngineApiRequest::Beacon(request) => {
                         match request {


### PR DESCRIPTION
adds new metric and a trace