### PR TITLE
tx-pool: migrate `ensure_max_init_code_size` to `PoolTransaction` trait

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -817,8 +817,8 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
 mod tests {
     use super::*;
     use crate::{
-        blobstore::InMemoryBlobStore, error::PoolErrorKind, CoinbaseTipOrdering,
-        EthPooledTransaction, Pool, TransactionPool,
+        blobstore::InMemoryBlobStore, error::PoolErrorKind, traits::PoolTransaction,
+        CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionPool,
     };
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{hex, U256};

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -223,7 +223,7 @@ where
 
         // Check whether the init code size has been exceeded.
         if self.fork_tracker.is_shanghai_activated() {
-            if let Err(err) = ensure_max_init_code_size(&transaction, MAX_INIT_CODE_BYTE_SIZE) {
+            if let Err(err) = transaction.ensure_max_init_code_size(MAX_INIT_CODE_BYTE_SIZE) {
                 return TransactionValidationOutcome::Invalid(transaction, err)
             }
         }
@@ -711,7 +711,7 @@ impl EthTransactionValidatorBuilder {
         EthTransactionValidator { inner: Arc::new(inner) }
     }
 
-    /// Builds a the [`EthTransactionValidator`] and spawns validation tasks via the
+    /// Builds a [`EthTransactionValidator`] and spawns validation tasks via the
     /// [`TransactionValidationTaskExecutor`]
     ///
     /// The validator will spawn `additional_tasks` additional tasks for validation.
@@ -780,22 +780,6 @@ impl ForkTracker {
     /// Returns `true` if Prague fork is activated.
     pub fn is_prague_activated(&self) -> bool {
         self.prague.load(std::sync::atomic::Ordering::Relaxed)
-    }
-}
-
-/// Ensure that the code size is not greater than `max_init_code_size`.
-/// `max_init_code_size` should be configurable so this will take it as an argument.
-pub fn ensure_max_init_code_size<T: PoolTransaction>(
-    transaction: &T,
-    max_init_code_size: usize,
-) -> Result<(), InvalidPoolTransactionError> {
-    if transaction.kind().is_create() && transaction.input().len() > max_init_code_size {
-        Err(InvalidPoolTransactionError::ExceedsMaxInitCodeSize(
-            transaction.size(),
-            max_init_code_size,
-        ))
-    } else {
-        Ok(())
     }
 }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     traits::TransactionOrigin,
     validate::{ValidTransaction, ValidationTask, MAX_INIT_CODE_BYTE_SIZE},
-    EthBlobTransactionSidecar, EthPoolTransaction, LocalTransactionConfig, PoolTransaction,
+    EthBlobTransactionSidecar, EthPoolTransaction, LocalTransactionConfig,
     TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
 };
 use alloy_consensus::constants::{


### PR DESCRIPTION
Seems like logical to move there instead of an independent function. Maybe in the future we can think of something like a supertrait `ValidatePoolTransaction: PoolTransaction` where we can store such a function and `ensure_intrinsic_gas` for example.