### PR TITLE
fix: ping oldest more often

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -8,8 +8,6 @@ use alloy_rlp::Encodable;
 use reth_net_banlist::BanList;
 use reth_net_nat::{NatResolver, ResolveNatInterval};
 use reth_network_peers::NodeRecord;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     time::Duration,
@@ -17,7 +15,7 @@ use std::{
 
 /// Configuration parameters that define the performance of the discovery network.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Discv4Config {
     /// Whether to enable the incoming packet filter. Default: false.
     pub enable_packet_filter: bool,
@@ -118,7 +116,7 @@ impl Default for Discv4Config {
             // Every outgoing request will eventually lead to an incoming response
             udp_ingress_message_buffer: 1024,
             max_find_node_failures: 5,
-            ping_interval: Duration::from_secs(60 * 10),
+            ping_interval: Duration::from_secs(10),
             // Unified expiration and timeout durations, mirrors geth's `expiration` duration
             ping_expiration: Duration::from_secs(20),
             bond_expiration: Duration::from_secs(60 * 60),
@@ -144,7 +142,7 @@ impl Default for Discv4Config {
 
 /// Builder type for [`Discv4Config`]
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Discv4ConfigBuilder {
     config: Discv4Config,
 }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -870,7 +870,9 @@ impl Discv4Service {
         false
     }
 
-    /// Update the entry on RE-ping
+    /// Update the entry on RE-ping.
+    ///
+    /// Invoked when we received the Pong to our [`PingReason::RePing`] ping.
     ///
     /// On re-ping we check for a changed `enr_seq` if eip868 is enabled and when it changed we sent
     /// a followup request to retrieve the updated ENR
@@ -2259,7 +2261,7 @@ impl NodeEntry {
 impl NodeEntry {
     /// Returns true if the node should be re-pinged.
     fn is_expired(&self) -> bool {
-        self.last_seen.elapsed() > ENDPOINT_PROOF_EXPIRATION
+        self.last_seen.elapsed() > (ENDPOINT_PROOF_EXPIRATION / 2)
     }
 }
 


### PR DESCRIPTION
fixes a flaw in the re-ping logic

first, the re-ping interval was too high because this should check for __expired__ nodes more often. 

we also can't use the `ENDPOINT_PROOF_EXPIRATION` is the threshold because by the time this is reached the peer has already lost its bond, this sets it to every 12h now