### PR TITLE
fix: allow SOURCE_DATE_EPOCH to be overridable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ install-op: ## Build and install the op-reth binary under `~/.cargo/bin`.
 build: ## Build the reth binary into `target` directory.
 	cargo build --bin reth --features "$(FEATURES)" --profile "$(PROFILE)"
 
-SOURCE_DATE_EPOCH := $(shell git log -1 --pretty=%ct)
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 .PHONY: reproducible
 reproducible: ## Build the reth binary into `target` directory with reproducible builds. Only works for x86_64-unknown-linux-gnu currently
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \


### PR DESCRIPTION
Adopting reproducible builds disrupted reproducibility downstream for those, like myself, who work outside of Git history and use release tarballs for packaging (e.g., for Debian and similar systems). A minor adjustment is needed to allow the build environment to use the SOURCE_DATE_EPOCH based on the changelog timestamp.