### PR TITLE
feat: `flashbots_validateBuilderSubmissionV3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8618,6 +8618,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-chainspec",
+ "reth-consensus",
  "reth-consensus-common",
  "reth-errors",
  "reth-evm",
@@ -8625,6 +8626,7 @@ dependencies = [
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
+ "reth-payload-validator",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
@@ -8674,6 +8676,8 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives",
  "reth-rpc-eth-api",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -8713,6 +8717,7 @@ dependencies = [
  "pin-project",
  "reth-beacon-consensus",
  "reth-chainspec",
+ "reth-consensus",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
  "reth-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7994,6 +7994,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-types-beacon",
  "alloy-signer",
  "alloy-sol-types",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6695,6 +6695,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-fs-util",
  "secp256k1",
+ "serde",
  "thiserror",
  "tikv-jemallocator",
  "tracy-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8621,6 +8621,7 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-errors",
+ "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-network-api",

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -367,8 +367,8 @@ RPC:
 
           [default: 25]
 
-      --flashbots.blacklist <PATH>
-          Path to file containing blacklisted addresses, json-encoded list of strings. Block validation API will reject blocks containing transactions from these addresses
+      --builder.disallow <PATH>
+          Path to file containing disallowed addresses, json-encoded list of strings. Block validation API will reject blocks containing transactions from these addresses
 
 RPC State Cache:
       --rpc-cache.max-blocks <MAX_BLOCKS>

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -367,6 +367,9 @@ RPC:
 
           [default: 25]
 
+      --flashbots.blacklist <PATH>
+          Path to file containing blacklisted addresses, json-encoded list of strings. Block validation API will reject blocks containing transactions from these addresses
+
 RPC State Cache:
       --rpc-cache.max-blocks <MAX_BLOCKS>
           Max number of blocks in cache

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -24,6 +24,7 @@ eyre.workspace = true
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
 thiserror.workspace = true
+serde.workspace = true
 
 tracy-client = { workspace = true, optional = true, features = ["demangle"] }
 

--- a/crates/cli/util/src/parsers.rs
+++ b/crates/cli/util/src/parsers.rs
@@ -1,7 +1,9 @@
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::B256;
+use reth_fs_util::FsPathError;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
+    path::Path,
     str::FromStr,
     time::Duration,
 };
@@ -80,6 +82,11 @@ pub fn parse_socket_address(value: &str) -> eyre::Result<SocketAddr, SocketAddre
         .to_socket_addrs()?
         .next()
         .ok_or_else(|| SocketAddressParsingError::Parse(value.to_string()))
+}
+
+/// Wrapper around [`reth_fs_util::read_json_file`] which can be used as a clap value parser.
+pub fn read_json_from_file<T: serde::de::DeserializeOwned>(path: &str) -> Result<T, FsPathError> {
+    reth_fs_util::read_json_file(Path::new(path))
 }
 
 #[cfg(test)]

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -7,6 +7,7 @@ use reth::{
     args::{DiscoveryArgs, NetworkArgs, RpcServerArgs},
     builder::{NodeBuilder, NodeConfig, NodeHandle},
     network::PeersHandleProvider,
+    rpc::server_types::RpcModuleSelection,
     tasks::TaskManager,
 };
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
@@ -147,7 +148,12 @@ where
         let node_config = NodeConfig::new(chain_spec.clone())
             .with_network(network_config.clone())
             .with_unused_ports()
-            .with_rpc(RpcServerArgs::default().with_unused_ports().with_http())
+            .with_rpc(
+                RpcServerArgs::default()
+                    .with_unused_ports()
+                    .with_http()
+                    .with_http_api(RpcModuleSelection::All),
+            )
             .set_dev(is_dev);
 
         let span = span!(Level::INFO, "node", idx);

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -24,7 +24,7 @@ use reth_primitives::{
 use std::{fmt::Debug, sync::Arc, time::SystemTime};
 
 /// The bound divisor of the gas limit, used in update calculations.
-const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
+pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 
 mod validation;
 pub use validation::validate_block_post_execution;

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -32,7 +32,7 @@ pub use validation::validate_block_post_execution;
 /// Ethereum beacon consensus
 ///
 /// This consensus engine does basic checks as outlined in the execution specs.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EthBeaconConsensus<ChainSpec> {
     /// Configuration
     chain_spec: Arc<ChainSpec>,

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -58,6 +58,7 @@ alloy-signer.workspace = true
 alloy-eips.workspace = true
 alloy-sol-types.workspace = true
 alloy-contract.workspace = true
+alloy-rpc-types-beacon.workspace = true
 
 [features]
 default = []

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -174,16 +174,16 @@ async fn test_flashbots_validate() -> eyre::Result<()> {
         .is_ok());
 
     request.registered_gas_limit -= 1;
-    assert!(!provider
+    assert!(provider
         .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV3".into(), (&request,))
         .await
-        .is_ok());
+        .is_err());
     request.registered_gas_limit += 1;
 
     request.request.execution_payload.payload_inner.payload_inner.state_root = B256::ZERO;
-    assert!(!provider
+    assert!(provider
         .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV3".into(), (&request,))
         .await
-        .is_ok());
+        .is_err());
     Ok(())
 }

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,8 +1,14 @@
 use crate::utils::eth_payload_attributes;
-use alloy_eips::calc_next_block_base_fee;
-use alloy_primitives::U256;
-use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
+use alloy_eips::{calc_next_block_base_fee, eip2718::Encodable2718};
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder, SendableTx};
+use alloy_rpc_types_beacon::relay::{BidTrace, SignedBidSubmissionV3};
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use reth::rpc::{
+    api::BuilderBlockValidationRequestV3,
+    compat::engine::payload::block_to_payload_v3,
+    types::{engine::BlobsBundleV1, TransactionRequest},
+};
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::setup_engine;
 use reth_node_ethereum::EthereumNode;
@@ -105,5 +111,79 @@ async fn test_fee_history() -> eyre::Result<()> {
         }
     }
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_flashbots_validate() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, _tasks, wallet) =
+        setup_engine::<EthereumNode>(1, chain_spec.clone(), false, eth_payload_attributes).await?;
+    let mut node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .with_recommended_fillers()
+        .wallet(EthereumWallet::new(wallet.gen().swap_remove(0)))
+        .on_http(node.rpc_url());
+
+    node.advance(100, |_| {
+        let provider = provider.clone();
+        Box::pin(async move {
+            let SendableTx::Envelope(tx) =
+                provider.fill(TransactionRequest::default().to(Address::ZERO)).await.unwrap()
+            else {
+                unreachable!()
+            };
+
+            tx.encoded_2718().into()
+        })
+    })
+    .await?;
+
+    let _ = provider.send_transaction(TransactionRequest::default().to(Address::ZERO)).await?;
+    let (payload, attrs) = node.new_payload().await?;
+
+    let mut request = BuilderBlockValidationRequestV3 {
+        request: SignedBidSubmissionV3 {
+            message: BidTrace {
+                parent_hash: payload.block().parent_hash,
+                block_hash: payload.block().hash(),
+                gas_used: payload.block().gas_used,
+                gas_limit: payload.block().gas_limit,
+                ..Default::default()
+            },
+            execution_payload: block_to_payload_v3(payload.block().clone()),
+            blobs_bundle: BlobsBundleV1::new([]),
+            signature: Default::default(),
+        },
+        parent_beacon_block_root: attrs.parent_beacon_block_root.unwrap(),
+        registered_gas_limit: payload.block().gas_limit,
+    };
+
+    assert!(provider
+        .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV3".into(), (&request,))
+        .await
+        .is_ok());
+
+    request.registered_gas_limit -= 1;
+    assert!(!provider
+        .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV3".into(), (&request,))
+        .await
+        .is_ok());
+    request.registered_gas_limit += 1;
+
+    request.request.execution_payload.payload_inner.payload_inner.state_root = B256::ZERO;
+    assert!(!provider
+        .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV3".into(), (&request,))
+        .await
+        .is_ok());
     Ok(())
 }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -198,6 +198,7 @@ pub struct RpcRegistry<Node: FullNodeComponents, EthApi: EthApiTypes> {
         Node::Provider,
         EthApi,
         Node::Executor,
+        Node::Consensus,
     >,
 }
 
@@ -214,6 +215,7 @@ where
         Node::Provider,
         EthApi,
         Node::Executor,
+        Node::Consensus,
     >;
 
     fn deref(&self) -> &Self::Target {
@@ -442,6 +444,7 @@ where
             .with_executor(node.task_executor().clone())
             .with_evm_config(node.evm_config().clone())
             .with_block_executor(node.block_executor().clone())
+            .with_consensus(node.consensus().clone())
             .build_with_auth_server(module_config, engine_api, eth_api_builder);
 
         // in dev mode we generate 20 random dev-signer accounts

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -185,10 +185,10 @@ pub struct RpcServerArgs {
     #[arg(long = "rpc.proof-permits", alias = "rpc-proof-permits", value_name = "COUNT", default_value_t = constants::DEFAULT_PROOF_PERMITS)]
     pub rpc_proof_permits: usize,
 
-    /// Path to file containing blacklisted addresses, json-encoded list of strings. Block
+    /// Path to file containing disallowed addresses, json-encoded list of strings. Block
     /// validation API will reject blocks containing transactions from these addresses.
-    #[arg(long = "flashbots.blacklist", value_name = "PATH", value_parser = reth_cli_util::parsers::read_json_from_file::<HashSet<Address>>)]
-    pub flashbots_blacklist: Option<HashSet<Address>>,
+    #[arg(long = "builder.disallow", value_name = "PATH", value_parser = reth_cli_util::parsers::read_json_from_file::<HashSet<Address>>)]
+    pub builder_disallow: Option<HashSet<Address>>,
 
     /// State cache configuration.
     #[command(flatten)]
@@ -331,7 +331,7 @@ impl Default for RpcServerArgs {
             gas_price_oracle: GasPriceOracleArgs::default(),
             rpc_state_cache: RpcStateCacheArgs::default(),
             rpc_proof_permits: constants::DEFAULT_PROOF_PERMITS,
-            flashbots_blacklist: Default::default(),
+            builder_disallow: Default::default(),
         }
     }
 }

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -1,11 +1,13 @@
 //! clap [Args](clap::Args) for RPC related arguments.
 
 use std::{
+    collections::HashSet,
     ffi::OsStr,
     net::{IpAddr, Ipv4Addr},
     path::PathBuf,
 };
 
+use alloy_primitives::Address;
 use alloy_rpc_types_engine::JwtSecret;
 use clap::{
     builder::{PossibleValue, RangedU64ValueParser, TypedValueParser},
@@ -183,6 +185,11 @@ pub struct RpcServerArgs {
     #[arg(long = "rpc.proof-permits", alias = "rpc-proof-permits", value_name = "COUNT", default_value_t = constants::DEFAULT_PROOF_PERMITS)]
     pub rpc_proof_permits: usize,
 
+    /// Path to file containing blacklisted addresses, json-encoded list of strings. Block
+    /// validation API will reject blocks containing transactions from these addresses.
+    #[arg(long = "flashbots.blacklist", value_name = "PATH", value_parser = reth_cli_util::parsers::read_json_from_file::<HashSet<Address>>)]
+    pub flashbots_blacklist: HashSet<Address>,
+
     /// State cache configuration.
     #[command(flatten)]
     pub rpc_state_cache: RpcStateCacheArgs,
@@ -318,6 +325,7 @@ impl Default for RpcServerArgs {
             gas_price_oracle: GasPriceOracleArgs::default(),
             rpc_state_cache: RpcStateCacheArgs::default(),
             rpc_proof_permits: constants::DEFAULT_PROOF_PERMITS,
+            flashbots_blacklist: Default::default(),
         }
     }
 }

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -206,6 +206,12 @@ impl RpcServerArgs {
         self
     }
 
+    /// Configures modules for the HTTP-RPC server.
+    pub fn with_http_api(mut self, http_api: RpcModuleSelection) -> Self {
+        self.http_api = Some(http_api);
+        self
+    }
+
     /// Enables the WS-RPC server.
     pub const fn with_ws(mut self) -> Self {
         self.ws = true;

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -188,7 +188,7 @@ pub struct RpcServerArgs {
     /// Path to file containing blacklisted addresses, json-encoded list of strings. Block
     /// validation API will reject blocks containing transactions from these addresses.
     #[arg(long = "flashbots.blacklist", value_name = "PATH", value_parser = reth_cli_util::parsers::read_json_from_file::<HashSet<Address>>)]
-    pub flashbots_blacklist: HashSet<Address>,
+    pub flashbots_blacklist: Option<HashSet<Address>>,
 
     /// State cache configuration.
     #[command(flatten)]

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -23,7 +23,7 @@ pub struct ExecutionPayloadValidator<ChainSpec> {
     chain_spec: Arc<ChainSpec>,
 }
 
-impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
+impl<ChainSpec> ExecutionPayloadValidator<ChainSpec> {
     /// Create a new validator.
     pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
         Self { chain_spec }
@@ -34,7 +34,9 @@ impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
     pub fn chain_spec(&self) -> &ChainSpec {
         &self.chain_spec
     }
+}
 
+impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
     /// Returns true if the Cancun hardfork is active at the given timestamp.
     #[inline]
     fn is_cancun_active_at_timestamp(&self, timestamp: u64) -> bool {

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -36,6 +36,8 @@ alloy-rpc-types-engine.workspace = true
 
 # misc
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
+serde.workspace = true
+serde_with.workspace = true
 
 [features]
 client = [

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -46,7 +46,7 @@ pub mod servers {
         rpc::RpcApiServer,
         trace::TraceApiServer,
         txpool::TxPoolApiServer,
-        validation::BlockSubmissionValidationApiServer,
+        validation::{BlockSubmissionValidationApiServer, BuilderBlockValidationRequestV3},
         web3::Web3ApiServer,
     };
     pub use reth_rpc_eth_api::{

--- a/crates/rpc/rpc-api/src/validation.rs
+++ b/crates/rpc/rpc-api/src/validation.rs
@@ -1,9 +1,28 @@
 //! API for block submission validation.
 
+use alloy_primitives::B256;
 use alloy_rpc_types_beacon::relay::{
-    BuilderBlockValidationRequest, BuilderBlockValidationRequestV2, BuilderBlockValidationRequestV3,
+    BuilderBlockValidationRequest, BuilderBlockValidationRequestV2, SignedBidSubmissionV3,
 };
 use jsonrpsee::proc_macros::rpc;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+/// A Request to validate a [`SignedBidSubmissionV3`]
+///
+/// <https://github.com/flashbots/builder/blob/7577ac81da21e760ec6693637ce2a81fe58ac9f8/eth/block-validation/api.go#L198-L202>
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuilderBlockValidationRequestV3 {
+    /// The request to be validated.
+    #[serde(flatten)]
+    pub request: SignedBidSubmissionV3,
+    /// The registered gas limit for the validation request.
+    #[serde_as(as = "DisplayFromStr")]
+    pub registered_gas_limit: u64,
+    /// The parent beacon block root for the validation request.
+    pub parent_beacon_block_root: B256,
+}
 
 /// Block validation rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "flashbots"))]

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # reth
 reth-ipc.workspace = true
 reth-chainspec.workspace = true
+reth-consensus.workspace = true
 reth-network-api.workspace = true
 reth-node-core.workspace = true
 reth-provider.workspace = true

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -106,7 +106,7 @@ impl RethRpcServerConfig for RpcServerArgs {
     }
 
     fn flashbots_config(&self) -> ValidationApiConfig {
-        ValidationApiConfig { blacklist: self.flashbots_blacklist.clone().unwrap_or_default() }
+        ValidationApiConfig { disallow: self.builder_disallow.clone().unwrap_or_default() }
     }
 
     fn state_cache_config(&self) -> EthStateCacheConfig {

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -106,7 +106,7 @@ impl RethRpcServerConfig for RpcServerArgs {
     }
 
     fn flashbots_config(&self) -> ValidationApiConfig {
-        ValidationApiConfig { blacklist: self.flashbots_blacklist.clone() }
+        ValidationApiConfig { blacklist: self.flashbots_blacklist.clone().unwrap_or_default() }
     }
 
     fn state_cache_config(&self) -> EthStateCacheConfig {

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -2,6 +2,7 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use jsonrpsee::server::ServerBuilder;
 use reth_node_core::{args::RpcServerArgs, utils::get_or_create_jwt_secret_from_path};
+use reth_rpc::ValidationApiConfig;
 use reth_rpc_eth_types::{EthConfig, EthStateCacheConfig, GasPriceOracleConfig};
 use reth_rpc_layer::{JwtError, JwtSecret};
 use reth_rpc_server_types::RpcModuleSelection;
@@ -26,6 +27,9 @@ pub trait RethRpcServerConfig {
 
     /// The configured ethereum RPC settings.
     fn eth_config(&self) -> EthConfig;
+
+    /// The configured ethereum RPC settings.
+    fn flashbots_config(&self) -> ValidationApiConfig;
 
     /// Returns state cache configuration.
     fn state_cache_config(&self) -> EthStateCacheConfig;
@@ -101,6 +105,10 @@ impl RethRpcServerConfig for RpcServerArgs {
             .proof_permits(self.rpc_proof_permits)
     }
 
+    fn flashbots_config(&self) -> ValidationApiConfig {
+        ValidationApiConfig { blacklist: self.flashbots_blacklist.clone() }
+    }
+
     fn state_cache_config(&self) -> EthStateCacheConfig {
         EthStateCacheConfig {
             max_blocks: self.rpc_state_cache.max_blocks,
@@ -124,7 +132,7 @@ impl RethRpcServerConfig for RpcServerArgs {
 
     fn transport_rpc_module_config(&self) -> TransportRpcModuleConfig {
         let mut config = TransportRpcModuleConfig::default()
-            .with_config(RpcModuleConfig::new(self.eth_config()));
+            .with_config(RpcModuleConfig::new(self.eth_config(), self.flashbots_config()));
 
         if self.http {
             config = config.with_http(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -673,6 +673,7 @@ where
     /// # Example
     ///
     /// ```no_run
