### PR TITLE
feat: drop ExEx WAL on `reth db drop`

### DIFF
--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -71,6 +71,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         let data_dir = self.env.datadir.clone().resolve_datadir(self.env.chain.chain());
         let db_path = data_dir.db();
         let static_files_path = data_dir.static_files();
+        let exex_wal_path = data_dir.exex_wal();
 
         // ensure the provided datadir exist
         eyre::ensure!(
@@ -127,7 +128,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 
                 let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
                 let tool = DbTool::new(provider_factory)?;
-                tool.drop(db_path, static_files_path)?;
+                tool.drop(db_path, static_files_path, exex_wal_path)?;
             }
             Subcommands::Clear(command) => {
                 let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;

--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -131,11 +131,12 @@ impl<N: ProviderNodeTypes> DbTool<N> {
             .map_err(|e| eyre::eyre!(e))
     }
 
-    /// Drops the database and the static files at the given path.
-    pub fn drop(
+    /// Drops the database, the static files and exex WAL at the given paths.
+    pub fn drop<P: AsRef<Path>>(
         &self,
-        db_path: impl AsRef<Path>,
-        static_files_path: impl AsRef<Path>,
+        db_path: P,
+        static_files_path: P,
+        exex_wal_path: P,
     ) -> Result<()> {
         let db_path = db_path.as_ref();
         info!(target: "reth::cli", "Dropping database at {:?}", db_path);
@@ -145,6 +146,10 @@ impl<N: ProviderNodeTypes> DbTool<N> {
         info!(target: "reth::cli", "Dropping static files at {:?}", static_files_path);
         fs::remove_dir_all(static_files_path)?;
         fs::create_dir_all(static_files_path)?;
+
+        let exex_wal_path = exex_wal_path.as_ref();
+        info!(target: "reth::cli", "Dropping ExEx WAL at {:?}", exex_wal_path);
+        fs::remove_dir_all(exex_wal_path)?;
 
         Ok(())
     }

--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -131,7 +131,7 @@ impl<N: ProviderNodeTypes> DbTool<N> {
             .map_err(|e| eyre::eyre!(e))
     }
 
-    /// Drops the database, the static files and exex WAL at the given paths.
+    /// Drops the database, the static files and ExEx WAL at the given paths.
     pub fn drop<P: AsRef<Path>>(
         &self,
         db_path: P,


### PR DESCRIPTION
Possible solutions:

1. Since we are use `reth db drop` primary as a re-sync, so I think we can drop not only db & static files, but WAL also.
2. Another option is `reth exex` - `exex` CLI subcommand to fully operate the WAL and future things around ExEx control.

This PR contains (1) approach.