### PR TITLE
perf: improve debug_traceBlock performance

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -135,7 +135,10 @@ where
                         }),
                         &mut shared_inspector,
                     )?;
-                    shared_inspector.as_mut().map(|i| i.fuse());
+
+                    if let Some(i) = shared_inspector.as_mut() {
+                        i.fuse();
+                    }
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {
@@ -601,7 +604,9 @@ where
                             &mut shared_inspector,
                         )?;
 
-                        shared_inspector.as_mut().map(|i| i.fuse());
+                        if let Some(i) = shared_inspector.as_mut() {
+                            i.fuse();
+                        }
 
                         // If there is more transactions, commit the database
                         // If there is no transactions, but more bundles, commit to the database too
@@ -845,7 +850,7 @@ where
         let gas_used = res.result.gas_used();
         let return_value = res.result.into_output().unwrap_or_default();
         inspector.set_transaction_gas_limit(env.tx.gas_limit);
-        let frame = inspector.geth_builder().geth_traces(gas_used, return_value, config.clone());
+        let frame = inspector.geth_builder().geth_traces(gas_used, return_value, *config);
 
         Ok((frame.into(), res.state))
     }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -112,6 +112,7 @@ where
                 let mut results = Vec::with_capacity(transactions.len());
                 let mut db = CacheDB::new(StateProviderDatabase::new(state));
                 let mut transactions = transactions.into_iter().enumerate().peekable();
+                let mut shared_inspector = None;
                 while let Some((index, tx)) = transactions.next() {
                     let tx_hash = tx.hash;
 
@@ -124,7 +125,7 @@ where
                         handler_cfg: cfg.handler_cfg,
                     };
                     let (result, state_changes) = this.trace_transaction(
-                        opts.clone(),
+                        &opts,
                         env,
                         &mut db,
                         Some(TransactionContext {
@@ -132,7 +133,9 @@ where
                             tx_hash: Some(tx_hash),
                             tx_index: Some(index),
                         }),
+                        &mut shared_inspector,
                     )?;
+                    shared_inspector.as_mut().map(|i| i.fuse());
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {
@@ -295,7 +298,7 @@ where
                 };
 
                 this.trace_transaction(
-                    opts,
+                    &opts,
                     env,
                     &mut db,
                     Some(TransactionContext {
@@ -303,6 +306,7 @@ where
                         tx_index: Some(index),
                         tx_hash: Some(tx.hash),
                     }),
+                    &mut None,
                 )
                 .map(|(trace, _)| trace)
             })
@@ -573,6 +577,7 @@ where
                     let Bundle { transactions, block_override } = bundle;
 
                     let block_overrides = block_override.map(Box::new);
+                    let mut shared_inspector = None;
 
                     let mut transactions = transactions.into_iter().peekable();
                     while let Some(tx) = transactions.next() {
@@ -588,8 +593,15 @@ where
                             overrides,
                         )?;
 
-                        let (trace, state) =
-                            this.trace_transaction(tracing_options.clone(), env, &mut db, None)?;
+                        let (trace, state) = this.trace_transaction(
+                            &tracing_options,
+                            env,
+                            &mut db,
+                            None,
+                            &mut shared_inspector,
+                        )?;
+
+                        shared_inspector.as_mut().map(|i| i.fuse());
 
                         // If there is more transactions, commit the database
                         // If there is no transactions, but more bundles, commit to the database too
@@ -699,10 +711,11 @@ where
     /// Caution: this is blocking and should be performed on a blocking task.
     fn trace_transaction(
         &self,
-        opts: GethDebugTracingOptions,
+        opts: &GethDebugTracingOptions,
         env: EnvWithHandlerCfg,
         db: &mut StateCacheDb<'_>,
         transaction_context: Option<TransactionContext>,
+        shared_inspector: &mut Option<TracingInspector>,
     ) -> Result<(GethTrace, revm_primitives::EvmState), Eth::Error> {
         let GethDebugTracingOptions { config, tracer, tracer_config, .. } = opts;
 
@@ -716,24 +729,27 @@ where
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
                         let call_config = tracer_config
+                            .clone()
                             .into_call_config()
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
 
-                        let mut inspector = TracingInspector::new(
+                        let mut inspector = shared_inspector.get_or_insert(TracingInspector::new(
                             TracingInspectorConfig::from_geth_call_config(&call_config),
-                        );
+                        ));
 
                         let (res, env) = self.eth_api().inspect(db, env, &mut inspector)?;
 
+                        inspector.set_transaction_gas_limit(env.tx.gas_limit);
+
                         let frame = inspector
-                            .with_transaction_gas_limit(env.tx.gas_limit)
-                            .into_geth_builder()
+                            .geth_builder()
                             .geth_call_traces(call_config, res.result.gas_used());
 
                         return Ok((frame.into(), res.state))
                     }
                     GethDebugBuiltInTracerType::PreStateTracer => {
                         let prestate_config = tracer_config
+                            .clone()
                             .into_pre_state_config()
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
 
@@ -755,6 +771,7 @@ where
                     }
                     GethDebugBuiltInTracerType::MuxTracer => {
                         let mux_config = tracer_config
+                            .clone()
                             .into_mux_config()
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
 
@@ -769,6 +786,7 @@ where
                     }
                     GethDebugBuiltInTracerType::FlatCallTracer => {
                         let flat_call_config = tracer_config
+                            .clone()
                             .into_flat_call_config()
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
 
@@ -799,10 +817,10 @@ where
                 }
                 #[cfg(feature = "js-tracer")]
                 GethDebugTracerType::JsTracer(code) => {
-                    let config = tracer_config.into_json();
+                    let config = tracer_config.clone().into_json();
                     let mut inspector =
                         revm_inspectors::tracing::js::JsInspector::with_transaction_context(
-                            code,
+                            code.clone(),
                             config,
                             transaction_context.unwrap_or_default(),
                         )
@@ -818,17 +836,16 @@ where
         }
 
         // default structlog tracer
-        let inspector_config = TracingInspectorConfig::from_geth_config(&config);
+        let inspector_config = TracingInspectorConfig::from_geth_config(config);
 
-        let mut inspector = TracingInspector::new(inspector_config);
+        //let mut inspector = TracingInspector::new(inspector_config);
+        let mut inspector = shared_inspector.get_or_insert(TracingInspector::new(inspector_config));
 
         let (res, env) = self.eth_api().inspect(db, env, &mut inspector)?;
         let gas_used = res.result.gas_used();
         let return_value = res.result.into_output().unwrap_or_default();
-        let frame = inspector
-            .with_transaction_gas_limit(env.tx.gas_limit)
-            .into_geth_builder()
-            .geth_traces(gas_used, return_value, config);
+        inspector.set_transaction_gas_limit(env.tx.gas_limit);
+        let frame = inspector.geth_builder().geth_traces(gas_used, return_value, config.clone());
 
         Ok((frame.into(), res.state))
     }


### PR DESCRIPTION
Fixes #11066 

Instead of creating TracingInspector on each call just use the optionally passed inspector and instead of cloning the whole `GethDebugTracingOptions` just clone the parts of it when necessary. 

One caveat of this approach is that if inspector was initialized with `CallConfig` and passed for `PreStateTracer` then this would not work, so caller of the `trace_transaction` needs to make sure that correct inspector is passed for the tracing.