### PR TITLE
chore(ci): update list of crates excluded from wasm checks

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -30,12 +30,10 @@ exclude_crates=(
   reth-engine-util
   reth-eth-wire
   reth-ethereum-cli
-  reth-ethereum-engine
   reth-ethereum-engine-primitives
   reth-ethereum-payload-builder
   reth-etl
   reth-evm-ethereum
-  reth-execution-errors
   reth-exex
   reth-exex-test-utils
   reth-ipc
@@ -49,7 +47,6 @@ exclude_crates=(
   reth-node-events
   reth-node-metrics
   reth-optimism-cli
-  reth-optimism-evm
   reth-optimism-node
   reth-optimism-payload-builder
   reth-optimism-rpc
@@ -63,9 +60,7 @@ exclude_crates=(
   reth-rpc-eth-api
   reth-rpc-eth-types
   reth-rpc-layer
-  reth-rpc-types
   reth-stages
-  reth-storage-errors
   reth-engine-local
   # The following are not supposed to be working
   reth # all of the crates below


### PR DESCRIPTION
Crates with wasm build currently working:
* reth-execution-errors
* reth-optimism-evm
* reth-storage-errors

No longer existing crates:
* reth-ethereum-engine
* reth-rpc-types
