### PR TITLE
fix(staged-sync): prevent `StaticFileProducer` from running with an unwinded target on legacy engine

### DIFF
--- a/crates/consensus/beacon/src/engine/hooks/static_file.rs
+++ b/crates/consensus/beacon/src/engine/hooks/static_file.rs
@@ -14,9 +14,7 @@ use reth_provider::{
 };
 use reth_static_file::{StaticFileProducer, StaticFileProducerWithResult};
 use reth_tasks::TaskSpawner;
-use std::{
-    task::{ready, Context, Poll},
-};
+use std::task::{ready, Context, Poll};
 use tokio::sync::oneshot;
 use tracing::trace;
 

--- a/crates/consensus/beacon/src/engine/hooks/static_file.rs
+++ b/crates/consensus/beacon/src/engine/hooks/static_file.rs
@@ -9,11 +9,15 @@ use futures::FutureExt;
 use reth_errors::RethResult;
 use reth_primitives::static_file::HighestStaticFiles;
 use reth_provider::{
-    BlockReader, DatabaseProviderFactory, StageCheckpointReader, StaticFileProviderFactory,
+    BlockReader, ChainStateBlockReader, DatabaseProviderFactory, StageCheckpointReader,
+    StaticFileProviderFactory,
 };
 use reth_static_file::{StaticFileProducer, StaticFileProducerWithResult};
 use reth_tasks::TaskSpawner;
-use std::task::{ready, Context, Poll};
+use std::{
+    ops::Deref,
+    task::{ready, Context, Poll},
+};
 use tokio::sync::oneshot;
 use tracing::trace;
 
