### PR TITLE
expose budgets for p2p via cli

### DIFF
--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -247,7 +247,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -236,6 +236,41 @@ Networking:
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
 
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
+
       --to <TO>
           The maximum block height
 

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -238,37 +238,37 @@ Networking:
 
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
       --to <TO>

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -235,40 +235,40 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-          
+
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
       --retries <RETRIES>

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -247,7 +247,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -235,6 +235,41 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
 
       --retries <RETRIES>
           The number of retries per request

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -235,40 +235,40 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-          
+
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
       --retries <RETRIES>

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -247,7 +247,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -235,6 +235,41 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
 
       --retries <RETRIES>
           The number of retries per request

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -247,7 +247,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -235,40 +235,40 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-          
+
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
       --engine-api-store <PATH>

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -235,6 +235,41 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
 
       --engine-api-store <PATH>
           The path to read engine API messages from

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -228,6 +228,41 @@ Networking:
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
 
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
+
 RPC:
       --http
           Enable the HTTP-RPC server

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -230,32 +230,32 @@ Networking:
 
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -239,7 +239,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 
@@ -260,7 +262,7 @@ Networking:
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
 RPC:

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -212,40 +212,40 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-          
+
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
 Datadir:

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -224,7 +224,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -212,6 +212,41 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
 
 Datadir:
       --datadir <DATA_DIR>

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -278,40 +278,40 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-          
+
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
 Logging:

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -278,6 +278,41 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
 
 Logging:
       --log.stdout.format <FORMAT>

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -290,7 +290,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -240,40 +240,40 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-          
+
       --budget-try-drain-system <DEFAULT_BUDGET>
           Default budget to try and drain streams
-          
+
           [default: 10]
 
       --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
           Default budget to try and drain headers and bodies download streams.
-          
+
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
           Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
-          
+
           [default: 10]
 
       --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
           Budget for draining egress transaction gossip
-          
+
           [default: 40]
 
       --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
           Budget for draining ingress transaction gossip and transaction requests
-          
+
           [default: 10]
 
       --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
           Budget for advancing import of transaction batches into pool.
-          
+
           [default: 40]
 
       --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
           Budget for propagating transactions that have successfully been imported into pool.
-          
+
           [default: 40]
 
       --offline

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -252,7 +252,9 @@ Networking:
           [default: 2]
 
       --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
-          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+          connection updates. When the node has stabilised at max peer count, work done by an
+          iteration in this stream will, to the most part, be accounted for by ingress traffic.
 
           [default: 10]
 

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -240,6 +240,41 @@ Networking:
           Name of network interface used to communicate with peers.
 
           If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          
+      --budget-try-drain-system <DEFAULT_BUDGET>
+          Default budget to try and drain streams
+          
+          [default: 10]
+
+      --budget-try-drain-downloaders <BUDGET_BLOCKS_DOWN>
+          Default budget to try and drain headers and bodies download streams.
+          
+          [default: 2]
+
+      --budget-try-drain-swarm <BUDGET_ALL_INGRESS>
+          Budget for draining all ingress traffic, eth [and other capability] messages, and p2p connection updates. When the node has stabilised at max peer count, work done by an iteration in this stream will, to the most part, be accounted for by ingress traffic.
+          
+          [default: 10]
+
+      --budget-try-drain-network-handle-channel <BUDGET_EGRESS_GOSSIP>
+          Budget for draining egress transaction gossip
+          
+          [default: 40]
+
+      --budget-try-drain-network-transaction-events <BUDGET_INGRESS_TX_MSGS>
+          Budget for draining ingress transaction gossip and transaction requests
+          
+          [default: 10]
+
+      --budget-try-drain-pending-pool-imports <BUDGET_POOL_IMPORTS>
+          Budget for advancing import of transaction batches into pool.
+          
+          [default: 40]
+
+      --budget-try-drain-pool-imports <BUDGET_PROPAGATE_GOSSIP>
+          Budget for propagating transactions that have successfully been imported into pool.
+          
+          [default: 40]
 
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound

--- a/crates/net/network/src/budget.rs
+++ b/crates/net/network/src/budget.rs
@@ -8,6 +8,7 @@ pub const DEFAULT_BUDGET_TRY_DRAIN_STREAM: u32 = 10;
 /// Default is 2 iterations.
 pub const DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS: u32 = 2;
 
+#[allow(rustdoc::private_intra_doc_links)]
 /// Default budget to try and drain [`Swarm`](crate::swarm::Swarm).
 ///
 /// Default is 10 [`SwarmEvent`](crate::swarm::SwarmEvent)s.

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -124,7 +124,9 @@ pub mod peers;
 pub mod protocol;
 pub mod transactions;
 
