### PR TITLE
feat(ci): move book clippy and tests to matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,16 +11,21 @@ env:
 
 jobs:
   clippy-binaries:
-    name: clippy / ${{ matrix.network }}
+    name: clippy / ${{ matrix.type }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
         include:
-          - binary: reth
-            network: ethereum
-          - binary: op-reth
-            network: optimism
+          - type: ethereum
+            args: --bin reth --workspace
+            features: "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
+          - type: optimism
+            args: --bin op-reth --workspace
+            features: "optimism asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
+          - type: book
+            args: --manifest-path book/sources/Cargo.toml --workspace --bins
+            features: ""
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
@@ -31,11 +36,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Run clippy on binaries
-        run: cargo clippy --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }} asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
-        env:
-          RUSTFLAGS: -D warnings
-      - name: Run clippy on book binary sources
-        run: cargo clippy --manifest-path book/sources/Cargo.toml --workspace --bins
+        run: cargo clippy ${{ matrix.args }} --features "${{ matrix.features }}"
         env:
           RUSTFLAGS: -D warnings
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,6 @@ jobs:
           - type: book
             args: --manifest-path book/sources/Cargo.toml --workspace --bins
             features: ""
-            install_protoc: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
@@ -36,7 +35,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - if: "${{ matrix.install_protoc }}"
+      - if: "${{ matrix.type == 'book' }}"
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   clippy-binaries:
-    name: clippy / ${{ matrix.type }}
+    name: clippy binaries / ${{ matrix.type }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
           - type: book
             args: --manifest-path book/sources/Cargo.toml --workspace --bins
             features: ""
+            install_protoc: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
@@ -35,6 +36,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - if: "${{ matrix.install_protoc }}"
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run clippy on binaries
         run: cargo clippy ${{ matrix.args }} --features "${{ matrix.features }}"
         env:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -32,7 +32,7 @@ jobs:
           - type: optimism
             args: --features "asm-keccak optimism" --locked
           - type: book
-            args: --manifest-path book/sources/Cargo.toml
+            args: --manifest-path "book/sources/Cargo.toml"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,10 +41,10 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      # - if: "${{ matrix.type == 'book' }}"
-      #   uses: arduino/setup-protoc@v3
-      #   with:
-      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - if: "${{ matrix.type == 'book' }}"
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: |
           cargo nextest run \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
+      - if: "${{ matrix.type == 'book' }}"
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: |
           cargo nextest run \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,10 +41,10 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      - if: "${{ matrix.type == 'book' }}"
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # - if: "${{ matrix.type == 'book' }}"
+      #   uses: arduino/setup-protoc@v3
+      #   with:
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: |
           cargo nextest run \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,9 +28,9 @@ jobs:
         partition: [1, 2]
         include:
           - type: ethereum
-            args: --features ethereum
+            args: --features "asm-keccak ethereum" --locked
           - type: optimism
-            args: --features optimism
+            args: --features "asm-keccak optimism" --locked
           - type: book
             args: --manifest-path book/sources/Cargo.toml
     timeout-minutes: 30
@@ -44,8 +44,7 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
-            --locked ${{ matrix.args }} --features "asm-keccak" \
-            --workspace --exclude ef-tests \
+            ${{ matrix.args }} --workspace --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/2 \
             -E "!kind(test)"
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,21 +18,34 @@ concurrency:
 
 jobs:
   test:
-    name: test / ${{ matrix.type }} (${{ matrix.partition }}/2)
+    name: test / ${{ matrix.type }} (${{ matrix.partition }}/${{ matrix.total_partitions }})
     runs-on:
       group: Reth
     env:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        partition: [1, 2]
         include:
           - type: ethereum
             args: --features "asm-keccak ethereum" --locked
+            partition: 1
+            total_partitions: 2
+          - type: ethereum
+            args: --features "asm-keccak ethereum" --locked
+            partition: 2
+            total_partitions: 2
           - type: optimism
             args: --features "asm-keccak optimism" --locked
-          # - type: book
-          #   args: --manifest-path book/sources/Cargo.toml
+            partition: 1
+            total_partitions: 2
+          - type: optimism
+            args: --features "asm-keccak optimism" --locked
+            partition: 2
+            total_partitions: 2
+          - type: book
+            args: --manifest-path book/sources/Cargo.toml
+            partition: 1
+            total_partitions: 1
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -41,10 +54,10 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      # - if: "${{ matrix.type == 'book' }}"
-      #   uses: arduino/setup-protoc@v3
-      #   with:
-      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - if: "${{ matrix.type == 'book' }}"
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: |
           cargo nextest run \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -32,7 +32,7 @@ jobs:
           - type: optimism
             args: --features optimism
           - type: book
-            args: --manifest-path book/sources/Cargo.toml --workspace
+            args: --manifest-path book/sources/Cargo.toml
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    name: test / ${{ matrix.network }} (${{ matrix.partition }}/2)
+    name: test / ${{ matrix.type }} (${{ matrix.partition }}/2)
     runs-on:
       group: Reth
     env:
@@ -26,7 +26,13 @@ jobs:
     strategy:
       matrix:
         partition: [1, 2]
-        network: ["ethereum", "optimism"]
+        include:
+          - type: ethereum
+            args: --features ethereum
+          - type: optimism
+            args: --features optimism
+          - type: book
+            args: --manifest-path book/sources/Cargo.toml --workspace
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -38,14 +44,9 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
-            --locked --features "asm-keccak ${{ matrix.network }}" \
+            --locked ${{ matrix.args }} --features "asm-keccak" \
             --workspace --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/2 \
-            -E "!kind(test)"
-      - name: Run tests on book sources
-        run: |
-          cargo nextest run \
-            --manifest-path book/sources/Cargo.toml --workspace \
             -E "!kind(test)"
 
   state:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -31,8 +31,8 @@ jobs:
             args: --features "asm-keccak ethereum" --locked
           - type: optimism
             args: --features "asm-keccak optimism" --locked
-          - type: book
-            args: --manifest-path "book/sources/Cargo.toml"
+          # - type: book
+          #   args: --manifest-path book/sources/Cargo.toml
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -41,10 +41,10 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      - if: "${{ matrix.type == 'book' }}"
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # - if: "${{ matrix.type == 'book' }}"
+      #   uses: arduino/setup-protoc@v3
+      #   with:
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: |
           cargo nextest run \


### PR DESCRIPTION
Moves the clippy and test runs on `book/sources` into the matrix that's shared between ethereum/optimism/book. Also, install `protoc` if the type is `book` (needed for https://github.com/paradigmxyz/reth/pull/11616).