### PR TITLE
feat(op): opchainspec builder

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -760,7 +760,7 @@ impl ChainSpecBuilder {
         self
     }
 
-    /// Add the given forks with the given activation condition to the spec.
+    /// Add the given chain hardforks to the spec.
     pub fn with_forks(mut self, forks: ChainHardforks) -> Self {
         self.hardforks = forks;
         self

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -755,13 +755,19 @@ impl ChainSpecBuilder {
     }
 
     /// Add the given fork with the given activation condition to the spec.
-    pub fn with_fork(mut self, fork: EthereumHardfork, condition: ForkCondition) -> Self {
+    pub fn with_fork<H: Hardfork>(mut self, fork: H, condition: ForkCondition) -> Self {
         self.hardforks.insert(fork, condition);
         self
     }
 
+    /// Add the given forks with the given activation condition to the spec.
+    pub fn with_forks(mut self, forks: ChainHardforks) -> Self {
+        self.hardforks = forks;
+        self
+    }
+
     /// Remove the given fork from the spec.
-    pub fn without_fork(mut self, fork: EthereumHardfork) -> Self {
+    pub fn without_fork<H: Hardfork>(mut self, fork: H) -> Self {
         self.hardforks.remove(fork);
         self
     }
@@ -873,63 +879,6 @@ impl ChainSpecBuilder {
     pub fn prague_activated(mut self) -> Self {
         self = self.cancun_activated();
         self.hardforks.insert(EthereumHardfork::Prague, ForkCondition::Timestamp(0));
-        self
-    }
-
-    /// Enable Bedrock at genesis
-    #[cfg(feature = "optimism")]
-    pub fn bedrock_activated(mut self) -> Self {
-        self = self.paris_activated();
-        self.hardforks
-            .insert(reth_optimism_forks::OptimismHardfork::Bedrock, ForkCondition::Block(0));
-        self
-    }
-
-    /// Enable Regolith at genesis
-    #[cfg(feature = "optimism")]
-    pub fn regolith_activated(mut self) -> Self {
-        self = self.bedrock_activated();
-        self.hardforks
-            .insert(reth_optimism_forks::OptimismHardfork::Regolith, ForkCondition::Timestamp(0));
-        self
-    }
-
-    /// Enable Canyon at genesis
-    #[cfg(feature = "optimism")]
-    pub fn canyon_activated(mut self) -> Self {
-        self = self.regolith_activated();
-        // Canyon also activates changes from L1's Shanghai hardfork
-        self.hardforks.insert(EthereumHardfork::Shanghai, ForkCondition::Timestamp(0));
-        self.hardforks
-            .insert(reth_optimism_forks::OptimismHardfork::Canyon, ForkCondition::Timestamp(0));
-        self
-    }
-
-    /// Enable Ecotone at genesis
-    #[cfg(feature = "optimism")]
-    pub fn ecotone_activated(mut self) -> Self {
-        self = self.canyon_activated();
-        self.hardforks.insert(EthereumHardfork::Cancun, ForkCondition::Timestamp(0));
-        self.hardforks
-            .insert(reth_optimism_forks::OptimismHardfork::Ecotone, ForkCondition::Timestamp(0));
-        self
-    }
-
-    /// Enable Fjord at genesis
-    #[cfg(feature = "optimism")]
-    pub fn fjord_activated(mut self) -> Self {
-        self = self.ecotone_activated();
-        self.hardforks
-            .insert(reth_optimism_forks::OptimismHardfork::Fjord, ForkCondition::Timestamp(0));
-        self
-    }
-
-    /// Enable Granite at genesis
-    #[cfg(feature = "optimism")]
-    pub fn granite_activated(mut self) -> Self {
-        self = self.fjord_activated();
-        self.hardforks
-            .insert(reth_optimism_forks::OptimismHardfork::Granite, ForkCondition::Timestamp(0));
         self
     }
 

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -426,6 +426,8 @@ mod tests {
 
     #[test]
     fn base_mainnet_forkids() {
+        let base_mainnet = OpChainSpecBuilder::base_mainnet().build();
+        let _ = base_mainnet.genesis_hash.set(BASE_MAINNET.genesis_hash.get().copied().unwrap());
         test_fork_ids(
             &BASE_MAINNET,
             &[
@@ -513,6 +515,7 @@ mod tests {
     #[test]
     fn op_mainnet_forkids() {
         let op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
+        let _ = op_mainnet.genesis_hash.set(OP_MAINNET.genesis_hash.get().copied().unwrap());
         test_fork_ids(
             &op_mainnet,
             &[
@@ -627,7 +630,7 @@ mod tests {
 
     #[test]
     fn is_bedrock_active() {
-        let op_mainnet = OpChainSpecBuilder::base_mainnet().build();
+        let op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
         assert!(!op_mainnet.is_bedrock_active_at_block(1))
     }
 

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -610,6 +610,14 @@ mod tests {
 
     #[test]
     fn latest_base_mainnet_fork_id() {
+        assert_eq!(
+            ForkId { hash: ForkHash([0xbc, 0x38, 0xf9, 0xca]), next: 0 },
+            BASE_MAINNET.latest_fork_id()
+        )
+    }
+
+    #[test]
+    fn latest_base_mainnet_fork_id_with_builder() {
         let base_mainnet = OpChainSpecBuilder::base_mainnet().build();
         assert_eq!(
             ForkId { hash: ForkHash([0xbc, 0x38, 0xf9, 0xca]), next: 0 },

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -32,12 +32,11 @@ use reth_chainspec::{
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
 use reth_network_peers::NodeRecord;
-use reth_optimism_forks::OptimismHardfork;
 use reth_primitives_traits::Header;
 use std::{fmt::Display, sync::Arc};
 
 /// Chain spec builder for a OP stack chain.
-#[derive(Debug, Default, From, Constructor)]
+#[derive(Debug, Default, From)]
 pub struct OpChainSpecBuilder {
     /// [`ChainSpecBuilder`]
     inner: ChainSpecBuilder,
@@ -92,19 +91,9 @@ impl OpChainSpecBuilder {
     }
 
     /// Remove the given fork from the spec.
-    pub fn without_fork(mut self, fork: OptimismHardfork) -> Self {
+    pub fn without_fork(mut self, fork: reth_optimism_forks::OptimismHardfork) -> Self {
         self.inner = self.inner.without_fork(fork);
         self
-    }
-
-    /// Enable the Paris hardfork at the given TTD.
-    ///
-    /// Does not set the merge netsplit block.
-    pub fn paris_at_ttd(self, ttd: U256) -> Self {
-        self.with_fork(
-            EthereumHardfork::Paris,
-            ForkCondition::TTD { total_difficulty: ttd, fork_block: None },
-        )
     }
 
     /// Enable Bedrock at genesis

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -504,7 +504,9 @@ mod tests {
     #[test]
     fn op_mainnet_forkids() {
         let op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
-        let _ = op_mainnet.genesis_hash.set(OP_MAINNET.genesis_hash.get().copied().unwrap());
+        // for OP mainnet we have to do this because the genesis header can't be properly computed
+        // from the genesis.json file
+        let _ = op_mainnet.genesis_hash.set(OP_MAINNET.genesis_hash());
         test_fork_ids(
             &op_mainnet,
             &[

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -33,7 +33,7 @@ use reth_chainspec::{
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
 use reth_network_peers::NodeRecord;
 use reth_primitives_traits::Header;
-use std::{fmt::Display, sync::Arc};
+use std::fmt::Display;
 
 /// Chain spec builder for a OP stack chain.
 #[derive(Debug, Default, From)]
@@ -162,17 +162,6 @@ impl OpChainSpecBuilder {
     /// [`Self::genesis`])
     pub fn build(self) -> OpChainSpec {
         OpChainSpec { inner: self.inner.build() }
-    }
-}
-
-impl From<&Arc<OpChainSpec>> for OpChainSpecBuilder {
-    fn from(value: &Arc<OpChainSpec>) -> Self {
-        let mut inner =
-            ChainSpecBuilder::default().chain(value.chain).genesis(value.genesis.clone());
-        let forks = value.hardforks.clone();
-        inner = inner.with_forks(forks);
-
-        Self { inner }
     }
 }
 

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -1,5 +1,5 @@
-use reth_chainspec::ChainSpec;
 use reth_ethereum_forks::{EthereumHardfork, Head};
+use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OptimismHardfork;
 
 /// Returns the revm [`SpecId`](revm_primitives::SpecId) at the given timestamp.
@@ -9,7 +9,7 @@ use reth_optimism_forks::OptimismHardfork;
 /// This is only intended to be used after the Bedrock, when hardforks are activated by
 /// timestamp.
 pub fn revm_spec_by_timestamp_after_bedrock(
-    chain_spec: &ChainSpec,
+    chain_spec: &OpChainSpec,
     timestamp: u64,
 ) -> revm_primitives::SpecId {
     if chain_spec.fork(OptimismHardfork::Granite).active_at_timestamp(timestamp) {
@@ -28,7 +28,7 @@ pub fn revm_spec_by_timestamp_after_bedrock(
 }
 
 /// Map the latest active hardfork at the given block to a revm [`SpecId`](revm_primitives::SpecId).
-pub fn revm_spec(chain_spec: &ChainSpec, block: &Head) -> revm_primitives::SpecId {
+pub fn revm_spec(chain_spec: &OpChainSpec, block: &Head) -> revm_primitives::SpecId {
     if chain_spec.fork(OptimismHardfork::Granite).active_at_head(block) {
         revm_primitives::GRANITE
     } else if chain_spec.fork(OptimismHardfork::Fjord).active_at_head(block) {
@@ -79,12 +79,13 @@ pub fn revm_spec(chain_spec: &ChainSpec, block: &Head) -> revm_primitives::SpecI
 mod tests {
     use super::*;
     use reth_chainspec::ChainSpecBuilder;
+    use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 
     #[test]
     fn test_revm_spec_by_timestamp_after_merge() {
         #[inline(always)]
-        fn op_cs(f: impl FnOnce(ChainSpecBuilder) -> ChainSpecBuilder) -> ChainSpec {
-            let cs = ChainSpecBuilder::mainnet().chain(reth_chainspec::Chain::from_id(10));
+        fn op_cs(f: impl FnOnce(OpChainSpecBuilder) -> OpChainSpecBuilder) -> OpChainSpec {
+            let cs = ChainSpecBuilder::mainnet().chain(reth_chainspec::Chain::from_id(10)).into();
             f(cs).build()
         }
         assert_eq!(
@@ -116,8 +117,8 @@ mod tests {
     #[test]
     fn test_to_revm_spec() {
         #[inline(always)]
-        fn op_cs(f: impl FnOnce(ChainSpecBuilder) -> ChainSpecBuilder) -> ChainSpec {
-            let cs = ChainSpecBuilder::mainnet().chain(reth_chainspec::Chain::from_id(10));
+        fn op_cs(f: impl FnOnce(OpChainSpecBuilder) -> OpChainSpecBuilder) -> OpChainSpec {
+            let cs = ChainSpecBuilder::mainnet().chain(reth_chainspec::Chain::from_id(10)).into();
             f(cs).build()
         }
         assert_eq!(

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -513,8 +513,10 @@ mod tests {
     use crate::OpChainSpec;
     use alloy_consensus::TxEip1559;
     use alloy_primitives::{b256, Address, StorageKey, StorageValue};
-    use reth_chainspec::{ChainSpecBuilder, MIN_TRANSACTION_GAS};
-    use reth_optimism_chainspec::{optimism_deposit_tx_signature, BASE_MAINNET};
+    use reth_chainspec::MIN_TRANSACTION_GAS;
+    use reth_optimism_chainspec::{
+        optimism_deposit_tx_signature, OpChainSpecBuilder, BASE_MAINNET,
+    };
     use reth_primitives::{Account, Block, BlockBody, Signature, Transaction, TransactionSigned};
     use reth_revm::{
         database::StateProviderDatabase, test_utils::StateProviderTest, L1_BLOCK_CONTRACT,
@@ -548,8 +550,7 @@ mod tests {
         db
     }
 
-    fn executor_provider(chain_spec: Arc<ChainSpec>) -> OpExecutorProvider<OptimismEvmConfig> {
-        let chain_spec = Arc::new(OpChainSpec::new(Arc::unwrap_or_clone(chain_spec)));
+    fn executor_provider(chain_spec: Arc<OpChainSpec>) -> OpExecutorProvider<OptimismEvmConfig> {
         OpExecutorProvider { evm_config: OptimismEvmConfig::new(chain_spec.clone()), chain_spec }
     }
 
@@ -572,11 +573,8 @@ mod tests {
         let account = Account { balance: U256::MAX, ..Account::default() };
         db.insert_account(addr, account, None, HashMap::default());
 
-        let chain_spec = Arc::new(
-            ChainSpecBuilder::from(&Arc::new(BASE_MAINNET.inner.clone()))
-                .regolith_activated()
-                .build(),
-        );
+        let chain_spec =
+            Arc::new(OpChainSpecBuilder::from(&BASE_MAINNET.clone()).regolith_activated().build());
 
         let tx = TransactionSigned::from_transaction_and_signature(
             Transaction::Eip1559(TxEip1559 {
@@ -656,11 +654,8 @@ mod tests {
 
         db.insert_account(addr, account, None, HashMap::default());
 
-        let chain_spec = Arc::new(
-            ChainSpecBuilder::from(&Arc::new(BASE_MAINNET.inner.clone()))
-                .canyon_activated()
-                .build(),
-        );
+        let chain_spec =
+            Arc::new(OpChainSpecBuilder::from(&BASE_MAINNET.clone()).canyon_activated().build());
 
         let tx = TransactionSigned::from_transaction_and_signature(
             Transaction::Eip1559(TxEip1559 {

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -514,9 +514,7 @@ mod tests {
     use alloy_consensus::TxEip1559;
     use alloy_primitives::{b256, Address, StorageKey, StorageValue};
     use reth_chainspec::MIN_TRANSACTION_GAS;
-    use reth_optimism_chainspec::{
-        optimism_deposit_tx_signature, OpChainSpecBuilder, BASE_MAINNET,
-    };
+    use reth_optimism_chainspec::{optimism_deposit_tx_signature, OpChainSpecBuilder};
     use reth_primitives::{Account, Block, BlockBody, Signature, Transaction, TransactionSigned};
     use reth_revm::{
         database::StateProviderDatabase, test_utils::StateProviderTest, L1_BLOCK_CONTRACT,
@@ -573,8 +571,7 @@ mod tests {
         let account = Account { balance: U256::MAX, ..Account::default() };
         db.insert_account(addr, account, None, HashMap::default());
 
-        let chain_spec =
-            Arc::new(OpChainSpecBuilder::from(&BASE_MAINNET.clone()).regolith_activated().build());
+        let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().regolith_activated().build());
 
         let tx = TransactionSigned::from_transaction_and_signature(
             Transaction::Eip1559(TxEip1559 {
@@ -654,8 +651,7 @@ mod tests {
 
         db.insert_account(addr, account, None, HashMap::default());
 
-        let chain_spec =
-            Arc::new(OpChainSpecBuilder::from(&BASE_MAINNET.clone()).canyon_activated().build());
+        let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().canyon_activated().build());
 
         let tx = TransactionSigned::from_transaction_and_signature(
             Transaction::Eip1559(TxEip1559 {

--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-
+use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
 use reth::{rpc::types::engine::PayloadAttributes, tasks::TaskManager};
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
@@ -8,15 +7,17 @@ use reth_optimism_node::{
     node::OptimismAddOns, OptimismBuiltPayload, OptimismNode, OptimismPayloadBuilderAttributes,
 };
 use reth_payload_builder::EthPayloadBuilderAttributes;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// Optimism Node Helper type
 pub(crate) type OpNode = NodeHelperType<OptimismNode, OptimismAddOns>;
 
 pub(crate) async fn setup(num_nodes: usize) -> eyre::Result<(Vec<OpNode>, TaskManager, Wallet)> {
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
     reth_e2e_test_utils::setup(
         num_nodes,
-        Arc::new(OpChainSpecBuilder::base_mainnet().ecotone_activated().build()),
+        Arc::new(OpChainSpecBuilder::base_mainnet().genesis(genesis).ecotone_activated().build()),
         false,
     )
     .await

--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
 use reth::{rpc::types::engine::PayloadAttributes, tasks::TaskManager};
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
-use reth_optimism_chainspec::{OpChainSpecBuilder, BASE_MAINNET};
+use reth_optimism_chainspec::OpChainSpecBuilder;
 use reth_optimism_node::{
     node::OptimismAddOns, OptimismBuiltPayload, OptimismNode, OptimismPayloadBuilderAttributes,
 };
@@ -15,16 +14,9 @@ use tokio::sync::Mutex;
 pub(crate) type OpNode = NodeHelperType<OptimismNode, OptimismAddOns>;
 
 pub(crate) async fn setup(num_nodes: usize) -> eyre::Result<(Vec<OpNode>, TaskManager, Wallet)> {
-    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
     reth_e2e_test_utils::setup(
         num_nodes,
-        Arc::new(
-            OpChainSpecBuilder::default()
-                .chain(BASE_MAINNET.chain)
-                .genesis(genesis)
-                .ecotone_activated()
-                .build(),
-        ),
+        Arc::new(OpChainSpecBuilder::base_mainnet().ecotone_activated().build()),
         false,
     )
     .await

--- a/crates/optimism/node/tests/e2e/utils.rs
+++ b/crates/optimism/node/tests/e2e/utils.rs
@@ -3,9 +3,8 @@ use std::sync::Arc;
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
 use reth::{rpc::types::engine::PayloadAttributes, tasks::TaskManager};
-use reth_chainspec::ChainSpecBuilder;
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
-use reth_optimism_chainspec::{OpChainSpec, BASE_MAINNET};
+use reth_optimism_chainspec::{OpChainSpecBuilder, BASE_MAINNET};
 use reth_optimism_node::{
     node::OptimismAddOns, OptimismBuiltPayload, OptimismNode, OptimismPayloadBuilderAttributes,
 };
@@ -19,13 +18,13 @@ pub(crate) async fn setup(num_nodes: usize) -> eyre::Result<(Vec<OpNode>, TaskMa
     let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
     reth_e2e_test_utils::setup(
         num_nodes,
-        Arc::new(OpChainSpec::new(
-            ChainSpecBuilder::default()
+        Arc::new(
+            OpChainSpecBuilder::default()
                 .chain(BASE_MAINNET.chain)
                 .genesis(genesis)
                 .ecotone_activated()
                 .build(),
-        )),
+        ),
         false,
     )
     .await


### PR DESCRIPTION
- Adds an `OpChainSpecBuilder`, utilizing an `ChainSpecBuilder` internally. 
- Adds a helper function `with_forks` on the `ChainSpecBuilder` and makes 2 other forks related functions generic over the forks.

Resolves #11561 