-mod budget;
+/// Default Budgets
+pub mod budget;
+
 mod builder;
 mod discovery;
 mod fetch;

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -49,7 +49,7 @@ use crate::{
 /// `include_mmd!("docs/mermaid/swarm.mmd`")
 #[derive(Debug)]
 #[must_use = "Swarm does nothing unless polled"]
-pub(crate) struct Swarm {
+pub struct Swarm {
     /// Listens for new incoming connections.
     incoming: ConnectionListener,
     /// All sessions.
@@ -333,7 +333,7 @@ impl Stream for Swarm {
 
 /// All events created or delegated by the [`Swarm`] that represents changes to the state of the
 /// network.
-pub(crate) enum SwarmEvent {
+pub enum SwarmEvent {
     /// Events related to the actual network protocol.
     ValidMessage {
         /// The peer that sent the message

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -163,31 +163,33 @@ pub struct NetworkArgs {
 
     #[arg(long = "budget-try-drain-system", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_STREAM, verbatim_doc_comment)]
     /// Default budget to try and drain streams
-    pub budget_try_drain_stream: u32,
+    pub default_budget: u32,
 
     #[arg(long = "budget-try-drain-downloaders", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS, verbatim_doc_comment)]
     /// Default budget to try and drain headers and bodies download streams.
-    pub budget_try_drain_downloaders: u32,
+    pub budget_blocks_down: u32,
 
     #[arg(long = "budget-try-drain-swarm", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_SWARM, verbatim_doc_comment)]
-    /// Budget for draining swarm
-    pub budget_try_drain_swarm: u32,
+    /// Budget for draining all ingress traffic, eth [and other capability] messages, and p2p
+    /// connection updates. When the node has stabilised at max peer count, work done by an
+    /// iteration in this stream will, to the most part, be accounted for by ingress traffic.
+    pub budget_all_ingress: u32,
 
     #[arg(long = "budget-try-drain-network-handle-channel", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_NETWORK_HANDLE_CHANNEL, verbatim_doc_comment)]
-    /// Budget for draining network handle channel
-    pub budget_try_drain_network_handle_channel: u32,
+    /// Budget for draining egress transaction gossip
+    pub budget_egress_gossip: u32,
 
     #[arg(long = "budget-try-drain-network-transaction-events", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_NETWORK_TRANSACTION_EVENTS, verbatim_doc_comment)]
-    /// Budget for draining network transaction events
-    pub budget_try_drain_network_transaction_events: u32,
+    /// Budget for draining ingress transaction gossip and transaction requests
+    pub budget_ingress_tx_msgs: u32,
 
     #[arg(long = "budget-try-drain-pending-pool-imports", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS, verbatim_doc_comment)]
-    /// Budget for draining pending pool imports
-    pub budget_try_drain_pending_pool_imports: u32,
+    /// Budget for advancing import of transaction batches into pool.
+    pub budget_pool_imports: u32,
 
     #[arg(long = "budget-try-drain-pool-imports", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_POOL_IMPORTS, verbatim_doc_comment)]
-    /// Budget for draining pool imports
-    pub budget_try_drain_pool_imports: u32,
+    /// Budget for propagating transactions that have successfully been imported into pool.
+    pub budget_propagate_gossip: u32,
 }
 
 impl NetworkArgs {
@@ -366,13 +368,13 @@ impl Default for NetworkArgs {
             max_seen_tx_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
             max_capacity_cache_txns_pending_fetch: DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH,
             net_if: None,
-            budget_try_drain_stream: DEFAULT_BUDGET_TRY_DRAIN_STREAM,
-            budget_try_drain_downloaders: DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS,
-            budget_try_drain_swarm: DEFAULT_BUDGET_TRY_DRAIN_SWARM,
-            budget_try_drain_network_handle_channel: DEFAULT_BUDGET_TRY_DRAIN_NETWORK_HANDLE_CHANNEL,
-            budget_try_drain_network_transaction_events: DEFAULT_BUDGET_TRY_DRAIN_NETWORK_TRANSACTION_EVENTS,
-            budget_try_drain_pending_pool_imports: DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS,
-            budget_try_drain_pool_imports: DEFAULT_BUDGET_TRY_DRAIN_POOL_IMPORTS,
+            default_budget: DEFAULT_BUDGET_TRY_DRAIN_STREAM,
+            budget_blocks_down: DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS,
+            budget_all_ingress: DEFAULT_BUDGET_TRY_DRAIN_SWARM,
+            budget_egress_gossip: DEFAULT_BUDGET_TRY_DRAIN_NETWORK_HANDLE_CHANNEL,
+            budget_ingress_tx_msgs: DEFAULT_BUDGET_TRY_DRAIN_NETWORK_TRANSACTION_EVENTS,
+            budget_pool_imports: DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS,
+            budget_propagate_gossip: DEFAULT_BUDGET_TRY_DRAIN_POOL_IMPORTS,
         }
     }
 }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -16,6 +16,12 @@ use reth_discv5::{
 };
 use reth_net_nat::{NatResolver, DEFAULT_NET_IF_NAME};
 use reth_network::{
+    budget::{
+        DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS, DEFAULT_BUDGET_TRY_DRAIN_NETWORK_HANDLE_CHANNEL,
+        DEFAULT_BUDGET_TRY_DRAIN_NETWORK_TRANSACTION_EVENTS,
+        DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS, DEFAULT_BUDGET_TRY_DRAIN_POOL_IMPORTS,
+        DEFAULT_BUDGET_TRY_DRAIN_STREAM, DEFAULT_BUDGET_TRY_DRAIN_SWARM,
+    },
     transactions::{
         constants::{
             tx_fetcher::{
@@ -154,6 +160,34 @@ pub struct NetworkArgs {
     /// If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
     #[arg(long = "net-if.experimental", conflicts_with = "addr", value_name = "IF_NAME")]
     pub net_if: Option<String>,
+
+    #[arg(long = "budget-try-drain-system", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_STREAM, verbatim_doc_comment)]
+    /// Default budget to try and drain streams
+    pub budget_try_drain_stream: u32,
+
+    #[arg(long = "budget-try-drain-downloaders", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS, verbatim_doc_comment)]
+    /// Default budget to try and drain headers and bodies download streams.
+    pub budget_try_drain_downloaders: u32,
+
+    #[arg(long = "budget-try-drain-swarm", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_SWARM, verbatim_doc_comment)]
+    /// Budget for draining swarm
+    pub budget_try_drain_swarm: u32,
+
+    #[arg(long = "budget-try-drain-network-handle-channel", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_NETWORK_HANDLE_CHANNEL, verbatim_doc_comment)]
+    /// Budget for draining network handle channel
+    pub budget_try_drain_network_handle_channel: u32,
+
+    #[arg(long = "budget-try-drain-network-transaction-events", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_NETWORK_TRANSACTION_EVENTS, verbatim_doc_comment)]
+    /// Budget for draining network transaction events
+    pub budget_try_drain_network_transaction_events: u32,
+
+    #[arg(long = "budget-try-drain-pending-pool-imports", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS, verbatim_doc_comment)]
+    /// Budget for draining pending pool imports
+    pub budget_try_drain_pending_pool_imports: u32,
+
+    #[arg(long = "budget-try-drain-pool-imports", default_value_t = DEFAULT_BUDGET_TRY_DRAIN_POOL_IMPORTS, verbatim_doc_comment)]
+    /// Budget for draining pool imports
+    pub budget_try_drain_pool_imports: u32,
 }
 
 impl NetworkArgs {
@@ -332,6 +366,13 @@ impl Default for NetworkArgs {
             max_seen_tx_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
             max_capacity_cache_txns_pending_fetch: DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH,
             net_if: None,
+            budget_try_drain_stream: DEFAULT_BUDGET_TRY_DRAIN_STREAM,
+            budget_try_drain_downloaders: DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS,
+            budget_try_drain_swarm: DEFAULT_BUDGET_TRY_DRAIN_SWARM,
+            budget_try_drain_network_handle_channel: DEFAULT_BUDGET_TRY_DRAIN_NETWORK_HANDLE_CHANNEL,
+            budget_try_drain_network_transaction_events: DEFAULT_BUDGET_TRY_DRAIN_NETWORK_TRANSACTION_EVENTS,
+            budget_try_drain_pending_pool_imports: DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS,
+            budget_try_drain_pool_imports: DEFAULT_BUDGET_TRY_DRAIN_POOL_IMPORTS,
         }
     }
 }


### PR DESCRIPTION
Hello @emhane !

This is a wip for #11637. I'm trying to follow the same steps as `max-pending-imports` from `crates/node/core/src/args/network.rs`, but the budgets are not showing up in the CLI. I'm uncertain if this is the right approach or if there's a better path to take.