+    /// use reth_consensus::noop::NoopConsensus;
     /// use reth_evm::ConfigureEvm;
     /// use reth_evm_ethereum::execute::EthExecutorProvider;
     /// use reth_network_api::noop::NoopNetwork;
@@ -692,6 +693,7 @@ where
     ///         .with_events(TestCanonStateSubscriptions::default())
     ///         .with_evm_config(evm)
     ///         .with_block_executor(EthExecutorProvider::mainnet())
+    ///         .with_consensus(NoopConsensus::default())
     ///         .into_registry(Default::default(), Box::new(EthApi::with_spawner));
     ///
     ///     let eth_api = registry.eth_api();

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -27,13 +27,14 @@
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::TransactionPool;
 //!
-//! pub async fn launch<Provider, Pool, Network, Events, EvmConfig, BlockExecutor>(
+//! pub async fn launch<Provider, Pool, Network, Events, EvmConfig, BlockExecutor, Consensus>(
 //!     provider: Provider,
 //!     pool: Pool,
 //!     network: Network,
 //!     events: Events,
 //!     evm_config: EvmConfig,
 //!     block_executor: BlockExecutor,
+//!     consensus: Consensus,
 //! ) where
 //!     Provider: FullRpcProvider + AccountReader + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
@@ -41,6 +42,7 @@
 //!     Events: CanonStateSubscriptions + Clone + 'static,
 //!     EvmConfig: ConfigureEvm<Header = Header>,
 //!     BlockExecutor: BlockExecutorProvider,
