### PR TITLE
primitives: rm useless `OP_` constants

### DIFF
--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -1,6 +1,6 @@
 //! Ethereum protocol-related constants
 
-use alloy_primitives::{address, b256, Address, B256};
+use alloy_primitives::{b256, B256};
 
 /// Gas units, for example [`GIGAGAS`].
 pub mod gas_units;
@@ -15,12 +15,6 @@ pub const MINIMUM_GAS_LIMIT: u64 = 5000;
 /// Holesky genesis hash: `0xb5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4`
 pub const HOLESKY_GENESIS_HASH: B256 =
     b256!("b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4");
-
-/// From address from Optimism system txs: `0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001`
-pub const OP_SYSTEM_TX_FROM_ADDR: Address = address!("deaddeaddeaddeaddeaddeaddeaddeaddead0001");
-
-/// To address from Optimism system txs: `0x4200000000000000000000000000000000000015`
-pub const OP_SYSTEM_TX_TO_ADDR: Address = address!("4200000000000000000000000000000000000015");
 
 /// The number of blocks to unwind during a reorg that already became a part of canonical chain.
 ///


### PR DESCRIPTION
These constants can be found in op-alloy directly and we don't need to reexport them here

https://github.com/alloy-rs/op-alloy/blob/8c0562d287ff680a121e2fd3ebeb5b0abac44e9a/crates/protocol/src/block_info.rs#L28-L31