### PR TITLE
TransactionsHandle propagation commands should not adhere to caching

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -458,6 +458,8 @@ where
                 // transaction lists, before deciding whether or not to send full transactions to
                 // the peer.
                 for tx in &to_propagate {
+                    // Only proceed if the transaction is not in the peer's list of seen
+                    // transactions
                     if !peer.seen_transactions.contains(&tx.hash()) {
                         builder.push(tx);
                     }

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -632,13 +632,6 @@ where
                 propagated.0.entry(hash).or_default().push(PropagateKind::Hash(peer_id));
             }
 
-            // Update the cache if respecting cache
-            if !propagation_mode.is_forced() {
-                for hash in new_pooled_hashes.iter_hashes().copied() {
-                    peer.seen_transactions.insert(hash);
-                }
-            }
-
             trace!(target: "net::tx::propagation", ?peer_id, ?new_pooled_hashes, "Propagating transactions to peer");
 
             // send hashes of transactions

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -561,26 +561,16 @@ pub enum PropagateKind {
     Full(PeerId),
     /// Only the Hash was propagated to the peer.
     Hash(PeerId),
-    /// Default propagation mode, filters out txs that we already sent or received
-    Basic,
-    /// Always propagate, even if we already sent or received the txs.
-    Forced,
 }
 
 // === impl PropagateKind ===
 
 impl PropagateKind {
     /// Returns the peer the transaction was sent to
-    pub const fn peer(&self) -> Option<&PeerId> {
+    pub const fn peer(&self) -> &PeerId {
         match self {
-            Self::Full(peer) | Self::Hash(peer) => Some(peer),
-            Self::Basic | Self::Forced => None,
+            Self::Full(peer) | Self::Hash(peer) => peer,
         }
-    }
-
-    /// Returns `true` if the propagation kind is `Forced`.
-    pub const fn is_forced(self) -> bool {
-        matches!(self, Self::Forced)
     }
 
     /// Returns true if the transaction was sent as a full transaction
@@ -591,6 +581,14 @@ impl PropagateKind {
     /// Returns true if the transaction was sent as a hash
     pub const fn is_hash(&self) -> bool {
         matches!(self, Self::Hash(_))
+    }
+}
+
+impl From<PropagateKind> for PeerId {
+    fn from(value: PropagateKind) -> Self {
+        match value {
+            PropagateKind::Full(peer) | PropagateKind::Hash(peer) => peer,
+        }
     }
 }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -561,16 +561,26 @@ pub enum PropagateKind {
     Full(PeerId),
     /// Only the Hash was propagated to the peer.
     Hash(PeerId),
+    /// Default propagation mode, filters out txs that we already sent or received
+    Basic,
+    /// Always propagate, even if we already sent or received the txs.
+    Forced,
 }
 
 // === impl PropagateKind ===
 
 impl PropagateKind {
     /// Returns the peer the transaction was sent to
-    pub const fn peer(&self) -> &PeerId {
+    pub const fn peer(&self) -> Option<&PeerId> {
         match self {
-            Self::Full(peer) | Self::Hash(peer) => peer,
+            Self::Full(peer) | Self::Hash(peer) => Some(peer),
+            Self::Basic | Self::Forced => None,
         }
+    }
+
+    /// Returns `true` if the propagation kind is `Forced`.
+    pub const fn is_forced(self) -> bool {
+        matches!(self, Self::Forced)
     }
 
     /// Returns true if the transaction was sent as a full transaction
@@ -581,14 +591,6 @@ impl PropagateKind {
     /// Returns true if the transaction was sent as a hash
     pub const fn is_hash(&self) -> bool {
         matches!(self, Self::Hash(_))
-    }
-}
-
-impl From<PropagateKind> for PeerId {
-    fn from(value: PropagateKind) -> Self {
-        match value {
-            PropagateKind::Full(peer) | PropagateKind::Hash(peer) => peer,
-        }
     }
 }
 


### PR DESCRIPTION
Closes #12033

**Description:**
This pull request addresses the issue where manual propagation commands in `TransactionsHandle` were adhering to caching, preventing forced broadcasts. The following changes have been made:

- **Added `PropgateKind` Enum:**
  Introduced a `PropagateKind` enum with variants `Basic` and `Forced` to control caching behavior during transaction propagation.

- **Modified Propagation Methods:**
  Updated methods such as `propagate_full_transactions_to_peer`, `propagate_hashes_to`, and `propagate_transactions` to accept a `PropgateKind` parameter.

- **Updated Manual Propagation Commands:**
  In the `on_command` method, manual propagation commands now use `PropgateKind::Basic` to bypass the cache, allowing forced broadcasts.

- **Ensured Regular Propagation Respects Cache:**
  Regular propagation commands continue to use `PropgateKind::Forced`, maintaining the caching mechanism to optimize network usage.

- **Updated Tests:**
  Modified existing tests and added new ones to cover scenarios with both cache policies, ensuring that the caching behavior is as expected.




@mattsse  Please review the changes and let me know if any adjustments are needed.
