### PR TITLE
feat: add `pending|queued` txs pool helpers 

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -506,14 +506,14 @@ where
     fn get_pending_transactions_by_sender(
         &self,
         sender: Address,
-    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>{
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.get_pending_transactions_by_sender(sender)
     }
 
     fn get_queued_transactions_by_sender(
         &self,
         sender: Address,
-    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>{
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.get_queued_transactions_by_sender(sender)
     }
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -503,6 +503,20 @@ where
         self.pool.get_transactions_by_sender(sender)
     }
 
+    fn get_pending_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>{
+        self.pool.get_pending_transactions_by_sender(sender)
+    }
+
+    fn get_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>{
+        self.pool.get_queued_transactions_by_sender(sender)
+    }
+
     fn get_highest_transaction_by_sender(
         &self,
         sender: Address,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -220,6 +220,20 @@ impl TransactionPool for NoopTransactionPool {
         vec![]
     }
 
+    fn get_pending_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    fn get_queued_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
     fn get_highest_transaction_by_sender(
         &self,
         _sender: Address,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -776,6 +776,26 @@ where
         self.get_pool_data().get_transactions_by_sender(sender_id)
     }
 
+    /// Returns all queued transactions of the address by sender
+    pub(crate) fn get_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let sender_id = self.get_sender_id(sender);
+        self.get_pool_data()
+            .pending_txs_by_sender(sender_id)
+    }
+
+    /// Returns all pending transactions of the address by sender
+    pub(crate) fn get_pending_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let sender_id = self.get_sender_id(sender);
+        self.get_pool_data()
+            .queued_txs_by_sender(sender_id)
+    }
+
     /// Returns the highest transaction of the address
     pub(crate) fn get_highest_transaction_by_sender(
         &self,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -782,8 +782,7 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         let sender_id = self.get_sender_id(sender);
-        self.get_pool_data()
-            .pending_txs_by_sender(sender_id)
+        self.get_pool_data().pending_txs_by_sender(sender_id)
     }
 
     /// Returns all pending transactions of the address by sender
@@ -792,8 +791,7 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         let sender_id = self.get_sender_id(sender);
-        self.get_pool_data()
-            .queued_txs_by_sender(sender_id)
+        self.get_pool_data().queued_txs_by_sender(sender_id)
     }
 
     /// Returns the highest transaction of the address

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -362,9 +362,24 @@ impl<T: TransactionOrdering> TxPool<T> {
         self.pending_pool.all()
     }
 
+    /// Returns all pending transactions for the specified sender
+    pub(crate) fn pending_txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.pending_transactions_iter().filter(|tx| tx.sender_id() == sender).collect()
+    }
+
     /// Returns all transactions from parked pools
     pub(crate) fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.basefee_pool.all().chain(self.queued_pool.all()).collect()
+    }
+
+    /// Returns an iterator over all transactions from parked pools
+    pub(crate) fn queued_transactions_iter(
+        &self,
+    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T::Transaction>>> + '_ {
+        self.basefee_pool.all().chain(self.queued_pool.all())
     }
 
     /// Returns queued and pending transactions for the specified sender
@@ -373,6 +388,14 @@ impl<T: TransactionOrdering> TxPool<T> {
         sender: SenderId,
     ) -> (SmallVec<[TransactionId; TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER]>, Vec<TransactionId>) {
         (self.queued_pool.get_txs_by_sender(sender), self.pending_pool.get_txs_by_sender(sender))
+    }
+
+    /// Returns all queued transactions for the specified sender
+    pub(crate) fn queued_txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.queued_transactions_iter().filter(|tx| tx.sender_id() == sender).collect()
     }
 
     /// Returns `true` if the transaction with the given hash is already included in this pool.

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -352,6 +352,18 @@ pub trait TransactionPool: Send + Sync + Clone {
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
+    /// Returns all pending transactions sent by a given user
+    fn get_pending_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
+    /// Returns all queued transactions sent by a given user
+    fn get_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
     /// Returns the highest transaction sent by a given user
     fn get_highest_transaction_by_sender(
         &self,
@@ -1332,13 +1344,13 @@ impl TryFrom<TransactionSignedEcRecovered> for EthPooledTransaction {
             }
             EIP4844_TX_TYPE_ID => {
                 // doesn't have a blob sidecar
-                return Err(TryFromRecoveredTransactionError::BlobSidecarMissing)
+                return Err(TryFromRecoveredTransactionError::BlobSidecarMissing);
             }
             unsupported => {
                 // unsupported transaction type
                 return Err(TryFromRecoveredTransactionError::UnsupportedTransactionType(
                     unsupported,
-                ))
+                ));
             }
         };
 
@@ -1454,7 +1466,7 @@ impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
             match self.st.try_recv() {
                 Ok(event) => {
                     if event.subpool == self.subpool {
-                        return Ok(event)
+                        return Ok(event);
                     }
                 }
                 Err(e) => return Err(e),
@@ -1471,7 +1483,7 @@ impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
             match ready!(self.st.poll_recv(cx)) {
                 Some(event) => {
                     if event.subpool == self.subpool {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
                 }
                 None => return Poll::Ready(None),

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1350,7 +1350,7 @@ impl TryFrom<TransactionSignedEcRecovered> for EthPooledTransaction {
                 // unsupported transaction type
                 return Err(TryFromRecoveredTransactionError::UnsupportedTransactionType(
                     unsupported,
-                ));
+                ))
             }
         };
 
@@ -1466,7 +1466,7 @@ impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
             match self.st.try_recv() {
                 Ok(event) => {
                     if event.subpool == self.subpool {
-                        return Ok(event);
+                        return Ok(event)
                     }
                 }
                 Err(e) => return Err(e),
@@ -1483,7 +1483,7 @@ impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
             match ready!(self.st.poll_recv(cx)) {
                 Some(event) => {
                     if event.subpool == self.subpool {
-                        return Poll::Ready(Some(event));
+                        return Poll::Ready(Some(event))
                     }
                 }
                 None => return Poll::Ready(None),


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/12091.

Add 2 helpers `get_pending_transactions_by_sender` and `get_queued_transactions_by_sender`.