### PR TITLE
Added InternalBlockExecutionError to execute.rs exports

### DIFF
--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -1,7 +1,9 @@
 //! Traits for execution.
 
 // Re-export execution types
-pub use reth_execution_errors::{BlockExecutionError, BlockValidationError, InternalBlockExecutionError};
+pub use reth_execution_errors::{
+    BlockExecutionError, BlockValidationError, InternalBlockExecutionError,
+};
 pub use reth_execution_types::{BlockExecutionInput, BlockExecutionOutput, ExecutionOutcome};
 pub use reth_storage_errors::provider::ProviderError;
 

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -1,7 +1,7 @@
 //! Traits for execution.
 
 // Re-export execution types
-pub use reth_execution_errors::{BlockExecutionError, BlockValidationError};
+pub use reth_execution_errors::{BlockExecutionError, BlockValidationError, InternalBlockExecutionError};
 pub use reth_execution_types::{BlockExecutionInput, BlockExecutionOutput, ExecutionOutcome};
 pub use reth_storage_errors::provider::ProviderError;
 


### PR DESCRIPTION
It's not possible to create custom/arbitrary errors rn in custom clients using BlockExecutionError because this enum is not exported.