### PR TITLE
 feat: `add op-reth test-vectors compact --write|--read` to CI

### DIFF
--- a/.github/workflows/compact.yml
+++ b/.github/workflows/compact.yml
@@ -16,6 +16,11 @@ jobs:
   compact-codec:
     runs-on:
       group: Reth
+    strategy:
+      matrix:
+        bin:
+          - cargo run --bin reth --features "dev"
+          - cargo run --bin op-reth --features "optimism dev" --manifest-path crates/optimism/bin/Cargo.toml
     steps:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -27,11 +32,11 @@ jobs:
           ref: ${{ github.base_ref || 'main' }}
       # On `main` branch, generates test vectors and serializes them to disk using `Compact`.
       - name: Generate compact vectors
-        run: cargo run --bin reth --features dev -- test-vectors compact --write
+        run: ${{ matrix.bin }} -- test-vectors compact --write
       - name: Checkout PR
         uses: actions/checkout@v4
         with:
           clean: false
       # On incoming merge try to read and decode previously generated vectors with `Compact`
       - name: Read vectors
-        run: cargo run --bin reth --features dev -- test-vectors compact --read
+        run: ${{ matrix.bin }} -- test-vectors compact --read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8089,6 +8089,8 @@ dependencies = [
  "clap",
  "eyre",
  "futures-util",
+ "op-alloy-consensus",
+ "proptest",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",

--- a/crates/cli/commands/src/test_vectors/tables.rs
+++ b/crates/cli/commands/src/test_vectors/tables.rs
@@ -17,7 +17,7 @@ const VECTORS_FOLDER: &str = "testdata/micro/db";
 const PER_TABLE: usize = 1000;
 
 /// Generates test vectors for specified `tables`. If list is empty, then generate for all tables.
-pub(crate) fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
+pub fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
     // Prepare random seed for test (same method as used by proptest)
     let mut seed = [0u8; 32];
     getrandom(&mut seed)?;

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -47,6 +47,10 @@ optimism = [
 	"reth-provider/optimism"
 ]
 
+dev = [
+	"reth-optimism-cli/dev"
+]
+
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]
 min-info-logs = ["tracing/release_max_level_info"]

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -65,6 +65,13 @@ tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 eyre.workspace = true
 
+# reth test-vectors
+proptest = { workspace = true, optional = true }
+op-alloy-consensus = { workspace = true, features = [
+    "arbitrary",
+], optional = true }
+
+
 [dev-dependencies]
 tempfile.workspace = true
 reth-stages = { workspace = true, features = ["test-utils"] }
@@ -93,4 +100,10 @@ asm-keccak = [
 jemalloc = [
     "reth-node-core/jemalloc",
     "reth-node-metrics/jemalloc"
+]
+
+dev = [
+    "dep:proptest",
+    "reth-cli-commands/arbitrary",
+    "op-alloy-consensus"
 ]

--- a/crates/optimism/cli/src/commands/mod.rs
+++ b/crates/optimism/cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod build_pipeline;
 pub mod import;
 pub mod import_receipts;
 pub mod init_state;
+pub mod test_vectors;
 
 /// Commands to be executed
 #[derive(Debug, Subcommand)]
@@ -55,4 +56,8 @@ pub enum Commands<Spec: ChainSpecParser = OpChainSpecParser, Ext: clap::Args + f
     /// Prune according to the configuration without any limits
     #[command(name = "prune")]
     Prune(prune::PruneCommand<Spec>),
+    /// Generate Test Vectors
+    #[cfg(feature = "dev")]
+    #[command(name = "test-vectors")]
+    TestVectors(test_vectors::Command),
 }

--- a/crates/optimism/cli/src/commands/test_vectors.rs
+++ b/crates/optimism/cli/src/commands/test_vectors.rs
@@ -1,9 +1,19 @@
 //! Command for generating test vectors.
 
 use clap::{Parser, Subcommand};
-
-pub mod compact;
-pub mod tables;
+use op_alloy_consensus::TxDeposit;
+use proptest::test_runner::TestRunner;
+use reth_cli_commands::{
+    compact_types,
+    test_vectors::{
+        compact,
+        compact::{
+            generate_vector, read_vector, GENERATE_VECTORS as ETH_GENERATE_VECTORS,
+            READ_VECTORS as ETH_READ_VECTORS,
+        },
+        tables,
+    },
+};
 
 /// Generate test-vectors for different data types.
 #[derive(Debug, Parser)]
