### PR TITLE
refactor(tx-pool): move `is_underpriced` to `ValidPoolTransaction` impl

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1510,52 +1510,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
         Ok(new_blob_tx)
     }
 
-    /// Returns true if the replacement candidate is underpriced and can't replace the existing
-    /// transaction.
-    #[inline]
-    fn is_underpriced(
-        existing_transaction: &ValidPoolTransaction<T>,
-        maybe_replacement: &ValidPoolTransaction<T>,
-        price_bumps: &PriceBumpConfig,
-    ) -> bool {
-        let price_bump = price_bumps.price_bump(existing_transaction.tx_type());
-
-        if maybe_replacement.max_fee_per_gas() <=
-            existing_transaction.max_fee_per_gas() * (100 + price_bump) / 100
-        {
-            return true
-        }
-
-        let existing_max_priority_fee_per_gas =
-            existing_transaction.transaction.max_priority_fee_per_gas().unwrap_or(0);
-        let replacement_max_priority_fee_per_gas =
-            maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or(0);
-
-        if replacement_max_priority_fee_per_gas <=
-            existing_max_priority_fee_per_gas * (100 + price_bump) / 100 &&
-            existing_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas != 0
-        {
-            return true
-        }
-
-        // check max blob fee per gas
-        if let Some(existing_max_blob_fee_per_gas) =
-            existing_transaction.transaction.max_fee_per_blob_gas()
-        {
-            // this enforces that blob txs can only be replaced by blob txs
-            let replacement_max_blob_fee_per_gas =
-                maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or(0);
-            if replacement_max_blob_fee_per_gas <=
-                existing_max_blob_fee_per_gas * (100 + price_bump) / 100
-            {
-                return true
-            }
-        }
-
-        false
-    }
-
     /// Inserts a new _valid_ transaction into the pool.
     ///
     /// If the transaction already exists, it will be replaced if not underpriced.
@@ -1670,8 +1624,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 let maybe_replacement = transaction.as_ref();
 
                 // Ensure the new transaction is not underpriced
-                if Self::is_underpriced(existing_transaction, maybe_replacement, &self.price_bumps)
-                {
+                if existing_transaction.is_underpriced(maybe_replacement, &self.price_bumps) {
                     return Err(InsertErr::Underpriced {
                         transaction: pool_tx.transaction,
                         existing: *entry.get().transaction.hash(),

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -374,8 +374,8 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         self.is_eip4844() != other.is_eip4844()
     }
 
-    /// Determines whether a candidate transaction (maybe_replacement) is underpriced compared to an
-    /// existing transaction in the pool.
+    /// Determines whether a candidate transaction (`maybe_replacement`) is underpriced compared to
+    /// an existing transaction in the pool.
     ///
     /// A transaction is considered underpriced if it doesn't meet the required fee bump threshold.
     /// This applies to both standard gas fees and, for blob-carrying transactions (EIP-4844),
@@ -383,7 +383,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     #[inline]
     pub(crate) fn is_underpriced(
         &self,
-        maybe_replacement: &ValidPoolTransaction<T>,
+        maybe_replacement: &Self,
         price_bumps: &PriceBumpConfig,
     ) -> bool {
         // Retrieve the required price bump percentage for this type of transaction.

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     error::InvalidPoolTransactionError,
     identifier::{SenderId, TransactionId},
     traits::{PoolTransaction, TransactionOrigin},
+    PriceBumpConfig,
 };
 use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
@@ -371,6 +372,58 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     #[inline]
     pub(crate) fn tx_type_conflicts_with(&self, other: &Self) -> bool {
         self.is_eip4844() != other.is_eip4844()
+    }
+
+    /// Determines whether a candidate transaction (maybe_replacement) is underpriced compared to an
+    /// existing transaction in the pool.
+    ///
+    /// A transaction is considered underpriced if it doesn't meet the required fee bump threshold.
+    /// This applies to both standard gas fees and, for blob-carrying transactions (EIP-4844),
+    /// the blob-specific fees.
+    #[inline]
+    pub(crate) fn is_underpriced(
+        &self,
+        maybe_replacement: &ValidPoolTransaction<T>,
+        price_bumps: &PriceBumpConfig,
+    ) -> bool {
+        // Retrieve the required price bump percentage for this type of transaction.
+        //
+        // The bump is different for EIP-4844 and other transactions. See `PriceBumpConfig`.
+        let price_bump = price_bumps.price_bump(self.tx_type());
+
+        // Check if the max fee per gas is underpriced.
+        if maybe_replacement.max_fee_per_gas() <= self.max_fee_per_gas() * (100 + price_bump) / 100
+        {
+            return true
+        }
+
+        let existing_max_priority_fee_per_gas =
+            self.transaction.max_priority_fee_per_gas().unwrap_or_default();
+        let replacement_max_priority_fee_per_gas =
+            maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or_default();
+
+        // Check max priority fee per gas (relevant for EIP-1559 transactions only)
+        if existing_max_priority_fee_per_gas != 0 &&
+            replacement_max_priority_fee_per_gas != 0 &&
+            replacement_max_priority_fee_per_gas <=
+                existing_max_priority_fee_per_gas * (100 + price_bump) / 100
+        {
+            return true
+        }
+
+        // Check max blob fee per gas
+        if let Some(existing_max_blob_fee_per_gas) = self.transaction.max_fee_per_blob_gas() {
+            // This enforces that blob txs can only be replaced by blob txs
+            let replacement_max_blob_fee_per_gas =
+                maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or_default();
+            if replacement_max_blob_fee_per_gas <=
+                existing_max_blob_fee_per_gas * (100 + price_bump) / 100
+            {
+                return true
+            }
+        }
+
+        false
     }
 }
 


### PR DESCRIPTION
- As `is_underpriced` contains two `ValidPoolTransaction` as arguments, it seems more logical to move the function inside `ValidPoolTransaction` implementation.
- The documentation is a little bit improved to explain steps because there are a lot of calculations there.
- `unwrap_or(0)` is replaced by default usage
- In if conditions, simplest assertions to check are moved first for the function to output fast is this necessary condition is not met.