### PR TITLE
chore(provider): add more test coverage on `BlockchainProvider::*by_tx_range` queries

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -4142,11 +4142,8 @@ mod tests {
             );
 
             // Test range in in-memory to unbounded end
-            assert_eq!(
-                $provider.$method(in_mem_range.start() + 1..)?,
-                &in_memory_data[1..]
-            );
-            
+            assert_eq!($provider.$method(in_mem_range.start() + 1..)?, &in_memory_data[1..]);
+
             // Test range that spans database and in-memory
             assert_eq!(
                 $provider.$method(in_mem_range.start() - 2..=in_mem_range.end() - 1)?,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -4141,12 +4141,28 @@ mod tests {
                 &in_memory_data[1..in_memory_data.len() - 1]
             );
 
+            // Test range in in-memory to unbounded end
+            assert_eq!(
+                $provider.$method(in_mem_range.start() + 1..)?,
+                &in_memory_data[1..]
+            );
+            
             // Test range that spans database and in-memory
             assert_eq!(
                 $provider.$method(in_mem_range.start() - 2..=in_mem_range.end() - 1)?,
                 database_data[database_data.len() - 2..]
                     .iter()
                     .chain(&in_memory_data[..in_memory_data.len() - 1])
+                    .cloned()
+                    .collect::<Vec<_>>()
+            );
+
+            // Test range that spans database and in-memory with unbounded end
+            assert_eq!(
+                $provider.$method(in_mem_range.start() - 2..)?,
+                database_data[database_data.len() - 2..]
+                    .iter()
+                    .chain(&in_memory_data[..])
                     .cloned()
                     .collect::<Vec<_>>()
             );


### PR DESCRIPTION
* smol refactor
* includes `transaction_by_tx_range` & `receipts_by_tx_range`
* test `unbounded` end ranges
* fixes bug when `tx_start` is ahead of the first in-memory block.