### PR TITLE
chore: log enode

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -11,7 +11,7 @@ use reth_ethereum_engine_primitives::{
 };
 use reth_evm::execute::BasicBlockExecutorProvider;
 use reth_evm_ethereum::execute::EthExecutionStrategyFactory;
-use reth_network::NetworkHandle;
+use reth_network::{NetworkHandle, PeersInfo};
 use reth_node_api::{
     AddOnsContext, ConfigureEvm, EngineValidator, FullNodeComponents, NodePrimitives,
     NodeTypesWithDB,
@@ -314,7 +314,7 @@ where
     ) -> eyre::Result<NetworkHandle> {
         let network = ctx.network_builder().await?;
         let handle = ctx.start_network(network, pool);
-
+        info!(target: "reth::cli", enode=%handle.local_node_record(), "P2P networking initialized");
         Ok(handle)
     }
 }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_chainspec::{EthChainSpec, Hardforks};
 use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
-use reth_network::{NetworkConfig, NetworkHandle, NetworkManager};
+use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, PeersInfo};
 use reth_node_api::{
     AddOnsContext, EngineValidator, FullNodeComponents, NodeAddOns, NodePrimitives,
 };
@@ -432,6 +432,7 @@ where
         let network_config = self.network_config(ctx)?;
         let network = NetworkManager::builder(network_config).await?;
         let handle = ctx.start_network(network, pool);
+        info!(target: "reth::cli", enode=%handle.local_node_record(), "P2P networking initialized");
 
         Ok(handle)
     }


### PR DESCRIPTION
we could do this also in one of the helpers, but feels cleaner to do this on the builder level like the other initialized logs even if this means duplicating this a bit