### PR TITLE
chore(sdk): define new `BlockHeader` trait

### DIFF
--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -30,6 +30,7 @@ revm-primitives.workspace = true
 # alloy
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
+alloy-consensus.workspace = true
 
 auto_impl.workspace = true
 futures-util.workspace = true

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -17,6 +17,15 @@
 
 extern crate alloc;
 
+use alloy_consensus::BlockHeader as _;
+use alloy_primitives::{Address, Bytes, B256, U256};
+use reth_primitives::TransactionSigned;
+use reth_primitives_traits::BlockHeader;
+use revm::{Database, Evm, GetInspector};
+use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, SpecId, TxEnv};
+
+use crate::builder::RethEvmBuilder;
+
 pub mod builder;
 pub mod either;
 pub mod execute;
@@ -29,15 +38,6 @@ pub mod system_calls;
 #[cfg(any(test, feature = "test-utils"))]
 /// test helpers for mocking executor
 pub mod test_utils;
-
-use alloy_consensus::BlockHeader as _;
-use alloy_primitives::{Address, Bytes, B256, U256};
-use reth_primitives::TransactionSigned;
-use reth_primitives_traits::BlockHeader;
-use revm::{Database, Evm, GetInspector};
-use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, SpecId, TxEnv};
-
-use crate::builder::RethEvmBuilder;
 
 /// Trait for configuring the EVM for executing full blocks.
 #[auto_impl::auto_impl(&, Arc)]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -17,13 +17,6 @@
 
 extern crate alloc;
 
-use crate::builder::RethEvmBuilder;
-use alloy_primitives::{Address, Bytes, B256, U256};
-use reth_primitives::TransactionSigned;
-use reth_primitives_traits::BlockHeader;
-use revm::{Database, Evm, GetInspector};
-use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, SpecId, TxEnv};
-
 pub mod builder;
 pub mod either;
 pub mod execute;
@@ -33,10 +26,18 @@ pub mod noop;
 pub mod provider;
 pub mod state_change;
 pub mod system_calls;
-
 #[cfg(any(test, feature = "test-utils"))]
 /// test helpers for mocking executor
 pub mod test_utils;
+
+use alloy_consensus::BlockHeader as _;
+use alloy_primitives::{Address, Bytes, B256, U256};
+use reth_primitives::TransactionSigned;
+use reth_primitives_traits::BlockHeader;
+use revm::{Database, Evm, GetInspector};
+use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, SpecId, TxEnv};
+
+use crate::builder::RethEvmBuilder;
 
 /// Trait for configuring the EVM for executing full blocks.
 #[auto_impl::auto_impl(&, Arc)]
@@ -155,7 +156,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
         block_env.coinbase = header.beneficiary();
         block_env.timestamp = U256::from(header.timestamp());
         if after_merge {
-            block_env.prevrandao = Some(header.mix_hash());
+            block_env.prevrandao = header.mix_hash();
             block_env.difficulty = U256::ZERO;
         } else {
             block_env.difficulty = header.difficulty();

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -1,0 +1,49 @@
+//! Block header data primitive.
+
+use core::fmt;
+
+use alloy_primitives::Sealable;
+use reth_codecs::Compact;
+
+/// Helper trait that unifies all behaviour required by block header to support full node
+/// operations.
+pub trait FullBlockHeader: BlockHeader + Compact {}
+
+impl<T> FullBlockHeader for T where T: BlockHeader + Compact {}
+
+/// Abstraction of a block header.
+pub trait BlockHeader:
+    Send
+    + Sync
+    + Unpin
+    + Clone
+    + Default
+    + fmt::Debug
+    + PartialEq
+    + Eq
+    + serde::Serialize
+    + for<'de> serde::Deserialize<'de>
+    + alloy_rlp::Encodable
+    + alloy_rlp::Decodable
+    + alloy_consensus::BlockHeader
+    + Sealable
+{
+}
+
+impl<T> BlockHeader for T where
+    T: Send
+        + Sync
+        + Unpin
+        + Clone
+        + Default
+        + fmt::Debug
+        + PartialEq
+        + Eq
+        + serde::Serialize
+        + for<'de> serde::Deserialize<'de>
+        + alloy_rlp::Encodable
+        + alloy_rlp::Decodable
+        + alloy_consensus::BlockHeader
+        + Sealable
+{
+}

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -1,19 +1,19 @@
 //! Block abstraction.
 
 pub mod body;
+pub mod header;
 
 use alloc::{fmt, vec::Vec};
 
-use alloy_consensus::BlockHeader;
-use alloy_primitives::{Address, Sealable, B256};
+use alloy_primitives::{Address, B256};
 use reth_codecs::Compact;
 
-use crate::BlockBody;
+use crate::{BlockBody, BlockHeader, FullBlockHeader};
 
 /// Helper trait that unifies all behaviour required by block to support full node operations.
 pub trait FullBlock: Block<Header: Compact> + Compact {}
 
-impl<T> FullBlock for T where T: Block<Header: Compact> + Compact {}
+impl<T> FullBlock for T where T: Block<Header: FullBlockHeader> + Compact {}
 
 /// Abstraction of block data type.
 // todo: make sealable super-trait, depends on <https://github.com/paradigmxyz/reth/issues/11449>
@@ -34,7 +34,7 @@ pub trait Block:
     + Into<(Self::Header, Self::Body)>
 {
     /// Header part of the block.
-    type Header: BlockHeader + Sealable;
+    type Header: BlockHeader;
 
     /// The block's body contains the transactions in the block.
     type Body: BlockBody;

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -34,7 +34,11 @@ mod integer_list;
 pub use integer_list::{IntegerList, IntegerListError};
 
 pub mod block;
-pub use block::{body::BlockBody, Block, FullBlock};
+pub use block::{
+    body::BlockBody,
+    header::{BlockHeader, FullBlockHeader},
+    Block, FullBlock,
+};
 
 mod withdrawal;
 pub use withdrawal::Withdrawal;
@@ -56,7 +60,7 @@ pub use tx_type::TxType;
 pub mod header;
 #[cfg(any(test, feature = "arbitrary", feature = "test-utils"))]
 pub use header::test_utils;
-pub use header::{BlockHeader, Header, HeaderError, SealedHeader};
+pub use header::{Header, HeaderError, SealedHeader};
 
 /// Bincode-compatible serde implementations for common abstracted types in Reth.
 ///


### PR DESCRIPTION
Use `alloy_consensus::BlockHeader` as super trait. Intends to replace the first draft of a block header trait in same crate.