### PR TITLE
fix(exex): limit the duration of a backfill job to 30 seconds

### DIFF
--- a/crates/exex/exex/src/backfill/factory.rs
+++ b/crates/exex/exex/src/backfill/factory.rs
@@ -1,5 +1,5 @@
 use crate::BackfillJob;
-use std::ops::RangeInclusive;
+use std::{ops::RangeInclusive, time::Duration};
 
 use alloy_primitives::BlockNumber;
 use reth_node_api::FullNodeComponents;
@@ -25,7 +25,15 @@ impl<E, P> BackfillJobFactory<E, P> {
             executor,
             provider,
             prune_modes: PruneModes::none(),
-            thresholds: ExecutionStageThresholds::default(),
+            thresholds: ExecutionStageThresholds {
+                // Default duration for a database transaction to be considered long-lived is
+                // 60 seconds, so we limit the backfill job to the half of it to be sure we finish
+                // before the warning is logged.
+                //
+                // See `reth_db::implementation::mdbx::tx::LONG_TRANSACTION_DURATION`.
+                max_duration: Some(Duration::from_secs(30)),
+                ..Default::default()
+            },
             stream_parallelism: DEFAULT_PARALLELISM,
         }
     }


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/11346