### PR TITLE
chore: move `(Full)NodePrimitives` to `reth-primitive-traits`

### DIFF
--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -9,9 +9,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use reth_primitives_traits::{Block, BlockBody, FullBlock, FullReceipt, FullSignedTx};
+pub use reth_primitives_traits::{
+    Block, BlockBody, FullBlock, FullNodePrimitives, FullReceipt, FullSignedTx, NodePrimitives,
+};
 
-use core::{fmt, marker::PhantomData};
+use core::marker::PhantomData;
 
 use reth_chainspec::EthChainSpec;
 use reth_db_api::{
@@ -20,41 +22,6 @@ use reth_db_api::{
 };
 use reth_engine_primitives::EngineTypes;
 use reth_trie_db::StateCommitment;
-
-/// Configures all the primitive types of the node.
-pub trait NodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
-    /// Block primitive.
-    type Block: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static;
-    /// Signed version of the transaction type.
-    type SignedTx: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static;
-    /// A receipt.
-    type Receipt: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static;
-}
-
-impl NodePrimitives for () {
-    type Block = ();
-    type SignedTx = ();
-    type Receipt = ();
-}
-
-/// Helper trait that sets trait bounds on [`NodePrimitives`].
-pub trait FullNodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
-    /// Block primitive.
-    type Block: FullBlock<Body: BlockBody<SignedTransaction = Self::SignedTx>>;
-    /// Signed version of the transaction type.
-    type SignedTx: FullSignedTx;
-    /// A receipt.
-    type Receipt: FullReceipt;
-}
-
-impl<T> NodePrimitives for T
-where
-    T: FullNodePrimitives<Block: 'static, SignedTx: 'static, Receipt: 'static>,
-{
-    type Block = T::Block;
-    type SignedTx = T::SignedTx;
-    type Receipt = T::Receipt;
-}
 
 /// The type that configures the essential types of an Ethereum-like node.
 ///

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -77,3 +77,7 @@ pub mod serde_bincode_compat {
 /// Heuristic size trait
 pub mod size;
 pub use size::InMemorySize;
+
+/// Node traits
+pub mod node;
+pub use node::{FullNodePrimitives, NodePrimitives};

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -1,5 +1,6 @@
-use crate::{BlockBody, FullBlock, FullReceipt, FullSignedTx};
 use core::fmt;
+
+use crate::{BlockBody, FullBlock, FullReceipt, FullSignedTx};
 
 /// Configures all the primitive types of the node.
 pub trait NodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -1,0 +1,37 @@
+use crate::{BlockBody, FullBlock, FullReceipt, FullSignedTx};
+use core::fmt;
+
+/// Configures all the primitive types of the node.
+pub trait NodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
+    /// Block primitive.
+    type Block: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static;
+    /// Signed version of the transaction type.
+    type SignedTx: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static;
+    /// A receipt.
+    type Receipt: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static;
+}
+
+impl NodePrimitives for () {
+    type Block = ();
+    type SignedTx = ();
+    type Receipt = ();
+}
+
+/// Helper trait that sets trait bounds on [`NodePrimitives`].
+pub trait FullNodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
+    /// Block primitive.
+    type Block: FullBlock<Body: BlockBody<SignedTransaction = Self::SignedTx>>;
+    /// Signed version of the transaction type.
+    type SignedTx: FullSignedTx;
+    /// A receipt.
+    type Receipt: FullReceipt;
+}
+
+impl<T> NodePrimitives for T
+where
+    T: FullNodePrimitives<Block: 'static, SignedTx: 'static, Receipt: 'static>,
+{
+    type Block = T::Block;
+    type SignedTx = T::SignedTx;
+    type Receipt = T::Receipt;
+}


### PR DESCRIPTION
Allows it to be imported on other crates without any cyclical dependencies.  eg. [`storage-api` ](https://github.com/paradigmxyz/reth/pull/12157/files#diff-f33449b56913dc08fdddee4cefff97a3a29332cce6b6361dd7939f0ed18aaa9bR34)