### PR TITLE
refactor: BlockchainTestCase::run rm repetitive convert ForkSpec to ChainSpec

### DIFF
--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloy_rlp::Decodable;
 use rayon::iter::{ParallelBridge, ParallelIterator};
+use reth_chainspec::ChainSpec;
 use reth_primitives::{BlockBody, SealedBlock, StaticFileSegment};
 use reth_provider::{
     providers::StaticFileWriter, test_utils::create_test_provider_factory_with_chain_spec,
@@ -83,11 +84,10 @@ impl Case for BlockchainTestCase {
             .par_bridge()
             .try_for_each(|case| {
                 // Create a new test database and initialize a provider for the test case.
-                let provider = create_test_provider_factory_with_chain_spec(Arc::new(
-                    case.network.clone().into(),
-                ))
-                .database_provider_rw()
-                .unwrap();
+                let chain_spec: Arc<ChainSpec> = Arc::new((&case.network).into());
+                let provider = create_test_provider_factory_with_chain_spec(chain_spec.clone())
+                    .database_provider_rw()
+                    .unwrap();
 
                 // Insert initial test state into the provider.
                 provider.insert_historical_block(
@@ -127,9 +127,7 @@ impl Case for BlockchainTestCase {
                 // Execute the execution stage using the EVM processor factory for the test case
                 // network.
                 let _ = ExecutionStage::new_with_executor(
-                    reth_evm_ethereum::execute::EthExecutorProvider::ethereum(Arc::new(
-                        case.network.clone().into(),
-                    )),
+                    reth_evm_ethereum::execute::EthExecutorProvider::ethereum(chain_spec),
                 )
                 .execute(
                     &provider,

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -84,7 +84,7 @@ impl Case for BlockchainTestCase {
             .par_bridge()
             .try_for_each(|case| {
                 // Create a new test database and initialize a provider for the test case.
-                let chain_spec: Arc<ChainSpec> = Arc::new((&case.network).into());
+                let chain_spec: Arc<ChainSpec> = Arc::new(case.network.into());
                 let provider = create_test_provider_factory_with_chain_spec(chain_spec.clone())
                     .database_provider_rw()
                     .unwrap();

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -257,7 +257,7 @@ impl Account {
 }
 
 /// Fork specification.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Ord, Clone, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Ord, Clone, Copy, Deserialize)]
 pub enum ForkSpec {
     /// Frontier
     Frontier,
@@ -313,11 +313,11 @@ pub enum ForkSpec {
     Unknown,
 }
 
-impl From<&ForkSpec> for ChainSpec {
-    fn from(fork_spec: &ForkSpec) -> Self {
+impl From<ForkSpec> for ChainSpec {
+    fn from(fork_spec: ForkSpec) -> Self {
         let spec_builder = ChainSpecBuilder::mainnet();
 
-        match *fork_spec {
+        match fork_spec {
             ForkSpec::Frontier => spec_builder.frontier_activated(),
             ForkSpec::Homestead | ForkSpec::FrontierToHomesteadAt5 => {
                 spec_builder.homestead_activated()

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -313,11 +313,11 @@ pub enum ForkSpec {
     Unknown,
 }
 
-impl From<ForkSpec> for ChainSpec {
-    fn from(fork_spec: ForkSpec) -> Self {
+impl From<&ForkSpec> for ChainSpec {
+    fn from(fork_spec: &ForkSpec) -> Self {
         let spec_builder = ChainSpecBuilder::mainnet();
 
-        match fork_spec {
+        match *fork_spec {
             ForkSpec::Frontier => spec_builder.frontier_activated(),
             ForkSpec::Homestead | ForkSpec::FrontierToHomesteadAt5 => {
                 spec_builder.homestead_activated()


### PR DESCRIPTION
It seems that `From<ForkSpec> for ChainSpec` should be `From<&ForkSpec> for ChainSpec`, we don't consume ForkSpec.
It seems that chain_spec we can only calc once.