### PR TITLE
feat: rate limit incoming ips

### DIFF
--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -24,6 +24,9 @@ pub const DEFAULT_MAX_COUNT_PEERS_INBOUND: u32 = 30;
 /// This restricts how many outbound dials can be performed concurrently.
 pub const DEFAULT_MAX_COUNT_CONCURRENT_OUTBOUND_DIALS: usize = 15;
 
+/// A temporary timeout for ips on incoming connection attempts.
+pub const INBOUND_IP_THROTTLE_DURATION: Duration = Duration::from_secs(30);
+
 /// The durations to use when a backoff should be applied to a peer.
 ///
 /// See also [`BackoffKind`].
@@ -155,6 +158,11 @@ pub struct PeersConfig {
     ///
     /// The backoff duration increases with number of backoff attempts.
     pub backoff_durations: PeerBackoffDurations,
+    /// How long to temporarily ban ips on incoming connection attempts.
+    ///
+    /// This acts as an IP based rate limit.
+    #[cfg_attr(feature = "serde", serde(default, with = "humantime_serde"))]
+    pub incoming_ip_throttle_duration: Duration,
 }
 
 impl Default for PeersConfig {
@@ -171,6 +179,7 @@ impl Default for PeersConfig {
             trusted_nodes_only: false,
             basic_nodes: Default::default(),
             max_backoff_count: 5,
+            incoming_ip_throttle_duration: INBOUND_IP_THROTTLE_DURATION,
         }
     }
 }


### PR DESCRIPTION
applies a simple rate limit per incoming connection attempt.

this uses the existing IP banlist and temporarily adds incoming ips to the banlist.

Note: IP bans only apply to non-local IPs