### PR TITLE
feat: allow awaiting payload in progress

### DIFF
--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -28,7 +28,7 @@ impl<E: EngineTypes> PayloadTestContext<E> {
     ) -> eyre::Result<E::PayloadBuilderAttributes> {
         self.timestamp += 1;
         let attributes: E::PayloadBuilderAttributes = attributes_generator(self.timestamp);
-        self.payload_builder.new_payload(attributes.clone()).await.unwrap();
+        self.payload_builder.send_new_payload(attributes.clone()).await.unwrap()?;
         Ok(attributes)
     }
 

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -9,7 +9,7 @@ use reth_chainspec::EthereumHardforks;
 use reth_engine_primitives::EngineTypes;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
-    BuiltPayload, PayloadAttributesBuilder, PayloadBuilder, PayloadTypes,
+    BuiltPayload, PayloadAttributesBuilder, PayloadBuilder, PayloadKind, PayloadTypes,
 };
 use reth_provider::{BlockReader, ChainSpecProvider};
 use reth_rpc_types_compat::engine::payload::block_to_payload;
@@ -202,7 +202,9 @@ where
 
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
 
-        let Some(Ok(payload)) = self.payload_builder.resolve(payload_id, true).await else {
+        let Some(Ok(payload)) =
+            self.payload_builder.resolve(payload_id, PayloadKind::WaitForPending).await
+        else {
             eyre::bail!("No payload")
         };
 

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -131,6 +131,7 @@ where
             tokio::select! {
                 // Wait for the interval or the pool to receive a transaction
                 _ = &mut self.mode => {
+                    println!("RECEIVED");
                     if let Err(e) = self.advance().await {
                         error!(target: "engine::local", "Error advancing the chain: {:?}", e);
                     }
@@ -202,10 +203,7 @@ where
 
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
 
-        // wait for some time to let the payload be built
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        let Some(Ok(payload)) = self.payload_builder.best_payload(payload_id).await else {
+        let Some(Ok(payload)) = self.payload_builder.resolve(payload_id, true).await else {
             eyre::bail!("No payload")
         };
 

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -131,7 +131,6 @@ where
             tokio::select! {
                 // Wait for the interval or the pool to receive a transaction
                 _ = &mut self.mode => {
-                    println!("RECEIVED");
                     if let Err(e) = self.advance().await {
                         error!(target: "engine::local", "Error advancing the chain: {:?}", e);
                     }

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -203,7 +203,7 @@ where
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
 
         let Some(Ok(payload)) =
-            self.payload_builder.resolve(payload_id, PayloadKind::WaitForPending).await
+            self.payload_builder.resolve_kind(payload_id, PayloadKind::WaitForPending).await
         else {
             eyre::bail!("No payload")
         };

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -475,7 +475,10 @@ where
         Ok(self.config.attributes.clone())
     }
 
-    fn resolve(&mut self, kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve_kind(
+        &mut self,
+        kind: PayloadKind,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let best_payload = self.best_payload.take();
 
         if best_payload.is_none() && self.pending_block.is_none() {

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -537,8 +537,7 @@ where
         let fut = ResolveBestPayload {
             best_payload,
             maybe_better,
-            empty_payload,
-            wait_for_pending: kind == PayloadKind::WaitForPending,
+            empty_payload: empty_payload.filter(|_| kind != PayloadKind::WaitForPending),
         };
 
         (fut, KeepPayloadJobAlive::No)
@@ -562,8 +561,6 @@ pub struct ResolveBestPayload<Payload> {
     pub maybe_better: Option<PendingPayload<Payload>>,
     /// The empty payload building job in progress, if any.
     pub empty_payload: Option<oneshot::Receiver<Result<Payload, PayloadBuilderError>>>,
-    /// Whether to wait for the pending payload to finish.
-    pub wait_for_pending: bool,
 }
 
 impl<Payload> ResolveBestPayload<Payload> {
@@ -589,8 +586,6 @@ where
                     debug!(target: "payload_builder", "resolving better payload");
                     return Poll::Ready(Ok(payload))
                 }
-            } else if this.wait_for_pending {
-                return Poll::Pending
             }
         }
 

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -473,7 +473,10 @@ where
         Ok(self.config.attributes.clone())
     }
 
-    fn resolve(&mut self) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve(
+        &mut self,
+        wait_for_pending: bool,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let best_payload = self.best_payload.take();
 
         if best_payload.is_none() && self.pending_block.is_none() {
@@ -529,7 +532,8 @@ where
             };
         }
 
-        let fut = ResolveBestPayload { best_payload, maybe_better, empty_payload };
+        let fut =
+            ResolveBestPayload { best_payload, maybe_better, empty_payload, wait_for_pending };
 
         (fut, KeepPayloadJobAlive::No)
     }
@@ -552,6 +556,8 @@ pub struct ResolveBestPayload<Payload> {
     pub maybe_better: Option<PendingPayload<Payload>>,
     /// The empty payload building job in progress, if any.
     pub empty_payload: Option<oneshot::Receiver<Result<Payload, PayloadBuilderError>>>,
+    /// Whether to wait for the pending payload to finish.
+    pub wait_for_pending: bool,
 }
 
 impl<Payload> ResolveBestPayload<Payload> {
@@ -577,6 +583,8 @@ where
                     debug!(target: "payload_builder", "resolving better payload");
                     return Poll::Ready(Ok(payload))
                 }
+            } else if this.wait_for_pending {
+                return Poll::Pending
             }
         }
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -73,7 +73,7 @@
 //!     Ok(self.attributes.clone())
 //! }
 //!
-//! fn resolve(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+//! fn resolve_kind(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
 //!        let payload = self.best_payload();
 //!        (futures_util::future::ready(payload), KeepPayloadJobAlive::No)
 //!     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -73,7 +73,7 @@
 //!     Ok(self.attributes.clone())
 //! }
 //!
-//! fn resolve(&mut self) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+//! fn resolve(&mut self, _wait_for_pending: bool) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
 //!        let payload = self.best_payload();
 //!        (futures_util::future::ready(payload), KeepPayloadJobAlive::No)
 //!     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -28,7 +28,7 @@
 //! use std::pin::Pin;
 //! use std::task::{Context, Poll};
 //! use alloy_primitives::U256;
-//! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, EthPayloadBuilderAttributes, PayloadJob, PayloadJobGenerator};
+//! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, EthPayloadBuilderAttributes, PayloadJob, PayloadJobGenerator, PayloadKind};
 //! use reth_primitives::{Block, Header};
 //!
 //! /// The generator type that creates new jobs that builds empty blocks.
@@ -73,7 +73,7 @@
 //!     Ok(self.attributes.clone())
 //! }
 //!
-//! fn resolve(&mut self, _wait_for_pending: bool) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+//! fn resolve(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
 //!        let payload = self.best_payload();
 //!        (futures_util::future::ready(payload), KeepPayloadJobAlive::No)
 //!     }
@@ -112,7 +112,7 @@ pub mod noop;
 pub mod test_utils;
 
 pub use alloy_rpc_types::engine::PayloadId;
-pub use reth_payload_primitives::PayloadBuilderError;
+pub use reth_payload_primitives::{PayloadBuilderError, PayloadKind};
 pub use service::{
     PayloadBuilderHandle, PayloadBuilderService, PayloadServiceCommand, PayloadStore,
 };

--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -51,7 +51,7 @@ where
                 }
                 PayloadServiceCommand::BestPayload(_, tx) => tx.send(None).ok(),
                 PayloadServiceCommand::PayloadAttributes(_, tx) => tx.send(None).ok(),
-                PayloadServiceCommand::Resolve(_, tx) => tx.send(None).ok(),
+                PayloadServiceCommand::Resolve(_, _, tx) => tx.send(None).ok(),
                 PayloadServiceCommand::Subscribe(_) => None,
             };
         }

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use alloy_primitives::U256;
 use reth_chain_state::ExecutedBlock;
