### PR TITLE
making `command` public

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -52,7 +52,7 @@ pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + f
         value_parser = C::parser(),
         global = true,
     )]
-    chain: Arc<C::ChainSpec>,
+    pub chain: Arc<C::ChainSpec>,
 
     /// Add a new instance of a node.
     ///
@@ -68,10 +68,10 @@ pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + f
     /// - `HTTP_RPC_PORT`: default - `instance` + 1
     /// - `WS_RPC_PORT`: default + `instance` * 2 - 2
     #[arg(long, value_name = "INSTANCE", global = true, default_value_t = 1, value_parser = value_parser!(u16).range(..=200))]
-    instance: u16,
+    pub instance: u16,
 
     #[command(flatten)]
-    logs: LogArgs,
+    pub logs: LogArgs,
 }
 
 impl Cli {

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -39,7 +39,7 @@ pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + f
 {
     /// The command to run
     #[command(subcommand)]
-    command: Commands<C, Ext>,
+    pub command: Commands<C, Ext>,
 
     /// The chain this node is running.
     ///

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -70,7 +70,7 @@ pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + f
     #[arg(long, value_name = "INSTANCE", global = true, default_value_t = 1, value_parser = value_parser!(u16).range(..=200))]
     pub instance: u16,
 
-    /// The logging configuration for the CLI. 
+    /// The logging configuration for the CLI.
     #[command(flatten)]
     pub logs: LogArgs,
 }

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -70,6 +70,7 @@ pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + f
     #[arg(long, value_name = "INSTANCE", global = true, default_value_t = 1, value_parser = value_parser!(u16).range(..=200))]
     pub instance: u16,
 
+    /// The logging configuration for the CLI. 
     #[command(flatten)]
     pub logs: LogArgs,
 }


### PR DESCRIPTION
Improve reth's extendibility pattern by making the command field public. Projects using reth can handle certain commands in custom ways.

Cli args should have visibility from any codebase which extends/uses reth. Keeping `command` public here would facilitate this.

Take the `Import` command, for example.

```rs
// in bin/reth/src/cli/mod.rs
Commands::Import(command) => runner.run_blocking_until_ctrl_c(
    command.execute::<EthereumNode, _, _>(EthExecutorProvider::ethereum),
),
```

This hardcodes the executer as Ethereum's default executor, which causes state root mismatches while processing blocks for a chain with custom post block execution logic. If we made this `command` field public, we could have custom execution logic for a specific command like this:

```rs
// in main.rs //
let cli = Cli::<EthereumChainSpecParser, NoArgs>::parse();
match cli.command {
    Commands::Import(command) => {
        // custom import logic starts here
        let runner = CliRunner::default();
        let res = runner.run_blocking_until_ctrl_c(
            command.execute::<GnosisNode, _, _>(gnosis_executor_provider)
        );
        if let Err(err) = res {
            eprintln!("Error: {err:?}");
            std::process::exit(1);
        }
        // custom execution logic ends here
    }
    _ => {
        if let Err(err) = cli.run(|builder, _| async move {
            // normal execution logic
            let handle = builder.node(GnosisNode::new()).launch().await?;
            handle.node_exit_future.await
        }) {
            eprintln!("Error: {err:?}");
            std::process::exit(1);
        }
    }
}
```