### PR TITLE
chore: Move FillTxEnv::fill_tx_env into SignedTransaction trait and implement in TransactionSigned

### DIFF
--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -6,6 +6,7 @@ use core::hash::Hash;
 use alloy_consensus::Transaction;
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{keccak256, Address, TxHash, B256};
+use revm_primitives::TxEnv;
 
 /// A signed transaction.
 pub trait SignedTransaction:
@@ -69,4 +70,7 @@ pub trait SignedTransaction:
     fn recalculate_hash(&self) -> B256 {
         keccak256(self.encoded_2718())
     }
+
+    /// Fills [`TxEnv`] with an [`Address`] and transaction.
+    fn fill_tx_env(&self, tx_env: &mut TxEnv, sender: Address);
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -67,6 +67,8 @@ use tx_type::{
 use reth_codecs::Compact;
 
 use alloc::vec::Vec;
+use reth_primitives_traits::SignedTransaction;
+use revm_primitives::{AuthorizationList, TxEnv};
 
 /// Either a transaction hash or number.
 pub type TxHashOrNumber = BlockHashOrNumber;
@@ -1126,6 +1128,11 @@ impl TransactionSigned {
         &self.signature
     }
 
+    /// Transaction
+    pub const fn transaction(&self) -> &Transaction {
+        &self.transaction
+    }
+
     /// Transaction hash. Used to identify transaction.
     pub const fn hash(&self) -> TxHash {
         self.hash
@@ -1398,6 +1405,115 @@ impl alloy_consensus::Transaction for TransactionSigned {
 
     fn kind(&self) -> TxKind {
         self.deref().kind()
+    }
+}
+
+impl SignedTransaction for TransactionSigned {
+    type Transaction = Transaction;
+    type Signature = Signature;
+
+    fn tx_hash(&self) -> &TxHash {
+        Self::hash_ref(self)
+    }
+
+    fn transaction(&self) -> &Self::Transaction {
+        Self::transaction(self)
+    }
+
+    fn signature(&self) -> &Self::Signature {
+        Self::signature(self)
+    }
+
+    fn recover_signer(&self) -> Option<Address> {
+        Self::recover_signer(self)
+    }
+
+    fn recover_signer_unchecked(&self) -> Option<Address> {
+        Self::recover_signer_unchecked(self)
+    }
+
+    fn from_transaction_and_signature(
+        transaction: Self::Transaction,
+        signature: Self::Signature,
+    ) -> Self {
+        Self::from_transaction_and_signature(transaction, signature)
+    }
+
+    fn fill_tx_env(&self, tx_env: &mut TxEnv, sender: Address) {
+        tx_env.caller = sender;
+        match self.as_ref() {
+            Transaction::Legacy(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = U256::from(tx.gas_price);
+                tx_env.gas_priority_fee = None;
+                tx_env.transact_to = tx.to;
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = tx.chain_id;
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clear();
+                tx_env.blob_hashes.clear();
+                tx_env.max_fee_per_blob_gas.take();
+                tx_env.authorization_list = None;
+            }
+            Transaction::Eip2930(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = U256::from(tx.gas_price);
+                tx_env.gas_priority_fee = None;
+                tx_env.transact_to = tx.to;
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = Some(tx.chain_id);
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clone_from(&tx.access_list.0);
+                tx_env.blob_hashes.clear();
+                tx_env.max_fee_per_blob_gas.take();
+                tx_env.authorization_list = None;
+            }
+            Transaction::Eip1559(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = U256::from(tx.max_fee_per_gas);
+                tx_env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
+                tx_env.transact_to = tx.to;
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = Some(tx.chain_id);
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clone_from(&tx.access_list.0);
+                tx_env.blob_hashes.clear();
+                tx_env.max_fee_per_blob_gas.take();
+                tx_env.authorization_list = None;
+            }
+            Transaction::Eip4844(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = U256::from(tx.max_fee_per_gas);
+                tx_env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
+                tx_env.transact_to = TxKind::Call(tx.to);
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = Some(tx.chain_id);
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clone_from(&tx.access_list.0);
+                tx_env.blob_hashes.clone_from(&tx.blob_versioned_hashes);
+                tx_env.max_fee_per_blob_gas = Some(U256::from(tx.max_fee_per_blob_gas));
+                tx_env.authorization_list = None;
+            }
+            Transaction::Eip7702(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = U256::from(tx.max_fee_per_gas);
+                tx_env.gas_priority_fee = Some(U256::from(tx.max_priority_fee_per_gas));
+                tx_env.transact_to = tx.to.into();
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = Some(tx.chain_id);
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clone_from(&tx.access_list.0);
+                tx_env.blob_hashes.clear();
+                tx_env.max_fee_per_blob_gas.take();
+                tx_env.authorization_list =
+                    Some(AuthorizationList::Signed(tx.authorization_list.clone()));
+            }
+        }
     }
 }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1513,6 +1513,9 @@ impl SignedTransaction for TransactionSigned {
                 tx_env.authorization_list =
                     Some(AuthorizationList::Signed(tx.authorization_list.clone()));
             }
+            Transaction::Deposit(tx) => {
+                // Only applicable to Optimism
+            }
         }
     }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1513,9 +1513,8 @@ impl SignedTransaction for TransactionSigned {
                 tx_env.authorization_list =
                     Some(AuthorizationList::Signed(tx.authorization_list.clone()));
             }
-            Transaction::Deposit(tx) => {
-                // Only applicable to Optimism
-            }
+            #[cfg(feature = "optimism")]
+            Transaction::Deposit(_) => {}
         }
     }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1407,7 +1407,6 @@ impl alloy_consensus::Transaction for TransactionSigned {
 
 impl SignedTransaction for TransactionSigned {
     type Transaction = Transaction;
-    type Signature = Signature;
 
     fn tx_hash(&self) -> &TxHash {
         Self::hash_ref(self)
@@ -1417,7 +1416,7 @@ impl SignedTransaction for TransactionSigned {
         Self::transaction(self)
     }
 
-    fn signature(&self) -> &Self::Signature {
+    fn signature(&self) -> &Signature {
         Self::signature(self)
     }
 
@@ -1431,7 +1430,7 @@ impl SignedTransaction for TransactionSigned {
 
     fn from_transaction_and_signature(
         transaction: Self::Transaction,
-        signature: Self::Signature,
+        signature: Signature,
     ) -> Self {
         Self::from_transaction_and_signature(transaction, signature)
     }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/12182

Moves `fill_tx_env` into the `SignedTransaction` trait and implements it in `TransactionSigned` 