### PR TITLE
feat: remove AnyNetwork usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8725,13 +8725,10 @@ dependencies = [
 name = "reth-rpc-builder"
 version = "1.1.0"
 dependencies = [
- "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
- "alloy-serde",
  "clap",
  "http",
  "jsonrpsee",
@@ -8860,7 +8857,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
- "alloy-serde",
  "alloy-sol-types",
  "derive_more 1.0.0",
  "futures",
@@ -8936,7 +8932,6 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde",
  "reth-primitives",
  "reth-trie-common",
  "serde",

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -86,7 +86,7 @@ where
         let signed_tx = tx.clone().into_signed();
         let hash = tx.hash;
 
-        let mut inner = EthTxBuilder.fill(tx, tx_info).inner;
+        let mut inner = EthTxBuilder.fill(tx, tx_info);
 
         if signed_tx.is_deposit() {
             inner.gas_price = Some(signed_tx.max_fee_per_gas())

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -31,11 +31,6 @@ reth-evm.workspace = true
 reth-engine-primitives.workspace = true
 reth-primitives.workspace = true
 
-# ethereum
-alloy-network.workspace = true
-alloy-rpc-types.workspace = true
-alloy-serde.workspace = true
-
 # rpc/net
 jsonrpsee = { workspace = true, features = ["server"] }
 tower-http = { workspace = true, features = ["full"] }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1094,14 +1094,7 @@ where
     /// If called outside of the tokio runtime. See also [`Self::eth_api`]
     pub fn register_ots(&mut self) -> &mut Self
     where
-        EthApi: TraceExt
-            + EthTransactions<
-                NetworkTypes: alloy_network::Network<
-                    TransactionResponse = alloy_serde::WithOtherFields<
-                        alloy_rpc_types::Transaction,
-                    >,
-                >,
-            >,
+        EthApi: TraceExt + EthTransactions,
     {
         let otterscan_api = self.otterscan_api();
         self.modules.insert(RethRpcModule::Ots, otterscan_api.into_rpc().into());

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -3,11 +3,10 @@
 
 use crate::utils::{launch_http, launch_http_ws, launch_ws};
 use alloy_primitives::{hex_literal::hex, Address, Bytes, TxHash, B256, B64, U256, U64};
-use alloy_rpc_types::{
-    Block, FeeHistory, Filter, Index, Log, PendingTransactionFilterKind, SyncStatus, Transaction,
-    TransactionReceipt,
+use alloy_rpc_types_eth::{
+    transaction::TransactionRequest, Block, FeeHistory, Filter, Index, Log,
+    PendingTransactionFilterKind, SyncStatus, Transaction, TransactionReceipt,
 };
-use alloy_rpc_types_eth::transaction::TransactionRequest;
 use alloy_rpc_types_trace::filter::TraceFilter;
 use jsonrpsee::{
     core::{

--- a/crates/rpc/rpc-builder/tests/it/middleware.rs
+++ b/crates/rpc/rpc-builder/tests/it/middleware.rs
@@ -1,5 +1,5 @@
 use crate::utils::{test_address, test_rpc_builder};
-use alloy_rpc_types::{Block, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block, Receipt, Transaction};
 use jsonrpsee::{
     server::{middleware::rpc::RpcServiceT, RpcServiceBuilder},
     types::Request,

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -10,7 +10,7 @@ use crate::{AsEthApiError, FromEthApiError, FromEvmError};
 
 /// Network specific `eth` API types.
 pub trait EthApiTypes: Send + Sync + Clone {
-    /// Extension of [`EthApiError`], with network specific errors.
+    /// Extension of [`FromEthApiError`], with network specific errors.
     type Error: Into<jsonrpsee_types::error::ErrorObject<'static>>
         + FromEthApiError
         + AsEthApiError

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -2,9 +2,8 @@
 
 use std::{error::Error, fmt};
 
-use alloy_network::{AnyNetwork, Network};
+use alloy_network::Network;
 use alloy_rpc_types::Block;
-use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::TransactionCompat;
 
 use crate::{AsEthApiError, FromEthApiError, FromEvmError};
@@ -26,16 +25,6 @@ pub trait EthApiTypes: Send + Sync + Clone {
 
     /// Returns reference to transaction response builder.
     fn tx_resp_builder(&self) -> &Self::TransactionCompat;
-}
-
-impl EthApiTypes for () {
-    type Error = EthApiError;
-    type NetworkTypes = AnyNetwork;
-    type TransactionCompat = ();
-
-    fn tx_resp_builder(&self) -> &Self::TransactionCompat {
-        self
-    }
 }
 
 /// Adapter for network specific transaction type.

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -36,7 +36,6 @@ revm.workspace = true
 revm-inspectors.workspace = true
 revm-primitives = { workspace = true, features = ["dev"] }
 alloy-rpc-types.workspace = true
-alloy-serde.workspace = true
 alloy-eips.workspace = true
 
 # rpc

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -37,5 +37,5 @@ pub use gas_oracle::{
 };
 pub use id_provider::EthSubscriptionIdProvider;
 pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
-pub use receipt::ReceiptBuilder;
+pub use receipt::EthReceiptBuilder;
 pub use transaction::TransactionSource;

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -1,24 +1,101 @@
 //! RPC receipt response builder, extends a layer one receipt with layer two data.
 
-use alloy_consensus::Transaction;
+use alloy_consensus::{ReceiptEnvelope, Transaction};
 use alloy_primitives::{Address, TxKind};
-use alloy_rpc_types::{AnyReceiptEnvelope, Log, ReceiptWithBloom, TransactionReceipt};
-use alloy_serde::OtherFields;
-use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
+use alloy_rpc_types::{Log, ReceiptWithBloom, TransactionReceipt};
+use reth_primitives::{Receipt, TransactionMeta, TransactionSigned, TxType};
 use revm_primitives::calc_blob_gasprice;
 
 use super::{EthApiError, EthResult};
 
-/// Receipt response builder.
-#[derive(Debug)]
-pub struct ReceiptBuilder {
-    /// The base response body, contains L1 fields.
-    pub base: TransactionReceipt<AnyReceiptEnvelope<Log>>,
-    /// Additional L2 fields.
-    pub other: OtherFields,
+/// Builds an [`TransactionReceipt`] obtaining the inner receipt envelope from the given closure.
+pub fn build_receipt<T>(
+    transaction: &TransactionSigned,
+    meta: TransactionMeta,
+    receipt: &Receipt,
+    all_receipts: &[Receipt],
+    build_envelope: impl FnOnce(ReceiptWithBloom<Log>) -> T,
+) -> EthResult<TransactionReceipt<T>> {
+    // Note: we assume this transaction is valid, because it's mined (or part of pending block)
+    // and we don't need to check for pre EIP-2
+    let from =
+        transaction.recover_signer_unchecked().ok_or(EthApiError::InvalidTransactionSignature)?;
+
+    // get the previous transaction cumulative gas used
+    let gas_used = if meta.index == 0 {
+        receipt.cumulative_gas_used
+    } else {
+        let prev_tx_idx = (meta.index - 1) as usize;
+        all_receipts
+            .get(prev_tx_idx)
+            .map(|prev_receipt| receipt.cumulative_gas_used - prev_receipt.cumulative_gas_used)
+            .unwrap_or_default()
+    };
+
+    let blob_gas_used = transaction.transaction.blob_gas_used();
+    // Blob gas price should only be present if the transaction is a blob transaction
+    let blob_gas_price = blob_gas_used.and_then(|_| meta.excess_blob_gas.map(calc_blob_gasprice));
+    let logs_bloom = receipt.bloom_slow();
+
+    // get number of logs in the block
+    let mut num_logs = 0;
+    for prev_receipt in all_receipts.iter().take(meta.index as usize) {
+        num_logs += prev_receipt.logs.len();
+    }
+
+    let logs: Vec<Log> = receipt
+        .logs
+        .iter()
+        .enumerate()
+        .map(|(tx_log_idx, log)| Log {
+            inner: log.clone(),
+            block_hash: Some(meta.block_hash),
+            block_number: Some(meta.block_number),
+            block_timestamp: Some(meta.timestamp),
+            transaction_hash: Some(meta.tx_hash),
+            transaction_index: Some(meta.index),
+            log_index: Some((num_logs + tx_log_idx) as u64),
+            removed: false,
+        })
+        .collect();
+
+    let rpc_receipt = alloy_rpc_types::Receipt {
+        status: receipt.success.into(),
+        cumulative_gas_used: receipt.cumulative_gas_used as u128,
+        logs,
+    };
+
+    let (contract_address, to) = match transaction.transaction.kind() {
+        TxKind::Create => (Some(from.create(transaction.transaction.nonce())), None),
+        TxKind::Call(addr) => (None, Some(Address(*addr))),
+    };
+
+    Ok(TransactionReceipt {
+        inner: build_envelope(ReceiptWithBloom { receipt: rpc_receipt, logs_bloom }),
+        transaction_hash: meta.tx_hash,
+        transaction_index: Some(meta.index),
+        block_hash: Some(meta.block_hash),
+        block_number: Some(meta.block_number),
+        from,
+        to,
+        gas_used: gas_used as u128,
+        contract_address,
+        effective_gas_price: transaction.effective_gas_price(meta.base_fee),
+        // EIP-4844 fields
+        blob_gas_price,
+        blob_gas_used: blob_gas_used.map(u128::from),
+        authorization_list: transaction.authorization_list().map(|l| l.to_vec()),
+    })
 }
 
-impl ReceiptBuilder {
+/// Receipt response builder.
+#[derive(Debug)]
+pub struct EthReceiptBuilder {
+    /// The base response body, contains L1 fields.
+    pub base: TransactionReceipt,
+}
+
+impl EthReceiptBuilder {
     /// Returns a new builder with the base response body (L1 fields) set.
     ///
     /// Note: This requires _all_ block receipts because we need to calculate the gas used by the
@@ -29,88 +106,23 @@ impl ReceiptBuilder {
         receipt: &Receipt,
         all_receipts: &[Receipt],
     ) -> EthResult<Self> {
-        // Note: we assume this transaction is valid, because it's mined (or part of pending block)
-        // and we don't need to check for pre EIP-2
-        let from = transaction
-            .recover_signer_unchecked()
-            .ok_or(EthApiError::InvalidTransactionSignature)?;
+        let base = build_receipt(transaction, meta, receipt, all_receipts, |receipt_with_bloom| {
+            match receipt.tx_type {
+                TxType::Legacy => ReceiptEnvelope::Legacy(receipt_with_bloom),
+                TxType::Eip2930 => ReceiptEnvelope::Eip2930(receipt_with_bloom),
+                TxType::Eip1559 => ReceiptEnvelope::Eip1559(receipt_with_bloom),
+                TxType::Eip4844 => ReceiptEnvelope::Eip4844(receipt_with_bloom),
+                TxType::Eip7702 => ReceiptEnvelope::Eip7702(receipt_with_bloom),
+                #[allow(unreachable_patterns)]
+                _ => unreachable!(),
+            }
+        })?;
 
-        // get the previous transaction cumulative gas used
-        let gas_used = if meta.index == 0 {
-            receipt.cumulative_gas_used
-        } else {
-            let prev_tx_idx = (meta.index - 1) as usize;
-            all_receipts
-                .get(prev_tx_idx)
-                .map(|prev_receipt| receipt.cumulative_gas_used - prev_receipt.cumulative_gas_used)
-                .unwrap_or_default()
-        };
-
-        let blob_gas_used = transaction.transaction.blob_gas_used();
-        // Blob gas price should only be present if the transaction is a blob transaction
-        let blob_gas_price =
-            blob_gas_used.and_then(|_| meta.excess_blob_gas.map(calc_blob_gasprice));
-        let logs_bloom = receipt.bloom_slow();
-
-        // get number of logs in the block
-        let mut num_logs = 0;
-        for prev_receipt in all_receipts.iter().take(meta.index as usize) {
-            num_logs += prev_receipt.logs.len();
-        }
-
-        let logs: Vec<Log> = receipt
-            .logs
-            .iter()
-            .enumerate()
-            .map(|(tx_log_idx, log)| Log {
-                inner: log.clone(),
-                block_hash: Some(meta.block_hash),
-                block_number: Some(meta.block_number),
-                block_timestamp: Some(meta.timestamp),
-                transaction_hash: Some(meta.tx_hash),
-                transaction_index: Some(meta.index),
-                log_index: Some((num_logs + tx_log_idx) as u64),
-                removed: false,
-            })
-            .collect();
-
-        let rpc_receipt = alloy_rpc_types::Receipt {
-            status: receipt.success.into(),
-            cumulative_gas_used: receipt.cumulative_gas_used as u128,
-            logs,
-        };
-
-        let (contract_address, to) = match transaction.transaction.kind() {
-            TxKind::Create => (Some(from.create(transaction.transaction.nonce())), None),
-            TxKind::Call(addr) => (None, Some(Address(*addr))),
-        };
-
-        #[allow(clippy::needless_update)]
-        let base = TransactionReceipt {
-            inner: AnyReceiptEnvelope {
-                inner: ReceiptWithBloom { receipt: rpc_receipt, logs_bloom },
-                r#type: transaction.transaction.tx_type().into(),
-            },
-            transaction_hash: meta.tx_hash,
-            transaction_index: Some(meta.index),
-            block_hash: Some(meta.block_hash),
-            block_number: Some(meta.block_number),
-            from,
-            to,
-            gas_used: gas_used as u128,
-            contract_address,
-            effective_gas_price: transaction.effective_gas_price(meta.base_fee),
-            // EIP-4844 fields
-            blob_gas_price,
-            blob_gas_used: blob_gas_used.map(u128::from),
-            authorization_list: transaction.authorization_list().map(|l| l.to_vec()),
-        };
-
-        Ok(Self { base, other: Default::default() })
+        Ok(Self { base })
     }
 
     /// Builds a receipt response from the base response body, and any set additional fields.
-    pub fn build(self) -> TransactionReceipt<AnyReceiptEnvelope<Log>> {
+    pub fn build(self) -> TransactionReceipt {
         self.base
     }
 }

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -22,7 +22,6 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-rpc-types.workspace = true
 alloy-rpc-types-eth = { workspace = true, default-features = false, features = ["serde"] }
-alloy-serde.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-consensus.workspace = true
 

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -8,9 +8,8 @@ use std::fmt;
 use alloy_consensus::Transaction as _;
 use alloy_rpc_types::{
     request::{TransactionInput, TransactionRequest},
-    Transaction, TransactionInfo,
+    TransactionInfo,
 };
-use alloy_serde::WithOtherFields;
 use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered, TxType};
 use serde::{Deserialize, Serialize};
 
@@ -87,28 +86,6 @@ pub trait TransactionCompat: Send + Sync + Unpin + Clone + fmt::Debug {
     /// Returns the transaction type.
     // todo: remove when alloy TransactionResponse trait it updated.
     fn tx_type(tx: &Self::Transaction) -> u8;
-}
-
-impl TransactionCompat for () {
-    // this noop impl depends on integration in `reth_rpc_eth_api::EthApiTypes` noop impl, and
-    // `alloy_network::AnyNetwork`
-    type Transaction = WithOtherFields<Transaction>;
-
-    fn fill(
-        &self,
-        _tx: TransactionSignedEcRecovered,
-        _tx_info: TransactionInfo,
-    ) -> Self::Transaction {
-        WithOtherFields::default()
-    }
-
-    fn otterscan_api_truncate_input(tx: &mut Self::Transaction) {
-        tx.input = tx.input.slice(..4);
-    }
-
-    fn tx_type(_tx: &Self::Transaction) -> u8 {
-        0
-    }
 }
 
 /// Gas price and max fee per gas for a transaction. Helper type to format transaction RPC response.

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use alloy_network::AnyNetwork;
+use alloy_network::Ethereum;
 use alloy_primitives::U256;
 use derive_more::Deref;
 use reth_primitives::BlockNumberOrTag;
@@ -132,8 +132,7 @@ where
     Self: Send + Sync,
 {
     type Error = EthApiError;
-    // todo: replace with alloy_network::Ethereum
-    type NetworkTypes = AnyNetwork;
+    type NetworkTypes = Ethereum;
     type TransactionCompat = EthTxBuilder;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -1,14 +1,13 @@
 //! Contains RPC handler implementations specific to blocks.
 
-use alloy_rpc_types::{AnyTransactionReceipt, BlockId};
-use alloy_serde::WithOtherFields;
+use alloy_rpc_types::{BlockId, TransactionReceipt};
 use reth_primitives::TransactionMeta;
 use reth_provider::{BlockReaderIdExt, HeaderProvider};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
     RpcReceipt,
 };
-use reth_rpc_eth_types::{EthApiError, ReceiptBuilder};
+use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 
 use crate::EthApi;
 
@@ -16,7 +15,7 @@ impl<Provider, Pool, Network, EvmConfig> EthBlocks for EthApi<Provider, Pool, Ne
 where
     Self: LoadBlock<
         Error = EthApiError,
-        NetworkTypes: alloy_network::Network<ReceiptResponse = AnyTransactionReceipt>,
+        NetworkTypes: alloy_network::Network<ReceiptResponse = TransactionReceipt>,
         Provider: HeaderProvider,
     >,
 {
@@ -51,9 +50,8 @@ where
                         excess_blob_gas,
                         timestamp,
                     };
-                    ReceiptBuilder::new(&tx, meta, receipt, &receipts)
+                    EthReceiptBuilder::new(&tx, meta, receipt, &receipts)
                         .map(|builder| builder.build())
-                        .map(WithOtherFields::new)
                 })
                 .collect::<Result<Vec<_>, Self::Error>>()
                 .map(Some)

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,9 +1,8 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
-use alloy_serde::WithOtherFields;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
-use reth_rpc_eth_types::{EthApiError, ReceiptBuilder};
+use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 
 use crate::EthApi;
 
@@ -26,6 +25,6 @@ where
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
 
-        Ok(WithOtherFields::new(ReceiptBuilder::new(&tx, meta, &receipt, &all_receipts)?.build()))
+        Ok(EthReceiptBuilder::new(&tx, meta, &receipt, &all_receipts)?.build())
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -1,10 +1,9 @@
 //! L1 `eth` API types.
 
 use alloy_consensus::Transaction as _;
-use alloy_network::{AnyNetwork, Network};
+use alloy_network::{Ethereum, Network};
 use alloy_primitives::{Address, TxKind};
 use alloy_rpc_types::{Transaction, TransactionInfo};
-use alloy_serde::WithOtherFields;
 use reth_primitives::TransactionSignedEcRecovered;
 use reth_rpc_types_compat::{
     transaction::{from_primitive_signature, GasPrice},
@@ -19,7 +18,7 @@ impl TransactionCompat for EthTxBuilder
 where
     Self: Send + Sync,
 {
-    type Transaction = <AnyNetwork as Network>::TransactionResponse;
+    type Transaction = <Ethereum as Network>::TransactionResponse;
 
     fn fill(
         &self,
@@ -53,41 +52,38 @@ where
             signed_tx.chain_id(),
         );
 
-        WithOtherFields {
-            inner: Transaction {
-                hash: signed_tx.hash(),
-                nonce: signed_tx.nonce(),
-                from: signer,
-                to,
-                value: signed_tx.value(),
-                gas_price,
-                max_fee_per_gas,
-                max_priority_fee_per_gas: signed_tx.max_priority_fee_per_gas(),
-                signature: Some(signature),
-                gas: signed_tx.gas_limit(),
-                input,
-                chain_id,
-                access_list,
-                transaction_type: Some(signed_tx.tx_type() as u8),
-                // These fields are set to None because they are not stored as part of the
-                // transaction
-                block_hash,
-                block_number,
-                transaction_index,
-                // EIP-4844 fields
-                max_fee_per_blob_gas: signed_tx.max_fee_per_blob_gas(),
-                blob_versioned_hashes,
-                authorization_list,
-            },
-            ..Default::default()
+        Transaction {
+            hash: signed_tx.hash(),
+            nonce: signed_tx.nonce(),
+            from: signer,
+            to,
+            value: signed_tx.value(),
+            gas_price,
+            max_fee_per_gas,
+            max_priority_fee_per_gas: signed_tx.max_priority_fee_per_gas(),
+            signature: Some(signature),
+            gas: signed_tx.gas_limit(),
+            input,
+            chain_id,
+            access_list,
+            transaction_type: Some(signed_tx.tx_type() as u8),
+            // These fields are set to None because they are not stored as part of the
+            // transaction
+            block_hash,
+            block_number,
+            transaction_index,
+            // EIP-4844 fields
+            max_fee_per_blob_gas: signed_tx.max_fee_per_blob_gas(),
+            blob_versioned_hashes,
+            authorization_list,
         }
     }
 
     fn otterscan_api_truncate_input(tx: &mut Self::Transaction) {
-        tx.inner.input = tx.inner.input.slice(..4);
+        tx.input = tx.input.slice(..4);
     }
 
     fn tx_type(tx: &Self::Transaction) -> u8 {
-        tx.inner.transaction_type.unwrap_or(0)
+        tx.transaction_type.unwrap_or(0)
     }
 }

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -8,9 +8,8 @@ use alloy_rpc_types::{
         Params, PubSubSyncStatus, SubscriptionKind, SubscriptionResult as EthSubscriptionResult,
         SyncStatusMetadata,
     },
-    FilteredParams, Header, Log, Transaction,
+    FilteredParams, Header, Log,
 };
-use alloy_serde::WithOtherFields;
 use futures::StreamExt;
 use jsonrpsee::{
     server::SubscriptionMessage, types::ErrorObject, PendingSubscriptionSink, SubscriptionSink,
@@ -123,11 +122,9 @@ where
 {
     match kind {
         SubscriptionKind::NewHeads => {
-            let stream = pubsub.new_headers_stream().map(|header| {
-                EthSubscriptionResult::<WithOtherFields<Transaction>>::Header(Box::new(
-                    header.into(),
-                ))
-            });
+            let stream = pubsub
+                .new_headers_stream()
+                .map(|header| EthSubscriptionResult::<()>::Header(Box::new(header.into())));
             pipe_from_stream(accepted_sink, stream).await
         }
         SubscriptionKind::Logs => {
@@ -139,9 +136,9 @@ where
                 }
                 _ => FilteredParams::default(),
             };
-            let stream = pubsub.log_stream(filter).map(|log| {
-                EthSubscriptionResult::<WithOtherFields<Transaction>>::Log(Box::new(log))
-            });
+            let stream = pubsub
+                .log_stream(filter)
+                .map(|log| EthSubscriptionResult::<()>::Log(Box::new(log)));
             pipe_from_stream(accepted_sink, stream).await
         }
         SubscriptionKind::NewPendingTransactions => {
@@ -170,7 +167,7 @@ where
 
             let stream = pubsub
                 .pending_transaction_hashes_stream()
-                .map(EthSubscriptionResult::<WithOtherFields<Transaction>>::TransactionHash);
+                .map(EthSubscriptionResult::<()>::TransactionHash);
             pipe_from_stream(accepted_sink, stream).await
         }
         SubscriptionKind::Syncing => {


### PR DESCRIPTION
Migrates `EthApi` to using `Ethereum` network instead of `AnyNetwork`

This would allow to make https://github.com/paradigmxyz/reth/pull/12215 cleaner as with https://github.com/alloy-rs/alloy/pull/1460 `AnyNetwork` rpc transaction structure is a bit different
