### PR TITLE
fix(ci): remove renaming from `compact-codec`

### DIFF
--- a/.github/workflows/compact.yml
+++ b/.github/workflows/compact.yml
@@ -37,8 +37,7 @@ jobs:
       # On `main` branch, generates test vectors and serializes them to disk using `Compact`.
       - name: Generate compact vectors
         run: |
-          ${{ matrix.bin }} -- test-vectors compact --write &&
-          for f in ./testdata/micro/compact/*; do mv "$f" "$(dirname "$f")/$(basename "$f" | awk -F '__' '{print $NF}')"; done
+          ${{ matrix.bin }} -- test-vectors compact --write
       - name: Checkout PR
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
introduced on https://github.com/paradigmxyz/reth/pull/12125, no longer necessary. all type names are without import paths.