### PR TITLE
chore(provider): move `state_provider_from_state` to `BlockState` impl

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -508,20 +508,6 @@ impl CanonicalInMemoryState {
     ///
     /// This merges the state of all blocks that are part of the chain that the requested block is
     /// the head of. This includes all blocks that connect back to the canonical block on disk.
-    pub fn state_provider_from_state(
-        &self,
-        state: &BlockState,
-        historical: StateProviderBox,
-    ) -> MemoryOverlayStateProvider {
-        let in_memory = state.chain().into_iter().map(|block_state| block_state.block()).collect();
-
-        MemoryOverlayStateProvider::new(historical, in_memory)
-    }
-
-    /// Return state provider with reference to in-memory blocks that overlay database state.
-    ///
-    /// This merges the state of all blocks that are part of the chain that the requested block is
-    /// the head of. This includes all blocks that connect back to the canonical block on disk.
     pub fn state_provider(
         &self,
         hash: B256,
@@ -722,6 +708,16 @@ impl BlockState {
     /// This yields the blocks from newest to oldest (highest to lowest).
     pub fn iter(self: Arc<Self>) -> impl Iterator<Item = Arc<Self>> {
         std::iter::successors(Some(self), |state| state.parent.clone())
+    }
+
+    /// Return state provider with reference to in-memory blocks that overlay database state.
+    ///
+    /// This merges the state of all blocks that are part of the chain that the this block is
+    /// the head of. This includes all blocks that connect back to the canonical block on disk.
+    pub fn state_provider(&self, historical: StateProviderBox) -> MemoryOverlayStateProvider {
+        let in_memory = self.chain().into_iter().map(|block_state| block_state.block()).collect();
+
+        MemoryOverlayStateProvider::new(historical, in_memory)
     }
 }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -402,7 +402,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
     ) -> ProviderResult<MemoryOverlayStateProvider> {
         let anchor_hash = state.anchor().hash;
         let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
-        Ok(self.canonical_in_memory_state.state_provider_from_state(state, latest_historical))
+        Ok(state.state_provider(latest_historical))
     }
 
     /// Fetches data from either in-memory state or persistent storage for a range of transactions.


### PR DESCRIPTION
Does not need `CanonicalMemoryState` to create the state provider