### PR TITLE
ci: pass `--locked` and use path deps in book

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo build --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }}"
+      - run: cargo build --bin "${{ matrix.binary }}" --workspace --features "${{ matrix.network }}" --locked
         env:
           RUSTFLAGS: -D warnings
 

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -36,7 +36,7 @@ jobs:
           cache-on-failure: true
       - name: Build reth
         run: |
-          cargo install --features asm-keccak,jemalloc --path bin/reth
+          make install
       - name: Run headers stage
         run: |
           reth stage run headers --from ${{ env.FROM_BLOCK }} --to ${{ env.TO_BLOCK }} --commit --checkpoints

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo nextest run --release -p ef-tests --features "asm-keccak ef-tests"
+      - run: cargo nextest run --release -p ef-tests --features "asm-keccak ef-tests" --locked
 
   doc:
     name: doc tests (${{ matrix.network }})
@@ -107,7 +107,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Run doctests
-        run: cargo test --doc --workspace --features "${{ matrix.network }}"
+        run: cargo test --doc --workspace --features "${{ matrix.network }}" --locked
 
   unit-success:
     name: unit success

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -1,10 +1,13 @@
 [workspace]
-members = [
-    "exex/hello-world",
-    "exex/remote",
-    "exex/tracking-state",
-]
+members = ["exex/hello-world", "exex/remote", "exex/tracking-state"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
+
+[patch.'https://github.com/paradigmxyz/reth']
+reth = { path = "../../bin/reth" }
+reth-exex = { path = "../../crates/exex/exex" }
+reth-node-ethereum = { path = "../../crates/ethereum/node" }
+reth-tracing = { path = "../../crates/tracing" }
+reth-node-api = { path = "../../crates/node/api" }

--- a/book/sources/exex/hello-world/Cargo.toml
+++ b/book/sources/exex/hello-world/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth.git" } # Reth
-reth-exex = { git = "https://github.com/paradigmxyz/reth.git" } # Execution Extensions
+reth = { git = "https://github.com/paradigmxyz/reth.git" }               # Reth
+reth-exex = { git = "https://github.com/paradigmxyz/reth.git" }          # Execution Extensions
 reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git" } # Ethereum Node implementation
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git" } # Logging
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git" }       # Logging
 
-eyre = "0.6" # Easy error handling
+eyre = "0.6"         # Easy error handling
 futures-util = "0.3" # Stream utilities for consuming notifications

--- a/book/sources/exex/tracking-state/Cargo.toml
+++ b/book/sources/exex/tracking-state/Cargo.toml
@@ -5,10 +5,12 @@ edition = "2021"
 
 [dependencies]
 reth = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth.git", features = ["serde"] }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git"}
+reth-exex = { git = "https://github.com/paradigmxyz/reth.git", features = [
+    "serde",
+] }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth.git" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth.git" }
 
-eyre = "0.6" # Easy error handling
-futures-util = "0.3" # Stream utilities for consuming notifications
+eyre = "0.6"               # Easy error handling
+futures-util = "0.3"       # Stream utilities for consuming notifications
 alloy-primitives = "0.8.7"


### PR DESCRIPTION
We were updating the lockfile in some CI workflows which breaks if e.g. Alloy has breaking changes.

To fix the book workflow, we use path dependencies