-use reth_payload_primitives::{PayloadBuilderError, PayloadTypes};
+use reth_payload_primitives::{PayloadBuilderError, PayloadKind, PayloadTypes};
 use reth_primitives::Block;
 use reth_provider::CanonStateNotification;
 use std::{
@@ -96,10 +96,7 @@ impl PayloadJob for TestPayloadJob {
         Ok(self.attr.clone())
     }
 
-    fn resolve(
-        &mut self,
-        _wait_for_pending: bool,
-    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let fut = futures_util::future::ready(self.best_payload());
         (fut, KeepPayloadJobAlive::No)
     }

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -96,7 +96,10 @@ impl PayloadJob for TestPayloadJob {
         Ok(self.attr.clone())
     }
 
-    fn resolve(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve_kind(
+        &mut self,
+        _kind: PayloadKind,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let fut = futures_util::future::ready(self.best_payload());
         (fut, KeepPayloadJobAlive::No)
     }

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -96,7 +96,10 @@ impl PayloadJob for TestPayloadJob {
         Ok(self.attr.clone())
     }
 
-    fn resolve(&mut self) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve(
+        &mut self,
+        _wait_for_pending: bool,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let fut = futures_util::future::ready(self.best_payload());
         (fut, KeepPayloadJobAlive::No)
     }

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -58,7 +58,15 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
     ///
     /// If `wait_for_pending` is provided and there's a payload building job in progress, returned
     /// future will first poll it until completion to get a potentially better payload.
-    fn resolve(&mut self, kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive);
+    fn resolve_kind(
+        &mut self,
+        kind: PayloadKind,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive);
+
+    /// Resolves the payload as fast as possible.
+    fn resolve(&mut self) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+        self.resolve_kind(PayloadKind::Earliest)
+    }
 }
 
 /// Whether the payload job should be kept alive or terminated after the payload was requested by

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -53,7 +53,13 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
     /// If this returns [`KeepPayloadJobAlive::Yes`], then the [`PayloadJob`] will be polled
     /// once more. If this returns [`KeepPayloadJobAlive::No`] then the [`PayloadJob`] will be
     /// dropped after this call.
