### PR TITLE
feat: add `debug_executePayload` RPC to capture arbitrary execution witnesses

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, Bytes, B256};
+use alloy_primitives::{Address, BlockHash, Bytes, B256};
 use alloy_rpc_types::{Block, Bundle, StateContext};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_eth::transaction::TransactionRequest;
@@ -141,6 +141,17 @@ pub trait DebugApi {
     /// indicating whether to include the preimages of keys in the response.
     #[method(name = "executionWitness")]
     async fn debug_execution_witness(&self, block: BlockNumberOrTag)
+        -> RpcResult<ExecutionWitness>;
+
+    /// The `debug_executionWitness` method allows for re-execution of a block with the purpose of
+    /// generating an execution witness. The witness comprises of a map of all hashed trie nodes
+    /// to their preimages that were required during the execution of the block, including during
+    /// state root recomputation.
+    ///
+    /// The first argument is the block number or block hash. The second argument is a boolean
+    /// indicating whether to include the preimages of keys in the response.
+    #[method(name = "executePayload")]
+    async fn debug_execute_payload(&self, transactions: Vec<Bytes>, parent_block_hash: BlockHash)
         -> RpcResult<ExecutionWitness>;
 
     /// Sets the logging backtrace location. When a backtrace location is set and a log message is

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::{Address, BlockHash, Bytes, B256};
 use alloy_rpc_types::{Block, Bundle, StateContext};
 use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_engine::PayloadAttributes;
 use alloy_rpc_types_eth::transaction::TransactionRequest;
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -151,8 +152,12 @@ pub trait DebugApi {
     /// The first argument is the block number or block hash. The second argument is a boolean
     /// indicating whether to include the preimages of keys in the response.
     #[method(name = "executePayload")]
-    async fn debug_execute_payload(&self, transactions: Vec<Bytes>, parent_block_hash: BlockHash)
-        -> RpcResult<ExecutionWitness>;
+    async fn debug_execute_payload(
+        &self,
+        parent_block_hash: BlockHash,
+        attributes: PayloadAttributes,
+        transactions: Vec<Bytes>,
+    ) -> RpcResult<ExecutionWitness>;
 
     /// Sets the logging backtrace location. When a backtrace location is set and a log message is
     /// emitted at that location, the stack of the goroutine executing the log statement will

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -144,13 +144,13 @@ pub trait DebugApi {
     async fn debug_execution_witness(&self, block: BlockNumberOrTag)
         -> RpcResult<ExecutionWitness>;
 
-    /// The `debug_executionWitness` method allows for re-execution of a block with the purpose of
-    /// generating an execution witness. The witness comprises of a map of all hashed trie nodes
-    /// to their preimages that were required during the execution of the block, including during
-    /// state root recomputation.
+    /// The `debug_executePayload` method allows for re-execution of a group of transactions with
+    /// the purpose of generating an execution witness. The witness comprises of a map of all
+    /// hashed trie nodes to their preimages that were required during the execution of the block,
+    ///  including during state root recomputation.
     ///
-    /// The first argument is the block number or block hash. The second argument is a boolean
-    /// indicating whether to include the preimages of keys in the response.
+    /// The first argument is the block number or block hash. The second argument is the payload
+    /// attributes for the new block. The third argument is a list of transactions to be included.
     #[method(name = "executePayload")]
     async fn debug_execute_payload(
         &self,


### PR DESCRIPTION
This PR adds a new RPC endpoint:

```
debug_executePayload(parentBlockHash: BlockHash, payloadAttributes: PayloadAttributes, transactions: Vec<Bytes>) -> ExecutionWitness
```

This endpoint allows executing arbitrary transactions on top of parent block hash and returns the necessary state keys and trie preimages to verify the execution with only a state root.

To allow executing partial blocks, if a transaction fails, the storage loads and stores will still result in witnesses being included to be able to prove that the execution failed.

## Return Value


```json
{
  "keys": { ... },
  "state": { ... },
  "codes": { ... },
}
```

Currently, I have it returning the same data as `debug_executionWitness`, but I think we'll also want to include transaction results (receipts, which transactions failed/succeeded, etc).

I'm not sure what the interface should look like for the transaction results, but we could go with something like this to keep things simple:

```json
{
  "result": {
    "state": "success",
    "receipts": [...],
    "successfulTransactions": ["tx1"],
    "failedTransactions": [],
  },
  "witness": {
    "keys": { ... },
    "state": { ... },
    "codes": { ... },
  }
}
```

Let me know if adding a transaction result makes sense and what 

## Open Questions

- Should we add a flag `allowFailure: boolean` that enables the behavior of not failing when a transaction fails?
- Should we include transaction status in the output? (See Return Value section)


**Update 10/31 2:50 PT: Added payload attributes field after clarifying with Optimism team.**