### PR TITLE
feat(stages): fail Execution if post execute commit input isn't consumed

### DIFF
--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -125,6 +125,9 @@ pub enum StageError {
     /// The prune checkpoint for the given segment is missing.
     #[error("missing prune checkpoint for {0}")]
     MissingPruneCheckpoint(PruneSegment),
+    /// Post Execute Commit error
+    #[error("post execute commit error occurred: {_0}")]
+    PostExecuteCommit(&'static str),
     /// Internal error
     #[error(transparent)]
     Internal(#[from] RethError),

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -350,12 +350,13 @@ where
 
             let previous_input =
                 self.post_execute_commit_input.replace(Chain::new(blocks, state.clone(), None));
-            debug_assert!(
-                previous_input.is_none(),
-                "Previous post execute commit input wasn't processed"
-            );
-            if let Some(previous_input) = previous_input {
-                tracing::debug!(target: "sync::stages::execution", ?previous_input, "Previous post execute commit input wasn't processed");
+
+            if previous_input.is_some() {
+                // Not processing the previous post execute commit input is a critical error, as it
+                // means that we didn't send the notification to ExExes
+                return Err(StageError::PostExecuteCommit(
+                    "Previous post execute commit input wasn't processed",
+                ))
             }
         }
 


### PR DESCRIPTION
Additional safety check to prevent https://github.com/paradigmxyz/reth/pull/11413