### PR TITLE
chore(rpc): use `block_hash` as `BlockId` on `eth_callMany`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -251,7 +251,7 @@ pub trait EthCall: Call + LoadPendingBlock {
             let is_block_target_pending = target_block.is_pending();
 
             // if it's not pending, we should always use block_hash over block_number to ensure that
-            // different providers query data related to the same block.
+            // different provider calls query data related to the same block.
             if !is_block_target_pending {
                 target_block = LoadBlock::provider(self)
                     .block_hash_for_id(target_block)

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -22,8 +22,7 @@ use reth_primitives::{
     },
     Header, TransactionSignedEcRecovered,
 };
-use reth_provider::{BlockIdReader, ChainSpecProvider, HeaderProvider, StateProvider,
-};
+use reth_provider::{BlockIdReader, ChainSpecProvider, HeaderProvider, StateProvider};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB, DatabaseRef};
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},


### PR DESCRIPTION
similar to https://github.com/paradigmxyz/reth/pull/11587 

https://github.com/paradigmxyz/reth/blob/1e1de3dd77b114977f2461982ca371a971dab005/crates/rpc/rpc-eth-api/src/helpers/call.rs#L250-L256

otherwise `evm_env_at` & `block_with_senders` will each one have its own view of what `block_number` is which might be different on a ill timed reorg