### PR TITLE
chore(sdk): make `ExecutionOutcome` generic over receipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7517,6 +7517,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-execution-errors",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-trie",
  "revm",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10548,18 +10548,18 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -375,7 +375,7 @@ where
     // and 4788 contract call
     state.merge_transitions(BundleRetention::PlainState);
 
-    let outcome = ExecutionOutcome::new(
+    let outcome: ExecutionOutcome = ExecutionOutcome::new(
         state.take_bundle(),
         Receipts::from(vec![receipts]),
         reorg_target.number,

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 reth-primitives.workspace = true
 reth-execution-errors.workspace = true
 reth-trie.workspace = true
+reth-primitives-traits.workspace = true
 
 revm.workspace = true
 
@@ -43,14 +44,16 @@ serde = [
 ]
 serde-bincode-compat = [
 	"reth-primitives/serde-bincode-compat",
+	"reth-primitives-traits/serde-bincode-compat",
 	"reth-trie/serde-bincode-compat",
 	"serde_with",
-	"alloy-eips/serde-bincode-compat"
+	"alloy-eips/serde-bincode-compat",
 ]
 std = [
 	"reth-primitives/std",
 	"alloy-eips/std",
 	"alloy-primitives/std",
 	"revm/std",
-	"serde?/std"
+	"serde?/std",
+	"reth-primitives-traits/std",
 ]

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -820,7 +820,7 @@ mod tests {
         };
 
         // Create an empty Receipts object
-        let receipts_empty = Receipts { receipt_vec: vec![] };
+        let receipts_empty = Receipts::<Receipt> { receipt_vec: vec![] };
 
         // Define the first block number
         let first_block = 123;

--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -22,6 +22,6 @@ pub trait Receipt:
     /// Returns transaction type.
     fn tx_type(&self) -> u8;
 
-    /// Calculates the receipts root of all receipts in a block.
+    /// Calculates the receipts root of the given receipts.
     fn receipts_root(receipts: &[&Self]) -> B256;
 }

--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -1,6 +1,7 @@
 //! Receipt abstraction
 
 use alloy_consensus::TxReceipt;
+use alloy_primitives::B256;
 use reth_codecs::Compact;
 use serde::{Deserialize, Serialize};
 
@@ -20,4 +21,7 @@ pub trait Receipt:
 {
     /// Returns transaction type.
     fn tx_type(&self) -> u8;
+
+    /// Calculates the receipts root of all receipts in a block.
+    fn receipts_root(receipts: &[&Self]) -> B256;
 }

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -64,6 +64,42 @@ impl Receipt {
     }
 }
 
+// todo: replace with alloy receipt
+impl TxReceipt for Receipt {
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.success.into()
+    }
+
+    fn status(&self) -> bool {
+        self.success
+    }
+
+    fn bloom(&self) -> Bloom {
+        alloy_primitives::logs_bloom(self.logs.iter())
+    }
+
+    fn cumulative_gas_used(&self) -> u128 {
+        self.cumulative_gas_used as u128
+    }
+
+    fn logs(&self) -> &[Log] {
+        &self.logs
+    }
+}
+
+impl reth_primitives_traits::Receipt for Receipt {
+    fn tx_type(&self) -> u8 {
+        self.tx_type as u8
+    }
+
+    fn receipts_root(_receipts: &[&Self]) -> B256 {
+        #[cfg(feature = "optimism")]
+        panic!("This should not be called in optimism mode. Use `optimism_receipts_root_slow` instead.");
+        #[cfg(not(feature = "optimism"))]
+        crate::proofs::calculate_receipt_root_no_memo(_receipts)
+    }
+}
+
 /// A collection of receipts organized as a two-dimensional vector.
 #[derive(
     Clone,

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -1,17 +1,20 @@
-#[cfg(feature = "reth-codec")]
-use crate::compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR};
-use crate::TxType;
 use alloc::{vec, vec::Vec};
-use alloy_consensus::constants::{
-    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+use core::{cmp::Ordering, ops::Deref};
+
+use alloy_consensus::{
+    constants::{EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID},
+    Eip658Value, TxReceipt,
 };
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Bloom, Log, B256};
 use alloy_rlp::{length_of_length, Decodable, Encodable, RlpDecodable, RlpEncodable};
 use bytes::{Buf, BufMut};
