### PR TITLE
chore: fix cargo feature warning

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -101,7 +101,7 @@ tempfile.workspace = true
 [features]
 default = ["jemalloc"]
 
-dev = ["reth-cli-commands/dev"]
+dev = ["reth-cli-commands/arbitrary"]
 
 asm-keccak = [
 	"reth-node-core/asm-keccak",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -88,7 +88,8 @@ reth-discv4.workspace = true
 
 [features]
 default = []
-dev = [
+dev = ["arbitrary"]
+arbitrary = [
     "dep:proptest",
     "dep:arbitrary",
     "dep:proptest-arbitrary-interop",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -94,4 +94,9 @@ arbitrary = [
     "dep:proptest-arbitrary-interop",
     "reth-primitives/arbitrary",
     "reth-db-api/arbitrary",
+    "reth-eth-wire/arbitrary",
+    "reth-db/arbitrary",
+    "reth-chainspec/arbitrary",
+    "alloy-eips/arbitrary",
+    "alloy-primitives/arbitrary",
 ]

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -88,7 +88,6 @@ reth-discv4.workspace = true
 
 [features]
 default = []
-dev = ["arbitrary"]
 arbitrary = [
     "dep:proptest",
     "dep:arbitrary",

--- a/crates/cli/commands/src/lib.rs
+++ b/crates/cli/commands/src/lib.rs
@@ -20,7 +20,7 @@ pub mod p2p;
 pub mod prune;
 pub mod recover;
 pub mod stage;
-#[cfg(feature = "dev")]
+#[cfg(feature = "arbitrary")]
 pub mod test_vectors;
 
 pub use node::NodeCommand;


### PR DESCRIPTION
I was getting the following warning when try to build with `--features arbitrary`:
```
Using dep: syntax in Cargo.toml makes it impossible to enable features for dependencies unless you also have a feature by that name 
```

This seems to fix it but I'm honestly not sure what the expected behavior of cargo is (https://github.com/rust-lang/cargo/issues/10788 was closed as fixed)