### PR TITLE
fix: use original bytes for codes

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -619,7 +619,7 @@ where
                                 .cache
                                 .contracts
                                 .iter()
-                                .map(|(hash, code)| (*hash, code.bytes()))
+                                .map(|(hash, code)| (*hash, code.original_bytes()))
                                 .collect();
 
                             for (address, account) in &statedb.cache.accounts {


### PR DESCRIPTION
this must use original bytes

imo `bytes` is a footgun, because I encountered this bug a few times now