### PR TITLE
perf(rpc): optimistically retrieve block if near the tip on `eth_getLogs`

### DIFF
--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -47,7 +47,7 @@ where
 
 /// Helper enum to fetch a transaction either from a block or from the provider.
 #[derive(Debug)]
-pub enum ProviderOrSealedBlock<'a, P: BlockReader> {
+pub enum ProviderOrBlock<'a, P: BlockReader> {
     /// Provider
     Provider(&'a P),
     /// [`SealedBlock`]
@@ -56,9 +56,9 @@ pub enum ProviderOrSealedBlock<'a, P: BlockReader> {
 
 /// Appends all matching logs of a block's receipts.
 /// If the log matches, look up the corresponding transaction hash.
-pub fn append_matching_block_logs(
+pub fn append_matching_block_logs<P: BlockReader>(
     all_logs: &mut Vec<Log>,
-    provider_or_block: ProviderOrSealedBlock<'_, impl BlockReader>,
+    provider_or_block: ProviderOrBlock<'_, P>,
     filter: &FilteredParams,
     block_num_hash: BlockNumHash,
     receipts: &[Receipt],
@@ -83,10 +83,10 @@ pub fn append_matching_block_logs(
                 // if this is the first match in the receipt's logs, look up the transaction hash
                 if transaction_hash.is_none() {
                     transaction_hash = match &provider_or_block {
-                        ProviderOrSealedBlock::Block(block) => {
+                        ProviderOrBlock::Block(block) => {
                             Some(block.body.transactions[receipt_idx].hash())
                         }
-                        ProviderOrSealedBlock::Provider(provider) => {
+                        ProviderOrBlock::Provider(provider) => {
                             let first_tx_num = match loaded_first_tx_num {
                                 Some(num) => num,
                                 None => {

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -6,7 +6,7 @@ use alloy_primitives::TxHash;
 use alloy_rpc_types::{FilteredParams, Log};
 use reth_chainspec::ChainInfo;
 use reth_errors::ProviderError;
-use reth_primitives::{BlockNumHash, Receipt};
+use reth_primitives::{BlockNumHash, Receipt, SealedBlock};
 use reth_storage_api::BlockReader;
 
 /// Returns all matching of a block's receipts when the transaction hashes are known.
@@ -45,11 +45,20 @@ where
     all_logs
 }
 
+/// Helper enum to fetch a transaction either from a block or from the provider.
+#[derive(Debug)]
+pub enum ProviderOrSealedBlock<'a, P: BlockReader> {
+    /// Provider
+    Provider(&'a P),
+    /// [`SealedBlock`]
+    Block(SealedBlock),
+}
+
 /// Appends all matching logs of a block's receipts.
 /// If the log matches, look up the corresponding transaction hash.
 pub fn append_matching_block_logs(
     all_logs: &mut Vec<Log>,
-    provider: impl BlockReader,
+    provider_or_block: ProviderOrSealedBlock<'_, impl BlockReader>,
     filter: &FilteredParams,
     block_num_hash: BlockNumHash,
     receipts: &[Receipt],
@@ -60,8 +69,8 @@ pub fn append_matching_block_logs(
     let mut log_index: u64 = 0;
 
     // Lazy loaded number of the first transaction in the block.
-    // This is useful for blocks with multiple matching logs because it prevents
-    // re-querying the block body indices.
+    // This is useful for blocks with multiple matching logs because it
+    // prevents re-querying the block body indices.
     let mut loaded_first_tx_num = None;
 
     // Iterate over receipts and append matching logs.
@@ -71,27 +80,37 @@ pub fn append_matching_block_logs(
 
         for log in &receipt.logs {
             if log_matches_filter(block_num_hash, log, filter) {
-                let first_tx_num = match loaded_first_tx_num {
-                    Some(num) => num,
-                    None => {
-                        let block_body_indices =
-                            provider.block_body_indices(block_num_hash.number)?.ok_or(
-                                ProviderError::BlockBodyIndicesNotFound(block_num_hash.number),
-                            )?;
-                        loaded_first_tx_num = Some(block_body_indices.first_tx_num);
-                        block_body_indices.first_tx_num
-                    }
-                };
-
                 // if this is the first match in the receipt's logs, look up the transaction hash
                 if transaction_hash.is_none() {
-                    // This is safe because Transactions and Receipts have the same keys.
-                    let transaction_id = first_tx_num + receipt_idx as u64;
-                    let transaction = provider
-                        .transaction_by_id(transaction_id)?
-                        .ok_or_else(|| ProviderError::TransactionNotFound(transaction_id.into()))?;
+                    transaction_hash = match &provider_or_block {
+                        ProviderOrSealedBlock::Block(block) => {
+                            Some(block.body.transactions[receipt_idx].hash())
+                        }
+                        ProviderOrSealedBlock::Provider(provider) => {
+                            let first_tx_num = match loaded_first_tx_num {
+                                Some(num) => num,
+                                None => {
+                                    let block_body_indices = provider
+                                        .block_body_indices(block_num_hash.number)?
+                                        .ok_or(ProviderError::BlockBodyIndicesNotFound(
+                                            block_num_hash.number,
+                                        ))?;
+                                    loaded_first_tx_num = Some(block_body_indices.first_tx_num);
+                                    block_body_indices.first_tx_num
+                                }
+                            };
 
-                    transaction_hash = Some(transaction.hash());
+                            // This is safe because Transactions and Receipts have the same
+                            // keys.
+                            let transaction_id = first_tx_num + receipt_idx as u64;
+                            let transaction =
+                                provider.transaction_by_id(transaction_id)?.ok_or_else(|| {
+                                    ProviderError::TransactionNotFound(transaction_id.into())
+                                })?;
+
+                            Some(transaction.hash())
+                        }
+                    };
                 }
 
                 let log = Log {

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -84,7 +84,7 @@ pub fn append_matching_block_logs<P: BlockReader>(
                 if transaction_hash.is_none() {
                     transaction_hash = match &provider_or_block {
                         ProviderOrBlock::Block(block) => {
-                            Some(block.body.transactions[receipt_idx].hash())
+                            block.body.transactions.get(receipt_idx).map(|t| t.hash())
                         }
                         ProviderOrBlock::Provider(provider) => {
                             let first_tx_num = match loaded_first_tx_num {

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -535,7 +535,7 @@ where
         block_num_hash: &BlockNumHash,
         best_number: u64,
     ) -> Result<Option<(Arc<Vec<Receipt>>, Option<SealedBlock>)>, EthFilterError> {
-        // The last 4 blocks are most likely cached, so we can just fetch them 
+        // The last 4 blocks are most likely cached, so we can just fetch them
         let cached_range = best_number.saturating_sub(4)..=best_number;
         let receipts_block = if cached_range.contains(&block_num_hash.number) {
             self.eth_cache

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -536,15 +536,14 @@ where
         header: &Header,
         best_number: u64,
     ) -> Result<Option<(Arc<Vec<Receipt>>, Option<SealedBlock>)>, EthFilterError> {
-        let cached_range = best_number - 4..=best_number;
-        if cached_range.contains(&header.number) {
-            return Ok(self
-                .eth_cache
-                .get_block_and_receipts(block_hash)
-                .await?
-                .map(|(b, r)| (r, Some(b))))
-        }
-        Ok(self.eth_cache.get_receipts(block_hash).await?.map(|r| (r, None)))
+        let receipts_block = if (best_number - 4..=best_number).contains(&header.number) {
+            self.eth_cache.get_block_and_receipts(block_hash).await?
+                .map(|(b, r)| (r, Some(b)))
+        } else {
+            self.eth_cache.get_receipts(block_hash).await?
+                .map(|r| (r, None))
+        };
+        Ok(receipts_block)
     }
 }
 

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -10,8 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_consensus::Header;
-use alloy_primitives::{BlockHash, TxHash};
+use alloy_primitives::TxHash;
 use alloy_rpc_types::{
     BlockNumHash, Filter, FilterBlockOption, FilterChanges, FilterId, FilteredParams, Log,
     PendingTransactionFilterKind,

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -538,13 +538,13 @@ where
     ) -> Result<Option<(Arc<Vec<Receipt>>, Option<SealedBlock>)>, EthFilterError> {
         let cached_range = best_number - 4..=best_number;
         if cached_range.contains(&header.number) {
-            if let Some((block, receipts)) =
-                self.eth_cache.get_block_and_receipts(block_hash).await?
-            {
-                return Ok(Some((receipts, Some(block))))
-            }
+            return Ok(self
+                .eth_cache
+                .get_block_and_receipts(block_hash)
+                .await?
+                .map(|(b, r)| (r, Some(b))))
         }
-        Ok(self.eth_cache.get_receipts(block_hash).await?.map(|receipts| (receipts, None)))
+        Ok(self.eth_cache.get_receipts(block_hash).await?.map(|r| (r, None)))
     }
 }
 


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/11553

If the block is near the tip (4 blocks), then query it from cache instead of requesting every block transaction from disk