### PR TITLE
chore(rpc): inline trait methods of `RpcNodeCore` impl

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -124,18 +124,22 @@ where
     type Network = <N as RpcNodeCore>::Network;
     type Evm = <N as RpcNodeCore>::Evm;
 
+    #[inline]
     fn pool(&self) -> &Self::Pool {
         self.inner.pool()
     }
 
+    #[inline]
     fn evm_config(&self) -> &Self::Evm {
         self.inner.evm_config()
     }
 
+    #[inline]
     fn network(&self) -> &Self::Network {
         self.inner.network()
     }
 
+    #[inline]
     fn provider(&self) -> &Self::Provider {
         self.inner.provider()
     }

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -40,18 +40,22 @@ where
     type Network = <T as FullNodeComponents>::Network;
     type Evm = <T as FullNodeComponents>::Evm;
 
+    #[inline]
     fn pool(&self) -> &Self::Pool {
         FullNodeComponents::pool(self)
     }
 
+    #[inline]
     fn evm_config(&self) -> &Self::Evm {
         FullNodeComponents::evm_config(self)
     }
 
+    #[inline]
     fn network(&self) -> &Self::Network {
         FullNodeComponents::network(self)
     }
 
+    #[inline]
     fn provider(&self) -> &Self::Provider {
         FullNodeComponents::provider(self)
     }


### PR DESCRIPTION
Inlines impl of trait methods of `RpcNodeCore` for `EthApi` and `OpEthApi`