### PR TITLE
feat: `map_chainspec` for `NodeConfig`

### DIFF
--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -1,10 +1,11 @@
 //! Mirrored version of [`ExExContext`](`crate::ExExContext`)
 //! without generic abstraction over [Node](`reth_node_api::FullNodeComponents`)
 
+use std::fmt::Debug;
+
 use reth_chainspec::{EthChainSpec, Head};
 use reth_node_api::FullNodeComponents;
 use reth_node_core::node_config::NodeConfig;
-use std::{fmt::Debug, sync::Arc};
 use tokio::sync::mpsc;
 
 use crate::{ExExContext, ExExEvent, ExExNotificationsStream};
@@ -54,24 +55,8 @@ where
     Node::Executor: Debug,
 {
     fn from(ctx: ExExContext<Node>) -> Self {
-        let config = ctx.config.map_chainspec(|config| {
-            let chain = Arc::new(Box::new(config.chain) as Box<dyn EthChainSpec>);
-            NodeConfig {
-                chain,
-                datadir: config.datadir,
-                config: config.config,
-                metrics: config.metrics,
-                instance: config.instance,
-                network: config.network,
-                rpc: config.rpc,
-                txpool: config.txpool,
-                builder: config.builder,
-                debug: config.debug,
-                db: config.db,
-                dev: config.dev,
-                pruning: config.pruning,
-            }
-        });
+        let config =
+            ctx.config.map_chainspec(|chainspec| Box::new(chainspec) as Box<dyn EthChainSpec>);
         let notifications = Box::new(ctx.notifications) as Box<dyn ExExNotificationsStream>;
 
         Self {

--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -1,11 +1,10 @@
 //! Mirrored version of [`ExExContext`](`crate::ExExContext`)
 //! without generic abstraction over [Node](`reth_node_api::FullNodeComponents`)
 
-use std::fmt::Debug;
-
 use reth_chainspec::{EthChainSpec, Head};
 use reth_node_api::FullNodeComponents;
 use reth_node_core::node_config::NodeConfig;
+use std::{fmt::Debug, sync::Arc};
 use tokio::sync::mpsc;
 
 use crate::{ExExContext, ExExEvent, ExExNotificationsStream};
@@ -55,7 +54,24 @@ where
     Node::Executor: Debug,
 {
     fn from(ctx: ExExContext<Node>) -> Self {
-        let config = ctx.config.erased();
+        let config = ctx.config.map_chainspec(|config| {
+            let chain = Arc::new(Box::new(config.chain) as Box<dyn EthChainSpec>);
+            NodeConfig {
+                chain,
+                datadir: config.datadir,
+                config: config.config,
+                metrics: config.metrics,
+                instance: config.instance,
+                network: config.network,
+                rpc: config.rpc,
+                txpool: config.txpool,
+                builder: config.builder,
+                debug: config.debug,
+                db: config.db,
+                dev: config.dev,
+                pruning: config.pruning,
+            }
+        });
         let notifications = Box::new(ctx.notifications) as Box<dyn ExExNotificationsStream>;
 
         Self {

--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -1,7 +1,7 @@
 //! Mirrored version of [`ExExContext`](`crate::ExExContext`)
 //! without generic abstraction over [Node](`reth_node_api::FullNodeComponents`)
 
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use reth_chainspec::{EthChainSpec, Head};
 use reth_node_api::FullNodeComponents;
@@ -55,24 +55,7 @@ where
     Node::Executor: Debug,
 {
     fn from(ctx: ExExContext<Node>) -> Self {
-        // convert `NodeConfig` with generic over chainspec into `NodeConfig<Box<dyn EthChainSpec>`
-        let chain: Arc<Box<dyn EthChainSpec + 'static>> =
-            Arc::new(Box::new(ctx.config.chain) as Box<dyn EthChainSpec>);
-        let config = NodeConfig {
-            chain,
-            datadir: ctx.config.datadir,
-            config: ctx.config.config,
-            metrics: ctx.config.metrics,
-            instance: ctx.config.instance,
-            network: ctx.config.network,
-            rpc: ctx.config.rpc,
-            txpool: ctx.config.txpool,
-            builder: ctx.config.builder,
-            debug: ctx.config.debug,
-            db: ctx.config.db,
-            dev: ctx.config.dev,
-            pruning: ctx.config.pruning,
-        };
+        let config = ctx.config.erased();
         let notifications = Box::new(ctx.notifications) as Box<dyn ExExNotificationsStream>;
 
         Self {

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -423,27 +423,12 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         }
     }
 
-    /// Type erases the [`ChainSpec`] generic into a [`Box<dyn EthChainSpec>`].
-    pub fn erased(self) -> NodeConfig<Box<dyn EthChainSpec>>
+    /// Maps the config using the provided closure to update the [`ChainSpec`] generic.
+    pub fn map_chainspec<F, C>(self, f: F) -> NodeConfig<C>
     where
-        ChainSpec: EthChainSpec + 'static,
+        F: FnOnce(Self) -> NodeConfig<C>,
     {
-        let chain = Arc::new(Box::new(self.chain) as Box<dyn EthChainSpec>);
-        NodeConfig {
-            chain,
-            datadir: self.datadir,
-            config: self.config,
-            metrics: self.metrics,
-            instance: self.instance,
-            network: self.network,
-            rpc: self.rpc,
-            txpool: self.txpool,
-            builder: self.builder,
-            debug: self.debug,
-            db: self.db,
-            dev: self.dev,
-            pruning: self.pruning,
-        }
+        f(self)
     }
 }
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -422,6 +422,29 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             Err(e) => Err(eyre!("Failed to load configuration: {e}")),
         }
     }
+
+    /// Type erases the [`ChainSpec`] generic into a [`Box<dyn EthChainSpec>`].
+    pub fn erased(self) -> NodeConfig<Box<dyn EthChainSpec>>
+    where
+        ChainSpec: EthChainSpec + 'static,
+    {
+        let chain = Arc::new(Box::new(self.chain) as Box<dyn EthChainSpec>);
+        NodeConfig {
+            chain,
+            datadir: self.datadir,
+            config: self.config,
+            metrics: self.metrics,
+            instance: self.instance,
+            network: self.network,
+            rpc: self.rpc,
+            txpool: self.txpool,
+            builder: self.builder,
+            debug: self.debug,
+            db: self.db,
+            dev: self.dev,
+            pruning: self.pruning,
+        }
+    }
 }
 
 impl Default for NodeConfig<ChainSpec> {

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -426,9 +426,24 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     /// Maps the config using the provided closure to update the [`ChainSpec`] generic.
     pub fn map_chainspec<F, C>(self, f: F) -> NodeConfig<C>
     where
-        F: FnOnce(Self) -> NodeConfig<C>,
+        F: FnOnce(Arc<ChainSpec>) -> C,
     {
-        f(self)
+        let chain = Arc::new(f(self.chain));
+        NodeConfig {
+            chain,
+            datadir: self.datadir,
+            config: self.config,
+            metrics: self.metrics,
+            instance: self.instance,
+            network: self.network,
+            rpc: self.rpc,
+            txpool: self.txpool,
+            builder: self.builder,
+            debug: self.debug,
+            db: self.db,
+            dev: self.dev,
+            pruning: self.pruning,
+        }
     }
 }
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -423,7 +423,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         }
     }
 
-    /// Maps the config using the provided closure to update the [`ChainSpec`] generic.
+    /// Modifies the [`ChainSpec`] generic of the config using the provided closure.
     pub fn map_chainspec<F, C>(self, f: F) -> NodeConfig<C>
     where
         F: FnOnce(Arc<ChainSpec>) -> C,


### PR DESCRIPTION
Introduce the `erased` method on `NodeConfig`, which allows to map a `NodeConfig<ChainSpec> where ChainSpec: EthChainSpec` into a `NodeConfig<Box<dyn EthChainSpec>>`.

Resolves #12040 