### PR TITLE
fix: env tempdir failure on WAL creation

### DIFF
--- a/crates/exex/test-utils/Cargo.toml
+++ b/crates/exex/test-utils/Cargo.toml
@@ -40,4 +40,5 @@ tokio.workspace = true
 ## misc
 eyre.workspace = true
 rand.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Creation of test ExEx context:

```rust
let (ctx, mut handle) = test_exex_context().await?;
```
produces an error on attempt to read from os(std) env (via `std::env::temp_dir`)

Opening a temporary directory via `tempdir` crate on WAL creation resolving that issue.
Also add some test to double-check, that context can be setup with that change.