### PR TITLE
chore: remove temporary allow attribute

### DIFF
--- a/crates/storage/db/src/static_file/mask.rs
+++ b/crates/storage/db/src/static_file/mask.rs
@@ -26,9 +26,6 @@ macro_rules! add_segments {
             $(
                 #[doc = concat!("Mask for ", stringify!($segment), " static file segment. See [`Mask`] for more.")]
                 #[derive(Debug)]
-                // TODO: remove next attribute when nightly is fixed (ie. does
-                // not return wrong warnings for never constructed structs).
-                #[allow(dead_code)]
                 pub struct [<$segment Mask>]<FIRST, SECOND = (), THIRD = ()>(Mask<FIRST, SECOND, THIRD>);
             )+
         }


### PR DESCRIPTION
was introduced in #9922, no longer needed with latest clippy