### PR TITLE
feat: default impl for some BlockExecutionStrategy methods

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -21,7 +21,7 @@ use reth_evm::{
     ConfigureEvm,
 };
 use reth_primitives::{BlockWithSenders, Receipt};
-use reth_revm::db::{states::bundle_state::BundleRetention, BundleState, State};
+use reth_revm::db::State;
 use revm_primitives::{
     db::{Database, DatabaseCommit},
     BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ResultAndState, U256,
@@ -262,11 +262,6 @@ where
 
     fn with_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
         self.system_caller.with_state_hook(hook);
-    }
-
-    fn finish(&mut self) -> BundleState {
-        self.state.merge_transitions(BundleRetention::Reverts);
-        self.state.take_bundle()
     }
 
     fn validate_block_post_execution(

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -119,6 +119,7 @@ impl<DB> BatchExecutor<DB> for MockExecutorProvider {
 impl<S, DB> BasicBlockExecutor<S, DB>
 where
     S: BlockExecutionStrategy<DB>,
+    DB: Database,
 {
     /// Provides safe read access to the state
     pub fn with_state<F, R>(&self, f: F) -> R
@@ -140,6 +141,7 @@ where
 impl<S, DB> BasicBatchExecutor<S, DB>
 where
     S: BlockExecutionStrategy<DB>,
+    DB: Database,
 {
     /// Provides safe read access to the state
     pub fn with_state<F, R>(&self, f: F) -> R

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -20,10 +20,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::validate_block_post_execution;
 use reth_optimism_forks::OptimismHardfork;
 use reth_primitives::{BlockWithSenders, Header, Receipt, TxType};
-use reth_revm::{
-    db::{states::bundle_state::BundleRetention, BundleState},
-    Database, State,
-};
+use reth_revm::{Database, State};
 use revm_primitives::{
     db::DatabaseCommit, BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ResultAndState, U256,
 };
@@ -269,11 +266,6 @@ where
 
     fn with_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
         self.system_caller.with_state_hook(hook);
-    }
-
-    fn finish(&mut self) -> BundleState {
-        self.state.merge_transitions(BundleRetention::Reverts);
-        self.state.take_bundle()
     }
 
     fn validate_block_post_execution(


### PR DESCRIPTION
The implemented methods are:
* `finish`: full implementation taking advantage of `state_mut`.
* `with_state_hook`: empty, no state hook by default.
* `validate_block_post_execution`: empty, no validation on batch executor by default.