### PR TITLE
chore(trie): use `RlpNode::as_hash`

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -267,8 +267,8 @@ impl RevealedSparseTrie {
         // take the current prefix set.
         let mut prefix_set = std::mem::take(&mut self.prefix_set).freeze();
         let root_rlp = self.rlp_node(Nibbles::default(), &mut prefix_set);
-        if root_rlp.len() == B256::len_bytes() + 1 {
-            B256::from_slice(&root_rlp[1..])
+        if let Some(root_hash) = root_rlp.as_hash() {
+            root_hash
         } else {
             keccak256(root_rlp)
         }
@@ -338,8 +338,8 @@ impl RevealedSparseTrie {
                     } else {
                         let value = self.values.get(&path).unwrap();
                         let rlp_node = LeafNodeRef { key, value }.rlp(&mut self.rlp_buf);
-                        if rlp_node.len() == B256::len_bytes() + 1 {
-                            *hash = Some(B256::from_slice(&rlp_node[1..]));
+                        if let Some(node_hash) = rlp_node.as_hash() {
+                            *hash = Some(node_hash);
                         }
                         rlp_node
                     }
@@ -353,8 +353,8 @@ impl RevealedSparseTrie {
                         let (_, child) = rlp_node_stack.pop().unwrap();
                         self.rlp_buf.clear();
                         let rlp_node = ExtensionNodeRef::new(key, &child).rlp(&mut self.rlp_buf);
-                        if rlp_node.len() == B256::len_bytes() + 1 {
-                            *hash = Some(B256::from_slice(&rlp_node[1..]));
+                        if let Some(node_hash) = rlp_node.as_hash() {
+                            *hash = Some(node_hash);
                         }
                         rlp_node
                     } else {
@@ -393,8 +393,8 @@ impl RevealedSparseTrie {
                     self.rlp_buf.clear();
                     let rlp_node = BranchNodeRef::new(&branch_value_stack_buf, *state_mask)
                         .rlp(&mut self.rlp_buf);
-                    if rlp_node.len() == B256::len_bytes() + 1 {
-                        *hash = Some(B256::from_slice(&rlp_node[1..]));
+                    if let Some(node_hash) = rlp_node.as_hash() {
+                        *hash = Some(node_hash);
                     }
                     rlp_node
                 }


### PR DESCRIPTION
## Description

https://github.com/paradigmxyz/reth/pull/11741#discussion_r1800907610