### PR TITLE
fix: correctly poll `BasicBlockDownloader`

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -113,9 +113,11 @@ where
             }
 
             // advance the downloader
-            if let Poll::Ready(DownloadOutcome::Blocks(blocks)) = self.downloader.poll(cx) {
-                // delegate the downloaded blocks to the handler
-                self.handler.on_event(FromEngine::DownloadedBlocks(blocks));
+            if let Poll::Ready(outcome) = self.downloader.poll(cx) {
+                if let DownloadOutcome::Blocks(blocks) = outcome {
+                    // delegate the downloaded blocks to the handler
+                    self.handler.on_event(FromEngine::DownloadedBlocks(blocks));
+                }
                 continue
             }
 


### PR DESCRIPTION
Right now if we schedule block download, on next poll of `BasicBlockDownloader` we'll return `Poll:Ready` with `NewDownloadStarted` event and never register waker with actual downloading future.

Found this to be an issue when writing e2e tests, not sure if can occur during normal node operation