### PR TITLE
feature: export tracing events via opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5420,6 +5420,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
+ "reqwest",
 ]
 
 [[package]]
@@ -5436,6 +5437,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
+ "reqwest",
  "serde_json",
  "thiserror",
  "tokio",
@@ -6348,6 +6350,7 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6799,8 +6799,8 @@ name = "reth-cli-runner"
 version = "1.1.0"
 dependencies = [
  "reth-tasks",
+ "reth-tracing",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5397,6 +5397,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "opentelemetry"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+dependencies = [
+ "hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5921,6 +6001,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.80",
 ]
 
 [[package]]
@@ -9147,11 +9250,15 @@ version = "1.1.0"
 dependencies = [
  "clap",
  "eyre",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rolling-file",
  "tracing",
  "tracing-appender",
  "tracing-journald",
  "tracing-logfmt",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -10792,6 +10899,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10956,6 +11084,24 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -11440,6 +11586,16 @@ name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9256,6 +9256,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "reqwest",
  "rolling-file",
  "tracing",
  "tracing-appender",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6023,7 +6023,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.80",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,7 +410,7 @@ reth-storage-errors = { path = "crates/storage/errors" }
 reth-tasks = { path = "crates/tasks" }
 reth-testing-utils = { path = "testing/testing-utils" }
 reth-tokio-util = { path = "crates/tokio-util" }
-reth-tracing = { path = "crates/tracing" }
+reth-tracing = { path = "crates/tracing", default-features = false }
 reth-transaction-pool = { path = "crates/transaction-pool" }
 reth-trie = { path = "crates/trie/trie" }
 reth-trie-common = { path = "crates/trie/common" }

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -3,7 +3,7 @@
 use clap::{Parser, Subcommand};
 use reth_cli_runner::CliContext;
 use reth_node_core::args::LogArgs;
-use reth_tracing::FileWorkerGuard;
+use reth_tracing::TracerHandle;
 
 mod context;
 mod new_payload_fcu;
@@ -46,8 +46,7 @@ impl BenchmarkCommand {
     ///
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
-        let guard = self.logs.init_tracing()?;
-        Ok(guard)
+    pub fn init_tracing(&self) -> eyre::Result<TracerHandle> {
+        self.logs.init_tracing()
     }
 }

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -190,7 +190,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
     ///
     /// If file logging is enabled, the returned handle has a guard that must be
     /// kept alive to ensure that all logs are flushed to disk. If OTLP is
-    /// enabled, the handle can be used to start the OpenTelemetry layer after
+    /// enabled, the handle can be used to start the `OpenTelemetry` layer after
     /// the tokio runtime is initialized.
     pub fn init_tracing(&self) -> eyre::Result<TracerHandle> {
         self.logs.init_tracing()

--- a/book/cli/reth.md
+++ b/book/cli/reth.md
@@ -126,4 +126,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/config.md
+++ b/book/cli/reth/config.md
@@ -114,4 +114,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db.md
+++ b/book/cli/reth/db.md
@@ -166,4 +166,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/checksum.md
+++ b/book/cli/reth/db/checksum.md
@@ -112,4 +112,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/clear.md
+++ b/book/cli/reth/db/clear.md
@@ -104,4 +104,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/clear/mdbx.md
+++ b/book/cli/reth/db/clear/mdbx.md
@@ -103,4 +103,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/clear/static-file.md
+++ b/book/cli/reth/db/clear/static-file.md
@@ -106,4 +106,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/diff.md
+++ b/book/cli/reth/db/diff.md
@@ -136,4 +136,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/drop.md
+++ b/book/cli/reth/db/drop.md
@@ -102,4 +102,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/get.md
+++ b/book/cli/reth/db/get.md
@@ -104,4 +104,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/get/mdbx.md
+++ b/book/cli/reth/db/get/mdbx.md
@@ -112,4 +112,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/get/static-file.md
+++ b/book/cli/reth/db/get/static-file.md
@@ -112,4 +112,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/list.md
+++ b/book/cli/reth/db/list.md
@@ -145,4 +145,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/path.md
+++ b/book/cli/reth/db/path.md
@@ -99,4 +99,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/stats.md
+++ b/book/cli/reth/db/stats.md
@@ -112,4 +112,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/db/version.md
+++ b/book/cli/reth/db/version.md
@@ -99,4 +99,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/debug.md
+++ b/book/cli/reth/debug.md
@@ -116,4 +116,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/debug/build-block.md
+++ b/book/cli/reth/debug/build-block.md
@@ -175,4 +175,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/debug/execution.md
+++ b/book/cli/reth/debug/execution.md
@@ -329,4 +329,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/debug/in-memory-merkle.md
+++ b/book/cli/reth/debug/in-memory-merkle.md
@@ -329,4 +329,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/debug/merkle.md
+++ b/book/cli/reth/debug/merkle.md
@@ -332,4 +332,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/debug/replay-engine.md
+++ b/book/cli/reth/debug/replay-engine.md
@@ -329,4 +329,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/dump-genesis.md
+++ b/book/cli/reth/dump-genesis.md
@@ -108,4 +108,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/import.md
+++ b/book/cli/reth/import.md
@@ -166,4 +166,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/init-state.md
+++ b/book/cli/reth/init-state.md
@@ -189,4 +189,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/init.md
+++ b/book/cli/reth/init.md
@@ -154,4 +154,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -771,4 +771,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/p2p.md
+++ b/book/cli/reth/p2p.md
@@ -332,4 +332,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/p2p/body.md
+++ b/book/cli/reth/p2p/body.md
@@ -103,4 +103,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/p2p/header.md
+++ b/book/cli/reth/p2p/header.md
@@ -103,4 +103,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/p2p/rlpx.md
+++ b/book/cli/reth/p2p/rlpx.md
@@ -103,4 +103,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/p2p/rlpx/ping.md
+++ b/book/cli/reth/p2p/rlpx/ping.md
@@ -103,4 +103,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/prune.md
+++ b/book/cli/reth/prune.md
@@ -154,4 +154,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/recover.md
+++ b/book/cli/reth/recover.md
@@ -112,4 +112,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/recover/storage-tries.md
+++ b/book/cli/reth/recover/storage-tries.md
@@ -154,4 +154,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage.md
+++ b/book/cli/reth/stage.md
@@ -115,4 +115,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/drop.md
+++ b/book/cli/reth/stage/drop.md
@@ -168,4 +168,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/dump.md
+++ b/book/cli/reth/stage/dump.md
@@ -161,4 +161,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/dump/account-hashing.md
+++ b/book/cli/reth/stage/dump/account-hashing.md
@@ -111,4 +111,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/dump/execution.md
+++ b/book/cli/reth/stage/dump/execution.md
@@ -111,4 +111,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/dump/merkle.md
+++ b/book/cli/reth/stage/dump/merkle.md
@@ -111,4 +111,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/dump/storage-hashing.md
+++ b/book/cli/reth/stage/dump/storage-hashing.md
@@ -111,4 +111,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/run.md
+++ b/book/cli/reth/stage/run.md
@@ -364,4 +364,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/unwind.md
+++ b/book/cli/reth/stage/unwind.md
@@ -329,4 +329,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/unwind/num-blocks.md
+++ b/book/cli/reth/stage/unwind/num-blocks.md
@@ -103,4 +103,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/book/cli/reth/stage/unwind/to-block.md
+++ b/book/cli/reth/stage/unwind/to-block.md
@@ -103,4 +103,34 @@ Display:
 
   -q, --quiet
           Silence all log output
+
+      --otel.endpoint <ENDPOINT>
+          Endpoint url to which to send spans and events. The endpoint URL must be a valid URL, including the protocol prefix (http or https) and any http basic auth information.
+
+          If the endpoint is not specified, events and spans will not be exported to any external service.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+      --otel.protocol <PROTOCOL>
+          The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: json]
+
+      --otel.level <LEVEL>
+          The log level to use for the `OpenTelemetry` layer. Values are "trace", "debug", "info", "warn", and "error". The default is "info". Events and spans above this level will not be exported. Events and spans at this level or below will be exported. See the documentation of [`Level`] for more information.
+
+          To specify `off`, omit the `--otel.url` argument.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: info]
+
+      --otel.timeout <TIMEOUT>
+          The timeout for sending spans and events, in milliseconds.
+
+          Available only when compiled with the `opentelemetry` feature.
+
+          [default: 1000]
 ```

--- a/crates/cli/runner/Cargo.toml
+++ b/crates/cli/runner/Cargo.toml
@@ -13,9 +13,12 @@ workspace = true
 [dependencies]
 # reth
 reth-tasks.workspace = true
+reth-tracing = { workspace = true, default-features = false }
 
 # async
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 
-# misc
-tracing.workspace = true
+[features]
+default = ["opentelemetry"]
+opentelemetry = ["reth-tracing/opentelemetry"]
+

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -30,7 +30,7 @@ pub struct CliRunner {
 
 impl CliRunner {
     /// Creates a new CLI runner with the given tracer handle.
-    pub fn new(handle: TracerHandle) -> Self {
+    pub const fn new(handle: TracerHandle) -> Self {
         Self { handle }
     }
 

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -75,10 +75,12 @@ proptest.workspace = true
 tokio.workspace = true
 
 [features]
+default = ["opentelemetry"]
 optimism = ["reth-primitives/optimism", "reth-db/optimism"]
 # Features for vergen to generate correct env vars
 jemalloc = ["reth-cli-util/jemalloc"]
 asm-keccak = ["reth-primitives/asm-keccak", "alloy-primitives/asm-keccak"]
+opentelemetry = ["reth-tracing/opentelemetry"]
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -133,12 +133,16 @@ impl LogArgs {
     }
 }
 
+/// Arguments for the `OpenTelemetry` tracing layer.
 #[cfg(feature = "opentelemetry")]
 #[derive(Debug, Args)]
 pub struct OtelArgs {
     /// Endpoint url to which to send spans and events. The endpoint URL must
     /// be a valid URL, including the protocol prefix (http or https) and any
     /// http basic auth information.
+    ///
+    /// If the endpoint is not specified, events and spans will not be exported
+    /// to any external service.
     ///
     /// Available only when compiled with the `opentelemetry` feature.
     #[arg(long = "otel.endpoint", value_name = "ENDPOINT", global = true)]

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -152,7 +152,6 @@ pub struct OtelArgs {
     /// "binary", or "json".
     ///
     /// Available only when compiled with the `opentelemetry` feature.
-
     #[arg(long = "otel.protocol", value_name = "PROTOCOL", global = true, default_value = "json")]
     pub protocol: reth_tracing::OtlpProtocols,
 

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -132,7 +132,7 @@ impl LogArgs {
     ///
     /// If file logging is enabled, the returned handle has a guard that must be
     /// kept alive to ensure that all logs are flushed to disk. If OTLP is
-    /// enabled, the handle can be used to start the OpenTelemetry layer after
+    /// enabled, the handle can be used to start the `OpenTelemetry` layer after
     /// the tokio runtime is initialized.
     pub fn init_tracing(&self) -> eyre::Result<TracerHandle> {
         self.tracer().init()

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -157,7 +157,12 @@ pub struct OtelArgs {
     pub protocol: reth_tracing::OtlpProtocols,
 
     /// The log level to use for the `OpenTelemetry` layer. Values are
-    /// "trace", "debug", "info", "warn", and "error".
+    /// "trace", "debug", "info", "warn", and "error". The default is "info".
+    /// Events and spans above this level will not be exported. Events and spans
+    /// at this level or below will be exported. See the documentation of
+    /// [`Level`] for more information.
+    ///
+    /// To specify `off`, omit the `--otel.url` argument.
     ///
     /// Available only when compiled with the `opentelemetry` feature.
     #[arg(long = "otel.level", value_name = "LEVEL", global = true, default_value = "info")]
@@ -178,7 +183,7 @@ impl TryFrom<&OtelArgs> for reth_tracing::OtlpConfig {
         Ok(Self {
             url: value.url.clone().ok_or("no otel url specified via --otel.url")?,
             protocol: value.protocol,
-            level: value.level,
+            level: value.level.into(),
             timeout: value.timeout,
         })
     }

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -3,8 +3,8 @@
 use crate::dirs::{LogsDir, PlatformPath};
 use clap::{ArgAction, Args, ValueEnum};
 use reth_tracing::{
-    tracing_subscriber::filter::Directive, FileInfo, FileWorkerGuard, LayerInfo, LogFormat,
-    RethTracer, Tracer,
+    tracing_subscriber::filter::Directive, FileInfo, LayerInfo, LogFormat, RethTracer, Tracer,
+    TracerHandle,
 };
 use std::fmt::{self, Display};
 use tracing::{level_filters::LevelFilter, Level};
@@ -130,8 +130,11 @@ impl LogArgs {
 
     /// Initializes tracing with the configured options from cli args.
     ///
-    /// Returns the file worker guard, and the file name, if a file worker was configured.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
+    /// If file logging is enabled, the returned handle has a guard that must be
+    /// kept alive to ensure that all logs are flushed to disk. If OTLP is
+    /// enabled, the handle can be used to start the OpenTelemetry layer after
+    /// the tokio runtime is initialized.
+    pub fn init_tracing(&self) -> eyre::Result<TracerHandle> {
         self.tracer().init()
     }
 }

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -144,14 +144,16 @@ pub struct OtelArgs {
     #[arg(long = "otel.endpoint", value_name = "ENDPOINT", global = true)]
     pub url: Option<String>,
 
-    /// The protocol to use for sending spans and events. Values are "grpc", "binary", or "json".
+    /// The protocol to use for sending spans and events. Values are "grpc",
+    /// "binary", or "json".
     ///
     /// Available only when compiled with the `opentelemetry` feature.
 
     #[arg(long = "otel.protocol", value_name = "PROTOCOL", global = true, default_value = "json")]
     pub protocol: reth_tracing::OtlpProtocols,
 
-    /// The log level to use for the `OpenTelemetry` layer.
+    /// The log level to use for the `OpenTelemetry` layer. Values are
+    /// "trace", "debug", "info", "warn", and "error".
     ///
     /// Available only when compiled with the `opentelemetry` feature.
     #[arg(long = "otel.level", value_name = "LEVEL", global = true, default_value = "info")]

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -158,17 +158,17 @@ pub struct OtelArgs {
     #[arg(long = "otel.protocol", value_name = "PROTOCOL", global = true, default_value = "json")]
     pub protocol: reth_tracing::OtlpProtocols,
 
-    /// The log level to use for the `OpenTelemetry` layer. Values are
-    /// "trace", "debug", "info", "warn", and "error". The default is "info".
-    /// Events and spans above this level will not be exported. Events and spans
-    /// at this level or below will be exported. See the documentation of
-    /// [`Level`] for more information.
+    /// The filter to use for spans and events exported to the `OpenTelemetry`
+    /// layer. Values are expected to be in the [`EnvFilter`]'s directive format
+    /// "info".
     ///
     /// To specify `off`, omit the `--otel.url` argument.
     ///
     /// Available only when compiled with the `opentelemetry` feature.
-    #[arg(long = "otel.level", value_name = "LEVEL", global = true, default_value = "info")]
-    pub level: tracing::Level,
+    ///
+    /// [`EnvFilter`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    #[arg(long = "otel.filter", value_name = "LEVEL", global = true, default_value = "info")]
+    pub directive: String,
 
     /// The timeout for sending spans and events, in milliseconds.
     ///
@@ -184,7 +184,7 @@ impl OtelArgs {
         Ok(reth_tracing::OtlpConfig {
             url: self.url.clone().ok_or("no otel url specified via --otel.url")?,
             protocol: self.protocol,
-            level: self.level.into(),
+            directive: self.directive.clone(),
             timeout: self.timeout,
         })
     }

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -48,7 +48,7 @@ use reth_node_core::{
 };
 use reth_optimism_evm::OpExecutorProvider;
 use reth_optimism_node::OptimismNode;
-use reth_tracing::FileWorkerGuard;
+use reth_tracing::TracerHandle;
 use tracing::info;
 
 // This allows us to manually enable node metrics features, required for proper jemalloc metric
@@ -178,9 +178,8 @@ where
     ///
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
-        let guard = self.logs.init_tracing()?;
-        Ok(guard)
+    pub fn init_tracing(&self) -> eyre::Result<TracerHandle> {
+        self.logs.init_tracing()
     }
 }
 

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -20,3 +20,18 @@ tracing-logfmt = "0.3.3"
 rolling-file = "0.2.0"
 eyre.workspace = true
 clap = { workspace = true, features = ["derive"] }
+
+# OpenTelemetry
+tracing-opentelemetry = { version = "0.27.0", optional = true }
+opentelemetry-otlp = { version = "0.26.0", default-features = false, features = ["http", "http-proto", "http-json", "logs", "tokio", "trace"], optional = true }
+opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio", "tokio"], optional = true }
+opentelemetry = { version = "0.26.0", optional = true }
+
+[features]
+default = ["opentelemetry"]
+opentelemetry = [
+    "dep:opentelemetry",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry_sdk",
+    "dep:tracing-opentelemetry",
+]

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -26,6 +26,7 @@ tracing-opentelemetry = { version = "0.27.0", optional = true }
 opentelemetry-otlp = { version = "0.26.0", default-features = false, features = ["http", "http-proto", "http-json", "logs", "reqwest-rustls", "tokio", "trace"], optional = true }
 opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio", "tokio"], optional = true }
 opentelemetry = { version = "0.26.0", optional = true }
+reqwest = { workspace = true, optional = true }
 
 [features]
 default = ["opentelemetry"]
@@ -33,5 +34,7 @@ opentelemetry = [
     "dep:opentelemetry",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry_sdk",
+    "dep:reqwest",
     "dep:tracing-opentelemetry",
 ]
+reqwest = ["dep:reqwest"]

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -23,7 +23,7 @@ clap = { workspace = true, features = ["derive"] }
 
 # OpenTelemetry
 tracing-opentelemetry = { version = "0.27.0", optional = true }
-opentelemetry-otlp = { version = "0.26.0", default-features = false, features = ["http", "http-proto", "http-json", "logs", "tokio", "trace"], optional = true }
+opentelemetry-otlp = { version = "0.26.0", default-features = false, features = ["http", "http-proto", "http-json", "logs", "reqwest-rustls", "tokio", "trace"], optional = true }
 opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio", "tokio"], optional = true }
 opentelemetry = { version = "0.26.0", optional = true }
 

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -129,7 +129,9 @@ impl Layers {
             .install_batch(opentelemetry_sdk::runtime::Tokio)?
             .tracer("reth");
 
-        let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        let layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(tracing_subscriber::filter::LevelFilter::from(otlp.level));
 
         self.inner.push(Box::new(layer));
         Ok(())

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -121,15 +121,18 @@ impl Layers {
         use opentelemetry::trace::TracerProvider;
         use opentelemetry_otlp::{ExportConfig, WithExportConfig};
 
+        let exporter = opentelemetry_otlp::new_exporter()
+            .http()
+            .with_export_config(ExportConfig {
+                endpoint: otlp.url,
+                protocol: otlp.protocol.into(),
+                timeout: std::time::Duration::from_millis(otlp.timeout),
+            })
+            .with_http_client(reqwest::Client::default());
+
         let tracer = opentelemetry_otlp::new_pipeline()
             .tracing()
-            .with_exporter(opentelemetry_otlp::new_exporter().http().with_export_config(
-                ExportConfig {
-                    endpoint: otlp.url,
-                    protocol: otlp.protocol.into(),
-                    timeout: std::time::Duration::from_millis(otlp.timeout),
-                },
-            ))
+            .with_exporter(exporter)
             .install_batch(opentelemetry_sdk::runtime::Tokio)?
             .tracer("reth");
 

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -136,9 +136,11 @@ impl Layers {
             .install_batch(opentelemetry_sdk::runtime::Tokio)?
             .tracer("reth");
 
-        let layer = tracing_opentelemetry::layer().with_tracer(tracer).with_filter(otlp.level);
+        let filter = build_env_filter(None, &otlp.directive)?;
 
-        self.inner.push(Box::new(layer));
+        let layer = tracing_opentelemetry::layer().with_tracer(tracer).with_filter(filter).boxed();
+
+        self.inner.push(layer);
         Ok(())
     }
 }

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -108,10 +108,14 @@ impl Layers {
         Ok(guard)
     }
 
-    /// Adds an OpenTelemetry layer to the layers collection.
+    /// Adds an `OpenTelemetry` layer to the layers collection.
     ///
     /// # Arguments
-    /// * `otlp` - The OpenTelemetry configuration.
+    /// * `otlp` - The `OpenTelemetry` configuration.
+    ///
+    /// # Returns
+    /// An `eyre::Result<()>` indicating the success or failure of the
+    /// operation.
     #[cfg(feature = "opentelemetry")]
     pub(crate) fn otlp(&mut self, otlp: crate::OtlpConfig) -> eyre::Result<()> {
         use opentelemetry::trace::TracerProvider;

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -133,9 +133,7 @@ impl Layers {
             .install_batch(opentelemetry_sdk::runtime::Tokio)?
             .tracer("reth");
 
-        let layer = tracing_opentelemetry::layer()
-            .with_tracer(tracer)
-            .with_filter(tracing_subscriber::filter::LevelFilter::from(otlp.level));
+        let layer = tracing_opentelemetry::layer().with_tracer(tracer).with_filter(otlp.level);
 
         self.inner.push(Box::new(layer));
         Ok(())

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -12,7 +12,7 @@ use crate::formatter::LogFormat;
 ///  belongs to.
 pub type FileWorkerGuard = tracing_appender::non_blocking::WorkerGuard;
 
-/// Reloadable handle for the OpenTelemetry layer.
+/// Reloadable handle for the `OpenTelemetry` layer.
 pub type ReloadableOtlpHandle = reload::Handle<Box<dyn Layer<Registry> + Send + Sync>, Registry>;
 
 ///  A boxed tracing [Layer].
@@ -116,7 +116,7 @@ impl Layers {
     /// # Returns
     ///
     /// A [`ReloadableOtlpHandle`] that can be used to configure the
-    /// OpenTelemetry layer after the tokio runtime is initialized.
+    /// `OpenTelemetry` layer after the tokio runtime is initialized.
     #[cfg(feature = "opentelemetry")]
     pub(crate) fn otlp_placeholder(&mut self) -> ReloadableOtlpHandle {
         //

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -67,13 +67,6 @@ use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-/// Placeholder to prevent annoying conditional compilation when feature is not
-/// enabled. This ensures we can keep the prop on the struct as a ZST, and
-/// avoid flagging it out of `new` and other constructor functions.
-#[cfg(not(feature = "opentelemetry"))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct OtlpConfig;
-
 ///  Tracer for application logging.
 ///
 ///  Manages the configuration and initialization of logging layers,
@@ -83,7 +76,7 @@ pub struct RethTracer {
     stdout: LayerInfo,
     journald: Option<String>,
     file: Option<(LayerInfo, FileInfo)>,
-    #[cfg_attr(not(feature = "opentelemetry"), allow(dead_code))]
+    #[cfg(feature = "opentelemetry")]
     otlp: Option<OtlpConfig>,
 }
 
@@ -93,7 +86,13 @@ impl RethTracer {
     ///  Initializes with default stdout layer configuration.
     ///  Journald and file layers are not set by default.
     pub fn new() -> Self {
-        Self { stdout: LayerInfo::default(), journald: None, file: None, otlp: None }
+        Self {
+            stdout: LayerInfo::default(),
+            journald: None,
+            file: None,
+            #[cfg(feature = "opentelemetry")]
+            otlp: None,
+        }
     }
 
     ///  Sets a custom configuration for the stdout layer.

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -187,6 +187,7 @@ impl Default for LayerInfo {
 }
 
 /// Tracer handle for managing the logging configuration.
+#[derive(Default)]
 pub struct TracerHandle {
     /// Guard for the file layer, if any
     pub file_guard: Option<WorkerGuard>,
@@ -197,18 +198,6 @@ pub struct TracerHandle {
     /// Handle for the tracing subscriber, to allow reloading after
     #[cfg(feature = "opentelemetry")]
     otlp_config: Option<OtlpConfig>,
-}
-
-impl Default for TracerHandle {
-    fn default() -> Self {
-        Self {
-            file_guard: None,
-            #[cfg(feature = "opentelemetry")]
-            otlp_handle: None,
-            #[cfg(feature = "opentelemetry")]
-            otlp_config: None,
-        }
-    }
 }
 
 impl fmt::Debug for TracerHandle {

--- a/crates/tracing/src/otlp.rs
+++ b/crates/tracing/src/otlp.rs
@@ -1,0 +1,48 @@
+/// OTLP protocol options.
+#[derive(Debug, Clone, Copy)]
+pub enum OtlpProtocols {
+    /// GRPC.
+    Grpc,
+    /// Binary.
+    Binary,
+    /// JSON.
+    Json,
+}
+
+impl std::str::FromStr for OtlpProtocols {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            s if s.eq_ignore_ascii_case("grpc") => Ok(Self::Grpc),
+            s if s.eq_ignore_ascii_case("binary") => Ok(Self::Binary),
+            s if s.eq_ignore_ascii_case("json") => Ok(Self::Json),
+            _ => Err(format!("Invalid protocol: {}", s)),
+        }
+    }
+}
+
+impl From<OtlpProtocols> for opentelemetry_otlp::Protocol {
+    fn from(protocol: OtlpProtocols) -> Self {
+        match protocol {
+            OtlpProtocols::Grpc => Self::Grpc,
+            OtlpProtocols::Binary => Self::HttpBinary,
+            OtlpProtocols::Json => Self::HttpJson,
+        }
+    }
+}
+
+/// OTLP configuration.
+#[derive(Debug, Clone)]
+pub struct OtlpConfig {
+    /// Endpoint url to which to send spans and events. The endpoint URL must
+    /// be a valid URL, including the protocol prefix (http or https) and any
+    /// http basic auth information.
+    pub url: String,
+    /// The protocol to use for sending spans and events.
+    pub protocol: OtlpProtocols,
+    /// The log level to use for the `OpenTelemetry` layer.
+    pub level: tracing::Level,
+    /// The timeout for sending spans and events.
+    pub timeout: u64,
+}

--- a/crates/tracing/src/otlp.rs
+++ b/crates/tracing/src/otlp.rs
@@ -1,5 +1,3 @@
-use tracing_subscriber::filter::LevelFilter;
-
 /// OTLP protocol options.
 #[derive(Debug, Clone, Copy)]
 pub enum OtlpProtocols {
@@ -43,8 +41,11 @@ pub struct OtlpConfig {
     pub url: String,
     /// The protocol to use for sending spans and events.
     pub protocol: OtlpProtocols,
-    /// The log level to use for the `OpenTelemetry` layer.
-    pub level: LevelFilter,
+    /// The [`EnvFilter`] directive to use for spans and events exported to the
+    /// `OpenTelemetry` layer.
+    ///
+    /// [`EnvFilter`]: tracing_subscriber::filter::EnvFilter
+    pub directive: String,
     /// The timeout for sending spans and events.
     pub timeout: u64,
 }

--- a/crates/tracing/src/otlp.rs
+++ b/crates/tracing/src/otlp.rs
@@ -1,3 +1,5 @@
+use tracing_subscriber::filter::LevelFilter;
+
 /// OTLP protocol options.
 #[derive(Debug, Clone, Copy)]
 pub enum OtlpProtocols {
@@ -42,7 +44,7 @@ pub struct OtlpConfig {
     /// The protocol to use for sending spans and events.
     pub protocol: OtlpProtocols,
     /// The log level to use for the `OpenTelemetry` layer.
-    pub level: tracing::Level,
+    pub level: LevelFilter,
     /// The timeout for sending spans and events.
     pub timeout: u64,
 }

--- a/crates/tracing/src/test_tracer.rs
+++ b/crates/tracing/src/test_tracer.rs
@@ -1,7 +1,6 @@
-use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 
-use crate::Tracer;
+use crate::{Tracer, TracerHandle};
 
 ///  Initializes a tracing subscriber for tests.
 ///
@@ -15,11 +14,11 @@ use crate::Tracer;
 pub struct TestTracer;
 
 impl Tracer for TestTracer {
-    fn init(self) -> eyre::Result<Option<WorkerGuard>> {
+    fn init(self) -> eyre::Result<TracerHandle> {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .with_writer(std::io::stderr)
             .try_init();
-        Ok(None)
+        Ok(TracerHandle::default())
     }
 }


### PR DESCRIPTION
Adds command line flags and `reth-tracing` support for exporting tracing events via OTLP to any OpenTelemetry-compatible http endpoint

Should allow reth deployments to participate in standard distributed tracing services like Jaeger, Honeycomb, etc.

Some notes:
- `otel` is the preferred naming convention for human-facing details and event/span collection. `otlp` is the preferred naming convention for the export protocol. As such, `otel` is used for CLI flags, while `otlp` is used for the tracing subscriber
- otlp was chosen to maximize compatibility. jaeger or honeycomb would be a more opinionated choice
- This is aimed at teams that use reth as part of complex deployments, and therefore auth flags are pretty low-prio. Teams are expected to have intranets, VPNs, AWS managed connections, or other pre-authed http channels