### PR TITLE
fix(exex): relax `ExExContext` trait bounds

### DIFF
--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -70,8 +70,6 @@ where
 impl<Node> ExExContext<Node>
 where
     Node: FullNodeComponents,
-    Node::Provider: Debug,
-    Node::Executor: Debug,
 {
     /// Returns the transaction pool of the node.
     pub fn pool(&self) -> &Node::Pool {
@@ -121,5 +119,35 @@ where
     /// with the provided head.
     pub fn set_notifications_with_head(&mut self, head: ExExHead) {
         self.notifications.set_with_head(head);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reth_exex_types::ExExHead;
+    use reth_node_api::FullNodeComponents;
+
+    use crate::ExExContext;
+
+    #[test]
+    const fn test_context_bounds() {
+        #[allow(dead_code)]
+        struct ExEx<Node: FullNodeComponents> {
+            ctx: ExExContext<Node>,
+        }
+
+        impl<Node: FullNodeComponents> ExEx<Node> {
+            async fn _test_bounds(mut self) -> eyre::Result<()> {
+                self.ctx.pool();
+                self.ctx.block_executor();
+                self.ctx.provider();
+                self.ctx.network();
+                self.ctx.payload_builder();
+                self.ctx.task_executor();
+                self.ctx.set_notifications_without_head();
+                self.ctx.set_notifications_with_head(ExExHead { block: Default::default() });
+                Ok(())
+            }
+        }
     }
 }

--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -129,8 +129,9 @@ mod tests {
 
     use crate::ExExContext;
 
+    /// <https://github.com/paradigmxyz/reth/issues/12054>
     #[test]
-    const fn test_context_bounds() {
+    const fn issue_12054() {
         #[allow(dead_code)]
         struct ExEx<Node: FullNodeComponents> {
             ctx: ExExContext<Node>,

--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -43,7 +43,7 @@ impl Debug for ExExContextDyn {
             .field("config", &self.config)
             .field("reth_config", &self.reth_config)
             .field("events", &self.events)
-            .field("notifications", &self.notifications)
+            .field("notifications", &"...")
             .finish()
     }
 }

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -24,7 +24,7 @@ pub struct ExExNotifications<P, E> {
 /// A trait, that represents a stream of [`ExExNotification`]s. The stream will emit notifications
 /// for all blocks. If the stream is configured with a head via [`ExExNotifications::set_with_head`]
 /// or [`ExExNotifications::with_head`], it will run backfill jobs to catch up to the node head.
-pub trait ExExNotificationsStream: Stream<Item = eyre::Result<ExExNotification>> {
+pub trait ExExNotificationsStream: Stream<Item = eyre::Result<ExExNotification>> + Unpin {
     /// Sets [`ExExNotificationsStream`] to a stream of [`ExExNotification`]s without a head.
     ///
     /// It's a no-op if the stream has already been configured without a head.
@@ -90,8 +90,8 @@ impl<P, E> ExExNotifications<P, E> {
 
 impl<P, E> ExExNotificationsStream for ExExNotifications<P, E>
 where
-    P: BlockReader + HeaderProvider + StateProviderFactory + Clone + Debug + Unpin + 'static,
-    E: BlockExecutorProvider + Clone + Debug + Unpin + 'static,
+    P: BlockReader + HeaderProvider + StateProviderFactory + Clone + Unpin + 'static,
+    E: BlockExecutorProvider + Clone + Unpin + 'static,
 {
     fn set_without_head(&mut self) {
         let current = std::mem::replace(&mut self.inner, ExExNotificationsInner::Invalid);

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -24,9 +24,7 @@ pub struct ExExNotifications<P, E> {
 /// A trait, that represents a stream of [`ExExNotification`]s. The stream will emit notifications
 /// for all blocks. If the stream is configured with a head via [`ExExNotifications::set_with_head`]
 /// or [`ExExNotifications::with_head`], it will run backfill jobs to catch up to the node head.
-pub trait ExExNotificationsStream:
-    Debug + Stream<Item = eyre::Result<ExExNotification>> + Unpin
-{
+pub trait ExExNotificationsStream: Stream<Item = eyre::Result<ExExNotification>> {
     /// Sets [`ExExNotificationsStream`] to a stream of [`ExExNotification`]s without a head.
     ///
     /// It's a no-op if the stream has already been configured without a head.


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/12054