### PR TITLE
chore: remove unused deconstruction

### DIFF
--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -8,7 +8,7 @@ use reth_evm::{
     execute::{BatchExecutor, BlockExecutorProvider},
     metrics::ExecutorMetrics,
 };
-use reth_execution_types::{Chain, ExecutionOutcome};
+use reth_execution_types::Chain;
 use reth_exex::{ExExManagerHandle, ExExNotification, ExExNotificationSource};
 use reth_primitives::{Header, SealedHeader, StaticFileSegment};
 use reth_primitives_traits::format_gas_throughput;
@@ -325,8 +325,7 @@ where
 
         // prepare execution output for writing
         let time = Instant::now();
-        let ExecutionOutcome { bundle, receipts, requests, first_block } = executor.finalize();
-        let state = ExecutionOutcome::new(bundle, receipts, first_block, requests);
+        let state = executor.finalize();
         let write_preparation_duration = time.elapsed();
 
         // log the gas per second for the range we just executed


### PR DESCRIPTION
Removes an unused deconstruction on `ExecutionOutcome` in the execution stage.