### PR TITLE
primitive-traits: rm redundant `EMPTY_ROOT_HASH` definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8726,6 +8726,7 @@ dependencies = [
 name = "reth-rpc-eth-api"
 version = "1.1.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
  "alloy-json-rpc",
@@ -9116,6 +9117,7 @@ dependencies = [
 name = "reth-trie"
 version = "1.1.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "auto_impl",
@@ -9171,6 +9173,7 @@ dependencies = [
 name = "reth-trie-db"
 version = "1.1.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "auto_impl",

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1376,7 +1376,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::TxEip1559;
+    use alloy_consensus::{TxEip1559, EMPTY_ROOT_HASH};
     use alloy_genesis::{Genesis, GenesisAccount};
     use alloy_primitives::{keccak256, Address, Sealable, B256};
     use assert_matches::assert_matches;
@@ -1388,7 +1388,7 @@ mod tests {
     use reth_evm::test_utils::MockExecutorProvider;
     use reth_evm_ethereum::execute::EthExecutorProvider;
     use reth_primitives::{
-        constants::{EIP1559_INITIAL_BASE_FEE, EMPTY_ROOT_HASH},
+        constants::EIP1559_INITIAL_BASE_FEE,
         proofs::{calculate_receipt_root, calculate_transaction_root},
         revm_primitives::AccountInfo,
         Account, BlockBody, Header, Signature, Transaction, TransactionSigned,

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -2,7 +2,7 @@ use crate::{
     in_memory::ExecutedBlock, CanonStateNotification, CanonStateNotifications,
     CanonStateSubscriptions,
 };
-use alloy_consensus::TxEip1559;
+use alloy_consensus::{TxEip1559, EMPTY_ROOT_HASH};
 use alloy_primitives::{Address, BlockNumber, Sealable, B256, U256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
@@ -10,7 +10,7 @@ use rand::{thread_rng, Rng};
 use reth_chainspec::{ChainSpec, EthereumHardfork, MIN_TRANSACTION_GAS};
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_primitives::{
-    constants::{EIP1559_INITIAL_BASE_FEE, EMPTY_ROOT_HASH},
+    constants::EIP1559_INITIAL_BASE_FEE,
     proofs::{calculate_receipt_root, calculate_transaction_root, calculate_withdrawals_root},
     BlockBody, Header, Receipt, Receipts, Requests, SealedBlock, SealedBlockWithSenders,
     SealedHeader, Transaction, TransactionSigned, TransactionSignedEcRecovered,

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -493,7 +493,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::TxLegacy;
+    use alloy_consensus::{TxLegacy, EMPTY_ROOT_HASH};
     use alloy_eips::{
         eip2935::{HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_CODE},
         eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE, SYSTEM_ADDRESS},
@@ -502,8 +502,7 @@ mod tests {
     use alloy_primitives::{b256, fixed_bytes, keccak256, Bytes, TxKind, B256};
     use reth_chainspec::{ChainSpecBuilder, ForkCondition};
     use reth_primitives::{
-        constants::{EMPTY_ROOT_HASH, ETH_TO_WEI},
-        public_key_to_address, Account, Block, BlockBody, Transaction,
+        constants::ETH_TO_WEI, public_key_to_address, Account, Block, BlockBody, Transaction,
     };
     use reth_revm::{
         database::StateProviderDatabase, test_utils::StateProviderTest, TransitionState,

--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -1,5 +1,6 @@
 //! Ethereum protocol-related constants
 
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{address, b256, Address, B256, U256};
 use core::time::Duration;
 
@@ -121,10 +122,6 @@ pub const KECCAK_EMPTY: B256 =
 /// Ommer root of empty list: `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347`
 pub const EMPTY_OMMER_ROOT_HASH: B256 =
     b256!("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
-
-/// Root hash of an empty trie: `0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421`
-pub const EMPTY_ROOT_HASH: B256 =
-    b256!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
 
 /// From address from Optimism system txs: `0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001`
 pub const OP_SYSTEM_TX_FROM_ADDR: Address = address!("deaddeaddeaddeaddeaddeaddeaddeaddead0001");

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -65,7 +65,8 @@ pub fn calculate_ommers_root(ommers: &[Header]) -> B256 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{constants::EMPTY_ROOT_HASH, Block};
+    use crate::Block;
+    use alloy_consensus::EMPTY_ROOT_HASH;
     use alloy_genesis::GenesisAccount;
     use alloy_primitives::{b256, hex_literal::hex, Address, U256};
     use alloy_rlp::Decodable;

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -40,6 +40,7 @@ alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types.workspace = true
 alloy-rpc-types-mev.workspace = true
+alloy-consensus.workspace = true
 
 # rpc
 jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 
 use crate::{EthApiTypes, FromEthApiError, FromEvmError};
 
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{BlockNumber, B256, U256};
 use alloy_rpc_types::BlockNumberOrTag;
 use futures::Future;
@@ -12,7 +13,7 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv};
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{
-    constants::{eip4844::MAX_DATA_GAS_PER_BLOCK, BEACON_NONCE, EMPTY_ROOT_HASH},
+    constants::{eip4844::MAX_DATA_GAS_PER_BLOCK, BEACON_NONCE},
     proofs::calculate_transaction_root,
     revm_primitives::{
         BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, EVMError, Env, ExecutionResult, InvalidTransaction,

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -58,6 +58,8 @@ reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie = { workspace = true, features = ["test-utils"] }
 reth-node-types.workspace = true
 
+alloy-consensus.workspace = true
+
 # trie
 triehash = "0.8"
 

--- a/crates/trie/db/tests/proof.rs
+++ b/crates/trie/db/tests/proof.rs
@@ -1,9 +1,10 @@
 #![allow(missing_docs)]
 
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_rlp::EMPTY_STRING_CODE;
 use reth_chainspec::{Chain, ChainSpec, HOLESKY, MAINNET};
-use reth_primitives::{constants::EMPTY_ROOT_HASH, Account};
+use reth_primitives::Account;
 use reth_provider::test_utils::{create_test_provider_factory, insert_genesis};
 use reth_trie::{proof::Proof, Nibbles};
 use reth_trie_common::{AccountProof, StorageProof};

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{hex_literal::hex, keccak256, Address, B256, U256};
 use proptest::{prelude::ProptestConfig, proptest};
 use proptest_arbitrary_interop::arb;
@@ -8,7 +9,7 @@ use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     transaction::DbTxMut,
 };
-use reth_primitives::{constants::EMPTY_ROOT_HASH, Account, StorageEntry};
+use reth_primitives::{Account, StorageEntry};
 use reth_provider::{
     test_utils::create_test_provider_factory, DatabaseProviderRW, StorageTrieWriter, TrieWriter,
 };

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{
     keccak256,
     map::{HashMap, HashSet},
@@ -8,7 +9,7 @@ use alloy_primitives::{
 use alloy_rlp::EMPTY_STRING_CODE;
 use reth_db::{cursor::DbCursorRW, tables};
 use reth_db_api::transaction::DbTxMut;
-use reth_primitives::{constants::EMPTY_ROOT_HASH, Account, StorageEntry};
+use reth_primitives::{Account, StorageEntry};
 use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
 use reth_trie::{proof::Proof, witness::TrieWitness, HashedPostState, HashedStorage, StateRoot};
 use reth_trie_db::{DatabaseProof, DatabaseStateRoot, DatabaseTrieWitness};

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -24,6 +24,7 @@ revm.workspace = true
 # alloy
 alloy-rlp.workspace = true
 alloy-primitives.workspace = true
+alloy-consensus.workspace = true
 
 # tracing
 tracing.workspace = true

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -9,10 +9,10 @@ use crate::{
     walker::TrieWalker,
     HashBuilder, Nibbles, TrieAccount,
 };
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{keccak256, Address, B256};
 use alloy_rlp::{BufMut, Encodable};
 use reth_execution_errors::{StateRootError, StorageRootError};
-use reth_primitives::constants::EMPTY_ROOT_HASH;
 use tracing::trace;
 
 #[cfg(feature = "metrics")]

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -5,6 +5,7 @@ use crate::{
     trie_cursor::TrieCursorFactory,
     HashedPostState,
 };
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{
     keccak256,
     map::{HashMap, HashSet},
@@ -13,7 +14,6 @@ use alloy_primitives::{
 use alloy_rlp::{BufMut, Decodable, Encodable};
 use itertools::{Either, Itertools};
 use reth_execution_errors::{StateProofError, TrieWitnessError};
-use reth_primitives::constants::EMPTY_ROOT_HASH;
 use reth_trie_common::{
     BranchNode, HashBuilder, Nibbles, StorageMultiProof, TrieAccount, TrieNode, CHILD_INDEX_RANGE,
 };


### PR DESCRIPTION
`EMPTY_ROOT_HASH` was defined multiple times (in the primitive-traits crate and in alloy). 

In my opinion, especially after the type import audit of primitive traits, it makes more sense to have this `EMPTY_ROOT_HASH` constant defined at a single position and use it from there (namely in alloy).