### PR TITLE
fix(ecies): ecies typo

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -868,7 +868,7 @@ async fn authenticate(
     extra_handlers: RlpxSubProtocolHandlers,
 ) {
     let local_addr = stream.local_addr().ok();
-    let stream = match get_eciess_stream(stream, secret_key, direction).await {
+    let stream = match get_ecies_stream(stream, secret_key, direction).await {
         Ok(stream) => stream,
         Err(error) => {
             let _ = events
@@ -917,7 +917,7 @@ async fn authenticate(
 
 /// Returns an [`ECIESStream`] if it can be built. If not, send a
 /// [`PendingSessionEvent::EciesAuthError`] and returns `None`
-async fn get_eciess_stream<Io: AsyncRead + AsyncWrite + Unpin>(
+async fn get_ecies_stream<Io: AsyncRead + AsyncWrite + Unpin>(
     stream: Io,
     secret_key: SecretKey,
     direction: Direction,


### PR DESCRIPTION
replace `eciess_stream` with `ecies_stream`