### PR TITLE
feat(engine-tree): feature gate out forkchoice timestamp check

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -120,6 +120,10 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
+# Do not check the timestamp for forkchoice update. This breaks the EngineAPI spec
+# but is helpful if subsecond block times are desired. Does not change the legacy engine.
+no-forkchoice-timestamp-check = ["reth-node-builder/no-forkchoice-timestamp-check"]
+
 [[bin]]
 name = "reth"
 path = "src/main.rs"

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -43,3 +43,8 @@ reth-chainspec.workspace = true
 
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
+
+[features]
+# Do not check the timestamp for forkchoice update. This breaks the EngineAPI spec
+# but is helpful if subsecond block times are desired.
+no-forkchoice-timestamp-check = ["reth-engine-tree/no-forkchoice-timestamp-check"]

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -88,3 +88,7 @@ test-utils = [
   "reth-static-file",
   "reth-tracing"
 ]
+
+# Do not check the timestamp for forkchoice update. This breaks the EngineAPI spec
+# but is helpful if subsecond block times are desired.
+no-forkchoice-timestamp-check = []

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2488,6 +2488,7 @@ where
         //    client software MUST respond with -38003: `Invalid payload attributes` and MUST NOT
         //    begin a payload build process. In such an event, the forkchoiceState update MUST NOT
         //    be rolled back.
+        #[cfg(not(feature = "no-forkchoice-timestamp-check"))]
         if attrs.timestamp() <= head.timestamp {
             return OnForkChoiceUpdated::invalid_payload_attributes()
         }

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -96,3 +96,7 @@ tempfile.workspace = true
 [features]
 default = []
 test-utils = ["reth-db/test-utils"]
+
+# Do not check the timestamp for forkchoice update. This breaks the EngineAPI spec
+# but is helpful if subsecond block times are desired.
+no-forkchoice-timestamp-check = ["reth-engine-service/no-forkchoice-timestamp-check"]


### PR DESCRIPTION
A potential solution to #11651.

This PR introduces a `no-forkchoice-timestamp-check` feature to the node-builder to allow disabling the timestamp check. Since the timestamp is denominated in seconds, this allows us to request payloads in the same second. 

I don't include any tests in this initial proposal, but I was able to locally setup a CL producing 300ms blocks using a docker image based on this branch.