### PR TITLE
fix: always flush in ecies stream

### DIFF
--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -42,3 +42,6 @@ aes = "0.8.1"
 hmac = "0.12.1"
 block-padding = "0.3.2"
 cipher = { version = "0.4.3", features = ["block-padding"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "net"] }

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -192,8 +192,7 @@ mod tests {
 
         let handle = tokio::spawn(async move {
             let (incoming, _) = listener.accept().await.unwrap();
-            let stream = ECIESStream::incoming(incoming, server_key).await.unwrap();
-            stream
+            ECIESStream::incoming(incoming, server_key).await.unwrap()
         });
 
         let server_id = pk2id(&server_key.public_key(SECP256K1));


### PR DESCRIPTION
in the p2p session we rely on a simple loop { `poll_ready` -> `start_send` }, with the assumption that poll_ready would flush internally.


https://github.com/paradigmxyz/reth/blob/613fc498ccfafbd81d00f9ad2b3822e074864040/crates/net/network/src/session/active.rs#L552-L557

however the underlying eciesstream uses framedImpl which uses a buffer

https://github.com/tokio-rs/tokio/blob/161b8c80d58a4a070c7f41db18d43ea258737db7/tokio-util/src/codec/framed_impl.rs#L261-L266

so we should always use poll_flush here

