### PR TITLE
chore(rpc): remove redundant trait bounds in eth api

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -10,10 +10,7 @@ use reth::{
     network::PeersHandleProvider,
     providers::{BlockReader, BlockReaderIdExt, CanonStateSubscriptions, StageCheckpointReader},
     rpc::{
-        api::eth::{
-            helpers::{EthApiSpec, EthTransactions, TraceExt},
-            FullEthApiTypes,
-        },
+        api::eth::helpers::{EthApiSpec, EthTransactions, TraceExt},
         types::engine::PayloadStatusEnum,
     },
 };
@@ -97,7 +94,7 @@ where
     where
         Engine::ExecutionPayloadEnvelopeV3: From<Engine::BuiltPayload> + PayloadEnvelopeExt,
         Engine::ExecutionPayloadEnvelopeV4: From<Engine::BuiltPayload> + PayloadEnvelopeExt,
-        AddOns::EthApi: EthApiSpec + EthTransactions + TraceExt + FullEthApiTypes,
+        AddOns::EthApi: EthApiSpec + EthTransactions + TraceExt,
     {
         let mut chain = Vec::with_capacity(length as usize);
         for i in 0..length {

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -231,7 +231,7 @@ pub trait EthTransactions: LoadTransaction {
         include_pending: bool,
     ) -> impl Future<Output = Result<Option<RpcTransaction<Self::NetworkTypes>>, Self::Error>> + Send
     where
-        Self: LoadBlock + LoadState + FullEthApiTypes,
+        Self: LoadBlock + LoadState,
     {
         async move {
             // Check the pool first

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -145,8 +145,7 @@ where
 impl<Provider, Pool, Eth> EthFilter<Provider, Pool, Eth>
 where
     Provider: BlockReader + BlockIdReader + EvmEnvProvider + 'static,
-    Pool: TransactionPool + 'static,
-    <Pool as TransactionPool>::Transaction: 'static,
+    Pool: TransactionPool<Transaction: 'static> + 'static,
     Eth: FullEthApiTypes,
 {
     /// Returns all the filter changes for the given id, if any


### PR DESCRIPTION
Removes redundant trait bounds in eth api