### PR TITLE
refactor: move receipts and block retrieval logic into cache

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -178,6 +178,20 @@ impl EthStateCache {
         Ok(block.zip(receipts))
     }
 
+    /// Fetches receipts and optionally fetches the block if available in the cache.
+    /// If the block is not in the cache, it only returns the receipts.
+    pub async fn get_receipts_and_maybe_block(
+        &self,
+        block_hash: B256,
+    ) -> ProviderResult<Option<(Arc<Vec<Receipt>>, Option<Arc<SealedBlockWithSenders>>)>> {
+        let block = self.get_sealed_block_with_senders(block_hash);
+        let receipts = self.get_receipts(block_hash);
+
+        let (block, receipts) = futures::try_join!(block, receipts)?;
+
+        Ok(receipts.map(|r| (r, block)))
+    }
+
     /// Requests the evm env config for the block hash.
     ///
     /// Returns an error if the corresponding header (required for populating the envs) was not

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -540,9 +540,8 @@ where
         let cached_range = best_number.saturating_sub(4)..=best_number;
         let receipts_block = if cached_range.contains(&block_num_hash.number) {
             self.eth_cache
-                .get_block_and_receipts(block_num_hash.hash)
+                .get_receipts_and_maybe_block(block_num_hash.hash)
                 .await?
-                .map(|(b, r)| (r, Some(b)))
         } else {
             self.eth_cache.get_receipts(block_num_hash.hash).await?.map(|r| (r, None))
         };


### PR DESCRIPTION
## Description

This PR refactors the logic for fetching receipts and block data in `filter.rs`. The logic for checking whether a block is near the tip (last 4 blocks) has been moved into the cache, simplifying the `filter.rs` code. This refactor:

- Introduces a new function in `EthStateCache`: `get_receipts_and_maybe_block`, which takes a `BlockNumHash` and `best_number` as parameters to determine whether to fetch both receipts and the block or just the receipts.
- Removes redundant logic from `filter.rs` by directly calling the cache function.
- The function now handles the logic for whether the block is near the tip or not, making the cache responsible for deciding the data to return.

## Testing

All existing tests pass. This change does not introduce any new functionality, but centralizes and simplifies existing logic. 

Closes #11610