### PR TITLE
test: make cargo t compile in codecs

### DIFF
--- a/crates/storage/codecs/src/alloy/mod.rs
+++ b/crates/storage/codecs/src/alloy/mod.rs
@@ -7,7 +7,7 @@ macro_rules! cond_mod {
             #[cfg(feature = "test-utils")]
             pub mod $mod_name;
             #[cfg(not(feature = "test-utils"))]
-            mod $mod_name;
+            pub(crate) mod $mod_name;
         )*
     };
 }

--- a/crates/storage/codecs/src/alloy/transaction/eip4844.rs
+++ b/crates/storage/codecs/src/alloy/transaction/eip4844.rs
@@ -106,7 +106,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TxEip4844 {
     }
 }
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-utils")]
 fn serialize_placeholder<S>(value: &Option<()>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -119,7 +119,7 @@ where
     }
 }
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-utils")]
 fn deserialize_placeholder<'de, D>(deserializer: D) -> Result<Option<()>, D::Error>
 where
     D: serde::Deserializer<'de>,


### PR DESCRIPTION
>    | |_- in this macro invocation
   = note: this error originates in the macro `cond_mod` (in Nightly builds, run with -Z macro-backtrace for more info)

> error[E0603]: module `eip7702` is private
  --> crates/storage/codecs/src/alloy/mod.rs:35:77
