### PR TITLE
feat(rpc/admin): return deposit_contract_address for the admin_NodeInfo RPC

### DIFF
--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -115,6 +115,7 @@ where
                 .get_final_paris_total_difficulty()
                 .is_some(),
             terminal_total_difficulty: self.chain_spec.fork(EthereumHardfork::Paris).ttd(),
+            deposit_contract_address: self.chain_spec.deposit_contract().map(|dc| dc.address),
             ..self.chain_spec.genesis().config.clone()
         };
 


### PR DESCRIPTION
indent with Geth's rpc, as geth implements EIP-6110 in ethereum/go-ethereum#29431, it will also includes the deposit contract address in the `admin_nodeInfo` RPC, eg:

```json
 "protocols": {
      "eth": {
        "config": {
          "arrowGlacierBlock": 13773000,
          "berlinBlock": 12244000,
          "byzantiumBlock": 4370000,
          "cancunTime": 1710338135,
          "chainId": 1,
          "constantinopleBlock": 7280000,
          "daoForkBlock": 1920000,
          "daoForkSupport": true,
          "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
          "eip150Block": 2463000,
          "eip155Block": 2675000,
          "eip158Block": 2675000,
          "ethash": {},
          "grayGlacierBlock": 15050000,
          "homesteadBlock": 1150000,
          "istanbulBlock": 9069000,
          "londonBlock": 12965000,
          "muirGlacierBlock": 9200000,
          "petersburgBlock": 7280000,
          "shanghaiTime": 1681338455,
          "terminalTotalDifficulty": 58750000000000000000000,
          "terminalTotalDifficultyPassed": true
        },
        "difficulty": 58750003716598352816469,
        "genesis": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
        "head": "0x4b60a18825a5d1500e131e3d33d01cceac66e5963aa3c763f923583f86a89c71",
        "network": 1
      }
```