### PR TITLE
feat(rpc): Start to implement flashbots_validateBuilderSubmissionV3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8576,6 +8576,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
+ "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -245,7 +245,7 @@ RPC:
       --http.api <HTTP_API>
           Rpc Modules to be configured for the HTTP server
 
-          [possible values: admin, debug, eth, net, trace, txpool, web3, rpc, reth, ots]
+          [possible values: admin, debug, eth, net, trace, txpool, web3, rpc, reth, ots, flashbots]
 
       --http.corsdomain <HTTP_CORSDOMAIN>
           Http Corsdomain to allow request from
@@ -269,7 +269,7 @@ RPC:
       --ws.api <WS_API>
           Rpc Modules to be configured for the WS server
 
-          [possible values: admin, debug, eth, net, trace, txpool, web3, rpc, reth, ots]
+          [possible values: admin, debug, eth, net, trace, txpool, web3, rpc, reth, ots, flashbots]
 
       --ipcdisable
           Disable the IPC-RPC server

--- a/crates/rpc/rpc-api/src/validation.rs
+++ b/crates/rpc/rpc-api/src/validation.rs
@@ -1,7 +1,7 @@
 //! API for block submission validation.
 
 use alloy_rpc_types_beacon::relay::{
-    BuilderBlockValidationRequest, BuilderBlockValidationRequestV2,
+    BuilderBlockValidationRequest, BuilderBlockValidationRequestV2, BuilderBlockValidationRequestV3,
 };
 use jsonrpsee::proc_macros::rpc;
 
@@ -21,5 +21,12 @@ pub trait BlockSubmissionValidationApi {
     async fn validate_builder_submission_v2(
         &self,
         request: BuilderBlockValidationRequestV2,
+    ) -> jsonrpsee::core::RpcResult<()>;
+
+    /// A Request to validate a block submission.
+    #[method(name = "validateBuilderSubmissionV3")]
+    async fn validate_builder_submission_v3(
+        &self,
+        request: BuilderBlockValidationRequestV3,
     ) -> jsonrpsee::core::RpcResult<()>;
 }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -179,7 +179,7 @@ use reth_provider::{
 };
 use reth_rpc::{
     AdminApi, DebugApi, EngineEthApi, EthBundle, NetApi, OtterscanApi, RPCApi, RethApi, TraceApi,
-    TxPoolApi, Web3Api,
+    TxPoolApi, ValidationApi, Web3Api,
 };
 use reth_rpc_api::servers::*;
 use reth_rpc_eth_api::{
@@ -1063,6 +1063,11 @@ where
     pub fn reth_api(&self) -> RethApi<Provider> {
         RethApi::new(self.provider.clone(), Box::new(self.executor.clone()))
     }
+
+    /// Instantiates `ValidationApi`
+    pub fn validation_api(&self) -> ValidationApi<Provider> {
+        ValidationApi::new(self.provider.clone())
+    }
 }
 
 impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor>
@@ -1218,6 +1223,9 @@ where
                             RethApi::new(self.provider.clone(), Box::new(self.executor.clone()))
                                 .into_rpc()
                                 .into()
+                        }
+                        RethRpcModule::Flashbots => {
+                            ValidationApi::new(self.provider.clone()).into_rpc().into()
                         }
                     })
                     .clone()

--- a/crates/rpc/rpc-server-types/src/module.rs
+++ b/crates/rpc/rpc-server-types/src/module.rs
@@ -258,6 +258,8 @@ pub enum RethRpcModule {
     Reth,
     /// `ots_` module
     Ots,
+    /// `flashbots_` module
+    Flashbots,
 }
 
 // === impl RethRpcModule ===
@@ -306,6 +308,7 @@ impl FromStr for RethRpcModule {
             "rpc" => Self::Rpc,
             "reth" => Self::Reth,
             "ots" => Self::Ots,
+            "flashbots" => Self::Flashbots,
             _ => return Err(ParseError::VariantNotFound),
         })
     }

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -46,6 +46,7 @@ alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-rpc-types.workspace = true
+alloy-rpc-types-beacon.workspace = true
 alloy-rpc-types-eth = { workspace = true, features = ["jsonrpsee-types"] }
 alloy-rpc-types-debug.workspace = true
 alloy-rpc-types-trace.workspace = true

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -42,7 +42,9 @@ mod reth;
 mod rpc;
 mod trace;
 mod txpool;
+mod validation;
 mod web3;
+
 pub use admin::AdminApi;
 pub use debug::DebugApi;
 pub use engine::{EngineApi, EngineEthApi};
@@ -53,4 +55,5 @@ pub use reth::RethApi;
 pub use rpc::RPCApi;
 pub use trace::TraceApi;
 pub use txpool::TxPoolApi;
+pub use validation::ValidationApi;
 pub use web3::Web3Api;

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -8,6 +8,7 @@ use reth_provider::{
     AccountReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory, WithdrawalsProvider,
 };
 use reth_rpc_api::BlockSubmissionValidationApiServer;
