### PR TITLE
chore(ci): pin kurtosis to working version

### DIFF
--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Run kurtosis
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
+          kurtosis_version: 1.3.1
           ethereum_package_args: '.github/assets/kurtosis_network_params.yaml'
 
   notify-on-error:


### PR DESCRIPTION
Builds are failing with kurtosis 1.4.0 like here https://github.com/paradigmxyz/reth/actions/runs/11604491194/job/32313647970, pinning to the previous version