### PR TITLE
fix: re-establish bond on ping

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1046,11 +1046,23 @@ impl Discv4Service {
 
         let old_enr = match self.kbuckets.entry(&key) {
             kbucket::Entry::Present(mut entry, _) => {
-                is_proven = entry.value().has_endpoint_proof;
+                if entry.value().is_expired() {
+                    // If no communication with the sender has occurred within the last 12h, a ping
+                    // should be sent in addition to pong in order to receive an endpoint proof.
+                    needs_bond = true;
+                } else {
+                    is_proven = entry.value().has_endpoint_proof;
+                }
                 entry.value_mut().update_with_enr(ping.enr_sq)
             }
             kbucket::Entry::Pending(mut entry, _) => {
-                is_proven = entry.value().has_endpoint_proof;
+                if entry.value().is_expired() {
+                    // If no communication with the sender has occurred within the last 12h, a ping
+                    // should be sent in addition to pong in order to receive an endpoint proof.
+                    needs_bond = true;
+                } else {
+                    is_proven = entry.value().has_endpoint_proof;
+                }
                 entry.value().update_with_enr(ping.enr_sq)
             }
             kbucket::Entry::Absent(entry) => {
@@ -1223,7 +1235,8 @@ impl Discv4Service {
                 self.update_on_pong(node, pong.enr_sq);
             }
             PingReason::EstablishBond => {
-                // nothing to do here
+                // same as `InitialInsert` which renews the bond if the peer is in the table
+                self.update_on_pong(node, pong.enr_sq);
             }
             PingReason::RePing => {
                 self.update_on_reping(node, pong.enr_sq);
@@ -2268,8 +2281,7 @@ impl NodeEntry {
 enum PingReason {
     /// Initial ping to a previously unknown peer that was inserted into the table.
     InitialInsert,
-    /// Initial ping to a previously unknown peer that didn't fit into the table. But we still want
-    /// to establish a bond.
+    /// A ping to a peer to establish a bond (endpoint proof).
     EstablishBond,
     /// Re-ping a peer.
     RePing,


### PR DESCRIPTION
according to the spec

> If no communication with the sender has occurred within the last 12h, a ping should be sent in addition to pong in order to receive an endpoint proof.

combined with https://github.com/paradigmxyz/reth/pull/11988 this will now re-bond the peer if we haven't seen it in the last 12hrs and treat this the same as an initial ping to renew the bond.