### PR TITLE
test(trie-db): add checks for tree mask invariant

### DIFF
--- a/crates/trie/db/tests/common.rs
+++ b/crates/trie/db/tests/common.rs
@@ -1,0 +1,34 @@
+#![allow(missing_docs)]
+
+use reth_trie::{BranchNodeCompact, Nibbles};
+use std::collections::{HashMap, HashSet};
+
+/// Helper function to verify tree mask invariant similar to the fuzzer
+pub(crate) fn verify_tree_mask_invariant(
+    nodes: &HashMap<Nibbles, BranchNodeCompact>,
+    removed: &HashSet<Nibbles>,
+) -> bool {
+    for (path, branch_node) in nodes {
+        let child_paths = (0..16)
+            .filter(|&pos| (branch_node.tree_mask.get() & (1 << pos)) != 0)
+            .map(|pos| {
+                let mut child_path = path.clone();
+                child_path.push(pos as u8);
+                child_path
+            })
+            .collect::<Vec<_>>();
+
+        for child_path in child_paths {
+            if !nodes.contains_key(&child_path) && !removed.contains(&child_path) {
+                println!(
+                    "Missing child node at path: {:?} for parent: {:?} with mask: {:016b}",
+                    child_path,
+                    path,
+                    branch_node.tree_mask.get()
+                );
+                return false;
+            }
+        }
+    }
+    true
+}

--- a/crates/trie/db/tests/common.rs
+++ b/crates/trie/db/tests/common.rs
@@ -3,7 +3,15 @@
 use reth_trie::{BranchNodeCompact, Nibbles};
 use std::collections::{HashMap, HashSet};
 
-/// Helper function to verify tree mask invariant similar to the fuzzer
+/// Helper function to verify tree mask invariant: for each branch node in trie
+/// nodes with path, for each position with 1 in its tree mask, there must be
+/// branch nodes in trie updates at paths path-position.
+///
+/// For instance, for branch node at path 0x01 with tree mask 0100000001010101,
+/// in trie updates we must have branch nodes at paths 0x010, 0x012, 0x014,
+/// 0x016, 0x01e (the mask indicates child nibbles but it goes from the right to
+/// left).
+#[allow(dead_code)]
 pub(crate) fn verify_tree_mask_invariant(
     nodes: &HashMap<Nibbles, BranchNodeCompact>,
     removed: &HashSet<Nibbles>,

--- a/crates/trie/db/tests/fuzz_in_memory_nodes.rs
+++ b/crates/trie/db/tests/fuzz_in_memory_nodes.rs
@@ -33,6 +33,16 @@ impl VerifiableTrieUpdates for StorageTrieUpdates {
     }
 }
 
+impl VerifiableTrieUpdates for TrieUpdates {
+    fn nodes_ref(&self) -> &HashMap<Nibbles, BranchNodeCompact> {
+        self.account_nodes_ref()
+    }
+
+    fn removed_nodes_ref(&self) -> &HashSet<Nibbles> {
+        self.removed_nodes_ref()
+    }
+}
+
 const fn is_bit_set(mask: u16, position: u8) -> bool {
     (mask & (1 << position)) != 0
 }
@@ -87,6 +97,9 @@ proptest! {
             .root_with_updates()
             .unwrap();
 
+        // verify initial tree mask invariant
+        assert!(verify_storage_trie_tree_mask_invariant(&trie_nodes));
+
         let mut state = init_state;
         for state_update in state_updates {
              // Insert state updates into database
@@ -120,6 +133,8 @@ proptest! {
             );
             assert_eq!(expected_root, state_root);
         }
+        // verify tree mask invariant after updates
+        assert!(verify_storage_trie_tree_mask_invariant(&trie_nodes));
     }
 
     #[test]

