### PR TITLE
refactor: change `PayloadConfig` to use parent header instead of parent block

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -29,7 +29,8 @@ use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider};
 use reth_payload_builder::database::CachedReads;
 use reth_primitives::{
     revm_primitives::KzgSettings, BlobTransaction, BlobTransactionSidecar,
-    PooledTransactionsElement, SealedBlock, SealedBlockWithSenders, Transaction, TransactionSigned,
+    PooledTransactionsElement, SealedBlock, SealedBlockWithSenders, SealedHeader, Transaction,
+    TransactionSigned,
 };
 use reth_provider::{
     providers::BlockchainProvider, BlockHashReader, BlockReader, BlockWriter, ChainSpecProvider,
@@ -224,7 +225,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             withdrawals: None,
         };
         let payload_config = PayloadConfig::new(
-            Arc::clone(&best_block),
+            Arc::new(SealedHeader::new(best_block.header().clone(), best_block.hash())),
             Bytes::default(),
             reth_payload_builder::EthPayloadBuilderAttributes::try_new(
                 best_block.hash(),

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -163,13 +163,13 @@ where
     let BuildArguments { client, pool, mut cached_reads, config, cancel, best_payload } = args;
 
     let chain_spec = client.chain_spec();
-    let state_provider = client.state_by_block_hash(config.parent_block.hash())?;
+    let state_provider = client.state_by_block_hash(config.parent_header.hash())?;
     let state = StateProviderDatabase::new(state_provider);
     let mut db =
         State::builder().with_database_ref(cached_reads.as_db(state)).with_bundle_update().build();
-    let PayloadConfig { parent_block, attributes, extra_data } = config;
+    let PayloadConfig { parent_header, attributes, extra_data } = config;
 
-    debug!(target: "payload_builder", id=%attributes.payload_attributes.payload_id(), parent_hash = ?parent_block.hash(), parent_number = parent_block.number, "building new payload");
+    debug!(target: "payload_builder", id=%attributes.payload_attributes.payload_id(), parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
 
     let mut cumulative_gas_used = 0;
     let block_gas_limit: u64 = attributes.gas_limit.unwrap_or_else(|| {
@@ -206,7 +206,7 @@ where
         )
         .map_err(|err| {
             warn!(target: "payload_builder",
-                parent_hash=%parent_block.hash(),
+                parent_header=%parent_header.hash(),
                 %err,
                 "failed to apply beacon root contract call for payload"
             );
@@ -449,7 +449,7 @@ where
         let state_provider = db.database.0.inner.borrow_mut();
         state_provider.db.state_root_with_updates(hashed_state.clone()).inspect_err(|err| {
             warn!(target: "payload_builder",
-                parent_hash=%parent_block.hash(),
+            parent_header=%parent_header.hash(),
                 %err,
                 "failed to calculate state root for payload"
             );
@@ -470,7 +470,7 @@ where
         };
 
     let header = Header {
-        parent_hash: parent_block.hash(),
+        parent_hash: parent_header.hash(),
         ommers_hash: EMPTY_OMMER_ROOT_HASH,
         beneficiary: initialized_block_env.coinbase,
         state_root,
@@ -482,7 +482,7 @@ where
         mix_hash: attributes.payload_attributes.prev_randao,
         nonce: BEACON_NONCE.into(),
         base_fee_per_gas: Some(base_fee),
-        number: parent_block.number + 1,
+        number: parent_header.number + 1,
         gas_limit: block_gas_limit,
         difficulty: U256::ZERO,
         gas_used: cumulative_gas_used,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -103,7 +103,7 @@ where
         &self,
         args: BuildArguments<Pool, Client, OptimismPayloadBuilderAttributes, OptimismBuiltPayload>,
     ) -> Result<BuildOutcome<OptimismBuiltPayload>, PayloadBuilderError> {
-        let (cfg_env, block_env) = self.cfg_and_block_env(&args.config, &args.config.parent_block);
+        let (cfg_env, block_env) = self.cfg_and_block_env(&args.config, &args.config.parent_header);
         optimism_payload(&self.evm_config, args, cfg_env, block_env, self.compute_pending_block)
     }
 
@@ -132,7 +132,7 @@ where
             cancel: Default::default(),
             best_payload: None,
         };
-        let (cfg_env, block_env) = self.cfg_and_block_env(&args.config, &args.config.parent_block);
+        let (cfg_env, block_env) = self.cfg_and_block_env(&args.config, &args.config.parent_header);
         optimism_payload(&self.evm_config, args, cfg_env, block_env, false)?
             .into_payload()
             .ok_or_else(|| PayloadBuilderError::MissingPayload)

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -341,7 +341,7 @@ where
         args: BuildArguments<Pool, Client, Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         let BuildArguments { client, pool, cached_reads, config, cancel, best_payload } = args;
-        let PayloadConfig { parent_block, extra_data, attributes } = config;
+        let PayloadConfig { parent_header, extra_data, attributes } = config;
 
         let chain_spec = client.chain_spec();
 
@@ -354,7 +354,7 @@ where
             client,
             pool,
             cached_reads,
-            config: PayloadConfig { parent_block, extra_data, attributes: attributes.0 },
+            config: PayloadConfig { parent_header, extra_data, attributes: attributes.0 },
             cancel,
             best_payload,
         })
@@ -365,10 +365,10 @@ where
         client: &Client,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        let PayloadConfig { parent_block, extra_data, attributes } = config;
+        let PayloadConfig { parent_header, extra_data, attributes } = config;
         let chain_spec = client.chain_spec();
         <reth_ethereum_payload_builder::EthereumPayloadBuilder as PayloadBuilder<Pool, Client>>::build_empty_payload(&reth_ethereum_payload_builder::EthereumPayloadBuilder::new(EthEvmConfig::new(chain_spec.clone())),client,
-                                                                                                                     PayloadConfig { parent_block, extra_data, attributes: attributes.0})
+                                                                                                                     PayloadConfig { parent_header, extra_data, attributes: attributes.0})
     }
 }
 

--- a/examples/custom-payload-builder/src/generator.rs
+++ b/examples/custom-payload-builder/src/generator.rs
@@ -8,7 +8,7 @@ use reth::{
 use reth_basic_payload_builder::{BasicPayloadJobGeneratorConfig, PayloadBuilder, PayloadConfig};
 use reth_node_api::PayloadBuilderAttributes;
 use reth_payload_builder::{PayloadBuilderError, PayloadJobGenerator};
-use reth_primitives::BlockNumberOrTag;
+use reth_primitives::{BlockNumberOrTag, SealedHeader};
 use std::sync::Arc;
 
 /// The generator type that creates new jobs that builds empty blocks.
@@ -77,7 +77,10 @@ where
             // we already know the hash, so we can seal it
             block.seal(attributes.parent())
         };
-        let config = PayloadConfig::new(Arc::new(parent_block), Bytes::default(), attributes);
+        let hash = parent_block.hash();
+        let header = SealedHeader::new(parent_block.header().clone(), hash);
+
+        let config = PayloadConfig::new(Arc::new(header), Bytes::default(), attributes);
         Ok(EmptyBlockPayloadJob {
             client: self.client.clone(),
             _pool: self.pool.clone(),


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/12103.

Optimizes `PayloadConfig` by using parent header instead of the full parent block.