### PR TITLE
fix: fail on unwind during `reth import`

### DIFF
--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -207,6 +207,7 @@ where
         .with_tip_sender(tip_tx)
         // we want to sync all blocks the file client provides or 0 if empty
         .with_max_block(max_block)
+        .with_fail_on_unwind(true)
         .add_stages(
             DefaultStages::new(
                 provider_factory.clone(),

--- a/crates/optimism/cli/src/commands/build_pipeline.rs
+++ b/crates/optimism/cli/src/commands/build_pipeline.rs
@@ -75,6 +75,7 @@ where
         .with_tip_sender(tip_tx)
         // we want to sync all blocks the file client provides or 0 if empty
         .with_max_block(max_block)
+        .with_fail_on_unwind(true)
         .add_stages(
             DefaultStages::new(
                 provider_factory.clone(),

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -188,4 +188,7 @@ pub enum PipelineError {
     /// Internal error
     #[error(transparent)]
     Internal(#[from] RethError),
+    /// The pipeline encountered an unwind when `fail_on_unwind` was set to `false`.
+    #[error("unexpected unwind")]
+    UnexpectedUnwind,
 }

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -188,7 +188,7 @@ pub enum PipelineError {
     /// Internal error
     #[error(transparent)]
     Internal(#[from] RethError),
-    /// The pipeline encountered an unwind when `fail_on_unwind` was set to `false`.
+    /// The pipeline encountered an unwind when `fail_on_unwind` was set to `true`.
     #[error("unexpected unwind")]
     UnexpectedUnwind,
 }

--- a/crates/stages/api/src/pipeline/builder.rs
+++ b/crates/stages/api/src/pipeline/builder.rs
@@ -63,7 +63,7 @@ impl<Provider> PipelineBuilder<Provider> {
         self
     }
 
-    /// Set the metric events sender.
+    /// Set whether pipeline should fail on unwind.
     pub const fn with_fail_on_unwind(mut self, yes: bool) -> Self {
         self.fail_on_unwind = yes;
         self

--- a/crates/stages/api/src/pipeline/builder.rs
+++ b/crates/stages/api/src/pipeline/builder.rs
@@ -64,7 +64,7 @@ impl<Provider> PipelineBuilder<Provider> {
     }
 
     /// Set the metric events sender.
-    pub fn with_fail_on_unwind(mut self, yes: bool) -> Self {
+    pub const fn with_fail_on_unwind(mut self, yes: bool) -> Self {
         self.fail_on_unwind = yes;
         self
     }
@@ -96,7 +96,13 @@ impl<Provider> PipelineBuilder<Provider> {
 
 impl<Provider> Default for PipelineBuilder<Provider> {
     fn default() -> Self {
-        Self { stages: Vec::new(), max_block: None, tip_tx: None, metrics_tx: None, fail_on_unwind: false }
+        Self {
+            stages: Vec::new(),
+            max_block: None,
+            tip_tx: None,
+            metrics_tx: None,
+            fail_on_unwind: false,
+        }
     }
 }
 

--- a/crates/stages/api/src/pipeline/builder.rs
+++ b/crates/stages/api/src/pipeline/builder.rs
@@ -14,6 +14,7 @@ pub struct PipelineBuilder<Provider> {
     /// A receiver for the current chain tip to sync to.
     tip_tx: Option<watch::Sender<B256>>,
     metrics_tx: Option<MetricEventsSender>,
+    fail_on_unwind: bool,
 }
 
 impl<Provider> PipelineBuilder<Provider> {
@@ -62,6 +63,12 @@ impl<Provider> PipelineBuilder<Provider> {
         self
     }
 
+    /// Set the metric events sender.
+    pub fn with_fail_on_unwind(mut self, yes: bool) -> Self {
+        self.fail_on_unwind = yes;
+        self
+    }
+
     /// Builds the final [`Pipeline`] using the given database.
     pub fn build<N>(
         self,
@@ -72,7 +79,7 @@ impl<Provider> PipelineBuilder<Provider> {
         N: ProviderNodeTypes,
         ProviderFactory<N>: DatabaseProviderFactory<ProviderRW = Provider>,
     {
-        let Self { stages, max_block, tip_tx, metrics_tx } = self;
+        let Self { stages, max_block, tip_tx, metrics_tx, fail_on_unwind } = self;
         Pipeline {
             provider_factory,
             stages,
@@ -82,13 +89,14 @@ impl<Provider> PipelineBuilder<Provider> {
             event_sender: Default::default(),
             progress: Default::default(),
             metrics_tx,
+            fail_on_unwind,
         }
     }
 }
 
 impl<Provider> Default for PipelineBuilder<Provider> {
     fn default() -> Self {
-        Self { stages: Vec::new(), max_block: None, tip_tx: None, metrics_tx: None }
+        Self { stages: Vec::new(), max_block: None, tip_tx: None, metrics_tx: None, fail_on_unwind: false }
     }
 }
 
@@ -97,6 +105,7 @@ impl<Provider> std::fmt::Debug for PipelineBuilder<Provider> {
         f.debug_struct("PipelineBuilder")
             .field("stages", &self.stages.iter().map(|stage| stage.id()).collect::<Vec<StageId>>())
             .field("max_block", &self.max_block)
+            .field("fail_on_unwind", &self.fail_on_unwind)
             .finish()
     }
 }


### PR DESCRIPTION
Should help with failing hive tests.

Added `fail_on_unwind` flag to `Pipeline`. If set, any unwind results in error in `Pipeline::run`. It is only set in `build_import_pipeline`