### PR TITLE
fix: active inflight count

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -904,6 +904,7 @@ where
             NetworkEvent::SessionClosed { peer_id, .. } => {
                 // remove the peer
                 self.peers.remove(&peer_id);
+                self.transaction_fetcher.remove_peer(&peer_id);
             }
             NetworkEvent::SessionEstablished {
                 peer_id, client_version, messages, version, ..


### PR DESCRIPTION
this fixes an issue where the inflight counter was always incremented even if we didn't store the request.

and we never removed the peer from the active set, so the inflight counter is never updated.

This changes two things:
* when we remove a peer, also remove it from the active set
* only increment the counter if we stored the request


use saturing sub for my sanity