### PR TITLE
fix(trie): intermediate trie node hashes

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -338,9 +338,7 @@ impl RevealedSparseTrie {
                     } else {
                         let value = self.values.get(&path).unwrap();
                         let rlp_node = LeafNodeRef { key, value }.rlp(&mut self.rlp_buf);
-                        if let Some(node_hash) = rlp_node.as_hash() {
-                            *hash = Some(node_hash);
-                        }
+                        *hash = rlp_node.as_hash();
                         rlp_node
                     }
                 }
@@ -353,9 +351,7 @@ impl RevealedSparseTrie {
                         let (_, child) = rlp_node_stack.pop().unwrap();
                         self.rlp_buf.clear();
                         let rlp_node = ExtensionNodeRef::new(key, &child).rlp(&mut self.rlp_buf);
-                        if let Some(node_hash) = rlp_node.as_hash() {
-                            *hash = Some(node_hash);
-                        }
+                        *hash = rlp_node.as_hash();
                         rlp_node
                     } else {
                         path_stack.extend([path, child_path]); // need to get rlp node for child first
@@ -393,9 +389,7 @@ impl RevealedSparseTrie {
                     self.rlp_buf.clear();
                     let rlp_node = BranchNodeRef::new(&branch_value_stack_buf, *state_mask)
                         .rlp(&mut self.rlp_buf);
-                    if let Some(node_hash) = rlp_node.as_hash() {
-                        *hash = Some(node_hash);
-                    }
+                    *hash = rlp_node.as_hash();
                     rlp_node
                 }
             };


### PR DESCRIPTION
## Description

If the path to the node is in the prefix set, `SparseNode` hash must always be reset regardless if it's a hash or not.