### PR TITLE
chore: rm feature gated op check

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{keccak256, Address, BlockHash, BlockNumber, TxHash, TxNum
 use dashmap::DashMap;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::RwLock;
-use reth_chainspec::{ChainInfo, ChainSpecProvider};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec};
 use reth_db::{
     lockfile::StorageLock,
     static_file::{iter_static_files, HeaderMask, ReceiptMask, StaticFileCursor, TransactionMask},
@@ -641,9 +641,7 @@ impl StaticFileProvider {
         //
         // If we detect an OVM import was done (block #1 <https://optimistic.etherscan.io/block/1>), skip it.
         // More on [#11099](https://github.com/paradigmxyz/reth/pull/11099).
-        #[cfg(feature = "optimism")]
-        if reth_chainspec::EthChainSpec::chain(&provider.chain_spec()) ==
-            reth_chainspec::Chain::optimism_mainnet() &&
+        if provider.chain_spec().chain_id() == reth_chainspec::Chain::optimism_mainnet().id() &&
             provider
                 .block_number(reth_optimism_primitives::bedrock::OVM_HEADER_1_HASH)?
                 .is_some()


### PR DESCRIPTION
we can safely remove the optimism feature gate here, always checking the chain id is fine