### PR TITLE
chore(lint): warning `clippy::needless_return`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,7 @@ redundant_pub_crate = "allow"
 significant_drop_in_scrutinee = "allow"
 significant_drop_tightening = "allow"
 too_long_first_doc_paragraph = "allow"
+needless_return = "allow"
 
 # Speed up tests.
 [profile.dev.package]


### PR DESCRIPTION
Allow lint warning `clippy::needless_return`