### PR TITLE
chore(cli): engine cli options conflict with legacy

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -33,11 +33,11 @@ pub struct EngineArgs {
     pub legacy: bool,
 
     /// Configure persistence threshold for engine experimental.
-    #[arg(long = "engine.persistence-threshold", requires = "experimental", default_value_t = DEFAULT_PERSISTENCE_THRESHOLD)]
+    #[arg(long = "engine.persistence-threshold", conflicts_with = "legacy", default_value_t = DEFAULT_PERSISTENCE_THRESHOLD)]
     pub persistence_threshold: u64,
 
     /// Configure the target number of blocks to keep in memory.
-    #[arg(long = "engine.memory-block-buffer-target", requires = "experimental", default_value_t = DEFAULT_MEMORY_BLOCK_BUFFER_TARGET)]
+    #[arg(long = "engine.memory-block-buffer-target", conflicts_with = "legacy", default_value_t = DEFAULT_MEMORY_BLOCK_BUFFER_TARGET)]
     pub memory_block_buffer_target: u64,
 }
 


### PR DESCRIPTION
## Description

Change engine CLI options to no longer require `--engine.experimental` (as it is default now) and conflict with `--engine.legacy`. 