-    fn resolve(&mut self) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive);
+    ///
+    /// If `wait_for_pending` is provided and there's a payload building job in progress, returned
+    /// future will first poll it until completion to get a potentially better payload.
+    fn resolve(
+        &mut self,
+        wait_for_pending: bool,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive);
 }
 
 /// Whether the payload job should be kept alive or terminated after the payload was requested by

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -55,6 +55,12 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
     /// If this returns [`KeepPayloadJobAlive::Yes`], then the [`PayloadJob`] will be polled
     /// once more. If this returns [`KeepPayloadJobAlive::No`] then the [`PayloadJob`] will be
     /// dropped after this call.
+    ///
+    /// The [`PayloadKind`] determines how the payload should be resolved in the
+    /// `ResolvePayloadFuture`. [`PayloadKind::Earliest`] should return the earliest available
+    /// payload (as fast as possible), e.g. racing an empty payload job against a pending job if
+    /// there's no payload available yet. [`PayloadKind::WaitForPending`] is allowed to wait
+    /// until a built payload is available.
     fn resolve_kind(
         &mut self,
         kind: PayloadKind,

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -1,6 +1,8 @@
 //! Trait abstractions used by the payload crate.
 
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadBuilderError};
+use reth_payload_primitives::{
+    BuiltPayload, PayloadBuilderAttributes, PayloadBuilderError, PayloadKind,
+};
 use reth_provider::CanonStateNotification;
 use std::future::Future;
 
@@ -56,10 +58,7 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
     ///
     /// If `wait_for_pending` is provided and there's a payload building job in progress, returned
     /// future will first poll it until completion to get a potentially better payload.
