### PR TITLE
chore: set request budget to 2

### DIFF
--- a/crates/net/network/src/budget.rs
+++ b/crates/net/network/src/budget.rs
@@ -5,8 +5,8 @@ pub const DEFAULT_BUDGET_TRY_DRAIN_STREAM: u32 = 10;
 
 /// Default budget to try and drain headers and bodies download streams.
 ///
-/// Default is 1 iteration.
-pub const DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS: u32 = 1;
+/// Default is 2 iteration.
+pub const DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS: u32 = 2;
 
 /// Default budget to try and drain [`Swarm`](crate::swarm::Swarm).
 ///

--- a/crates/net/network/src/budget.rs
+++ b/crates/net/network/src/budget.rs
@@ -5,7 +5,7 @@ pub const DEFAULT_BUDGET_TRY_DRAIN_STREAM: u32 = 10;
 
 /// Default budget to try and drain headers and bodies download streams.
 ///
-/// Default is 2 iteration.
+/// Default is 2 iterations.
 pub const DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS: u32 = 2;
 
 /// Default budget to try and drain [`Swarm`](crate::swarm::Swarm).


### PR DESCRIPTION
followup https://github.com/paradigmxyz/reth/pull/11636

@emhane we should actually set this to 2, on average this should be more efficient because with 1 each request would now result in 2 polls and it's very likely then there's only ever 1 request pending, so 2 iterations would be enough to reach pending most of the time