### PR TITLE
test: ensure default hash matches

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1130,4 +1130,13 @@ mod tests {
             Some(SealedBlockWithSenders { block: sealed, senders: vec![sender] })
         );
     }
+
+    #[test]
+    fn test_default_seal() {
+        let block = SealedBlock::default();
+        let sealed = block.hash();
+        let block = block.unseal();
+        let block = block.seal_slow();
+        assert_eq!(sealed, block.hash());
+    }
 }


### PR DESCRIPTION
@emhane this works for block because SealedHeader default matches an empty block body