### PR TITLE
fix(op-reth): add jemalloc feature to optimism-cli for version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7996,6 +7996,7 @@ dependencies = [
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
+ "reth-node-metrics",
  "reth-optimism-chainspec",
  "reth-optimism-evm",
  "reth-optimism-node",

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -31,7 +31,7 @@ workspace = true
 [features]
 default = ["jemalloc"]
 
-jemalloc = ["reth-cli-util/jemalloc"]
+jemalloc = ["reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc"]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
 tracy-allocator = ["reth-cli-util/tracy-allocator"]
 

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -27,6 +27,9 @@ reth-node-core.workspace = true
 reth-optimism-node.workspace = true
 reth-primitives.workspace = true
 
+# so jemalloc metrics can be included
+reth-node-metrics.workspace = true
+
 ## optimism
 reth-optimism-primitives.workspace = true
 reth-optimism-chainspec.workspace = true
@@ -81,4 +84,10 @@ asm-keccak = [
     "reth-node-core/asm-keccak",
     "reth-optimism-node/asm-keccak",
     "reth-primitives/asm-keccak",
+]
+
+# Jemalloc feature for vergen to generate correct env vars
+jemalloc = [
+    "reth-node-core/jemalloc",
+    "reth-node-metrics/jemalloc"
 ]

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -51,6 +51,10 @@ use reth_optimism_node::OptimismNode;
 use reth_tracing::FileWorkerGuard;
 use tracing::info;
 
+// This allows us to manually enable node metrics features, required for proper jemalloc metric
+// reporting
+use reth_node_metrics as _;
+
 /// The main op-reth cli interface.
 ///
 /// This is the entrypoint to the executable.


### PR DESCRIPTION
This fixes jemalloc metrics and version information on op-reth by enabling the `jemalloc` feature on `reth-node-metrics` and `reth-node-core`