### PR TITLE
fix: always handle payload building for opstack

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -99,6 +99,6 @@ impl EthChainSpec for ChainSpec {
     }
 
     fn is_optimism(&self) -> bool {
-        ChainSpec::is_optimism(self)
+        Self::is_optimism(self)
     }
 }

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -46,6 +46,11 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
 
     /// The bootnodes for the chain, if any.
     fn bootnodes(&self) -> Option<Vec<NodeRecord>>;
+
+    /// Returns `true` if this chain contains Optimism configuration.
+    fn is_optimism(&self) -> bool {
+        self.chain().is_optimism()
+    }
 }
 
 impl EthChainSpec for ChainSpec {
@@ -91,5 +96,9 @@ impl EthChainSpec for ChainSpec {
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
         self.bootnodes()
+    }
+
+    fn is_optimism(&self) -> bool {
+        ChainSpec::is_optimism(self)
     }
 }

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -24,6 +24,7 @@ reth-prune.workspace = true
 reth-stages-api.workspace = true
 reth-tasks.workspace = true
 reth-node-types.workspace = true
+reth-chainspec.workspace = true
 
 # async
 futures.workspace = true

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -225,12 +225,12 @@ pub enum EngineApiKind {
 impl EngineApiKind {
     /// Returns true if this is the ethereum variant
     pub const fn is_ethereum(&self) -> bool {
-        matches!(self, EngineApiKind::Ethereum)
+        matches!(self, Self::Ethereum)
     }
 
     /// Returns true if this is the ethereum variant
     pub const fn is_opstack(&self) -> bool {
-        matches!(self, EngineApiKind::OpStack)
+        matches!(self, Self::OpStack)
     }
 }
 

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -212,13 +212,26 @@ where
     }
 }
 
-/// The type for specifying the kind of engine api
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The type for specifying the kind of engine api.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EngineApiKind {
     /// The chain contains Ethereum configuration.
+    #[default]
     Ethereum,
     /// The chain contains Optimism configuration.
     OpStack,
+}
+
+impl EngineApiKind {
+    /// Returns true if this is the ethereum variant
+    pub const fn is_ethereum(&self) -> bool {
+        matches!(self, EngineApiKind::Ethereum)
+    }
+
+    /// Returns true if this is the ethereum variant
+    pub const fn is_opstack(&self) -> bool {
+        matches!(self, EngineApiKind::OpStack)
+    }
 }
 
 /// The request variants that the engine API handler can receive.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -66,7 +66,10 @@ pub mod config;
 mod invalid_block_hook;
 mod metrics;
 mod persistence_state;
-use crate::{engine::EngineApiRequest, tree::metrics::EngineApiMetrics};
+use crate::{
+    engine::{EngineApiKind, EngineApiRequest},
+    tree::metrics::EngineApiMetrics,
+};
 pub use config::TreeConfig;
 pub use invalid_block_hook::{InvalidBlockHooks, NoopInvalidBlockHook};
 pub use persistence_state::PersistenceState;
@@ -498,6 +501,8 @@ pub struct EngineApiTreeHandler<P, E, T: EngineTypes, Spec> {
     metrics: EngineApiMetrics,
     /// An invalid block hook.
     invalid_block_hook: Box<dyn InvalidBlockHook>,
+    /// The engine API variant of this handler
+    engine_kind: EngineApiKind,
 }
 
 impl<P: Debug, E: Debug, T: EngineTypes + Debug, Spec: Debug> std::fmt::Debug
@@ -519,6 +524,7 @@ impl<P: Debug, E: Debug, T: EngineTypes + Debug, Spec: Debug> std::fmt::Debug
             .field("config", &self.config)
             .field("metrics", &self.metrics)
             .field("invalid_block_hook", &format!("{:p}", self.invalid_block_hook))
+            .field("engine_kind", &self.engine_kind)
             .finish()
     }
 }
@@ -545,6 +551,7 @@ where
         persistence_state: PersistenceState,
         payload_builder: PayloadBuilderHandle<T>,
         config: TreeConfig,
+        engine_kind: EngineApiKind,
     ) -> Self {
         let (incoming_tx, incoming) = std::sync::mpsc::channel();
 
@@ -565,6 +572,7 @@ where
             metrics: Default::default(),
             incoming_tx,
             invalid_block_hook: Box::new(NoopInvalidBlockHook),
+            engine_kind,
         }
     }
 
@@ -589,6 +597,7 @@ where
         canonical_in_memory_state: CanonicalInMemoryState,
         config: TreeConfig,
         invalid_block_hook: Box<dyn InvalidBlockHook>,
+        kind: EngineApiKind,
     ) -> (Sender<FromEngine<EngineApiRequest<T>>>, UnboundedReceiver<EngineApiEvent>) {
         let best_block_number = provider.best_block_number().unwrap_or(0);
         let header = provider.sealed_header(best_block_number).ok().flatten().unwrap_or_default();
@@ -618,6 +627,7 @@ where
             persistence_state,
             payload_builder,
             config,
+            kind,
         );
         task.set_invalid_block_hook(invalid_block_hook);
         let incoming = task.incoming_tx.clone();
@@ -1041,8 +1051,15 @@ where
         if let Ok(Some(canonical_header)) = self.find_canonical_header(state.head_block_hash) {
             debug!(target: "engine::tree", head = canonical_header.number, "fcu head block is already canonical");
 
-            // TODO(mattsse): for optimism we'd need to trigger a build job as well because on
-            // Optimism, the proposers are allowed to reorg their own chain at will.
+            // For OpStack the proposers are allowed to reorg their own chain at will, so we need to
+            // always trigger a new payload job if requested.
+            if self.engine_kind.is_opstack() {
+                if let Some(attr) = attrs {
+                    debug!(target: "engine::tree", head = canonical_header.number, "handling payload attributes for canonical head");
+                    let updated = self.process_payload_attributes(attr, &canonical_header, state);
+                    return Ok(TreeOutcome::new(updated))
+                }
+            }
 
             // 2. Client software MAY skip an update of the forkchoice state and MUST NOT begin a
             //    payload build process if `forkchoiceState.headBlockHash` references a `VALID`
@@ -2683,6 +2700,7 @@ mod tests {
                 PersistenceState::default(),
                 payload_builder,
                 TreeConfig::default(),
+                EngineApiKind::Ethereum,
             );
 
             let block_builder = TestBlockBuilder::default().with_chain_spec((*chain_spec).clone());

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -93,6 +93,10 @@ impl EthChainSpec for OpChainSpec {
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
         self.inner.bootnodes()
     }
+
+    fn is_optimism(&self) -> bool {
+        true
+    }
 }
 
 impl Hardforks for OpChainSpec {


### PR DESCRIPTION
this ports missing check for opstack because there we always need to trigger a new payload job if this happens

https://github.com/paradigmxyz/reth/blob/9cf8282de03982ee7c63894c91be42af712cdef6/crates/consensus/beacon/src/engine/mod.rs#L463-L474


This adds is_optimism to ethchainspec trait for simplicity, which isn't great but also not horrible