### PR TITLE
Refactor get_payload_bodies_by_hash_with to be non-blocking

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -543,7 +543,7 @@ where
             return Err(EngineApiError::TerminalTD {
                 execution: merge_terminal_td,
                 consensus: terminal_total_difficulty,
-            });
+            })
         }
 
         self.inner.beacon_consensus.transition_configuration_exchanged();
@@ -553,7 +553,7 @@ where
             return Ok(TransitionConfiguration {
                 terminal_total_difficulty: merge_terminal_td,
                 ..Default::default()
-            });
+            })
         }
 
         // Attempt to look up terminal block hash
@@ -618,9 +618,9 @@ where
                 // TODO: decide if we want this branch - the FCU INVALID response might be more
                 // useful than the payload attributes INVALID response
                 if fcu_res.is_invalid() {
-                    return Ok(fcu_res);
+                    return Ok(fcu_res)
                 }
-                return Err(err.into());
+                return Err(err.into())
             }
         }
 
@@ -935,7 +935,7 @@ where
     ) -> RpcResult<Vec<Option<BlobAndProofV1>>> {
         trace!(target: "rpc::engine", "Serving engine_getBlobsV1");
         if versioned_hashes.len() > MAX_BLOB_LIMIT {
-            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() }.into());
+            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() }.into())
         }
 
         Ok(self

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -477,10 +477,10 @@ where
         if len > MAX_PAYLOAD_BODIES_LIMIT {
             return Err(EngineApiError::PayloadRequestTooLarge { len });
         }
-    
+
         let (tx, rx) = oneshot::channel();
         let inner = self.inner.clone();
-    
+
         self.inner.task_spawner.spawn_blocking(Box::pin(async move {
             let mut result = Vec::with_capacity(hashes.len());
             for hash in hashes {
@@ -497,7 +497,7 @@ where
             }
             tx.send(Ok(result)).ok();
         }));
-    
+
         rx.await.map_err(|err| EngineApiError::Internal(Box::new(err)))?
     }
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1117,8 +1117,8 @@ mod tests {
                 blocks
                     .iter()
                     .filter(|b| {
-                        !first_missing_range.contains(&b.number)
-                            && !second_missing_range.contains(&b.number)
+                        !first_missing_range.contains(&b.number) &&
+                            !second_missing_range.contains(&b.number)
                     })
                     .map(|b| (b.hash(), b.clone().unseal())),
             );
@@ -1147,8 +1147,8 @@ mod tests {
                 // ensure we still return trailing `None`s here because by-hash will not be aware
                 // of the missing block's number, and cannot compare it to the current best block
                 .map(|b| {
-                    if first_missing_range.contains(&b.number)
-                        || second_missing_range.contains(&b.number)
+                    if first_missing_range.contains(&b.number) ||
+                        second_missing_range.contains(&b.number)
                     {
                         None
                     } else {
@@ -1178,8 +1178,8 @@ mod tests {
                     .chain_spec
                     .fork(EthereumHardfork::Paris)
                     .ttd()
-                    .unwrap()
-                    + U256::from(1),
+                    .unwrap() +
+                    U256::from(1),
                 ..Default::default()
             };
 


### PR DESCRIPTION
Closes #11508

**Changes:**
- Refactored `get_payload_bodies_by_hash_with` to be asynchronous and non-blocking by using `spawn_blocking`
- Modified `get_payload_bodies_by_hash_with` to be `async` and use `spawn_blocking` to offload blocking I/O operations.
