### PR TITLE
fix: task executor metrics

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -18,6 +18,7 @@ use reth_db::DatabaseEnv;
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_node_ethereum::{EthExecutorProvider, EthereumNode};
+use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_tracing::FileWorkerGuard;
 use std::{ffi::OsString, fmt, future::Future, sync::Arc};
 use tracing::info;
@@ -144,6 +145,10 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
 
         let _guard = self.init_tracing()?;
         info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
+
+        // Install the prometheus recorder to be sure to record task
+        // executor's metrics
+        let _ = install_prometheus_recorder();
 
         let runner = CliRunner::default();
         match self.command {

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -16,7 +16,6 @@ use reth_node_core::{
     node_config::NodeConfig,
     version,
 };
-use reth_node_metrics::recorder::install_prometheus_recorder;
 use std::{ffi::OsString, fmt, future::Future, net::SocketAddr, path::PathBuf, sync::Arc};
 
 /// Start the node
@@ -179,10 +178,6 @@ impl<
             dev,
             pruning,
         };
-
-        // Register the prometheus recorder before creating the database,
-        // because database init needs it to register metrics.
-        let _ = install_prometheus_recorder();
 
         let data_dir = node_config.datadir();
         let db_path = data_dir.db();

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -288,7 +288,7 @@ pub struct TaskExecutor {
     on_shutdown: Shutdown,
     /// Sender half for sending panic signals to this type
     panicked_tasks_tx: UnboundedSender<PanickedTaskError>,
-    // Task Executor Metrics
+    /// Task Executor Metrics
     metrics: TaskExecutorMetrics,
     /// How many [`GracefulShutdown`] tasks are currently active
     graceful_tasks: Arc<AtomicUsize>,


### PR DESCRIPTION
Make a call to `install_prometheus_recorder` earlier in the start up of the node. This permits the `TaskExecutor` metrics to be described to the correct recorder and avoid them being lost.

This is linked to #8332.