### PR TITLE
perf(trie): cache prefix set lookups in sparse trie

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -618,7 +618,7 @@ impl RevealedSparseTrie {
 
     fn rlp_node(&mut self, path: Nibbles, prefix_set: &mut PrefixSet) -> RlpNode {
         // stack of paths we need rlp nodes for
-        let mut path_stack = Vec::from([(path, false)]);
+        let mut path_stack = Vec::from([(path, None)]);
         // stack of rlp nodes
         let mut rlp_node_stack = Vec::<(Nibbles, RlpNode)>::new();
         // reusable branch child path
@@ -626,7 +626,17 @@ impl RevealedSparseTrie {
         // reusable branch value stack
         let mut branch_value_stack_buf = SmallVec::<[RlpNode; 16]>::new_const();
 
-        'main: while let Some((path, is_in_prefix_set)) = path_stack.pop() {
+        'main: while let Some((path, mut is_in_prefix_set)) = path_stack.pop() {
+            // Check if the path is in the prefix set.
+            // First, check the cached value. If it's `None`, then check the prefix set, and update
+            // the cached value.
+            let mut prefix_set_contains = |path: &Nibbles| {
+                if let Some(is_in_prefix_set) = is_in_prefix_set {
+                    return is_in_prefix_set
+                }
+                *is_in_prefix_set.insert(prefix_set.contains(path))
+            };
+
             let rlp_node = match self.nodes.get_mut(&path).unwrap() {
                 SparseNode::Empty => RlpNode::word_rlp(&EMPTY_ROOT_HASH),
                 SparseNode::Hash(hash) => RlpNode::word_rlp(hash),
@@ -634,7 +644,7 @@ impl RevealedSparseTrie {
                     self.rlp_buf.clear();
                     let mut path = path.clone();
                     path.extend_from_slice_unchecked(key);
-                    if let Some(hash) = hash.filter(|_| !prefix_set.contains(&path)) {
+                    if let Some(hash) = hash.filter(|_| prefix_set_contains(&path)) {
                         RlpNode::word_rlp(&hash)
                     } else {
                         let value = self.values.get(&path).unwrap();
@@ -646,9 +656,7 @@ impl RevealedSparseTrie {
                 SparseNode::Extension { key, hash } => {
                     let mut child_path = path.clone();
                     child_path.extend_from_slice_unchecked(key);
-                    if let Some(hash) =
-                        hash.filter(|_| !is_in_prefix_set && !prefix_set.contains(&path))
-                    {
+                    if let Some(hash) = hash.filter(|_| prefix_set_contains(&path)) {
                         RlpNode::word_rlp(&hash)
                     } else if rlp_node_stack.last().map_or(false, |e| e.0 == child_path) {
                         let (_, child) = rlp_node_stack.pop().unwrap();
@@ -658,14 +666,12 @@ impl RevealedSparseTrie {
                         rlp_node
                     } else {
                         // need to get rlp node for child first
-                        path_stack.extend([(path, true), (child_path, false)]);
+                        path_stack.extend([(path, is_in_prefix_set), (child_path, None)]);
                         continue
                     }
                 }
                 SparseNode::Branch { state_mask, hash } => {
-                    if let Some(hash) =
-                        hash.filter(|_| !is_in_prefix_set && !prefix_set.contains(&path))
-                    {
+                    if let Some(hash) = hash.filter(|_| prefix_set_contains(&path)) {
                         rlp_node_stack.push((path, RlpNode::word_rlp(&hash)));
                         continue
                     }
@@ -686,8 +692,8 @@ impl RevealedSparseTrie {
                             branch_value_stack_buf.push(child);
                         } else {
                             debug_assert!(branch_value_stack_buf.is_empty());
-                            path_stack.push((path, true));
-                            path_stack.extend(branch_child_buf.drain(..).map(|p| (p, false)));
+                            path_stack.push((path, is_in_prefix_set));
+                            path_stack.extend(branch_child_buf.drain(..).map(|p| (p, None)));
                             continue 'main
                         }
                     }


### PR DESCRIPTION
We can save on a `PrefixSet::contains` lookup for those nodes that were already checked. It can happen when checking the children of a branch node and then checking the branch node again, and when checking the extension node and then checking it again.