### PR TITLE
test(trie): proptest <-> alloy maps integration

### DIFF
--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -8,4 +8,3 @@ members = [
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
-

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -198,6 +198,8 @@ fn generate_test_data(size: usize) -> HashMap<B256, U256> {
         .new_tree(&mut runner)
         .unwrap()
         .current()
+        .into_iter()
+        .collect()
 }
 
 criterion_group!(root, calculate_root_from_leaves, calculate_root_from_leaves_repeated);

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1240,6 +1240,6 @@ mod tests {
                 ),
                 1..100,
             )
-        )| { test(updates) });
+        )| { test(updates.into_iter().collect()) });
     }
 }


### PR DESCRIPTION
Alloy maps changed the default hasher in https://github.com/alloy-rs/core/pull/777, so we need to transform the `proptest`-generated HashMap into a new type.