### PR TITLE
fix: restrict concurrent incoming connections

### DIFF
--- a/crates/net/network-types/src/peers/state.rs
+++ b/crates/net/network-types/src/peers/state.rs
@@ -31,6 +31,12 @@ impl PeerConnectionState {
         }
     }
 
+    /// Returns true if this is the idle state.
+    #[inline]
+    pub const fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+
     /// Returns true if this is an active incoming connection.
     #[inline]
     pub const fn is_incoming(&self) -> bool {


### PR DESCRIPTION
we didn't properly check how many pending incoming connections are already in progress.

this adds an additional check for this.

there's an edge where no incoming connections from untrusted peers are allowed, so we need to check this differently.

