### PR TITLE
feat(cli): add ChainSpecParser type to rethCli

### DIFF
--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -14,6 +14,7 @@ use std::{borrow::Cow, ffi::OsString};
 
 /// The chainspec module defines the different chainspecs that can be used by the node.
 pub mod chainspec;
+use crate::chainspec::ChainSpecParser;
 
 /// Reth based node cli.
 ///
@@ -22,6 +23,9 @@ pub mod chainspec;
 /// It provides commonly used functionality for running commands and information about the CL, such
 /// as the name and version.
 pub trait RethCli: Sized {
+    /// The associated ChainSpecParser type
+    type ChainSpecParser: ChainSpecParser;
+
     /// The name of the implementation, eg. `reth`, `op-reth`, etc.
     fn name(&self) -> Cow<'static, str>;
 

--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -23,7 +23,7 @@ use crate::chainspec::ChainSpecParser;
 /// It provides commonly used functionality for running commands and information about the CL, such
 /// as the name and version.
 pub trait RethCli: Sized {
-    /// The associated ChainSpecParser type
+    /// The associated `ChainSpecParser` type
     type ChainSpecParser: ChainSpecParser;
 
     /// The name of the implementation, eg. `reth`, `op-reth`, etc.

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -139,7 +139,6 @@ where
     ///
     /// This transforms the node command into a node config and launches the node using the given
     /// closure.
-    /// <R as RethCli>::ChainSpecParser as reth_cli::chainspec::ChainSpecParser>::ChainSpec: reth_chainspec::EthChainSpec
     pub async fn execute<L, Fut>(self, ctx: CliContext, launcher: L) -> eyre::Result<()>
     where
         L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, <R::ChainSpecParser as ChainSpecParser>::ChainSpec>>, Ext) -> Fut,


### PR DESCRIPTION
I've added added  `ChainSpecParser` type to `RethCli` trait and updated the `NodeCommand` struct to use this instead.

Fixes https://github.com/paradigmxyz/reth/issues/11770