### PR TITLE
docs: remove deleted op-sync workflow from docs

### DIFF
--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -7,8 +7,7 @@ The CI runs a couple of workflows:
 - **[unit]**: Runs unit tests (tests in `src/`) and doc tests
 - **[integration]**: Runs integration tests (tests in `tests/` and sync tests)
 - **[bench]**: Runs benchmarks
-- **[eth-sync]**: Runs Ethereum mainnet sync tests
-- **[op-sync]**: Runs base mainnet sync tests for Optimism
+- **[sync]**: Runs sync tests
 - **[stage]**: Runs all `stage run` commands
 
 ### Docs

--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -39,7 +39,6 @@ The CI runs a couple of workflows:
 [integration]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/integration.yml
 [bench]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/bench.yml
 [eth-sync]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/eth-sync.yml
-[op-sync]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/op-sync.yml
 [stage]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/stage.yml
 [book]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/book.yml
 [deny]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/deny.yml

--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -38,7 +38,7 @@ The CI runs a couple of workflows:
 [unit]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/unit.yml
 [integration]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/integration.yml
 [bench]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/bench.yml
-[eth-sync]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/eth-sync.yml
+[sync]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/sync.yml
 [stage]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/stage.yml
 [book]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/book.yml
 [deny]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/deny.yml


### PR DESCRIPTION
Hi there the [op-sync ci](https://github.com/paradigmxyz/reth/blob/main/.github/workflows/op-sync.yml) was deleted