-    fn resolve(
-        &mut self,
-        wait_for_pending: bool,
-    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive);
+    fn resolve(&mut self, kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive);
 }
 
 /// Whether the payload job should be kept alive or terminated after the payload was requested by

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -55,9 +55,6 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
     /// If this returns [`KeepPayloadJobAlive::Yes`], then the [`PayloadJob`] will be polled
     /// once more. If this returns [`KeepPayloadJobAlive::No`] then the [`PayloadJob`] will be
     /// dropped after this call.
-    ///
-    /// If `wait_for_pending` is provided and there's a payload building job in progress, returned
-    /// future will first poll it until completion to get a potentially better payload.
     fn resolve_kind(
         &mut self,
         kind: PayloadKind,

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -346,7 +346,7 @@ pub enum EngineApiMessageVersion {
 pub enum PayloadKind {
     /// Returns the best available payload, without waiting for pending job to finish.
     #[default]
-    BestAvailable,
+    Earliest,
     /// If there's a pending job in progress, waits for it to finish and then chooses best payload
     /// accounting for the one just built.
     WaitForPending,

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -341,6 +341,17 @@ pub enum EngineApiMessageVersion {
     V4,
 }
 
+/// Determines how we should choose the payload to return.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PayloadKind {
+    /// Returns the best available payload, without waiting for pending job to finish.
+    #[default]
+    BestAvailable,
+    /// If there's a pending job in progress, waits for it to finish and then chooses best payload
+    /// accounting for the one just built.
+    WaitForPending,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -347,8 +347,7 @@ pub enum PayloadKind {
     /// Returns the best available payload, without waiting for pending job to finish.
     #[default]
     Earliest,
-    /// If there's a pending job in progress, waits for it to finish and then chooses best payload
-    /// accounting for the one just built.
+    /// Only returns once we have at least one built payload.
     WaitForPending,
 }
 

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -344,10 +344,22 @@ pub enum EngineApiMessageVersion {
 /// Determines how we should choose the payload to return.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PayloadKind {
-    /// Returns the best available payload, without waiting for pending job to finish.
+    /// Returns the next best available payload (the earliest available payload).
+    /// This does not wait for a real for pending job to finish if there's no best payload yet and
+    /// is allowed to race various payload jobs (empty, pending best) against each other and
+    /// returns whichever job finishes faster.
+    ///
+    /// This should be used when it's more important to return a valid payload as fast as possible.
+    /// For example, the engine API timeout for `engine_getPayload` is 1s and clients should rather
+    /// return an empty payload than indefinitely waiting for the pending payload job to finish and
+    /// risk missing the deadline.
     #[default]
     Earliest,
     /// Only returns once we have at least one built payload.
+    ///
+    /// Compared to [`PayloadKind::Earliest`] this does not race an empty payload job against the
+    /// already in progress one, and returns the best available built payload or awaits the job in
+    /// progress.
     WaitForPending,
 }
 

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -32,11 +32,20 @@ pub trait PayloadBuilder: Send + Unpin {
     ) -> Option<Result<<Self::PayloadType as PayloadTypes>::BuiltPayload, Self::Error>>;
 
     /// Resolves the payload job and returns the best payload that has been built so far.
-    async fn resolve(
+    async fn resolve_kind(
         &self,
         id: PayloadId,
         kind: PayloadKind,
     ) -> Option<Result<<Self::PayloadType as PayloadTypes>::BuiltPayload, Self::Error>>;
+
+    /// Resolves the payload job as fast and possible and returns the best payload that has been
+    /// built so far.
+    async fn resolve(
+        &self,
+        id: PayloadId,
+    ) -> Option<Result<<Self::PayloadType as PayloadTypes>::BuiltPayload, Self::Error>> {
+        self.resolve_kind(id, PayloadKind::Earliest).await
+    }
 
     /// Sends a message to the service to subscribe to payload events.
     /// Returns a receiver that will receive them.

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{PayloadEvents, PayloadTypes};
+use crate::{PayloadEvents, PayloadKind, PayloadTypes};
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::{
     engine::{PayloadAttributes as EthPayloadAttributes, PayloadId},
@@ -35,7 +35,7 @@ pub trait PayloadBuilder: Send + Unpin {
     async fn resolve(
         &self,
         id: PayloadId,
-        wait_for_pending: bool,
+        kind: PayloadKind,
     ) -> Option<Result<<Self::PayloadType as PayloadTypes>::BuiltPayload, Self::Error>>;
 
     /// Sends a message to the service to subscribe to payload events.

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{PayloadBuilderError, PayloadEvents, PayloadTypes};
+use crate::{PayloadEvents, PayloadTypes};
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::{
     engine::{PayloadAttributes as EthPayloadAttributes, PayloadId},
@@ -7,11 +7,7 @@ use alloy_rpc_types::{
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chain_state::ExecutedBlock;
 use reth_primitives::{SealedBlock, Withdrawals};
-use std::{future::Future, pin::Pin};
 use tokio::sync::oneshot;
-
-pub(crate) type PayloadFuture<P> =
-    Pin<Box<dyn Future<Output = Result<P, PayloadBuilderError>> + Send + Sync>>;
 
 /// A type that can request, subscribe to and resolve payloads.
 #[async_trait::async_trait]
@@ -21,12 +17,13 @@ pub trait PayloadBuilder: Send + Unpin {
     /// The error type returned by the builder.
     type Error;
 
-    /// Sends a message to the service to start building a new payload for the given payload
-    /// attributes and returns a future that resolves to the payload.
-    async fn send_and_resolve_payload(
+    /// Sends a message to the service to start building a new payload for the given payload.
+    ///
+    /// Returns a receiver that will receive the payload id.
+    fn send_new_payload(
         &self,
         attr: <Self::PayloadType as PayloadTypes>::PayloadBuilderAttributes,
-    ) -> Result<PayloadFuture<<Self::PayloadType as PayloadTypes>::BuiltPayload>, Self::Error>;
+    ) -> oneshot::Receiver<Result<PayloadId, Self::Error>>;
 
     /// Returns the best payload for the given identifier.
     async fn best_payload(
@@ -34,22 +31,12 @@ pub trait PayloadBuilder: Send + Unpin {
         id: PayloadId,
     ) -> Option<Result<<Self::PayloadType as PayloadTypes>::BuiltPayload, Self::Error>>;
 
-    /// Sends a message to the service to start building a new payload for the given payload.
-    ///
-    /// This is the same as [`PayloadBuilder::new_payload`] but does not wait for the result
-    /// and returns the receiver instead
-    fn send_new_payload(
+    /// Resolves the payload job and returns the best payload that has been built so far.
+    async fn resolve(
         &self,
-        attr: <Self::PayloadType as PayloadTypes>::PayloadBuilderAttributes,
-    ) -> oneshot::Receiver<Result<PayloadId, Self::Error>>;
-
-    /// Starts building a new payload for the given payload attributes.
-    ///
-    /// Returns the identifier of the payload.
-    async fn new_payload(
-        &self,
-        attr: <Self::PayloadType as PayloadTypes>::PayloadBuilderAttributes,
-    ) -> Result<PayloadId, Self::Error>;
+        id: PayloadId,
+        wait_for_pending: bool,
+    ) -> Option<Result<<Self::PayloadType as PayloadTypes>::BuiltPayload, Self::Error>>;
 
     /// Sends a message to the service to subscribe to payload events.
     /// Returns a receiver that will receive them.

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -260,7 +260,7 @@ where
     ) -> EngineApiResult<EngineT::ExecutionPayloadV1> {
         self.inner
             .payload_store
-            .resolve(payload_id)
+            .resolve(payload_id, false)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -295,7 +295,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id)
+            .resolve(payload_id, false)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -330,7 +330,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id)
+            .resolve(payload_id, false)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -365,7 +365,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id)
+            .resolve(payload_id, false)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -17,7 +17,7 @@ use reth_engine_primitives::{EngineTypes, EngineValidator};
 use reth_evm::provider::EvmEnvProvider;
 use reth_payload_builder::PayloadStore;
 use reth_payload_primitives::{
-    validate_payload_timestamp, EngineApiMessageVersion, PayloadBuilderAttributes,
+    validate_payload_timestamp, EngineApiMessageVersion, PayloadBuilderAttributes, PayloadKind,
     PayloadOrAttributes,
 };
 use reth_primitives::{Block, BlockHashOrNumber, EthereumHardfork};
@@ -260,7 +260,7 @@ where
     ) -> EngineApiResult<EngineT::ExecutionPayloadV1> {
         self.inner
             .payload_store
-            .resolve(payload_id, false)
+            .resolve(payload_id, PayloadKind::BestAvailable)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -295,7 +295,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id, false)
+            .resolve(payload_id, PayloadKind::BestAvailable)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -330,7 +330,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id, false)
+            .resolve(payload_id, PayloadKind::BestAvailable)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -365,7 +365,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id, false)
+            .resolve(payload_id, PayloadKind::BestAvailable)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -17,7 +17,7 @@ use reth_engine_primitives::{EngineTypes, EngineValidator};
 use reth_evm::provider::EvmEnvProvider;
 use reth_payload_builder::PayloadStore;
 use reth_payload_primitives::{
-    validate_payload_timestamp, EngineApiMessageVersion, PayloadBuilderAttributes, PayloadKind,
+    validate_payload_timestamp, EngineApiMessageVersion, PayloadBuilderAttributes,
     PayloadOrAttributes,
 };
 use reth_primitives::{Block, BlockHashOrNumber, EthereumHardfork};
@@ -260,7 +260,7 @@ where
     ) -> EngineApiResult<EngineT::ExecutionPayloadV1> {
         self.inner
             .payload_store
-            .resolve(payload_id, PayloadKind::BestAvailable)
+            .resolve(payload_id)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -295,7 +295,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id, PayloadKind::BestAvailable)
+            .resolve(payload_id)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -330,7 +330,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id, PayloadKind::BestAvailable)
+            .resolve(payload_id)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?
@@ -365,7 +365,7 @@ where
         // Now resolve the payload
         self.inner
             .payload_store
-            .resolve(payload_id, PayloadKind::BestAvailable)
+            .resolve(payload_id)
             .await
             .ok_or(EngineApiError::UnknownPayload)?
             .map_err(|_| EngineApiError::UnknownPayload)?

--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -53,7 +53,10 @@ where
         Ok(self.config.attributes.clone())
     }
 
-    fn resolve(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve_kind(
+        &mut self,
+        _kind: PayloadKind,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let payload = self.best_payload();
         (futures_util::future::ready(payload), KeepPayloadJobAlive::No)
     }

--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -52,7 +52,10 @@ where
         Ok(self.config.attributes.clone())
     }
 
-    fn resolve(&mut self) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve(
+        &mut self,
+        _wait_for_pending: bool,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let payload = self.best_payload();
         (futures_util::future::ready(payload), KeepPayloadJobAlive::No)
     }

--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -3,6 +3,7 @@ use reth::{
     providers::StateProviderFactory, tasks::TaskSpawner, transaction_pool::TransactionPool,
 };
 use reth_basic_payload_builder::{PayloadBuilder, PayloadConfig};
+use reth_node_api::PayloadKind;
 use reth_payload_builder::{KeepPayloadJobAlive, PayloadBuilderError, PayloadJob};
 
 use std::{
@@ -52,10 +53,7 @@ where
         Ok(self.config.attributes.clone())
     }
 
-    fn resolve(
-        &mut self,
-        _wait_for_pending: bool,
-    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+    fn resolve(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
         let payload = self.best_payload();
         (futures_util::future::ready(payload), KeepPayloadJobAlive::No)
     }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/11716

Added `wait_for_pending` argument to `resolve` methods which allows to configure whether returned future should wait for a payload job in progress.

Added `resolve` method and removed unused `new_payload` and `send_and_resolve_payload` methods from `PayloadBuilder` trait.