### PR TITLE
feat(engine): use execute_with_state_hook in ExecutorMetrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,7 +4863,9 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.0",
+ "indexmap 2.6.0",
  "metrics",
+ "ordered-float",
  "quanta",
  "sketches-ddsketch",
 ]
@@ -5403,6 +5405,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "overload"
@@ -7440,6 +7451,7 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "metrics",
+ "metrics-util",
  "parking_lot",
  "reth-chainspec",
  "reth-consensus",

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -44,6 +44,7 @@ use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
 use reth_trie::{updates::TrieUpdates, HashedPostState, TrieInput};
 use reth_trie_parallel::parallel_root::{ParallelStateRoot, ParallelStateRootError};
+use revm_primitives::ResultAndState;
 use std::{
     cmp::Ordering,
     collections::{btree_map, hash_map, BTreeMap, VecDeque},
@@ -2187,7 +2188,14 @@ where
         let block = block.unseal();
 
         let exec_time = Instant::now();
-        let output = self.metrics.executor.execute_metered(executor, (&block, U256::MAX).into())?;
+        // TODO: create StateRootTask with the receiving end of a channel and
+        // pass the sending end of the channel to the state hook.
+        let noop_state_hook = |_result_and_state: &ResultAndState| {};
+        let output = self.metrics.executor.execute_metered(
+            executor,
+            (&block, U256::MAX).into(),
+            Box::new(noop_state_hook),
+        )?;
 
         trace!(target: "engine::tree", elapsed=?exec_time.elapsed(), ?block_number, "Executed block");
         if let Err(err) = self.consensus.validate_block_post_execution(

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -40,6 +40,7 @@ parking_lot = { workspace = true, optional = true }
 parking_lot.workspace = true
 reth-ethereum-forks.workspace = true
 alloy-consensus.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
 
 [features]
 default = ["std"]

--- a/crates/evm/src/metrics.rs
+++ b/crates/evm/src/metrics.rs
@@ -11,12 +11,12 @@ use revm_primitives::ResultAndState;
 use std::time::Instant;
 
 /// Wrapper struct that combines metrics and state hook
-struct StateHookWrapper {
+struct MeteredStateHook {
     metrics: ExecutorMetrics,
     inner_hook: Box<dyn OnStateHook>,
 }
 
-impl OnStateHook for StateHookWrapper {
+impl OnStateHook for MeteredStateHook {
     fn on_state(&mut self, result_and_state: &ResultAndState) {
         // Update the metrics for the number of accounts, storage slots and bytecodes loaded
         let accounts = result_and_state.state.keys().len();
@@ -111,7 +111,7 @@ impl ExecutorMetrics {
         // clone here is cheap, all the metrics are Option<Arc<_>>. additionally
         // they are gloally registered so that the data recorded in the hook will
         // be accessible.
-        let wrapper = StateHookWrapper { metrics: self.clone(), inner_hook: state_hook };
+        let wrapper = MeteredStateHook { metrics: self.clone(), inner_hook: state_hook };
 
         // Store reference to block for metered
         let block = input.block;


### PR DESCRIPTION
Towards #12053

Preparing ground to integrate state root task with executor, this PR includes changes to allow the introduction of a state hook during block execution in engine tree, so that the `StateRootTask` can receive state updates after each transaction execution.

The changes in `ExecutorMetrics` are mainly about getting execution metrics using `execute_with_state_hook` instead of `execute_with_state_closure` as before. 

Added tests to cover `ExecutorMetrics` changes, metrics still recorded and state hook being called.