### PR TITLE
chore(exex): more backfill debug logs

### DIFF
--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -64,6 +64,12 @@ where
     }
 
     fn execute_range(&mut self) -> Result<Chain, BlockExecutionError> {
+        debug!(
+            target: "exex::backfill",
+            range = ?self.range,
+            "Executing block range"
+        );
+
         let mut executor = self.executor.batch_executor(StateProviderDatabase::new(
             self.provider.history_by_block_number(self.range.start().saturating_sub(1))?,
         ));

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -15,6 +15,7 @@ use reth_primitives::{BlockWithSenders, Receipt};
 use reth_provider::{BlockReader, Chain, HeaderProvider, StateProviderFactory};
 use reth_prune_types::PruneModes;
 use reth_stages_api::ExecutionStageThresholds;
+use reth_tracing::tracing::debug;
 use tokio::task::JoinHandle;
 
 /// The default parallelism for active tasks in [`StreamBackfillJob`].
@@ -118,6 +119,7 @@ where
             // If we have range bounds, then we can spawn a new task for that range
             if let Some((first, last)) = range_bounds {
                 let range = first..=last;
+                debug!(target: "exex::backfill", tasks = %this.tasks.len(), ?range, "Spawning new backfill task");
                 let mut job = BackfillJob {
                     executor: this.executor.clone(),
                     provider: this.provider.clone(),


### PR DESCRIPTION
Helps to understand what's going on when backfill is taking too long or reporting a transaction timeout.