@@ -31,8 +35,9 @@ pub struct StaticFileHook<Provider> {
 impl<Provider> StaticFileHook<Provider>
 where
     Provider: StaticFileProviderFactory
-        + DatabaseProviderFactory<Provider: StageCheckpointReader + BlockReader>
-        + 'static,
+        + DatabaseProviderFactory<
+            Provider: StageCheckpointReader + BlockReader + ChainStateBlockReader,
+        > + 'static,
 {
     /// Create a new instance
     pub fn new(
@@ -104,6 +109,11 @@ where
                     return Ok(None)
                 };
 
+                let finalized_block_number = locked_static_file_producer
+                    .last_finalized_block()?
+                    .map(|on_disk| finalized_block_number.min(on_disk))
+                    .unwrap_or(finalized_block_number);
+
                 let targets =
                     locked_static_file_producer.get_static_file_targets(HighestStaticFiles {
                         headers: Some(finalized_block_number),
@@ -137,8 +147,9 @@ where
 impl<Provider> EngineHook for StaticFileHook<Provider>
 where
     Provider: StaticFileProviderFactory
-        + DatabaseProviderFactory<Provider: StageCheckpointReader + BlockReader>
-        + 'static,
+        + DatabaseProviderFactory<
+            Provider: StageCheckpointReader + BlockReader + ChainStateBlockReader,
+        > + 'static,
 {
     fn name(&self) -> &'static str {
         "StaticFile"

--- a/crates/consensus/beacon/src/engine/hooks/static_file.rs
+++ b/crates/consensus/beacon/src/engine/hooks/static_file.rs
@@ -15,7 +15,6 @@ use reth_provider::{
 use reth_static_file::{StaticFileProducer, StaticFileProducerWithResult};
 use reth_tasks::TaskSpawner;
 use std::{
-    ops::Deref,
     task::{ready, Context, Poll},
 };
 use tokio::sync::oneshot;

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -276,6 +276,10 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
         // Unwind stages in reverse order of execution
         let unwind_pipeline = self.stages.iter_mut().rev();
 
+        // Legacy Engine: This prevents a race condition in which the `StaticFileProducer` would
+        // attempt to proceed with a finalized block which has been unwinded
+        let _locked_sf_producer = self.static_file_producer.lock();
+
         let mut provider_rw = self.provider_factory.database_provider_rw()?;
 
         for stage in unwind_pipeline {

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -276,7 +276,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
         // Unwind stages in reverse order of execution
         let unwind_pipeline = self.stages.iter_mut().rev();
 
-        // Legacy Engine: This prevents a race condition in which the `StaticFileProducer` would
+        // Legacy Engine: This prevents a race condition in which the `StaticFileProducer` could
         // attempt to proceed with a finalized block which has been unwinded
         let _locked_sf_producer = self.static_file_producer.lock();
 

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -5,8 +5,8 @@ use alloy_primitives::BlockNumber;
 use parking_lot::Mutex;
 use rayon::prelude::*;
 use reth_provider::{
-    providers::StaticFileWriter, BlockReader, DBProvider, DatabaseProviderFactory,
-    StageCheckpointReader, StaticFileProviderFactory,
+    providers::StaticFileWriter, BlockReader, ChainStateBlockReader, DBProvider,
+    DatabaseProviderFactory, StageCheckpointReader, StaticFileProviderFactory,
 };
 use reth_prune_types::PruneModes;
 use reth_stages_types::StageId;
@@ -103,6 +103,16 @@ impl StaticFileTargets {
 impl<Provider> StaticFileProducerInner<Provider> {
     fn new(provider: Provider, prune_modes: PruneModes) -> Self {
         Self { provider, prune_modes, event_sender: Default::default() }
+    }
+}
+
+impl<Provider> StaticFileProducerInner<Provider>
+where
+    Provider: StaticFileProviderFactory + DatabaseProviderFactory<Provider: ChainStateBlockReader>,
+{
+    /// Returns the last finalized block number on disk.
+    pub fn last_finalized_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        self.provider.database_provider_ro()?.last_finalized_block_number()
     }
 }
 


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/11471#issuecomment-2408743799

```bash

Oct 12 15:56:21 dev base_reth[2277506]: 2024-10-12T22:56:21.744839Z  INFO Unwinding{stage=Bodies}: Stage unwound stage=Bodies unwind_to=20971399 progress=20971399 done=true
Oct 12 15:56:21 dev base_reth[2277506]: 2024-10-12T22:56:21.751162Z  INFO Unwinding{stage=Headers}: Starting unwind from=20971402 to=20971399 bad_block=Some(20971402)
Oct 12 15:56:21 dev base_reth[2277506]: 2024-10-12T22:56:21.751360Z  INFO Unwinding{stage=Headers}: Stage unwound stage=Headers unwind_to=20971399 progress=20971399 done=true
Oct 12 15:56:21 dev base_reth[2277506]: 2024-10-12T22:56:21.757154Z  WARN Bad block detected in unwind invalid_hash=0x7fd6dda911d2d5029a6026896f9c9ca13fc51e28ad7b6be5ae3922824cd4a705 invalid_number=20971402
Oct 12 15:56:21 dev base_reth[2277506]: 2024-10-12T22:56:21.757172Z  WARN Bad block with hash hash=0x7fd6dda911d2d5029a6026896f9c9ca13fc51e28ad7b6be5ae3922824cd4a705 header=Header { parent_hash: 0x377039ab4fc9b631e0f587690d837c6297550f23b2cf8e3ef885204617ebc1c1, ommers_hash: 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347, beneficiary: 0x4200000000000000000000000000000000000011, state_root: 0xdb1bd8d61865b9ec3e62137c8ac279bc791c20de8ab5e3764042c3ed39bdec99, transactions_root: 0x29c1be10e2c5398e2d8cc32ea26772b715d7ebbcbcc308902f1c088de453a546, receipts_root: 0x52455d186de4ae748882ab9a510c886478a588890ed81d3a01ba00b31f297f7a, withdrawals_root: Some(0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421), logs_bloom: 0x5f32242244bcb4c6cb510f1cc31d38e4f471dc7d116da498d69f5a041bf8073b8deddb989e6497ba3f8290d17c7736aef938f04f9e8523c7a3770a127ebcb0aa0f469a1e066e96eb8634701fe92a2ba7059657831fff9ab38bea4badf76a2df2fc8ea1249bc630242a26bcd1d08648f447311c423acd1537b0c7fb306f69f0ed1288cb1fb9b898a86d8dd35a80b5753205609fc1b8eda91edc3ec7d6b386b12aa7c8cfe3a8b8ac6eb548359538c28795a633bd207de3db18d1b3676b7b0cd79ef7d0f4ab42e51ec5a3f159bde753fb62eb51a85ca0dc12f61bebaabe938a66b6d3790c47c9bd974179781ced5c4b67d1f40a79833b90a4716a647a14c118a7be, difficulty: 0, number: 20971402, gas_limit: 156000000, gas_used: 38194603, timestamp: 1728732151, mix_hash: 0x0582ccfe34b0720fafbbe8a1b653a68cea06ee0fe3cfcbbe4ba1ad16ce1f0f05, nonce: 0x0000000000000000, base_fee_per_gas: Some(3891229), blob_gas_used: Some(0), excess_blob_gas: Some(0), parent_beacon_block_root: Some(0xaa036b148ef760f20732d4d6bb415a86590bbac2a13e2e5ca4b59ab9794c4bf4), requests_root: None, extra_data: 0x }
Oct 12 15:56:21 dev base_reth[2277506]: 2024-10-12T22:56:21.853903Z  INFO Static File Producer started targets=StaticFileTargets { headers: Some(20971400..=20971402), receipts: Some(20971400..=20971402), transactions: Some(20971400..=20971402) }
```

* Ensures that`StaticFileProducer` cannot run when there's a `pipeline` unwind happening. 
* `StaticFileProducer` gets the `last_finalized_block` from disk and chooses the minimum between that and the one from `EngineContext`