-use core::{cmp::Ordering, ops::Deref};
 use derive_more::{DerefMut, From, IntoIterator};
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "reth-codec")]
+use crate::compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR};
+use crate::TxType;
 
 /// Receipt containing result of transaction execution.
 #[derive(
@@ -114,12 +117,12 @@ impl reth_primitives_traits::Receipt for Receipt {
     DerefMut,
     IntoIterator,
 )]
-pub struct Receipts {
+pub struct Receipts<T = Receipt> {
     /// A two-dimensional vector of optional `Receipt` instances.
-    pub receipt_vec: Vec<Vec<Option<Receipt>>>,
+    pub receipt_vec: Vec<Vec<Option<T>>>,
 }
 
-impl Receipts {
+impl<T> Receipts<T> {
     /// Returns the length of the `Receipts` vector.
     pub fn len(&self) -> usize {
         self.receipt_vec.len()
@@ -131,26 +134,26 @@ impl Receipts {
     }
 
     /// Push a new vector of receipts into the `Receipts` collection.
-    pub fn push(&mut self, receipts: Vec<Option<Receipt>>) {
+    pub fn push(&mut self, receipts: Vec<Option<T>>) {
         self.receipt_vec.push(receipts);
     }
 
     /// Retrieves all recorded receipts from index and calculates the root using the given closure.
-    pub fn root_slow(&self, index: usize, f: impl FnOnce(&[&Receipt]) -> B256) -> Option<B256> {
+    pub fn root_slow(&self, index: usize, f: impl FnOnce(&[&T]) -> B256) -> Option<B256> {
         let receipts =
             self.receipt_vec[index].iter().map(Option::as_ref).collect::<Option<Vec<_>>>()?;
         Some(f(receipts.as_slice()))
     }
 }
 
-impl From<Vec<Receipt>> for Receipts {
-    fn from(block_receipts: Vec<Receipt>) -> Self {
+impl<T> From<Vec<T>> for Receipts<T> {
+    fn from(block_receipts: Vec<T>) -> Self {
         Self { receipt_vec: vec![block_receipts.into_iter().map(Option::Some).collect()] }
     }
 }
 
-impl FromIterator<Vec<Option<Receipt>>> for Receipts {
-    fn from_iter<I: IntoIterator<Item = Vec<Option<Receipt>>>>(iter: I) -> Self {
+impl<T> FromIterator<Vec<Option<T>>> for Receipts<T> {
+    fn from_iter<I: IntoIterator<Item = Vec<Option<T>>>>(iter: I) -> Self {
         iter.into_iter().collect::<Vec<_>>().into()
     }
 }

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -1129,7 +1129,8 @@ mod tests {
 
         let bundle = state.take_bundle();
 
-        let outcome = ExecutionOutcome::new(bundle, Receipts::default(), 1, Vec::new());
+        let outcome: ExecutionOutcome =
+            ExecutionOutcome::new(bundle, Receipts::default(), 1, Vec::new());
         let mut writer = UnifiedStorageWriter::from_database(&provider);
         writer
             .write_to_storage(outcome, OriginalValuesKnown::Yes)
@@ -1375,7 +1376,7 @@ mod tests {
 
     #[test]
     fn revert_to_indices() {
-        let base = ExecutionOutcome {
+        let base: ExecutionOutcome = ExecutionOutcome {
             bundle: BundleState::default(),
             receipts: vec![vec![Some(Receipt::default()); 2]; 7].into(),
             first_block: 10,
@@ -1441,7 +1442,7 @@ mod tests {
             assert_eq!(
                 StateRoot::overlay_root(
                     tx,
-                    ExecutionOutcome::new(
+                    ExecutionOutcome::<Receipt>::new(
                         state.bundle_state.clone(),
                         Receipts::default(),
                         0,
@@ -1592,7 +1593,7 @@ mod tests {
             .build();
         assert_eq!(previous_state.reverts.len(), 1);
 
-        let mut test = ExecutionOutcome {
+        let mut test: ExecutionOutcome = ExecutionOutcome {
             bundle: present_state,
             receipts: vec![vec![Some(Receipt::default()); 2]; 1].into(),
             first_block: 2,


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/12447

Closes https://github.com/paradigmxyz/reth/issues/11108, ref https://github.com/paradigmxyz/reth/issues/12358