### PR TITLE
fix: dont remove txs manually

### DIFF
--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -139,11 +139,6 @@ where
                         &executor,
                     ) {
                         Ok((new_header, _bundle_state)) => {
-                            // clear all transactions from pool
-                            pool.remove_transactions(
-                                transactions.iter().map(|tx| tx.hash()).collect(),
-                            );
-
                             let state = ForkchoiceState {
                                 head_block_hash: new_header.hash(),
                                 finalized_block_hash: new_header.hash(),
@@ -167,7 +162,16 @@ where
                                 match rx.await.unwrap() {
                                     Ok(fcu_response) => {
                                         match fcu_response.forkchoice_status() {
-                                            ForkchoiceStatus::Valid => break,
+                                            ForkchoiceStatus::Valid => {
+                                                // clear all transactions from pool
+                                                pool.remove_transactions(
+                                                    transactions
+                                                        .iter()
+                                                        .map(|tx| tx.hash())
+                                                        .collect(),
+                                                );
+                                                break
+                                            }
                                             ForkchoiceStatus::Invalid => {
                                                 error!(target: "consensus::auto", ?fcu_response, "Forkchoice update returned invalid response");
                                                 return None

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -113,7 +113,6 @@ where
                 let to_engine = this.to_engine.clone();
                 let client = this.client.clone();
                 let chain_spec = Arc::clone(&this.chain_spec);
-                let pool = this.pool.clone();
                 let events = this.pipe_line_events.take();
                 let executor = this.block_executor.clone();
 
@@ -162,16 +161,7 @@ where
                                 match rx.await.unwrap() {
                                     Ok(fcu_response) => {
                                         match fcu_response.forkchoice_status() {
-                                            ForkchoiceStatus::Valid => {
-                                                // clear all transactions from pool
-                                                pool.remove_transactions(
-                                                    transactions
-                                                        .iter()
-                                                        .map(|tx| tx.hash())
-                                                        .collect(),
-                                                );
-                                                break
-                                            }
+                                            ForkchoiceStatus::Valid => break,
                                             ForkchoiceStatus::Invalid => {
                                                 error!(target: "consensus::auto", ?fcu_response, "Forkchoice update returned invalid response");
                                                 return None


### PR DESCRIPTION
closes #10881

we cant remove the txs before we have committed the state because this results in those race conditions.

this will be taken care of by the pool's own maintain task anyway.