--- a/crates/trie/db/tests/fuzz_in_memory_nodes.rs
+++ b/crates/trie/db/tests/fuzz_in_memory_nodes.rs
@@ -43,7 +43,7 @@ proptest! {
             .unwrap();
 
         // verify initial tree mask invariant
-        assert!(verify_tree_mask_invariant(&trie_nodes.account_nodes_ref(), &trie_nodes.removed_nodes_ref()));
+        assert!(verify_tree_mask_invariant(trie_nodes.account_nodes_ref(), trie_nodes.removed_nodes_ref()));
 
         let mut state = init_state;
         for state_update in state_updates {
@@ -79,7 +79,7 @@ proptest! {
             assert_eq!(expected_root, state_root);
         }
         // verify tree mask invariant after updates
-        assert!(verify_tree_mask_invariant(&trie_nodes.account_nodes_ref(), &trie_nodes.removed_nodes_ref()));
+        assert!(verify_tree_mask_invariant(trie_nodes.account_nodes_ref(), trie_nodes.removed_nodes_ref()));
     }
 
     #[test]
@@ -102,7 +102,7 @@ proptest! {
             StorageRoot::from_tx_hashed(provider.tx_ref(), hashed_address).root_with_updates().unwrap();
 
         // verify initial tree mask invariant
-        assert!(verify_tree_mask_invariant(&storage_trie_nodes.storage_nodes_ref(), &storage_trie_nodes.removed_nodes_ref()));
+        assert!(verify_tree_mask_invariant(storage_trie_nodes.storage_nodes_ref(), storage_trie_nodes.removed_nodes_ref()));
 
         let mut storage = init_storage;
         for (is_deleted, mut storage_update) in storage_updates {
@@ -143,6 +143,6 @@ proptest! {
         }
 
         // verify tree mask invariant after updates
-        assert!(verify_tree_mask_invariant(&storage_trie_nodes.storage_nodes_ref(), &storage_trie_nodes.removed_nodes_ref()));
+        assert!(verify_tree_mask_invariant(storage_trie_nodes.storage_nodes_ref(), storage_trie_nodes.removed_nodes_ref()));
     }
 }

--- a/crates/trie/db/tests/tree_mask.rs
+++ b/crates/trie/db/tests/tree_mask.rs
@@ -1,0 +1,159 @@
+#![allow(missing_docs)]
+
+use alloy_primitives::{B256, U256};
+use reth_db::{cursor::DbCursorRW, tables, transaction::DbTxMut};
+use reth_primitives::Account;
+use reth_provider::test_utils::create_test_provider_factory;
+use reth_trie::{trie_cursor::InMemoryTrieCursorFactory, HashedPostState, Nibbles, StateRoot};
+use reth_trie_common::BranchNodeCompact;
+use reth_trie_db::{DatabaseStateRoot, DatabaseTrieCursorFactory};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    str::FromStr,
+};
+
+/// Helper function to verify tree mask invariant similar to the fuzzer
+fn verify_tree_mask_invariant(
+    nodes: &HashMap<Nibbles, BranchNodeCompact>,
+    removed: &HashSet<Nibbles>,
+) -> bool {
+    for (path, branch_node) in nodes {
+        let child_paths = (0..16)
+            .filter(|&pos| (branch_node.tree_mask.get() & (1 << pos)) != 0)
+            .map(|pos| {
+                let mut child_path = path.clone();
+                child_path.push(pos as u8);
+                child_path
+            })
+            .collect::<Vec<_>>();
+
+        for child_path in child_paths {
+            if !nodes.contains_key(&child_path) && !removed.contains(&child_path) {
+                println!(
+                    "Missing child node at path: {:?} for parent: {:?} with mask: {:016b}",
+                    child_path,
+                    path,
+                    branch_node.tree_mask.get()
+                );
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[test]
+fn test_tree_mask_invariant_regression() {
+    let factory = create_test_provider_factory();
+    let provider = factory.provider_rw().unwrap();
+    let mut hashed_account_cursor =
+        provider.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
+
+    // initial state that triggered the bug
+    let mut init_state = BTreeMap::new();
+    init_state.insert(
+        B256::from_str("b0eadc24c8b856c298f120d53504054937ad6f10981f6cfd4f7dd28b488de6bb").unwrap(),
+        U256::from_str(
+            "8191087236450936987389588093826784753915004608762462187916580788651909579970",
+        )
+        .unwrap(),
+    );
+    init_state.insert(
+        B256::from_str("b650000000000000000000000000000000000000000000000000000000000000").unwrap(),
+        U256::from_str("1502831726292624754819496855058931322619830474306082077188255614238720")
+            .unwrap(),
+    );
+    init_state.insert(
+        B256::from_str("b65217bdbbccae258ec1b7ddfbc73abd91693a291c9ee2df9756408f4e097d7f").unwrap(),
+        U256::from_str(
+            "67678148959447529652628808732627110556888940958577363264860875821424387015141",
+        )
+        .unwrap(),
+    );
+    init_state.insert(
+        B256::from_str("b652c6105e18b957ed216d5dabe509dc9b87060e1cc3da097e96b60859a473fb").unwrap(),
+        U256::from_str(
+            "112824820931552671541607645878429951093128233648894736867125614595897428715080",
+        )
+        .unwrap(),
+    );
+
+    // insert init state into database
+    for (hashed_address, balance) in init_state.clone() {
+        hashed_account_cursor
+            .upsert(hashed_address, Account { balance, ..Default::default() })
+            .unwrap();
+    }
+
+    // get initial root and updates
+    let (_, mut trie_nodes) = StateRoot::from_tx(provider.tx_ref()).root_with_updates().unwrap();
+
+    // verify initial tree mask invariant
+    assert!(verify_tree_mask_invariant(
+        trie_nodes.account_nodes_ref(),
+        trie_nodes.removed_nodes_ref()
+    ));
+
+    // first update from the failing test case
+    let update = BTreeMap::from([
+        (
+            B256::from_str("245edb422018381f402c25b6cd6510b23adfb89e8aae077e2267dd1e38d65b82")
+                .unwrap(),
+            Some(
+                U256::from_str(
+                    "32389638575033086484031574202531845846535608532580941050116309514422859555371",
+                )
+                .unwrap(),
+            ),
+        ),
+        (
+            B256::from_str("785021a08d7111e76c17897b02df917dd86b381260b51bf80f5b868e3029e7c2")
+                .unwrap(),
+            Some(
+                U256::from_str(
+                    "19591547302947487246265266157960068499012679158449160478744628061815918167659",
+                )
+                .unwrap(),
+            ),
+        ),
+        (
+            B256::from_str("c30771ee925a78dec279b691233b7445ef826648fe8d95ffe49f563edc5cb713")
+                .unwrap(),
+            Some(
+                U256::from_str(
+                    "67939140076345108486057192637455821946901230687705312285974934873833035160833",
+                )
+                .unwrap(),
+            ),
+        ),
+    ]);
+
+    // apply update
+    let mut hashed_state = HashedPostState::default();
+    for (hashed_address, balance) in update {
+        if let Some(balance) = balance {
+            let account = Account { balance, ..Default::default() };
+            hashed_account_cursor.upsert(hashed_address, account).unwrap();
+            hashed_state.accounts.insert(hashed_address, Some(account));
+        } else {
+            hashed_state.accounts.insert(hashed_address, None);
+        }
+    }
+
+    // calculate new root with in-memory trie nodes overlay
+    let (_, trie_updates) = StateRoot::from_tx(provider.tx_ref())
+        .with_prefix_sets(hashed_state.construct_prefix_sets().freeze())
+        .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
+            DatabaseTrieCursorFactory::new(provider.tx_ref()),
+            &trie_nodes.clone().into_sorted(),
+        ))
+        .root_with_updates()
+        .unwrap();
+
+    trie_nodes.extend(trie_updates);
+
+    assert!(verify_tree_mask_invariant(
+        trie_nodes.account_nodes_ref(),
+        trie_nodes.removed_nodes_ref()
+    ));
+}

--- a/crates/trie/db/tests/tree_mask.rs
+++ b/crates/trie/db/tests/tree_mask.rs
@@ -57,6 +57,15 @@ fn test_tree_mask_invariant_regression() {
     // get initial root and updates
     let (_, mut trie_nodes) = StateRoot::from_tx(provider.tx_ref()).root_with_updates().unwrap();
 
+    println!("Node state at failure:");
+    for (path, node) in trie_nodes.account_nodes_ref() {
+        println!("Path: {:?}", path);
+        println!("  State mask: {:016b}", node.state_mask.get());
+        println!("  Tree mask:  {:016b}", node.tree_mask.get());
+        println!("  Hash mask:  {:016b}", node.hash_mask.get());
+        println!("  Hashes: {}", node.hashes.len());
+    }
+
     // verify initial tree mask invariant
     assert!(verify_tree_mask_invariant(
         trie_nodes.account_nodes_ref(),
@@ -120,6 +129,15 @@ fn test_tree_mask_invariant_regression() {
         .unwrap();
 
     trie_nodes.extend(trie_updates);
+
+    println!("Node state at failure:");
+    for (path, node) in trie_nodes.account_nodes_ref() {
+        println!("Path: {:?}", path);
+        println!("  State mask: {:016b}", node.state_mask.get());
+        println!("  Tree mask:  {:016b}", node.tree_mask.get());
+        println!("  Hash mask:  {:016b}", node.hash_mask.get());
+        println!("  Hashes: {}", node.hashes.len());
+    }
 
     assert!(verify_tree_mask_invariant(
         trie_nodes.account_nodes_ref(),

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -149,6 +149,7 @@ where
     }
 
     fn calculate(self, retain_updates: bool) -> Result<StateRootProgress, StateRootError> {
+        println!("in StateRoot::calculate");
         trace!(target: "trie::state_root", "calculating state root");
         let mut tracker = TrieTracker::default();
         let mut trie_updates = TrieUpdates::default();
@@ -158,6 +159,7 @@ where
         let hashed_account_cursor = self.hashed_cursor_factory.hashed_account_cursor()?;
         let (mut hash_builder, mut account_node_iter) = match self.previous_state {
             Some(state) => {
+                println!("in StateRoot::calculate, there is previous_state");
                 let hash_builder = state.hash_builder.with_updates(retain_updates);
                 let walker = TrieWalker::from_stack(
                     trie_cursor,
@@ -170,6 +172,7 @@ where
                 (hash_builder, node_iter)
             }
             None => {
+                println!("in StateRoot::calculate, no previous_state");
                 let hash_builder = HashBuilder::default().with_updates(retain_updates);
                 let walker = TrieWalker::new(trie_cursor, self.prefix_sets.account_prefix_set)
                     .with_deletions_retained(retain_updates);
@@ -184,10 +187,12 @@ where
         while let Some(node) = account_node_iter.try_next()? {
             match node {
                 TrieElement::Branch(node) => {
+                    println!("in StateRoot::calculate, in iter, branch node {node:?}");
                     tracker.inc_branch();
                     hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
                 }
                 TrieElement::Leaf(hashed_address, account) => {
+                    println!("in StateRoot::calculate, in iter, leaf node {hashed_address:?}, {account:?}");
                     tracker.inc_leaf();
                     hashed_entries_walked += 1;
 


### PR DESCRIPTION
Ref: https://github.com/paradigmxyz/reth/issues/12129

The invariant checked is: for each branch node in trie nodes with `path`, for each `position` with 1 in its tree mask, there must be branch nodes in trie updates at paths `path`-`position`.

For instance, for branch node at path 0x01 with tree mask 0100000001010101, in trie updates we must have branch nodes at paths 0x010, 0x012, 0x014, 0x016, 0x01e (the mask indicates child nibbles but it goes from the right to left)