### PR TITLE
feat(trie): reveal storage slots and calculate storage root in sparse trie

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -116,6 +116,11 @@ impl SparseStateTrie {
     pub fn root(&mut self) -> Option<B256> {
         self.state.root()
     }
+
+    /// Returns storage sparse trie root if the trie has been revealed.
+    pub fn storage_root(&mut self, account: B256) -> Option<B256> {
+        self.storages.get_mut(&account).and_then(|trie| trie.root())
+    }
 }
 
 #[cfg(test)]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -12,10 +12,8 @@ pub struct SparseStateTrie {
     /// Sparse account trie.
     pub(crate) state: SparseTrie,
     /// Sparse storage tries.
-    #[allow(dead_code)]
     pub(crate) storages: HashMap<B256, SparseTrie>,
     /// Collection of revealed account and storage keys.
-    #[allow(dead_code)]
     pub(crate) revealed: HashMap<B256, HashSet<B256>>,
 }
 
@@ -35,7 +33,7 @@ impl SparseStateTrie {
         self.revealed.get(account).map_or(false, |slots| slots.contains(slot))
     }
 
-    /// Reveal unknown trie paths from provided leaf path and its proof for account.
+    /// Reveal unknown trie paths from provided leaf path and its proof for the account.
     /// NOTE: This method does not extensively validate the proof.
     pub fn reveal_account(
         &mut self,
@@ -71,7 +69,7 @@ impl SparseStateTrie {
         Ok(())
     }
 
-    /// Reveal unknown trie paths from provided leaf path and its proof for account.
+    /// Reveal unknown trie paths from provided leaf path and its proof for the storage slot.
     /// NOTE: This method does not extensively validate the proof.
     pub fn reveal_storage_slot(
         &mut self,


### PR DESCRIPTION
Adds a high-level API for revealing a storage slot in the sparse trie.