### PR TITLE
chore: introduce ExecuteOutput

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -14,7 +14,7 @@ use reth_ethereum_consensus::validate_block_post_execution;
 use reth_evm::{
     execute::{
         BasicBlockExecutorProvider, BlockExecutionError, BlockExecutionStrategy,
-        BlockExecutionStrategyFactory, BlockValidationError, ProviderError,
+        BlockExecutionStrategyFactory, BlockValidationError, ExecuteOutput, ProviderError,
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, SystemCaller},
@@ -152,7 +152,7 @@ where
         &mut self,
         block: &BlockWithSenders,
         total_difficulty: U256,
-    ) -> Result<(Vec<Receipt>, u64), Self::Error> {
+    ) -> Result<ExecuteOutput, Self::Error> {
         let env = self.evm_env_for_block(&block.header, total_difficulty);
         let mut evm = self.evm_config.evm_with_env(&mut self.state, env);
 
@@ -203,7 +203,7 @@ where
                 },
             );
         }
-        Ok((receipts, cumulative_gas_used))
+        Ok(ExecuteOutput { receipts, gas_used: cumulative_gas_used })
     }
 
     fn apply_post_execution_changes(

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -166,6 +166,15 @@ pub trait BlockExecutorProvider: Send + Sync + Clone + Unpin + 'static {
         DB: Database<Error: Into<ProviderError> + Display>;
 }
 
+/// Helper type for the output of executing a block.
+#[derive(Debug, Clone)]
+pub struct ExecuteOutput {
+    /// Receipts obtained after executing a block.
+    pub receipts: Vec<Receipt>,
+    /// Cumulative gas used in the block execution.
+    pub gas_used: u64,
+}
+
 /// Defines the strategy for executing a single block.
 pub trait BlockExecutionStrategy<DB> {
     /// The error type returned by this strategy's methods.
@@ -183,7 +192,7 @@ pub trait BlockExecutionStrategy<DB> {
         &mut self,
         block: &BlockWithSenders,
         total_difficulty: U256,
-    ) -> Result<(Vec<Receipt>, u64), Self::Error>;
+    ) -> Result<ExecuteOutput, Self::Error>;
 
     /// Applies any necessary changes after executing the block's transactions.
     fn apply_post_execution_changes(
@@ -313,7 +322,8 @@ where
         let BlockExecutionInput { block, total_difficulty } = input;
 
         self.strategy.apply_pre_execution_changes(block, total_difficulty)?;
-        let (receipts, gas_used) = self.strategy.execute_transactions(block, total_difficulty)?;
+        let ExecuteOutput { receipts, gas_used } =
+            self.strategy.execute_transactions(block, total_difficulty)?;
         let requests =
             self.strategy.apply_post_execution_changes(block, total_difficulty, &receipts)?;
         let state = self.strategy.finish();
@@ -332,7 +342,8 @@ where
         let BlockExecutionInput { block, total_difficulty } = input;
 
         self.strategy.apply_pre_execution_changes(block, total_difficulty)?;
-        let (receipts, gas_used) = self.strategy.execute_transactions(block, total_difficulty)?;
+        let ExecuteOutput { receipts, gas_used } =
+            self.strategy.execute_transactions(block, total_difficulty)?;
         let requests =
             self.strategy.apply_post_execution_changes(block, total_difficulty, &receipts)?;
 
@@ -356,7 +367,8 @@ where
         self.strategy.with_state_hook(Some(Box::new(state_hook)));
 
         self.strategy.apply_pre_execution_changes(block, total_difficulty)?;
-        let (receipts, gas_used) = self.strategy.execute_transactions(block, total_difficulty)?;
+        let ExecuteOutput { receipts, gas_used } =
+            self.strategy.execute_transactions(block, total_difficulty)?;
         let requests =
             self.strategy.apply_post_execution_changes(block, total_difficulty, &receipts)?;
 
@@ -407,7 +419,8 @@ where
         }
 
         self.strategy.apply_pre_execution_changes(block, total_difficulty)?;
-        let (receipts, _gas_used) = self.strategy.execute_transactions(block, total_difficulty)?;
+        let ExecuteOutput { receipts, .. } =
+            self.strategy.execute_transactions(block, total_difficulty)?;
         let requests =
             self.strategy.apply_post_execution_changes(block, total_difficulty, &receipts)?;
 
@@ -545,14 +558,14 @@ mod tests {
         _chain_spec: Arc<ChainSpec>,
         _evm_config: EvmConfig,
         state: State<DB>,
-        execute_transactions_result: (Vec<Receipt>, u64),
+        execute_transactions_result: ExecuteOutput,
         apply_post_execution_changes_result: Requests,
         finish_result: BundleState,
     }
 
     #[derive(Clone)]
     struct TestExecutorStrategyFactory {
-        execute_transactions_result: (Vec<Receipt>, u64),
+        execute_transactions_result: ExecuteOutput,
         apply_post_execution_changes_result: Requests,
         finish_result: BundleState,
     }
@@ -599,7 +612,7 @@ mod tests {
             &mut self,
             _block: &BlockWithSenders,
             _total_difficulty: U256,
-        ) -> Result<(Vec<Receipt>, u64), Self::Error> {
+        ) -> Result<ExecuteOutput, Self::Error> {
             Ok(self.execute_transactions_result.clone())
         }
 
@@ -651,7 +664,8 @@ mod tests {
     fn test_strategy() {
         let expected_gas_used = 10;
         let expected_receipts = vec![Receipt::default()];
-        let expected_execute_transactions_result = (expected_receipts.clone(), expected_gas_used);
+        let expected_execute_transactions_result =
+            ExecuteOutput { receipts: expected_receipts.clone(), gas_used: expected_gas_used };
         let expected_apply_post_execution_changes_result = Requests::new(vec![bytes!("deadbeef")]);
         let expected_finish_result = BundleState::default();
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -10,7 +10,7 @@ use reth_consensus::ConsensusError;
 use reth_evm::{
     execute::{
         BasicBlockExecutorProvider, BlockExecutionError, BlockExecutionStrategy,
-        BlockExecutionStrategyFactory, BlockValidationError, ProviderError,
+        BlockExecutionStrategyFactory, BlockValidationError, ExecuteOutput, ProviderError,
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, SystemCaller},
@@ -155,7 +155,7 @@ where
         &mut self,
         block: &BlockWithSenders,
         total_difficulty: U256,
-    ) -> Result<(Vec<Receipt>, u64), Self::Error> {
+    ) -> Result<ExecuteOutput, Self::Error> {
         let env = self.evm_env_for_block(&block.header, total_difficulty);
         let mut evm = self.evm_config.evm_with_env(&mut self.state, env);
 
@@ -240,7 +240,7 @@ where
             });
         }
 
-        Ok((receipts, cumulative_gas_used))
+        Ok(ExecuteOutput { receipts, gas_used: cumulative_gas_used })
     }
 
     fn apply_post_execution_changes(


### PR DESCRIPTION
Follow up of #11838 and #11846, introduce helper type `ExecuteOutput { receipts, gas_used }` to represent the ok result of `BlockExecutionStrategy::execute_transactions` instead of `(Vec<Receipt>, u64)`