### PR TITLE
chore: bump alloy-eip7702

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.3.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15873ee28dfe5a1aeddd762483bc7f378b465ec49bdce8165c4c46b4f55cb0a"
+checksum = "eeffd2590ce780ddfaa9d0ae340eb2b4e08627650c4676eef537cef0b4bf535d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "k256",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ffc577390ce50234e02d841214b3dc0bea6aaaae8e04bbf3cb82e9a45da9eb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -182,7 +194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "769da342b6bcd945013925ef4c40763cc82f11e002c60702dba8b444bb60e5a7"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702",
+ "alloy-eip7702 0.3.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -2592,7 +2604,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-stages",
- "revm",
+ "revm 17.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -6359,7 +6371,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-transaction-pool",
  "reth-trie",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6384,7 +6396,7 @@ dependencies = [
  "reth-provider",
  "reth-tasks",
  "reth-transaction-pool",
- "revm",
+ "revm 17.0.0",
  "tokio",
  "tracing",
 ]
@@ -6549,7 +6561,7 @@ dependencies = [
  "reth-storage-api",
  "reth-testing-utils",
  "reth-trie",
- "revm",
+ "revm 17.0.0",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6747,7 +6759,7 @@ dependencies = [
  "reth-consensus",
  "reth-primitives",
  "reth-storage-api",
- "revm-primitives",
+ "revm-primitives 13.0.0",
 ]
 
 [[package]]
@@ -7203,7 +7215,7 @@ dependencies = [
  "reth-revm",
  "reth-rpc-types-compat",
  "reth-trie",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "serde",
  "serde_json",
  "tokio",
@@ -7366,8 +7378,8 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
- "revm-primitives",
+ "revm 17.0.0",
+ "revm-primitives 13.0.0",
  "tracing",
 ]
 
@@ -7404,8 +7416,8 @@ dependencies = [
  "reth-prune-types",
  "reth-revm",
  "reth-storage-errors",
- "revm",
- "revm-primitives",
+ "revm 17.0.0",
+ "revm-primitives 13.0.0",
 ]
 
 [[package]]
@@ -7426,7 +7438,7 @@ dependencies = [
  "reth-primitives",
  "reth-revm",
  "reth-testing-utils",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "secp256k1",
  "serde_json",
 ]
@@ -7443,7 +7455,7 @@ dependencies = [
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
- "revm-primitives",
+ "revm-primitives 13.0.0",
 ]
 
 [[package]]
@@ -7458,7 +7470,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-trie",
- "revm",
+ "revm 17.0.0",
  "serde",
  "serde_with",
 ]
@@ -7989,7 +8001,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "revm",
+ "revm 17.0.0",
  "serde_json",
  "tokio",
 ]
@@ -8154,8 +8166,8 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-revm",
- "revm",
- "revm-primitives",
+ "revm 17.0.0",
+ "revm-primitives 13.0.0",
  "tracing",
 ]
 
@@ -8208,7 +8220,7 @@ dependencies = [
  "reth-revm",
  "reth-tracing",
  "reth-transaction-pool",
- "revm",
+ "revm 17.0.0",
  "serde",
  "serde_json",
  "tokio",
@@ -8241,8 +8253,8 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
- "revm-primitives",
+ "revm 17.0.0",
+ "revm-primitives 13.0.0",
  "sha2 0.10.8",
  "thiserror",
  "tracing",
@@ -8290,7 +8302,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tasks",
  "reth-transaction-pool",
- "revm",
+ "revm 17.0.0",
  "serde_json",
  "thiserror",
  "tokio",
@@ -8323,7 +8335,7 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives",
  "reth-provider",
- "revm",
+ "revm 17.0.0",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8397,7 +8409,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-testing-utils",
  "reth-trie-common",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "secp256k1",
  "serde",
  "serde_json",
@@ -8426,7 +8438,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-codecs",
  "reth-testing-utils",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "roaring",
  "serde",
  "serde_json",
@@ -8476,7 +8488,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-trie",
  "reth-trie-db",
- "revm",
+ "revm 17.0.0",
  "strum",
  "tempfile",
  "tokio",
@@ -8546,7 +8558,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm",
+ "revm 17.0.0",
 ]
 
 [[package]]
@@ -8604,9 +8616,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 17.0.0",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -8781,9 +8793,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 17.0.0",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "tokio",
  "tracing",
 ]
@@ -8820,9 +8832,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 17.0.0",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "schnellru",
  "serde",
  "serde_json",
@@ -9122,7 +9134,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-tracing",
- "revm",
+ "revm 17.0.0",
  "rustc-hash 2.0.0",
  "schnellru",
  "serde",
