### PR TITLE
feat(`reth-alloy`): helper types to work with alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6286,7 +6286,9 @@ name = "reth-alloy"
 version = "1.0.7"
 dependencies = [
  "alloy-eips",
+ "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-client",
  "alloy-transport",
  "eyre",
  "reth-chainspec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6282,6 +6282,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-alloy"
+version = "1.0.7"
+dependencies = [
+ "alloy-eips",
+ "eyre",
+ "reth-db",
+ "reth-node-ethereum",
+ "reth-node-types",
+ "reth-provider",
+]
+
+[[package]]
 name = "reth-auto-seal-consensus"
 version = "1.0.7"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6286,7 +6286,10 @@ name = "reth-alloy"
 version = "1.0.7"
 dependencies = [
  "alloy-eips",
+ "alloy-provider",
+ "alloy-transport",
  "eyre",
+ "reth-chainspec",
  "reth-db",
  "reth-node-ethereum",
  "reth-node-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [".github/"]
 members = [
     "bin/reth-bench/",
     "bin/reth/",
+    "crates/alloy/",
     "crates/blockchain-tree-api/",
     "crates/blockchain-tree/",
     "crates/chain-state/",

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -23,6 +23,8 @@ reth-chainspec.workspace = true
 alloy-eips.workspace = true
 alloy-provider.workspace = true
 alloy-transport.workspace = true
+alloy-primitives.workspace = true
+alloy-rpc-client.workspace = true
 
 ## misc
 eyre.workspace = true

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -17,9 +17,12 @@ reth-db.workspace = true
 reth-provider.workspace = true
 reth-node-types.workspace = true
 reth-node-ethereum.workspace = true
+reth-chainspec.workspace = true
 
 # alloy
 alloy-eips.workspace = true
+alloy-provider.workspace = true
+alloy-transport.workspace = true
 
 ## misc
 eyre.workspace = true

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "reth-alloy"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Reth helper types that aid in working with alloy"
+
+[lints]
+workspace = true
+
+[dependencies]
+## reth
+reth-db.workspace = true
+reth-provider.workspace = true
+reth-node-types.workspace = true
+reth-node-ethereum.workspace = true
+
+# alloy
+alloy-eips.workspace = true
+
+## misc
+eyre.workspace = true

--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -1,0 +1,4 @@
+//! Reth helpers types that aid in working with alloy.
+mod reth_db_layer;
+
+pub use reth_db_layer::{DbAccessor, RethDbLayer};

--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -1,4 +1,4 @@
 //! Reth helpers types that aid in working with alloy.
 mod reth_db_layer;
 
-pub use reth_db_layer::{DbAccessor, RethDbLayer};
+pub use reth_db_layer::{DbAccessor, RethDbLayer, RethDbProvider};

--- a/crates/alloy/src/reth_db_layer.rs
+++ b/crates/alloy/src/reth_db_layer.rs
@@ -14,8 +14,8 @@ use reth_provider::{
 };
 use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 
-/// A tower-like layer that should be used as a [ProviderLayer] to wrap the [Provider] trait over
-/// reth-db.
+/// A tower-like layer that should be used as a [`ProviderLayer`] to wrap the [`Provider`] trait
+/// over reth-db.
 #[derive(Debug, Clone)]
 pub struct RethDbLayer {
     db_path: PathBuf,
@@ -33,7 +33,7 @@ impl RethDbLayer {
     }
 }
 
-/// Implement the [`ProviderLayer`] trait for the [`RethDBLayer`] struct.
+/// Implement the [`ProviderLayer`] trait for the [`RethDbLayer`] struct.
 impl<P, T> ProviderLayer<P, T> for RethDbLayer
 where
     P: Provider<T>,

--- a/crates/alloy/src/reth_db_layer.rs
+++ b/crates/alloy/src/reth_db_layer.rs
@@ -1,0 +1,72 @@
+use alloy_eips::{BlockId, BlockNumberOrTag};
+use eyre::Result;
+use reth_db::DatabaseEnv;
+use reth_node_ethereum::EthereumNode;
+use reth_node_types::NodeTypesWithDBAdapter;
+use reth_provider::{
+    BlockNumReader, DatabaseProviderFactory, ProviderError, ProviderFactory, StateProvider,
+    TryIntoHistoricalStateProvider,
+};
+use std::{path::PathBuf, sync::Arc};
+
+/// A tower-like layer that should be used as a [ProviderLayer](https://docs.rs/alloy/latest/alloy/providers/trait.ProviderLayer.html) in alloy when wrapping the
+/// [Provider](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) trait over reth-db.
+#[derive(Debug, Clone)]
+pub struct RethDbLayer {
+    db_path: PathBuf,
+}
+
+impl RethDbLayer {
+    /// Initialize the `RethDbLayer` with the path to the reth datadir.
+    pub const fn new(db_path: PathBuf) -> Self {
+        Self { db_path }
+    }
+
+    /// Get the provided path.
+    pub const fn db_path(&self) -> &PathBuf {
+        &self.db_path
+    }
+}
+
+/// A helper type to get the appropriate DB provider.
+#[derive(Debug, Clone)]
+pub struct DbAccessor<DB = ProviderFactory<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>>
+where
+    DB: DatabaseProviderFactory<Provider: TryIntoHistoricalStateProvider + BlockNumReader>,
+{
+    inner: DB,
+}
+
+impl<DB> DbAccessor<DB>
+where
+    DB: DatabaseProviderFactory<Provider: TryIntoHistoricalStateProvider + BlockNumReader>,
+{
+    /// Initialize the `DbAccessor` with the provided `DB` type.
+    pub const fn new(inner: DB) -> Self {
+        Self { inner }
+    }
+
+    /// Get a read-only provider.
+    pub fn provider(&self) -> Result<DB::Provider, ProviderError> {
+        self.inner.database_provider_ro()
+    }
+
+    /// Get a read-only provider with state at the specified `BlockId`.
+    pub fn provider_at(&self, block_id: BlockId) -> Result<Box<dyn StateProvider>, ProviderError> {
+        let provider = self.inner.database_provider_ro()?;
+
+        let block_number = match block_id {
+            BlockId::Hash(hash) => {
+                if let Some(num) = provider.block_number(hash.into())? {
+                    num
+                } else {
+                    return Err(ProviderError::BlockHashNotFound(hash.into()));
+                }
+            }
+            BlockId::Number(BlockNumberOrTag::Number(num)) => num,
+            _ => provider.best_block_number()?,
+        };
+
+        provider.try_into_history_at_block(block_number)
+    }
+}

--- a/crates/alloy/src/reth_db_layer.rs
+++ b/crates/alloy/src/reth_db_layer.rs
@@ -33,10 +33,9 @@ impl<P> RethDbLayer<P> {
 /// A provider that overrides the vanilla `Provider` trait to get results from the reth-db.
 #[derive(Clone, Debug)]
 pub struct RethDbProvider<P, T> {
-    #[allow(dead_code)]
     inner: P,
     db_path: PathBuf,
-    provider_factory: DbAccessor,
+    accessor: DbAccessor,
     _pd: PhantomData<T>,
 }
 
@@ -51,13 +50,18 @@ impl<P, T> RethDbProvider<P, T> {
         let provider_factory =
             ProviderFactory::new(db.into(), chain_spec.into(), static_file_provider);
 
-        let db_accessor = DbAccessor::new(provider_factory);
-        Self { inner, db_path, provider_factory: db_accessor, _pd: PhantomData }
+        let accessor = DbAccessor::new(provider_factory);
+        Self { inner, db_path, accessor, _pd: PhantomData }
+    }
+
+    /// Get the underlying `Provider`.
+    pub const fn inner(&self) -> &P {
+        &self.inner
     }
 
     /// Get the underlying `DbAccessor`.
-    pub const fn factory(&self) -> &DbAccessor {
-        &self.provider_factory
+    pub const fn accessor(&self) -> &DbAccessor {
+        &self.accessor
     }
 
     /// Get the DB Path

--- a/crates/alloy/src/reth_db_layer.rs
+++ b/crates/alloy/src/reth_db_layer.rs
@@ -14,8 +14,8 @@ use reth_provider::{
 };
 use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 
-/// A tower-like layer that should be used as a [ProviderLayer](https://docs.rs/alloy/latest/alloy/providers/trait.ProviderLayer.html) in alloy when wrapping the
-/// [Provider](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) trait over reth-db.
+/// A tower-like layer that should be used as a [ProviderLayer] to wrap the [Provider] trait over
+/// reth-db.
 #[derive(Debug, Clone)]
 pub struct RethDbLayer {
     db_path: PathBuf,
@@ -33,7 +33,7 @@ impl RethDbLayer {
     }
 }
 
-/// Implement the `ProviderLayer` trait for the `RethDBLayer` struct.
+/// Implement the [`ProviderLayer`] trait for the [`RethDBLayer`] struct.
 impl<P, T> ProviderLayer<P, T> for RethDbLayer
 where
     P: Provider<T>,
@@ -46,7 +46,7 @@ where
     }
 }
 
-/// A provider that overrides the vanilla `Provider` trait to get results from the reth-db.
+/// A provider that overrides the vanilla [`Provider`] trait to get results from the reth-db.
 #[derive(Clone, Debug)]
 pub struct RethDbProvider<P, T> {
     inner: P,
@@ -56,7 +56,7 @@ pub struct RethDbProvider<P, T> {
 }
 
 impl<P, T> RethDbProvider<P, T> {
-    /// Create a new `RethDbProvider` instance.
+    /// Create a new [`RethDbProvider`] instance.
     pub fn new(inner: P, db_path: PathBuf) -> Self {
         let db = open_db_read_only(&db_path, Default::default()).unwrap();
         let chain_spec = ChainSpecBuilder::mainnet().build();
@@ -70,12 +70,12 @@ impl<P, T> RethDbProvider<P, T> {
         Self { inner, db_path, accessor, _pd: PhantomData }
     }
 
-    /// Get the underlying `Provider`.
+    /// Get the underlying [`Provider`].
     pub const fn inner(&self) -> &P {
         &self.inner
     }
 
-    /// Get the underlying `DbAccessor`.
+    /// Get the underlying [`DbAccessor`].
     pub const fn accessor(&self) -> &DbAccessor {
         &self.accessor
     }
@@ -86,7 +86,7 @@ impl<P, T> RethDbProvider<P, T> {
     }
 }
 
-/// Implement the `Provider` trait for the `RethDbProvider` struct.
+/// Implement the [`Provider`] trait for the [`RethDbProvider`] struct.
 ///
 /// This is where we override specific RPC methods to fetch from the reth-db.
 impl<P, T> Provider<T> for RethDbProvider<P, T>
@@ -109,7 +109,7 @@ where
 
     /// Override the `get_transaction_count` method to fetch the transaction count of an address.
     ///
-    /// `RpcWithBlock` uses `ProviderCall` under the hood.
+    /// [`RpcWithBlock`] uses [`ProviderCall`] under the hood.
     fn get_transaction_count(&self, address: Address) -> RpcWithBlock<T, Address, U64, u64> {
         let this = self.accessor().clone();
         RpcWithBlock::new_provider(move |block_id| {
@@ -138,7 +138,7 @@ impl<DB> DbAccessor<DB>
 where
     DB: DatabaseProviderFactory<Provider: TryIntoHistoricalStateProvider + BlockNumReader>,
 {
-    /// Initialize the `DbAccessor` with the provided `DB` type.
+    /// Initialize the [`DbAccessor`] with the provided `DB` type.
     pub const fn new(inner: DB) -> Self {
         Self { inner }
     }


### PR DESCRIPTION
## Motivation

Ref https://github.com/alloy-rs/examples/pull/144#pullrequestreview-2343223989

Housing these types here makes them easier to maintain. 

## Solution

Introduces new `reth-alloy` that will house types based on reth, making it simpler to work with alloy.

For now, these types include `RethDbLayer` and a `DbAccessor` which make it easier to wrap the `alloy_provider::Provider` over reth-db.