### PR TITLE
fix(exex): check exex head against node head to determine canonical

### DIFF
--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -176,10 +176,13 @@ where
 
     /// Checks if the ExEx head is on the canonical chain.
     ///
-    /// If the head block is not found in the database, it means we're not on the canonical chain
-    /// and we need to revert the notification with the ExEx head block.
+    /// If the head block is not found in the database or it's ahead of the node head, it means
+    /// we're not on the canonical chain and we need to revert the notification with the ExEx
+    /// head block.
     fn check_canonical(&mut self) -> eyre::Result<Option<ExExNotification>> {
-        if self.provider.is_known(&self.exex_head.block.hash)? {
+        if self.provider.is_known(&self.exex_head.block.hash)? &&
+            self.exex_head.block.number <= self.node_head.number
+        {
             debug!(target: "exex::notifications", "ExEx head is on the canonical chain");
             return Ok(None)
         }


### PR DESCRIPTION
## Motivation

Stumbled upon it when the node crashed during the pipeline sync. On restart, we had a header for the ExEx head block in the database, but the node head was behind it because it looks at the `Finish` stage of the pipeline and the pipeline didn't finish fully for that block yet.

## Solution

Even if a header for the ExEx head block is found in the database, but it's ahead of the node head, we need to revert the ExEx to the node head.