### PR TITLE
fix: spawn network manager on test exex ctx

### DIFF
--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -268,15 +268,16 @@ pub async fn test_exex_context_with_chain_spec(
     let network_manager = NetworkManager::new(
         NetworkConfigBuilder::new(SecretKey::new(&mut rand::thread_rng()))
             .with_unused_discovery_port()
+            .with_unused_listener_port()
             .build(provider_factory.clone()),
     )
     .await?;
     let network = network_manager.handle().clone();
-
-    let (_, payload_builder) = NoopPayloadBuilderService::<EthEngineTypes>::new();
-
     let tasks = TaskManager::current();
     let task_executor = tasks.executor();
+    tasks.executor().spawn(network_manager);
+
+    let (_, payload_builder) = NoopPayloadBuilderService::<EthEngineTypes>::new();
 
     let components = NodeAdapter::<FullNodeTypesAdapter<NodeTypesWithDBAdapter<TestNode, _>, _>, _> {
         components: Components {


### PR DESCRIPTION
I realized with https://github.com/paradigmxyz/reth-exex-examples/pull/26

That on adding a peer the Network manager would not pick up the message to add it. After some digging i realised it was not being spawned.

CC: @mattsse @shekhirin 