### PR TITLE
fix: clippy lints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         include:
           - type: ethereum
-            args: --bin reth --workspace --locked
+            args: --bin reth --workspace --lib --examples --tests --benches --locked
             features: "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
           - type: optimism
-            args: --bin op-reth --workspace --locked
+            args: --bin op-reth --workspace --lib --examples --tests --benches --locked
             features: "optimism asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
           - type: book
             args: --manifest-path book/sources/Cargo.toml --workspace --bins

--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -297,7 +297,7 @@ mod tests {
         block2.set_hash(block2_hash);
 
         // Create a receipt for the transaction in block1.
-        #[expect(clippy::needless_update)]
+        #[allow(clippy::needless_update)]
         let receipt1 = Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 12345,
@@ -347,7 +347,7 @@ mod tests {
         old_block1.block.body.transactions.push(TransactionSigned::default());
 
         // Create a receipt for a transaction in the reverted block.
-        #[expect(clippy::needless_update)]
+        #[allow(clippy::needless_update)]
         let old_receipt = Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 54321,
@@ -370,7 +370,7 @@ mod tests {
         new_block1.block.body.transactions.push(TransactionSigned::default());
 
         // Create a receipt for a transaction in the new committed block.
-        #[expect(clippy::needless_update)]
+        #[allow(clippy::needless_update)]
         let new_receipt = Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 12345,

--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -297,6 +297,7 @@ mod tests {
         block2.set_hash(block2_hash);
 
         // Create a receipt for the transaction in block1.
+        #[expect(clippy::needless_update)]
         let receipt1 = Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 12345,
@@ -346,6 +347,7 @@ mod tests {
         old_block1.block.body.transactions.push(TransactionSigned::default());
 
         // Create a receipt for a transaction in the reverted block.
+        #[expect(clippy::needless_update)]
         let old_receipt = Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 54321,
@@ -368,6 +370,7 @@ mod tests {
         new_block1.block.body.transactions.push(TransactionSigned::default());
 
         // Create a receipt for a transaction in the new committed block.
+        #[expect(clippy::needless_update)]
         let new_receipt = Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 12345,


### PR DESCRIPTION
this currently causes `make lint` to fail locally

I've updated lint workflows to run checks over tests and benches too so that we catch such issues in CI