### PR TITLE
chore: remove unused `from_cached_state` method

### DIFF
--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{keccak256, Address, B256, U256};
 use itertools::Itertools;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use reth_primitives::Account;
-use revm::db::{states::CacheAccount, AccountStatus, BundleAccount};
+use revm::db::{AccountStatus, BundleAccount};
 use std::{
     borrow::Cow,
     collections::{hash_map, HashMap, HashSet},
@@ -36,33 +36,6 @@ impl HashedPostState {
                 let hashed_storage = HashedStorage::from_plain_storage(
                     account.status,
                     account.storage.iter().map(|(slot, value)| (slot, &value.present_value)),
-                );
-                (hashed_address, (hashed_account, hashed_storage))
-            })
-            .collect::<Vec<(B256, (Option<Account>, HashedStorage))>>();
-
-        let mut accounts = HashMap::with_capacity(hashed.len());
-        let mut storages = HashMap::with_capacity(hashed.len());
-        for (address, (account, storage)) in hashed {
-            accounts.insert(address, account);
-            storages.insert(address, storage);
-        }
-        Self { accounts, storages }
-    }
-
-    /// Initialize [`HashedPostState`] from cached state.
-    /// Hashes all changed accounts and storage entries that are currently stored in cache.
-    pub fn from_cache_state<'a>(
-        state: impl IntoParallelIterator<Item = (&'a Address, &'a CacheAccount)>,
-    ) -> Self {
-        let hashed = state
-            .into_par_iter()
-            .map(|(address, account)| {
-                let hashed_address = keccak256(address);
-                let hashed_account = account.account.as_ref().map(|a| a.info.clone().into());
-                let hashed_storage = HashedStorage::from_plain_storage(
-                    account.status,
-                    account.account.as_ref().map(|a| a.storage.iter()).into_iter().flatten(),
                 );
                 (hashed_address, (hashed_account, hashed_storage))
             })
@@ -349,10 +322,7 @@ impl HashedStorageSorted {
 mod tests {
     use alloy_primitives::Bytes;
     use revm::{
-        db::{
-            states::{plain_account::PlainStorage, StorageSlot},
-            PlainAccount, StorageWithOriginalValues,
-        },
+        db::{states::StorageSlot, StorageWithOriginalValues},
         primitives::{AccountInfo, Bytecode},
     };
 
@@ -464,45 +434,6 @@ mod tests {
 
         // Convert the bundle state into a hashed post state.
         let hashed_state = HashedPostState::from_bundle_state(state);
-
-        // Validate the hashed post state.
-        assert_eq!(hashed_state.accounts.len(), 1);
-        assert_eq!(hashed_state.storages.len(), 1);
-
-        // Validate the account info.
-        assert_eq!(
-            *hashed_state.accounts.get(&keccak256(address)).unwrap(),
-            Some(account_info.into())
-        );
-    }
-
-    #[test]
-    fn test_hashed_post_state_from_cache_state() {
-        // Prepare a random Ethereum address.
-        let address = Address::random();
-
-        // Create mock account info.
-        let account_info = AccountInfo {
-            balance: U256::from(500),
-            nonce: 5,
-            code_hash: B256::random(),
-            code: None,
-        };
-
-        let mut storage = PlainStorage::default();
-        storage.insert(U256::from(1), U256::from(35636));
-
-        // Create a `CacheAccount` with the mock account info.
-        let account = CacheAccount {
-            account: Some(PlainAccount { info: account_info.clone(), storage }),
-            status: AccountStatus::Changed,
-        };
-
-        // Create a vector of tuples representing the cache state.
-        let state = vec![(&address, &account)];
-
-        // Convert the cache state into a hashed post state.
-        let hashed_state = HashedPostState::from_cache_state(state);
 
         // Validate the hashed post state.
         assert_eq!(hashed_state.accounts.len(), 1);


### PR DESCRIPTION
Remove unused `from_cached_state` from the `HashedPostState`. The method was only used in the `test_hashed_post_state_from_cache_state` test.