### PR TITLE
Refactor: Optimize subnode cursor trie search

### DIFF
--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -161,7 +161,7 @@ impl CursorSubNode {
             (true, false) => {
                 self.full_key.pop();
             }
-            (false, false) => (), // No change needed
+            (false, false) => (), 
         }
     }
 }


### PR DESCRIPTION
optimizes the `CursorSubNode` implementation and should increase performance when searching Trie
I think this coulde be made constant and further increase in performance if we use de bruijin sequence(https://en.wikipedia.org/wiki/De_Bruijn_sequence) for the trie traversal

This should are actually minor perf and most times the compiler should be able to predict them ahead of time but with increasing complexity, this should matter more.