### PR TITLE
feat: expose Op node network_config helper

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -106,6 +106,14 @@ impl<C> NetworkConfig<C> {
         NetworkConfig::builder(secret_key).build(client)
     }
 
+    /// Apply a function to the config.
+    pub fn apply<F>(self, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        f(self)
+    }
+
     /// Sets the config to use for the discovery v4 protocol.
     pub fn set_discovery_v4(mut self, discovery_config: Discv4Config) -> Self {
         self.discovery_v4_config = Some(discovery_config);

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -3,8 +3,9 @@
 use std::sync::Arc;
 
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
+use reth_chainspec::{EthChainSpec, Hardforks};
 use reth_evm::ConfigureEvm;
-use reth_network::{NetworkHandle, NetworkManager};
+use reth_network::{NetworkConfig, NetworkHandle, NetworkManager};
 use reth_node_api::{EngineValidator, FullNodeComponents, NodeAddOns};
 use reth_node_builder::{
     components::{
@@ -327,18 +328,18 @@ pub struct OptimismNetworkBuilder {
     pub disable_discovery_v4: bool,
 }
 
-impl<Node, Pool> NetworkBuilder<Node, Pool> for OptimismNetworkBuilder
-where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec>>,
-    Pool: TransactionPool + Unpin + 'static,
-{
-    async fn build_network(
-        self,
+impl OptimismNetworkBuilder {
+    /// Returns the [`NetworkConfig`] that contains the settings to launch the p2p network.
+    ///
+    /// This applies the configured [`OptimismNetworkBuilder`] settings.
+    pub fn network_config<Node>(
+        &self,
         ctx: &BuilderContext<Node>,
-        pool: Pool,
-    ) -> eyre::Result<NetworkHandle> {
-        let Self { disable_txpool_gossip, disable_discovery_v4 } = self;
-
+    ) -> eyre::Result<NetworkConfig<<Node as FullNodeTypes>::Provider>>
+    where
+        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
+    {
+        let Self { disable_txpool_gossip, disable_discovery_v4 } = self.clone();
         let args = &ctx.config().network;
         let network_builder = ctx
             .network_config_builder()?
@@ -371,8 +372,22 @@ where
         // gossip to prevent other parties in the network from learning about them.
         network_config.tx_gossip_disabled = disable_txpool_gossip;
 
-        let network = NetworkManager::builder(network_config).await?;
+        Ok(network_config)
+    }
+}
 
+impl<Node, Pool> NetworkBuilder<Node, Pool> for OptimismNetworkBuilder
+where
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec>>,
+    Pool: TransactionPool + Unpin + 'static,
+{
+    async fn build_network(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+    ) -> eyre::Result<NetworkHandle> {
+        let network_config = self.network_config(ctx)?;
+        let network = NetworkManager::builder(network_config).await?;
         let handle = ctx.start_network(network, pool);
 
         Ok(handle)


### PR DESCRIPTION
towards #11504

makes it easier to reuse and modify the network config before launching it.

cc @onbjerg 