### PR TITLE
chore: rm optimism feature from chainspec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6522,7 +6522,6 @@ dependencies = [
  "once_cell",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-optimism-forks",
  "reth-primitives-traits",
  "reth-trie-common",
  "serde_json",

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -17,9 +17,6 @@ reth-network-peers.workspace = true
 reth-trie-common.workspace = true
 reth-primitives-traits.workspace = true
 
-# op-reth
-reth-optimism-forks = { workspace = true, optional = true }
-
 # ethereum
 alloy-chains = { workspace = true, features = ["serde", "rlp"] }
 alloy-eips = { workspace = true, features = ["serde"] }
@@ -42,7 +39,6 @@ alloy-genesis.workspace = true
 
 [features]
 default = ["std"]
-optimism = ["reth-optimism-forks"]
 std = [
     "alloy-chains/std",
     "alloy-eips/std",

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -99,6 +99,6 @@ impl EthChainSpec for ChainSpec {
     }
 
     fn is_optimism(&self) -> bool {
-        Self::is_optimism(self)
+        self.chain.is_optimism()
     }
 }

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -27,7 +27,7 @@ pub use reth_ethereum_forks::*;
 
 pub use api::EthChainSpec;
 pub use info::ChainInfo;
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;
 pub use spec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, ChainSpecProvider,

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -239,21 +239,6 @@ impl ChainSpec {
         self.chain.is_ethereum()
     }
 
-    /// Returns `true` if this chain contains Optimism configuration.
-    #[inline]
-    #[cfg(feature = "optimism")]
-    pub fn is_optimism(&self) -> bool {
-        self.chain.is_optimism() ||
-            self.hardforks.get(reth_optimism_forks::OptimismHardfork::Bedrock).is_some()
-    }
-
-    /// Returns `true` if this chain contains Optimism configuration.
-    #[inline]
-    #[cfg(not(feature = "optimism"))]
-    pub const fn is_optimism(&self) -> bool {
-        self.chain.is_optimism()
-    }
-
     /// Returns `true` if this chain is Optimism mainnet.
     #[inline]
     pub fn is_optimism_mainnet(&self) -> bool {
@@ -705,9 +690,6 @@ impl EthereumHardforks for ChainSpec {
         self.final_paris_total_difficulty(block_number)
     }
 }
-
-#[cfg(feature = "optimism")]
-impl reth_optimism_forks::OptimismHardforks for ChainSpec {}
 
 /// A trait for reading the current chainspec.
 #[auto_impl::auto_impl(&, Arc)]

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -28,6 +28,7 @@ reth-tokio-util.workspace = true
 reth-engine-primitives.workspace = true
 reth-network-p2p.workspace = true
 reth-node-types.workspace = true
+reth-chainspec.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true
@@ -47,8 +48,6 @@ tracing.workspace = true
 thiserror.workspace = true
 schnellru.workspace = true
 itertools.workspace = true
-
-reth-chainspec = { workspace = true, optional = true }
 
 [dev-dependencies]
 # reth
@@ -71,7 +70,6 @@ reth-config.workspace = true
 reth-testing-utils.workspace = true
 reth-exex-types.workspace = true
 reth-prune-types.workspace = true
-reth-chainspec.workspace = true
 alloy-genesis.workspace = true
 
 assert_matches.workspace = true
@@ -81,5 +79,4 @@ optimism = [
     "reth-primitives/optimism",
     "reth-provider/optimism",
     "reth-blockchain-tree/optimism",
-    "reth-chainspec"
 ]

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -28,7 +28,7 @@ reth-tokio-util.workspace = true
 reth-engine-primitives.workspace = true
 reth-network-p2p.workspace = true
 reth-node-types.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, optional = true }
 
 # ethereum
 alloy-primitives.workspace = true
