### PR TITLE
chore: only check for better payload if tx_pool

### DIFF
--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -414,8 +414,8 @@ where
         }
     }
 
-    // check if we have a better block
-    if !is_better_payload(best_payload.as_ref(), total_fees) {
+    // check if we have a better block, but only if we included transactions from the pool
+    if !attributes.no_tx_pool && !is_better_payload(best_payload.as_ref(), total_fees) {
         // can skip building the block
         return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
     }


### PR DESCRIPTION
if `no_tx_pool` is set we don't include txs from the pool. then the block is deterministic and we don't need to check this