### PR TITLE
feat: cleaned up prepare_call_env()

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -256,7 +256,6 @@ pub trait EthCall: Call + LoadPendingBlock {
             )?;
 
             let block = block.ok_or(EthApiError::HeaderNotFound(target_block))?;
-            let gas_limit = self.call_gas_limit();
 
             // we're essentially replaying the transactions in the block here, hence we need the
             // state that points to the beginning of the block, which is the state at
@@ -306,7 +305,6 @@ pub trait EthCall: Call + LoadPendingBlock {
                             cfg.clone(),
                             block_env.clone(),
                             tx,
-                            gas_limit,
                             &mut db,
                             overrides,
                         )
@@ -563,7 +561,6 @@ pub trait Call: LoadState + SpawnBlocking {
                     cfg,
                     block_env,
                     request,
-                    this.call_gas_limit(),
                     &mut db,
                     overrides,
                 )?;
@@ -1099,7 +1096,6 @@ pub trait Call: LoadState + SpawnBlocking {
         mut cfg: CfgEnvWithHandlerCfg,
         mut block: BlockEnv,
         mut request: TransactionRequest,
-        gas_limit: u64,
         db: &mut CacheDB<DB>,
         overrides: EvmOverrides,
     ) -> Result<EnvWithHandlerCfg, Self::Error>
@@ -1108,7 +1104,7 @@ pub trait Call: LoadState + SpawnBlocking {
         EthApiError: From<<DB as DatabaseRef>::Error>,
     {
         // TODO(mattsse): cleanup, by not disabling gaslimit and instead use self.call_gas_limit
-        if request.gas > Some(gas_limit) {
+        if request.gas > Some(self.call_gas_limit()) {
             // configured gas exceeds limit
             return Err(
                 EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
@@ -1117,7 +1113,7 @@ pub trait Call: LoadState + SpawnBlocking {
 
         // we want to disable this in eth_call, since this is common practice used by other node
         // impls and providers <https://github.com/foundry-rs/foundry/issues/4388>
-        cfg.disable_block_gas_limit = true;
+        // cfg.disable_block_gas_limit = true;
 
         // Disabled because eth_call is sometimes used with eoa senders
         // See <https://github.com/paradigmxyz/reth/issues/1959>
@@ -1154,7 +1150,7 @@ pub trait Call: LoadState + SpawnBlocking {
                 // <https://github.com/ledgerwatch/erigon/blob/eae2d9a79cb70dbe30b3a6b79c436872e4605458/cmd/rpcdaemon/commands/trace_adhoc.go#L956
                 // https://github.com/ledgerwatch/erigon/blob/eae2d9a79cb70dbe30b3a6b79c436872e4605458/eth/ethconfig/config.go#L94>
                 trace!(target: "rpc::eth::call", ?env, "Applying gas limit cap as the maximum gas limit");
-                env.tx.gas_limit = gas_limit;
+                env.tx.gas_limit = self.call_gas_limit();
             }
         }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -506,7 +506,6 @@ where
         let opts = opts.unwrap_or_default();
         let block = block.ok_or(EthApiError::HeaderNotFound(target_block))?;
         let GethDebugTracingCallOptions { tracing_options, mut state_overrides, .. } = opts;
-        let gas_limit = self.inner.eth_api.call_gas_limit();
 
         // we're essentially replaying the transactions in the block here, hence we need the state
         // that points to the beginning of the block, which is the state at the parent block

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -570,7 +570,6 @@ where
                             cfg.clone(),
                             block_env.clone(),
                             tx,
-                            gas_limit,
                             &mut db,
                             overrides,
                         )?;

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -168,7 +168,6 @@ where
                         cfg.clone(),
                         block_env.clone(),
                         call,
-                        gas_limit,
                         &mut db,
                         Default::default(),
                     )?;

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -153,7 +153,6 @@ where
         let at = block_id.unwrap_or(BlockId::pending());
         let (cfg, block_env, at) = self.inner.eth_api.evm_env_at(at).await?;
 
-        let gas_limit = self.inner.eth_api.call_gas_limit();
         let this = self.clone();
         // execute all transactions on top of each other and record the traces
         self.eth_api()


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/11464

## Description

- Cleaned up `prepare_call_env()`
- Removed `gas_limit` parameter
- all calls to gas_limit are not done using `self.call_gas_limit()`
- disabled `cfg.disable_block_gas_limit = true;` in  `prepare_call_env()`