### PR TITLE
fix: check failed find nodes requests before sending new ones

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -23,7 +23,7 @@ pub struct Discv4Config {
     pub udp_egress_message_buffer: usize,
     /// Size of the channel buffer for incoming messages.
     pub udp_ingress_message_buffer: usize,
-    /// The number of allowed failures for `FindNode` requests. Default: 5.
+    /// The number of allowed consecutive failures for `FindNode` requests. Default: 5.
     pub max_find_node_failures: u8,
     /// The interval to use when checking for expired nodes that need to be re-pinged. Default:
     /// 10min.


### PR DESCRIPTION
closes #11992

this adds new checks before we send a new FindNode request.
if previous FindNode requests failed we try to establish a new endpoint proof first by pinging the node first before continuing with the lookup.

this will renew the endpoint proof on the other peer's end.