### PR TITLE
fix: simplify reorg handling

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -899,16 +899,9 @@ where
                 return Ok(None);
             }
 
-            if old_hash == current_hash {
-                // We've found the fork point
-                break;
-            }
-
             if let Some(block) = self.executed_block_by_hash(current_hash)? {
-                if self.is_fork(block.block.hash())? {
-                    current_hash = block.block.parent_hash;
-                    new_chain.push(block);
-                }
+                current_hash = block.block.parent_hash;
+                new_chain.push(block);
             } else {
                 // This shouldn't happen as we've already walked this path
                 warn!(target: "engine::tree", invalid_hash=?current_hash, "New chain block not found in TreeState");


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/11583

`is_fork` call is not really useful here. at this point we know that we have 2 blocks of the same height with different hashes. given that one of the blocks is canonical, it is not possible for `current_hash` to become canonical without being the common ancestor for the two