+//!     Consensus: reth_consensus::Consensus + Clone + 'static,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -57,6 +59,7 @@
 //!         events,
 //!         evm_config,
 //!         block_executor,
+//!         consensus,
 //!     )
 //!     .build(transports, Box::new(EthApi::with_spawner));
 //!     let handle = RpcServerConfig::default()
@@ -95,6 +98,7 @@
 //!     EngineT,
 //!     EvmConfig,
 //!     BlockExecutor,
+//!     Consensus,
 //! >(
 //!     provider: Provider,
 //!     pool: Pool,
@@ -103,6 +107,7 @@
 //!     engine_api: EngineApi,
 //!     evm_config: EvmConfig,
 //!     block_executor: BlockExecutor,
+//!     consensus: Consensus,
 //! ) where
 //!     Provider: FullRpcProvider + AccountReader + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
@@ -112,6 +117,7 @@
 //!     EngineT: EngineTypes,
 //!     EvmConfig: ConfigureEvm<Header = Header>,
 //!     BlockExecutor: BlockExecutorProvider,
+//!     Consensus: reth_consensus::Consensus + Clone + 'static,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -128,6 +134,7 @@
 //!         events,
 //!         evm_config,
 //!         block_executor,
+//!         consensus,
 //!     );
 //!
 //!     // configure the server modules

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -3,6 +3,7 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use alloy_rpc_types_engine::{ClientCode, ClientVersionV1};
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
 use reth_chainspec::MAINNET;
