### PR TITLE
chore: increase max proof window

### DIFF
--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -51,9 +51,9 @@ pub const DEFAULT_MAX_SIMULATE_BLOCKS: u64 = 256;
 /// The default eth historical proof window.
 pub const DEFAULT_ETH_PROOF_WINDOW: u64 = 0;
 
-/// Maximum eth historical proof window. Equivalent to roughly one and a half months of data on a 12
-/// second block time, and a week on a 2 second block time.
-pub const MAX_ETH_PROOF_WINDOW: u64 = 7 * 24 * 60 * 60 / 2;
+/// Maximum eth historical proof window. Equivalent to roughly 6 months of data on a 12
+/// second block time, and a month on a 2 second block time.
+pub const MAX_ETH_PROOF_WINDOW: u64 = 28 * 24 * 60 * 60 / 2;
 
 /// GPO specific constants
 pub mod gas_oracle {


### PR DESCRIPTION
Increases the max configurable proof window to 1 month. @0x00101010 mentioned this change had already been discussed.