### PR TITLE
fix: ignore discovered peers with tcp port 0

### DIFF
--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -214,6 +214,10 @@ impl Discovery {
     fn on_node_record_update(&mut self, record: NodeRecord, fork_id: Option<ForkId>) {
         let peer_id = record.id;
         let tcp_addr = record.tcp_addr();
+        if tcp_addr.port() == 0 {
+            // useless peer for p2p
+            return
+        }
         let udp_addr = record.udp_addr();
         let addr = PeerAddr::new(tcp_addr, Some(udp_addr));
         _ =


### PR DESCRIPTION
closes #12014

these are useless and should be ignored

fyi @stevencartavia I quickly made this pr because this was just 3 lines :)