### PR TITLE
perf(`EthBuiltPayload`): `Arc` `SealedBlock`

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -439,12 +439,12 @@ where
         body: BlockBody { transactions: executed_txs, ommers: vec![], withdrawals },
     };
 
-    let sealed_block = block.seal_slow();
+    let sealed_block = Arc::new(block.seal_slow());
     debug!(target: "payload_builder", ?sealed_block, "sealed built block");
 
     // create the executed block data
     let executed = ExecutedBlock {
-        block: Arc::new(sealed_block.clone()),
+        block: sealed_block.clone(),
         senders: Arc::new(executed_senders),
         execution_output: Arc::new(execution_outcome),
         hashed_state: Arc::new(hashed_state),

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -26,6 +26,7 @@
 //! ```
 //! use std::future::Future;
 //! use std::pin::Pin;
+//! use std::sync::Arc;
 //! use std::task::{Context, Poll};
 //! use alloy_primitives::U256;
 //! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, EthPayloadBuilderAttributes, PayloadJob, PayloadJobGenerator, PayloadKind};
@@ -56,7 +57,7 @@
 //!
 //! fn best_payload(&self) -> Result<EthBuiltPayload, PayloadBuilderError> {
 //!     // NOTE: some fields are omitted here for brevity
-//!     let payload = Block {
+//!     let block = Block {
 //!         header: Header {
 //!             parent_hash: self.attributes.parent,
 //!             timestamp: self.attributes.timestamp,
@@ -65,7 +66,7 @@
 //!         },
 //!         ..Default::default()
 //!     };
-//!     let payload = EthBuiltPayload::new(self.attributes.id, payload.seal_slow(), U256::ZERO, None, None);
+//!     let payload = EthBuiltPayload::new(self.attributes.id, Arc::new(block.seal_slow()), U256::ZERO, None, None);
 //!     Ok(payload)
 //! }
 //!

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -13,6 +13,7 @@ use reth_provider::CanonStateNotification;
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -86,7 +87,7 @@ impl PayloadJob for TestPayloadJob {
     fn best_payload(&self) -> Result<EthBuiltPayload, PayloadBuilderError> {
         Ok(EthBuiltPayload::new(
             self.attr.payload_id(),
-            Block::default().seal_slow(),
+            Arc::new(Block::default().seal_slow()),
             U256::ZERO,
             Some(ExecutedBlock::default()),
             Some(Default::default()),


### PR DESCRIPTION
Most `EthBuiltPayload`s have duplicate `SealedBlock`s in `block` and `executed_block.block`. Since the latter is already an `Arc` we should make the former one to share, instead of cloning anew like currently.

P/s: This is also applicable to `OpBuiltPayload`.