### PR TITLE
feat: make Consensus trait generic over block parts

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -4,7 +4,9 @@ use alloy_consensus::constants::MAXIMUM_EXTRA_DATA_SIZE;
 use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::ConsensusError;
-use reth_primitives::{EthereumHardfork, GotExpected, Header, SealedBlock, SealedHeader};
+use reth_primitives::{
+    BlockBody, EthereumHardfork, GotExpected, Header, SealedBlock, SealedHeader,
+};
 use revm_primitives::calc_excess_blob_gas;
 
 /// Gas used needs to be less than gas limit. Gas used is going to be checked after execution.
@@ -70,6 +72,49 @@ pub fn validate_cancun_gas(block: &SealedBlock) -> Result<(), ConsensusError> {
             expected: total_blob_gas,
         }));
     }
+    Ok(())
+}
+
+/// Ensures the block response data matches the header.
+///
+/// This ensures the body response items match the header's hashes:
+///   - ommer hash
+///   - transaction root
+///   - withdrawals root
+pub fn validate_body_againt_header(
+    body: &BlockBody,
+    header: &SealedHeader,
+) -> Result<(), ConsensusError> {
+    let ommers_hash = body.calculate_ommers_root();
+    if header.ommers_hash != ommers_hash {
+        return Err(ConsensusError::BodyOmmersHashDiff(
+            GotExpected { got: ommers_hash, expected: header.ommers_hash }.into(),
+        ))
+    }
+
+    let tx_root = body.calculate_tx_root();
+    if header.transactions_root != tx_root {
+        return Err(ConsensusError::BodyTransactionRootDiff(
+            GotExpected { got: tx_root, expected: header.transactions_root }.into(),
+        ))
+    }
+
+    match (header.withdrawals_root, &body.withdrawals) {
+        (Some(header_withdrawals_root), Some(withdrawals)) => {
+            let withdrawals = withdrawals.as_slice();
+            let withdrawals_root = reth_primitives::proofs::calculate_withdrawals_root(withdrawals);
+            if withdrawals_root != header_withdrawals_root {
+                return Err(ConsensusError::BodyWithdrawalsRootDiff(
+                    GotExpected { got: withdrawals_root, expected: header_withdrawals_root }.into(),
+                ))
+            }
+        }
+        (None, None) => {
+            // this is ok because we assume the fork is not active in this case
+        }
+        _ => return Err(ConsensusError::WithdrawalsRootUnexpected),
+    }
+
     Ok(())
 }
 

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -81,7 +81,7 @@ pub fn validate_cancun_gas(block: &SealedBlock) -> Result<(), ConsensusError> {
 ///   - ommer hash
 ///   - transaction root
 ///   - withdrawals root
-pub fn validate_body_againt_header(
+pub fn validate_body_against_header(
     body: &BlockBody,
     header: &SealedHeader,
 ) -> Result<(), ConsensusError> {

--- a/crates/consensus/consensus/src/noop.rs
+++ b/crates/consensus/consensus/src/noop.rs
@@ -1,34 +1,45 @@
 use crate::{Consensus, ConsensusError, PostExecutionInput};
 use alloy_primitives::U256;
-use reth_primitives::{BlockWithSenders, Header, SealedBlock, SealedHeader};
+use reth_primitives::{BlockWithSenders, SealedBlock, SealedHeader};
 
 /// A Consensus implementation that does nothing.
 #[derive(Debug, Copy, Clone, Default)]
 #[non_exhaustive]
 pub struct NoopConsensus;
 
-impl Consensus for NoopConsensus {
-    fn validate_header(&self, _header: &SealedHeader) -> Result<(), ConsensusError> {
+impl<H, B> Consensus<H, B> for NoopConsensus {
+    fn validate_header(&self, _header: &SealedHeader<H>) -> Result<(), ConsensusError> {
         Ok(())
     }
 
     fn validate_header_against_parent(
         &self,
-        _header: &SealedHeader,
-        _parent: &SealedHeader,
+        _header: &SealedHeader<H>,
+        _parent: &SealedHeader<H>,
     ) -> Result<(), ConsensusError> {
         Ok(())
     }
 
     fn validate_header_with_total_difficulty(
         &self,
-        _header: &Header,
+        _header: &H,
         _total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
         Ok(())
     }
 
-    fn validate_block_pre_execution(&self, _block: &SealedBlock) -> Result<(), ConsensusError> {
+    fn validate_body_against_header(
+        &self,
+        _body: &B,
+        _header: &SealedHeader<H>,
+    ) -> Result<(), ConsensusError> {
+        Ok(())
+    }
+
+    fn validate_block_pre_execution(
+        &self,
+        _block: &SealedBlock<H, B>,
+    ) -> Result<(), ConsensusError> {
         Ok(())
     }
 

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -35,6 +35,11 @@ impl TestConsensus {
         self.fail_body_against_header.store(val, Ordering::SeqCst);
     }
 
+    /// Returns the body validation flag.
+    pub fn fail_body_against_header(&self) -> bool {
+        self.fail_body_against_header.load(Ordering::SeqCst)
+    }
+
     /// Update the body validation flag.
     pub fn set_fail_body_against_header(&self, val: bool) {
         self.fail_body_against_header.store(val, Ordering::SeqCst);
@@ -79,7 +84,7 @@ impl<H, B> Consensus<H, B> for TestConsensus {
         _body: &B,
         _header: &SealedHeader<H>,
     ) -> Result<(), ConsensusError> {
-        if self.fail_validation() {
+        if self.fail_body_against_header() {
             Err(ConsensusError::BaseFeeMissing)
         } else {
             Ok(())

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -16,7 +16,10 @@ pub struct TestConsensus {
 
 impl Default for TestConsensus {
     fn default() -> Self {
-        Self { fail_validation: AtomicBool::new(false), fail_body_against_header: AtomicBool::new(false) }
+        Self {
+            fail_validation: AtomicBool::new(false),
+            fail_body_against_header: AtomicBool::new(false),
+        }
     }
 }
 

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::{Consensus, ConsensusError, PostExecutionInput};
 use alloy_primitives::U256;
 use core::sync::atomic::{AtomicBool, Ordering};
-use reth_primitives::{BlockWithSenders, Header, SealedBlock, SealedHeader};
+use reth_primitives::{BlockWithSenders, SealedBlock, SealedHeader};
 
 /// Consensus engine implementation for testing
 #[derive(Debug)]
@@ -28,8 +28,8 @@ impl TestConsensus {
     }
 }
 
-impl Consensus for TestConsensus {
-    fn validate_header(&self, _header: &SealedHeader) -> Result<(), ConsensusError> {
+impl<H, B> Consensus<H, B> for TestConsensus {
+    fn validate_header(&self, _header: &SealedHeader<H>) -> Result<(), ConsensusError> {
         if self.fail_validation() {
             Err(ConsensusError::BaseFeeMissing)
         } else {
@@ -39,8 +39,8 @@ impl Consensus for TestConsensus {
 
     fn validate_header_against_parent(
         &self,
-        _header: &SealedHeader,
-        _parent: &SealedHeader,
+        _header: &SealedHeader<H>,
+        _parent: &SealedHeader<H>,
     ) -> Result<(), ConsensusError> {
         if self.fail_validation() {
             Err(ConsensusError::BaseFeeMissing)
@@ -51,7 +51,7 @@ impl Consensus for TestConsensus {
 
     fn validate_header_with_total_difficulty(
         &self,
-        _header: &Header,
+        _header: &H,
         _total_difficulty: U256,
     ) -> Result<(), ConsensusError> {
         if self.fail_validation() {
@@ -61,7 +61,22 @@ impl Consensus for TestConsensus {
         }
     }
 
-    fn validate_block_pre_execution(&self, _block: &SealedBlock) -> Result<(), ConsensusError> {
+    fn validate_body_against_header(
+        &self,
+        _body: &B,
+        _header: &SealedHeader<H>,
+    ) -> Result<(), ConsensusError> {
+        if self.fail_validation() {
+            Err(ConsensusError::BaseFeeMissing)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate_block_pre_execution(
+        &self,
+        _block: &SealedBlock<H, B>,
+    ) -> Result<(), ConsensusError> {
         if self.fail_validation() {
             Err(ConsensusError::BaseFeeMissing)
         } else {

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -8,11 +8,15 @@ use reth_primitives::{BlockWithSenders, SealedBlock, SealedHeader};
 pub struct TestConsensus {
     /// Flag whether the header validation should purposefully fail
     fail_validation: AtomicBool,
+    /// Separate flag for setting whether `validate_body_against_header` should fail. It is needed
+    /// for testing networking logic for which the body failing this check is getting completely
+    /// rejected while more high-level failures are handled by the sync logic.
+    fail_body_against_header: AtomicBool,
 }
 
 impl Default for TestConsensus {
     fn default() -> Self {
-        Self { fail_validation: AtomicBool::new(false) }
+        Self { fail_validation: AtomicBool::new(false), fail_body_against_header: AtomicBool::new(false) }
     }
 }
 
@@ -24,7 +28,13 @@ impl TestConsensus {
 
     /// Update the validation flag.
     pub fn set_fail_validation(&self, val: bool) {
-        self.fail_validation.store(val, Ordering::SeqCst)
+        self.fail_validation.store(val, Ordering::SeqCst);
+        self.fail_body_against_header.store(val, Ordering::SeqCst);
+    }
+
+    /// Update the body validation flag.
+    pub fn set_fail_body_against_header(&self, val: bool) {
+        self.fail_body_against_header.store(val, Ordering::SeqCst);
     }
 }
 

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -15,11 +15,11 @@ use reth_consensus::{Consensus, ConsensusError, PostExecutionInput};
 use reth_consensus_common::validation::{
     validate_4844_header_standalone, validate_against_parent_4844,
     validate_against_parent_eip1559_base_fee, validate_against_parent_hash_number,
-    validate_against_parent_timestamp, validate_block_pre_execution, validate_header_base_fee,
-    validate_header_extradata, validate_header_gas,
+    validate_against_parent_timestamp, validate_block_pre_execution, validate_body_againt_header,
+    validate_header_base_fee, validate_header_extradata, validate_header_gas,
 };
 use reth_primitives::{
-    constants::MINIMUM_GAS_LIMIT, BlockWithSenders, Header, SealedBlock, SealedHeader,
+    constants::MINIMUM_GAS_LIMIT, BlockBody, BlockWithSenders, Header, SealedBlock, SealedHeader,
 };
 use std::{fmt::Debug, sync::Arc, time::SystemTime};
 
@@ -210,6 +210,14 @@ impl<ChainSpec: Send + Sync + EthChainSpec + EthereumHardforks + Debug> Consensu
         }
 
         Ok(())
+    }
+
+    fn validate_body_against_header(
+        &self,
+        body: &BlockBody,
+        header: &SealedHeader,
+    ) -> Result<(), ConsensusError> {
+        validate_body_againt_header(body, header)
     }
 
     fn validate_block_pre_execution(&self, block: &SealedBlock) -> Result<(), ConsensusError> {

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -15,7 +15,7 @@ use reth_consensus::{Consensus, ConsensusError, PostExecutionInput};
 use reth_consensus_common::validation::{
     validate_4844_header_standalone, validate_against_parent_4844,
     validate_against_parent_eip1559_base_fee, validate_against_parent_hash_number,
-    validate_against_parent_timestamp, validate_block_pre_execution, validate_body_againt_header,
+    validate_against_parent_timestamp, validate_block_pre_execution, validate_body_against_header,
     validate_header_base_fee, validate_header_extradata, validate_header_gas,
 };
 use reth_primitives::{
@@ -217,7 +217,7 @@ impl<ChainSpec: Send + Sync + EthChainSpec + EthereumHardforks + Debug> Consensu
         body: &BlockBody,
         header: &SealedHeader,
     ) -> Result<(), ConsensusError> {
-        validate_body_againt_header(body, header)
+        validate_body_against_header(body, header)
     }
 
     fn validate_block_pre_execution(&self, block: &SealedBlock) -> Result<(), ConsensusError> {

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -1310,7 +1310,7 @@ mod tests {
     fn test_head_update() {
         let client = Arc::new(TestHeadersClient::default());
 
-        let header = SealedHeader::default();
+        let header: SealedHeader = SealedHeader::default();
 
         let mut downloader = ReverseHeadersDownloaderBuilder::default()
             .build(Arc::clone(&client), Arc::new(TestConsensus::default()));

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -473,7 +473,6 @@ mod tests {
     use super::*;
     use crate::{peers::PeersManager, PeersConfig};
     use alloy_primitives::B512;
-    use reth_primitives::SealedHeader;
     use std::future::poll_fn;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -590,8 +589,7 @@ mod tests {
                 },
                 response: tx,
             };
-            let mut header = SealedHeader::default().unseal();
-            header.number = 0u64;
+            let header = Header { number: 0, ..Default::default() };
             (req, header)
         };
 

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -6,10 +6,10 @@ use crate::{
     BlockClient,
 };
 use alloy_primitives::{Sealable, B256};
-use reth_consensus::{Consensus, ConsensusError};
+use reth_consensus::Consensus;
 use reth_eth_wire_types::HeadersDirection;
 use reth_network_peers::WithPeerId;
-use reth_primitives::{BlockBody, GotExpected, Header, SealedBlock, SealedHeader};
+use reth_primitives::{BlockBody, Header, SealedBlock, SealedHeader};
 use std::{
     cmp::Reverse,
     collections::{HashMap, VecDeque},
@@ -55,6 +55,7 @@ where
         let client = self.client.clone();
         FetchFullBlockFuture {
             hash,
+            consensus: self.consensus.clone(),
             request: FullBlockRequest {
                 header: Some(client.get_header(hash.into())),
                 body: Some(client.get_block_body(hash)),
@@ -110,6 +111,7 @@ where
     Client: BlockClient,
 {
     client: Client,
+    consensus: Arc<dyn Consensus>,
     hash: B256,
     request: FullBlockRequest<Client>,
     header: Option<SealedHeader>,
@@ -142,7 +144,8 @@ where
             BodyResponse::Validated(body) => Some(SealedBlock::new(header, body)),
             BodyResponse::PendingValidation(resp) => {
                 // ensure the block is valid, else retry
-                if let Err(err) = ensure_valid_body_response(&header, resp.data()) {
+                if let Err(err) = self.consensus.validate_body_against_header(resp.data(), &header)
+                {
                     debug!(target: "downloaders", %err, hash=?header.hash(), "Received wrong body");
                     self.client.report_bad_message(resp.peer_id());
                     self.header = Some(header);
@@ -156,7 +159,7 @@ where
 
     fn on_block_response(&mut self, resp: WithPeerId<BlockBody>) {
         if let Some(ref header) = self.header {
-            if let Err(err) = ensure_valid_body_response(header, resp.data()) {
+            if let Err(err) = self.consensus.validate_body_against_header(resp.data(), header) {
                 debug!(target: "downloaders", %err, hash=?header.hash(), "Received wrong body");
                 self.client.report_bad_message(resp.peer_id());
                 return
@@ -306,50 +309,6 @@ enum BodyResponse {
     /// Still needs to be validated against header
     PendingValidation(WithPeerId<BlockBody>),
 }
-
-/// Ensures the block response data matches the header.
-///
-/// This ensures the body response items match the header's hashes:
-///   - ommer hash
-///   - transaction root
-///   - withdrawals root
-fn ensure_valid_body_response(
-    header: &SealedHeader,
-    block: &BlockBody,
-) -> Result<(), ConsensusError> {
-    let ommers_hash = block.calculate_ommers_root();
-    if header.ommers_hash != ommers_hash {
-        return Err(ConsensusError::BodyOmmersHashDiff(
-            GotExpected { got: ommers_hash, expected: header.ommers_hash }.into(),
-        ))
-    }
-
-    let tx_root = block.calculate_tx_root();
-    if header.transactions_root != tx_root {
-        return Err(ConsensusError::BodyTransactionRootDiff(
-            GotExpected { got: tx_root, expected: header.transactions_root }.into(),
-        ))
-    }
-
-    match (header.withdrawals_root, &block.withdrawals) {
-        (Some(header_withdrawals_root), Some(withdrawals)) => {
-            let withdrawals = withdrawals.as_slice();
-            let withdrawals_root = reth_primitives::proofs::calculate_withdrawals_root(withdrawals);
-            if withdrawals_root != header_withdrawals_root {
-                return Err(ConsensusError::BodyWithdrawalsRootDiff(
-                    GotExpected { got: withdrawals_root, expected: header_withdrawals_root }.into(),
-                ))
-            }
-        }
-        (None, None) => {
-            // this is ok because we assume the fork is not active in this case
-        }
-        _ => return Err(ConsensusError::WithdrawalsRootUnexpected),
-    }
-
-    Ok(())
-}
-
 /// A future that downloads a range of full blocks from the network.
 ///
 /// This first fetches the headers for the given range using the inner `Client`. Once the request
@@ -446,7 +405,9 @@ where
                     BodyResponse::Validated(body) => body,
                     BodyResponse::PendingValidation(resp) => {
                         // ensure the block is valid, else retry
-                        if let Err(err) = ensure_valid_body_response(header, resp.data()) {
+                        if let Err(err) =
+                            self.consensus.validate_body_against_header(resp.data(), header)
+                        {
                             debug!(target: "downloaders", %err, hash=?header.hash(), "Received wrong body in range response");
                             self.client.report_bad_message(resp.peer_id());
 
@@ -695,7 +656,7 @@ mod tests {
     #[tokio::test]
     async fn download_single_full_block() {
         let client = TestFullBlockClient::default();
-        let header = SealedHeader::default();
+        let header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         client.insert(header.clone(), body.clone());
         let client = FullBlockClient::test_client(client);
@@ -707,7 +668,7 @@ mod tests {
     #[tokio::test]
     async fn download_single_full_block_range() {
         let client = TestFullBlockClient::default();
-        let header = SealedHeader::default();
+        let header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         client.insert(header.clone(), body.clone());
         let client = FullBlockClient::test_client(client);
@@ -722,7 +683,7 @@ mod tests {
         client: &TestFullBlockClient,
         range: Range<usize>,
     ) -> (SealedHeader, BlockBody) {
-        let mut sealed_header = SealedHeader::default();
+        let mut sealed_header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         for _ in range {
             let (mut header, hash) = sealed_header.split();

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -746,6 +746,7 @@ mod tests {
 
         let test_consensus = reth_consensus::test_utils::TestConsensus::default();
         test_consensus.set_fail_validation(true);
+        test_consensus.set_fail_body_against_header(false);
         let client = FullBlockClient::new(client, Arc::new(test_consensus));
 
         let received = client.get_full_block_range(header.hash(), range_length as u64).await;

--- a/crates/net/p2p/src/test_utils/headers.rs
+++ b/crates/net/p2p/src/test_utils/headers.rs
@@ -143,8 +143,10 @@ impl Stream for TestDownload {
                 return Poll::Ready(None)
             }
 
-            let empty = SealedHeader::default();
-            if let Err(error) = this.consensus.validate_header_against_parent(&empty, &empty) {
+            let empty: SealedHeader = SealedHeader::default();
+            if let Err(error) =
+                Consensus::<_>::validate_header_against_parent(&this.consensus, &empty, &empty)
+            {
                 this.done = true;
                 return Poll::Ready(Some(Err(DownloadError::HeaderValidation {
                     hash: empty.hash(),

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -16,7 +16,7 @@ use reth_consensus::{Consensus, ConsensusError, PostExecutionInput};
 use reth_consensus_common::validation::{
     validate_against_parent_4844, validate_against_parent_eip1559_base_fee,
     validate_against_parent_hash_number, validate_against_parent_timestamp,
-    validate_body_againt_header, validate_cancun_gas, validate_header_base_fee,
+    validate_body_against_header, validate_cancun_gas, validate_header_base_fee,
     validate_header_extradata, validate_header_gas, validate_shanghai_withdrawals,
 };
 use reth_optimism_chainspec::OpChainSpec;
@@ -126,7 +126,7 @@ impl Consensus for OpBeaconConsensus {
         body: &BlockBody,
         header: &SealedHeader,
     ) -> Result<(), ConsensusError> {
-        validate_body_againt_header(body, header)
+        validate_body_against_header(body, header)
     }
 
     fn validate_block_pre_execution(&self, block: &SealedBlock) -> Result<(), ConsensusError> {

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -20,7 +20,7 @@ use reth_consensus_common::validation::{
     validate_header_extradata, validate_header_gas, validate_shanghai_withdrawals,
 };
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_forks::OptimismHardforks;
+use reth_optimism_forks::OpHardforks;
 use reth_primitives::{
     BlockBody, BlockWithSenders, GotExpected, Header, SealedBlock, SealedHeader,
 };

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -15,13 +15,15 @@ use reth_chainspec::EthereumHardforks;
 use reth_consensus::{Consensus, ConsensusError, PostExecutionInput};
 use reth_consensus_common::validation::{
     validate_against_parent_4844, validate_against_parent_eip1559_base_fee,
-    validate_against_parent_hash_number, validate_against_parent_timestamp, validate_cancun_gas,
-    validate_header_base_fee, validate_header_extradata, validate_header_gas,
-    validate_shanghai_withdrawals,
+    validate_against_parent_hash_number, validate_against_parent_timestamp,
+    validate_body_againt_header, validate_cancun_gas, validate_header_base_fee,
+    validate_header_extradata, validate_header_gas, validate_shanghai_withdrawals,
 };
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_forks::OpHardforks;
-use reth_primitives::{BlockWithSenders, GotExpected, Header, SealedBlock, SealedHeader};
+use reth_optimism_forks::OptimismHardforks;
+use reth_primitives::{
+    BlockBody, BlockWithSenders, GotExpected, Header, SealedBlock, SealedHeader,
+};
 use std::{sync::Arc, time::SystemTime};
 
 mod proof;
@@ -117,6 +119,14 @@ impl Consensus for OpBeaconConsensus {
         }
 
         Ok(())
+    }
+
+    fn validate_body_against_header(
+        &self,
+        body: &BlockBody,
+        header: &SealedHeader,
+    ) -> Result<(), ConsensusError> {
+        validate_body_againt_header(body, header)
     }
 
     fn validate_block_pre_execution(&self, block: &SealedBlock) -> Result<(), ConsensusError> {

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -30,12 +30,10 @@ impl<H> SealedHeader<H> {
     pub const fn new(header: H, hash: BlockHash) -> Self {
         Self { header, hash }
     }
-}
 
-impl SealedHeader {
     /// Returns the sealed Header fields.
     #[inline]
-    pub const fn header(&self) -> &Header {
+    pub const fn header(&self) -> &H {
         &self.header
     }
 
@@ -46,15 +44,17 @@ impl SealedHeader {
     }
 
     /// Extract raw header that can be modified.
-    pub fn unseal(self) -> Header {
+    pub fn unseal(self) -> H {
         self.header
     }
 
     /// This is the inverse of [`Header::seal_slow`] which returns the raw header and hash.
-    pub fn split(self) -> (Header, BlockHash) {
+    pub fn split(self) -> (H, BlockHash) {
         (self.header, self.hash)
     }
+}
 
+impl SealedHeader {
     /// Return the number hash tuple.
     pub fn num_hash(&self) -> BlockNumHash {
         BlockNumHash::new(self.number, self.hash)
@@ -67,9 +67,9 @@ impl SealedHeader {
     }
 }
 
-impl Default for SealedHeader {
+impl<H: Sealable + Default> Default for SealedHeader<H> {
     fn default() -> Self {
-        let sealed = Header::default().seal_slow();
+        let sealed = H::default().seal_slow();
         let (header, hash) = sealed.into_parts();
         Self { header, hash }
     }


### PR DESCRIPTION
Preparation for abstraction of block for network/downloaders.

Moves `ensure_valid_body_response` fn from networking crate to `Consensus` trait as `validate_body_against_header`.
Makes `Consensus` generic over header and body