### PR TITLE
chore(ci): update excluded crates in wasm checker

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -36,7 +36,6 @@ exclude_crates=(
   reth-ethereum-engine-primitives
   reth-ethereum-payload-builder
   reth-etl
-  reth-evm-ethereum
   reth-exex
   reth-exex-test-utils
   reth-ipc


### PR DESCRIPTION
After https://github.com/paradigmxyz/reth/pull/11838 `reth-evm-ethereum` crate builds correctly for `wasm32-wasip1` target.