### PR TITLE
primitive-traits: rm `ALLOWED_FUTURE_BLOCK_TIME_SECONDS` constant

### DIFF
--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -90,15 +90,6 @@ pub const OP_SYSTEM_TX_TO_ADDR: Address = address!("4200000000000000000000000000
 /// the database.
 pub const BEACON_CONSENSUS_REORG_UNWIND_DEPTH: u64 = 3;
 
-/// Max seconds from current time allowed for blocks, before they're considered future blocks.
-///
-/// This is only used when checking whether or not the timestamp for pre-merge blocks is in the
-/// future.
-///
-/// See:
-/// <https://github.com/ethereum/go-ethereum/blob/a196f3e8a22b6ad22ced5c2e3baf32bc3ebd4ec9/consensus/ethash/consensus.go#L227-L229>
-pub const ALLOWED_FUTURE_BLOCK_TIME_SECONDS: u64 = 15;
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Can be imported directly from alloy https://github.com/alloy-rs/alloy/blob/31a5cf22a470452877221c4ef5c6940532e4ca7b/crates/eips/src/merge.rs#L46