### PR TITLE
fix: check hashed state for loading `TriePrefixSets::destroyed_accounts`

### DIFF
--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -36,13 +36,13 @@ impl<TX: DbTx> PrefixSetLoader<'_, TX> {
 
         // Walk account changeset and insert account prefixes.
         let mut account_changeset_cursor = self.cursor_read::<tables::AccountChangeSets>()?;
-        let mut account_plain_state_cursor = self.cursor_read::<tables::PlainAccountState>()?;
+        let mut account_hashed_state_cursor = self.cursor_read::<tables::HashedAccounts>()?;
         for account_entry in account_changeset_cursor.walk_range(range.clone())? {
             let (_, AccountBeforeTx { address, .. }) = account_entry?;
             let hashed_address = keccak256(address);
             account_prefix_set.insert(Nibbles::unpack(hashed_address));
 
-            if account_plain_state_cursor.seek_exact(address)?.is_none() {
+            if account_hashed_state_cursor.seek_exact(hashed_address)?.is_none() {
                 destroyed_accounts.insert(hashed_address);
             }
         }


### PR DESCRIPTION
[![hive](https://github.com/paradigmxyz/reth/actions/workflows/hive.yml/badge.svg)](https://github.com/paradigmxyz/reth/actions/runs/11617578066)

During a pipeline unwind, the `MerkleUnwind` stage will deal with an unwound hashed state and a *non*-unwound plain state. On normal execution, `destroyed_accounts` are populated if accounts are no longer present on `PlainState`. This will eventually delete any existing storage tries. 

However, on a unwind to a block where an address is no longer present **and** used to have storage tries, this does not happen, since we only unwind `PlainState` after the `MerkleUnwind`.  Resulting in forgotten storage tries. Leading to the the following failure case on holesky:
2631791 → unwind 2631774 ✅  → 2631775  state root error ❌

By looking at hashed state instead, this can be solved

edit:

Performance wise I don't know if this has an impact actually. We're searching a table with 32byte key instead of 20byte. Should additional logic be added? `if _unwind_ { check hashed_state } else { check plain_state }`