+use reth_consensus::noop::NoopConsensus;
 use reth_ethereum_engine_primitives::{EthEngineTypes, EthereumEngineValidator};
 use reth_evm::execute::BasicBlockExecutorProvider;
 use reth_evm_ethereum::{execute::EthExecutionStrategyFactory, EthEvmConfig};
@@ -126,6 +127,7 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
     TestCanonStateSubscriptions,
     EthEvmConfig,
     BasicBlockExecutorProvider<EthExecutionStrategyFactory>,
+    NoopConsensus,
 > {
     RpcModuleBuilder::default()
         .with_provider(NoopProvider::default())
@@ -137,4 +139,5 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
         .with_block_executor(
             BasicBlockExecutorProvider::new(EthExecutionStrategyFactory::mainnet()),
         )
+        .with_consensus(NoopConsensus::default())
 }

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_STALE_FILTER_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// Additional config values for the eth namespace.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EthConfig {
     /// Settings for the caching layer
     pub cache: EthStateCacheConfig,

--- a/crates/rpc/rpc-server-types/src/result.rs
+++ b/crates/rpc/rpc-server-types/src/result.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use alloy_rpc_types_engine::PayloadError;
 use jsonrpsee_core::RpcResult;
+use reth_errors::ConsensusError;
 use reth_primitives::BlockId;
 
 /// Helper trait to easily convert various `Result` types into [`RpcResult`]
