### PR TITLE
fix(net): decrease budget for header reqs to process before yielding thread

### DIFF
--- a/crates/net/network/src/budget.rs
+++ b/crates/net/network/src/budget.rs
@@ -5,8 +5,8 @@ pub const DEFAULT_BUDGET_TRY_DRAIN_STREAM: u32 = 10;
 
 /// Default budget to try and drain headers and bodies download streams.
 ///
-/// Default is 4 iterations.
-pub const DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS: u32 = 4;
+/// Default is 1 iteration.
+pub const DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS: u32 = 1;
 
 /// Default budget to try and drain [`Swarm`](crate::swarm::Swarm).
 ///


### PR DESCRIPTION
Decreases budget for header reqs to process before yielding thread.

Ref https://github.com/paradigmxyz/reth/issues/8115