### PR TITLE
chore: rm unused reth-revm c-kzg feature

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -32,8 +32,7 @@ reth-ethereum-forks.workspace = true
 alloy-primitives.workspace = true
 
 [features]
-default = ["std", "c-kzg"]
+default = ["std"]
 std = []
-c-kzg = ["revm/c-kzg"]
 test-utils = ["dep:reth-trie"]
 serde = ["revm/serde"]


### PR DESCRIPTION
removes no longer used c-kzg feature.

we should remove all delegating features because this can result in a footgun instead all revm features should be enabled on revm directly on the node level:

https://github.com/paradigmxyz/reth/blob/a6946e0693f94ee2dbd08416707eaf5f23fd71ab/crates/ethereum/node/Cargo.toml#L35-L35

https://github.com/paradigmxyz/reth/blob/a6946e0693f94ee2dbd08416707eaf5f23fd71ab/crates/optimism/node/Cargo.toml#L46-L46