### PR TITLE
chore: rm unused optimism feature

### DIFF
--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -79,7 +79,6 @@ tempfile.workspace = true
 optimism = [
     "reth-primitives/optimism",
     "reth-rpc-types-compat/optimism",
-    "reth-rpc-eth-api/optimism",
 ]
 # Features for vergen to generate correct env vars
 jemalloc = []

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -65,6 +65,5 @@ optimism = [
     "reth-optimism-evm/optimism",
     "reth-primitives/optimism",
     "reth-provider/optimism",
-    "reth-rpc-eth-api/optimism",
     "revm/optimism",
 ]

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -59,8 +59,3 @@ tracing.workspace = true
 [features]
 js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]
-optimism = [
-    "reth-primitives/optimism",
-    "revm/optimism",
-    "reth-provider/optimism",
-]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -102,6 +102,5 @@ optimism = [
     "reth-primitives/optimism",
     "reth-rpc-types-compat/optimism",
     "reth-provider/optimism",
-    "reth-rpc-eth-api/optimism",
     "reth-revm/optimism",
 ]


### PR DESCRIPTION
there's no cfg in this crate and the transitive activations are all enforced in rpc-optimism

cc @onbjerg 