### PR TITLE
chore(lint): fix lint primitives

### DIFF
--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -182,7 +182,7 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::SealedHeader> for SealedHeader<'a> {
+    impl SerializeAs<super::SealedHeader> for SealedHeader<'_> {
         fn serialize_as<S>(source: &super::SealedHeader, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -756,7 +756,7 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::BlockBody> for BlockBody<'a> {
+    impl SerializeAs<super::BlockBody> for BlockBody<'_> {
         fn serialize_as<S>(source: &super::BlockBody, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -807,7 +807,7 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::SealedBlock> for SealedBlock<'a> {
+    impl SerializeAs<super::SealedBlock> for SealedBlock<'_> {
         fn serialize_as<S>(source: &super::SealedBlock, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -858,7 +858,7 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::SealedBlockWithSenders> for SealedBlockWithSenders<'a> {
+    impl SerializeAs<super::SealedBlockWithSenders> for SealedBlockWithSenders<'_> {
         fn serialize_as<S>(
             source: &super::SealedBlockWithSenders,
             serializer: S,

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -373,7 +373,7 @@ impl<'a> ReceiptWithBloomRef<'a> {
     }
 }
 
-impl<'a> Encodable for ReceiptWithBloomRef<'a> {
+impl Encodable for ReceiptWithBloomRef<'_> {
     fn encode(&self, out: &mut dyn BufMut) {
         self.as_encoder().encode_inner(out, true)
     }
@@ -394,7 +394,7 @@ struct ReceiptWithBloomEncoder<'a> {
     receipt: &'a Receipt,
 }
 
-impl<'a> ReceiptWithBloomEncoder<'a> {
+impl ReceiptWithBloomEncoder<'_> {
     /// Returns the rlp header for the receipt payload.
     fn receipt_rlp_header(&self) -> alloy_rlp::Header {
         let mut rlp_head = alloy_rlp::Header { list: true, payload_length: 0 };
@@ -481,7 +481,7 @@ impl<'a> ReceiptWithBloomEncoder<'a> {
     }
 }
 
-impl<'a> Encodable for ReceiptWithBloomEncoder<'a> {
+impl Encodable for ReceiptWithBloomEncoder<'_> {
     fn encode(&self, out: &mut dyn BufMut) {
         self.encode_inner(out, true)
     }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1640,7 +1640,7 @@ pub mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::Transaction> for Transaction<'a> {
+    impl SerializeAs<super::Transaction> for Transaction<'_> {
         fn serialize_as<S>(source: &super::Transaction, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -1700,7 +1700,7 @@ pub mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::TransactionSigned> for TransactionSigned<'a> {
+    impl SerializeAs<super::TransactionSigned> for TransactionSigned<'_> {
         fn serialize_as<S>(
             source: &super::TransactionSigned,
             serializer: S,


### PR DESCRIPTION
Fixes lint `clippy::needles_lifetimes` in storage