@@ -9156,7 +9168,7 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 17.0.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -9184,7 +9196,7 @@ dependencies = [
  "proptest-arbitrary-interop",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "serde",
 ]
 
@@ -9209,7 +9221,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "revm",
+ "revm 17.0.0",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -9272,8 +9284,23 @@ dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter",
- "revm-precompile",
+ "revm-interpreter 12.0.0",
+ "revm-precompile 13.0.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eab16cb0a8cd5ac88b11230b20df588b7e8aae7dfab4b3f830e98aebeb4b365"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter 13.0.0",
+ "revm-precompile 14.0.0",
  "serde",
  "serde_json",
 ]
@@ -9292,7 +9319,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 16.0.0",
  "serde_json",
  "thiserror",
 ]
@@ -9303,7 +9330,17 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f89940d17d5d077570de1977f52f69049595322e237cb6c754c3d47f668f023"
 dependencies = [
- "revm-primitives",
+ "revm-primitives 12.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac2034454f8bc69dc7d3c94cdb1b57559e27f5ef0518771f1787de543d7d6a1"
+dependencies = [
+ "revm-primitives 13.0.0",
  "serde",
 ]
 
@@ -9314,13 +9351,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f816aaea3245cbdbe7fdd84955df33597f9322c7912c3e3ba7bc855e03211f"
 dependencies = [
  "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "once_cell",
+ "revm-primitives 12.0.0",
+ "ripemd",
+ "secp256k1",
+ "sha2 0.10.8",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a88c8c7c5f9b988a9e65fc0990c6ce859cdb74114db705bd118a96d22d08027"
+dependencies = [
+ "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
  "once_cell",
  "p256",
- "revm-primitives",
+ "revm-primitives 13.0.0",
  "ripemd",
  "secp256k1",
  "sha2 0.10.8",
@@ -9330,10 +9385,30 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "12.0.0"
-source = "git+https://github.com/klkvr/revm?rev=65208a7#65208a7a883cb0f537265e854394198ea7037a7e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532411bbde45a46707c1d434dcdc29866cf261c1b748fb01b303ce3b4310b361"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702",
+ "alloy-eip7702 0.2.0",
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags 2.6.0",
+ "bitvec",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hex",
+ "serde",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d11fa1e195b0bebaf3fb18596f314a13ba3a4cb1fdd16d3465934d812fd921e"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702 0.3.2",
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,8 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf02dfacfc815214f9b54ff50d54900ba527a68fd73e2c5637ced3460005045"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -176,8 +177,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769da342b6bcd945013925ef4c40763cc82f11e002c60702dba8b444bb60e5a7"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -196,8 +198,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c698ce0ada980b17f0323e1a28c7da8a2e9abc6dff5be9ee33d1525b28ac46b6"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -218,8 +221,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1050e1d65524c030b17442b6546b564da51fdab7f71bd534b001ba65f2ebb16"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -231,8 +235,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da34a18446a27734473af3d77eb21c5ebbdf97ea8eb65c39c0b50916bc659023"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -251,8 +256,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a968c063fcfcb937736665c865a71fc2242b68916156f5ffa41fee7b44bb695"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -263,8 +269,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439fc6a933b9f8e8b272a8cac35dbeabaf2b2eaf9590482bebedb5782153118e"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -311,8 +318,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45dbc0e3630becef9e988b69d43339f68d67e32a854e3c855bc28bd5031895b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -351,8 +359,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3961a56e10f44bfd69dd3f4b0854b90b84c612b0c43708e738933e8b47f93a"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -391,8 +400,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917e5504e4f8f7e39bdc322ff81589ed54c1e462240adaeb58162c2d986a5a2b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -415,8 +425,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c7eb2dc6db1dd41e5e7bd2b98a38813854efc30e034afd90d1e420e7f3de2b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -427,8 +438,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd468a4e3eddcd9d612cad657852de4b7475ac2080e7af9224fbf1df20ddffe0"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -438,8 +450,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2640928d9b1d43bb1cec7a0d615e10c2b407c5bd8ff1fcbe49e6318a2b62d731"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -448,8 +461,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f731ad2ef8d7dd75a4d28214f4922a5b683feee1e6df35bd7b427315f94366"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -461,8 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06bd0757bfb3eccde06ee3f4e378f5839fe923d40956cff586018d4427a15bb5"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -470,8 +485,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3d95c3bf03efbb7bdc1d097e2931f520aac47438b709ccd8f065a7793dd371"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -490,8 +506,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e855b0daccf2320ba415753c3fed422abe9d3ad5d77b2d6cafcc9bcf32fe387f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -510,8 +527,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca3753b9894235f915437f908644e737d8714c686ce4e8d03afbf585b23f074"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -522,8 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae58a997afde032cd021547c960a53eef6245f47969dd71886e9f63fb45a6048"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -535,8 +554,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667e45c882fda207d4cc94c4bb35e24a23347955113dcb236a5e4e0eaddef826"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -546,8 +566,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c2661ca6785add8fc37aff8005439c806ffad58254c19939c6f59ac0d6596e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -557,8 +578,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eca011160d18a7dc6d8cdc1e8dc13e2e86c908f8e41b02aa76e429d6fe7085"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -570,8 +592,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c54b195a6ee5a83f32e7c697b4e6b565966737ed5a2ef9176bbbb39f720d023"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -657,8 +680,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4a136e733f55fef0870b81e1f8f1db28e78973d1b1ae5a5df642ba39538a07"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -676,8 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a6b358a89b6d107b92d09b61a61fbc04243942182709752c796f4b29402cead"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -690,8 +715,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a899c43b7f5e3bc83762dfe5128fccd9cfa99f1f03c5f26bbfb2495ae8dcd35"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -708,8 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.5.2"
-source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27aac1246e13c9e6fa0c784fbb0c56872c6224f78dbde388bb2213ccdf8af02"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42642aed67f938363d9c7543e5ca4163cfb4205d9ec15fe933dc4e865d2932dd"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -161,13 +160,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeffd2590ce780ddfaa9d0ae340eb2b4e08627650c4676eef537cef0b4bf535d"
+checksum = "c15873ee28dfe5a1aeddd762483bc7f378b465ec49bdce8165c4c46b4f55cb0a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
+ "derive_more 1.0.0",
  "k256",
  "rand 0.8.5",
  "serde",
@@ -177,8 +177,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbc52a30df46f9831ed74557dfad0d94b12420393662a8b9ef90e2d6c8cb4b0"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -198,8 +197,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0787d1688b9806290313cc335d416cc7ee39b11e3245f3d218544c62572d92ba"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -221,8 +219,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55a16a5f9ca498a217c060414bcd1c43e934235dc8058b31b87dcd69ff4f105"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -235,8 +232,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d236a8c3e1d5adc09b1b63c81815fc9b757d9a4ba9482cc899f9679b55dd437"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -256,8 +252,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15a0990fa8a56d85a42d6a689719aa4eebf5e2f1a5c5354658c0bfc52cac9a"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -269,8 +264,7 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2249f3c3ce446cf4063fe3d1aa7530823643c2706a1cc63045e0683ebc497a0a"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -318,8 +312,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316f522bb6f9ac3805132112197957013b570e20cfdad058e8339dae6030c849"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -359,8 +352,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222cd9b17b1c5ad48de51a88ffbdb17f17145170288f22662f80ac88739125e6"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -400,8 +392,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ab59712c594c9624aaa69e38e4d38f180cb569f1fa46cdaf8c21fd50793e5"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -425,8 +416,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba21284319e12d053baa204d438db6c1577aedd94c1298e4becefdac1f9cec87"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -438,8 +428,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416cc9f391d0b876c4c8da85f7131e771a88a55b917cc9a35e1724d9409e3b1c"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -450,8 +439,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba40bea86c3102b9ed9b3be579e32e0b3e54e766248d873de5fc0437238c8df2"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -461,8 +449,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b535781fe224c101c3d957b514cb9f438d165ff0280e5c0b2f87a0d9a2950593"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -475,8 +462,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4303deacf4cbf12ed4431a5a1bbc3284f0defb4b8b72d9aa2b888656cc5ae657"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -485,8 +471,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44848fced3b42260b9cb61f22102246636dfe5a2d0132f8d10a617df3cb1a74b"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -506,8 +491,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35894711990019fafff0012b82b9176cbb744516eb2a9bbe6b8e5cae522163ee"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -527,8 +511,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac6250cad380a005ecb5ffc6d2facf03df0e72628d819a63dd8c3ade7a766ff"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -540,8 +523,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f568c5624881896d8a25e19acbdcbabadd8df339427ea2f10b2ee447d57c4509"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -554,8 +536,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a37d2e1ed9b7daf20ad0b3e0092613cbae46737e0e988b23caa556c7067ce6"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -566,8 +547,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2843c195675f06b29c09a4315cccdc233ab5bdc7c0a3775909f9f0cab5e9ae0f"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -578,8 +558,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b2a00d9803dfef99963303ffe41a7bf2221f3342f0a503d6741a9f4a18e5e5"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -592,8 +571,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2505d4f8c98dcae86152d58d549cb4bcf953f8352fca903410e0a0ef535571"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -680,8 +658,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc2c8f6b8c227ef0398f702d954c4ab572c2ead3c1ed4a5157aa1cbaf959747"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -700,8 +677,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd328e990d57f4c4e63899fb2c26877597d6503f8e0022a3d71b2d753ecbfc0c"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -715,8 +691,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89aea26aaf1d67904a7ff95ec4a24ddd5e7d419a6945f641b885962d7c2803e2"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -734,8 +709,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e222e950ecc4ea12fbfb524b9a2275cac2cd5f57c8ce25bcaf1bd3ff80dd8fc8"
+source = "git+https://github.com/alloy-rs/alloy?rev=1a9c406#1a9c4060fc53a53c483258015d0dd46a43be4b8d"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -9329,8 +9303,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532411bbde45a46707c1d434dcdc29866cf261c1b748fb01b303ce3b4310b361"
+source = "git+https://github.com/klkvr/revm?rev=65208a7#65208a7a883cb0f537265e854394198ea7037a7e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,18 +161,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeffd2590ce780ddfaa9d0ae340eb2b4e08627650c4676eef537cef0b4bf535d"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "k256",
- "serde",
-]
-
-[[package]]
-name = "alloy-eip7702"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ffc577390ce50234e02d841214b3dc0bea6aaaae8e04bbf3cb82e9a45da9eb"
@@ -194,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "769da342b6bcd945013925ef4c40763cc82f11e002c60702dba8b444bb60e5a7"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702 0.3.2",
+ "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -2604,7 +2592,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-stages",
- "revm 17.0.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror",
@@ -6371,7 +6359,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-transaction-pool",
  "reth-trie",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6396,7 +6384,7 @@ dependencies = [
  "reth-provider",
  "reth-tasks",
  "reth-transaction-pool",
- "revm 17.0.0",
+ "revm",
  "tokio",
  "tracing",
 ]
@@ -6561,7 +6549,7 @@ dependencies = [
  "reth-storage-api",
  "reth-testing-utils",
  "reth-trie",
- "revm 17.0.0",
+ "revm",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6759,7 +6747,7 @@ dependencies = [
  "reth-consensus",
  "reth-primitives",
  "reth-storage-api",
- "revm-primitives 13.0.0",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -7215,7 +7203,7 @@ dependencies = [
  "reth-revm",
  "reth-rpc-types-compat",
  "reth-trie",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "serde",
  "serde_json",
  "tokio",
@@ -7378,8 +7366,8 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie",
- "revm 17.0.0",
- "revm-primitives 13.0.0",
+ "revm",
+ "revm-primitives",
  "tracing",
 ]
 
@@ -7416,8 +7404,8 @@ dependencies = [
  "reth-prune-types",
  "reth-revm",
  "reth-storage-errors",
- "revm 17.0.0",
- "revm-primitives 13.0.0",
+ "revm",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -7438,7 +7426,7 @@ dependencies = [
  "reth-primitives",
  "reth-revm",
  "reth-testing-utils",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "secp256k1",
  "serde_json",
 ]
@@ -7455,7 +7443,7 @@ dependencies = [
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
- "revm-primitives 13.0.0",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -7470,7 +7458,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-trie",
- "revm 17.0.0",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -8001,7 +7989,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "revm 17.0.0",
+ "revm",
  "serde_json",
  "tokio",
 ]
@@ -8166,8 +8154,8 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-revm",
- "revm 17.0.0",
- "revm-primitives 13.0.0",
+ "revm",
+ "revm-primitives",
  "tracing",
 ]
 
@@ -8220,7 +8208,7 @@ dependencies = [
  "reth-revm",
  "reth-tracing",
  "reth-transaction-pool",
- "revm 17.0.0",
+ "revm",
  "serde",
  "serde_json",
  "tokio",
@@ -8253,8 +8241,8 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-transaction-pool",
  "reth-trie",
- "revm 17.0.0",
- "revm-primitives 13.0.0",
+ "revm",
+ "revm-primitives",
  "sha2 0.10.8",
  "thiserror",
  "tracing",
@@ -8302,7 +8290,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tasks",
  "reth-transaction-pool",
- "revm 17.0.0",
+ "revm",
  "serde_json",
  "thiserror",
  "tokio",
@@ -8335,7 +8323,7 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives",
  "reth-provider",
- "revm 17.0.0",
+ "revm",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8409,7 +8397,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-testing-utils",
  "reth-trie-common",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "secp256k1",
  "serde",
  "serde_json",
@@ -8438,7 +8426,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-codecs",
  "reth-testing-utils",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "roaring",
  "serde",
  "serde_json",
@@ -8488,7 +8476,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-trie",
  "reth-trie-db",
- "revm 17.0.0",
+ "revm",
  "strum",
  "tempfile",
  "tokio",
@@ -8558,7 +8546,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm 17.0.0",
+ "revm",
 ]
 
 [[package]]
@@ -8616,9 +8604,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "reth-trie",
- "revm 17.0.0",
+ "revm",
  "revm-inspectors",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "serde",
  "serde_json",
  "thiserror",
@@ -8793,9 +8781,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 17.0.0",
+ "revm",
  "revm-inspectors",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "tokio",
  "tracing",
 ]
@@ -8832,9 +8820,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 17.0.0",
+ "revm",
  "revm-inspectors",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "schnellru",
  "serde",
  "serde_json",
@@ -9134,7 +9122,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-tracing",
- "revm 17.0.0",
+ "revm",
  "rustc-hash 2.0.0",
  "schnellru",
  "serde",
@@ -9168,7 +9156,7 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 17.0.0",
+ "revm",
  "serde",
  "serde_json",
  "serde_with",
@@ -9196,7 +9184,7 @@ dependencies = [
  "proptest-arbitrary-interop",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "serde",
 ]
 
@@ -9221,7 +9209,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "revm 17.0.0",
+ "revm",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -9277,21 +9265,6 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e44692d5736cc44c697a372e507890f8797f06d1541c5f4b9bec594d90fd8a"
-dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter 12.0.0",
- "revm-precompile 13.0.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "revm"
 version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eab16cb0a8cd5ac88b11230b20df588b7e8aae7dfab4b3f830e98aebeb4b365"
@@ -9299,17 +9272,17 @@ dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter 13.0.0",
- "revm-precompile 14.0.0",
+ "revm-interpreter",
+ "revm-precompile",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64e2246ad480167548724eb9c9c66945241b867c7d50894de3ca860c9823a45"
+checksum = "1e29c662f7887f3b659d4b0fd234673419a8fcbeaa1ecc29bf7034c0a75cc8ea"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -9319,19 +9292,9 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 16.0.0",
+ "revm",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f89940d17d5d077570de1977f52f69049595322e237cb6c754c3d47f668f023"
-dependencies = [
- "revm-primitives 12.0.0",
- "serde",
 ]
 
 [[package]]
@@ -9340,26 +9303,8 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac2034454f8bc69dc7d3c94cdb1b57559e27f5ef0518771f1787de543d7d6a1"
 dependencies = [
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f816aaea3245cbdbe7fdd84955df33597f9322c7912c3e3ba7bc855e03211f"
-dependencies = [
- "aurora-engine-modexp",
- "c-kzg",
- "cfg-if",
- "k256",
- "once_cell",
- "revm-primitives 12.0.0",
- "ripemd",
- "secp256k1",
- "sha2 0.10.8",
- "substrate-bn",
 ]
 
 [[package]]
@@ -9375,30 +9320,11 @@ dependencies = [
  "k256",
  "once_cell",
  "p256",
- "revm-primitives 13.0.0",
+ "revm-primitives",
  "ripemd",
  "secp256k1",
  "sha2 0.10.8",
  "substrate-bn",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532411bbde45a46707c1d434dcdc29866cf261c1b748fb01b303ce3b4310b361"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702 0.2.0",
- "alloy-primitives",
- "auto_impl",
- "bitflags 2.6.0",
- "bitvec",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hex",
- "serde",
 ]
 
 [[package]]
@@ -9408,7 +9334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d11fa1e195b0bebaf3fb18596f314a13ba3a4cb1fdd16d3465934d812fd921e"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702 0.3.2",
+ "alloy-eip7702",
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -425,39 +425,39 @@ alloy-rlp = "0.3.4"
 alloy-sol-types = "0.8.0"
 alloy-trie = { version = "0.7", default-features = false }
 
-alloy-consensus = { version = "0.5.2", default-features = false }
-alloy-eips = { version = "0.5.2", default-features = false }
-alloy-genesis = { version = "0.5.2", default-features = false }
-alloy-json-rpc = { version = "0.5.2", default-features = false }
-alloy-network = { version = "0.5.2", default-features = false }
-alloy-network-primitives = { version = "0.5.2", default-features = false }
-alloy-node-bindings = { version = "0.5.2", default-features = false }
-alloy-provider = { version = "0.5.2", features = [
+alloy-consensus = { version = "0.5.3", default-features = false }
+alloy-eips = { version = "0.5.3", default-features = false }
+alloy-genesis = { version = "0.5.3", default-features = false }
+alloy-json-rpc = { version = "0.5.3", default-features = false }
+alloy-network = { version = "0.5.3", default-features = false }
+alloy-network-primitives = { version = "0.5.3", default-features = false }
+alloy-node-bindings = { version = "0.5.3", default-features = false }
+alloy-provider = { version = "0.5.3", features = [
     "reqwest",
 ], default-features = false }
-alloy-pubsub = { version = "0.5.2", default-features = false }
-alloy-rpc-client = { version = "0.5.2", default-features = false }
-alloy-rpc-types = { version = "0.5.2", features = [
+alloy-pubsub = { version = "0.5.3", default-features = false }
+alloy-rpc-client = { version = "0.5.3", default-features = false }
+alloy-rpc-types = { version = "0.5.3", features = [
     "eth",
 ], default-features = false }
-alloy-rpc-types-admin = { version = "0.5.2", default-features = false }
-alloy-rpc-types-anvil = { version = "0.5.2", default-features = false }
-alloy-rpc-types-beacon = { version = "0.5.2", default-features = false }
-alloy-rpc-types-debug = { version = "0.5.2", default-features = false }
-alloy-rpc-types-engine = { version = "0.5.2", default-features = false }
-alloy-rpc-types-eth = { version = "0.5.2", default-features = false }
-alloy-rpc-types-mev = { version = "0.5.2", default-features = false }
-alloy-rpc-types-trace = { version = "0.5.2", default-features = false }
-alloy-rpc-types-txpool = { version = "0.5.2", default-features = false }
-alloy-serde = { version = "0.5.2", default-features = false }
-alloy-signer = { version = "0.5.2", default-features = false }
-alloy-signer-local = { version = "0.5.2", default-features = false }
-alloy-transport = { version = "0.5.2" }
-alloy-transport-http = { version = "0.5.2", features = [
+alloy-rpc-types-admin = { version = "0.5.3", default-features = false }
+alloy-rpc-types-anvil = { version = "0.5.3", default-features = false }
+alloy-rpc-types-beacon = { version = "0.5.3", default-features = false }
+alloy-rpc-types-debug = { version = "0.5.3", default-features = false }
+alloy-rpc-types-engine = { version = "0.5.3", default-features = false }
+alloy-rpc-types-eth = { version = "0.5.3", default-features = false }
+alloy-rpc-types-mev = { version = "0.5.3", default-features = false }
+alloy-rpc-types-trace = { version = "0.5.3", default-features = false }
+alloy-rpc-types-txpool = { version = "0.5.3", default-features = false }
+alloy-serde = { version = "0.5.3", default-features = false }
+alloy-signer = { version = "0.5.3", default-features = false }
+alloy-signer-local = { version = "0.5.3", default-features = false }
+alloy-transport = { version = "0.5.3" }
+alloy-transport-http = { version = "0.5.3", features = [
     "reqwest-rustls-tls",
 ], default-features = false }
-alloy-transport-ipc = { version = "0.5.2", default-features = false }
-alloy-transport-ws = { version = "0.5.2", default-features = false }
+alloy-transport-ipc = { version = "0.5.3", default-features = false }
+alloy-transport-ws = { version = "0.5.3", default-features = false }
 
 # op
 op-alloy-rpc-types = "0.5"
@@ -595,33 +595,32 @@ tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
 
 [patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+#alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
 
 #op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
 #op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,7 +412,7 @@ reth-trie-parallel = { path = "crates/trie/parallel" }
 
 # revm
 revm = { version = "17.0.0", features = ["std"], default-features = false }
-revm-inspectors = "0.9.0"
+revm-inspectors = "0.10.0"
 revm-primitives = { version = "13.0.0", features = [
     "std",
 ], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -594,35 +594,38 @@ tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
 
-#[patch.crates-io]
-#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
+[patch.crates-io]
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "1a9c406" }
 
 #op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
 #op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
 #op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
 #op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
+
+revm-primitives = { git = "https://github.com/klkvr/revm", rev = "65208a7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,9 +411,9 @@ reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 
 # revm
-revm = { version = "16.0.0", features = ["std"], default-features = false }
+revm = { version = "17.0.0", features = ["std"], default-features = false }
 revm-inspectors = "0.9.0"
-revm-primitives = { version = "12.0.0", features = [
+revm-primitives = { version = "13.0.0", features = [
     "std",
 ], default-features = false }
 
@@ -594,7 +594,7 @@ tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
 
-[patch.crates-io]
+#[patch.crates-io]
 #alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
 #alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
 #alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
@@ -626,5 +626,3 @@ tracy-client = "0.17.3"
 #op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
 #op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
 #op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
-
-revm-primitives = { git = "https://github.com/klkvr/revm", rev = "65208a7" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -1,10 +1,13 @@
 [workspace]
-members = [
-    "exex/hello-world",
-    "exex/remote",
-    "exex/tracking-state",
-]
+members = ["exex/hello-world", "exex/remote", "exex/tracking-state"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
+
+[patch.'https://github.com/paradigmxyz/reth']
+reth = { path = "../../bin/reth" }
+reth-exex = { path = "../../crates/exex/exex" }
+reth-node-ethereum = { path = "../../crates/ethereum/node" }
+reth-tracing = { path = "../../crates/tracing" }
+reth-node-api = { path = "../../crates/node/api" }

--- a/book/sources/exex/hello-world/Cargo.toml
+++ b/book/sources/exex/hello-world/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth.git" } # Reth
-reth-exex = { git = "https://github.com/paradigmxyz/reth.git" } # Execution Extensions
+reth = { git = "https://github.com/paradigmxyz/reth.git" }               # Reth
+reth-exex = { git = "https://github.com/paradigmxyz/reth.git" }          # Execution Extensions
 reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git" } # Ethereum Node implementation
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git" } # Logging
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git" }       # Logging
 
-eyre = "0.6" # Easy error handling
+eyre = "0.6"         # Easy error handling
 futures-util = "0.3" # Stream utilities for consuming notifications

--- a/book/sources/exex/tracking-state/Cargo.toml
+++ b/book/sources/exex/tracking-state/Cargo.toml
@@ -5,10 +5,12 @@ edition = "2021"
 
 [dependencies]
 reth = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth.git", features = ["serde"] }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git"}
+reth-exex = { git = "https://github.com/paradigmxyz/reth.git", features = [
+    "serde",
+] }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth.git" }
 
-eyre = "0.6" # Easy error handling
-futures-util = "0.3" # Stream utilities for consuming notifications
+eyre = "0.6"               # Easy error handling
+futures-util = "0.3"       # Stream utilities for consuming notifications
 alloy-primitives = "0.8.7"

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -230,7 +230,6 @@ mod tests {
         eip4844::Bytes48,
     };
     use alloy_primitives::hex;
-    use alloy_rlp::Encodable;
     use std::{fs, path::PathBuf, str::FromStr};
 
     #[test]

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -12,8 +12,6 @@ pub use alloy_eips::eip4844::BlobTransactionSidecar;
 #[cfg(feature = "c-kzg")]
 pub use alloy_eips::eip4844::BlobTransactionValidationError;
 
-use alloc::vec::Vec;
-
 /// A response to `GetPooledTransactions` that includes blob data, their commitments, and their
 /// corresponding proofs.
 ///
@@ -196,6 +194,7 @@ impl BlobTransaction {
 /// Generates a [`BlobTransactionSidecar`] structure containing blobs, commitments, and proofs.
 #[cfg(all(feature = "c-kzg", any(test, feature = "arbitrary")))]
 pub fn generate_blob_sidecar(blobs: Vec<c_kzg::Blob>) -> BlobTransactionSidecar {
+    use alloc::vec::Vec;
     use alloy_eips::eip4844::env_settings::EnvKzgSettings;
     use c_kzg::{KzgCommitment, KzgProof};
 
@@ -225,6 +224,7 @@ pub fn generate_blob_sidecar(blobs: Vec<c_kzg::Blob>) -> BlobTransactionSidecar 
 mod tests {
     use super::*;
     use crate::{kzg::Blob, PooledTransactionsElement};
+    use alloc::vec::Vec;
     use alloy_eips::{
         eip2718::{Decodable2718, Encodable2718},
         eip4844::Bytes48,

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -163,7 +163,7 @@ impl BlobTransaction {
 
         // The payload length is the length of the `tranascation_payload_body` list, plus the
         // length of the blobs, commitments, and proofs.
-        let payload_length = tx_length + self.transaction.sidecar.fields_len();
+        let payload_length = tx_length + self.transaction.sidecar.rlp_encoded_fields_length();
 
         // We use the calculated payload len to construct the first list header, which encompasses
         // everything in the tx - the length of the second, inner list header is part of

--- a/crates/primitives/src/transaction/sidecar.rs
+++ b/crates/primitives/src/transaction/sidecar.rs
@@ -32,7 +32,7 @@ impl BlobTransaction {
     /// Constructs a new [`BlobTransaction`] from a [`TransactionSigned`] and a
     /// [`BlobTransactionSidecar`].
     ///
-    /// Returns an error if the signed transaction is not [`TxEip4844`]
+    /// Returns an error if the signed transaction is not [`Transaction::Eip4844`]
     pub fn try_from_signed(
         tx: TransactionSigned,
         sidecar: BlobTransactionSidecar,
@@ -53,7 +53,7 @@ impl BlobTransaction {
 
     /// Verifies that the transaction's blob data, commitments, and proofs are all valid.
     ///
-    /// See also [`TxEip4844::validate_blob`]
+    /// See also [`alloy_consensus::TxEip4844::validate_blob`]
     #[cfg(feature = "c-kzg")]
     pub fn validate(
         &self,

--- a/crates/storage/codecs/src/alloy/authorization_list.rs
+++ b/crates/storage/codecs/src/alloy/authorization_list.rs
@@ -44,11 +44,9 @@ impl Compact for SignedAuthorization {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        let signature = self.signature();
-        let (v, r, s) = (signature.v(), signature.r(), signature.s());
-        buf.put_u8(v.y_parity_byte());
-        buf.put_slice(r.as_le_slice());
-        buf.put_slice(s.as_le_slice());
+        buf.put_u8(self.y_parity());
+        buf.put_slice(self.r().as_le_slice());
+        buf.put_slice(self.s().as_le_slice());
 
         // to_compact doesn't write the len to buffer.
         // By placing it as last, we don't need to store it either.

--- a/crates/storage/codecs/src/alloy/authorization_list.rs
+++ b/crates/storage/codecs/src/alloy/authorization_list.rs
@@ -54,17 +54,15 @@ impl Compact for SignedAuthorization {
     }
 
     fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let y = alloy_primitives::Parity::Parity(buf.get_u8() == 1);
+        let y_parity = buf.get_u8();
         let r = U256::from_le_slice(&buf[0..32]);
         buf.advance(32);
         let s = U256::from_le_slice(&buf[0..32]);
         buf.advance(32);
 
-        let signature = alloy_primitives::Signature::from_rs_and_parity(r, s, y)
-            .expect("invalid authorization signature");
         let (auth, buf) = AlloyAuthorization::from_compact(buf, len);
 
-        (auth.into_signed(signature), buf)
+        (Self::new_unchecked(auth, y_parity, r, s), buf)
     }
 }
 

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -3,7 +3,6 @@
 use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobStoreSize};
 use alloy_eips::eip4844::BlobAndProofV1;
 use alloy_primitives::{TxHash, B256};
-use alloy_rlp::{Decodable, Encodable};
 use parking_lot::{Mutex, RwLock};
 use reth_primitives::BlobTransactionSidecar;
 use schnellru::{ByLength, LruMap};
@@ -205,7 +204,7 @@ impl DiskFileBlobStoreInner {
     /// Ensures blob is in the blob cache and written to the disk.
     fn insert_one(&self, tx: B256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError> {
         let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
-        data.encode(&mut buf);
+        data.rlp_encode_fields(&mut buf);
         self.blob_cache.lock().insert(tx, data);
         let size = self.write_one_encoded(tx, &buf)?;
 
@@ -220,7 +219,7 @@ impl DiskFileBlobStoreInner {
             .iter()
             .map(|(tx, data)| {
                 let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
-                data.encode(&mut buf);
+                data.rlp_encode_fields(&mut buf);
                 (self.blob_disk_file(*tx), buf)
             })
             .collect::<Vec<_>>();

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -204,7 +204,7 @@ impl DiskFileBlobStoreInner {
 
     /// Ensures blob is in the blob cache and written to the disk.
     fn insert_one(&self, tx: B256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError> {
-        let mut buf = Vec::with_capacity(data.fields_len());
+        let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
         data.encode(&mut buf);
         self.blob_cache.lock().insert(tx, data);
         let size = self.write_one_encoded(tx, &buf)?;
@@ -219,7 +219,7 @@ impl DiskFileBlobStoreInner {
         let raw = txs
             .iter()
             .map(|(tx, data)| {
-                let mut buf = Vec::with_capacity(data.fields_len());
+                let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
                 data.encode(&mut buf);
                 (self.blob_disk_file(*tx), buf)
             })

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -312,7 +312,7 @@ impl DiskFileBlobStoreInner {
                 }
             }
         };
-        BlobTransactionSidecar::decode(&mut data.as_slice())
+        BlobTransactionSidecar::rlp_decode_fields(&mut data.as_slice())
             .map(Some)
             .map_err(BlobStoreError::DecodeError)
     }
@@ -322,7 +322,7 @@ impl DiskFileBlobStoreInner {
         self.read_many_raw(txs)
             .into_iter()
             .filter_map(|(tx, data)| {
-                BlobTransactionSidecar::decode(&mut data.as_slice())
+                BlobTransactionSidecar::rlp_decode_fields(&mut data.as_slice())
                     .map(|sidecar| (tx, sidecar))
                     .ok()
             })


### PR DESCRIPTION
- Bump alloy, alloy-eip7702 and revm
- Fix Compact impl for SignedAuthorization
- Earlier we were using `Encodable`/`Decodable` impls  for encoding/decoding sidecars. Format for those was changed in https://github.com/alloy-rs/alloy/pull/1528 so I've replaced all `encode` with `rlp_encode_fields` and `decode` with `rlp_decode_fields`.