### PR TITLE
fix(provider): fix sub overflow on `tx_range` queries for empty blocks

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -463,7 +463,8 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
             let block_tx_count = block_state.block_ref().block().body.transactions.len();
             let remaining = (tx_range.end() - tx_range.start() + 1) as usize;
 
-            // If the transaction range start is equal or higher than the next block first transaction, advance
+            // If the transaction range start is equal or higher than the next block first
+            // transaction, advance
             if *tx_range.start() >= in_memory_tx_num + block_tx_count as u64 {
                 in_memory_tx_num += block_tx_count as u64;
                 continue

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -463,7 +463,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
             let block_tx_count = block_state.block_ref().block().body.transactions.len();
             let remaining = (tx_range.end() - tx_range.start() + 1) as usize;
 
-            // If the transaction range start is higher than this block last transaction, advance
+            // If the transaction range start is equal or higher than the next block first transaction, advance
             if *tx_range.start() >= in_memory_tx_num + block_tx_count as u64 {
                 in_memory_tx_num += block_tx_count as u64;
                 continue

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -464,7 +464,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
             let remaining = (tx_range.end() - tx_range.start() + 1) as usize;
 
             // If the transaction range start is higher than this block last transaction, advance
-            if *tx_range.start() > in_memory_tx_num + block_tx_count as u64 - 1 {
+            if *tx_range.start() >= in_memory_tx_num + block_tx_count as u64 {
                 in_memory_tx_num += block_tx_count as u64;
                 continue
             }


### PR DESCRIPTION
If the `tx_range` start is equal or higher than the next block first transaction, we should skip the current one. This should handle the subtract overflow on empty blocks