@@ -76,6 +76,7 @@ assert_matches.workspace = true
 
 [features]
 optimism = [
+    "reth-chainspec",
     "reth-primitives/optimism",
     "reth-provider/optimism",
     "reth-blockchain-tree/optimism",

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -70,6 +70,7 @@ reth-config.workspace = true
 reth-testing-utils.workspace = true
 reth-exex-types.workspace = true
 reth-prune-types.workspace = true
+reth-chainspec.workspace = true
 alloy-genesis.workspace = true
 
 assert_matches.workspace = true

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -73,6 +73,7 @@ use sync::{EngineSyncController, EngineSyncEvent};
 /// [consensus engine][`crate::engine::BeaconConsensusEngine`].
 pub mod hooks;
 use hooks::{EngineHookContext, EngineHookEvent, EngineHooks, EngineHooksController, PolledHook};
+use reth_chainspec::EthChainSpec;
 
 #[cfg(test)]
 pub mod test_utils;
@@ -462,8 +463,7 @@ where
     ) -> bool {
         // On Optimism, the proposers are allowed to reorg their own chain at will.
         #[cfg(feature = "optimism")]
-        if reth_chainspec::EthChainSpec::chain(self.blockchain.chain_spec().as_ref()).is_optimism()
-        {
+        if self.blockchain.chain_spec().is_optimism() {
             debug!(
                 target: "consensus::engine",
                 fcu_head_num=?header.number,

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -73,7 +73,6 @@ use sync::{EngineSyncController, EngineSyncEvent};
 /// [consensus engine][`crate::engine::BeaconConsensusEngine`].
 pub mod hooks;
 use hooks::{EngineHookContext, EngineHookEvent, EngineHooks, EngineHooksController, PolledHook};
-use reth_chainspec::EthChainSpec;
 
 #[cfg(test)]
 pub mod test_utils;
@@ -463,7 +462,7 @@ where
     ) -> bool {
         // On Optimism, the proposers are allowed to reorg their own chain at will.
         #[cfg(feature = "optimism")]
-        if self.blockchain.chain_spec().is_optimism() {
+        if reth_chainspec::EthChainSpec::is_optimism(&self.blockchain.chain_spec()) {
             debug!(
                 target: "consensus::engine",
                 fcu_head_num=?header.number,

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec = { workspace = true, features = ["optimism"] }
+reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
 reth-primitives-traits.workspace = true
 reth-network-peers.workspace = true

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -32,6 +32,7 @@ use reth_chainspec::{
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
 use reth_network_peers::NodeRecord;
+use reth_optimism_forks::OptimismHardforks;
 use reth_primitives_traits::Header;
 use std::fmt::Display;
 
@@ -261,6 +262,8 @@ impl EthereumHardforks for OpChainSpec {
         self.inner.final_paris_total_difficulty(block_number)
     }
 }
+
+impl OptimismHardforks for OpChainSpec {}
 
 impl From<Genesis> for OpChainSpec {
     fn from(genesis: Genesis) -> Self {

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -124,7 +124,7 @@ impl ConfigureEvmEnv for OptimismEvmConfig {
         cfg_env.perf_analyse_created_bytecodes = AnalysisKind::Analyse;
 
         cfg_env.handler_cfg.spec_id = spec_id;
-        cfg_env.handler_cfg.is_optimism = self.chain_spec.is_optimism();
+        cfg_env.handler_cfg.is_optimism = true;
     }
 
     fn next_cfg_and_block_env(

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -79,7 +79,6 @@ op-alloy-consensus.workspace = true
 
 [features]
 optimism = [
-    "reth-chainspec/optimism",
     "reth-primitives/optimism",
     "reth-provider/optimism",
     "reth-optimism-evm/optimism",

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -49,7 +49,6 @@ sha2.workspace = true
 
 [features]
 optimism = [
-    "reth-chainspec/optimism",
     "reth-primitives/optimism",
     "reth-provider/optimism",
     "reth-optimism-evm/optimism",

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -4,7 +4,6 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_rpc_types::{AnyReceiptEnvelope, Log, TransactionReceipt};
 use op_alloy_consensus::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope};
 use op_alloy_rpc_types::{receipt::L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
-use reth_chainspec::ChainSpec;
 use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::RethL1BlockInfo;
@@ -55,25 +54,6 @@ where
     }
 }
 
-impl<N> OpEthApi<N>
-where
-    N: FullNodeComponents<Types: NodeTypes<ChainSpec = ChainSpec>>,
-{
-    /// Builds a receipt w.r.t. chain spec.
-    pub fn build_op_receipt_meta(
-        &self,
-        tx: &TransactionSigned,
-        l1_block_info: revm::L1BlockInfo,
-        receipt: &Receipt,
-    ) -> Result<OpTransactionReceiptFields, OpEthApiError> {
-        Ok(OpReceiptFieldsBuilder::default()
-            .l1_block_info(&self.inner.provider().chain_spec(), tx, l1_block_info)?
-            .deposit_nonce(receipt.deposit_nonce)
-            .deposit_version(receipt.deposit_receipt_version)
-            .build())
-    }
-}
-
 /// L1 fee and data gas for a non-deposit transaction, or deposit nonce and receipt version for a
 /// deposit transaction.
 #[derive(Debug, Default, Clone)]
@@ -113,7 +93,7 @@ impl OpReceiptFieldsBuilder {
     /// Applies [`L1BlockInfo`](revm::L1BlockInfo).
     pub fn l1_block_info(
         mut self,
-        chain_spec: &ChainSpec,
+        chain_spec: &OpChainSpec,
         tx: &TransactionSigned,
         l1_block_info: revm::L1BlockInfo,
     ) -> Result<Self, OpEthApiError> {


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/8904

we can finally do this, has no impact on any usage in beacon-consensus because we already use the proper OpChainSpec type everywhere