### PR TITLE
refactor: replace extra fields with `ExecutionPayloadSidecar` in engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6393,7 +6393,6 @@ dependencies = [
 name = "reth-beacon-consensus"
 version = "1.1.0"
 dependencies = [
- "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8354,7 +8353,6 @@ dependencies = [
 name = "reth-payload-validator"
 version = "1.1.0"
 dependencies = [
- "alloy-eips",
  "alloy-rpc-types",
  "reth-chainspec",
  "reth-primitives",

--- a/bin/reth/src/commands/debug_cmd/replay_engine.rs
+++ b/bin/reth/src/commands/debug_cmd/replay_engine.rs
@@ -170,10 +170,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                         beacon_engine_handle.fork_choice_updated(state, payload_attrs).await?;
                     debug!(target: "reth::cli", ?response, "Received for forkchoice updated");
                 }
-                StoredEngineApiMessage::NewPayload { payload, cancun_fields } => {
-                    // todo: prague (last arg)
-                    let response =
-                        beacon_engine_handle.new_payload(payload, cancun_fields, None).await?;
+                StoredEngineApiMessage::NewPayload { payload, sidecar } => {
+                    let response = beacon_engine_handle.new_payload(payload, sidecar).await?;
                     debug!(target: "reth::cli", ?response, "Received for new payload");
                 }
             };

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -31,7 +31,6 @@ reth-node-types.workspace = true
 reth-chainspec = { workspace = true, optional = true }
 
 # ethereum
-alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 
@@ -78,10 +77,10 @@ assert_matches.workspace = true
 
 [features]
 optimism = [
-	"reth-chainspec",
-	"reth-primitives/optimism",
-	"reth-provider/optimism",
-	"reth-blockchain-tree/optimism",
-	"reth-db/optimism",
-	"reth-db-api/optimism"
+    "reth-chainspec",
+    "reth-primitives/optimism",
+    "reth-provider/optimism",
+    "reth-blockchain-tree/optimism",
+    "reth-db/optimism",
+    "reth-db-api/optimism",
 ]

--- a/crates/consensus/beacon/src/engine/message.rs
+++ b/crates/consensus/beacon/src/engine/message.rs
@@ -1,7 +1,6 @@
 use crate::engine::{error::BeaconOnNewPayloadError, forkchoice::ForkchoiceStatus};
-use alloy_eips::eip7685::Requests;
 use alloy_rpc_types_engine::{
-    CancunPayloadFields, ExecutionPayload, ForkChoiceUpdateResult, ForkchoiceState,
+    ExecutionPayload, ExecutionPayloadSidecar, ForkChoiceUpdateResult, ForkchoiceState,
     ForkchoiceUpdateError, ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum,
 };
 use futures::{future::Either, FutureExt};
@@ -145,12 +144,9 @@ pub enum BeaconEngineMessage<Engine: EngineTypes> {
     NewPayload {
         /// The execution payload received by Engine API.
         payload: ExecutionPayload,
-        /// The cancun-related newPayload fields, if any.
-        cancun_fields: Option<CancunPayloadFields>,
-        // HACK(onbjerg): We should have a pectra payload fields struct, this is just a temporary
-        // workaround.
-        /// The pectra EIP-7685 execution requests.
-        execution_requests: Option<Requests>,
+        /// The execution payload sidecar with additional version-specific fields received by
+        /// engine API.
+        sidecar: ExecutionPayloadSidecar,
         /// The sender for returning payload status result.
         tx: oneshot::Sender<Result<PayloadStatus, BeaconOnNewPayloadError>>,
     },

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_primitives::{BlockNumber, Sealable, B256};
 use alloy_rpc_types_engine::{
-    CancunPayloadFields, ExecutionPayload, ForkchoiceState, ForkchoiceUpdated, PayloadStatus,
+    ExecutionPayload, ExecutionPayloadSidecar, ForkchoiceState, ForkchoiceUpdated, PayloadStatus,
 };
 use reth_blockchain_tree::{
     config::BlockchainTreeConfig, externals::TreeExternals, BlockchainTree, ShareableBlockchainTree,
@@ -68,9 +68,9 @@ impl<DB> TestEnv<DB> {
     pub async fn send_new_payload<T: Into<ExecutionPayload>>(
         &self,
         payload: T,
-        cancun_fields: Option<CancunPayloadFields>,
+        sidecar: ExecutionPayloadSidecar,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
-        self.engine_handle.new_payload(payload.into(), cancun_fields, None).await
+        self.engine_handle.new_payload(payload.into(), sidecar).await
     }
 
     /// Sends the `ExecutionPayload` message to the consensus engine and retries if the engine
@@ -78,11 +78,11 @@ impl<DB> TestEnv<DB> {
     pub async fn send_new_payload_retry_on_syncing<T: Into<ExecutionPayload>>(
         &self,
         payload: T,
-        cancun_fields: Option<CancunPayloadFields>,
+        sidecar: ExecutionPayloadSidecar,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
         let payload: ExecutionPayload = payload.into();
         loop {
-            let result = self.send_new_payload(payload.clone(), cancun_fields.clone()).await?;
+            let result = self.send_new_payload(payload.clone(), sidecar.clone()).await?;
             if !result.is_syncing() {
                 return Ok(result)
             }

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -1,7 +1,7 @@
 //! Contains the implementation of the mining mode for the local engine.
 
 use alloy_primitives::{TxHash, B256};
-use alloy_rpc_types_engine::{CancunPayloadFields, ForkchoiceState};
+use alloy_rpc_types_engine::{CancunPayloadFields, ExecutionPayloadSidecar, ForkchoiceState};
 use eyre::OptionExt;
 use futures_util::{stream::Fuse, StreamExt};
 use reth_beacon_consensus::BeaconEngineMessage;
@@ -221,9 +221,10 @@ where
         let (tx, rx) = oneshot::channel();
         self.to_engine.send(BeaconEngineMessage::NewPayload {
             payload: block_to_payload(payload.block().clone()),
-            cancun_fields,
-            // todo: prague
-            execution_requests: None,
+            // todo: prague support
+            sidecar: cancun_fields
+                .map(ExecutionPayloadSidecar::v3)
+                .unwrap_or_else(ExecutionPayloadSidecar::none),
             tx,
         })?;
 

--- a/crates/engine/util/src/skip_new_payload.rs
+++ b/crates/engine/util/src/skip_new_payload.rs
@@ -41,19 +41,14 @@ where
         loop {
             let next = ready!(this.stream.poll_next_unpin(cx));
             let item = match next {
-                Some(BeaconEngineMessage::NewPayload {
-                    payload,
-                    cancun_fields,
-                    execution_requests,
-                    tx,
-                }) => {
+                Some(BeaconEngineMessage::NewPayload { payload, sidecar, tx }) => {
                     if this.skipped < this.threshold {
                         *this.skipped += 1;
                         tracing::warn!(
                             target: "engine::stream::skip_new_payload",
                             block_number = payload.block_number(),
                             block_hash = %payload.block_hash(),
-                            ?cancun_fields,
+                            ?sidecar,
                             threshold=this.threshold,
                             skipped=this.skipped, "Skipping new payload"
                         );
@@ -61,12 +56,7 @@ where
                         continue
                     }
                     *this.skipped = 0;
-                    Some(BeaconEngineMessage::NewPayload {
-                        payload,
-                        cancun_fields,
-                        execution_requests,
-                        tx,
-                    })
+                    Some(BeaconEngineMessage::NewPayload { payload, sidecar, tx })
                 }
                 next => next,
             };

--- a/crates/payload/validator/Cargo.toml
+++ b/crates/payload/validator/Cargo.toml
@@ -18,5 +18,4 @@ reth-primitives.workspace = true
 reth-rpc-types-compat.workspace = true
 
 # alloy
-alloy-eips.workspace = true
 alloy-rpc-types = { workspace = true, features = ["engine"] }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -5,8 +5,8 @@ use alloy_eips::{eip4844::BlobAndProofV1, eip7685::Requests};
 use alloy_primitives::{BlockHash, BlockNumber, B256, U64};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ClientVersionV1, ExecutionPayload, ExecutionPayloadBodiesV1,
-    ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV3, ForkchoiceState,
-    ForkchoiceUpdated, PayloadId, PayloadStatus, TransitionConfiguration,
+    ExecutionPayloadInputV2, ExecutionPayloadSidecar, ExecutionPayloadV1, ExecutionPayloadV3,
+    ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus, TransitionConfiguration,
 };
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
@@ -140,7 +140,11 @@ where
         self.inner
             .validator
             .validate_version_specific_fields(EngineApiMessageVersion::V1, payload_or_attrs)?;
-        Ok(self.inner.beacon_consensus.new_payload(payload, None, None).await?)
+        Ok(self
+            .inner
+            .beacon_consensus
+            .new_payload(payload, ExecutionPayloadSidecar::none())
+            .await?)
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2>
@@ -156,7 +160,11 @@ where
         self.inner
             .validator
             .validate_version_specific_fields(EngineApiMessageVersion::V2, payload_or_attrs)?;
-        Ok(self.inner.beacon_consensus.new_payload(payload, None, None).await?)
+        Ok(self
+            .inner
+            .beacon_consensus
+            .new_payload(payload, ExecutionPayloadSidecar::none())
+            .await?)
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#engine_newpayloadv3>
@@ -176,9 +184,17 @@ where
             .validator
             .validate_version_specific_fields(EngineApiMessageVersion::V3, payload_or_attrs)?;
 
-        let cancun_fields = CancunPayloadFields { versioned_hashes, parent_beacon_block_root };
-
-        Ok(self.inner.beacon_consensus.new_payload(payload, Some(cancun_fields), None).await?)
+        Ok(self
+            .inner
+            .beacon_consensus
+            .new_payload(
+                payload,
+                ExecutionPayloadSidecar::v3(CancunPayloadFields {
+                    versioned_hashes,
+                    parent_beacon_block_root,
+                }),
+            )
+            .await?)
     }
 
     /// See also <https://github.com/ethereum/execution-apis/blob/7907424db935b93c2fe6a3c0faab943adebe8557/src/engine/prague.md#engine_newpayloadv4>
@@ -187,8 +203,6 @@ where
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
-        // TODO(onbjerg): Figure out why we even get these here, since we'll check the requests
-        // from execution against the requests root in the header.
         execution_requests: Requests,
     ) -> EngineApiResult<PayloadStatus> {
         let payload = ExecutionPayload::from(payload);
@@ -201,14 +215,16 @@ where
             .validator
             .validate_version_specific_fields(EngineApiMessageVersion::V4, payload_or_attrs)?;
 
-        let cancun_fields = CancunPayloadFields { versioned_hashes, parent_beacon_block_root };
-
-        // HACK(onbjerg): We should have a pectra payload fields struct, this is just a temporary
-        // workaround.
         Ok(self
             .inner
             .beacon_consensus
-            .new_payload(payload, Some(cancun_fields), Some(execution_requests))
+            .new_payload(
+                payload,
+                ExecutionPayloadSidecar::v4(
+                    CancunPayloadFields { versioned_hashes, parent_beacon_block_root },
+                    execution_requests,
+                ),
+            )
             .await?)
     }
 

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -3,7 +3,8 @@
 use alloy_primitives::{Bytes, Sealable, U256};
 use alloy_rlp::{Decodable, Error as RlpError};
 use alloy_rpc_types_engine::{
-    ExecutionPayload, ExecutionPayloadBodyV1, ExecutionPayloadV1, PayloadError,
+    ExecutionPayload, ExecutionPayloadBodyV1, ExecutionPayloadSidecar, ExecutionPayloadV1,
+    PayloadError,
 };
 use assert_matches::assert_matches;
 use reth_primitives::{proofs, Block, SealedBlock, SealedHeader, TransactionSigned, Withdrawals};
@@ -75,7 +76,10 @@ fn payload_validation() {
         b
     });
 
-    assert_matches!(try_into_sealed_block(block_with_valid_extra_data, None, None), Ok(_));
+    assert_matches!(
+        try_into_sealed_block(block_with_valid_extra_data, &ExecutionPayloadSidecar::none()),
+        Ok(_)
+    );
 
     // Invalid extra data
     let block_with_invalid_extra_data = Bytes::from_static(&[0; 33]);
@@ -84,7 +88,7 @@ fn payload_validation() {
         b
     });
     assert_matches!(
-        try_into_sealed_block(invalid_extra_data_block, None, None),
+        try_into_sealed_block(invalid_extra_data_block, &ExecutionPayloadSidecar::none()),
         Err(PayloadError::ExtraData(data)) if data == block_with_invalid_extra_data
     );
 
@@ -94,7 +98,7 @@ fn payload_validation() {
         b
     });
     assert_matches!(
-        try_into_sealed_block(block_with_zero_base_fee, None, None),
+        try_into_sealed_block(block_with_zero_base_fee, &ExecutionPayloadSidecar::none()),
         Err(PayloadError::BaseFee(val)) if val.is_zero()
     );
 
@@ -113,7 +117,7 @@ fn payload_validation() {
         b
     });
     assert_matches!(
-        try_into_sealed_block(block_with_ommers.clone(), None, None),
+        try_into_sealed_block(block_with_ommers.clone(), &ExecutionPayloadSidecar::none()),
         Err(PayloadError::BlockHash { consensus, .. })
             if consensus == block_with_ommers.block_hash()
     );
@@ -124,7 +128,7 @@ fn payload_validation() {
         b
     });
     assert_matches!(
-        try_into_sealed_block(block_with_difficulty.clone(), None, None),
+        try_into_sealed_block(block_with_difficulty.clone(), &ExecutionPayloadSidecar::none()),
         Err(PayloadError::BlockHash { consensus, .. }) if consensus == block_with_difficulty.block_hash()
     );
 
@@ -134,9 +138,8 @@ fn payload_validation() {
         b
     });
     assert_matches!(
-        try_into_sealed_block(block_with_nonce.clone(), None, None),
+        try_into_sealed_block(block_with_nonce.clone(), &ExecutionPayloadSidecar::none()),
         Err(PayloadError::BlockHash { consensus, .. }) if consensus == block_with_nonce.block_hash()
-
     );
 
     // Valid block


### PR DESCRIPTION
Follow up on #11865 

Replaces the hack to add execution requests throughout the engine + engine interceptor components with the new `ExecutionPayloadSidecar` introduced in https://github.com/alloy-rs/alloy/pull/1517. The `ExecutionPayloadSidecar` replaces both Prague and Cancun fields.

This also finishes Prague integration in most of the engine interceptors, but does not adjust a lot of the testing code we have to support execution requests.