### PR TITLE
fix(ci): remove import path from type names on `compact-codec` 

### DIFF
--- a/.github/workflows/compact.yml
+++ b/.github/workflows/compact.yml
@@ -36,7 +36,9 @@ jobs:
           ref: ${{ github.base_ref || 'main' }}
       # On `main` branch, generates test vectors and serializes them to disk using `Compact`.
       - name: Generate compact vectors
-        run: ${{ matrix.bin }} -- test-vectors compact --write
+        run: |
+          ${{ matrix.bin }} -- test-vectors compact --write &&
+          for f in ./testdata/micro/compact/*; do mv "$f" "$(dirname "$f")/$(basename "$f" | awk -F '__' '{print $NF}')"; done
       - name: Checkout PR
         uses: actions/checkout@v4
         with:

--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -267,5 +267,5 @@ where
 }
 
 pub fn type_name<T>() -> String {
-    std::any::type_name::<T>().replace("::", "__")
+    std::any::type_name::<T>().split("::").last().unwrap_or(std::any::type_name::<T>()).to_string()
 }


### PR DESCRIPTION
fixes https://github.com/paradigmxyz/reth/pull/12119#issuecomment-2440637861

Removes import path from the type name, otherwise the CI will fail when moving types.