### PR TITLE
feat: improve e2e tests API + feeHistory test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-contract"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460ab80ce4bda1c80bcf96fe7460520476f2c7b734581c6567fac2708e2a60ef"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-dyn-abi"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7013,6 +7033,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-signer",
  "alloy-signer-local",
+ "derive_more 1.0.0",
  "eyre",
  "futures-util",
  "jsonrpsee",
@@ -7966,10 +7987,13 @@ name = "reth-node-ethereum"
 version = "1.1.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-provider",
  "alloy-signer",
+ "alloy-sol-types",
  "eyre",
  "futures",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,6 +433,7 @@ alloy-sol-types = "0.8.0"
 alloy-trie = { version = "0.7", default-features = false }
 
 alloy-consensus = { version = "0.5.4", default-features = false }
+alloy-contract = { version = "0.5.4", default-features = false }
 alloy-eips = { version = "0.5.4", default-features = false }
 alloy-genesis = { version = "0.5.4", default-features = false }
 alloy-json-rpc = { version = "0.5.4", default-features = false }

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -45,3 +45,4 @@ alloy-rpc-types.workspace = true
 alloy-network.workspace = true
 alloy-consensus = { workspace = true, features = ["kzg"] }
 tracing.workspace = true
+derive_more.workspace = true

--- a/crates/e2e-test-utils/src/engine_api.rs
+++ b/crates/e2e-test-utils/src/engine_api.rs
@@ -50,12 +50,13 @@ impl<E: EngineTypes, ChainSpec: EthereumHardforks> EngineApiTestContext<E, Chain
         payload: E::BuiltPayload,
         payload_builder_attributes: E::PayloadBuilderAttributes,
         expected_status: PayloadStatusEnum,
