### PR TITLE
test: make cargo t compile in db-models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,7 +6920,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "reth-codecs",
- "reth-primitives",
+ "reth-primitives-traits",
  "serde",
  "test-fuzz",
 ]

--- a/crates/storage/db-models/Cargo.toml
+++ b/crates/storage/db-models/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-codecs.workspace = true
-reth-primitives = { workspace = true, features = ["reth-codec"] }
+reth-primitives-traits.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true
@@ -32,20 +32,22 @@ proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
 # reth
-reth-primitives = { workspace = true, features = ["arbitrary"] }
+reth-primitives-traits = { workspace = true, features = ["arbitrary"] }
 reth-codecs.workspace = true
+arbitrary = { workspace = true, features = ["derive"] }
 
+proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 test-fuzz.workspace = true
 
 [features]
 test-utils = [
+	"reth-primitives-traits/test-utils",
 	"arbitrary",
-	"reth-primitives/test-utils",
 	"reth-codecs/test-utils"
 ]
 arbitrary = [
-	"reth-primitives/arbitrary",
+	"reth-primitives-traits/arbitrary",
 	"dep:arbitrary",
 	"dep:proptest",
 	"alloy-primitives/arbitrary",

--- a/crates/storage/db-models/src/accounts.rs
+++ b/crates/storage/db-models/src/accounts.rs
@@ -2,7 +2,7 @@ use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::Serialize;
 
 use alloy_primitives::{bytes::Buf, Address};
-use reth_primitives::Account;
+use reth_primitives_traits::Account;
 
 /// Account as it is saved in the database.
 ///

--- a/crates/storage/db-models/src/blocks.rs
+++ b/crates/storage/db-models/src/blocks.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use alloy_primitives::TxNumber;
 use reth_codecs::{add_arbitrary_tests, Compact};
-use reth_primitives::Withdrawals;
+use reth_primitives_traits::Withdrawals;
 use serde::{Deserialize, Serialize};
 
 /// Total number of transactions.


### PR DESCRIPTION
missing dev-deps

drive by reth-primitives -> reth-primitives-traits