### PR TITLE
chore: restrict payload builder error type

### DIFF
--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{PayloadEvents, PayloadKind, PayloadTypes};
+use crate::{PayloadBuilderError, PayloadEvents, PayloadKind, PayloadTypes};
 use alloy_eips::{eip4895::Withdrawal, eip7685::Requests};
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types_engine::{PayloadAttributes as EthPayloadAttributes, PayloadId};
@@ -12,7 +12,7 @@ pub trait PayloadBuilder: Send + Unpin {
     /// The Payload type for the builder.
     type PayloadType: PayloadTypes;
     /// The error type returned by the builder.
-    type Error;
+    type Error: Into<PayloadBuilderError>;
 
     /// Sends a message to the service to start building a new payload for the given payload.
     ///


### PR DESCRIPTION
this is fine because PayloadBuilderError has

https://github.com/paradigmxyz/reth/blob/d94bca314cc77565dab2fd30f8e6f2f0a852afd2/crates/payload/primitives/src/error.rs#L39-L41

and this helps with https://github.com/paradigmxyz/reth/issues/12422