+use reth_rpc_server_types::result::internal_rpc_err;
 use std::sync::Arc;
 use tracing::warn;
 
@@ -55,14 +56,14 @@ where
         &self,
         _request: BuilderBlockValidationRequest,
     ) -> RpcResult<()> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     async fn validate_builder_submission_v2(
         &self,
         _request: BuilderBlockValidationRequestV2,
     ) -> RpcResult<()> {
-        todo!()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     /// Validates a block submitted to the relay
@@ -70,7 +71,7 @@ where
         &self,
         request: BuilderBlockValidationRequestV3,
     ) -> RpcResult<()> {
-        warn!("validate_builder_submission_v3: blindly accepting {:?}", request);
+        warn!("flashbots_validateBuilderSubmissionV3: blindly accepting request without validation {:?}", request);
         Ok(())
     }
 }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -9,6 +9,7 @@ use reth_provider::{
 };
 use reth_rpc_api::BlockSubmissionValidationApiServer;
 use std::sync::Arc;
+use tracing::warn;
 
 /// The type that implements the `validation` rpc namespace trait
 pub struct ValidationApi<Provider> {
@@ -69,6 +70,7 @@ where
         &self,
         request: BuilderBlockValidationRequestV3,
     ) -> RpcResult<()> {
+        warn!("validate_builder_submission_v3: blindly accepting {:?}", request);
         Ok(())
     }
 }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -1,0 +1,91 @@
+use alloy_rpc_types_beacon::relay::{
+    BuilderBlockValidationRequest, BuilderBlockValidationRequestV2, BuilderBlockValidationRequestV3,
+};
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+use reth_chainspec::ChainSpecProvider;
+use reth_provider::{
+    AccountReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory, WithdrawalsProvider,
+};
+use reth_rpc_api::BlockSubmissionValidationApiServer;
+use std::sync::Arc;
+
+/// The type that implements the `validation` rpc namespace trait
+pub struct ValidationApi<Provider> {
+    inner: Arc<ValidationApiInner<Provider>>,
+}
+
+impl<Provider> ValidationApi<Provider>
+where
+    Provider: BlockReaderIdExt
+        + ChainSpecProvider
+        + StateProviderFactory
+        + HeaderProvider
+        + AccountReader
+        + WithdrawalsProvider
+        + Clone
+        + 'static,
+{
+    /// The provider that can interact with the chain.
+    pub fn provider(&self) -> Provider {
+        self.inner.provider.clone()
+    }
+
+    /// Create a new instance of the [`ValidationApi`]
+    pub fn new(provider: Provider) -> Self {
+        let inner = Arc::new(ValidationApiInner { provider });
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<Provider> BlockSubmissionValidationApiServer for ValidationApi<Provider>
+where
+    Provider: BlockReaderIdExt
+        + ChainSpecProvider
+        + StateProviderFactory
+        + HeaderProvider
+        + AccountReader
+        + WithdrawalsProvider
+        + Clone
+        + 'static,
+{
+    async fn validate_builder_submission_v1(
+        &self,
+        _request: BuilderBlockValidationRequest,
+    ) -> RpcResult<()> {
+        todo!()
+    }
+
+    async fn validate_builder_submission_v2(
+        &self,
+        _request: BuilderBlockValidationRequestV2,
+    ) -> RpcResult<()> {
+        todo!()
+    }
+
+    /// Validates a block submitted to the relay
+    async fn validate_builder_submission_v3(
+        &self,
+        request: BuilderBlockValidationRequestV3,
+    ) -> RpcResult<()> {
+        Ok(())
+    }
+}
+
+impl<Provider> std::fmt::Debug for ValidationApi<Provider> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ValidationApi").finish_non_exhaustive()
+    }
+}
+
+impl<Provider> Clone for ValidationApi<Provider> {
+    fn clone(&self) -> Self {
+        Self { inner: Arc::clone(&self.inner) }
+    }
+}
+
+struct ValidationApiInner<Provider> {
+    /// The provider that can interact with the chain.
+    provider: Provider,
+}


### PR DESCRIPTION
This first incremental version just accepts all inputs it can deserialize for `flashbots_validateBuilderSubmissionV3`.  To make it clear this is the case, it logs each request at warning level.

The older V1 and V2 RPCs are left unimplemented, they were used for older forks so I can't see a good reason to implement them, but they are needed to complete the `BlockSubmissionValidationApiServer` trait.

Next steps are:

- Implement the full V3 RPC using https://github.com/ultrasoundmoney/reth-payload-validator/tree/main as a reference
- Implement V3 w/ ExecutionRequests (this will require updates to alloy as currently V4 is just an alias for V3). 

But just having this stub available allows us to make progress on switching https://github.com/ethpandaops/ethereum-package/tree/bbusa/rbuilder over to using `rbuilder` and `reth` for block building in kurtosis. 