-        versioned_hashes: Vec<B256>,
     ) -> eyre::Result<B256>
     where
         E::ExecutionPayloadEnvelopeV3: From<E::BuiltPayload> + PayloadEnvelopeExt,
         E::ExecutionPayloadEnvelopeV4: From<E::BuiltPayload> + PayloadEnvelopeExt,
     {
+        let versioned_hashes =
+            payload.block().blob_versioned_hashes_iter().copied().collect::<Vec<_>>();
         // submit payload to engine api
         let submission = if self
             .chain_spec

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -49,6 +49,7 @@ pub async fn setup<N>(
     num_nodes: usize,
     chain_spec: Arc<N::ChainSpec>,
     is_dev: bool,
+    attributes_generator: impl Fn(u64) -> <<N as NodeTypesWithEngine>::Engine as PayloadTypes>::PayloadBuilderAttributes + Copy + 'static,
 ) -> eyre::Result<(Vec<NodeHelperType<N, N::AddOns>>, TaskManager, Wallet)>
 where
     N: Default + Node<TmpNodeAdapter<N>> + NodeTypesWithEngine<ChainSpec: EthereumHardforks>,
@@ -84,7 +85,7 @@ where
             .launch()
             .await?;
 
-        let mut node = NodeTestContext::new(node).await?;
+        let mut node = NodeTestContext::new(node, attributes_generator).await?;
 
         // Connect each node in a chain.
         if let Some(previous_node) = nodes.last_mut() {
@@ -109,6 +110,7 @@ pub async fn setup_engine<N>(
     num_nodes: usize,
     chain_spec: Arc<N::ChainSpec>,
     is_dev: bool,
+    attributes_generator: impl Fn(u64) -> <<N as NodeTypesWithEngine>::Engine as PayloadTypes>::PayloadBuilderAttributes + Copy + 'static,
 ) -> eyre::Result<(
     Vec<NodeHelperType<N, N::AddOns, BlockchainProvider2<NodeTypesWithDBAdapter<N, TmpDB>>>>,
     TaskManager,
@@ -166,7 +168,7 @@ where
             })
             .await?;
 
-        let mut node = NodeTestContext::new(node).await?;
+        let mut node = NodeTestContext::new(node, attributes_generator).await?;
 
         // Connect each node in a chain.
         if let Some(previous_node) = nodes.last_mut() {

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -55,6 +55,9 @@ alloy-consensus.workspace = true
 alloy-provider.workspace = true
 rand.workspace = true
 alloy-signer.workspace = true
+alloy-eips.workspace = true
+alloy-sol-types.workspace = true
+alloy-contract.workspace = true
 
 [features]
 default = []

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -13,11 +13,13 @@ use reth_node_builder::{
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_provider::{providers::BlockchainProvider2, CanonStateSubscriptions};
 use reth_tasks::TaskManager;
+use crate::utils::eth_payload_attributes;
 
 #[tokio::test]
 async fn can_run_dev_node() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
-    let (mut nodes, _tasks, _) = setup::<EthereumNode>(1, custom_chain(), true).await?;
+    let (mut nodes, _tasks, _) =
+        setup::<EthereumNode>(1, custom_chain(), true, eth_payload_attributes).await?;
 
     assert_chain_advances(nodes.pop().unwrap().inner).await;
     Ok(())

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::utils::eth_payload_attributes;
 use alloy_genesis::Genesis;
 use alloy_primitives::{b256, hex};
 use futures::StreamExt;
@@ -13,7 +14,6 @@ use reth_node_builder::{
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_provider::{providers::BlockchainProvider2, CanonStateSubscriptions};
 use reth_tasks::TaskManager;
-use crate::utils::eth_payload_attributes;
 
 #[tokio::test]
 async fn can_run_dev_node() -> eyre::Result<()> {

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -26,6 +26,7 @@ async fn can_run_eth_node() -> eyre::Result<()> {
                 .build(),
         ),
         false,
+        eth_payload_attributes,
     )
     .await?;
 
@@ -36,7 +37,7 @@ async fn can_run_eth_node() -> eyre::Result<()> {
     let tx_hash = node.rpc.inject_tx(raw_tx).await?;
 
     // make the node advance
-    let (payload, _) = node.advance_block(vec![], eth_payload_attributes).await?;
+    let (payload, _) = node.advance_block().await?;
 
     let block_hash = payload.block().hash();
     let block_number = payload.block().number;
@@ -74,7 +75,7 @@ async fn can_run_eth_node_with_auth_engine_api_over_ipc() -> eyre::Result<()> {
         .node(EthereumNode::default())
         .launch()
         .await?;
-    let mut node = NodeTestContext::new(node).await?;
+    let mut node = NodeTestContext::new(node, eth_payload_attributes).await?;
 
     // Configure wallet from test mnemonic and create dummy transfer tx
     let wallet = Wallet::default();
@@ -84,7 +85,7 @@ async fn can_run_eth_node_with_auth_engine_api_over_ipc() -> eyre::Result<()> {
     let tx_hash = node.rpc.inject_tx(raw_tx).await?;
 
     // make the node advance
-    let (payload, _) = node.advance_block(vec![], eth_payload_attributes).await?;
+    let (payload, _) = node.advance_block().await?;
 
     let block_hash = payload.block().hash();
     let block_number = payload.block().number;
@@ -120,7 +121,7 @@ async fn test_failed_run_eth_node_with_no_auth_engine_api_over_ipc_opts() -> eyr
         .launch()
         .await?;
 
-    let node = NodeTestContext::new(node).await?;
+    let node = NodeTestContext::new(node, eth_payload_attributes).await?;
 
     // Ensure that the engine api client is not available
     let client = node.inner.engine_ipc_client().await;

--- a/crates/ethereum/node/tests/e2e/main.rs
+++ b/crates/ethereum/node/tests/e2e/main.rs
@@ -4,6 +4,7 @@ mod blobs;
 mod dev;
 mod eth;
 mod p2p;
+mod rpc;
 mod utils;
 
 const fn main() {}

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -30,6 +30,7 @@ async fn can_sync() -> eyre::Result<()> {
                 .build(),
         ),
         false,
+        eth_payload_attributes,
     )
     .await?;
 
@@ -41,7 +42,7 @@ async fn can_sync() -> eyre::Result<()> {
     let tx_hash = first_node.rpc.inject_tx(raw_tx).await?;
 
     // make the node advance
-    let (payload, _) = first_node.advance_block(vec![], eth_payload_attributes).await?;
+    let (payload, _) = first_node.advance_block().await?;
 
     let block_hash = payload.block().hash();
     let block_number = payload.block().number;
@@ -76,7 +77,7 @@ async fn e2e_test_send_transactions() -> eyre::Result<()> {
     );
 
     let (mut nodes, _tasks, wallet) =
-        setup_engine::<EthereumNode>(2, chain_spec.clone(), false).await?;
+        setup_engine::<EthereumNode>(2, chain_spec.clone(), false, eth_payload_attributes).await?;
     let mut node = nodes.pop().unwrap();
     let signers = wallet.gen();
     let provider = ProviderBuilder::new().with_recommended_fillers().on_http(node.rpc_url());
@@ -139,7 +140,7 @@ async fn e2e_test_send_transactions() -> eyre::Result<()> {
             pending.push(provider.send_tx_envelope(tx).await?);
         }
 
-        let (payload, _) = node.advance_block(vec![], eth_payload_attributes).await?;
+        let (payload, _) = node.advance_block().await?;
         assert!(payload.block().raw_transactions().len() == tx_count);
 
         for pending in pending {

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,0 +1,109 @@
+use crate::utils::eth_payload_attributes;
+use alloy_eips::calc_next_block_base_fee;
+use alloy_primitives::U256;
+use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_e2e_test_utils::setup_engine;
+use reth_node_ethereum::EthereumNode;
+use std::sync::Arc;
+
+alloy_sol_types::sol! {
+    #[sol(rpc, bytecode = "6080604052348015600f57600080fd5b5060405160db38038060db833981016040819052602a91607a565b60005b818110156074576040805143602082015290810182905260009060600160408051601f19818403018152919052805160209091012080555080606d816092565b915050602d565b505060b8565b600060208284031215608b57600080fd5b5051919050565b60006001820160b157634e487b7160e01b600052601160045260246000fd5b5060010190565b60168060c56000396000f3fe6080604052600080fdfea164736f6c6343000810000a")]
+    contract GasWaster {
+        constructor(uint256 iterations) {
+            for (uint256 i = 0; i < iterations; i++) {
+                bytes32 slot = keccak256(abi.encode(block.number, i));
+                assembly {
+                    sstore(slot, slot)
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_fee_history() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let seed: [u8; 32] = rand::thread_rng().gen();
+    let mut rng = StdRng::from_seed(seed);
+    println!("Seed: {:?}", seed);
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, _tasks, wallet) =
+        setup_engine::<EthereumNode>(1, chain_spec.clone(), false, eth_payload_attributes).await?;
+    let mut node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .with_recommended_fillers()
+        .wallet(EthereumWallet::new(wallet.gen().swap_remove(0)))
+        .on_http(node.rpc_url());
+
+    let fee_history = provider.get_fee_history(10, 0_u64.into(), &[]).await?;
+
+    let genesis_base_fee = chain_spec.initial_base_fee().unwrap() as u128;
+    let expected_first_base_fee = genesis_base_fee -
+        genesis_base_fee / chain_spec.base_fee_params_at_block(0).max_change_denominator;
+    assert_eq!(fee_history.base_fee_per_gas[0], genesis_base_fee);
+    assert_eq!(fee_history.base_fee_per_gas[1], expected_first_base_fee,);
+
+    // Spend some gas
+    let builder = GasWaster::deploy_builder(&provider, U256::from(500)).send().await?;
+    node.advance_block().await?;
+    let receipt = builder.get_receipt().await?;
+    assert!(receipt.status());
+
+    let block = provider.get_block_by_number(1.into(), false).await?.unwrap();
+    assert_eq!(block.header.gas_used as u128, receipt.gas_used,);
+    assert_eq!(block.header.base_fee_per_gas.unwrap(), expected_first_base_fee as u64);
+
+    for _ in 0..100 {
+        let _ =
+            GasWaster::deploy_builder(&provider, U256::from(rng.gen_range(0..1000))).send().await?;
+
+        node.advance_block().await?;
+    }
+
+    let latest_block = provider.get_block_number().await?;
+
+    for _ in 0..100 {
+        let latest_block = rng.gen_range(0..=latest_block);
+        let block_count = rng.gen_range(1..=(latest_block + 1));
+
+        let fee_history = provider.get_fee_history(block_count, latest_block.into(), &[]).await?;
+
+        let mut prev_header = provider
+            .get_block_by_number((latest_block + 1 - block_count).into(), false)
+            .await?
+            .unwrap()
+            .header;
+        for block in (latest_block + 2 - block_count)..=latest_block {
+            let expected_base_fee = calc_next_block_base_fee(
+                prev_header.gas_used,
+                prev_header.gas_limit,
+                prev_header.base_fee_per_gas.unwrap(),
+                chain_spec.base_fee_params_at_block(block),
+            );
+
+            let header = provider.get_block_by_number(block.into(), false).await?.unwrap().header;
+
+            assert_eq!(header.base_fee_per_gas.unwrap(), expected_base_fee as u64);
+            assert_eq!(
+                header.base_fee_per_gas.unwrap(),
+                fee_history.base_fee_per_gas[(block + block_count - 1 - latest_block) as usize]
+                    as u64
+            );
+
+            prev_header = header;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/optimism/node/tests/e2e/p2p.rs
+++ b/crates/optimism/node/tests/e2e/p2p.rs
@@ -51,7 +51,6 @@ async fn can_sync() -> eyre::Result<()> {
             side_payload_chain[0].0.clone(),
             side_payload_chain[0].1.clone(),
             PayloadStatusEnum::Valid,
-            Default::default(),
         )
         .await;
 
@@ -81,7 +80,6 @@ async fn can_sync() -> eyre::Result<()> {
                 }
                 .to_string(),
             },
-            Default::default(),
         )
         .await;
 


### PR DESCRIPTION
ref #12003 

Simplifies e2e tests API by requiring payload building fn to be passed during node setup and by removing `versioned_hashes` argument from payload building functions as it can be fetched from `BuiltPayload`

Also added a test for `feeHistory` endpoint