### PR TITLE
test(eth-engine): add unit tests for `payload_id` method

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -301,10 +301,109 @@ pub(crate) fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> Paylo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::B64;
+    use reth_primitives::Withdrawal;
+    use std::str::FromStr;
 
     #[test]
     fn attributes_serde() {
         let attributes = r#"{"timestamp":"0x1235","prevRandao":"0xf343b00e02dc34ec0124241f74f32191be28fb370bb48060f5fa4df99bda774c","suggestedFeeRecipient":"0x0000000000000000000000000000000000000000","withdrawals":null,"parentBeaconBlockRoot":null}"#;
         let _attributes: PayloadAttributes = serde_json::from_str(attributes).unwrap();
+    }
+
+    #[test]
+    fn test_payload_id_basic() {
+        // Create a parent block and payload attributes
+        let parent =
+            B256::from_str("0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a")
+                .unwrap();
+        let attributes = PayloadAttributes {
+            timestamp: 0x5,
+            prev_randao: B256::from_str(
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            suggested_fee_recipient: Address::from_str(
+                "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            )
+            .unwrap(),
+            withdrawals: None,
+            parent_beacon_block_root: None,
+        };
+
+        // Verify that the generated payload ID matches the expected value
+        assert_eq!(
+            payload_id(&parent, &attributes),
+            PayloadId(B64::from_str("0xa247243752eb10b4").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_payload_id_with_withdrawals() {
+        // Set up the parent and attributes with withdrawals
+        let parent =
+            B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
+                .unwrap();
+        let attributes = PayloadAttributes {
+            timestamp: 1622553200,
+            prev_randao: B256::from_slice(&[1; 32]),
+            suggested_fee_recipient: Address::from_str(
+                "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            )
+            .unwrap(),
+            withdrawals: Some(vec![
+                Withdrawal {
+                    index: 1,
+                    validator_index: 123,
+                    address: Address::from([0xAA; 20]),
+                    amount: 10,
+                },
+                Withdrawal {
+                    index: 2,
+                    validator_index: 456,
+                    address: Address::from([0xBB; 20]),
+                    amount: 20,
+                },
+            ]),
+            parent_beacon_block_root: None,
+        };
+
+        // Verify that the generated payload ID matches the expected value
+        assert_eq!(
+            payload_id(&parent, &attributes),
+            PayloadId(B64::from_str("0xedddc2f84ba59865").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_payload_id_with_parent_beacon_block_root() {
+        // Set up the parent and attributes with a parent beacon block root
+        let parent =
+            B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
+                .unwrap();
+        let attributes = PayloadAttributes {
+            timestamp: 1622553200,
+            prev_randao: B256::from_str(
+                "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234",
+            )
+            .unwrap(),
+            suggested_fee_recipient: Address::from_str(
+                "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            )
+            .unwrap(),
+            withdrawals: None,
+            parent_beacon_block_root: Some(
+                B256::from_str(
+                    "0x2222222222222222222222222222222222222222222222222222222222222222",
+                )
+                .unwrap(),
+            ),
+        };
+
+        // Verify that the generated payload ID matches the expected value
+        assert_eq!(
+            payload_id(&parent, &attributes),
+            PayloadId(B64::from_str("0x0fc49cd532094cce").unwrap())
+        );
     }
 }

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -301,8 +301,8 @@ pub(crate) fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> Paylo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_eips::eip4895::Withdrawal;
     use alloy_primitives::B64;
-    use reth_primitives::Withdrawal;
     use std::str::FromStr;
 
     #[test]


### PR DESCRIPTION
Results are validated against a similar Python script to double check everything is ok. As a reference, here is the script:

```python
import hashlib
from eth_utils import encode_hex, decode_hex, to_bytes
import rlp
from rlp.sedes import big_endian_int, Binary

# Define the Withdrawal structure for RLP encoding
class Withdrawal(rlp.Serializable):
    fields = [
        ('index', big_endian_int),
        ('validator_index', big_endian_int),
        ('address', Binary.fixed_length(20, allow_empty=False)),
        ('amount', big_endian_int),
    ]

def calculate_payload_id(parent, attributes):
    """
    Calculates the payload ID based on the parent and attributes.

    Args:
        parent (str): Hexadecimal string representing the parent B256.
        attributes (dict): Dictionary containing payload attributes.

    Returns:
        str: Hexadecimal string of the first 8 bytes of the SHA-256 hash.
    """
    hasher = hashlib.sha256()
    
    # Update the hasher with the parent
    parent_bytes = decode_hex(parent)
    hasher.update(parent_bytes)
    
    # Update the hasher with the timestamp (8-byte big-endian)
    timestamp_bytes = attributes['timestamp'].to_bytes(8, byteorder='big')
    hasher.update(timestamp_bytes)
    
    # Update the hasher with prev_randao
    prev_randao_bytes = decode_hex(attributes['prev_randao'])
    hasher.update(prev_randao_bytes)
    
    # Update the hasher with suggested_fee_recipient
    fee_recipient_bytes = decode_hex(attributes['suggested_fee_recipient'])
    hasher.update(fee_recipient_bytes)
    
    # If withdrawals are present, encode them in RLP and add to the hasher
    if attributes.get('withdrawals'):
        withdrawals = attributes['withdrawals']
        # Encode each withdrawal
        encoded_withdrawals = [Withdrawal(
            index=w['index'],
            validator_index=w['validator_index'],
            address=decode_hex(w['address']),
            amount=w['amount']
        ) for w in withdrawals]
        # Encode the list of withdrawals
        rlp_encoded_withdrawals = rlp.encode(encoded_withdrawals)
        hasher.update(rlp_encoded_withdrawals)
    
    # If parent_beacon_block_root is present, add it to the hasher
    if attributes.get('parent_beacon_block_root'):
        parent_beacon_block_bytes = decode_hex(attributes['parent_beacon_block_root'])
        hasher.update(parent_beacon_block_bytes)
    
    # Finalize the hash and take the first 8 bytes
    payload_hash = hasher.digest()
    payload_id = payload_hash[:8]
    
    return encode_hex(payload_id)

# Define test cases
test_cases = [
    {
        "name": "Basic Payload",
        "parent": "0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
        "attributes": {
            "timestamp": 0x5,
            "prev_randao": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "suggested_fee_recipient": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
            "withdrawals": None,
            "parent_beacon_block_root": None,
        },
        "expected": "0xa247243752eb10b4",
    },
    {
        "name": "Payload with Withdrawals",
        "parent": "0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef",
        "attributes": {
            "timestamp": 1622553200,
            "prev_randao": "0x0101010101010101010101010101010101010101010101010101010101010101",
            "suggested_fee_recipient": "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
            "withdrawals": [
                {
                    "index": 1,
                    "validator_index": 123,
                    "address": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                    "amount": 10,
                },
                {
                    "index": 2,
                    "validator_index": 456,
                    "address": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                    "amount": 20,
                },
            ],
            "parent_beacon_block_root": None,
        },
        "expected": "0xedddc2f84ba59865",
    },
    {
        "name": "Payload with Parent Beacon Block Root",
        "parent": "0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef",
        "attributes": {
            "timestamp": 1622553200,
            "prev_randao": "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234",
            "suggested_fee_recipient": "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
            "withdrawals": None,
            "parent_beacon_block_root": "0x2222222222222222222222222222222222222222222222222222222222222222",
        },
        "expected": "0x0fc49cd532094cce",
    },
]

# Run test cases
for test_case in test_cases:
    print(f"Running test: {test_case['name']}")
    calculated_id = calculate_payload_id(test_case['parent'], test_case['attributes'])
    expected_id = test_case["expected"]
    print(f"Expected ID:   {expected_id}")
    print(f"Calculated ID: {calculated_id}")
    print("Test Passes:", calculated_id == expected_id)
    print()

```