@@ -20,12 +30,8 @@ pub enum Subcommands {
         /// List of table names. Case-sensitive.
         names: Vec<String>,
     },
-    /// Randomly generate test vectors for each `Compact` type using the `--write` flag.
-    ///
-    /// The generated vectors are serialized in both `json` and `Compact` formats and saved to a
-    /// file.
-    ///
-    /// Use the `--read` flag to read and validate the previously generated vectors from file.
+    /// Generates test vectors for `Compact` types with `--write`. Reads and checks generated
+    /// vectors with `--read`.
     #[group(multiple = false, required = true)]
     Compact {
         /// Write test vectors to a file.
@@ -46,10 +52,18 @@ impl Command {
                 tables::generate_vectors(names)?;
             }
             Subcommands::Compact { write, .. } => {
+                compact_types!(
+                    regular: [
+                        TxDeposit
+                    ], identifier: []
+                );
+
                 if write {
-                    compact::generate_vectors()?;
+                    compact::generate_vectors_with(ETH_GENERATE_VECTORS)?;
+                    compact::generate_vectors_with(GENERATE_VECTORS)?;
                 } else {
-                    compact::read_vectors()?;
+                    compact::read_vectors_with(ETH_READ_VECTORS)?;
+                    compact::read_vectors_with(READ_VECTORS)?;
                 }
             }
         }

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -169,6 +169,8 @@ where
                 runner.run_command_until_exit(|ctx| command.execute::<OptimismNode>(ctx))
             }
             Commands::Prune(command) => runner.run_until_ctrl_c(command.execute::<OptimismNode>()),
+            #[cfg(feature = "dev")]
+            Commands::TestVectors(command) => runner.run_until_ctrl_c(command.execute()),
         }
     }
 

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -503,11 +503,15 @@ mod tests {
     use super::*;
     use alloy_primitives::{address, b256, bytes, hex_literal::hex};
 
-    #[cfg(not(feature = "optimism"))]
     #[test]
     fn test_decode_receipt() {
+        #[cfg(not(feature = "optimism"))]
         reth_codecs::test_utils::test_decode::<Receipt>(&hex!(
             "c428b52ffd23fc42696156b10200f034792b6a94c3850215c2fef7aea361a0c31b79d9a32652eefc0d4e2e730036061cff7344b6fc6132b50cda0ed810a991ae58ef013150c12b2522533cb3b3a8b19b7786a8b5ff1d3cdc84225e22b02def168c8858df"
+        ));
+        #[cfg(feature = "optimism")]
+        reth_codecs::test_utils::test_decode::<Receipt>(&hex!(
+            "c30328b52ffd23fc426961a00105007eb0042307705a97e503562eacf2b95060cce9de6de68386b6c155b73a9650021a49e2f8baad17f30faff5899d785c4c0873e45bc268bcf07560106424570d11f9a59e8f3db1efa4ceec680123712275f10d92c3411e1caaa11c7c5d591bc11487168e09934a9986848136da1b583babf3a7188e3aed007a1520f1cf4c1ca7d3482c6c28d37c298613c70a76940008816c4c95644579fd08471dc34732fd0f24"
         ));
     }
 

--- a/crates/storage/codecs/src/alloy/transaction/mod.rs
+++ b/crates/storage/codecs/src/alloy/transaction/mod.rs
@@ -88,4 +88,12 @@ mod tests {
             "112210080a8ba06a8d108540bb3140e9f71a0812c46226f9ea77ae880d98d19fe27e5911801175c3b32620b2e887af0296af343526e439b775ee3b1c06750058e9e5fc4cd5965c3010f86184"
         ));
     }
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn test_decode_deposit() {
+        test_decode::<op_alloy_consensus::TxDeposit>(&hex!(
+            "8108ac8f15983d59b6ae4911a00ff7bfcd2e53d2950926f8c82c12afad02861c46fcb293e776204052725e1c08ff2e9ff602ca916357601fa972a14094891fe3598b718758f22c46f163c18bcaa6296ce87e5267ef3fd932112842fbbf79011548cdf067d93ce6098dfc0aaf5a94531e439f30d6dfd0c6"
+        )); 
+    }
 }


### PR DESCRIPTION
on top of https://github.com/paradigmxyz/reth/pull/11954

* adds `test-vectors` to op-reth
* adds `TxDeposit` to tested types
* adds op-reth to `compact-codecs.yml`