### PR TITLE
feat(exex): subscribe to notifications with head using `ExExContext`

### DIFF
--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use reth_exex_types::ExExHead;
 use reth_node_api::{FullNodeComponents, NodeTypes, NodeTypesWithEngine};
 use reth_node_core::node_config::NodeConfig;
 use reth_primitives::Head;
@@ -32,7 +33,7 @@ pub struct ExExContext<Node: FullNodeComponents> {
     /// considered delivered by the node.
     pub notifications: ExExNotifications<Node::Provider, Node::Executor>,
 
-    /// node components
+    /// Node components
     pub components: Node,
 }
 
@@ -91,5 +92,13 @@ impl<Node: FullNodeComponents> ExExContext<Node> {
     /// Returns the task executor.
     pub fn task_executor(&self) -> &TaskExecutor {
         self.components.task_executor()
+    }
+
+    pub fn with_notifications_without_head(self) -> Self {
+        Self { notifications: self.notifications.without_head(), ..self }
+    }
+
+    pub fn with_notifications_with_head(self, head: ExExHead) -> Self {
+        Self { notifications: self.notifications.with_head(head), ..self }
     }
 }

--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -94,27 +94,14 @@ impl<Node: FullNodeComponents> ExExContext<Node> {
         self.components.task_executor()
     }
 
-    /// Replaces notifications stream with a stream of notifications without a head.
-    ///
-    /// Consumes the type and returns a new instance of [`ExExContext`].
-    pub fn with_notifications_without_head(self) -> Self {
-        Self { notifications: self.notifications.without_head(), ..self }
-    }
-
-    /// Replaces notifications stream with a stream of notifications with a head using the
-    /// provided head.
-    ///
-    /// Consumes the type and returns a new instance of [`ExExContext`].
-    pub fn with_notifications_with_head(self, head: ExExHead) -> Self {
-        Self { notifications: self.notifications.with_head(head), ..self }
-    }
-
-    /// Sets notifications stream to a stream of notifications without a head.
+    /// Sets notifications stream to [`crate::ExExNotificationsWithoutHead`], a stream of
+    /// notifications without a head.
     pub fn set_notifications_without_head(&mut self) {
         self.notifications.set_without_head();
     }
 
-    /// Sets notifications stream to a stream of notifications with a head using the provided head.
+    /// Sets notifications stream to [`crate::ExExNotificationsWithHead`], a stream of notifications
+    /// with the provided head.
     pub fn set_notifications_with_head(&mut self, head: ExExHead) {
         self.notifications.set_with_head(head);
     }

--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -94,11 +94,28 @@ impl<Node: FullNodeComponents> ExExContext<Node> {
         self.components.task_executor()
     }
 
+    /// Replaces notifications stream with a stream of notifications without a head.
+    ///
+    /// Consumes the type and returns a new instance of [`ExExContext`].
     pub fn with_notifications_without_head(self) -> Self {
         Self { notifications: self.notifications.without_head(), ..self }
     }
 
