### PR TITLE
feat: abstraction over with_head

### DIFF
--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -6,7 +6,7 @@ use reth_primitives::Head;
 use reth_tasks::TaskExecutor;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::{ExExEvent, ExExNotifications};
+use crate::{ExExEvent, ExExNotificationStream};
 
 /// Captures the context that an `ExEx` has access to.
 pub struct ExExContext<Node: FullNodeComponents> {
@@ -30,7 +30,7 @@ pub struct ExExContext<Node: FullNodeComponents> {
     ///
     /// Once an [`ExExNotification`](crate::ExExNotification) is sent over the channel, it is
     /// considered delivered by the node.
-    pub notifications: ExExNotifications<Node::Provider, Node::Executor>,
+    pub notifications: ExExNotificationStream<Node::Provider, Node::Executor>,
 
     /// node components
     pub components: Node,

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -70,10 +70,19 @@ impl<P, E> ExExNotificationStream<P, E> {
         matches!(self, Self::WithHead(_))
     }
 
-    /// Get a reference to the exex head, if the stream has a head
-    pub const fn exex_head(&self) -> Option<&ExExHead> {
+    /// Convert the stream into a stream with a head that emits
+    /// `Result<ExExNotification>`.
+    pub fn try_into_with_head(self) -> Option<ExExNotificationsWithHead<P, E>> {
         match self {
-            Self::WithHead(notifications) => Some(&notifications.exex_head),
+            Self::WithHead(notifications) => Some(notifications),
+            _ => None,
+        }
+    }
+
+    /// Get a reference to the exex head, if the stream has a head
+    pub const fn exex_head(&self) -> Option<ExExHead> {
+        match self {
+            Self::WithHead(notifications) => Some(notifications.exex_head),
             Self::Raw(_) => None,
             Self::Invalid => panic!("invalid stream state"),
         }

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -20,10 +20,10 @@ use tokio::sync::mpsc::Receiver;
 ///
 /// This stream produces `Result` types because the backfill job is fallible.
 /// If no specific backfill head is needed, this stream can be converted into a
-/// [`ExExNotifications`] stream via [`into_raw`] which will produce
+/// [`ExExNotifications`] stream via [`try_into_raw`] which will produce
 /// [`ExExNotification`] types directly.
 ///
-/// [`into_raw`]: ExExNotificationStream::into_raw
+/// [`try_into_raw`]: ExExNotificationStream::try_into_raw
 #[derive(Debug)]
 #[allow(clippy::manual_non_exhaustive)] // false positive
 pub enum ExExNotificationStream<P, E> {

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -56,7 +56,7 @@ impl<P, E> ExExNotificationStream<P, E> {
     pub const fn exex_head(&self) -> Option<&ExExHead> {
         match self {
             Self::WithHead(notifications) => Some(&notifications.exex_head),
-            Self::Raw => None,
+            Self::Raw(_) => None,
             Self::Invalid => panic!("invalid stream state"),
         }
     }

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -323,7 +323,8 @@ pub async fn test_exex_context_with_chain_spec(
         components.components.executor.clone(),
         notifications_rx,
         wal.handle(),
-    );
+    )
+    .into();
 
     let ctx = ExExContext {
         head,

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -77,7 +77,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
                 reth_config: config_container.toml_config.clone(),
                 components: components.clone(),
                 events,
-                notifications,
+                notifications: notifications.into(),
             };
 
             let executor = components.task_executor().clone();


### PR DESCRIPTION
Closes #11215

Adds an abstraction stream that wraps either a `ExExNotifications` or a `ExExNotificationsWithHead`

** this is a breaking change to the ExEx interface **