### PR TITLE
chore(rpc): use `block_hash` instead on fetching `debug_trace_block` block

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -209,7 +209,7 @@ where
 
         let ((cfg, block_env, _), block) = futures::try_join!(
             self.eth_api().evm_env_at(block_hash.into()),
-            self.eth_api().block_with_senders(block_id),
+            self.eth_api().block_with_senders(block_hash.into()),
         )?;
 
         let block = block.ok_or(EthApiError::HeaderNotFound(block_id))?;


### PR DESCRIPTION
I don't know if it can be a consistency issue doing by number, but since we already have the `block_hash` we should probably use it. 