### PR TITLE
fix: use net::discv5 for reth's discv5 tracing target namespace (reverts #12045)

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -412,7 +412,7 @@ pub fn discv5_sockets_wrt_rlpx_addr(
                 discv5_addr_ipv6.map(|ip| SocketAddrV6::new(ip, discv5_port_ipv6, 0, 0));
 
             if let Some(discv5_addr) = discv5_addr_ipv4 {
-                warn!(target: "discv5",
+                warn!(target: "net::discv5",
                     %discv5_addr,
                     %rlpx_addr,
                     "Overwriting discv5 IPv4 address with RLPx IPv4 address, limited to one advertised IP address per IP version"
@@ -429,7 +429,7 @@ pub fn discv5_sockets_wrt_rlpx_addr(
                 discv5_addr_ipv4.map(|ip| SocketAddrV4::new(ip, discv5_port_ipv4));
 
             if let Some(discv5_addr) = discv5_addr_ipv6 {
-                warn!(target: "discv5",
+                warn!(target: "net::discv5",
                     %discv5_addr,
                     %rlpx_addr,
                     "Overwriting discv5 IPv6 address with RLPx IPv6 address, limited to one advertised IP address per IP version"

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -95,14 +95,14 @@ impl Discv5 {
     /// CAUTION: The value **must** be rlp encoded
     pub fn set_eip868_in_local_enr(&self, key: Vec<u8>, rlp: Bytes) {
         let Ok(key_str) = std::str::from_utf8(&key) else {
-            error!(target: "discv5",
+            error!(target: "net::discv5",
                 err="key not utf-8",
                 "failed to update local enr"
             );
             return
         };
         if let Err(err) = self.discv5.enr_insert(key_str, &rlp) {
-            error!(target: "discv5",
+            error!(target: "net::discv5",
                 %err,
                 "failed to update local enr"
             );
@@ -131,7 +131,7 @@ impl Discv5 {
                 self.discv5.ban_node(&node_id, None);
                 self.ban_ip(ip);
             }
-            Err(err) => error!(target: "discv5",
+            Err(err) => error!(target: "net::discv5",
                 %err,
                 "failed to ban peer"
             ),

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -167,7 +167,7 @@ impl Discv5 {
         //
         let (enr, bc_enr, fork_key, rlpx_ip_mode) = build_local_enr(sk, &discv5_config);
 
-        trace!(target: "discv5",
+        trace!(target: "net::discv5",
             ?enr,
             "local ENR"
         );
@@ -271,7 +271,7 @@ impl Discv5 {
                 // to them over RLPx, to be compatible with EL discv5 implementations that don't
                 // enforce this security measure.
 
-                trace!(target: "discv5",
+                trace!(target: "net::discv5",
                     ?enr,
                     %socket,
                     "discovered unverifiable enr, source socket doesn't match socket advertised in ENR"
@@ -296,7 +296,7 @@ impl Discv5 {
         let node_record = match self.try_into_reachable(enr, socket) {
             Ok(enr_bc) => enr_bc,
             Err(err) => {
-                trace!(target: "discv5",
+                trace!(target: "net::discv5",
                     %err,
                     ?enr,
                     "discovered peer is unreachable"
@@ -308,7 +308,7 @@ impl Discv5 {
             }
         };
         if let FilterOutcome::Ignore { reason } = self.filter_discovered_peer(enr) {
-            trace!(target: "discv5",
+            trace!(target: "net::discv5",
                 ?enr,
                 reason,
                 "filtered out discovered peer"
@@ -324,7 +324,7 @@ impl Discv5 {
             .then(|| self.get_fork_id(enr).ok())
             .flatten();
 
-        trace!(target: "discv5",
+        trace!(target: "net::discv5",
             ?fork_id,
             ?enr,
             "discovered peer"
@@ -491,7 +491,7 @@ pub async fn bootstrap(
     bootstrap_nodes: HashSet<BootNode>,
     discv5: &Arc<discv5::Discv5>,
 ) -> Result<(), Error> {
-    trace!(target: "discv5",
+    trace!(target: "net::discv5",
         ?bootstrap_nodes,
         "adding bootstrap nodes .."
     );
@@ -508,7 +508,7 @@ pub async fn bootstrap(
                 let discv5 = discv5.clone();
                 enr_requests.push(async move {
                     if let Err(err) = discv5.request_enr(enode.to_string()).await {
-                        debug!(target: "discv5",
+                        debug!(target: "net::discv5",
                             ?enode,
                             %err,
                             "failed adding boot node"
@@ -545,7 +545,7 @@ pub fn spawn_populate_kbuckets_bg(
             for i in (0..bootstrap_lookup_countdown).rev() {
                 let target = discv5::enr::NodeId::random();
 
-                trace!(target: "discv5",
+                trace!(target: "net::discv5",
                     %target,
                     bootstrap_boost_runs_countdown=i,
                     lookup_interval=format!("{:#?}", pulse_lookup_interval),
@@ -563,7 +563,7 @@ pub fn spawn_populate_kbuckets_bg(
                 // selection (ref kademlia)
                 let target = get_lookup_target(kbucket_index, local_node_id);
 
-                trace!(target: "discv5",
+                trace!(target: "net::discv5",
                     %target,
                     lookup_interval=format!("{:#?}", lookup_interval),
                     "starting periodic lookup query"
@@ -628,11 +628,11 @@ pub async fn lookup(
     );
 
     match discv5.find_node(target).await {
-        Err(err) => trace!(target: "discv5",
+        Err(err) => trace!(target: "net::discv5",
             %err,
             "lookup query failed"
         ),
-        Ok(peers) => trace!(target: "discv5",
+        Ok(peers) => trace!(target: "net::discv5",
             target=format!("{:#?}", target),
             peers_count=peers.len(),
             peers=format!("[{:#}]", peers.iter()
@@ -645,7 +645,7 @@ pub async fn lookup(
     // `Discv5::connected_peers` can be subset of sessions, not all peers make it
     // into kbuckets, e.g. incoming sessions from peers with
     // unreachable enrs
-    debug!(target: "discv5",
+    debug!(target: "net::discv5",
         connected_peers=discv5.connected_peers(),
         "connected peers in routing table"
     );

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -19,11 +19,10 @@ const RETH_LOG_FILE_NAME: &str = "reth.log";
 
 /// Default [directives](Directive) for [`EnvFilter`] which disables high-frequency debug logs from
 /// `hyper`, `trust-dns`, `jsonrpsee-server`, and `discv5`.
-const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 5] = [
+const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 4] = [
     "hyper::proto::h1=off",
     "trust_dns_proto=off",
     "trust_dns_resolver=off",
-    "discv5=off",
     "jsonrpsee-server=off",
 ];
 

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -19,10 +19,11 @@ const RETH_LOG_FILE_NAME: &str = "reth.log";
 
 /// Default [directives](Directive) for [`EnvFilter`] which disables high-frequency debug logs from
 /// `hyper`, `trust-dns`, `jsonrpsee-server`, and `discv5`.
-const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 4] = [
+const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 5] = [
     "hyper::proto::h1=off",
     "trust_dns_proto=off",
     "trust_dns_resolver=off",
+    "discv5=off",
     "jsonrpsee-server=off",
 ];
 


### PR DESCRIPTION
The tracing target for Reth's discv5 logs was changed from `net::discv5` to `discv5` in PR https://github.com/paradigmxyz/reth/pull/12045 (fixed issue https://github.com/paradigmxyz/reth/issues/12043)

Currently none of these traces are logged as there is a default directive `discv5=off` which is applied from `DEFAULT_ENV_FILTER_DIRECTIVES`. These are applied after the directives from `RUST_LOG`, so even if `RUST_LOG=discv5=trace` is used, this is overridden with `discv5=off`

https://github.com/paradigmxyz/reth/blob/ddc9bda315c0815369794f51bc232dff0ac9f43e/crates/tracing/src/layers.rs#L22-L28

The discv5 external crate traces were initially disabled in PR https://github.com/paradigmxyz/reth/pull/7458 due to noise.

This PR simply removes `discv5=off` from `DEFAULT_ENV_FILTER_DIRECTIVES`.

If it's still deemed that the `discv5` external crate logs are too verbose and that this should remain turned off, then https://github.com/paradigmxyz/reth/pull/12045 will need to be reverted or reth's discv5 crate target renamed.