### PR TITLE
chore(rpc): simplify trait bounds on `EthApiSpec` impl

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -3,20 +3,17 @@ use reth_chainspec::EthereumHardforks;
 use reth_network_api::NetworkInfo;
 use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
 use reth_rpc_eth_api::{helpers::EthApiSpec, RpcNodeCore};
-use reth_transaction_pool::TransactionPool;
 
 use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> EthApiSpec for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: RpcNodeCore<Provider = Provider, Network = Network>,
-    Pool: TransactionPool + 'static,
-    Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
-        + BlockNumReader
-        + StageCheckpointReader
-        + 'static,
-    Network: NetworkInfo + 'static,
-    EvmConfig: Send + Sync,
+    Self: RpcNodeCore<
+        Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
+                      + BlockNumReader
+                      + StageCheckpointReader,
+        Network: NetworkInfo,
+    >,
 {
     fn starting_block(&self) -> U256 {
         self.inner.starting_block()


### PR DESCRIPTION
Simplifies `where` clause on `EthApiSpec` impl for `EthApi`