### PR TITLE
fix(docs): remove ci link

### DIFF
--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -26,6 +26,7 @@ The CI runs a couple of workflows:
 
 ### Integration Testing
 
+- **[kurtosis]**: Spins up a Kurtosis testnet and runs Assertoor tests on Reth pairs.
 - **[hive]**: Runs `ethereum/hive` tests.
 
 ### Linting and Checks

--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -48,7 +48,7 @@ The CI runs a couple of workflows:
 [dependencies]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/dependencies.yml
 [stale]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/stale.yml
 [docker]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/docker.yml
-[assertoor]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/assertoor.yml
+[kurtosis]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/kurtosis.yml
 [hive]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/hive.yml
 [lint]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/lint.yml
 [lint-actions]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/lint-actions.yml

--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -26,7 +26,6 @@ The CI runs a couple of workflows:
 
 ### Integration Testing
 
-- **[assertoor]**: Runs Assertoor tests on Reth pairs.
 - **[hive]**: Runs `ethereum/hive` tests.
 
 ### Linting and Checks


### PR DESCRIPTION
removed a link to a deleted (#11656) ci workflow