### PR TITLE
fix: fetch header by hash

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1524,19 +1524,13 @@ where
     /// Return sealed block from database or in-memory state by hash.
     fn sealed_header_by_hash(&self, hash: B256) -> ProviderResult<Option<SealedHeader>> {
         // check memory first
-        let block = self
-            .state
-            .tree_state
-            .block_by_hash(hash)
-            // TODO: clone for compatibility. should we return an Arc here?
-            .map(|block| block.as_ref().clone().header);
+        let block =
+            self.state.tree_state.block_by_hash(hash).map(|block| block.as_ref().clone().header);
 
         if block.is_some() {
             Ok(block)
-        } else if let Some(block_num) = self.provider.block_number(hash)? {
-            Ok(self.provider.sealed_header(block_num)?)
         } else {
-            Ok(None)
+            self.provider.sealed_header_by_hash(hash)
         }
     }
 

--- a/crates/storage/storage-api/src/header.rs
+++ b/crates/storage/storage-api/src/header.rs
@@ -15,6 +15,11 @@ pub trait HeaderProvider: Send + Sync {
     /// Get header by block hash
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>>;
 
+    /// Retrieves the header sealed by the given block hash.
+    fn sealed_header_by_hash(&self, block_hash: BlockHash) -> ProviderResult<Option<SealedHeader>> {
+        Ok(self.header(&block_hash)?.map(|header| SealedHeader::new(header, block_hash)))
+    }
+
     /// Get header by block number
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>>;
 


### PR DESCRIPTION
this fetches the header by hash only.
before we first fetched the number for that hash and then the header by number, in another db tx which could be problematic.

this was most likely implemented like this because we didn't have `sealed_header_by_hash`