### PR TITLE
fix(pool-args): `saturating_mul` max sizes to avoid overflow

### DIFF
--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -125,19 +125,19 @@ impl RethTransactionPoolConfig for TxPoolArgs {
             },
             pending_limit: SubPoolLimit {
                 max_txs: self.pending_max_count,
-                max_size: self.pending_max_size * 1024 * 1024,
+                max_size: self.pending_max_size.saturating_mul(1024 * 1024),
             },
             basefee_limit: SubPoolLimit {
                 max_txs: self.basefee_max_count,
-                max_size: self.basefee_max_size * 1024 * 1024,
+                max_size: self.basefee_max_size.saturating_mul(1024 * 1024),
             },
             queued_limit: SubPoolLimit {
                 max_txs: self.queued_max_count,
-                max_size: self.queued_max_size * 1024 * 1024,
+                max_size: self.queued_max_size.saturating_mul(1024 * 1024),
             },
             blob_limit: SubPoolLimit {
                 max_txs: self.queued_max_count,
-                max_size: self.queued_max_size * 1024 * 1024,
+                max_size: self.queued_max_size.saturating_mul(1024 * 1024),
             },
             max_account_slots: self.max_account_slots,
             price_bumps: PriceBumpConfig {


### PR DESCRIPTION
Currently passing in 17592186044416 would panic on debug and overflow to 0 on release 64bit builds. We can also panic in release, but I guess someone going that high would accept the implicit behaviour of setting to the max `usize`. 