### PR TITLE
fix(trie): sparse trie walk should be done in a sorted manner

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -666,7 +666,7 @@ impl RevealedSparseTrie {
                     }
 
                     branch_child_buf.clear();
-                    for bit in CHILD_INDEX_RANGE {
+                    for bit in CHILD_INDEX_RANGE.rev() {
                         if state_mask.is_bit_set(bit) {
                             let mut child = path.clone();
                             child.push_unchecked(bit);
@@ -686,6 +686,7 @@ impl RevealedSparseTrie {
                             continue 'main
                         }
                     }
+                    branch_value_stack_buf.reverse();
 
                     self.rlp_buf.clear();
                     let rlp_node = BranchNodeRef::new(&branch_value_stack_buf, *state_mask)

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -666,6 +666,8 @@ impl RevealedSparseTrie {
                     }
 
                     branch_child_buf.clear();
+                    // Walk children in a reverse order from `f` to `0`, so we pop the `0` first
+                    // from the stack.
                     for bit in CHILD_INDEX_RANGE.rev() {
                         if state_mask.is_bit_set(bit) {
                             let mut child = path.clone();
@@ -679,6 +681,8 @@ impl RevealedSparseTrie {
                     for (i, child_path) in branch_child_buf.iter().enumerate() {
                         if rlp_node_stack.last().map_or(false, |e| &e.0 == child_path) {
                             let (_, child) = rlp_node_stack.pop().unwrap();
+                            // Insert children in the resulting buffer in a normal order, because
+                            // initially we iterated in reverse.
                             branch_value_stack_buf[branch_child_buf.len() - i - 1] = child;
                             added_children = true;
                         } else {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -674,19 +674,20 @@ impl RevealedSparseTrie {
                         }
                     }
 
-                    branch_value_stack_buf.clear();
-                    for child_path in &branch_child_buf {
+                    branch_value_stack_buf.resize(branch_child_buf.len(), Default::default());
+                    let mut added_children = false;
+                    for (i, child_path) in branch_child_buf.iter().enumerate() {
                         if rlp_node_stack.last().map_or(false, |e| &e.0 == child_path) {
                             let (_, child) = rlp_node_stack.pop().unwrap();
-                            branch_value_stack_buf.push(child);
+                            branch_value_stack_buf[branch_child_buf.len() - i - 1] = child;
+                            added_children = true;
                         } else {
-                            debug_assert!(branch_value_stack_buf.is_empty());
+                            debug_assert!(!added_children);
                             path_stack.push(path);
                             path_stack.extend(branch_child_buf.drain(..));
                             continue 'main
                         }
                     }
-                    branch_value_stack_buf.reverse();
 
                     self.rlp_buf.clear();
                     let rlp_node = BranchNodeRef::new(&branch_value_stack_buf, *state_mask)


### PR DESCRIPTION
Two fixes:
1. Iterate children of a branch node in reverse, because we push them to the stack and then pop from it. So pushing `a..=f` means popping `f..=a`. We need to push `f..=a` and pop `a..=f` to make it a DFS search.
2. Return paths in the same order as they were popped from the trie, and it's a sorted order. It's crucial for the prefix set to work efficiently.