@@ -102,6 +103,7 @@ macro_rules! impl_to_rpc_result {
 }
 
 impl_to_rpc_result!(PayloadError);
+impl_to_rpc_result!(ConsensusError);
 impl_to_rpc_result!(reth_errors::RethError);
 impl_to_rpc_result!(reth_errors::ProviderError);
 impl_to_rpc_result!(reth_network_api::NetworkError);

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -40,7 +40,7 @@ reth-payload-validator.workspace = true
 alloy-consensus.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
-alloy-eips.workspace = true
+alloy-eips = { workspace = true, features = ["kzg"] }
 alloy-dyn-abi.workspace = true
 alloy-genesis.workspace = true
 alloy-network.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -18,6 +18,7 @@ reth-primitives = { workspace = true, features = ["secp256k1"] }
 reth-rpc-api.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-errors.workspace = true
+reth-ethereum-consensus.workspace = true
 reth-provider.workspace = true
 reth-transaction-pool.workspace = true
 reth-network-api.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -33,6 +33,8 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-types.workspace = true
 reth-trie.workspace = true
+reth-consensus.workspace = true
+reth-payload-validator.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -55,5 +55,5 @@ pub use reth::RethApi;
 pub use rpc::RPCApi;
 pub use trace::TraceApi;
 pub use txpool::TxPoolApi;
