### PR TITLE
chore(metrics): remove redundant `starting metrics` log

### DIFF
--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -11,7 +11,6 @@ use metrics_process::Collector;
 use reth_metrics::metrics::Unit;
 use reth_tasks::TaskExecutor;
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
-use tracing::info;
 
 /// Configuration for the [`MetricServer`]
 #[derive(Debug)]
@@ -52,8 +51,6 @@ impl MetricServer {
     pub async fn serve(&self) -> eyre::Result<()> {
         let MetricServerConfig { listen_addr, hooks, task_executor, version_info, chain_spec_info } =
             &self.config;
-
-        info!(target: "reth::cli", addr = %listen_addr, "Starting metrics endpoint");
 
         let hooks = hooks.clone();
         self.start_endpoint(


### PR DESCRIPTION
We have two of these logs that appear on startup, one in node builder and one in `serve` .

Now this is only in node builder:
https://github.com/paradigmxyz/reth/blob/803a5908effd73b95f02361e57c73f8d3f0fb343/crates/node/builder/src/launch/common.rs#L515