### PR TITLE
chore(lint): fix `clippy::needles_lifetimes`

### DIFF
--- a/crates/blockchain-tree/src/bundle.rs
+++ b/crates/blockchain-tree/src/bundle.rs
@@ -18,7 +18,7 @@ pub struct BundleStateDataRef<'a> {
     pub canonical_fork: ForkBlock,
 }
 
-impl<'a> ExecutionDataProvider for BundleStateDataRef<'a> {
+impl ExecutionDataProvider for BundleStateDataRef<'_> {
     fn execution_outcome(&self) -> &ExecutionOutcome {
         self.execution_outcome
     }
@@ -33,7 +33,7 @@ impl<'a> ExecutionDataProvider for BundleStateDataRef<'a> {
     }
 }
 
-impl<'a> BlockExecutionForkProvider for BundleStateDataRef<'a> {
+impl BlockExecutionForkProvider for BundleStateDataRef<'_> {
     fn canonical_fork(&self) -> ForkBlock {
         self.canonical_fork
     }

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -89,7 +89,7 @@ impl BuiltPayload for EthBuiltPayload {
     }
 }
 
-impl<'a> BuiltPayload for &'a EthBuiltPayload {
+impl BuiltPayload for &EthBuiltPayload {
     fn block(&self) -> &SealedBlock {
         (**self).block()
     }

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -355,7 +355,7 @@ impl Chain {
 #[derive(Debug)]
 pub struct DisplayBlocksChain<'a>(pub &'a BTreeMap<BlockNumber, SealedBlockWithSenders>);
 
-impl<'a> fmt::Display for DisplayBlocksChain<'a> {
+impl fmt::Display for DisplayBlocksChain<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut list = f.debug_list();
         let mut values = self.0.values().map(|block| block.num_hash());
@@ -376,7 +376,7 @@ pub struct ChainBlocks<'a> {
     blocks: Cow<'a, BTreeMap<BlockNumber, SealedBlockWithSenders>>,
 }
 
-impl<'a> ChainBlocks<'a> {
+impl ChainBlocks<'_> {
     /// Creates a consuming iterator over all blocks in the chain with increasing block number.
     ///
     /// Note: this always yields at least one block.
@@ -442,7 +442,7 @@ impl<'a> ChainBlocks<'a> {
     }
 }
 
-impl<'a> IntoIterator for ChainBlocks<'a> {
+impl IntoIterator for ChainBlocks<'_> {
     type Item = (BlockNumber, SealedBlockWithSenders);
     type IntoIter = std::collections::btree_map::IntoIter<BlockNumber, SealedBlockWithSenders>;
 
@@ -571,7 +571,7 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::Chain> for Chain<'a> {
+    impl SerializeAs<super::Chain> for Chain<'_> {
         fn serialize_as<S>(source: &super::Chain, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -85,7 +85,7 @@ where
         .build()
 }
 
-impl<'a, EvmConfig, Chainspec, Hook> SystemCaller<'a, EvmConfig, Chainspec, Hook>
+impl<EvmConfig, Chainspec, Hook> SystemCaller<'_, EvmConfig, Chainspec, Hook>
 where
     EvmConfig: ConfigureEvm<Header = Header>,
     Chainspec: EthereumHardforks,

--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -136,7 +136,7 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> SerializeAs<super::ExExNotification> for ExExNotification<'a> {
+    impl SerializeAs<super::ExExNotification> for ExExNotification<'_> {
         fn serialize_as<S>(
             source: &super::ExExNotification,
             serializer: S,

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -1131,7 +1131,7 @@ mod tests {
         peers: &'a mut PeersManager,
     }
 
-    impl<'a> Future for PeerActionFuture<'a> {
+    impl Future for PeerActionFuture<'_> {
         type Output = PeerAction;
 
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -254,7 +254,7 @@ pub struct RpcContext<'a, Node: FullNodeComponents, EthApi: EthApiTypes> {
     pub auth_module: &'a mut AuthRpcModule,
 }
 
-impl<'a, Node, EthApi> RpcContext<'a, Node, EthApi>
+impl<Node, EthApi> RpcContext<'_, Node, EthApi>
 where
     Node: FullNodeComponents,
     EthApi: EthApiTypes,

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -183,7 +183,7 @@ impl BuiltPayload for OptimismBuiltPayload {
     }
 }
 
-impl<'a> BuiltPayload for &'a OptimismBuiltPayload {
+impl BuiltPayload for &OptimismBuiltPayload {
     fn block(&self) -> &SealedBlock {
         (**self).block()
     }

--- a/crates/payload/builder/src/database.rs
+++ b/crates/payload/builder/src/database.rs
@@ -67,7 +67,7 @@ pub struct CachedReadsDbMut<'a, DB> {
     pub db: DB,
 }
 
-impl<'a, DB: DatabaseRef> Database for CachedReadsDbMut<'a, DB> {
+impl<DB: DatabaseRef> Database for CachedReadsDbMut<'_, DB> {
     type Error = <DB as DatabaseRef>::Error;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -130,7 +130,7 @@ pub struct CachedReadsDBRef<'a, DB> {
     pub inner: RefCell<CachedReadsDbMut<'a, DB>>,
 }
 
-impl<'a, DB: DatabaseRef> DatabaseRef for CachedReadsDBRef<'a, DB> {
+impl<DB: DatabaseRef> DatabaseRef for CachedReadsDBRef<'_, DB> {
     type Error = <DB as DatabaseRef>::Error;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {

--- a/crates/prune/prune/src/segments/static_file/headers.rs
+++ b/crates/prune/prune/src/segments/static_file/headers.rs
@@ -137,7 +137,7 @@ where
     }
 }
 
-impl<'a, Provider> Iterator for HeaderTablesIter<'a, Provider>
+impl<Provider> Iterator for HeaderTablesIter<'_, Provider>
 where
     Provider: DBProvider<Tx: DbTxMut>,
 {

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -20,7 +20,7 @@ pub type StateCacheDb<'a> = CacheDB<StateProviderDatabase<StateProviderTraitObjW
 #[allow(missing_debug_implementations)]
 pub struct StateProviderTraitObjWrapper<'a>(pub &'a dyn StateProvider);
 
-impl<'a> reth_storage_api::StateRootProvider for StateProviderTraitObjWrapper<'a> {
+impl reth_storage_api::StateRootProvider for StateProviderTraitObjWrapper<'_> {
     fn state_root(
         &self,
         hashed_state: reth_trie::HashedPostState,
@@ -50,7 +50,7 @@ impl<'a> reth_storage_api::StateRootProvider for StateProviderTraitObjWrapper<'a
     }
 }
 
-impl<'a> reth_storage_api::StorageRootProvider for StateProviderTraitObjWrapper<'a> {
+impl reth_storage_api::StorageRootProvider for StateProviderTraitObjWrapper<'_> {
     fn storage_root(
         &self,
         address: Address,
@@ -60,7 +60,7 @@ impl<'a> reth_storage_api::StorageRootProvider for StateProviderTraitObjWrapper<
     }
 }
 
-impl<'a> reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'a> {
+impl reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'_> {
     fn proof(
         &self,
         input: reth_trie::TrieInput,
@@ -88,7 +88,7 @@ impl<'a> reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'
     }
 }
 
-impl<'a> reth_storage_api::AccountReader for StateProviderTraitObjWrapper<'a> {
+impl reth_storage_api::AccountReader for StateProviderTraitObjWrapper<'_> {
     fn basic_account(
         &self,
         address: revm_primitives::Address,
@@ -97,7 +97,7 @@ impl<'a> reth_storage_api::AccountReader for StateProviderTraitObjWrapper<'a> {
     }
 }
 
-impl<'a> reth_storage_api::BlockHashReader for StateProviderTraitObjWrapper<'a> {
+impl reth_storage_api::BlockHashReader for StateProviderTraitObjWrapper<'_> {
     fn block_hash(
         &self,
         block_number: alloy_primitives::BlockNumber,
@@ -121,7 +121,7 @@ impl<'a> reth_storage_api::BlockHashReader for StateProviderTraitObjWrapper<'a> 
     }
 }
 
-impl<'a> StateProvider for StateProviderTraitObjWrapper<'a> {
+impl StateProvider for StateProviderTraitObjWrapper<'_> {
     fn account_balance(
         &self,
         addr: revm_primitives::Address,
@@ -164,7 +164,7 @@ impl<'a> StateProvider for StateProviderTraitObjWrapper<'a> {
 #[allow(missing_debug_implementations)]
 pub struct StateCacheDbRefMutWrapper<'a, 'b>(pub &'b mut StateCacheDb<'a>);
 
-impl<'a, 'b> Database for StateCacheDbRefMutWrapper<'a, 'b> {
+impl<'a> Database for StateCacheDbRefMutWrapper<'a, '_> {
     type Error = <StateCacheDb<'a> as Database>::Error;
     fn basic(
         &mut self,
@@ -190,7 +190,7 @@ impl<'a, 'b> Database for StateCacheDbRefMutWrapper<'a, 'b> {
     }
 }
 
-impl<'a, 'b> DatabaseRef for StateCacheDbRefMutWrapper<'a, 'b> {
+impl<'a> DatabaseRef for StateCacheDbRefMutWrapper<'a, '_> {
     type Error = <StateCacheDb<'a> as Database>::Error;
 
     fn basic_ref(

--- a/crates/rpc/rpc-layer/src/auth_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_layer.rs
@@ -176,7 +176,7 @@ mod tests {
         missing_jwt_error().await;
         wrong_jwt_signature_error().await;
         invalid_issuance_timestamp_error().await;
-        jwt_decode_error().await;
+        jwt_decode_error().await
     }
 
     async fn valid_jwt() {

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -304,7 +304,7 @@ impl<'a> DebugTraceTransactionsStream<'a> {
     }
 }
 
-impl<'a> Stream for DebugTraceTransactionsStream<'a> {
+impl Stream for DebugTraceTransactionsStream<'_> {
     type Item = TraceTransactionResult;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -312,7 +312,7 @@ impl<'a> Stream for DebugTraceTransactionsStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for DebugTraceTransactionsStream<'a> {
+impl std::fmt::Debug for DebugTraceTransactionsStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DebugTraceTransactionsStream").finish_non_exhaustive()
     }
@@ -336,7 +336,7 @@ impl<'a> DebugTraceBlockStream<'a> {
     }
 }
 
-impl<'a> Stream for DebugTraceBlockStream<'a> {
+impl Stream for DebugTraceBlockStream<'_> {
     type Item = DebugTraceBlockResult;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -344,7 +344,7 @@ impl<'a> Stream for DebugTraceBlockStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for DebugTraceBlockStream<'a> {
+impl std::fmt::Debug for DebugTraceBlockStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DebugTraceBlockStream").finish_non_exhaustive()
     }

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -114,7 +114,7 @@ pub struct TraceCallStream<'a> {
     stream: Pin<Box<dyn Stream<Item = TraceCallResult> + 'a>>,
 }
 
-impl<'a> Stream for TraceCallStream<'a> {
+impl Stream for TraceCallStream<'_> {
     type Item = TraceCallResult;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -122,7 +122,7 @@ impl<'a> Stream for TraceCallStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for TraceCallStream<'a> {
+impl std::fmt::Debug for TraceCallStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TraceCallStream").finish()
     }
@@ -134,7 +134,7 @@ pub struct TraceFilterStream<'a> {
     stream: Pin<Box<dyn Stream<Item = TraceFilterResult> + 'a>>,
 }
 
-impl<'a> Stream for TraceFilterStream<'a> {
+impl Stream for TraceFilterStream<'_> {
     type Item = TraceFilterResult;
 
     /// Attempts to pull out the next value of the stream.
@@ -143,7 +143,7 @@ impl<'a> Stream for TraceFilterStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for TraceFilterStream<'a> {
+impl std::fmt::Debug for TraceFilterStream<'_> {
     /// Provides a debug representation of the `TraceFilterStream`.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TraceFilterStream").finish_non_exhaustive()
@@ -157,7 +157,7 @@ pub struct TraceGetStream<'a> {
     stream: Pin<Box<dyn Stream<Item = TraceGetResult> + 'a>>,
 }
 
-impl<'a> Stream for TraceGetStream<'a> {
+impl Stream for TraceGetStream<'_> {
     type Item = TraceGetResult;
 
     /// Attempts to pull out the next item of the stream
@@ -166,7 +166,7 @@ impl<'a> Stream for TraceGetStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for TraceGetStream<'a> {
+impl std::fmt::Debug for TraceGetStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TraceGetStream").finish_non_exhaustive()
     }
@@ -180,7 +180,7 @@ pub struct CallManyTraceStream<'a> {
     stream: Pin<Box<dyn Stream<Item = CallManyTraceResult> + 'a>>,
 }
 
-impl<'a> Stream for CallManyTraceStream<'a> {
+impl Stream for CallManyTraceStream<'_> {
     type Item = CallManyTraceResult;
 
     /// Polls for the next item from the stream.
@@ -189,7 +189,7 @@ impl<'a> Stream for CallManyTraceStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for CallManyTraceStream<'a> {
+impl std::fmt::Debug for CallManyTraceStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CallManyTraceStream").finish()
     }
@@ -201,7 +201,7 @@ pub struct RawTransactionTraceStream<'a> {
     stream: RawTransactionTraceResult<'a>,
 }
 
-impl<'a> Stream for RawTransactionTraceStream<'a> {
+impl Stream for RawTransactionTraceStream<'_> {
     type Item = Result<(TraceResults, Bytes), (RpcError, Bytes)>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -209,7 +209,7 @@ impl<'a> Stream for RawTransactionTraceStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for RawTransactionTraceStream<'a> {
+impl std::fmt::Debug for RawTransactionTraceStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RawTransactionTraceStream").finish()
     }
@@ -221,7 +221,7 @@ pub struct ReplayTransactionStream<'a> {
     stream: Pin<Box<dyn Stream<Item = ReplayTransactionResult> + 'a>>,
 }
 
-impl<'a> Stream for ReplayTransactionStream<'a> {
+impl Stream for ReplayTransactionStream<'_> {
     type Item = ReplayTransactionResult;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -229,7 +229,7 @@ impl<'a> Stream for ReplayTransactionStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for ReplayTransactionStream<'a> {
+impl std::fmt::Debug for ReplayTransactionStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReplayTransactionStream").finish()
     }
@@ -393,7 +393,7 @@ impl<'a> TraceBlockStream<'a> {
     }
 }
 
-impl<'a> Stream for TraceBlockStream<'a> {
+impl Stream for TraceBlockStream<'_> {
     type Item = TraceBlockResult;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -401,7 +401,7 @@ impl<'a> Stream for TraceBlockStream<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for TraceBlockStream<'a> {
+impl std::fmt::Debug for TraceBlockStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TraceBlockStream").finish_non_exhaustive()
     }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -227,7 +227,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> AccountReader for HistoricalStateProviderRef<'b, TX> {
+impl<TX: DbTx> AccountReader for HistoricalStateProviderRef<'_, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         match self.account_history_lookup(address)? {
@@ -249,7 +249,7 @@ impl<'b, TX: DbTx> AccountReader for HistoricalStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
+impl<TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'_, TX> {
     /// Get block hash by number.
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.static_file_provider.get_with_static_file_or_database(
@@ -285,7 +285,7 @@ impl<'b, TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
+impl<TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'_, TX> {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let mut revert_state = self.revert_state()?;
         revert_state.extend(hashed_state);
@@ -319,7 +319,7 @@ impl<'b, TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StorageRootProvider for HistoricalStateProviderRef<'b, TX> {
+impl<TX: DbTx> StorageRootProvider for HistoricalStateProviderRef<'_, TX> {
     fn storage_root(
         &self,
         address: Address,
@@ -332,7 +332,7 @@ impl<'b, TX: DbTx> StorageRootProvider for HistoricalStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'b, TX> {
+impl<TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'_, TX> {
     /// Get account and storage proofs.
     fn proof(
         &self,
@@ -364,7 +364,7 @@ impl<'b, TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StateProvider for HistoricalStateProviderRef<'b, TX> {
+impl<TX: DbTx> StateProvider for HistoricalStateProviderRef<'_, TX> {
     /// Get storage.
     fn storage(
         &self,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -36,14 +36,14 @@ impl<'b, TX: DbTx> LatestStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> AccountReader for LatestStateProviderRef<'b, TX> {
+impl<TX: DbTx> AccountReader for LatestStateProviderRef<'_, TX> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         self.tx.get::<tables::PlainAccountState>(address).map_err(Into::into)
     }
 }
 
-impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
+impl<TX: DbTx> BlockHashReader for LatestStateProviderRef<'_, TX> {
     /// Get block hash by number.
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.static_file_provider.get_with_static_file_or_database(
@@ -79,7 +79,7 @@ impl<'b, TX: DbTx> BlockHashReader for LatestStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
+impl<TX: DbTx> StateRootProvider for LatestStateProviderRef<'_, TX> {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         StateRoot::overlay_root(self.tx, hashed_state)
             .map_err(|err| ProviderError::Database(err.into()))
@@ -107,7 +107,7 @@ impl<'b, TX: DbTx> StateRootProvider for LatestStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StorageRootProvider for LatestStateProviderRef<'b, TX> {
+impl<TX: DbTx> StorageRootProvider for LatestStateProviderRef<'_, TX> {
     fn storage_root(
         &self,
         address: Address,
@@ -118,7 +118,7 @@ impl<'b, TX: DbTx> StorageRootProvider for LatestStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StateProofProvider for LatestStateProviderRef<'b, TX> {
+impl<TX: DbTx> StateProofProvider for LatestStateProviderRef<'_, TX> {
     fn proof(
         &self,
         input: TrieInput,
@@ -146,7 +146,7 @@ impl<'b, TX: DbTx> StateProofProvider for LatestStateProviderRef<'b, TX> {
     }
 }
 
-impl<'b, TX: DbTx> StateProvider for LatestStateProviderRef<'b, TX> {
+impl<TX: DbTx> StateProvider for LatestStateProviderRef<'_, TX> {
     /// Get storage.
     fn storage(
         &self,

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -75,7 +75,7 @@ impl<'a> StaticFileJarProvider<'a> {
     }
 }
 
-impl<'a> HeaderProvider for StaticFileJarProvider<'a> {
+impl HeaderProvider for StaticFileJarProvider<'_> {
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         Ok(self
             .cursor()?
@@ -147,7 +147,7 @@ impl<'a> HeaderProvider for StaticFileJarProvider<'a> {
     }
 }
 
-impl<'a> BlockHashReader for StaticFileJarProvider<'a> {
+impl BlockHashReader for StaticFileJarProvider<'_> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.cursor()?.get_one::<HeaderMask<BlockHash>>(number.into())
     }
@@ -169,7 +169,7 @@ impl<'a> BlockHashReader for StaticFileJarProvider<'a> {
     }
 }
 
-impl<'a> BlockNumReader for StaticFileJarProvider<'a> {
+impl BlockNumReader for StaticFileJarProvider<'_> {
     fn chain_info(&self) -> ProviderResult<ChainInfo> {
         // Information on live database
         Err(ProviderError::UnsupportedProvider)
@@ -194,7 +194,7 @@ impl<'a> BlockNumReader for StaticFileJarProvider<'a> {
     }
 }
 
-impl<'a> TransactionsProvider for StaticFileJarProvider<'a> {
+impl TransactionsProvider for StaticFileJarProvider<'_> {
     fn transaction_id(&self, hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         let mut cursor = self.cursor()?;
 
@@ -290,7 +290,7 @@ impl<'a> TransactionsProvider for StaticFileJarProvider<'a> {
     }
 }
 
-impl<'a> ReceiptProvider for StaticFileJarProvider<'a> {
+impl ReceiptProvider for StaticFileJarProvider<'_> {
     fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Receipt>> {
         self.cursor()?.get_one::<ReceiptMask<Receipt>>(num.into())
     }

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -67,14 +67,14 @@ pub struct StaticFileProviderRWRefMut<'a>(
     pub(crate) RwLockWriteGuard<'a, RawRwLock, Option<StaticFileProviderRW>>,
 );
 
-impl<'a> std::ops::DerefMut for StaticFileProviderRWRefMut<'a> {
+impl std::ops::DerefMut for StaticFileProviderRWRefMut<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // This is always created by [`StaticFileWriters::get_or_create`]
         self.0.as_mut().expect("static file writer provider should be init")
     }
 }
 
-impl<'a> std::ops::Deref for StaticFileProviderRWRefMut<'a> {
+impl std::ops::Deref for StaticFileProviderRWRefMut<'_> {
     type Target = StaticFileProviderRW;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/storage/provider/src/writer/database.rs
+++ b/crates/storage/provider/src/writer/database.rs
@@ -9,7 +9,7 @@ use reth_storage_api::ReceiptWriter;
 
 pub(crate) struct DatabaseWriter<'a, W>(pub(crate) &'a mut W);
 
-impl<'a, W> ReceiptWriter for DatabaseWriter<'a, W>
+impl<W> ReceiptWriter for DatabaseWriter<'_, W>
 where
     W: DbCursorRO<tables::Receipts> + DbCursorRW<tables::Receipts>,
 {

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -147,7 +147,7 @@ impl UnifiedStorageWriter<'_, (), ()> {
     }
 }
 
-impl<'a, 'b, ProviderDB> UnifiedStorageWriter<'a, ProviderDB, &'b StaticFileProvider>
+impl<ProviderDB> UnifiedStorageWriter<'_, ProviderDB, &StaticFileProvider>
 where
     ProviderDB: DBProvider<Tx: DbTx + DbTxMut>
         + BlockWriter
@@ -318,7 +318,7 @@ where
     }
 }
 
-impl<'a, 'b, ProviderDB> UnifiedStorageWriter<'a, ProviderDB, StaticFileProviderRWRefMut<'b>>
+impl<ProviderDB> UnifiedStorageWriter<'_, ProviderDB, StaticFileProviderRWRefMut<'_>>
 where
     ProviderDB: DBProvider<Tx: DbTx> + HeaderProvider,
 {
@@ -429,7 +429,7 @@ where
     }
 }
 
-impl<'a, 'b, ProviderDB> UnifiedStorageWriter<'a, ProviderDB, StaticFileProviderRWRefMut<'b>>
+impl<ProviderDB> UnifiedStorageWriter<'_, ProviderDB, StaticFileProviderRWRefMut<'_>>
 where
     ProviderDB: DBProvider<Tx: DbTxMut + DbTx> + HeaderProvider,
 {
@@ -510,8 +510,8 @@ where
     }
 }
 
-impl<'a, 'b, ProviderDB> StateWriter
-    for UnifiedStorageWriter<'a, ProviderDB, StaticFileProviderRWRefMut<'b>>
+impl<ProviderDB> StateWriter
+    for UnifiedStorageWriter<'_, ProviderDB, StaticFileProviderRWRefMut<'_>>
 where
     ProviderDB: DBProvider<Tx: DbTxMut + DbTx> + StateChangeWriter + HeaderProvider,
 {

--- a/crates/storage/provider/src/writer/static_file.rs
+++ b/crates/storage/provider/src/writer/static_file.rs
@@ -6,7 +6,7 @@ use reth_storage_api::ReceiptWriter;
 
 pub(crate) struct StaticFileWriter<'a, W>(pub(crate) &'a mut W);
 
-impl<'a> ReceiptWriter for StaticFileWriter<'a, StaticFileProviderRWRefMut<'_>> {
+impl ReceiptWriter for StaticFileWriter<'_, StaticFileProviderRWRefMut<'_>> {
     fn append_block_receipts(
         &mut self,
         first_tx_index: TxNumber,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -644,7 +644,7 @@ pub struct CanonicalStateUpdate<'a> {
     pub mined_transactions: Vec<B256>,
 }
 
-impl<'a> CanonicalStateUpdate<'a> {
+impl CanonicalStateUpdate<'_> {
     /// Returns the number of the tip block.
     pub fn number(&self) -> u64 {
         self.new_tip.number

--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -11,7 +11,7 @@ use reth_trie::hashed_cursor::{HashedCursor, HashedCursorFactory, HashedStorageC
 #[derive(Debug)]
 pub struct DatabaseHashedCursorFactory<'a, TX>(&'a TX);
 
-impl<'a, TX> Clone for DatabaseHashedCursorFactory<'a, TX> {
+impl<TX> Clone for DatabaseHashedCursorFactory<'_, TX> {
     fn clone(&self) -> Self {
         Self(self.0)
     }
@@ -24,7 +24,7 @@ impl<'a, TX> DatabaseHashedCursorFactory<'a, TX> {
     }
 }
 
-impl<'a, TX: DbTx> HashedCursorFactory for DatabaseHashedCursorFactory<'a, TX> {
+impl<TX: DbTx> HashedCursorFactory for DatabaseHashedCursorFactory<'_, TX> {
     type AccountCursor = DatabaseHashedAccountCursor<<TX as DbTx>::Cursor<tables::HashedAccounts>>;
     type StorageCursor =
         DatabaseHashedStorageCursor<<TX as DbTx>::DupCursor<tables::HashedStorages>>;

--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -26,7 +26,7 @@ impl<'a, TX> PrefixSetLoader<'a, TX> {
     }
 }
 
-impl<'a, TX: DbTx> PrefixSetLoader<'a, TX> {
+impl<TX: DbTx> PrefixSetLoader<'_, TX> {
     /// Load all account and storage changes for the given block range.
     pub fn load(self, range: RangeInclusive<BlockNumber>) -> Result<TriePrefixSets, DatabaseError> {
         // Initialize prefix sets.

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -19,7 +19,7 @@ use reth_trie_common::StorageTrieEntry;
 #[derive(Debug)]
 pub struct DatabaseTrieCursorFactory<'a, TX>(&'a TX);
 
-impl<'a, TX> Clone for DatabaseTrieCursorFactory<'a, TX> {
+impl<TX> Clone for DatabaseTrieCursorFactory<'_, TX> {
     fn clone(&self) -> Self {
         Self(self.0)
     }
@@ -33,7 +33,7 @@ impl<'a, TX> DatabaseTrieCursorFactory<'a, TX> {
 }
 
 /// Implementation of the trie cursor factory for a database transaction.
-impl<'a, TX: DbTx> TrieCursorFactory for DatabaseTrieCursorFactory<'a, TX> {
+impl<TX: DbTx> TrieCursorFactory for DatabaseTrieCursorFactory<'_, TX> {
     type AccountTrieCursor = DatabaseAccountTrieCursor<<TX as DbTx>::Cursor<tables::AccountsTrie>>;
     type StorageTrieCursor =
         DatabaseStorageTrieCursor<<TX as DbTx>::DupCursor<tables::StoragesTrie>>;

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -113,7 +113,7 @@ impl<'a, C: TrieCursor> InMemoryAccountTrieCursor<'a, C> {
     }
 }
 
-impl<'a, C: TrieCursor> TrieCursor for InMemoryAccountTrieCursor<'a, C> {
+impl<C: TrieCursor> TrieCursor for InMemoryAccountTrieCursor<'_, C> {
     fn seek_exact(
         &mut self,
         key: Nibbles,


### PR DESCRIPTION
Fixes lint warning `clippy::needles_lifetimes`