### PR TITLE
feat(discv4): add soft_remove_node

### DIFF
--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -46,7 +46,7 @@ serde = { workspace = true, optional = true }
 [dev-dependencies]
 assert_matches.workspace = true
 rand.workspace = true
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 reth-tracing.workspace = true
 
 [features]


### PR DESCRIPTION
prep for #11968

this extracts the half empty bucket check to a standalone function so it can be reused