### PR TITLE
chore(rpc): add super trait `RpcNodeCoreExt` to `LoadReceipt`

### DIFF
--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -11,7 +11,7 @@ use reth_optimism_forks::OptimismHardforks;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned, TxType};
 use reth_provider::ChainSpecProvider;
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcReceipt};
-use reth_rpc_eth_types::{EthApiError, EthStateCache, ReceiptBuilder};
+use reth_rpc_eth_types::{EthApiError, ReceiptBuilder};
 
 use crate::{OpEthApi, OpEthApiError};
 
@@ -20,18 +20,14 @@ where
     Self: Send + Sync,
     N: FullNodeComponents<Types: NodeTypes<ChainSpec = OpChainSpec>>,
 {
-    #[inline]
-    fn cache(&self) -> &EthStateCache {
-        self.inner.cache()
-    }
-
     async fn build_transaction_receipt(
         &self,
         tx: TransactionSigned,
         meta: TransactionMeta,
         receipt: Receipt,
     ) -> Result<RpcReceipt<Self::NetworkTypes>, Self::Error> {
-        let (block, receipts) = LoadReceipt::cache(self)
+        let (block, receipts) = self
+            .cache()
             .get_block_and_receipts(meta.block_hash)
             .await
             .map_err(Self::Error::from_eth_err)?

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -145,7 +145,8 @@ pub trait EthBlocks: LoadBlock {
             if let Some(block_hash) =
                 self.provider().block_hash_for_id(block_id).map_err(Self::Error::from_eth_err)?
             {
-                return LoadReceipt::cache(self)
+                return self
+                    .cache()
                     .get_block_and_receipts(block_hash)
                     .await
                     .map_err(Self::Error::from_eth_err)

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -3,19 +3,13 @@
 
 use futures::Future;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
-use reth_rpc_eth_types::EthStateCache;
 
-use crate::{EthApiTypes, RpcReceipt};
+use crate::{EthApiTypes, RpcNodeCoreExt, RpcReceipt};
 
 /// Assembles transaction receipt data w.r.t to network.
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` receipts RPC methods.
-pub trait LoadReceipt: EthApiTypes + Send + Sync {
-    /// Returns a handle for reading data from memory.
-    ///
-    /// Data access in default (L1) trait method implementations.
-    fn cache(&self) -> &EthStateCache;
-
+pub trait LoadReceipt: EthApiTypes + RpcNodeCoreExt + Send + Sync {
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.
     fn build_transaction_receipt(
         &self,

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -2,20 +2,15 @@
 
 use alloy_serde::WithOtherFields;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
-use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcReceipt};
-use reth_rpc_eth_types::{EthApiError, EthStateCache, ReceiptBuilder};
+use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
+use reth_rpc_eth_types::{EthApiError, ReceiptBuilder};
 
 use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> LoadReceipt for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: Send + Sync,
+    Self: RpcNodeCoreExt,
 {
-    #[inline]
-    fn cache(&self) -> &EthStateCache {
-        self.inner.cache()
-    }
-
     async fn build_transaction_receipt(
         &self,
         tx: TransactionSigned,


### PR DESCRIPTION
Remove redundant `LoadReceipt::cache` in favour of adding `RpcNodeCoreExt` as super trait