### PR TITLE
 chore(provider): add more test coverage on `BlockchainProvider` non-range queries

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -3109,24 +3109,13 @@ mod tests {
     /// ( `NUMBER_ARGUMENTS`, METHOD, FN -> ((`METHOD_ARGUMENT(s)`,...), `EXPECTED_RESULT`),
     /// `INVALID_ARGUMENTS`)
     macro_rules! test_non_range {
-    ([$(($arg_count:ident, $method:ident, $item_extractor:expr, $invalid_args:expr)),* $(,)?]) => {{
+    ($provider:expr, $database_blocks:expr, $in_memory_blocks:expr, $receipts:expr, [$(($arg_count:ident, $method:ident, $item_extractor:expr, $invalid_args:expr)),* $(,)?]) => {{
         $(
-            let mut rng = generators::rng();
-            let (provider, database_blocks, in_memory_blocks, receipts) = provider_with_random_blocks(
-                &mut rng,
-                TEST_BLOCKS_COUNT,
-                TEST_BLOCKS_COUNT,
-                BlockRangeParams {
-                    tx_count: TEST_TRANSACTIONS_COUNT..TEST_TRANSACTIONS_COUNT,
-                    ..Default::default()
-                },
-            )?;
-
             let tx_hash = |block: &SealedBlock| block.body.transactions[0].hash();
             let tx_num = |block: &SealedBlock| {
-                database_blocks
+                $database_blocks
                     .iter()
-                    .chain(in_memory_blocks.iter())
+                    .chain($in_memory_blocks.iter())
                     .take_while(|b| b.number < block.number)
                     .map(|b| b.body.transactions.len())
                     .sum::<usize>() as u64
@@ -3136,23 +3125,23 @@ mod tests {
             // In the future this block will be persisted to disk and removed from memory AFTER the firsk database query.
             // This ensures that we query the in-memory state before the database avoiding any race condition.
             {
-                call_method!($arg_count, provider, $method, $item_extractor, tx_num, tx_hash, &in_memory_blocks[0], &receipts);
+                call_method!($arg_count, $provider, $method, $item_extractor, tx_num, tx_hash, &$in_memory_blocks[0], &$receipts);
             }
 
             // Invalid/Non-existent argument should return `None`
             {
-                call_method!($arg_count, provider, $method, |_,_,_,_| ( ($invalid_args, None)), tx_num, tx_hash, &in_memory_blocks[0], &receipts);
+                call_method!($arg_count, $provider, $method, |_,_,_,_| ( ($invalid_args, None)), tx_num, tx_hash, &$in_memory_blocks[0], &$receipts);
             }
 
             // Check that the item is only in memory and not in database
             {
-                let last_mem_block = &in_memory_blocks[in_memory_blocks.len() - 1];
+                let last_mem_block = &$in_memory_blocks[$in_memory_blocks.len() - 1];
 
-                let (args, expected_item) = $item_extractor(last_mem_block, tx_num(last_mem_block), tx_hash(last_mem_block), &receipts);
-                call_method!($arg_count, provider, $method, |_,_,_,_| (args.clone(), expected_item), tx_num, tx_hash, last_mem_block, &receipts);
+                let (args, expected_item) = $item_extractor(last_mem_block, tx_num(last_mem_block), tx_hash(last_mem_block), &$receipts);
+                call_method!($arg_count, $provider, $method, |_,_,_,_| (args.clone(), expected_item), tx_num, tx_hash, last_mem_block, &$receipts);
 
                 // Ensure the item is not in storage
-                call_method!($arg_count, provider.database, $method, |_,_,_,_| ( (args, None)), tx_num, tx_hash, last_mem_block, &receipts);
+                call_method!($arg_count, $provider.database, $method, |_,_,_,_| ( (args, None)), tx_num, tx_hash, last_mem_block, &$receipts);
             }
         )*
     }};
@@ -3162,232 +3151,265 @@ mod tests {
     fn test_non_range_methods() -> eyre::Result<()> {
         let test_tx_index = 0;
 
-        test_non_range!([
-            // TODO: header should use B256 like others instead of &B256
-            // (
-            //     ONE,
-            //     header,
-            //     |block: &SealedBlock, tx_num: TxNumber, tx_hash: B256, receipts: &Vec<Vec<Receipt>>| (&block.hash(), Some(block.header.header().clone())),
-            //     (&B256::random())
-            // ),
-            (
-                ONE,
-                header_by_number,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    block.number,
-                    Some(block.header.header().clone())
+        let mut rng = generators::rng();
+        let (provider, database_blocks, in_memory_blocks, receipts) = provider_with_random_blocks(
+            &mut rng,
+            TEST_BLOCKS_COUNT,
+            TEST_BLOCKS_COUNT,
+            BlockRangeParams {
+                tx_count: TEST_TRANSACTIONS_COUNT..TEST_TRANSACTIONS_COUNT,
+                ..Default::default()
+            },
+        )?;
+
+        test_non_range!(
+            provider,
+            database_blocks,
+            in_memory_blocks,
+            receipts,
+            [
+                // TODO: header should use B256 like others instead of &B256
+                // (
+                //     ONE,
+                //     header,
+                //     |block: &SealedBlock, tx_num: TxNumber, tx_hash: B256, receipts: &Vec<Vec<Receipt>>| (&block.hash(), Some(block.header.header().clone())),
+                //     (&B256::random())
+                // ),
+                (
+                    ONE,
+                    header_by_number,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        block.number,
+                        Some(block.header.header().clone())
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                sealed_header,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    block.number,
-                    Some(block.header.clone())
+                (
+                    ONE,
+                    sealed_header,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        block.number,
+                        Some(block.header.clone())
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                block_hash,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    block.number,
-                    Some(block.hash())
+                (
+                    ONE,
+                    block_hash,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        block.number,
+                        Some(block.hash())
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                block_number,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    block.hash(),
-                    Some(block.number)
+                (
+                    ONE,
+                    block_number,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        block.hash(),
+                        Some(block.number)
+                    ),
+                    B256::random()
                 ),
-                B256::random()
-            ),
-            (
-                ONE,
-                block,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    BlockHashOrNumber::Hash(block.hash()),
-                    Some(block.clone().unseal())
+                (
+                    ONE,
+                    block,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        BlockHashOrNumber::Hash(block.hash()),
+                        Some(block.clone().unseal())
+                    ),
+                    BlockHashOrNumber::Hash(B256::random())
                 ),
-                BlockHashOrNumber::Hash(B256::random())
-            ),
-            (
-                ONE,
-                block,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    BlockHashOrNumber::Number(block.number),
-                    Some(block.clone().unseal())
+                (
+                    ONE,
+                    block,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        BlockHashOrNumber::Number(block.number),
+                        Some(block.clone().unseal())
+                    ),
+                    BlockHashOrNumber::Number(u64::MAX)
                 ),
-                BlockHashOrNumber::Number(u64::MAX)
-            ),
-            (
-                ONE,
-                block_body_indices,
-                |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    block.number,
-                    Some(StoredBlockBodyIndices {
-                        first_tx_num: tx_num,
-                        tx_count: block.body.transactions.len() as u64
-                    })
+                (
+                    ONE,
+                    block_body_indices,
+                    |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        block.number,
+                        Some(StoredBlockBodyIndices {
+                            first_tx_num: tx_num,
+                            tx_count: block.body.transactions.len() as u64
+                        })
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                TWO,
-                block_with_senders,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    (BlockHashOrNumber::Number(block.number), TransactionVariant::WithHash),
-                    block.clone().unseal().with_recovered_senders()
+                (
+                    TWO,
+                    block_with_senders,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        (BlockHashOrNumber::Number(block.number), TransactionVariant::WithHash),
+                        block.clone().unseal().with_recovered_senders()
+                    ),
+                    (BlockHashOrNumber::Number(u64::MAX), TransactionVariant::WithHash)
                 ),
-                (BlockHashOrNumber::Number(u64::MAX), TransactionVariant::WithHash)
-            ),
-            (
-                TWO,
-                block_with_senders,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    (BlockHashOrNumber::Hash(block.hash()), TransactionVariant::WithHash),
-                    block.clone().unseal().with_recovered_senders()
+                (
+                    TWO,
+                    block_with_senders,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        (BlockHashOrNumber::Hash(block.hash()), TransactionVariant::WithHash),
+                        block.clone().unseal().with_recovered_senders()
+                    ),
+                    (BlockHashOrNumber::Hash(B256::random()), TransactionVariant::WithHash)
                 ),
-                (BlockHashOrNumber::Hash(B256::random()), TransactionVariant::WithHash)
-            ),
-            (
-                TWO,
-                sealed_block_with_senders,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    (BlockHashOrNumber::Number(block.number), TransactionVariant::WithHash),
-                    Some(
-                        block.clone().unseal().with_recovered_senders().unwrap().seal(block.hash())
-                    )
+                (
+                    TWO,
+                    sealed_block_with_senders,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        (BlockHashOrNumber::Number(block.number), TransactionVariant::WithHash),
+                        Some(
+                            block
+                                .clone()
+                                .unseal()
+                                .with_recovered_senders()
+                                .unwrap()
+                                .seal(block.hash())
+                        )
+                    ),
+                    (BlockHashOrNumber::Number(u64::MAX), TransactionVariant::WithHash)
                 ),
-                (BlockHashOrNumber::Number(u64::MAX), TransactionVariant::WithHash)
-            ),
-            (
-                TWO,
-                sealed_block_with_senders,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    (BlockHashOrNumber::Hash(block.hash()), TransactionVariant::WithHash),
-                    Some(
-                        block.clone().unseal().with_recovered_senders().unwrap().seal(block.hash())
-                    )
+                (
+                    TWO,
+                    sealed_block_with_senders,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        (BlockHashOrNumber::Hash(block.hash()), TransactionVariant::WithHash),
+                        Some(
+                            block
+                                .clone()
+                                .unseal()
+                                .with_recovered_senders()
+                                .unwrap()
+                                .seal(block.hash())
+                        )
+                    ),
+                    (BlockHashOrNumber::Hash(B256::random()), TransactionVariant::WithHash)
                 ),
-                (BlockHashOrNumber::Hash(B256::random()), TransactionVariant::WithHash)
-            ),
-            (
-                ONE,
-                transaction_id,
-                |_: &SealedBlock, tx_num: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
-                    tx_hash,
-                    Some(tx_num)
+                (
+                    ONE,
+                    transaction_id,
+                    |_: &SealedBlock, tx_num: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
+                        tx_hash,
+                        Some(tx_num)
+                    ),
+                    B256::random()
                 ),
-                B256::random()
-            ),
-            (
-                ONE,
-                transaction_by_id,
-                |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    tx_num,
-                    Some(block.body.transactions[test_tx_index].clone())
+                (
+                    ONE,
+                    transaction_by_id,
+                    |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        tx_num,
+                        Some(block.body.transactions[test_tx_index].clone())
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                transaction_by_id_no_hash,
-                |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    tx_num,
-                    Some(Into::<TransactionSignedNoHash>::into(
-                        block.body.transactions[test_tx_index].clone()
-                    ))
+                (
+                    ONE,
+                    transaction_by_id_no_hash,
+                    |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        tx_num,
+                        Some(Into::<TransactionSignedNoHash>::into(
+                            block.body.transactions[test_tx_index].clone()
+                        ))
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                transaction_by_hash,
-                |block: &SealedBlock, _: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
-                    tx_hash,
-                    Some(block.body.transactions[test_tx_index].clone())
+                (
+                    ONE,
+                    transaction_by_hash,
+                    |block: &SealedBlock, _: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
+                        tx_hash,
+                        Some(block.body.transactions[test_tx_index].clone())
+                    ),
+                    B256::random()
                 ),
-                B256::random()
-            ),
-            (
-                ONE,
-                transaction_block,
-                |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    tx_num,
-                    Some(block.number)
+                (
+                    ONE,
+                    transaction_block,
+                    |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        tx_num,
+                        Some(block.number)
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                transactions_by_block,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    BlockHashOrNumber::Number(block.number),
-                    Some(block.body.transactions.clone())
+                (
+                    ONE,
+                    transactions_by_block,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        BlockHashOrNumber::Number(block.number),
+                        Some(block.body.transactions.clone())
+                    ),
+                    BlockHashOrNumber::Number(u64::MAX)
                 ),
-                BlockHashOrNumber::Number(u64::MAX)
-            ),
-            (
-                ONE,
-                transactions_by_block,
-                |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    BlockHashOrNumber::Hash(block.hash()),
-                    Some(block.body.transactions.clone())
+                (
+                    ONE,
+                    transactions_by_block,
+                    |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        BlockHashOrNumber::Hash(block.hash()),
+                        Some(block.body.transactions.clone())
+                    ),
+                    BlockHashOrNumber::Number(u64::MAX)
                 ),
-                BlockHashOrNumber::Number(u64::MAX)
-            ),
-            (
-                ONE,
-                transaction_sender,
-                |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
-                    tx_num,
-                    block.body.transactions[test_tx_index].recover_signer()
+                (
+                    ONE,
+                    transaction_sender,
+                    |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
+                        tx_num,
+                        block.body.transactions[test_tx_index].recover_signer()
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                receipt,
-                |block: &SealedBlock, tx_num: TxNumber, _: B256, receipts: &Vec<Vec<Receipt>>| (
-                    tx_num,
-                    Some(receipts[block.number as usize][test_tx_index].clone())
+                (
+                    ONE,
+                    receipt,
+                    |block: &SealedBlock,
+                     tx_num: TxNumber,
+                     _: B256,
+                     receipts: &Vec<Vec<Receipt>>| (
+                        tx_num,
+                        Some(receipts[block.number as usize][test_tx_index].clone())
+                    ),
+                    u64::MAX
                 ),
-                u64::MAX
-            ),
-            (
-                ONE,
-                receipt_by_hash,
-                |block: &SealedBlock, _: TxNumber, tx_hash: B256, receipts: &Vec<Vec<Receipt>>| (
-                    tx_hash,
-                    Some(receipts[block.number as usize][test_tx_index].clone())
+                (
+                    ONE,
+                    receipt_by_hash,
+                    |block: &SealedBlock,
+                     _: TxNumber,
+                     tx_hash: B256,
+                     receipts: &Vec<Vec<Receipt>>| (
+                        tx_hash,
+                        Some(receipts[block.number as usize][test_tx_index].clone())
+                    ),
+                    B256::random()
                 ),
-                B256::random()
-            ),
-            (
-                ONE,
-                receipts_by_block,
-                |block: &SealedBlock, _: TxNumber, _: B256, receipts: &Vec<Vec<Receipt>>| (
-                    BlockHashOrNumber::Number(block.number),
-                    Some(receipts[block.number as usize].clone())
+                (
+                    ONE,
+                    receipts_by_block,
+                    |block: &SealedBlock, _: TxNumber, _: B256, receipts: &Vec<Vec<Receipt>>| (
+                        BlockHashOrNumber::Number(block.number),
+                        Some(receipts[block.number as usize].clone())
+                    ),
+                    BlockHashOrNumber::Number(u64::MAX)
                 ),
-                BlockHashOrNumber::Number(u64::MAX)
-            ),
-            (
-                ONE,
-                receipts_by_block,
-                |block: &SealedBlock, _: TxNumber, _: B256, receipts: &Vec<Vec<Receipt>>| (
-                    BlockHashOrNumber::Hash(block.hash()),
-                    Some(receipts[block.number as usize].clone())
+                (
+                    ONE,
+                    receipts_by_block,
+                    |block: &SealedBlock, _: TxNumber, _: B256, receipts: &Vec<Vec<Receipt>>| (
+                        BlockHashOrNumber::Hash(block.hash()),
+                        Some(receipts[block.number as usize].clone())
+                    ),
+                    BlockHashOrNumber::Hash(B256::random())
                 ),
-                BlockHashOrNumber::Hash(B256::random())
-            ),
-            // TODO: withdrawals, requests, ommers
-        ]);
+                // TODO: withdrawals, requests, ommers
+            ]
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Follow-up to  #11488 

It aggregates a bunch (but not all) of straightforward provider queries that use `u64` or `B256` under one macro.

cc @tcoratger please take a look again in case i missed some important scenario in the removed tests