### PR TITLE
fix(exex): use thresholds in stream backfill

### DIFF
--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -40,6 +40,7 @@ pub struct StreamBackfillJob<E, P, T> {
     tasks: BackfillTasks<T>,
     parallelism: usize,
     batch_size: usize,
+    thresholds: ExecutionStageThresholds,
 }
 
 impl<E, P, T> StreamBackfillJob<E, P, T> {
@@ -122,7 +123,7 @@ where
                     executor: this.executor.clone(),
                     provider: this.provider.clone(),
                     prune_modes: this.prune_modes.clone(),
-                    thresholds: ExecutionStageThresholds::default(),
+                    thresholds: this.thresholds.clone(),
                     range,
                     stream_parallelism: this.parallelism,
                 };
@@ -148,12 +149,14 @@ impl<E, P> From<SingleBlockBackfillJob<E, P>> for StreamBackfillJob<E, P, Single
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,
             batch_size: 1,
+            thresholds: ExecutionStageThresholds { max_blocks: Some(1), ..Default::default() },
         }
     }
 }
 
 impl<E, P> From<BackfillJob<E, P>> for StreamBackfillJob<E, P, BatchBlockStreamItem> {
     fn from(job: BackfillJob<E, P>) -> Self {
+        let batch_size = job.thresholds.max_blocks.map_or(DEFAULT_BATCH_SIZE, |max| max as usize);
         Self {
             executor: job.executor,
             provider: job.provider,
@@ -161,7 +164,11 @@ impl<E, P> From<BackfillJob<E, P>> for StreamBackfillJob<E, P, BatchBlockStreamI
             range: job.range,
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,
-            batch_size: job.thresholds.max_blocks.map_or(DEFAULT_BATCH_SIZE, |max| max as usize),
+            batch_size,
+            thresholds: ExecutionStageThresholds {
+                max_blocks: Some(batch_size as u64),
+                ..job.thresholds
+            },
         }
     }
 }


### PR DESCRIPTION
Passes thresholds to the streaming backfill executor