### PR TITLE
fix: `eth_getProof` response

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -122,7 +122,7 @@ pub trait EthState: LoadState + SpawnBlocking {
                 let proof = state
                     .proof(Default::default(), address, &storage_keys)
                     .map_err(Self::Error::from_eth_err)?;
-                Ok(from_primitive_account_proof(proof))
+                Ok(from_primitive_account_proof(proof, keys))
             })
             .await
         })

--- a/crates/rpc/rpc-types-compat/src/proof.rs
+++ b/crates/rpc/rpc-types-compat/src/proof.rs
@@ -5,16 +5,18 @@ use alloy_rpc_types_eth::{EIP1186AccountProofResponse, EIP1186StorageProof};
 use reth_trie_common::{AccountProof, StorageProof};
 
 /// Creates a new rpc storage proof from a primitive storage proof type.
-pub fn from_primitive_storage_proof(proof: StorageProof) -> EIP1186StorageProof {
-    EIP1186StorageProof {
-        key: JsonStorageKey::Number(proof.key.into()),
-        value: proof.value,
-        proof: proof.proof,
-    }
+pub fn from_primitive_storage_proof(
+    proof: StorageProof,
+    slot: JsonStorageKey,
+) -> EIP1186StorageProof {
+    EIP1186StorageProof { key: slot, value: proof.value, proof: proof.proof }
 }
 
 /// Creates a new rpc account proof from a primitive account proof type.
-pub fn from_primitive_account_proof(proof: AccountProof) -> EIP1186AccountProofResponse {
+pub fn from_primitive_account_proof(
+    proof: AccountProof,
+    slots: Vec<JsonStorageKey>,
+) -> EIP1186AccountProofResponse {
     let info = proof.info.unwrap_or_default();
     EIP1186AccountProofResponse {
         address: proof.address,
@@ -23,6 +25,11 @@ pub fn from_primitive_account_proof(proof: AccountProof) -> EIP1186AccountProofR
         nonce: info.nonce,
         storage_hash: proof.storage_root,
         account_proof: proof.proof,
-        storage_proof: proof.storage_proofs.into_iter().map(from_primitive_storage_proof).collect(),
+        storage_proof: proof
+            .storage_proofs
+            .into_iter()
+            .zip(slots)
+            .map(|(proof, slot)| from_primitive_storage_proof(proof, slot))
+            .collect(),
     }
 }

--- a/crates/rpc/rpc-types-compat/src/proof.rs
+++ b/crates/rpc/rpc-types-compat/src/proof.rs
@@ -7,7 +7,7 @@ use reth_trie_common::{AccountProof, StorageProof};
 /// Creates a new rpc storage proof from a primitive storage proof type.
 pub fn from_primitive_storage_proof(proof: StorageProof) -> EIP1186StorageProof {
     EIP1186StorageProof {
-        key: JsonStorageKey::Hash(proof.key),
+        key: JsonStorageKey::Number(proof.key.into()),
         value: proof.value,
         proof: proof.proof,
     }

--- a/crates/rpc/rpc-types-compat/src/proof.rs
+++ b/crates/rpc/rpc-types-compat/src/proof.rs
@@ -28,8 +28,10 @@ pub fn from_primitive_account_proof(
         storage_proof: proof
             .storage_proofs
             .into_iter()
-            .zip(slots)
-            .map(|(proof, slot)| from_primitive_storage_proof(proof, slot))
+            .filter_map(|proof| {
+                let input_slot = slots.iter().find(|s| s.as_b256() == proof.key)?;
+                Some(from_primitive_storage_proof(proof, *input_slot))
+            })
             .collect(),
     }
 }


### PR DESCRIPTION
keys should always be serialized as uints