+    /// Replaces notifications stream with a stream of notifications with a head using the
+    /// provided head.
+    ///
+    /// Consumes the type and returns a new instance of [`ExExContext`].
     pub fn with_notifications_with_head(self, head: ExExHead) -> Self {
         Self { notifications: self.notifications.with_head(head), ..self }
+    }
+
+    /// Sets notifications stream to a stream of notifications without a head.
+    pub fn set_notifications_without_head(&mut self) {
+        self.notifications.set_without_head();
+    }
+
+    /// Sets notifications stream to a stream of notifications with a head using the provided head.
+    pub fn set_notifications_with_head(&mut self, head: ExExHead) {
+        self.notifications.set_with_head(head);
     }
 }

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -81,8 +81,13 @@ impl ExExHandle {
     ) -> (Self, UnboundedSender<ExExEvent>, ExExNotifications<P, E>) {
         let (notification_tx, notification_rx) = mpsc::channel(1);
         let (event_tx, event_rx) = mpsc::unbounded_channel();
-        let notifications =
-            ExExNotifications::new(node_head, provider, executor, notification_rx, wal_handle);
+        let notifications = ExExNotifications::new_without_head(
+            node_head,
+            provider,
+            executor,
+            notification_rx,
+            wal_handle,
+        );
 
         (
             Self {
@@ -610,12 +615,16 @@ impl Clone for ExExManagerHandle {
 mod tests {
     use super::*;
     use alloy_primitives::B256;
-    use eyre::OptionExt;
-    use futures::{FutureExt, StreamExt};
+    use futures::StreamExt;
     use rand::Rng;
+    use reth_db_common::init::init_genesis;
+    use reth_evm_ethereum::execute::EthExecutorProvider;
     use reth_primitives::SealedBlockWithSenders;
-    use reth_provider::{test_utils::create_test_provider_factory, BlockWriter, Chain};
-    use reth_testing_utils::generators::{self, random_block};
+    use reth_provider::{
+        providers::BlockchainProvider2, test_utils::create_test_provider_factory, BlockReader,
+        Chain, TransactionVariant,
+    };
+    use reth_testing_utils::generators;
 
     fn empty_finalized_header_stream() -> ForkChoiceStream<SealedHeader> {
         let (tx, rx) = watch::channel(None);
@@ -975,11 +984,20 @@ mod tests {
 
     #[tokio::test]
     async fn exex_handle_new() {
+        let provider_factory = create_test_provider_factory();
+        init_genesis(&provider_factory).unwrap();
+        let provider = BlockchainProvider2::new(provider_factory).unwrap();
+
         let temp_dir = tempfile::tempdir().unwrap();
         let wal = Wal::new(temp_dir.path()).unwrap();
 
-        let (mut exex_handle, _, mut notifications) =
-            ExExHandle::new("test_exex".to_string(), Head::default(), (), (), wal.handle());
+        let (mut exex_handle, _, mut notifications) = ExExHandle::new(
+            "test_exex".to_string(),
+            Head::default(),
+            provider,
+            EthExecutorProvider::mainnet(),
+            wal.handle(),
+        );
 
         // Check initial state
         assert_eq!(exex_handle.id, "test_exex");
@@ -1008,7 +1026,7 @@ mod tests {
         // Send a notification and ensure it's received correctly
         match exex_handle.send(&mut cx, &(22, notification.clone())) {
             Poll::Ready(Ok(())) => {
-                let received_notification = notifications.next().await.unwrap();
+                let received_notification = notifications.next().await.unwrap().unwrap();
                 assert_eq!(received_notification, notification);
             }
             Poll::Pending => panic!("Notification send is pending"),
@@ -1021,11 +1039,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_notification_if_finished_height_gt_chain_tip() {
+        let provider_factory = create_test_provider_factory();
+        init_genesis(&provider_factory).unwrap();
+        let provider = BlockchainProvider2::new(provider_factory).unwrap();
+
         let temp_dir = tempfile::tempdir().unwrap();
         let wal = Wal::new(temp_dir.path()).unwrap();
 
-        let (mut exex_handle, _, mut notifications) =
-            ExExHandle::new("test_exex".to_string(), Head::default(), (), (), wal.handle());
+        let (mut exex_handle, _, mut notifications) = ExExHandle::new(
+            "test_exex".to_string(),
+            Head::default(),
+            provider,
+            EthExecutorProvider::mainnet(),
+            wal.handle(),
+        );
 
         // Set finished_height to a value higher than the block tip
         exex_handle.finished_height = Some(BlockNumHash::new(15, B256::random()));
@@ -1046,11 +1073,7 @@ mod tests {
                 poll_fn(|cx| {
                     // The notification should be skipped, so nothing should be sent.
                     // Check that the receiver channel is indeed empty
-                    assert_eq!(
-                        notifications.poll_next_unpin(cx),
-                        Poll::Pending,
-                        "Receiver channel should be empty"
-                    );
+                    assert!(notifications.poll_next_unpin(cx).is_pending());
                     Poll::Ready(())
                 })
                 .await;
@@ -1066,11 +1089,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_sends_chain_reorged_notification() {
+        let provider_factory = create_test_provider_factory();
+        init_genesis(&provider_factory).unwrap();
+        let provider = BlockchainProvider2::new(provider_factory).unwrap();
+
         let temp_dir = tempfile::tempdir().unwrap();
         let wal = Wal::new(temp_dir.path()).unwrap();
 
-        let (mut exex_handle, _, mut notifications) =
-            ExExHandle::new("test_exex".to_string(), Head::default(), (), (), wal.handle());
+        let (mut exex_handle, _, mut notifications) = ExExHandle::new(
+            "test_exex".to_string(),
+            Head::default(),
+            provider,
+            EthExecutorProvider::mainnet(),
+            wal.handle(),
+        );
 
         let notification = ExExNotification::ChainReorged {
             old: Arc::new(Chain::default()),
@@ -1086,7 +1118,7 @@ mod tests {
         // Send the notification
         match exex_handle.send(&mut cx, &(22, notification.clone())) {
             Poll::Ready(Ok(())) => {
-                let received_notification = notifications.next().await.unwrap();
+                let received_notification = notifications.next().await.unwrap().unwrap();
                 assert_eq!(received_notification, notification);
             }
             Poll::Pending | Poll::Ready(Err(_)) => {
@@ -1100,11 +1132,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_sends_chain_reverted_notification() {
+        let provider_factory = create_test_provider_factory();
+        init_genesis(&provider_factory).unwrap();
+        let provider = BlockchainProvider2::new(provider_factory).unwrap();
+
         let temp_dir = tempfile::tempdir().unwrap();
         let wal = Wal::new(temp_dir.path()).unwrap();
 
-        let (mut exex_handle, _, mut notifications) =
-            ExExHandle::new("test_exex".to_string(), Head::default(), (), (), wal.handle());
+        let (mut exex_handle, _, mut notifications) = ExExHandle::new(
+            "test_exex".to_string(),
+            Head::default(),
+            provider,
+            EthExecutorProvider::mainnet(),
+            wal.handle(),
+        );
 
         let notification = ExExNotification::ChainReverted { old: Arc::new(Chain::default()) };
 
@@ -1117,7 +1158,7 @@ mod tests {
         // Send the notification
         match exex_handle.send(&mut cx, &(22, notification.clone())) {
             Poll::Ready(Ok(())) => {
-                let received_notification = notifications.next().await.unwrap();
+                let received_notification = notifications.next().await.unwrap().unwrap();
                 assert_eq!(received_notification, notification);
             }
             Poll::Pending | Poll::Ready(Err(_)) => {
@@ -1135,30 +1176,34 @@ mod tests {
 
         let mut rng = generators::rng();
 
+        let provider_factory = create_test_provider_factory();
+        let genesis_hash = init_genesis(&provider_factory).unwrap();
+        let genesis_block = provider_factory
+            .sealed_block_with_senders(genesis_hash.into(), TransactionVariant::NoHash)
+            .unwrap()
+            .ok_or_else(|| eyre::eyre!("genesis block not found"))?;
+        let provider = BlockchainProvider2::new(provider_factory).unwrap();
+
         let temp_dir = tempfile::tempdir().unwrap();
         let wal = Wal::new(temp_dir.path()).unwrap();
 
-        let provider_factory = create_test_provider_factory();
-
-        let block = random_block(&mut rng, 0, Default::default())
-            .seal_with_senders()
-            .ok_or_eyre("failed to recover senders")?;
-        let provider_rw = provider_factory.provider_rw()?;
-        provider_rw.insert_block(block.clone())?;
-        provider_rw.commit()?;
+        let (exex_handle, events_tx, mut notifications) = ExExHandle::new(
+            "test_exex".to_string(),
+            Head::default(),
+            provider.clone(),
+            EthExecutorProvider::mainnet(),
+            wal.handle(),
+        );
 
         let notification = ExExNotification::ChainCommitted {
-            new: Arc::new(Chain::new(vec![block.clone()], Default::default(), None)),
+            new: Arc::new(Chain::new(vec![genesis_block.clone()], Default::default(), None)),
         };
 
         let (finalized_headers_tx, rx) = watch::channel(None);
         let finalized_header_stream = ForkChoiceStream::new(rx);
 
-        let (exex_handle, events_tx, mut notifications) =
-            ExExHandle::new("test_exex".to_string(), Head::default(), (), (), wal.handle());
-
         let mut exex_manager = std::pin::pin!(ExExManager::new(
-            provider_factory,
+            provider,
             vec![exex_handle],
             1,
             wal,
@@ -1170,16 +1215,13 @@ mod tests {
         exex_manager.handle().send(notification.clone())?;
 
         assert!(exex_manager.as_mut().poll(&mut cx)?.is_pending());
-        assert_eq!(
-            notifications.next().poll_unpin(&mut cx),
-            Poll::Ready(Some(notification.clone()))
-        );
+        assert_eq!(notifications.next().await.unwrap().unwrap(), notification.clone());
         assert_eq!(
             exex_manager.wal.iter_notifications()?.collect::<eyre::Result<Vec<_>>>()?,
             [notification.clone()]
         );
 
-        finalized_headers_tx.send(Some(block.header.clone()))?;
+        finalized_headers_tx.send(Some(genesis_block.header.clone()))?;
         assert!(exex_manager.as_mut().poll(&mut cx).is_pending());
         // WAL isn't finalized because the ExEx didn't emit the `FinishedHeight` event
         assert_eq!(
@@ -1192,7 +1234,7 @@ mod tests {
             .send(ExExEvent::FinishedHeight((rng.gen::<u64>(), rng.gen::<B256>()).into()))
             .unwrap();
 
-        finalized_headers_tx.send(Some(block.header.clone()))?;
+        finalized_headers_tx.send(Some(genesis_block.header.clone()))?;
         assert!(exex_manager.as_mut().poll(&mut cx).is_pending());
         // WAL isn't finalized because the ExEx emitted a `FinishedHeight` event with a
         // non-canonical block
@@ -1202,9 +1244,9 @@ mod tests {
         );
 
         // Send a `FinishedHeight` event with a canonical block
-        events_tx.send(ExExEvent::FinishedHeight(block.num_hash())).unwrap();
+        events_tx.send(ExExEvent::FinishedHeight(genesis_block.num_hash())).unwrap();
 
-        finalized_headers_tx.send(Some(block.header.clone()))?;
+        finalized_headers_tx.send(Some(genesis_block.header.clone()))?;
         assert!(exex_manager.as_mut().poll(&mut cx).is_pending());
         // WAL is finalized
         assert!(exex_manager.wal.iter_notifications()?.next().is_none());

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -81,13 +81,8 @@ impl ExExHandle {
     ) -> (Self, UnboundedSender<ExExEvent>, ExExNotifications<P, E>) {
         let (notification_tx, notification_rx) = mpsc::channel(1);
         let (event_tx, event_rx) = mpsc::unbounded_channel();
-        let notifications = ExExNotifications::new_without_head(
-            node_head,
-            provider,
-            executor,
-            notification_rx,
-            wal_handle,
-        );
+        let notifications =
+            ExExNotifications::new(node_head, provider, executor, notification_rx, wal_handle);
 
         (
             Self {

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -54,7 +54,9 @@ impl<P, E> ExExNotifications<P, E> {
     /// Sets [`ExExNotifications`] to a stream of [`ExExNotification`]s without a head.
     ///
     /// It's a no-op if the stream has already been configured without a head.
-    pub(super) fn set_without_head(&mut self) {
+    ///
+    /// See the documentation of [`ExExNotificationsWithoutHead`] for more details.
+    pub fn set_without_head(&mut self) {
         let current = std::mem::replace(&mut self.inner, ExExNotificationsInner::Invalid);
         self.inner = ExExNotificationsInner::WithoutHead(match current {
             ExExNotificationsInner::Invalid => unreachable!(),
@@ -69,10 +71,30 @@ impl<P, E> ExExNotifications<P, E> {
         });
     }
 
+    /// Returns a new [`ExExNotifications`] without a head.
+    ///
+    /// See the documentation of [`ExExNotificationsWithoutHead`] for more details.
+    pub fn without_head(mut self) -> Self {
+        self.inner = ExExNotificationsInner::WithoutHead(match self.inner {
+            ExExNotificationsInner::Invalid => unreachable!(),
+            ExExNotificationsInner::WithoutHead(notifications) => notifications,
+            ExExNotificationsInner::WithHead(notifications) => ExExNotificationsWithoutHead::new(
+                notifications.node_head,
+                notifications.provider,
+                notifications.executor,
+                notifications.notifications,
+                notifications.wal_handle,
+            ),
+        });
+        self
+    }
+
     /// Sets [`ExExNotifications`] to a stream of [`ExExNotification`]s with the provided head.
     ///
     /// It's a no-op if the stream has already been configured with a head.
-    pub(super) fn set_with_head(&mut self, exex_head: ExExHead) {
+    ///
+    /// See the documentation of [`ExExNotificationsWithHead`] for more details.
+    pub fn set_with_head(&mut self, exex_head: ExExHead) {
         let current = std::mem::replace(&mut self.inner, ExExNotificationsInner::Invalid);
         self.inner = ExExNotificationsInner::WithHead(match current {
             ExExNotificationsInner::Invalid => unreachable!(),
@@ -81,6 +103,32 @@ impl<P, E> ExExNotifications<P, E> {
             }
             ExExNotificationsInner::WithHead(notifications) => notifications,
         });
+    }
+
+    /// Returns a new [`ExExNotifications`] with the provided head.
+    ///
+    /// See the documentation of [`ExExNotificationsWithHead`] for more details.
+    pub fn with_head(mut self, exex_head: ExExHead) -> Self {
+        self.inner = ExExNotificationsInner::WithHead(match self.inner {
+            ExExNotificationsInner::Invalid => unreachable!(),
+            ExExNotificationsInner::WithoutHead(notifications) => ExExNotificationsWithHead::new(
+                notifications.node_head,
+                notifications.provider,
+                notifications.executor,
+                notifications.notifications,
+                notifications.wal_handle,
+                exex_head,
+            ),
+            ExExNotificationsInner::WithHead(notifications) => ExExNotificationsWithHead::new(
+                notifications.node_head,
+                notifications.provider,
+                notifications.executor,
+                notifications.notifications,
+                notifications.wal_handle,
+                exex_head,
+            ),
+        });
+        self
     }
 }
 

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -184,13 +184,7 @@ impl<P, E> ExExNotificationsWithoutHead<P, E> {
         Self { node_head, provider, executor, notifications, wal_handle }
     }
 
-    /// Subscribe to notifications with the given head. This head is the ExEx's
-    /// latest view of the host chain.
-    ///
-    /// Notifications will be sent starting from the head, not inclusive. For
-    /// example, if `head.number == 10`, then the first notification will be
-    /// with `block.number == 11`. A `head.number` of 10 indicates that the ExEx
-    /// has processed up to block 10, and is ready to process block 11.
+    /// Subscribe to notifications with the given head.
     fn with_head(self, head: ExExHead) -> ExExNotificationsWithHead<P, E> {
         ExExNotificationsWithHead::new(
             self.node_head,
@@ -212,7 +206,13 @@ impl<P: Unpin, E: Unpin> Stream for ExExNotificationsWithoutHead<P, E> {
 }
 
 /// A stream of [`ExExNotification`]s. The stream will only emit notifications for blocks that are
-/// committed or reverted after the given head.
+/// committed or reverted after the given head. The head is the ExEx's latest view of the host
+/// chain.
+///
+/// Notifications will be sent starting from the head, not inclusive. For example, if
+/// `exex_head.number == 10`, then the first notification will be with `block.number == 11`. An
+/// `exex_head.number` of 10 indicates that the ExEx has processed up to block 10, and is ready to
+/// process block 11.
 #[derive(Debug)]
 pub struct ExExNotificationsWithHead<P, E> {
     node_head: Head,

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -13,7 +13,9 @@ use std::{
 };
 use tokio::sync::mpsc::Receiver;
 
-/// A stream of [`ExExNotification`]s.
+/// A stream of [`ExExNotification`]s. The stream will emit notifications for all blocks. If the
+/// stream is configured with a head via [`ExExNotifications::set_with_head`] or
+/// [`ExExNotifications::with_head`], it will run backfill jobs to catch up to the node head.
 #[derive(Debug)]
 pub struct ExExNotifications<P, E> {
     inner: ExExNotificationsInner<P, E>,

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -317,7 +317,7 @@ pub async fn test_exex_context_with_chain_spec(
 
     let (events_tx, events_rx) = tokio::sync::mpsc::unbounded_channel();
     let (notifications_tx, notifications_rx) = tokio::sync::mpsc::channel(1);
-    let notifications = ExExNotifications::new_without_head(
+    let notifications = ExExNotifications::new(
         head,
         components.provider.clone(),
         components.components.executor.clone(),

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -317,7 +317,7 @@ pub async fn test_exex_context_with_chain_spec(
 
     let (events_tx, events_rx) = tokio::sync::mpsc::unbounded_channel();
     let (notifications_tx, notifications_rx) = tokio::sync::mpsc::channel(1);
-    let notifications = ExExNotifications::new(
+    let notifications = ExExNotifications::new_without_head(
         head,
         components.provider.clone(),
         components.components.executor.clone(),


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/11215

Similar to https://github.com/paradigmxyz/reth/pull/11495, but takes an approach of a newtype wrapper with a private enum, so that we don't expose the internal `Invalid` variant to the user.