### PR TITLE
chore(cli): add `default_client_version` to rethCli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6551,6 +6551,8 @@ dependencies = [
  "clap",
  "eyre",
  "reth-cli-runner",
+ "reth-db",
+ "reth-node-core",
  "serde_json",
  "shellexpand",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6552,7 +6552,6 @@ dependencies = [
  "eyre",
  "reth-cli-runner",
  "reth-db",
- "reth-node-core",
  "serde_json",
  "shellexpand",
 ]

--- a/crates/cli/cli/Cargo.toml
+++ b/crates/cli/cli/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 # reth
 reth-cli-runner.workspace = true
 reth-db.workspace = true
-reth-node-core.workspace = true
 alloy-genesis.workspace = true
 
 # misc

--- a/crates/cli/cli/Cargo.toml
+++ b/crates/cli/cli/Cargo.toml
@@ -14,7 +14,8 @@ workspace = true
 [dependencies]
 # reth
 reth-cli-runner.workspace = true
-
+reth-db.workspace = true
+reth-node-core.workspace = true
 alloy-genesis.workspace = true
 
 # misc

--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -11,6 +11,8 @@
 use clap::{Error, Parser};
 use reth_cli_runner::CliRunner;
 use std::{borrow::Cow, ffi::OsString};
+use reth_db::ClientVersion;
+use reth_node_core::version::default_client_version;
 
 /// The chainspec module defines the different chainspecs that can be used by the node.
 pub mod chainspec;
@@ -65,5 +67,10 @@ pub trait RethCli: Sized {
         let cli = Self::parse_args()?;
 
         Ok(cli.with_runner(f))
+    }
+
+    /// The default client version accessing the database. ref: reth_node_core::version::default_client_version
+    fn default_client_version() -> ClientVersion {
+        default_client_version()
     }
 }

--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -12,7 +12,6 @@ use clap::{Error, Parser};
 use reth_cli_runner::CliRunner;
 use std::{borrow::Cow, ffi::OsString};
 use reth_db::ClientVersion;
-use reth_node_core::version::default_client_version;
 
 /// The chainspec module defines the different chainspecs that can be used by the node.
 pub mod chainspec;

--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -69,8 +69,6 @@ pub trait RethCli: Sized {
         Ok(cli.with_runner(f))
     }
 
-    /// The default client version accessing the database. ref: reth_node_core::version::default_client_version
-    fn default_client_version() -> ClientVersion {
-        default_client_version()
-    }
+    /// The client version of the node.
+    fn client_version() -> ClientVersion;
 }

--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -10,8 +10,8 @@
 
 use clap::{Error, Parser};
 use reth_cli_runner::CliRunner;
-use std::{borrow::Cow, ffi::OsString};
 use reth_db::ClientVersion;
+use std::{borrow::Cow, ffi::OsString};
 
 /// The chainspec module defines the different chainspecs that can be used by the node.
 pub mod chainspec;


### PR DESCRIPTION
added a `default_client_version` in rethCli which references the same version used in node_core crate.

Fixes: https://github.com/paradigmxyz/reth/issues/11768