### PR TITLE
feat: update SystemCaller

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -84,7 +84,8 @@ where
             EnvWithHandlerCfg::new_with_cfg_env(cfg, block_env, Default::default()),
         );
 
-        let mut system_caller = SystemCaller::new(&self.evm_config, self.provider.chain_spec());
+        let mut system_caller =
+            SystemCaller::new(self.evm_config.clone(), self.provider.chain_spec());
 
         // Apply pre-block system contract calls.
         system_caller.apply_pre_execution_changes(&block.clone().unseal(), &mut evm)?;

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -286,7 +286,7 @@ where
     let mut evm = evm_config.evm_with_env(&mut state, env);
 
     // apply eip-4788 pre block contract call
-    let mut system_caller = SystemCaller::new(evm_config, chain_spec);
+    let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec);
 
     system_caller.apply_beacon_root_contract_call(
         reorg_target.timestamp,

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -141,10 +141,12 @@ where
     where
         DB: Database,
         DB::Error: Into<ProviderError> + Display,
-        F: OnStateHook,
+        F: OnStateHook + 'static,
     {
-        let mut system_caller =
-            SystemCaller::new(&self.evm_config, &self.chain_spec).with_state_hook(state_hook);
+        let mut system_caller = SystemCaller::new(self.evm_config.clone(), &self.chain_spec);
+        if let Some(hook) = state_hook {
+            system_caller.with_state_hook(Some(Box::new(hook) as Box<dyn OnStateHook>));
+        }
 
         system_caller.apply_pre_execution_changes(block, &mut evm)?;
 
@@ -290,7 +292,7 @@ where
         state_hook: Option<F>,
     ) -> Result<EthExecuteOutput, BlockExecutionError>
     where
-        F: OnStateHook,
+        F: OnStateHook + 'static,
     {
         // 1. prepare state on new block
         self.on_new_block(&block.header);
@@ -396,7 +398,7 @@ where
         state_hook: F,
     ) -> Result<Self::Output, Self::Error>
     where
-        F: OnStateHook,
+        F: OnStateHook + 'static,
     {
         let BlockExecutionInput { block, total_difficulty } = input;
         let EthExecuteOutput { receipts, requests, gas_used } = self

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -160,7 +160,7 @@ where
 
     let block_number = initialized_block_env.number.to::<u64>();
 
-    let mut system_caller = SystemCaller::new(&evm_config, chain_spec.clone());
+    let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
 
     // apply eip-4788 pre block contract call
     system_caller

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -97,7 +97,7 @@ where
         state_hook: F,
     ) -> Result<Self::Output, Self::Error>
     where
-        F: OnStateHook,
+        F: OnStateHook + 'static,
     {
         match self {
             Self::Left(a) => a.execute_with_state_hook(input, state_hook),

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -56,7 +56,7 @@ pub trait Executor<DB> {
         state_hook: F,
     ) -> Result<Self::Output, Self::Error>
     where
-        F: OnStateHook;
+        F: OnStateHook + 'static;
 }
 
 /// A general purpose executor that can execute multiple inputs in sequence, validate the outputs,

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -121,10 +121,12 @@ where
     ) -> Result<(Vec<Receipt>, u64), BlockExecutionError>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
-        F: OnStateHook,
+        F: OnStateHook + 'static,
     {
-        let mut system_caller =
-            SystemCaller::new(&self.evm_config, &self.chain_spec).with_state_hook(state_hook);
+        let mut system_caller = SystemCaller::new(self.evm_config.clone(), &self.chain_spec);
+        if let Some(hook) = state_hook {
+            system_caller.with_state_hook(Some(Box::new(hook) as Box<dyn OnStateHook>));
+        }
 
         // apply pre execution changes
         system_caller.apply_beacon_root_contract_call(
@@ -306,7 +308,7 @@ where
         state_hook: Option<F>,
     ) -> Result<(Vec<Receipt>, u64), BlockExecutionError>
     where
-        F: OnStateHook,
+        F: OnStateHook + 'static,
     {
         // 1. prepare state on new block
         self.on_new_block(&block.header);
@@ -410,7 +412,7 @@ where
         state_hook: F,
     ) -> Result<Self::Output, Self::Error>
     where
-        F: OnStateHook,
+        F: OnStateHook + 'static,
     {
         let BlockExecutionInput { block, total_difficulty } = input;
         let (receipts, gas_used) = self.execute_without_verification_with_state_hook(

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -201,7 +201,7 @@ where
     );
 
     // apply eip-4788 pre block contract call
-    let mut system_caller = SystemCaller::new(&evm_config, &chain_spec);
+    let mut system_caller = SystemCaller::new(evm_config.clone(), &chain_spec);
 
     system_caller
         .pre_block_beacon_root_contract_call(

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -260,8 +260,7 @@ pub trait LoadPendingBlock: EthApiTypes {
 
         let chain_spec = self.provider().chain_spec();
 
-        let evm_config = self.evm_config().clone();
-        let mut system_caller = SystemCaller::new(&evm_config, chain_spec.clone());
+        let mut system_caller = SystemCaller::new(self.evm_config().clone(), chain_spec.clone());
 
         let parent_beacon_block_root = if origin.is_actual_pending() {
             // apply eip-4788 pre block contract call if we got the block from the CL with the real

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -199,7 +199,7 @@ pub trait Trace: LoadState {
 
                 // apply relevant system calls
                 let mut system_caller = SystemCaller::new(
-                    Trace::evm_config(&this),
+                    Trace::evm_config(&this).clone(),
                     LoadState::provider(&this).chain_spec(),
                 );
                 system_caller
@@ -332,7 +332,7 @@ pub trait Trace: LoadState {
 
                 // apply relevant system calls
                 let mut system_caller = SystemCaller::new(
-                    Trace::evm_config(&this),
+                    Trace::evm_config(&this).clone(),
                     LoadState::provider(&this).chain_spec(),
                 );
                 system_caller


### PR DESCRIPTION
Towards #11584

* `OnStateHook` generic -> `Box<dyn OnStateHook>` 
* `&'a EvmConfig` -> `EvmConfig` (clones relatively cheap for the existing implementations)

This will make it easier to add `SystemCaller` members to concrete implementations of `BlockExecutionStrategy`.

The changes are already applied and tested on https://github.com/paradigmxyz/reth/pull/11584, will remove them from that PR once this one is merged.