### PR TITLE
feat(ci): add workflow for git sha container builds

### DIFF
--- a/.github/workflows/docker-git.yml
+++ b/.github/workflows/docker-git.yml
@@ -1,11 +1,11 @@
-# Publishes the Docker image.
+# Publishes the Docker image, only to be used with `workflow_dispatch`. The
+# images from this workflow will be tagged with the git sha of the branch used
+# and will NOT tag it as `latest`.
 
-name: docker
+name: docker-git
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch: {}
 
 env:
   REPO_NAME: ${{ github.repository_owner }}/reth
@@ -15,6 +15,7 @@ env:
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reth
   OP_DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/op-reth
   DOCKER_USERNAME: ${{ github.actor }}
+  GIT_SHA: ${{ github.sha }}
 
 jobs:
   build:
@@ -37,11 +38,7 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
-      - name: Build and push reth image, tag as "latest"
-        run: make PROFILE=maxperf docker-build-push-latest
-      - name: Build and push reth image
-        run: make PROFILE=maxperf docker-build-push
-      - name: Build and push op-reth image, tag as "latest"
-        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest
-      - name: Build and push op-reth image
-        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push
+      - name: Build and push the git-sha-tagged reth image
+        run: make PROFILE=maxperf GIT_SHA=$GIT_SHA docker-build-push-git-sha
+      - name: Build and push the git-sha-tagged op-reth image
+        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME GIT_SHA=$GIT_SHA PROFILE=maxperf op-docker-build-push-git-sha

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Heavily inspired by Lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/Makefile
 .DEFAULT_GOAL := help
 
+GIT_SHA ?= $(shell git rev-parse HEAD)
 GIT_TAG ?= $(shell git describe --tags --abbrev=0)
 BIN_DIR = "dist/bin"
 
@@ -203,6 +204,14 @@ docker-build-push: ## Build and push a cross-arch Docker image tagged with the l
 #
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --driver docker-container --name cross-builder`
+.PHONY: docker-build-push-git-sha
+docker-build-push-git-sha: ## Build and push a cross-arch Docker image tagged with the latest git sha.
+	$(call docker_build_push,$(GIT_SHA),$(GIT_SHA))
+
+# Note: This requires a buildx builder with emulation support. For example:
+#
+# `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
+# `docker buildx create --use --driver docker-container --name cross-builder`
 .PHONY: docker-build-push-latest
 docker-build-push-latest: ## Build and push a cross-arch Docker image tagged with the latest git tag and `latest`.
 	$(call docker_build_push,$(GIT_TAG),latest)
@@ -242,6 +251,14 @@ endef
 .PHONY: op-docker-build-push
 op-docker-build-push: ## Build and push a cross-arch Docker image tagged with the latest git tag.
 	$(call op_docker_build_push,$(GIT_TAG),$(GIT_TAG))
+
+# Note: This requires a buildx builder with emulation support. For example:
+#
+# `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
+# `docker buildx create --use --driver docker-container --name cross-builder`
+.PHONY: op-docker-build-push-git-sha
+op-docker-build-push-git-sha: ## Build and push a cross-arch Docker image tagged with the latest git sha.
+	$(call op_docker_build_push,$(GIT_SHA),$(GIT_SHA))
 
 # Note: This requires a buildx builder with emulation support. For example:
 #


### PR DESCRIPTION
Removes the `workflow_dispatch` from the current `docker` action, and instead adds a dedicated action to docker push images, tagged using the git sha.

These images should NOT be tagged as `latest`