### PR TITLE
fix: in-memory trie updates pruning

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -282,7 +282,7 @@ impl TreeState {
         }
 
         // remove trie updates that are below the finalized block
-        self.persisted_trie_updates.retain(|_, (block_num, _)| *block_num >= finalized_num);
+        self.persisted_trie_updates.retain(|_, (block_num, _)| *block_num > finalized_num);
 
         // The only block that should remain at the `finalized` number now, is the finalized
         // block, if it exists.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -282,7 +282,7 @@ impl TreeState {
         }
 
         // remove trie updates that are below the finalized block
-        self.persisted_trie_updates.retain(|_, (block_num, _)| *block_num < finalized_num);
+        self.persisted_trie_updates.retain(|_, (block_num, _)| *block_num >= finalized_num);
 
         // The only block that should remain at the `finalized` number now, is the finalized
         // block, if it exists.


### PR DESCRIPTION
Right now it keeps all blocks below the finalized one, causing us to fallback to querying the network when we should have data in-memory