### PR TITLE
chore(db): capture tx opening backtrace in debug mode

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -239,18 +239,17 @@ impl<K: TransactionKind> MetricsHandler<K> {
             let open_duration = self.start.elapsed();
             if open_duration >= self.long_transaction_duration {
                 self.backtrace_recorded.store(true, Ordering::Relaxed);
-                let message = if cfg!(debug_assertions) {
-                    format!(
-                        "The database read transaction has been open for too long. Open backtrace:\n{}\n\nCurrent backtrace:\n{}",
-                        self.open_backtrace,
-                        Backtrace::force_capture()
-                    )
-                } else {
-                    format!(
-                        "The database read transaction has been open for too long. Backtrace:\n{}",
-                        Backtrace::force_capture()
-                    )
-                };
+                #[cfg(debug_assertions)]
+                let message = format!(
+                   "The database read transaction has been open for too long. Open backtrace:\n{}\n\nCurrent backtrace:\n{}",
+                   self.open_backtrace,
+                   Backtrace::force_capture()
+                );
+                #[cfg(not(debug_assertions))]
+                let message = format!(
+                    "The database read transaction has been open for too long. Backtrace:\n{}",
+                    Backtrace::force_capture()
+                );
                 warn!(
                     target: "storage::db::mdbx",
                     ?open_duration,

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -180,7 +180,12 @@ struct MetricsHandler<K: TransactionKind> {
     /// If `true`, the backtrace of transaction has already been recorded and logged.
     /// See [`MetricsHandler::log_backtrace_on_long_read_transaction`].
     backtrace_recorded: AtomicBool,
+    /// Shared database environment metrics.
     env_metrics: Arc<DatabaseEnvMetrics>,
+    /// Backtrace of the location where the transaction has been opened. Reported only with debug
+    /// assertions, because capturing the backtrace on every transaction opening is expensive.
+    #[cfg(debug_assertions)]
+    open_backtrace: Backtrace,
     _marker: PhantomData<K>,
 }
 
@@ -193,6 +198,8 @@ impl<K: TransactionKind> MetricsHandler<K> {
             close_recorded: false,
             record_backtrace: true,
             backtrace_recorded: AtomicBool::new(false),
+            #[cfg(debug_assertions)]
+            open_backtrace: Backtrace::force_capture(),
             env_metrics,
             _marker: PhantomData,
         }
@@ -232,11 +239,23 @@ impl<K: TransactionKind> MetricsHandler<K> {
             let open_duration = self.start.elapsed();
             if open_duration >= self.long_transaction_duration {
                 self.backtrace_recorded.store(true, Ordering::Relaxed);
+                let message = if cfg!(debug_assertions) {
+                    format!(
+                        "The database read transaction has been open for too long. Open backtrace:\n{}\n\nCurrent backtrace:\n{}",
+                        self.open_backtrace,
+                        Backtrace::force_capture()
+                    )
+                } else {
+                    format!(
+                        "The database read transaction has been open for too long. Backtrace:\n{}",
+                        Backtrace::force_capture()
+                    )
+                };
                 warn!(
                     target: "storage::db::mdbx",
                     ?open_duration,
                     %self.txn_id,
-                    "The database read transaction has been open for too long. Backtrace:\n{}", Backtrace::force_capture()
+                    "{message}"
                 );
             }
         }


### PR DESCRIPTION
When there's a long read transaction, we may not always know where it was started or coming from initially.

This PR helps to understand that by capturing a backtrace of the location where the transaction is opened, but only in debug mode, so that the release builds aren't affected by a perf penalty of backtrace capturing.