### PR TITLE
fix: invoke prometheus recorder on op-reth Cli::run

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -146,8 +146,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
         let _guard = self.init_tracing()?;
         info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
 
-        // Install the prometheus recorder to be sure to record task
-        // executor's metrics
+        // Install the prometheus recorder to be sure to record all metrics
         let _ = install_prometheus_recorder();
 
         let runner = CliRunner::default();

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -54,6 +54,7 @@ use tracing::info;
 // This allows us to manually enable node metrics features, required for proper jemalloc metric
 // reporting
 use reth_node_metrics as _;
+use reth_node_metrics::recorder::install_prometheus_recorder;
 
 /// The main op-reth cli interface.
 ///
@@ -134,6 +135,9 @@ where
 
         let _guard = self.init_tracing()?;
         info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
+
+        // Install the prometheus recorder to be sure to record all metrics
+        let _ = install_prometheus_recorder();
 
         let runner = CliRunner::default();
         match self.command {


### PR DESCRIPTION
fixes a metrics regression introduced in https://github.com/paradigmxyz/reth/pull/11738 this moved the install call into `Cli::run` but only did it for ethereum cli

