### PR TITLE
chore(stages): reduce the progress logging 

### DIFF
--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -1,3 +1,4 @@
+use crate::log_progress;
 use alloy_primitives::{keccak256, B256};
 use itertools::Itertools;
 use reth_config::config::{EtlConfig, HashingConfig};
@@ -187,19 +188,18 @@ where
             let mut hashed_account_cursor =
                 tx.cursor_write::<RawTable<tables::HashedAccounts>>()?;
 
-            let total_hashes = collector.len();
-            let log_interval = Duration::from_secs(5);
+            let total = collector.len();
+            let interval = Duration::from_secs(5);
             let mut last_log = Instant::now();
             for (index, item) in collector.iter()?.enumerate() {
-                let now = Instant::now();
-                if now.duration_since(last_log) >= log_interval {
-                    info!(
-                        target: "sync::stages::hashing_account",
-                        progress = %format!("{:.2}%", (index as f64 / total_hashes as f64) * 100.0),
-                        "Inserting hashes"
-                    );
-                    last_log = now;
-                }
+                log_progress!(
+                    "sync::stages::hashing_account",
+                    index,
+                    total,
+                    last_log,
+                    interval,
+                    "Inserting hashes"
+                );
 
                 let (key, value) = item?;
                 hashed_account_cursor

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -19,7 +19,7 @@ use std::{
     fmt::Debug,
     ops::{Range, RangeInclusive},
     sync::mpsc::{self, Receiver},
-    time::{Duration, Instant},
+    time::Instant,
 };
 use tracing::*;
 
@@ -189,7 +189,6 @@ where
                 tx.cursor_write::<RawTable<tables::HashedAccounts>>()?;
 
             let total = collector.len();
-            let interval = Duration::from_secs(5);
             let mut last_log = Instant::now();
             for (index, item) in collector.iter()?.enumerate() {
                 log_progress!(
@@ -197,7 +196,6 @@ where
                     index,
                     total,
                     last_log,
-                    interval,
                     "Inserting hashes"
                 );
 

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -20,7 +20,7 @@ use reth_storage_errors::provider::ProviderResult;
 use std::{
     fmt::Debug,
     sync::mpsc::{self, Receiver},
-    time::{Duration, Instant},
+    time::Instant,
 };
 use tracing::*;
 
@@ -120,7 +120,6 @@ where
             collect(&mut channels, &mut collector)?;
 
             let total = collector.len();
-            let interval = Duration::from_secs(5);
             let mut last_log = Instant::now();
             let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>()?;
             for (index, item) in collector.iter()?.enumerate() {
@@ -129,7 +128,6 @@ where
                     index,
                     total,
                     last_log,
-                    interval,
                     "Inserting hashes"
                 );
 

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -26,7 +26,7 @@ use reth_storage_errors::provider::ProviderError;
 use std::{
     sync::Arc,
     task::{ready, Context, Poll},
-    time::{Duration, Instant},
+    time::Instant,
 };
 use tokio::sync::watch;
 use tracing::*;
@@ -115,19 +115,11 @@ where
         // Although headers were downloaded in reverse order, the collector iterates it in ascending
         // order
         let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-        let interval = Duration::from_secs(5);
         let mut last_log = Instant::now();
         for (index, header) in self.header_collector.iter()?.enumerate() {
             let (_, header_buf) = header?;
 
-            log_progress!(
-                "sync::stages::headers",
-                index,
-                total,
-                last_log,
-                interval,
-                "Writing headers"
-            );
+            log_progress!("sync::stages::headers", index, total, last_log, "Writing headers");
 
             let sealed_header: SealedHeader =
                 bincode::deserialize::<serde_bincode_compat::SealedHeader<'_>>(&header_buf)
@@ -181,7 +173,6 @@ where
                 index,
                 total,
                 last_log,
-                interval,
                 "Writing headers hash index"
             );
 

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -173,7 +173,6 @@ where
 
         // Since ETL sorts all entries by hashes, we are either appending (first sync) or inserting
         // in order (further syncs).
-        last_log = Instant::now();
         for (index, hash_to_number) in self.hash_collector.iter()?.enumerate() {
             let (hash, number) = hash_to_number?;
 

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -17,6 +17,7 @@ use reth_stages_api::{
     UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderError;
+use std::time::{Duration, Instant};
 use tracing::*;
 
 /// The transaction lookup stage.
@@ -147,16 +148,19 @@ where
                     .cursor_write::<tables::RawTable<tables::TransactionHashNumbers>>()?;
 
                 let total_hashes = hash_collector.len();
-                let interval = (total_hashes / 10).max(1);
+                let log_interval = Duration::from_secs(5);
+                let mut last_log = Instant::now();
                 for (index, hash_to_number) in hash_collector.iter()?.enumerate() {
                     let (hash, number) = hash_to_number?;
-                    if index > 0 && index % interval == 0 {
+                    let now = Instant::now();
+                    if now.duration_since(last_log) >= log_interval {
                         info!(
                             target: "sync::stages::transaction_lookup",
                             ?append_only,
                             progress = %format!("{:.2}%", (index as f64 / total_hashes as f64) * 100.0),
                             "Inserting hashes"
                         );
+                        last_log = now;
                     }
 
                     let key = RawKey::<TxHash>::from_vec(hash);

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -1,3 +1,4 @@
+use super::utils::LOG_INTERVAL;
 use alloy_primitives::{TxHash, TxNumber};
 use num_traits::Zero;
 use reth_config::config::{EtlConfig, TransactionLookupConfig};
@@ -17,7 +18,7 @@ use reth_stages_api::{
     UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderError;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tracing::*;
 
 /// The transaction lookup stage.
@@ -148,12 +149,11 @@ where
                     .cursor_write::<tables::RawTable<tables::TransactionHashNumbers>>()?;
 
                 let total_hashes = hash_collector.len();
-                let log_interval = Duration::from_secs(5);
                 let mut last_log = Instant::now();
                 for (index, hash_to_number) in hash_collector.iter()?.enumerate() {
                     let (hash, number) = hash_to_number?;
                     let now = Instant::now();
-                    if now.duration_since(last_log) >= log_interval {
+                    if now.duration_since(last_log) >= LOG_INTERVAL {
                         info!(
                             target: "sync::stages::transaction_lookup",
                             ?append_only,

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -121,15 +121,18 @@ where
 
     // observability
     let total_entries = collector.len();
-    let interval = (total_entries / 100).max(1);
+    let log_interval = Duration::from_secs(5);
+    let mut last_log = Instant::now();
 
     for (index, element) in collector.iter()?.enumerate() {
         let (k, v) = element?;
         let sharded_key = decode_key(k)?;
         let new_list = BlockNumberList::decompress_owned(v)?;
 
-        if index > 0 && index % interval == 0 && total_entries > 100 {
+        let now = Instant::now();
+        if now.duration_since(last_log) >= log_interval {
             info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing indices");
+            last_log = now;
         }
 
         // AccountsHistory: `Address`.

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -82,7 +82,7 @@ where
 
         let now = Instant::now();
         if now.duration_since(last_log) >= log_interval {
-            info!(target: "sync::stages::index_history", progress = %format!("{:.4}%", (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
+            info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
             last_log = now;
         }
 


### PR DESCRIPTION
There're many similiar `Writing xxx` logs in my reth node in a short time, after that node was restarted:

```
2024-10-08T15:53:16.587632Z  INFO Loading indices into database
2024-10-08T15:53:16.640678Z  INFO Writing indices progress=0.99%
2024-10-08T15:53:16.673921Z  INFO Writing indices progress=1.98%
2024-10-08T15:53:16.694879Z  INFO Writing indices progress=2.97%
2024-10-08T15:53:16.712707Z  INFO Writing indices progress=3.97%
2024-10-08T15:53:16.723617Z  INFO Writing indices progress=4.96%
2024-10-08T15:53:16.729454Z  INFO Writing indices progress=5.95%
2024-10-08T15:53:16.729891Z  INFO Writing indices progress=6.94%
2024-10-08T15:53:16.730354Z  INFO Writing indices progress=7.93%
2024-10-08T15:53:16.731004Z  INFO Writing indices progress=8.92%
2024-10-08T15:53:16.738051Z  INFO Writing indices progress=9.92%
2024-10-08T15:53:16.763732Z  INFO Writing indices progress=10.91%
2024-10-08T15:53:16.787495Z  INFO Writing indices progress=11.90%
2024-10-08T15:53:16.809150Z  INFO Writing indices progress=12.89%
2024-10-08T15:53:16.832691Z  INFO Writing indices progress=13.88%
2024-10-08T15:53:16.856580Z  INFO Writing indices progress=14.87%
2024-10-08T15:53:16.884020Z  INFO Writing indices progress=15.86%
2024-10-08T15:53:16.922661Z  INFO Writing indices progress=16.86%
2024-10-08T15:53:16.949469Z  INFO Writing indices progress=17.85%
2024-10-08T15:53:16.968421Z  INFO Writing indices progress=18.84%
2024-10-08T15:53:16.971475Z  INFO Writing indices progress=19.83%
2024-10-08T15:53:16.991315Z  INFO Writing indices progress=20.82%
...
```

so I propose to logging the progress by a period interval, instead of the count(eg: at most once per 5s).