-pub use validation::ValidationApi;
+pub use validation::{ValidationApi, ValidationApiConfig};
 pub use web3::Web3Api;

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -64,7 +64,7 @@ pub struct ValidationApiInner<Provider: ChainSpecProvider, E> {
     executor_provider: E,
     /// Whether to exclude withdrawals when validating proposer payment.
     exclude_withdrawals: bool,
-    /// Whether to try verifying profit through fee receipient balance difference.
+    /// Whether to try verifying profit through fee recipient balance difference.
     use_balance_diff_profit: bool,
 }
 

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -244,7 +244,7 @@ where
         }
 
         if let Some(block_base_fee) = block.base_fee_per_gas {
-            if tx.effective_tip_per_gas(block_base_fee) > 0 {
+            if tx.effective_tip_per_gas(block_base_fee) != Some(0) {
                 return Err(ValidationApiError::ProposerPayment)
             }
         }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -243,6 +243,12 @@ where
             return Err(ValidationApiError::ProposerPayment)
         }
 
+        if let Some(block_base_fee) = block.base_fee_per_gas {
+            if tx.effective_tip_per_gas(block_base_fee) > 0 {
+                return Err(ValidationApiError::ProposerPayment)
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -217,7 +217,7 @@ where
 
     /// Ensures that the proposer has received [`BidTrace::value`] for this block.
     ///
-    /// Firstly attemts to verify the payment by checking the state changes, otherwise falls back to
+    /// Firstly attempts to verify the payment by checking the state changes, otherwise falls back to
     /// checking the latest block transaction.
     fn ensure_payment(
         &self,

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -244,7 +244,7 @@ where
         }
 
         if let Some(block_base_fee) = block.base_fee_per_gas {
-            if tx.effective_tip_per_gas(block_base_fee) != Some(0) {
+            if tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0 {
                 return Err(ValidationApiError::ProposerPayment)
             }
         }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -217,8 +217,8 @@ where
 
     /// Ensures that the proposer has received [`BidTrace::value`] for this block.
     ///
-    /// Firstly attempts to verify the payment by checking the state changes, otherwise falls back to
-    /// checking the latest block transaction.
+    /// Firstly attempts to verify the payment by checking the state changes, otherwise falls back
+    /// to checking the latest block transaction.
     fn ensure_payment(
         &self,
         block: &Block,

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -16,6 +16,7 @@ use std::{path::Path, sync::Arc};
 
 use reth::{
     api::NodeTypesWithDBAdapter,
+    beacon_consensus::EthBeaconConsensus,
     providers::{
         providers::{BlockchainProvider, StaticFileProvider},
         ProviderFactory,
@@ -66,9 +67,10 @@ async fn main() -> eyre::Result<()> {
         .with_noop_pool()
         .with_noop_network()
         .with_executor(TokioTaskExecutor::default())
-        .with_evm_config(EthEvmConfig::new(spec))
+        .with_evm_config(EthEvmConfig::new(spec.clone()))
         .with_events(TestCanonStateSubscriptions::default())
-        .with_block_executor(EthExecutorProvider::ethereum(provider.chain_spec()));
+        .with_block_executor(EthExecutorProvider::ethereum(provider.chain_spec()))
+        .with_consensus(EthBeaconConsensus::new(spec));
 
     // Pick which namespaces to expose.
     let config = TransportRpcModuleConfig::default().with_http([RethRpcModule::Eth]);


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/12132

Core logic is already ported, blacklisted addresses checks and configuration are missing for now. Also need to expose exiting configuration options to CLI.

I've added `Consensus` generic to rpc-builder types so that we can use it on `ValidationApi` to validate blocks/headers