### PR TITLE
refactor(primitives-traits): rm useless trait bounds for `Receipt`

### DIFF
--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -1,7 +1,5 @@
 //! Receipt abstraction
 
-use alloc::fmt;
-
 use alloy_consensus::TxReceipt;
 use reth_codecs::Compact;
 use serde::{Deserialize, Serialize};
@@ -14,10 +12,6 @@ impl<T> FullReceipt for T where T: Receipt + Compact {}
 /// Abstraction of a receipt.
 pub trait Receipt:
     TxReceipt
-    + Clone
-    + fmt::Debug
-    + PartialEq
-    + Eq
     + Default
     + alloy_rlp::Encodable
     + alloy_rlp::Decodable


### PR DESCRIPTION
Already implemented at an alloy level: 

https://github.com/alloy-rs/alloy/blob/f1ebdb3c6928a1dcfa26c39dd2f166897c6c2568/crates/consensus/src/receipt/mod.rs#L19