### PR TITLE
fix: `estimateGas` edge case

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -888,7 +888,11 @@ pub trait Call: LoadState + SpawnBlocking {
             // Execute transaction and handle potential gas errors, adjusting limits accordingly.
             match self.transact(&mut db, env.clone()) {
                 Err(err) if err.is_gas_too_high() => {
-                    // Increase the lowest gas limit if gas is too high
+                    // Decrease the highest gas limit if gas is too low
+                    highest_gas_limit = mid_gas_limit;
+                }
+                Err(err) if err.is_gas_too_low() => {
+                    // Increase the lowest gas limit if gas is too low
                     lowest_gas_limit = mid_gas_limit;
                 }
                 // Handle other cases, including successful transactions.

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -888,7 +888,7 @@ pub trait Call: LoadState + SpawnBlocking {
             // Execute transaction and handle potential gas errors, adjusting limits accordingly.
             match self.transact(&mut db, env.clone()) {
                 Err(err) if err.is_gas_too_high() => {
-                    // Decrease the highest gas limit if gas is too low
+                    // Decrease the highest gas limit if gas is too high
                     highest_gas_limit = mid_gas_limit;
                 }
                 Err(err) if err.is_gas_too_low() => {

--- a/crates/rpc/rpc-eth-api/src/helpers/error.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/error.rs
@@ -59,6 +59,16 @@ pub trait AsEthApiError {
 
         false
     }
+
+    /// Returns `true` if error is
+    /// [`RpcInvalidTransactionError::GasTooLow`](reth_rpc_eth_types::RpcInvalidTransactionError::GasTooLow).
+    fn is_gas_too_low(&self) -> bool {
+        if let Some(err) = self.as_err() {
+            return err.is_gas_too_low()
+        }
+
+        false
+    }
 }
 
 impl AsEthApiError for EthApiError {

--- a/crates/rpc/rpc-eth-types/src/error.rs
+++ b/crates/rpc/rpc-eth-types/src/error.rs
@@ -151,6 +151,11 @@ impl EthApiError {
     pub const fn is_gas_too_high(&self) -> bool {
         matches!(self, Self::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh))
     }
+
+    /// Returns `true` if error is [`RpcInvalidTransactionError::GasTooLow`]
+    pub const fn is_gas_too_low(&self) -> bool {
+        matches!(self, Self::InvalidTransaction(RpcInvalidTransactionError::GasTooLow))
+    }
 }
 
 impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {


### PR DESCRIPTION
Looks like in some cases we may end up with `mid_gas_limit` being lower than initial gas transaction consumes.

Can be reproduced like this:
```rust
let signer = PrivateKeySigner::from_bytes(&b256!(
    "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
))?;

let provider = ProviderBuilder::new().on_http("https://odyssey.ithaca.xyz".parse()?);

let auth = Authorization {
    chain_id: U256::from(provider.get_chain_id().await?),
    address: address!("23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"),
    nonce: provider.get_transaction_count(signer.address()).await?,
};

let signature = signer.sign_hash_sync(&auth.signature_hash())?;
let auth = auth.into_signed(signature);

let tx = TransactionRequest::default()
    .with_authorization_list(vec![auth])
    .with_to(signer.address());

// Error: ErrorResp(ErrorPayload { code: -32000, message: "intrinsic gas too low", data: None })
println!("{:?}", provider.estimate_gas(&tx).await?);
```

Such transaction needs 46000 of gas with 9200 getting refunded. because of `lowest_gas_limit` being set to just `gas_used` we're ending up trying to transact with gas limit of 38k which is not enough

Solution is to add handling of insufficient initial gas