### PR TITLE
chore(op): simplify blob fields in newly built block header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8279,7 +8279,6 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie",
  "revm",
- "revm-primitives",
  "sha2 0.10.8",
  "thiserror",
  "tracing",

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -39,7 +39,6 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 op-alloy-rpc-types-engine.workspace = true
-revm-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-consensus.workspace = true
 
@@ -56,5 +55,4 @@ optimism = [
 	"revm/optimism",
 	"reth-execution-types/optimism",
 	"reth-optimism-consensus/optimism",
-	"revm-primitives/optimism"
 ]


### PR DESCRIPTION
Simplify some no-ops, replace an Ethereum hardfork check with OP's, and remove `revm-primitives` as a dependency for OP payload building.