### PR TITLE
feat: add a metric for get_state calls

### DIFF
--- a/crates/blockchain-tree/src/metrics.rs
+++ b/crates/blockchain-tree/src/metrics.rs
@@ -63,6 +63,8 @@ pub struct TreeMetrics {
     pub trie_updates_insert_cached: Counter,
     /// The number of times trie updates were recomputed for insert.
     pub trie_updates_insert_recomputed: Counter,
+    /// Tracks the blocks for which we fetched the entire execution output from disk.
+    pub get_state_call_block_numbers: Histogram,
 }
 
 /// Represents actions for making a canonical chain.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1512,10 +1512,15 @@ where
             return Ok(None)
         };
 
+        // we need to read the execution outcome from disk
+
         let SealedBlockWithSenders { block, senders } = self
             .provider
             .sealed_block_with_senders(hash.into(), TransactionVariant::WithHash)?
             .ok_or_else(|| ProviderError::HeaderNotFound(hash.into()))?;
+
+        self.metrics.tree.get_state_call_block_numbers.record(block.number as f64);
+
         let execution_output = self
             .provider
             .get_state(block.number)?


### PR DESCRIPTION
adds a metric that helps us track how even we actually call this.
tracks the block numbers we call this will

open for naming suggestions.