### PR TITLE
Relax tokio version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -527,7 +527,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 # tokio
-tokio = { version = "1.39", default-features = false }
+tokio = { version = "1", default-features = false }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["codec"] }
 


### PR DESCRIPTION
There's something going on between versions 1.38 and 1.39 of tokio. Something happened with the handling of the `net` feature in `mio`. As a result some of my dependencies can't really use tokio higher than 1.39 at the moment.