### PR TITLE
feat(engine): integrate executor with StateRootTask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7202,6 +7202,7 @@ dependencies = [
  "assert_matches",
  "futures",
  "metrics",
+ "pin-project",
  "reth-beacon-consensus",
  "reth-blockchain-tree",
  "reth-blockchain-tree-api",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -43,6 +43,7 @@ revm-primitives.workspace = true
 
 # common
 futures.workspace = true
+pin-project.workspace = true
 tokio = { workspace = true, features = ["macros", "sync"] }
 tokio-stream.workspace = true
 thiserror.workspace = true

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2190,7 +2190,7 @@ where
 
         let exec_time = Instant::now();
 
-        let (state_root_tx, state_root_rx) = unbounded_channel();
+        let (_state_root_tx, state_root_rx) = unbounded_channel();
         // TODO: create consistent_view using `new_with_latest_tip` when we
         // switch to `StateRootTask`.
         let consistent_view = ConsistentDbView::new(self.provider.clone(), None);
@@ -2200,8 +2200,11 @@ where
             Arc::new(TrieInput::default()),
             UnboundedReceiverStream::new(state_root_rx),
         );
-        let state_hook = move |result_and_state: &ResultAndState| {
-            let _ = state_root_tx.send(result_and_state.state.clone());
+        let state_hook = move |_result_and_state: &ResultAndState| {
+            // TODO: uncomment when we start using `StateRootTask`, otherwise
+            // the messages sent here would not be consumed and we would
+            // increase memory usage for no reason.
+            // let _ = state_root_tx.send(result_and_state.state.clone());
         };
 
         let output = self.metrics.executor.execute_metered(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -45,6 +45,7 @@ use reth_stages_api::ControlFlow;
 use reth_trie::{updates::TrieUpdates, HashedPostState, TrieInput};
 use reth_trie_parallel::parallel_root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::ResultAndState;
+use root::StateRootTask;
 use std::{
     cmp::Ordering,
     collections::{btree_map, hash_map, BTreeMap, VecDeque},
@@ -57,10 +58,10 @@ use std::{
     time::Instant,
 };
 use tokio::sync::{
-    mpsc::{UnboundedReceiver, UnboundedSender},
-    oneshot,
-    oneshot::error::TryRecvError,
+    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    oneshot::{self, error::TryRecvError},
 };
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::*;
 
 pub mod config;
@@ -612,7 +613,7 @@ where
             remove_above_state: VecDeque::new(),
         };
 
-        let (tx, outgoing) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, outgoing) = unbounded_channel();
         let state = EngineApiTreeState::new(
             config.block_buffer_limit(),
             config.max_invalid_header_cache_length(),
@@ -2188,13 +2189,25 @@ where
         let block = block.unseal();
 
         let exec_time = Instant::now();
-        // TODO: create StateRootTask with the receiving end of a channel and
-        // pass the sending end of the channel to the state hook.
-        let noop_state_hook = |_result_and_state: &ResultAndState| {};
+
+        let (state_root_tx, state_root_rx) = unbounded_channel();
+        // TODO: create consistent_view using `new_with_latest_tip` when we
+        // switch to `StateRootTask`.
+        let consistent_view = ConsistentDbView::new(self.provider.clone(), None);
+        let _state_root_task = StateRootTask::new(
+            consistent_view,
+            // TODO: calculate `TrieInput` like in `self.compute_state_root_parallel`.
+            Arc::new(TrieInput::default()),
+            UnboundedReceiverStream::new(state_root_rx),
+        );
+        let state_hook = move |result_and_state: &ResultAndState| {
+            let _ = state_root_tx.send(result_and_state.state.clone());
+        };
+
         let output = self.metrics.executor.execute_metered(
             executor,
             (&block, U256::MAX).into(),
-            Box::new(noop_state_hook),
+            Box::new(state_hook),
         )?;
 
         trace!(target: "engine::tree", elapsed=?exec_time.elapsed(), ?block_number, "Executed block");
@@ -2217,6 +2230,8 @@ where
         trace!(target: "engine::tree", block=?sealed_block.num_hash(), "Calculating block state root");
         let root_time = Instant::now();
         let mut state_root_result = None;
+
+        // TODO: switch to calculate state root using `StateRootTask`.
 
         // We attempt to compute state root in parallel if we are currently not persisting anything
         // to database. This is safe, because the database state cannot change until we
@@ -2305,6 +2320,9 @@ where
         parent_hash: B256,
         hashed_state: &HashedPostState,
     ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
+        // TODO: when we switch to calculate state root using `StateRootTask` this
+        // method can be still useful to calculate the required `TrieInput` to
+        // create the task.
         let consistent_view = ConsistentDbView::new_with_latest_tip(self.provider.clone())?;
         let mut input = TrieInput::default();
 
@@ -2607,7 +2625,6 @@ mod tests {
         str::FromStr,
         sync::mpsc::{channel, Sender},
     };
-    use tokio::sync::mpsc::unbounded_channel;
 
     /// This is a test channel that allows you to `release` any value that is in the channel.
     ///

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -22,7 +22,7 @@ pub(crate) struct StateRootHandle {
 #[allow(dead_code)]
 impl StateRootHandle {
     /// Waits for the state root calculation to complete.
-    pub(crate) fn wait_result(self) -> StateRootResult {
+    pub(crate) fn wait_for_result(self) -> StateRootResult {
         self.rx.recv().expect("state root task was dropped without sending result")
     }
 }

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -1,21 +1,36 @@
 //! State root task related functionality.
 
+use futures::StreamExt;
 use reth_provider::providers::ConsistentDbView;
 use reth_trie::{updates::TrieUpdates, TrieInput};
 use reth_trie_parallel::parallel_root::ParallelStateRootError;
 use revm_primitives::{EvmState, B256};
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::sync::{mpsc, Arc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::debug;
+
+/// Result of the state root calculation
+pub(crate) type StateRootResult = Result<(B256, TrieUpdates), ParallelStateRootError>;
+
+/// Handle to a spawned state root task.
+#[derive(Debug)]
+pub(crate) struct StateRootHandle {
+    /// Channel for receiving the final result.
+    rx: mpsc::Receiver<StateRootResult>,
+}
+
+impl StateRootHandle {
+    /// Waits for the state root calculation to complete.
+    #[allow(dead_code)]
+    pub(crate) async fn wait_result(self) -> StateRootResult {
+        self.rx.recv().expect("state root task was dropped without sending result")
+    }
+}
 
 /// Standalone task that receives a transaction state stream and updates relevant
 /// data structures to calculate state root.
 ///
-/// It is responsile of  initializing a blinded sparse trie and subscribe to
+/// It is responsible of  initializing a blinded sparse trie and subscribe to
 /// transaction state stream. As it receives transaction execution results, it
 /// fetches the proofs for relevant accounts from the database and reveal them
 /// to the tree.
@@ -31,7 +46,10 @@ pub(crate) struct StateRootTask<Factory> {
 }
 
 #[allow(dead_code)]
-impl<Factory> StateRootTask<Factory> {
+impl<Factory> StateRootTask<Factory>
+where
+    Factory: Send + 'static,
+{
     /// Creates a new `StateRootTask`.
     pub(crate) const fn new(
         consistent_view: ConsistentDbView<Factory>,
@@ -41,20 +59,34 @@ impl<Factory> StateRootTask<Factory> {
         Self { consistent_view, state_stream, input }
     }
 
+    /// Spawns the state root task and returns a handle to await its result.
+    pub(crate) fn spawn(mut self) -> StateRootHandle {
+        let (tx, rx) = mpsc::channel();
+
+        // Spawn the task that will process state updates and calculate the root
+        tokio::spawn(async move {
+            debug!(target: "engine::tree", "Starting state root task");
+            let result = self.run().await;
+            let _ = tx.send(result);
+        });
+
+        StateRootHandle { rx }
+    }
+
     /// Handles state updates.
-    pub(crate) fn on_state_update(&self, _update: EvmState) {
+    fn on_state_update(&self, _update: EvmState) {
         // TODO: calculate hashed state update and dispatch proof gathering for it.
     }
-}
 
-impl<Factory> Future for StateRootTask<Factory> {
-    type Output = Result<(B256, TrieUpdates), ParallelStateRootError>;
+    async fn run(&mut self) -> StateRootResult {
+        while let Some(state) = self.state_stream.next().await {
+            self.on_state_update(state);
+        }
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         // TODO:
-        //    * poll incoming state updates stream
         //    * keep track of proof calculation
         //    * keep track of intermediate root computation
-        Poll::Pending
+        //    * return final state root result
+        Ok((B256::default(), TrieUpdates::default()))
     }
 }

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -13,11 +13,13 @@ pub(crate) type StateRootResult = Result<(B256, TrieUpdates), ParallelStateRootE
 
 /// Handle to a spawned state root task.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) struct StateRootHandle {
     /// Channel for receiving the final result.
     rx: mpsc::Receiver<StateRootResult>,
 }
 
+#[allow(dead_code)]
 impl StateRootHandle {
     /// Waits for the state root calculation to complete.
     pub(crate) fn wait_result(self) -> StateRootResult {

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -22,7 +22,7 @@ pub(crate) struct StateRootHandle {
 impl StateRootHandle {
     /// Waits for the state root calculation to complete.
     #[allow(dead_code)]
-    pub(crate) async fn wait_result(self) -> StateRootResult {
+    pub(crate) fn wait_result(self) -> StateRootResult {
         self.rx.recv().expect("state root task was dropped without sending result")
     }
 }


### PR DESCRIPTION
Towards: #12053
Requires: #12316

Creates a `StateRootTask` instance and wires it with the state hook passed to the executor using an unbounded channel. For now the `StateRootTask` instance is not created yet, some TODOs added for when all the functionality is in place and we can switch to use it.