### PR TITLE
feat: make downloaders and clients generic over block parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7339,7 +7339,6 @@ dependencies = [
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-primitives",
- "reth-primitives-traits",
  "serde",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6381,6 +6381,7 @@ dependencies = [
  "reth-payload-primitives",
  "reth-payload-validator",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-revm",
@@ -7019,6 +7020,7 @@ dependencies = [
 name = "reth-downloaders"
 version = "1.1.1"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
@@ -7337,6 +7339,7 @@ dependencies = [
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-primitives",
+ "reth-primitives-traits",
  "serde",
  "thiserror",
 ]
@@ -7818,6 +7821,7 @@ dependencies = [
 name = "reth-network-p2p"
 version = "1.1.1"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
@@ -7986,7 +7990,7 @@ dependencies = [
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
- "reth-consensus-common",
+ "reth-consensus",
  "reth-db",
  "reth-discv4",
  "reth-discv5",
@@ -7995,6 +7999,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-prune-types",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -19,6 +19,7 @@ reth-ethereum-cli.workspace = true
 reth-chainspec.workspace = true
 reth-config.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-fs-util.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -21,7 +21,7 @@ use reth_downloaders::{
 use reth_exex::ExExManagerHandle;
 use reth_network::{BlockDownloaderProvider, NetworkEventListenerProvider, NetworkHandle};
 use reth_network_api::NetworkInfo;
-use reth_network_p2p::{headers::client::HeadersClient, BlockClient};
+use reth_network_p2p::{headers::client::HeadersClient, EthBlockClient};
 use reth_node_api::{NodeTypesWithDB, NodeTypesWithDBAdapter, NodeTypesWithEngine};
 use reth_node_ethereum::EthExecutorProvider;
 use reth_provider::{
@@ -68,7 +68,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         static_file_producer: StaticFileProducer<ProviderFactory<N>>,
     ) -> eyre::Result<Pipeline<N>>
     where
-        Client: BlockClient + 'static,
+        Client: EthBlockClient + 'static,
     {
         // building network downloaders using the fetch client
         let header_downloader = ReverseHeadersDownloaderBuilder::new(config.stages.headers)

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -137,11 +137,14 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         Ok(network)
     }
 
-    async fn fetch_block_hash<Client: HeadersClient>(
+    async fn fetch_block_hash<Client>(
         &self,
         client: Client,
         block: BlockNumber,
-    ) -> eyre::Result<B256> {
+    ) -> eyre::Result<B256>
+    where
+        Client: HeadersClient<Header: reth_primitives_traits::BlockHeader>,
+    {
         info!(target: "reth::cli", ?block, "Fetching block from the network.");
         loop {
             match get_single_header(&client, BlockHashOrNumber::Number(block)).await {

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -7,6 +7,7 @@ use crate::{
 use alloy_eips::BlockHashOrNumber;
 use backon::{ConstantBuilder, Retryable};
 use clap::Parser;
+use reth_beacon_consensus::EthBeaconConsensus;
 use reth_chainspec::ChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, Environment, EnvironmentArgs};
@@ -124,7 +125,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
         let client = fetch_client.clone();
         let chain = provider_factory.chain_spec();
-        let block = (move || get_single_body(client.clone(), Arc::clone(&chain), header.clone()))
+        let consensus = Arc::new(EthBeaconConsensus::new(chain.clone()));
+        let block = (move || get_single_body(client.clone(), header.clone(), consensus.clone()))
             .retry(backoff)
             .notify(
                 |err, _| warn!(target: "reth::cli", "Error requesting body: {err}. Retrying..."),

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -14,7 +14,7 @@ use reth_engine_primitives::{EngineApiMessageVersion, EngineTypes, PayloadTypes}
 use reth_errors::{BlockValidationError, ProviderResult, RethError, RethResult};
 use reth_network_p2p::{
     sync::{NetworkSyncUpdater, SyncState},
-    BlockClient,
+    EthBlockClient,
 };
 use reth_node_types::NodeTypesWithEngine;
 use reth_payload_builder::PayloadBuilderHandle;
@@ -174,7 +174,7 @@ type PendingForkchoiceUpdate<PayloadAttributes> =
 pub struct BeaconConsensusEngine<N, BT, Client>
 where
     N: EngineNodeTypes,
-    Client: BlockClient,
+    Client: EthBlockClient,
     BT: BlockchainTreeEngine
         + BlockReader
         + BlockIdReader
@@ -237,7 +237,7 @@ where
         + StageCheckpointReader
         + ChainSpecProvider<ChainSpec = N::ChainSpec>
         + 'static,
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
 {
     /// Create a new instance of the [`BeaconConsensusEngine`].
     #[allow(clippy::too_many_arguments)]
@@ -1799,7 +1799,7 @@ where
 impl<N, BT, Client> Future for BeaconConsensusEngine<N, BT, Client>
 where
     N: EngineNodeTypes,
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
     BT: BlockchainTreeEngine
         + BlockReader
         + BlockIdReader

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{BlockNumber, B256};
 use futures::FutureExt;
 use reth_network_p2p::{
     full_block::{FetchFullBlockFuture, FetchFullBlockRangeFuture, FullBlockClient},
-    BlockClient,
+    EthBlockClient,
 };
 use reth_primitives::SealedBlock;
 use reth_provider::providers::ProviderNodeTypes;
@@ -34,7 +34,7 @@ use tracing::trace;
 pub(crate) struct EngineSyncController<N, Client>
 where
     N: ProviderNodeTypes,
-    Client: BlockClient,
+    Client: EthBlockClient,
 {
     /// A downloader that can download full blocks from the network.
     full_block_client: FullBlockClient<Client>,
@@ -64,7 +64,7 @@ where
 impl<N, Client> EngineSyncController<N, Client>
 where
     N: ProviderNodeTypes,
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
 {
     /// Create a new instance
     pub(crate) fn new(
@@ -522,7 +522,7 @@ mod tests {
         ) -> EngineSyncController<N, Either<Client, TestFullBlockClient>>
         where
             N: ProviderNodeTypes,
-            Client: BlockClient + 'static,
+            Client: EthBlockClient + 'static,
         {
             let client = self
                 .client

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -24,7 +24,9 @@ use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_evm::{either::Either, test_utils::MockExecutorProvider};
 use reth_evm_ethereum::execute::EthExecutorProvider;
 use reth_exex_types::FinishedExExHeight;
-use reth_network_p2p::{sync::NoopSyncStateUpdater, test_utils::NoopFullBlockClient, BlockClient};
+use reth_network_p2p::{
+    sync::NoopSyncStateUpdater, test_utils::NoopFullBlockClient, EthBlockClient,
+};
 use reth_payload_builder::test_utils::spawn_test_payload_service;
 use reth_primitives::SealedHeader;
 use reth_provider::{
@@ -237,7 +239,7 @@ impl TestConsensusEngineBuilder {
         client: Client,
     ) -> NetworkedTestConsensusEngineBuilder<Client>
     where
-        Client: BlockClient + 'static,
+        Client: EthBlockClient + 'static,
     {
         NetworkedTestConsensusEngineBuilder { base_config: self, client: Some(client) }
     }
@@ -264,7 +266,7 @@ pub struct NetworkedTestConsensusEngineBuilder<Client> {
 
 impl<Client> NetworkedTestConsensusEngineBuilder<Client>
 where
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
 {
     /// Set the pipeline execution outputs to use for the test consensus engine.
     #[allow(dead_code)]
@@ -319,7 +321,7 @@ where
         client: ClientType,
     ) -> NetworkedTestConsensusEngineBuilder<ClientType>
     where
-        ClientType: BlockClient + 'static,
+        ClientType: EthBlockClient + 'static,
     {
         NetworkedTestConsensusEngineBuilder { base_config: self.base_config, client: Some(client) }
     }
@@ -450,7 +452,7 @@ pub fn spawn_consensus_engine<Client>(
     engine: TestBeaconConsensusEngine<Client>,
 ) -> oneshot::Receiver<Result<(), BeaconConsensusEngineError>>
 where
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
 {
     let (tx, rx) = oneshot::channel();
     tokio::spawn(async move {

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -15,7 +15,7 @@ pub use reth_engine_tree::{
     engine::EngineApiEvent,
 };
 use reth_evm::execute::BlockExecutorProvider;
-use reth_network_p2p::BlockClient;
+use reth_network_p2p::EthBlockClient;
 use reth_node_types::NodeTypesWithEngine;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_validator::ExecutionPayloadValidator;
@@ -49,7 +49,7 @@ type EngineServiceType<N, Client> = ChainOrchestrator<
 pub struct EngineService<N, Client, E>
 where
     N: EngineNodeTypes,
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
     E: BlockExecutorProvider + 'static,
 {
     orchestrator: EngineServiceType<N, Client>,
@@ -59,7 +59,7 @@ where
 impl<N, Client, E> EngineService<N, Client, E>
 where
     N: EngineNodeTypes,
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
     E: BlockExecutorProvider + 'static,
 {
     /// Constructor for `EngineService`.
@@ -124,7 +124,7 @@ where
 impl<N, Client, E> Stream for EngineService<N, Client, E>
 where
     N: EngineNodeTypes,
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
     E: BlockExecutorProvider + 'static,
 {
     type Item = ChainEvent<BeaconConsensusEngineEvent>;

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -28,6 +28,7 @@ reth-db-api = { workspace = true, optional = true }
 reth-testing-utils = { workspace = true, optional = true }
 
 # ethereum
+alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -66,7 +66,7 @@ pub struct BodiesDownloader<B: BodiesClient, Provider> {
 
 impl<B, Provider> BodiesDownloader<B, Provider>
 where
-    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
+    B: BodiesClient<Body: InMemorySize> + 'static,
     Provider: HeaderProvider + Unpin + 'static,
 {
     /// Returns the next contiguous request.
@@ -298,7 +298,7 @@ where
 
 impl<B, Provider> BodyDownloader for BodiesDownloader<B, Provider>
 where
-    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
+    B: BodiesClient<Body: InMemorySize> + 'static,
     Provider: HeaderProvider + Unpin + 'static,
 {
     type Body = B::Body;
@@ -348,7 +348,7 @@ where
 
 impl<B, Provider> Stream for BodiesDownloader<B, Provider>
 where
-    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
+    B: BodiesClient<Body: InMemorySize> + 'static,
     Provider: HeaderProvider + Unpin + 'static,
 {
     type Item = BodyDownloaderResult<B::Body>;

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -37,7 +37,7 @@ pub struct BodiesDownloader<B: BodiesClient, Provider> {
     /// The bodies client
     client: Arc<B>,
     /// The consensus client
-    consensus: Arc<dyn Consensus>,
+    consensus: Arc<dyn Consensus<reth_primitives::Header, B::Body>>,
     /// The database handle
     provider: Provider,
     /// The maximum number of non-empty blocks per one request
@@ -57,16 +57,16 @@ pub struct BodiesDownloader<B: BodiesClient, Provider> {
     /// Requests in progress
     in_progress_queue: BodiesRequestQueue<B>,
     /// Buffered responses
-    buffered_responses: BinaryHeap<OrderedBodiesResponse>,
+    buffered_responses: BinaryHeap<OrderedBodiesResponse<B::Body>>,
     /// Queued body responses that can be returned for insertion into the database.
-    queued_bodies: Vec<BlockResponse>,
+    queued_bodies: Vec<BlockResponse<B::Body>>,
     /// The bodies downloader metrics.
     metrics: BodyDownloaderMetrics,
 }
 
 impl<B, Provider> BodiesDownloader<B, Provider>
 where
-    B: BodiesClient + 'static,
+    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
     Provider: HeaderProvider + Unpin + 'static,
 {
     /// Returns the next contiguous request.
@@ -191,14 +191,14 @@ where
     }
 
     /// Queues bodies and sets the latest queued block number
-    fn queue_bodies(&mut self, bodies: Vec<BlockResponse>) {
+    fn queue_bodies(&mut self, bodies: Vec<BlockResponse<B::Body>>) {
         self.latest_queued_block_number = Some(bodies.last().expect("is not empty").block_number());
         self.queued_bodies.extend(bodies);
         self.metrics.queued_blocks.set(self.queued_bodies.len() as f64);
     }
 
     /// Removes the next response from the buffer.
-    fn pop_buffered_response(&mut self) -> Option<OrderedBodiesResponse> {
+    fn pop_buffered_response(&mut self) -> Option<OrderedBodiesResponse<B::Body>> {
         let resp = self.buffered_responses.pop()?;
         self.metrics.buffered_responses.decrement(1.);
         self.buffered_blocks_size_bytes -= resp.size();
@@ -208,10 +208,10 @@ where
     }
 
     /// Adds a new response to the internal buffer
-    fn buffer_bodies_response(&mut self, response: Vec<BlockResponse>) {
+    fn buffer_bodies_response(&mut self, response: Vec<BlockResponse<B::Body>>) {
         // take into account capacity
         let size = response.iter().map(BlockResponse::size).sum::<usize>() +
-            response.capacity() * mem::size_of::<BlockResponse>();
+            response.capacity() * mem::size_of::<BlockResponse<B::Body>>();
 
         let response = OrderedBodiesResponse { resp: response, size };
         let response_len = response.len();
@@ -225,7 +225,7 @@ where
     }
 
     /// Returns a response if it's first block number matches the next expected.
-    fn try_next_buffered(&mut self) -> Option<Vec<BlockResponse>> {
+    fn try_next_buffered(&mut self) -> Option<Vec<BlockResponse<B::Body>>> {
         if let Some(next) = self.buffered_responses.peek() {
             let expected = self.next_expected_block_number();
             let next_block_range = next.block_range();
@@ -251,7 +251,7 @@ where
 
     /// Returns the next batch of block bodies that can be returned if we have enough buffered
     /// bodies
-    fn try_split_next_batch(&mut self) -> Option<Vec<BlockResponse>> {
+    fn try_split_next_batch(&mut self) -> Option<Vec<BlockResponse<B::Body>>> {
         if self.queued_bodies.len() >= self.stream_batch_size {
             let next_batch = self.queued_bodies.drain(..self.stream_batch_size).collect::<Vec<_>>();
             self.queued_bodies.shrink_to_fit();
@@ -283,12 +283,12 @@ where
     Self: BodyDownloader + 'static,
 {
     /// Spawns the downloader task via [`tokio::task::spawn`]
-    pub fn into_task(self) -> TaskDownloader {
+    pub fn into_task(self) -> TaskDownloader<<Self as BodyDownloader>::Body> {
         self.into_task_with(&TokioTaskExecutor::default())
     }
 
     /// Convert the downloader into a [`TaskDownloader`] by spawning it via the given spawner.
-    pub fn into_task_with<S>(self, spawner: &S) -> TaskDownloader
+    pub fn into_task_with<S>(self, spawner: &S) -> TaskDownloader<<Self as BodyDownloader>::Body>
     where
         S: TaskSpawner,
     {
@@ -298,9 +298,11 @@ where
 
 impl<B, Provider> BodyDownloader for BodiesDownloader<B, Provider>
 where
-    B: BodiesClient + 'static,
+    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
     Provider: HeaderProvider + Unpin + 'static,
 {
+    type Body = B::Body;
+
     /// Set a new download range (exclusive).
     ///
     /// This method will drain all queued bodies, filter out ones outside the range and put them
@@ -346,10 +348,10 @@ where
 
 impl<B, Provider> Stream for BodiesDownloader<B, Provider>
 where
-    B: BodiesClient + 'static,
+    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
     Provider: HeaderProvider + Unpin + 'static,
 {
-    type Item = BodyDownloaderResult;
+    type Item = BodyDownloaderResult<B::Body>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -431,13 +433,13 @@ where
 }
 
 #[derive(Debug)]
-struct OrderedBodiesResponse {
-    resp: Vec<BlockResponse>,
+struct OrderedBodiesResponse<B> {
+    resp: Vec<BlockResponse<B>>,
     /// The total size of the response in bytes
     size: usize,
 }
 
-impl OrderedBodiesResponse {
+impl<B> OrderedBodiesResponse<B> {
     /// Returns the block number of the first element
     ///
     /// # Panics
@@ -468,21 +470,21 @@ impl OrderedBodiesResponse {
     }
 }
 
-impl PartialEq for OrderedBodiesResponse {
+impl<B> PartialEq for OrderedBodiesResponse<B> {
     fn eq(&self, other: &Self) -> bool {
         self.first_block_number() == other.first_block_number()
     }
 }
 
-impl Eq for OrderedBodiesResponse {}
+impl<B> Eq for OrderedBodiesResponse<B> {}
 
-impl PartialOrd for OrderedBodiesResponse {
+impl<B> PartialOrd for OrderedBodiesResponse<B> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for OrderedBodiesResponse {
+impl<B> Ord for OrderedBodiesResponse<B> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.first_block_number().cmp(&other.first_block_number()).reverse()
     }
@@ -562,7 +564,7 @@ impl BodiesDownloaderBuilder {
     pub fn build<B, Provider>(
         self,
         client: B,
-        consensus: Arc<dyn Consensus>,
+        consensus: Arc<dyn Consensus<reth_primitives::Header, B::Body>>,
         provider: Provider,
     ) -> BodiesDownloader<B, Provider>
     where

--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -4,6 +4,7 @@ use reth_network_p2p::{
     bodies::{downloader::BodyDownloader, response::BlockResponse},
     error::{DownloadError, DownloadResult},
 };
+use reth_primitives::BlockBody;
 use std::ops::RangeInclusive;
 
 /// A [`BodyDownloader`] implementation that does nothing.
@@ -12,13 +13,15 @@ use std::ops::RangeInclusive;
 pub struct NoopBodiesDownloader;
 
 impl BodyDownloader for NoopBodiesDownloader {
+    type Body = BlockBody;
+
     fn set_download_range(&mut self, _: RangeInclusive<BlockNumber>) -> DownloadResult<()> {
         Ok(())
     }
 }
 
 impl Stream for NoopBodiesDownloader {
-    type Item = Result<Vec<BlockResponse>, DownloadError>;
+    type Item = Result<Vec<BlockResponse<BlockBody>>, DownloadError>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -57,9 +57,11 @@ where
     pub(crate) fn push_new_request(
         &mut self,
         client: Arc<B>,
-        consensus: Arc<dyn Consensus>,
+        consensus: Arc<dyn Consensus<reth_primitives::Header, B::Body>>,
         request: Vec<SealedHeader>,
-    ) {
+    ) where
+        B::Body: reth_primitives_traits::BlockBody,
+    {
         // Set last max requested block number
         self.last_requested_block_number = request
             .last()
@@ -77,9 +79,9 @@ where
 
 impl<B> Stream for BodiesRequestQueue<B>
 where
-    B: BodiesClient + 'static,
+    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
 {
-    type Item = DownloadResult<Vec<BlockResponse>>;
+    type Item = DownloadResult<Vec<BlockResponse<B::Body>>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.get_mut().inner.poll_next_unpin(cx)

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -9,6 +9,7 @@ use reth_network_p2p::{
     error::DownloadResult,
 };
 use reth_primitives::SealedHeader;
+use reth_primitives_traits::InMemorySize;
 use std::{
     pin::Pin,
     sync::Arc,
@@ -59,9 +60,7 @@ where
         client: Arc<B>,
         consensus: Arc<dyn Consensus<reth_primitives::Header, B::Body>>,
         request: Vec<SealedHeader>,
-    ) where
-        B::Body: reth_primitives_traits::BlockBody,
-    {
+    ) {
         // Set last max requested block number
         self.last_requested_block_number = request
             .last()
@@ -79,7 +78,7 @@ where
 
 impl<B> Stream for BodiesRequestQueue<B>
 where
-    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
+    B: BodiesClient<Body: InMemorySize> + 'static,
 {
     type Item = DownloadResult<Vec<BlockResponse<B::Body>>>;
 

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -39,7 +39,7 @@ use std::{
 /// and eventually disconnected.
 pub(crate) struct BodiesRequestFuture<B: BodiesClient> {
     client: Arc<B>,
-    consensus: Arc<dyn Consensus>,
+    consensus: Arc<dyn Consensus<reth_primitives::Header, B::Body>>,
     metrics: BodyDownloaderMetrics,
     /// Metrics for individual responses. This can be used to observe how the size (in bytes) of
     /// responses change while bodies are being downloaded.
@@ -47,7 +47,7 @@ pub(crate) struct BodiesRequestFuture<B: BodiesClient> {
     // Headers to download. The collection is shrunk as responses are buffered.
     pending_headers: VecDeque<SealedHeader>,
     /// Internal buffer for all blocks
-    buffer: Vec<BlockResponse>,
+    buffer: Vec<BlockResponse<B::Body>>,
     fut: Option<B::Output>,
     /// Tracks how many bodies we requested in the last request.
     last_request_len: Option<usize>,
@@ -60,7 +60,7 @@ where
     /// Returns an empty future. Use [`BodiesRequestFuture::with_headers`] to set the request.
     pub(crate) fn new(
         client: Arc<B>,
-        consensus: Arc<dyn Consensus>,
+        consensus: Arc<dyn Consensus<reth_primitives::Header, B::Body>>,
         metrics: BodyDownloaderMetrics,
     ) -> Self {
         Self {
@@ -115,7 +115,10 @@ where
 
     /// Process block response.
     /// Returns an error if the response is invalid.
-    fn on_block_response(&mut self, response: WithPeerId<Vec<BlockBody>>) -> DownloadResult<()> {
+    fn on_block_response(&mut self, response: WithPeerId<Vec<B::Body>>) -> DownloadResult<()>
+    where
+        B::Body: InMemorySize,
+    {
         let (peer_id, bodies) = response.split();
         let request_len = self.last_request_len.unwrap_or_default();
         let response_len = bodies.len();
@@ -158,7 +161,10 @@ where
     ///
     /// This method removes headers from the internal collection.
     /// If the response fails validation, then the header will be put back.
-    fn try_buffer_blocks(&mut self, bodies: Vec<BlockBody>) -> DownloadResult<()> {
+    fn try_buffer_blocks(&mut self, bodies: Vec<B::Body>) -> DownloadResult<()>
+    where
+        B::Body: InMemorySize,
+    {
         let bodies_capacity = bodies.capacity();
         let bodies_len = bodies.len();
         let mut bodies = bodies.into_iter().peekable();
@@ -208,9 +214,9 @@ where
 
 impl<B> Future for BodiesRequestFuture<B>
 where
-    B: BodiesClient + 'static,
+    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
 {
-    type Output = DownloadResult<Vec<BlockResponse>>;
+    type Output = DownloadResult<Vec<BlockResponse<B::Body>>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -214,7 +214,7 @@ where
 
 impl<B> Future for BodiesRequestFuture<B>
 where
-    B: BodiesClient<Body: reth_primitives_traits::BlockBody> + 'static,
+    B: BodiesClient<Body: InMemorySize> + 'static,
 {
     type Output = DownloadResult<Vec<BlockResponse<B::Body>>>;
 

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -23,15 +23,15 @@ pub const BODIES_TASK_BUFFER_SIZE: usize = 4;
 /// A [BodyDownloader] that drives a spawned [BodyDownloader] on a spawned task.
 #[derive(Debug)]
 #[pin_project]
-pub struct TaskDownloader {
+pub struct TaskDownloader<B> {
     #[pin]
-    from_downloader: ReceiverStream<BodyDownloaderResult>,
+    from_downloader: ReceiverStream<BodyDownloaderResult<B>>,
     to_downloader: UnboundedSender<RangeInclusive<BlockNumber>>,
 }
 
 // === impl TaskDownloader ===
 
-impl TaskDownloader {
+impl<B: Send + Sync + Unpin + 'static> TaskDownloader<B> {
     /// Spawns the given `downloader` via [`tokio::task::spawn`] returns a [`TaskDownloader`] that's
     /// connected to that task.
     ///
@@ -59,7 +59,7 @@ impl TaskDownloader {
     /// ```
     pub fn spawn<T>(downloader: T) -> Self
     where
-        T: BodyDownloader + 'static,
+        T: BodyDownloader<Body = B> + 'static,
     {
         Self::spawn_with(downloader, &TokioTaskExecutor::default())
     }
@@ -68,7 +68,7 @@ impl TaskDownloader {
     /// that's connected to that task.
     pub fn spawn_with<T, S>(downloader: T, spawner: &S) -> Self
     where
-        T: BodyDownloader + 'static,
+        T: BodyDownloader<Body = B> + 'static,
         S: TaskSpawner,
     {
         let (bodies_tx, bodies_rx) = mpsc::channel(BODIES_TASK_BUFFER_SIZE);
@@ -86,15 +86,17 @@ impl TaskDownloader {
     }
 }
 
-impl BodyDownloader for TaskDownloader {
+impl<B: Send + Sync + Unpin + 'static> BodyDownloader for TaskDownloader<B> {
+    type Body = B;
+
     fn set_download_range(&mut self, range: RangeInclusive<BlockNumber>) -> DownloadResult<()> {
         let _ = self.to_downloader.send(range);
         Ok(())
     }
 }
 
-impl Stream for TaskDownloader {
-    type Item = BodyDownloaderResult;
+impl<B> Stream for TaskDownloader<B> {
+    type Item = BodyDownloaderResult<B>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().from_downloader.poll_next(cx)
@@ -102,9 +104,9 @@ impl Stream for TaskDownloader {
 }
 
 /// A [`BodyDownloader`] that runs on its own task
-struct SpawnedDownloader<T> {
+struct SpawnedDownloader<T: BodyDownloader> {
     updates: UnboundedReceiverStream<RangeInclusive<BlockNumber>>,
-    bodies_tx: PollSender<BodyDownloaderResult>,
+    bodies_tx: PollSender<BodyDownloaderResult<T::Body>>,
     downloader: T,
 }
 

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -45,12 +45,16 @@ impl<B: Send + Sync + Unpin + 'static> TaskDownloader<B> {
     /// use reth_consensus::Consensus;
     /// use reth_downloaders::bodies::{bodies::BodiesDownloaderBuilder, task::TaskDownloader};
     /// use reth_network_p2p::bodies::client::BodiesClient;
+    /// use reth_primitives_traits::InMemorySize;
     /// use reth_storage_api::HeaderProvider;
     /// use std::sync::Arc;
     ///
-    /// fn t<B: BodiesClient + 'static, Provider: HeaderProvider + Unpin + 'static>(
+    /// fn t<
+    ///     B: BodiesClient<Body: InMemorySize> + 'static,
+    ///     Provider: HeaderProvider + Unpin + 'static,
+    /// >(
     ///     client: Arc<B>,
-    ///     consensus: Arc<dyn Consensus>,
+    ///     consensus: Arc<dyn Consensus<reth_primitives::Header, B::Body>>,
     ///     provider: Provider,
     /// ) {
     ///     let downloader = BodiesDownloaderBuilder::default().build(client, consensus, provider);

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -265,6 +265,7 @@ impl FromReader for FileClient {
 }
 
 impl HeadersClient for FileClient {
+    type Header = Header;
     type Output = HeadersFut;
 
     fn get_headers_with_priority(
@@ -315,6 +316,7 @@ impl HeadersClient for FileClient {
 }
 
 impl BodiesClient for FileClient {
+    type Body = BlockBody;
     type Output = BodiesFut;
 
     fn get_block_bodies_with_priority(

--- a/crates/net/downloaders/src/headers/noop.rs
+++ b/crates/net/downloaders/src/headers/noop.rs
@@ -1,3 +1,4 @@
+use alloy_consensus::Header;
 use futures::Stream;
 use reth_network_p2p::headers::{
     downloader::{HeaderDownloader, SyncTarget},
@@ -11,6 +12,8 @@ use reth_primitives::SealedHeader;
 pub struct NoopHeaderDownloader;
 
 impl HeaderDownloader for NoopHeaderDownloader {
+    type Header = Header;
+
     fn update_local_head(&mut self, _: SealedHeader) {}
 
     fn update_sync_target(&mut self, _: SyncTarget) {}
@@ -19,7 +22,7 @@ impl HeaderDownloader for NoopHeaderDownloader {
 }
 
 impl Stream for NoopHeaderDownloader {
-    type Item = Result<Vec<SealedHeader>, HeadersDownloaderError>;
+    type Item = Result<Vec<SealedHeader>, HeadersDownloaderError<Header>>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -2,6 +2,7 @@
 
 use super::task::TaskDownloader;
 use crate::metrics::HeaderDownloaderMetrics;
+use alloy_consensus::BlockHeader;
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{BlockNumber, Sealable, B256};
 use futures::{stream::Stream, FutureExt};
@@ -19,7 +20,7 @@ use reth_network_p2p::{
     priority::Priority,
 };
 use reth_network_peers::PeerId;
-use reth_primitives::{GotExpected, Header, SealedHeader};
+use reth_primitives::{GotExpected, SealedHeader};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use std::{
     cmp::{Ordering, Reverse},
@@ -39,14 +40,14 @@ const REQUESTS_PER_PEER_MULTIPLIER: usize = 5;
 
 /// Wrapper for internal downloader errors.
 #[derive(Error, Debug)]
-enum ReverseHeadersDownloaderError {
+enum ReverseHeadersDownloaderError<H> {
     #[error(transparent)]
-    Downloader(#[from] HeadersDownloaderError),
+    Downloader(#[from] HeadersDownloaderError<H>),
     #[error(transparent)]
     Response(#[from] Box<HeadersResponseError>),
 }
 
-impl From<HeadersResponseError> for ReverseHeadersDownloaderError {
+impl<H> From<HeadersResponseError> for ReverseHeadersDownloaderError<H> {
     fn from(value: HeadersResponseError) -> Self {
         Self::Response(Box::new(value))
     }
@@ -66,17 +67,17 @@ impl From<HeadersResponseError> for ReverseHeadersDownloaderError {
 #[derive(Debug)]
 pub struct ReverseHeadersDownloader<H: HeadersClient> {
     /// Consensus client used to validate headers
-    consensus: Arc<dyn Consensus>,
+    consensus: Arc<dyn Consensus<H::Header>>,
     /// Client used to download headers.
     client: Arc<H>,
     /// The local head of the chain.
-    local_head: Option<SealedHeader>,
+    local_head: Option<SealedHeader<H::Header>>,
     /// Block we want to close the gap to.
     sync_target: Option<SyncTargetBlock>,
     /// The block number to use for requests.
     next_request_block_number: u64,
     /// Keeps track of the block we need to validate next.
-    lowest_validated_header: Option<SealedHeader>,
+    lowest_validated_header: Option<SealedHeader<H::Header>>,
     /// Tip block number to start validating from (in reverse)
     next_chain_tip_block_number: u64,
     /// The batch size per one request
@@ -97,11 +98,11 @@ pub struct ReverseHeadersDownloader<H: HeadersClient> {
     /// requests in progress
     in_progress_queue: FuturesUnordered<HeadersRequestFuture<H::Output>>,
     /// Buffered, unvalidated responses
-    buffered_responses: BinaryHeap<OrderedHeadersResponse>,
+    buffered_responses: BinaryHeap<OrderedHeadersResponse<H::Header>>,
     /// Buffered, _sorted_ and validated headers ready to be returned.
     ///
     /// Note: headers are sorted from high to low
-    queued_validated_headers: Vec<SealedHeader>,
+    queued_validated_headers: Vec<SealedHeader<H::Header>>,
     /// Header downloader metrics.
     metrics: HeaderDownloaderMetrics,
 }
@@ -110,7 +111,7 @@ pub struct ReverseHeadersDownloader<H: HeadersClient> {
 
 impl<H> ReverseHeadersDownloader<H>
 where
-    H: HeadersClient + 'static,
+    H: HeadersClient<Header: reth_primitives_traits::BlockHeader> + 'static,
 {
     /// Convenience method to create a [`ReverseHeadersDownloaderBuilder`] without importing it
     pub fn builder() -> ReverseHeadersDownloaderBuilder {
@@ -120,7 +121,7 @@ where
     /// Returns the block number the local node is at.
     #[inline]
     fn local_block_number(&self) -> Option<BlockNumber> {
-        self.local_head.as_ref().map(|h| h.number)
+        self.local_head.as_ref().map(|h| h.number())
     }
 
     /// Returns the existing local head block number
@@ -130,7 +131,7 @@ where
     /// If the local head has not been set.
     #[inline]
     fn existing_local_block_number(&self) -> BlockNumber {
-        self.local_head.as_ref().expect("is initialized").number
+        self.local_head.as_ref().expect("is initialized").number()
     }
 
     /// Returns the existing sync target.
@@ -197,14 +198,14 @@ where
     /// `lowest_validated_header`.
     ///
     /// This only returns `None` if we haven't fetched the initial chain tip yet.
-    fn lowest_validated_header(&self) -> Option<&SealedHeader> {
+    fn lowest_validated_header(&self) -> Option<&SealedHeader<H::Header>> {
         self.queued_validated_headers.last().or(self.lowest_validated_header.as_ref())
     }
 
     /// Validate that the received header matches the expected sync target.
     fn validate_sync_target(
         &self,
-        header: &SealedHeader,
+        header: &SealedHeader<H::Header>,
         request: HeadersRequest,
         peer_id: PeerId,
     ) -> Result<(), Box<HeadersResponseError>> {
@@ -220,12 +221,12 @@ where
                     ),
                 }))
             }
-            SyncTargetBlock::Number(number) if header.number != number => {
+            SyncTargetBlock::Number(number) if header.number() != number => {
                 Err(Box::new(HeadersResponseError {
                     request,
                     peer_id: Some(peer_id),
                     error: DownloadError::InvalidTipNumber(GotExpected {
-                        got: header.number,
+                        got: header.number(),
                         expected: number,
                     }),
                 }))
@@ -244,9 +245,9 @@ where
     fn process_next_headers(
         &mut self,
         request: HeadersRequest,
-        headers: Vec<Header>,
+        headers: Vec<H::Header>,
         peer_id: PeerId,
-    ) -> Result<(), ReverseHeadersDownloaderError> {
+    ) -> Result<(), ReverseHeadersDownloaderError<H::Header>> {
         let mut validated = Vec::with_capacity(headers.len());
 
         let sealed_headers = headers
@@ -280,17 +281,17 @@ where
         if let Some((last_header, head)) = validated
             .last_mut()
             .zip(self.local_head.as_ref())
-            .filter(|(last, head)| last.number == head.number + 1)
+            .filter(|(last, head)| last.number() == head.number() + 1)
         {
             // Every header must be valid on its own
-            if let Err(error) = self.consensus.validate_header(last_header) {
+            if let Err(error) = self.consensus.validate_header(&*last_header) {
                 trace!(target: "downloaders::headers", %error, "Failed to validate header");
                 return Err(HeadersResponseError {
                     request,
                     peer_id: Some(peer_id),
                     error: DownloadError::HeaderValidation {
                         hash: head.hash(),
-                        number: head.number,
+                        number: head.number(),
                         error: Box::new(error),
                     },
                 }
@@ -299,9 +300,9 @@ where
 
             // If the header is valid on its own, but not against its parent, we return it as
             // detached head error.
-            if let Err(error) = self.consensus.validate_header_against_parent(last_header, head) {
+            if let Err(error) = self.consensus.validate_header_against_parent(&*last_header, head) {
                 // Replace the last header with a detached variant
-                error!(target: "downloaders::headers", %error, number = last_header.number, hash = ?last_header.hash(), "Header cannot be attached to known canonical chain");
+                error!(target: "downloaders::headers", %error, number = last_header.number(), hash = ?last_header.hash(), "Header cannot be attached to known canonical chain");
                 return Err(HeadersDownloaderError::DetachedHead {
                     local_head: Box::new(head.clone()),
                     header: Box::new(last_header.clone()),
@@ -313,7 +314,7 @@ where
 
         // update tracked block info (falling block number)
         self.next_chain_tip_block_number =
-            validated.last().expect("exists").number.saturating_sub(1);
+            validated.last().expect("exists").number().saturating_sub(1);
         self.queued_validated_headers.extend(validated);
 
         Ok(())
@@ -345,7 +346,7 @@ where
                 let skip = self
                     .queued_validated_headers
                     .iter()
-                    .take_while(|last| last.number > target_block_number)
+                    .take_while(|last| last.number() > target_block_number)
                     .count();
                 // removes all headers that are higher than current target
                 self.queued_validated_headers.drain(..skip);
@@ -360,8 +361,8 @@ where
     /// Handles the response for the request for the sync target
     fn on_sync_target_outcome(
         &mut self,
-        response: HeadersRequestOutcome,
-    ) -> Result<(), ReverseHeadersDownloaderError> {
+        response: HeadersRequestOutcome<H::Header>,
+    ) -> Result<(), ReverseHeadersDownloaderError<H::Header>> {
         let sync_target = self.existing_sync_target();
         let HeadersRequestOutcome { request, outcome } = response;
         match outcome {
@@ -372,7 +373,7 @@ where
                 self.metrics.total_downloaded.increment(headers.len() as u64);
 
                 // sort headers from highest to lowest block number
-                headers.sort_unstable_by_key(|h| Reverse(h.number));
+                headers.sort_unstable_by_key(|h| Reverse(h.number()));
 
                 if headers.is_empty() {
                     return Err(HeadersResponseError {
@@ -401,12 +402,12 @@ where
                         }
                     }
                     SyncTargetBlock::Number(number) => {
-                        if target.number != number {
+                        if target.number() != number {
                             return Err(HeadersResponseError {
                                 request,
                                 peer_id: Some(peer_id),
                                 error: DownloadError::InvalidTipNumber(GotExpected {
-                                    got: target.number,
+                                    got: target.number(),
                                     expected: number,
                                 }),
                             }
@@ -415,17 +416,17 @@ where
                     }
                 }
 
-                trace!(target: "downloaders::headers", head=?self.local_block_number(), hash=?target.hash(), number=%target.number, "Received sync target");
+                trace!(target: "downloaders::headers", head=?self.local_block_number(), hash=?target.hash(), number=%target.number(), "Received sync target");
 
                 // This is the next block we need to start issuing requests from
-                let parent_block_number = target.number.saturating_sub(1);
-                self.on_block_number_update(target.number, parent_block_number);
+                let parent_block_number = target.number().saturating_sub(1);
+                self.on_block_number_update(target.number(), parent_block_number);
 
                 self.queued_validated_headers.push(target);
 
                 // try to validate all buffered responses blocked by this successful response
                 self.try_validate_buffered()
-                    .map(Err::<(), ReverseHeadersDownloaderError>)
+                    .map(Err::<(), ReverseHeadersDownloaderError<H::Header>>)
                     .transpose()?;
 
                 Ok(())
@@ -439,8 +440,8 @@ where
     /// Invoked when we received a response
     fn on_headers_outcome(
         &mut self,
-        response: HeadersRequestOutcome,
-    ) -> Result<(), ReverseHeadersDownloaderError> {
+        response: HeadersRequestOutcome<H::Header>,
+    ) -> Result<(), ReverseHeadersDownloaderError<H::Header>> {
         let requested_block_number = response.block_number();
         let HeadersRequestOutcome { request, outcome } = response;
 
@@ -475,19 +476,19 @@ where
                 }
 
                 // sort headers from highest to lowest block number
-                headers.sort_unstable_by_key(|h| Reverse(h.number));
+                headers.sort_unstable_by_key(|h| Reverse(h.number()));
 
                 // validate the response
                 let highest = &headers[0];
 
-                trace!(target: "downloaders::headers", requested_block_number, highest=?highest.number, "Validating non-empty headers response");
+                trace!(target: "downloaders::headers", requested_block_number, highest=?highest.number(), "Validating non-empty headers response");
 
-                if highest.number != requested_block_number {
+                if highest.number() != requested_block_number {
                     return Err(HeadersResponseError {
                         request,
                         peer_id: Some(peer_id),
                         error: DownloadError::HeadersResponseStartBlockMismatch(GotExpected {
-                            got: highest.number,
+                            got: highest.number(),
                             expected: requested_block_number,
                         }),
                     }
@@ -495,14 +496,14 @@ where
                 }
 
                 // check if the response is the next expected
-                if highest.number == self.next_chain_tip_block_number {
+                if highest.number() == self.next_chain_tip_block_number {
                     // is next response, validate it
                     self.process_next_headers(request, headers, peer_id)?;
                     // try to validate all buffered responses blocked by this successful response
                     self.try_validate_buffered()
-                        .map(Err::<(), ReverseHeadersDownloaderError>)
+                        .map(Err::<(), ReverseHeadersDownloaderError<H::Header>>)
                         .transpose()?;
-                } else if highest.number > self.existing_local_block_number() {
+                } else if highest.number() > self.existing_local_block_number() {
                     self.metrics.buffered_responses.increment(1.);
                     // can't validate yet
                     self.buffered_responses.push(OrderedHeadersResponse {
@@ -549,7 +550,7 @@ where
     /// Attempts to validate the buffered responses
     ///
     /// Returns an error if the next expected response was popped, but failed validation.
-    fn try_validate_buffered(&mut self) -> Option<ReverseHeadersDownloaderError> {
+    fn try_validate_buffered(&mut self) -> Option<ReverseHeadersDownloaderError<H::Header>> {
         loop {
             // Check to see if we've already received the next value
             let next_response = self.buffered_responses.peek_mut()?;
@@ -598,7 +599,11 @@ where
     }
 
     /// Validate whether the header is valid in relation to it's parent
-    fn validate(&self, header: &SealedHeader, parent: &SealedHeader) -> DownloadResult<()> {
+    fn validate(
+        &self,
+        header: &SealedHeader<H::Header>,
+        parent: &SealedHeader<H::Header>,
+    ) -> DownloadResult<()> {
         validate_header_download(&self.consensus, header, parent)
     }
 
@@ -614,7 +619,7 @@ where
     }
 
     /// Splits off the next batch of headers
-    fn split_next_batch(&mut self) -> Vec<SealedHeader> {
+    fn split_next_batch(&mut self) -> Vec<SealedHeader<H::Header>> {
         let batch_size = self.stream_batch_size.min(self.queued_validated_headers.len());
         let mut rem = self.queued_validated_headers.split_off(batch_size);
         std::mem::swap(&mut rem, &mut self.queued_validated_headers);
@@ -644,12 +649,15 @@ where
     Self: HeaderDownloader + 'static,
 {
     /// Spawns the downloader task via [`tokio::task::spawn`]
-    pub fn into_task(self) -> TaskDownloader {
+    pub fn into_task(self) -> TaskDownloader<<Self as HeaderDownloader>::Header> {
         self.into_task_with(&TokioTaskExecutor::default())
     }
 
     /// Convert the downloader into a [`TaskDownloader`] by spawning it via the given `spawner`.
-    pub fn into_task_with<S>(self, spawner: &S) -> TaskDownloader
+    pub fn into_task_with<S>(
+        self,
+        spawner: &S,
+    ) -> TaskDownloader<<Self as HeaderDownloader>::Header>
     where
         S: TaskSpawner,
     {
@@ -659,11 +667,17 @@ where
 
 impl<H> HeaderDownloader for ReverseHeadersDownloader<H>
 where
-    H: HeadersClient + 'static,
+    H: HeadersClient<Header: reth_primitives_traits::BlockHeader> + 'static,
 {
-    fn update_local_head(&mut self, head: SealedHeader) {
+    type Header = H::Header;
+
+    fn update_local_head(&mut self, head: SealedHeader<H::Header>) {
         // ensure we're only yielding headers that are in range and follow the current local head.
-        while self.queued_validated_headers.last().is_some_and(|last| last.number <= head.number) {
+        while self
+            .queued_validated_headers
+            .last()
+            .is_some_and(|last| last.number() <= head.number())
+        {
             // headers are sorted high to low
             self.queued_validated_headers.pop();
         }
@@ -686,7 +700,7 @@ where
                         .queued_validated_headers
                         .first()
                         .filter(|h| h.hash() == tip)
-                        .map(|h| h.number)
+                        .map(|h| h.number())
                     {
                         self.sync_target = Some(new_sync_target.with_number(target_number));
                         return
@@ -740,9 +754,9 @@ where
 
 impl<H> Stream for ReverseHeadersDownloader<H>
 where
-    H: HeadersClient + 'static,
+    H: HeadersClient<Header: reth_primitives_traits::BlockHeader> + 'static,
 {
-    type Item = HeadersDownloaderResult<Vec<SealedHeader>>;
+    type Item = HeadersDownloaderResult<Vec<SealedHeader<H::Header>>, H::Header>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -890,11 +904,11 @@ struct HeadersRequestFuture<F> {
     fut: F,
 }
 
-impl<F> Future for HeadersRequestFuture<F>
+impl<F, H> Future for HeadersRequestFuture<F>
 where
-    F: Future<Output = PeerRequestResult<Vec<Header>>> + Sync + Send + Unpin,
+    F: Future<Output = PeerRequestResult<Vec<H>>> + Sync + Send + Unpin,
 {
-    type Output = HeadersRequestOutcome;
+    type Output = HeadersRequestOutcome<H>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -906,14 +920,14 @@ where
 }
 
 /// The outcome of the [`HeadersRequestFuture`]
-struct HeadersRequestOutcome {
+struct HeadersRequestOutcome<H> {
     request: HeadersRequest,
-    outcome: PeerRequestResult<Vec<Header>>,
+    outcome: PeerRequestResult<Vec<H>>,
 }
 
 // === impl OrderedHeadersResponse ===
 
-impl HeadersRequestOutcome {
+impl<H> HeadersRequestOutcome<H> {
     fn block_number(&self) -> u64 {
         self.request.start.as_number().expect("is number")
     }
@@ -921,35 +935,35 @@ impl HeadersRequestOutcome {
 
 /// Wrapper type to order responses
 #[derive(Debug)]
-struct OrderedHeadersResponse {
-    headers: Vec<Header>,
+struct OrderedHeadersResponse<H> {
+    headers: Vec<H>,
     request: HeadersRequest,
     peer_id: PeerId,
 }
 
 // === impl OrderedHeadersResponse ===
 
-impl OrderedHeadersResponse {
+impl<H> OrderedHeadersResponse<H> {
     fn block_number(&self) -> u64 {
         self.request.start.as_number().expect("is number")
     }
 }
 
-impl PartialEq for OrderedHeadersResponse {
+impl<H> PartialEq for OrderedHeadersResponse<H> {
     fn eq(&self, other: &Self) -> bool {
         self.block_number() == other.block_number()
     }
 }
 
-impl Eq for OrderedHeadersResponse {}
+impl<H> Eq for OrderedHeadersResponse<H> {}
 
-impl PartialOrd for OrderedHeadersResponse {
+impl<H> PartialOrd for OrderedHeadersResponse<H> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for OrderedHeadersResponse {
+impl<H> Ord for OrderedHeadersResponse<H> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.block_number().cmp(&other.block_number())
     }
@@ -1156,7 +1170,11 @@ impl ReverseHeadersDownloaderBuilder {
 
     /// Build [`ReverseHeadersDownloader`] with provided consensus
     /// and header client implementations
-    pub fn build<H>(self, client: H, consensus: Arc<dyn Consensus>) -> ReverseHeadersDownloader<H>
+    pub fn build<H>(
+        self,
+        client: H,
+        consensus: Arc<dyn Consensus<H::Header>>,
+    ) -> ReverseHeadersDownloader<H>
     where
         H: HeadersClient + 'static,
     {

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -897,7 +897,7 @@ where
     }
 }
 
-/// A future that returns a list of [`Header`] on success.
+/// A future that returns a list of headers on success.
 #[derive(Debug)]
 struct HeadersRequestFuture<F> {
     request: Option<HeadersRequest>,

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -1232,6 +1232,7 @@ fn calc_next_request(
 mod tests {
     use super::*;
     use crate::headers::test_utils::child_header;
+    use alloy_consensus::Header;
     use assert_matches::assert_matches;
     use reth_consensus::test_utils::TestConsensus;
     use reth_network_p2p::test_utils::TestHeadersClient;
@@ -1314,7 +1315,7 @@ mod tests {
         assert!(downloader.sync_target_request.is_some());
 
         downloader.sync_target_request.take();
-        let target = SyncTarget::Gap(SealedHeader::new(Header::default(), B256::random()));
+        let target = SyncTarget::Gap(SealedHeader::new(Default::default(), B256::random()));
         downloader.update_sync_target(target);
         assert!(downloader.sync_target_request.is_none());
         assert_matches!(
@@ -1391,7 +1392,7 @@ mod tests {
     fn test_resp_order() {
         let mut heap = BinaryHeap::new();
         let hi = 1u64;
-        heap.push(OrderedHeadersResponse {
+        heap.push(OrderedHeadersResponse::<Header> {
             headers: vec![],
             request: HeadersRequest { start: hi.into(), limit: 0, direction: Default::default() },
             peer_id: Default::default(),

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -22,15 +22,15 @@ pub const HEADERS_TASK_BUFFER_SIZE: usize = 8;
 /// A [HeaderDownloader] that drives a spawned [HeaderDownloader] on a spawned task.
 #[derive(Debug)]
 #[pin_project]
-pub struct TaskDownloader {
+pub struct TaskDownloader<H> {
     #[pin]
-    from_downloader: ReceiverStream<HeadersDownloaderResult<Vec<SealedHeader>>>,
-    to_downloader: UnboundedSender<DownloaderUpdates>,
+    from_downloader: ReceiverStream<HeadersDownloaderResult<Vec<SealedHeader<H>>, H>>,
+    to_downloader: UnboundedSender<DownloaderUpdates<H>>,
 }
 
 // === impl TaskDownloader ===
 
-impl TaskDownloader {
+impl<H: Send + Sync + Unpin + 'static> TaskDownloader<H> {
     /// Spawns the given `downloader` via [`tokio::task::spawn`] and returns a [`TaskDownloader`]
     /// that's connected to that task.
     ///
@@ -55,7 +55,7 @@ impl TaskDownloader {
     /// # }
     pub fn spawn<T>(downloader: T) -> Self
     where
-        T: HeaderDownloader + 'static,
+        T: HeaderDownloader<Header = H> + 'static,
     {
         Self::spawn_with(downloader, &TokioTaskExecutor::default())
     }
@@ -64,7 +64,7 @@ impl TaskDownloader {
     /// that's connected to that task.
     pub fn spawn_with<T, S>(downloader: T, spawner: &S) -> Self
     where
-        T: HeaderDownloader + 'static,
+        T: HeaderDownloader<Header = H> + 'static,
         S: TaskSpawner,
     {
         let (headers_tx, headers_rx) = mpsc::channel(HEADERS_TASK_BUFFER_SIZE);
@@ -81,12 +81,14 @@ impl TaskDownloader {
     }
 }
 
-impl HeaderDownloader for TaskDownloader {
-    fn update_sync_gap(&mut self, head: SealedHeader, target: SyncTarget) {
+impl<H: Send + Sync + Unpin + 'static> HeaderDownloader for TaskDownloader<H> {
+    type Header = H;
+
+    fn update_sync_gap(&mut self, head: SealedHeader<H>, target: SyncTarget) {
         let _ = self.to_downloader.send(DownloaderUpdates::UpdateSyncGap(head, target));
     }
 
-    fn update_local_head(&mut self, head: SealedHeader) {
+    fn update_local_head(&mut self, head: SealedHeader<H>) {
         let _ = self.to_downloader.send(DownloaderUpdates::UpdateLocalHead(head));
     }
 
@@ -99,8 +101,8 @@ impl HeaderDownloader for TaskDownloader {
     }
 }
 
-impl Stream for TaskDownloader {
-    type Item = HeadersDownloaderResult<Vec<SealedHeader>>;
+impl<H> Stream for TaskDownloader<H> {
+    type Item = HeadersDownloaderResult<Vec<SealedHeader<H>>, H>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().from_downloader.poll_next(cx)
@@ -108,9 +110,9 @@ impl Stream for TaskDownloader {
 }
 
 /// A [`HeaderDownloader`] that runs on its own task
-struct SpawnedDownloader<T> {
-    updates: UnboundedReceiverStream<DownloaderUpdates>,
-    headers_tx: PollSender<HeadersDownloaderResult<Vec<SealedHeader>>>,
+struct SpawnedDownloader<T: HeaderDownloader> {
+    updates: UnboundedReceiverStream<DownloaderUpdates<T::Header>>,
+    headers_tx: PollSender<HeadersDownloaderResult<Vec<SealedHeader<T::Header>>, T::Header>>,
     downloader: T,
 }
 
@@ -170,9 +172,9 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
 }
 
 /// Commands delegated tot the spawned [`HeaderDownloader`]
-enum DownloaderUpdates {
-    UpdateSyncGap(SealedHeader, SyncTarget),
-    UpdateLocalHead(SealedHeader),
+enum DownloaderUpdates<H> {
+    UpdateSyncGap(SealedHeader<H>, SyncTarget),
+    UpdateLocalHead(SealedHeader<H>),
     UpdateSyncTarget(SyncTarget),
     SetBatchSize(usize),
 }

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -110,6 +110,7 @@ impl<H> Stream for TaskDownloader<H> {
 }
 
 /// A [`HeaderDownloader`] that runs on its own task
+#[expect(clippy::complexity)]
 struct SpawnedDownloader<T: HeaderDownloader> {
     updates: UnboundedReceiverStream<DownloaderUpdates<T::Header>>,
     headers_tx: PollSender<HeadersDownloaderResult<Vec<SealedHeader<T::Header>>, T::Header>>,

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -46,7 +46,8 @@ impl<H: Send + Sync + Unpin + 'static> TaskDownloader<H> {
     /// # use reth_downloaders::headers::task::TaskDownloader;
     /// # use reth_consensus::Consensus;
     /// # use reth_network_p2p::headers::client::HeadersClient;
-    /// # fn t<H: HeadersClient + 'static>(consensus:Arc<dyn Consensus>, client: Arc<H>) {
+    /// # use reth_primitives_traits::BlockHeader;
+    /// # fn t<H: HeadersClient<Header: BlockHeader> + 'static>(consensus:Arc<dyn Consensus<H::Header>>, client: Arc<H>) {
     ///    let downloader = ReverseHeadersDownloader::<H>::builder().build(
     ///        client,
     ///        consensus

--- a/crates/net/downloaders/src/test_utils/bodies_client.rs
+++ b/crates/net/downloaders/src/test_utils/bodies_client.rs
@@ -78,6 +78,7 @@ impl DownloadClient for TestBodiesClient {
 }
 
 impl BodiesClient for TestBodiesClient {
+    type Body = BlockBody;
     type Output = BodiesFut;
 
     fn get_block_bodies_with_priority(

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 reth-chainspec.workspace = true
 reth-codecs-derive.workspace = true
 reth-primitives.workspace = true
-reth-primitives-traits.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -16,8 +16,10 @@ workspace = true
 reth-chainspec.workspace = true
 reth-codecs-derive.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 
 # ethereum
+alloy-consensus.workspace = true
 alloy-chains = { workspace = true, features = ["rlp"] }
 alloy-eips.workspace = true
 alloy-primitives.workspace = true

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -35,7 +35,7 @@ pub enum MessageError {
 /// An `eth` protocol message, containing a message ID and payload.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ProtocolMessage<N: NetworkPrimitives> {
+pub struct ProtocolMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The unique identifier representing the type of the Ethereum message.
     pub message_type: EthMessageID,
     /// The content of the message, including specific data based on the message type.
@@ -148,7 +148,7 @@ impl<N: NetworkPrimitives> From<EthMessage<N>> for ProtocolMessage<N> {
 
 /// Represents messages that can be sent to multiple peers.
 #[derive(Clone, Debug)]
-pub struct ProtocolBroadcastMessage<N: NetworkPrimitives> {
+pub struct ProtocolBroadcastMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The unique identifier representing the type of the Ethereum message.
     pub message_type: EthMessageID,
     /// The content of the message to be broadcasted, including specific data based on the message
@@ -193,7 +193,7 @@ impl<N: NetworkPrimitives> From<EthBroadcastMessage<N>> for ProtocolBroadcastMes
 /// [`NewPooledTransactionHashes68`] is defined.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum EthMessage<N: NetworkPrimitives> {
+pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Represents a Status message required for the protocol handshake.
     Status(Status),
     /// Represents a `NewBlockHashes` message broadcast to the network.
@@ -317,7 +317,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
 ///
 /// Note: This is only useful for outgoing messages.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum EthBroadcastMessage<N: NetworkPrimitives> {
+pub enum EthBroadcastMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Represents a new block broadcast message.
     NewBlock(Arc<NewBlock<N::Block>>),
     /// Represents a transactions broadcast message.

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -35,7 +35,7 @@ pub enum MessageError {
 /// An `eth` protocol message, containing a message ID and payload.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ProtocolMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
+pub struct ProtocolMessage<N: NetworkPrimitives> {
     /// The unique identifier representing the type of the Ethereum message.
     pub message_type: EthMessageID,
     /// The content of the message, including specific data based on the message type.
@@ -193,7 +193,7 @@ impl<N: NetworkPrimitives> From<EthBroadcastMessage<N>> for ProtocolBroadcastMes
 /// [`NewPooledTransactionHashes68`] is defined.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
+pub enum EthMessage<N: NetworkPrimitives> {
     /// Represents a Status message required for the protocol handshake.
     Status(Status),
     /// Represents a `NewBlockHashes` message broadcast to the network.
@@ -317,7 +317,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
 ///
 /// Note: This is only useful for outgoing messages.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum EthBroadcastMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
+pub enum EthBroadcastMessage<N: NetworkPrimitives> {
     /// Represents a new block broadcast message.
     NewBlock(Arc<NewBlock<N::Block>>),
     /// Represents a transactions broadcast message.

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -2,7 +2,9 @@
 
 use std::fmt::Debug;
 
+use alloy_consensus::BlockHeader;
 use alloy_rlp::{Decodable, Encodable};
+use reth_primitives_traits::BlockBody;
 
 /// Abstraction over primitive types which might appear in network messages. See
 /// [`crate::EthMessage`] for more context.
@@ -10,7 +12,8 @@ pub trait NetworkPrimitives:
     Send + Sync + Unpin + Clone + Debug + PartialEq + Eq + 'static
 {
     /// The block header type.
-    type BlockHeader: Encodable
+    type BlockHeader: BlockHeader
+        + Encodable
         + Decodable
         + Send
         + Sync
@@ -21,7 +24,8 @@ pub trait NetworkPrimitives:
         + Eq
         + 'static;
     /// The block body type.
-    type BlockBody: Encodable
+    type BlockBody: BlockBody
+        + Encodable
         + Decodable
         + Send
         + Sync

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 
 use alloy_consensus::BlockHeader;
 use alloy_rlp::{Decodable, Encodable};
-use reth_primitives_traits::BlockBody;
 
 /// Abstraction over primitive types which might appear in network messages. See
 /// [`crate::EthMessage`] for more context.
@@ -24,8 +23,7 @@ pub trait NetworkPrimitives:
         + Eq
         + 'static;
     /// The block body type.
-    type BlockBody: BlockBody
-        + Encodable
+    type BlockBody: Encodable
         + Decodable
         + Send
         + Sync

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use alloy_primitives::bytes::Bytes;
 use derive_more::{Deref, DerefMut};
+use reth_eth_wire_types::{EthMessage, EthNetworkPrimitives, NetworkPrimitives};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -30,7 +31,13 @@ pub struct RawCapabilityMessage {
 /// network.
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum CapabilityMessage {
+pub enum CapabilityMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
+    /// Eth sub-protocol message.
+    #[cfg_attr(
+        feature = "serde",
+        serde(bound = "EthMessage<N>: Serialize + serde::de::DeserializeOwned")
+    )]
+    Eth(EthMessage<N>),
     /// Any other capability message.
     Other(RawCapabilityMessage),
 }

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -31,8 +31,6 @@ pub struct RawCapabilityMessage {
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CapabilityMessage {
-    /// Eth sub-protocol message.
-    Eth(EthMessage),
     /// Any other capability message.
     Other(RawCapabilityMessage),
 }

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -5,7 +5,7 @@ use crate::{
     p2pstream::MAX_RESERVED_MESSAGE_ID,
     protocol::{ProtoVersion, Protocol},
     version::ParseVersionError,
-    Capability, EthMessage, EthMessageID, EthVersion,
+    Capability, EthMessageID, EthVersion,
 };
 use alloy_primitives::bytes::Bytes;
 use derive_more::{Deref, DerefMut};

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -675,6 +675,7 @@ mod tests {
         },
         UnauthedP2PStream,
     };
+    use reth_eth_wire_types::EthNetworkPrimitives;
     use tokio::{net::TcpListener, sync::oneshot};
     use tokio_util::codec::Decoder;
 
@@ -694,7 +695,7 @@ mod tests {
                 UnauthedP2PStream::new(stream).handshake(server_hello).await.unwrap();
 
             let (_eth_stream, _) = UnauthedEthStream::new(p2p_stream)
-                .handshake(other_status, other_fork_filter)
+                .handshake::<EthNetworkPrimitives>(other_status, other_fork_filter)
                 .await
                 .unwrap();
 
@@ -709,7 +710,9 @@ mod tests {
             .into_satellite_stream_with_handshake(
                 eth.capability().as_ref(),
                 move |proxy| async move {
-                    UnauthedEthStream::new(proxy).handshake(status, fork_filter).await
+                    UnauthedEthStream::new(proxy)
+                        .handshake::<EthNetworkPrimitives>(status, fork_filter)
+                        .await
                 },
             )
             .await
@@ -732,7 +735,7 @@ mod tests {
             let (conn, _) = UnauthedP2PStream::new(stream).handshake(server_hello).await.unwrap();
 
             let (mut st, _their_status) = RlpxProtocolMultiplexer::new(conn)
-                .into_eth_satellite_stream(other_status, other_fork_filter)
+                .into_eth_satellite_stream::<EthNetworkPrimitives>(other_status, other_fork_filter)
                 .await
                 .unwrap();
 
@@ -763,7 +766,7 @@ mod tests {
 
         let conn = connect_passthrough(local_addr, test_hello().0).await;
         let (mut st, _their_status) = RlpxProtocolMultiplexer::new(conn)
-            .into_eth_satellite_stream(status, fork_filter)
+            .into_eth_satellite_stream::<EthNetworkPrimitives>(status, fork_filter)
             .await
             .unwrap();
 

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 use bytes::{Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream, StreamExt, TryStream, TryStreamExt};
+use reth_eth_wire_types::NetworkPrimitives;
 use reth_primitives::ForkFilter;
 use tokio::sync::{mpsc, mpsc::UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -204,11 +205,11 @@ impl<St> RlpxProtocolMultiplexer<St> {
 
     /// Converts this multiplexer into a [`RlpxSatelliteStream`] with eth protocol as the given
     /// primary protocol.
-    pub async fn into_eth_satellite_stream(
+    pub async fn into_eth_satellite_stream<N: NetworkPrimitives>(
         self,
         status: Status,
         fork_filter: ForkFilter,
-    ) -> Result<(RlpxSatelliteStream<St, EthStream<ProtocolProxy>>, Status), EthStreamError>
+    ) -> Result<(RlpxSatelliteStream<St, EthStream<ProtocolProxy, N>>, Status), EthStreamError>
     where
         St: Stream<Item = io::Result<BytesMut>> + Sink<Bytes, Error = io::Error> + Unpin,
     {

--- a/crates/net/network-api/src/downloaders.rs
+++ b/crates/net/network-api/src/downloaders.rs
@@ -1,5 +1,7 @@
 //! API related to syncing blocks.
 
+use std::fmt::Debug;
+
 use futures::Future;
 use reth_network_p2p::BlockClient;
 use tokio::sync::oneshot;
@@ -7,10 +9,13 @@ use tokio::sync::oneshot;
 /// Provides client for downloading blocks.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockDownloaderProvider {
+    /// The client this type can provide.
+    type Client: BlockClient<Header: Debug, Body: Debug> + Send + Sync + Clone + 'static;
+
     /// Returns a new [`BlockClient`], used for fetching blocks from peers.
     ///
     /// The client is the entrypoint for sending block requests to the network.
     fn fetch_client(
         &self,
-    ) -> impl Future<Output = Result<impl BlockClient + 'static, oneshot::error::RecvError>> + Send;
+    ) -> impl Future<Output = Result<Self::Client, oneshot::error::RecvError>> + Send;
 }

--- a/crates/net/network-api/src/events.rs
+++ b/crates/net/network-api/src/events.rs
@@ -66,10 +66,10 @@ pub enum NetworkEvent<R = PeerRequest> {
 impl<R> Clone for NetworkEvent<R> {
     fn clone(&self) -> Self {
         match self {
-            NetworkEvent::SessionClosed { peer_id, reason } => {
-                NetworkEvent::SessionClosed { peer_id: *peer_id, reason: reason.clone() }
+            Self::SessionClosed { peer_id, reason } => {
+                Self::SessionClosed { peer_id: *peer_id, reason: *reason }
             }
-            NetworkEvent::SessionEstablished {
+            Self::SessionEstablished {
                 peer_id,
                 remote_addr,
                 client_version,
@@ -77,7 +77,7 @@ impl<R> Clone for NetworkEvent<R> {
                 messages,
                 status,
                 version,
-            } => NetworkEvent::SessionEstablished {
+            } => Self::SessionEstablished {
                 peer_id: *peer_id,
                 remote_addr: *remote_addr,
                 client_version: client_version.clone(),
@@ -86,8 +86,8 @@ impl<R> Clone for NetworkEvent<R> {
                 status: status.clone(),
                 version: *version,
             },
-            NetworkEvent::PeerAdded(peer) => NetworkEvent::PeerAdded(peer.clone()),
-            NetworkEvent::PeerRemoved(peer) => NetworkEvent::PeerRemoved(peer.clone()),
+            Self::PeerAdded(peer) => Self::PeerAdded(*peer),
+            Self::PeerRemoved(peer) => Self::PeerRemoved(*peer),
         }
     }
 }

--- a/crates/net/network-api/src/events.rs
+++ b/crates/net/network-api/src/events.rs
@@ -3,9 +3,7 @@
 use std::{fmt, net::SocketAddr, sync::Arc};
 
 use reth_eth_wire_types::{
-    message::RequestPair, BlockBodies, BlockHeaders, Capabilities, DisconnectReason, EthMessage,
-    EthVersion, GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
-    NodeData, PooledTransactions, Receipts, Status,
+    message::RequestPair, BlockBodies, BlockHeaders, Capabilities, DisconnectReason, EthMessage, EthVersion, GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts, NetworkPrimitives, NodeData, PooledTransactions, Receipts, Status
 };
 use reth_ethereum_forks::ForkId;
 use reth_network_p2p::error::{RequestError, RequestResult};
@@ -18,8 +16,11 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 /// Provides event subscription for the network.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait NetworkEventListenerProvider: Send + Sync {
+    /// Type of requests that can be sent to peers.
+    type PeerRequest: Send + Sync + 'static;
+
     /// Creates a new [`NetworkEvent`] listener channel.
-    fn event_listener(&self) -> EventStream<NetworkEvent>;
+    fn event_listener(&self) -> EventStream<NetworkEvent<Self::PeerRequest>>;
     /// Returns a new [`DiscoveryEvent`] stream.
     ///
     /// This stream yields [`DiscoveryEvent`]s for each peer that is discovered.
@@ -31,7 +32,7 @@ pub trait NetworkEventListenerProvider: Send + Sync {
 /// This includes any event types that may be relevant to tasks, for metrics, keep track of peers
 /// etc.
 #[derive(Debug, Clone)]
-pub enum NetworkEvent {
+pub enum NetworkEvent<R> {
     /// Closed the peer session.
     SessionClosed {
         /// The identifier of the peer to which a session was closed.
@@ -50,7 +51,7 @@ pub enum NetworkEvent {
         /// Capabilities the peer announced
         capabilities: Arc<Capabilities>,
         /// A request channel to the session task.
-        messages: PeerRequestSender,
+        messages: PeerRequestSender<R>,
         /// The status of the peer to which a session was established.
         status: Arc<Status>,
         /// negotiated eth version of the session
@@ -98,7 +99,7 @@ pub enum DiscoveredEvent {
 
 /// Protocol related request messages that expect a response
 #[derive(Debug)]
-pub enum PeerRequest {
+pub enum PeerRequest<N: NetworkPrimitives> {
     /// Requests block headers from the peer.
     ///
     /// The response should be sent through the channel.
@@ -106,7 +107,7 @@ pub enum PeerRequest {
         /// The request for block headers.
         request: GetBlockHeaders,
         /// The channel to send the response for block headers.
-        response: oneshot::Sender<RequestResult<BlockHeaders>>,
+        response: oneshot::Sender<RequestResult<BlockHeaders<N::BlockHeader>>>,
     },
     /// Requests block bodies from the peer.
     ///
@@ -115,7 +116,7 @@ pub enum PeerRequest {
         /// The request for block bodies.
         request: GetBlockBodies,
         /// The channel to send the response for block bodies.
-        response: oneshot::Sender<RequestResult<BlockBodies>>,
+        response: oneshot::Sender<RequestResult<BlockBodies<N::BlockBody>>>,
     },
     /// Requests pooled transactions from the peer.
     ///
@@ -148,7 +149,7 @@ pub enum PeerRequest {
 
 // === impl PeerRequest ===
 
-impl PeerRequest {
+impl<N: NetworkPrimitives> PeerRequest<N> {
     /// Invoked if we received a response which does not match the request
     pub fn send_bad_response(self) {
         self.send_err_response(RequestError::BadResponse)
@@ -166,7 +167,7 @@ impl PeerRequest {
     }
 
     /// Returns the [`EthMessage`] for this type
-    pub fn create_request_message(&self, request_id: u64) -> EthMessage {
+    pub fn create_request_message(&self, request_id: u64) -> EthMessage<N> {
         match self {
             Self::GetBlockHeaders { request, .. } => {
                 EthMessage::GetBlockHeaders(RequestPair { request_id, message: *request })
@@ -200,23 +201,23 @@ impl PeerRequest {
 
 /// A Cloneable connection for sending _requests_ directly to the session of a peer.
 #[derive(Clone)]
-pub struct PeerRequestSender {
+pub struct PeerRequestSender<R> {
     /// id of the remote node.
     pub peer_id: PeerId,
     /// The Sender half connected to a session.
-    pub to_session_tx: mpsc::Sender<PeerRequest>,
+    pub to_session_tx: mpsc::Sender<R>,
 }
 
 // === impl PeerRequestSender ===
 
-impl PeerRequestSender {
+impl<R> PeerRequestSender<R> {
     /// Constructs a new sender instance that's wired to a session
-    pub const fn new(peer_id: PeerId, to_session_tx: mpsc::Sender<PeerRequest>) -> Self {
+    pub const fn new(peer_id: PeerId, to_session_tx: mpsc::Sender<R>) -> Self {
         Self { peer_id, to_session_tx }
     }
 
     /// Attempts to immediately send a message on this Sender
-    pub fn try_send(&self, req: PeerRequest) -> Result<(), mpsc::error::TrySendError<PeerRequest>> {
+    pub fn try_send(&self, req: R) -> Result<(), mpsc::error::TrySendError<R>> {
         self.to_session_tx.try_send(req)
     }
 
@@ -226,7 +227,7 @@ impl PeerRequestSender {
     }
 }
 
-impl fmt::Debug for PeerRequestSender {
+impl<R> fmt::Debug for PeerRequestSender<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PeerRequestSender").field("peer_id", &self.peer_id).finish_non_exhaustive()
     }

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -36,6 +36,7 @@ pub use events::{
 use std::{future::Future, net::SocketAddr, sync::Arc, time::Instant};
 
 use reth_eth_wire_types::{capability::Capabilities, DisconnectReason, EthVersion, Status};
+use reth_network_p2p::EthBlockClient;
 use reth_network_peers::NodeRecord;
 
 /// The `PeerId` type.
@@ -43,7 +44,7 @@ pub type PeerId = alloy_primitives::B512;
 
 /// Helper trait that unifies network API needed to launch node.
 pub trait FullNetwork:
-    BlockDownloaderProvider
+    BlockDownloaderProvider<Client: EthBlockClient>
     + NetworkSyncUpdater
     + NetworkInfo
     + NetworkEventListenerProvider
@@ -55,7 +56,7 @@ pub trait FullNetwork:
 }
 
 impl<T> FullNetwork for T where
-    T: BlockDownloaderProvider
+    T: BlockDownloaderProvider<Client: EthBlockClient>
         + NetworkSyncUpdater
         + NetworkInfo
         + NetworkEventListenerProvider

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -34,6 +34,7 @@ reth-network-peers = { workspace = true, features = ["net"] }
 reth-network-types.workspace = true
 
 # ethereum
+alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true

--- a/crates/net/network/src/fetch/client.rs
+++ b/crates/net/network/src/fetch/client.rs
@@ -7,6 +7,7 @@ use std::sync::{
 
 use alloy_primitives::B256;
 use futures::{future, future::Either};
+use reth_eth_wire::{EthNetworkPrimitives, NetworkPrimitives};
 use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::{
     bodies::client::{BodiesClient, BodiesFut},
@@ -17,7 +18,6 @@ use reth_network_p2p::{
 };
 use reth_network_peers::PeerId;
 use reth_network_types::ReputationChangeKind;
-use reth_primitives::Header;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 use crate::{fetch::DownloadRequest, flattened_response::FlattenedResponse};
@@ -30,16 +30,16 @@ use crate::{fetch::DownloadRequest, flattened_response::FlattenedResponse};
 ///
 /// include_mmd!("docs/mermaid/fetch-client.mmd")
 #[derive(Debug, Clone)]
-pub struct FetchClient {
+pub struct FetchClient<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Sender half of the request channel.
-    pub(crate) request_tx: UnboundedSender<DownloadRequest>,
+    pub(crate) request_tx: UnboundedSender<DownloadRequest<N>>,
     /// The handle to the peers
     pub(crate) peers_handle: PeersHandle,
     /// Number of active peer sessions the node's currently handling.
     pub(crate) num_active_peers: Arc<AtomicUsize>,
 }
 
-impl DownloadClient for FetchClient {
+impl<N: NetworkPrimitives> DownloadClient for FetchClient<N> {
     fn report_bad_message(&self, peer_id: PeerId) {
         self.peers_handle.reputation_change(peer_id, ReputationChangeKind::BadMessage);
     }
@@ -53,8 +53,9 @@ impl DownloadClient for FetchClient {
 // or an error.
 type HeadersClientFuture<T> = Either<FlattenedResponse<T>, future::Ready<T>>;
 
-impl HeadersClient for FetchClient {
-    type Output = HeadersClientFuture<PeerRequestResult<Vec<Header>>>;
+impl<N: NetworkPrimitives> HeadersClient for FetchClient<N> {
+    type Header = N::BlockHeader;
+    type Output = HeadersClientFuture<PeerRequestResult<Vec<N::BlockHeader>>>;
 
     /// Sends a `GetBlockHeaders` request to an available peer.
     fn get_headers_with_priority(
@@ -75,8 +76,9 @@ impl HeadersClient for FetchClient {
     }
 }
 
-impl BodiesClient for FetchClient {
-    type Output = BodiesFut;
+impl<N: NetworkPrimitives> BodiesClient for FetchClient<N> {
+    type Body = N::BlockBody;
+    type Output = BodiesFut<N::BlockBody>;
 
     /// Sends a `GetBlockBodies` request to an available peer.
     fn get_block_bodies_with_priority(

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -18,10 +18,7 @@ use reth_network_api::{
     NetworkEventListenerProvider, NetworkInfo, NetworkStatus, PeerInfo, PeerRequest, Peers,
     PeersInfo,
 };
-use reth_network_p2p::{
-    sync::{NetworkSyncUpdater, SyncState, SyncStateProvider},
-    BlockClient,
-};
+use reth_network_p2p::sync::{NetworkSyncUpdater, SyncState, SyncStateProvider};
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_network_types::{PeerAddr, PeerKind, Reputation, ReputationChangeKind};
 use reth_primitives::{Head, TransactionSigned};
@@ -400,7 +397,9 @@ impl NetworkSyncUpdater for NetworkHandle {
 }
 
 impl BlockDownloaderProvider for NetworkHandle {
-    async fn fetch_client(&self) -> Result<impl BlockClient + 'static, oneshot::error::RecvError> {
+    type Client = FetchClient;
+
+    async fn fetch_client(&self) -> Result<Self::Client, oneshot::error::RecvError> {
         let (tx, rx) = oneshot::channel();
         let _ = self.manager().send(NetworkHandleMessage::FetchClient(tx));
         rx.await

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -56,5 +56,6 @@ std = [
 	"reth-primitives/std",
 	"alloy-eips/std",
 	"alloy-primitives/std",
-	"reth-primitives-traits/std"
+	"reth-primitives-traits/std",
+    "alloy-consensus/std",
 ]

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -22,6 +22,7 @@ reth-network-types.workspace = true
 reth-storage-errors.workspace = true
 
 # ethereum
+alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 

--- a/crates/net/p2p/src/bodies/downloader.rs
+++ b/crates/net/p2p/src/bodies/downloader.rs
@@ -5,14 +5,19 @@ use futures::Stream;
 use std::ops::RangeInclusive;
 
 /// Body downloader return type.
-pub type BodyDownloaderResult = DownloadResult<Vec<BlockResponse>>;
+pub type BodyDownloaderResult<B> = DownloadResult<Vec<BlockResponse<B>>>;
 
 /// A downloader capable of fetching and yielding block bodies from block headers.
 ///
 /// A downloader represents a distinct strategy for submitting requests to download block bodies,
 /// while a [`BodiesClient`][crate::bodies::client::BodiesClient] represents a client capable of
 /// fulfilling these requests.
-pub trait BodyDownloader: Send + Sync + Stream<Item = BodyDownloaderResult> + Unpin {
+pub trait BodyDownloader:
+    Send + Sync + Stream<Item = BodyDownloaderResult<Self::Body>> + Unpin
+{
+    /// The type of the body that is being downloaded.
+    type Body: Send + Sync + Unpin + 'static;
+
     /// Method for setting the download range.
     fn set_download_range(&mut self, range: RangeInclusive<BlockNumber>) -> DownloadResult<()>;
 }

--- a/crates/net/p2p/src/bodies/response.rs
+++ b/crates/net/p2p/src/bodies/response.rs
@@ -4,14 +4,14 @@ use reth_primitives_traits::InMemorySize;
 
 /// The block response
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum BlockResponse {
+pub enum BlockResponse<B> {
     /// Full block response (with transactions or ommers)
-    Full(SealedBlock),
+    Full(SealedBlock<reth_primitives::Header, B>),
     /// The empty block response
     Empty(SealedHeader),
 }
 
-impl BlockResponse {
+impl<B> BlockResponse<B> {
     /// Return the reference to the response header
     pub const fn header(&self) -> &SealedHeader {
         match self {
@@ -34,8 +34,7 @@ impl BlockResponse {
     }
 }
 
-impl InMemorySize for BlockResponse {
-    /// Calculates a heuristic for the in-memory size of the [`BlockResponse`].
+impl<B: InMemorySize> InMemorySize for BlockResponse<B> {
     #[inline]
     fn size(&self) -> usize {
         match self {

--- a/crates/net/p2p/src/bodies/response.rs
+++ b/crates/net/p2p/src/bodies/response.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::{BlockNumber, U256};
-use reth_primitives::{SealedBlock, SealedHeader};
+use reth_primitives::{BlockBody, SealedBlock, SealedHeader};
 use reth_primitives_traits::InMemorySize;
 
 /// The block response
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum BlockResponse<B> {
+pub enum BlockResponse<B = BlockBody> {
     /// Full block response (with transactions or ommers)
     Full(SealedBlock<reth_primitives::Header, B>),
     /// The empty block response

--- a/crates/net/p2p/src/either.rs
+++ b/crates/net/p2p/src/either.rs
@@ -32,8 +32,9 @@ where
 impl<A, B> BodiesClient for Either<A, B>
 where
     A: BodiesClient,
-    B: BodiesClient,
+    B: BodiesClient<Body = A::Body>,
 {
+    type Body = A::Body;
     type Output = Either<A::Output, B::Output>;
 
     fn get_block_bodies_with_priority(
@@ -51,8 +52,9 @@ where
 impl<A, B> HeadersClient for Either<A, B>
 where
     A: HeadersClient,
-    B: HeadersClient,
+    B: HeadersClient<Header = A::Header>,
 {
+    type Header = A::Header;
     type Output = Either<A::Output, B::Output>;
 
     fn get_headers_with_priority(

--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -1,13 +1,14 @@
 use std::ops::RangeInclusive;
 
 use super::headers::client::HeadersRequest;
+use alloy_consensus::BlockHeader;
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{BlockNumber, B256};
 use derive_more::{Display, Error};
 use reth_consensus::ConsensusError;
 use reth_network_peers::WithPeerId;
 use reth_network_types::ReputationChangeKind;
-use reth_primitives::{GotExpected, GotExpectedBoxed, Header};
+use reth_primitives::{GotExpected, GotExpectedBoxed};
 use reth_storage_errors::{db::DatabaseError, provider::ProviderError};
 use tokio::sync::{mpsc, oneshot};
 
@@ -26,7 +27,7 @@ pub trait EthResponseValidator {
     fn reputation_change_err(&self) -> Option<ReputationChangeKind>;
 }
 
-impl EthResponseValidator for RequestResult<Vec<Header>> {
+impl<H: BlockHeader> EthResponseValidator for RequestResult<Vec<H>> {
     fn is_likely_bad_headers_response(&self, request: &HeadersRequest) -> bool {
         match self {
             Ok(headers) => {
@@ -38,7 +39,7 @@ impl EthResponseValidator for RequestResult<Vec<Header>> {
 
                 match request.start {
                     BlockHashOrNumber::Number(block_number) => {
-                        headers.first().is_some_and(|header| block_number != header.number)
+                        headers.first().is_some_and(|header| block_number != header.number())
                     }
                     BlockHashOrNumber::Hash(_) => {
                         // we don't want to hash the header

--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -217,6 +217,8 @@ impl From<ProviderError> for DownloadError {
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::Header;
+
     use super::*;
 
     #[test]

--- a/crates/net/p2p/src/headers/client.rs
+++ b/crates/net/p2p/src/headers/client.rs
@@ -27,8 +27,10 @@ pub type HeadersFut = Pin<Box<dyn Future<Output = PeerRequestResult<Vec<Header>>
 /// The block headers downloader client
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait HeadersClient: DownloadClient {
+    /// The header type this client fetches.
+    type Header: Send + Sync + Unpin;
     /// The headers future type
-    type Output: Future<Output = PeerRequestResult<Vec<Header>>> + Sync + Send + Unpin;
+    type Output: Future<Output = PeerRequestResult<Vec<Self::Header>>> + Sync + Send + Unpin;
 
     /// Sends the header request to the p2p network and returns the header response received from a
     /// peer.

--- a/crates/net/p2p/src/headers/client.rs
+++ b/crates/net/p2p/src/headers/client.rs
@@ -75,11 +75,11 @@ pub struct SingleHeaderRequest<Fut> {
     fut: Fut,
 }
 
-impl<Fut> Future for SingleHeaderRequest<Fut>
+impl<Fut, H> Future for SingleHeaderRequest<Fut>
 where
-    Fut: Future<Output = PeerRequestResult<Vec<Header>>> + Sync + Send + Unpin,
+    Fut: Future<Output = PeerRequestResult<Vec<H>>> + Sync + Send + Unpin,
 {
-    type Output = PeerRequestResult<Option<Header>>;
+    type Output = PeerRequestResult<Option<H>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let resp = ready!(self.get_mut().fut.poll_unpin(cx));

--- a/crates/net/p2p/src/headers/downloader.rs
+++ b/crates/net/p2p/src/headers/downloader.rs
@@ -19,7 +19,7 @@ pub trait HeaderDownloader:
     + Stream<Item = HeadersDownloaderResult<Vec<SealedHeader<Self::Header>>, Self::Header>>
     + Unpin
 {
-    /// The header type being downlaoded.
+    /// The header type being downloaded.
     type Header: Send + Sync + Unpin + 'static;
 
     /// Updates the gap to sync which ranges from local head to the sync target

--- a/crates/net/p2p/src/headers/downloader.rs
+++ b/crates/net/p2p/src/headers/downloader.rs
@@ -1,5 +1,6 @@
 use super::error::HeadersDownloaderResult;
 use crate::error::{DownloadError, DownloadResult};
+use alloy_consensus::BlockHeader;
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::B256;
 use futures::Stream;
@@ -13,19 +14,25 @@ use reth_primitives::SealedHeader;
 ///
 /// A [`HeaderDownloader`] is a [Stream] that returns batches of headers.
 pub trait HeaderDownloader:
-    Send + Sync + Stream<Item = HeadersDownloaderResult<Vec<SealedHeader>>> + Unpin
+    Send
+    + Sync
+    + Stream<Item = HeadersDownloaderResult<Vec<SealedHeader<Self::Header>>, Self::Header>>
+    + Unpin
 {
+    /// The header type being downlaoded.
+    type Header: Send + Sync + Unpin + 'static;
+
     /// Updates the gap to sync which ranges from local head to the sync target
     ///
     /// See also [`HeaderDownloader::update_sync_target`] and
     /// [`HeaderDownloader::update_local_head`]
-    fn update_sync_gap(&mut self, head: SealedHeader, target: SyncTarget) {
+    fn update_sync_gap(&mut self, head: SealedHeader<Self::Header>, target: SyncTarget) {
         self.update_local_head(head);
         self.update_sync_target(target);
     }
 
     /// Updates the block number of the local database
-    fn update_local_head(&mut self, head: SealedHeader);
+    fn update_local_head(&mut self, head: SealedHeader<Self::Header>);
 
     /// Updates the target we want to sync to
     fn update_sync_target(&mut self, target: SyncTarget);
@@ -74,23 +81,23 @@ impl SyncTarget {
 /// Validate whether the header is valid in relation to it's parent
 ///
 /// Returns Ok(false) if the
-pub fn validate_header_download(
-    consensus: &dyn Consensus,
-    header: &SealedHeader,
-    parent: &SealedHeader,
+pub fn validate_header_download<H: BlockHeader>(
+    consensus: &dyn Consensus<H>,
+    header: &SealedHeader<H>,
+    parent: &SealedHeader<H>,
 ) -> DownloadResult<()> {
     // validate header against parent
     consensus.validate_header_against_parent(header, parent).map_err(|error| {
         DownloadError::HeaderValidation {
             hash: header.hash(),
-            number: header.number,
+            number: header.number(),
             error: Box::new(error),
         }
     })?;
     // validate header standalone
     consensus.validate_header(header).map_err(|error| DownloadError::HeaderValidation {
         hash: header.hash(),
-        number: header.number,
+        number: header.number(),
         error: Box::new(error),
     })?;
     Ok(())

--- a/crates/net/p2p/src/headers/error.rs
+++ b/crates/net/p2p/src/headers/error.rs
@@ -3,19 +3,19 @@ use reth_consensus::ConsensusError;
 use reth_primitives::SealedHeader;
 
 /// Header downloader result
-pub type HeadersDownloaderResult<T> = Result<T, HeadersDownloaderError>;
+pub type HeadersDownloaderResult<T, H> = Result<T, HeadersDownloaderError<H>>;
 
 /// Error variants that can happen when sending requests to a session.
 #[derive(Debug, Clone, Eq, PartialEq, Display, Error)]
-pub enum HeadersDownloaderError {
+pub enum HeadersDownloaderError<H> {
     /// The downloaded header cannot be attached to the local head,
     /// but is valid otherwise.
     #[display("valid downloaded header cannot be attached to the local head: {error}")]
     DetachedHead {
         /// The local head we attempted to attach to.
-        local_head: Box<SealedHeader>,
+        local_head: Box<SealedHeader<H>>,
         /// The header we attempted to attach.
-        header: Box<SealedHeader>,
+        header: Box<SealedHeader<H>>,
         /// The error that occurred when attempting to attach the header.
         #[error(source)]
         error: Box<ConsensusError>,

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -52,3 +52,14 @@ pub use headers::client::HeadersClient;
 pub trait BlockClient: HeadersClient + BodiesClient + Unpin + Clone {}
 
 impl<T> BlockClient for T where T: HeadersClient + BodiesClient + Unpin + Clone {}
+
+/// The [`BlockClient`] providing Ethereum block parts.
+pub trait EthBlockClient:
+    BlockClient<Header = reth_primitives::Header, Body = reth_primitives::BlockBody>
+{
+}
+
+impl<T> EthBlockClient for T where
+    T: BlockClient<Header = reth_primitives::Header, Body = reth_primitives::BlockBody>
+{
+}

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -49,18 +49,6 @@ pub use bodies::client::BodiesClient;
 pub use headers::client::HeadersClient;
 
 /// Helper trait that unifies network behaviour needed for fetching blocks.
-pub trait BlockClient:
-    HeadersClient<Header = reth_primitives::Header>
-    + BodiesClient<Body = reth_primitives::BlockBody>
-    + Unpin
-    + Clone
-{
-}
+pub trait BlockClient: HeadersClient + BodiesClient + Unpin + Clone {}
 
-impl<T> BlockClient for T where
-    T: HeadersClient<Header = reth_primitives::Header>
-        + BodiesClient<Body = reth_primitives::BlockBody>
-        + Unpin
-        + Clone
-{
-}
+impl<T> BlockClient for T where T: HeadersClient + BodiesClient + Unpin + Clone {}

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -49,6 +49,18 @@ pub use bodies::client::BodiesClient;
 pub use headers::client::HeadersClient;
 
 /// Helper trait that unifies network behaviour needed for fetching blocks.
-pub trait BlockClient: HeadersClient + BodiesClient + Unpin + Clone {}
+pub trait BlockClient:
+    HeadersClient<Header = reth_primitives::Header>
+    + BodiesClient<Body = reth_primitives::BlockBody>
+    + Unpin
+    + Clone
+{
+}
 
-impl<T> BlockClient for T where T: HeadersClient + BodiesClient + Unpin + Clone {}
+impl<T> BlockClient for T where
+    T: HeadersClient<Header = reth_primitives::Header>
+        + BodiesClient<Body = reth_primitives::BlockBody>
+        + Unpin
+        + Clone
+{
+}

--- a/crates/net/p2p/src/test_utils/bodies.rs
+++ b/crates/net/p2p/src/test_utils/bodies.rs
@@ -36,6 +36,7 @@ impl<F> BodiesClient for TestBodiesClient<F>
 where
     F: Fn(Vec<B256>) -> PeerRequestResult<Vec<BlockBody>> + Send + Sync,
 {
+    type Body = BlockBody;
     type Output = BodiesFut;
 
     fn get_block_bodies_with_priority(

--- a/crates/net/p2p/src/test_utils/full_block.rs
+++ b/crates/net/p2p/src/test_utils/full_block.rs
@@ -40,6 +40,7 @@ impl DownloadClient for NoopFullBlockClient {
 
 /// Implements the `BodiesClient` trait for the `NoopFullBlockClient` struct.
 impl BodiesClient for NoopFullBlockClient {
+    type Body = BlockBody;
     /// Defines the output type of the function.
     type Output = futures::future::Ready<PeerRequestResult<Vec<BlockBody>>>;
 
@@ -65,6 +66,7 @@ impl BodiesClient for NoopFullBlockClient {
 }
 
 impl HeadersClient for NoopFullBlockClient {
+    type Header = Header;
     /// The output type representing a future containing a peer request result with a vector of
     /// headers.
     type Output = futures::future::Ready<PeerRequestResult<Vec<Header>>>;
@@ -152,6 +154,7 @@ impl DownloadClient for TestFullBlockClient {
 
 /// Implements the `HeadersClient` trait for the `TestFullBlockClient` struct.
 impl HeadersClient for TestFullBlockClient {
+    type Header = Header;
     /// Specifies the associated output type.
     type Output = futures::future::Ready<PeerRequestResult<Vec<Header>>>;
 
@@ -205,6 +208,7 @@ impl HeadersClient for TestFullBlockClient {
 
 /// Implements the `BodiesClient` trait for the `TestFullBlockClient` struct.
 impl BodiesClient for TestFullBlockClient {
+    type Body = BlockBody;
     /// Defines the output type of the function.
     type Output = futures::future::Ready<PeerRequestResult<Vec<BlockBody>>>;
 

--- a/crates/net/p2p/src/test_utils/headers.rs
+++ b/crates/net/p2p/src/test_utils/headers.rs
@@ -62,6 +62,8 @@ impl TestHeaderDownloader {
 }
 
 impl HeaderDownloader for TestHeaderDownloader {
+    type Header = Header;
+
     fn update_local_head(&mut self, _head: SealedHeader) {}
 
     fn update_sync_target(&mut self, _target: SyncTarget) {}
@@ -72,7 +74,7 @@ impl HeaderDownloader for TestHeaderDownloader {
 }
 
 impl Stream for TestHeaderDownloader {
-    type Item = HeadersDownloaderResult<Vec<SealedHeader>>;
+    type Item = HeadersDownloaderResult<Vec<SealedHeader>, Header>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -229,6 +231,7 @@ impl DownloadClient for TestHeadersClient {
 }
 
 impl HeadersClient for TestHeadersClient {
+    type Header = Header;
     type Output = TestHeadersFut;
 
     fn get_headers_with_priority(

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -760,7 +760,7 @@ where
     /// necessary
     pub async fn max_block<C>(&self, client: C) -> eyre::Result<Option<BlockNumber>>
     where
-        C: HeadersClient,
+        C: HeadersClient<Header = reth_primitives::Header>,
     {
         self.node_config().max_block(client, self.provider_factory().clone()).await
     }

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -12,7 +12,7 @@ use reth_downloaders::{
 use reth_evm::execute::BlockExecutorProvider;
 use reth_exex::ExExManagerHandle;
 use reth_network_p2p::{
-    bodies::downloader::BodyDownloader, headers::downloader::HeaderDownloader, BlockClient,
+    bodies::downloader::BodyDownloader, headers::downloader::HeaderDownloader, EthBlockClient,
 };
 use reth_provider::{providers::ProviderNodeTypes, ProviderFactory};
 use reth_stages::{prelude::DefaultStages, stages::ExecutionStage, Pipeline, StageSet};
@@ -38,7 +38,7 @@ pub fn build_networked_pipeline<N, Client, Executor>(
 ) -> eyre::Result<Pipeline<N>>
 where
     N: ProviderNodeTypes,
-    Client: BlockClient + 'static,
+    Client: EthBlockClient + 'static,
     Executor: BlockExecutorProvider,
 {
     // building network downloaders using the fetch client

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -84,8 +84,8 @@ pub fn build_pipeline<N, H, B, Executor>(
 ) -> eyre::Result<Pipeline<N>>
 where
     N: ProviderNodeTypes,
-    H: HeaderDownloader + 'static,
-    B: BodyDownloader + 'static,
+    H: HeaderDownloader<Header = reth_primitives::Header> + 'static,
+    B: BodyDownloader<Body = reth_primitives::BlockBody> + 'static,
     Executor: BlockExecutorProvider,
 {
     let mut builder = Pipeline::<N>::builder();

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 [dependencies]
 # reth
 reth-chainspec.workspace = true
+reth-consensus.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-cli-util.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-storage-errors.workspace = true
@@ -30,7 +32,6 @@ reth-discv4.workspace = true
 reth-discv5.workspace = true
 reth-net-nat.workspace = true
 reth-network-peers.workspace = true
-reth-consensus-common.workspace = true
 reth-prune-types.workspace = true
 reth-stages-types.workspace = true
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -8,6 +8,7 @@ use crate::{
     dirs::{ChainPath, DataDirPath},
     utils::get_single_header,
 };
+use alloy_consensus::BlockHeader;
 use eyre::eyre;
 use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
 use reth_config::config::PruneConfig;
@@ -273,7 +274,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     ) -> eyre::Result<Option<BlockNumber>>
     where
         Provider: HeaderProvider,
-        Client: HeadersClient,
+        Client: HeadersClient<Header: reth_primitives_traits::BlockHeader>,
     {
         let max_block = if let Some(block) = self.debug.max_block {
             Some(block)
@@ -332,7 +333,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     ) -> ProviderResult<u64>
     where
         Provider: HeaderProvider,
-        Client: HeadersClient,
+        Client: HeadersClient<Header: reth_primitives_traits::BlockHeader>,
     {
         let header = provider.header_by_hash_or_number(tip.into())?;
 
@@ -342,7 +343,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             return Ok(header.number)
         }
 
-        Ok(self.fetch_tip_from_network(client, tip.into()).await.number)
+        Ok(self.fetch_tip_from_network(client, tip.into()).await.number())
     }
 
     /// Attempt to look up the block with the given number and return the header.
@@ -352,9 +353,9 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         &self,
         client: Client,
         tip: BlockHashOrNumber,
-    ) -> SealedHeader
+    ) -> SealedHeader<Client::Header>
     where
-        Client: HeadersClient,
+        Client: HeadersClient<Header: reth_primitives_traits::BlockHeader>,
     {
         info!(target: "reth::cli", ?tip, "Fetching tip block from the network.");
         let mut fetch_failures = 0;

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -1,12 +1,10 @@
 //! Block body abstraction.
 
-use alloc::{fmt, vec::Vec};
+use alloc::fmt;
 
-use alloy_consensus::{BlockHeader, Transaction, TxType};
-use alloy_eips::{eip4895::Withdrawal, eip7685::Requests};
-use alloy_primitives::{Address, B256};
+use alloy_consensus::Transaction;
 
-use crate::Block;
+use crate::InMemorySize;
 
 /// Abstraction for block's body.
 pub trait BlockBody:
@@ -18,82 +16,14 @@ pub trait BlockBody:
     + fmt::Debug
     + PartialEq
     + Eq
-    + serde::Serialize
-    + for<'de> serde::Deserialize<'de>
     + alloy_rlp::Encodable
     + alloy_rlp::Decodable
+    + InMemorySize
 {
     /// Ordered list of signed transactions as committed in block.
     // todo: requires trait for signed transaction
-    type SignedTransaction: Transaction;
-
-    /// Header type (uncle blocks).
-    type Header: BlockHeader;
-
-    /// Withdrawals in block.
-    type Withdrawals: Iterator<Item = Withdrawal>;
+    type Transaction: Transaction;
 
     /// Returns reference to transactions in block.
-    fn transactions(&self) -> &[Self::SignedTransaction];
-
-    /// Returns `Withdrawals` in the block, if any.
-    // todo: branch out into extension trait
-    fn withdrawals(&self) -> Option<&Self::Withdrawals>;
-
-    /// Returns reference to uncle block headers.
-    fn ommers(&self) -> &[Self::Header];
-
-    /// Returns [`Requests`] in block, if any.
-    fn requests(&self) -> Option<&Requests>;
-
-    /// Create a [`Block`] from the body and its header.
-    fn into_block<T: Block<Header = Self::Header, Body = Self>>(self, header: Self::Header) -> T {
-        T::from((header, self))
-    }
-
-    /// Calculate the transaction root for the block body.
-    fn calculate_tx_root(&self) -> B256;
-
-    /// Calculate the ommers root for the block body.
-    fn calculate_ommers_root(&self) -> B256;
-
-    /// Calculate the withdrawals root for the block body, if withdrawals exist. If there are no
-    /// withdrawals, this will return `None`.
-    // todo: can be default impl if `calculate_withdrawals_root` made into a method on
-    // `Withdrawals` and `Withdrawals` moved to alloy
-    fn calculate_withdrawals_root(&self) -> Option<B256>;
-
-    /// Recover signer addresses for all transactions in the block body.
-    fn recover_signers(&self) -> Option<Vec<Address>>;
-
-    /// Returns whether or not the block body contains any blob transactions.
-    fn has_blob_transactions(&self) -> bool {
-        self.transactions().iter().any(|tx| tx.ty() == TxType::Eip4844 as u8)
-    }
-
-    /// Returns whether or not the block body contains any EIP-7702 transactions.
-    fn has_eip7702_transactions(&self) -> bool {
-        self.transactions().iter().any(|tx| tx.ty() == TxType::Eip7702 as u8)
-    }
-
-    /// Returns an iterator over all blob transactions of the block
-    fn blob_transactions_iter(&self) -> impl Iterator<Item = &Self::SignedTransaction> + '_ {
-        self.transactions().iter().filter(|tx| tx.ty() == TxType::Eip4844 as u8)
-    }
-
-    /// Returns only the blob transactions, if any, from the block body.
-    fn blob_transactions(&self) -> Vec<&Self::SignedTransaction> {
-        self.blob_transactions_iter().collect()
-    }
-
-    /// Returns an iterator over all blob versioned hashes from the block body.
-    fn blob_versioned_hashes_iter(&self) -> impl Iterator<Item = &B256> + '_;
-
-    /// Returns all blob versioned hashes from the block body.
-    fn blob_versioned_hashes(&self) -> Vec<&B256> {
-        self.blob_versioned_hashes_iter().collect()
-    }
-
-    /// Calculates a heuristic for the in-memory size of the [`BlockBody`].
-    fn size(&self) -> usize;
+    fn transactions(&self) -> &[Self::Transaction];
 }

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -1,10 +1,12 @@
 //! Block body abstraction.
 
-use alloc::fmt;
+use alloc::{fmt, vec::Vec};
 
-use alloy_consensus::Transaction;
+use alloy_consensus::{BlockHeader, Transaction, TxType};
+use alloy_eips::{eip4895::Withdrawal, eip7685::Requests};
+use alloy_primitives::{Address, B256};
 
-use crate::InMemorySize;
+use crate::Block;
 
 /// Abstraction for block's body.
 pub trait BlockBody:
@@ -16,14 +18,82 @@ pub trait BlockBody:
     + fmt::Debug
     + PartialEq
     + Eq
+    + serde::Serialize
+    + for<'de> serde::Deserialize<'de>
     + alloy_rlp::Encodable
     + alloy_rlp::Decodable
-    + InMemorySize
 {
     /// Ordered list of signed transactions as committed in block.
     // todo: requires trait for signed transaction
-    type Transaction: Transaction;
+    type SignedTransaction: Transaction;
+
+    /// Header type (uncle blocks).
+    type Header: BlockHeader;
+
+    /// Withdrawals in block.
+    type Withdrawals: Iterator<Item = Withdrawal>;
 
     /// Returns reference to transactions in block.
-    fn transactions(&self) -> &[Self::Transaction];
+    fn transactions(&self) -> &[Self::SignedTransaction];
+
+    /// Returns `Withdrawals` in the block, if any.
+    // todo: branch out into extension trait
+    fn withdrawals(&self) -> Option<&Self::Withdrawals>;
+
+    /// Returns reference to uncle block headers.
+    fn ommers(&self) -> &[Self::Header];
+
+    /// Returns [`Requests`] in block, if any.
+    fn requests(&self) -> Option<&Requests>;
+
+    /// Create a [`Block`] from the body and its header.
+    fn into_block<T: Block<Header = Self::Header, Body = Self>>(self, header: Self::Header) -> T {
+        T::from((header, self))
+    }
+
+    /// Calculate the transaction root for the block body.
+    fn calculate_tx_root(&self) -> B256;
+
+    /// Calculate the ommers root for the block body.
+    fn calculate_ommers_root(&self) -> B256;
+
+    /// Calculate the withdrawals root for the block body, if withdrawals exist. If there are no
+    /// withdrawals, this will return `None`.
+    // todo: can be default impl if `calculate_withdrawals_root` made into a method on
+    // `Withdrawals` and `Withdrawals` moved to alloy
+    fn calculate_withdrawals_root(&self) -> Option<B256>;
+
+    /// Recover signer addresses for all transactions in the block body.
+    fn recover_signers(&self) -> Option<Vec<Address>>;
+
+    /// Returns whether or not the block body contains any blob transactions.
+    fn has_blob_transactions(&self) -> bool {
+        self.transactions().iter().any(|tx| tx.ty() == TxType::Eip4844 as u8)
+    }
+
+    /// Returns whether or not the block body contains any EIP-7702 transactions.
+    fn has_eip7702_transactions(&self) -> bool {
+        self.transactions().iter().any(|tx| tx.ty() == TxType::Eip7702 as u8)
+    }
+
+    /// Returns an iterator over all blob transactions of the block
+    fn blob_transactions_iter(&self) -> impl Iterator<Item = &Self::SignedTransaction> + '_ {
+        self.transactions().iter().filter(|tx| tx.ty() == TxType::Eip4844 as u8)
+    }
+
+    /// Returns only the blob transactions, if any, from the block body.
+    fn blob_transactions(&self) -> Vec<&Self::SignedTransaction> {
+        self.blob_transactions_iter().collect()
+    }
+
+    /// Returns an iterator over all blob versioned hashes from the block body.
+    fn blob_versioned_hashes_iter(&self) -> impl Iterator<Item = &B256> + '_;
+
+    /// Returns all blob versioned hashes from the block body.
+    fn blob_versioned_hashes(&self) -> Vec<&B256> {
+        self.blob_versioned_hashes_iter().collect()
+    }
+
+    /// Calculates a heuristic for the in-memory size of the [`BlockBody`].
+    fn size(&self) -> usize;
 }

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -5,6 +5,8 @@ use core::fmt;
 use alloy_primitives::Sealable;
 use reth_codecs::Compact;
 
+use crate::InMemorySize;
+
 /// Helper trait that unifies all behaviour required by block header to support full node
 /// operations.
 pub trait FullBlockHeader: BlockHeader + Compact {}
@@ -25,13 +27,25 @@ pub trait BlockHeader:
     + alloy_rlp::Decodable
     + alloy_consensus::BlockHeader
     + Sealable
+    + InMemorySize
 {
-    /// Calculates a heuristic for the in-memory size of the [`BlockHeader`].
-    fn size(&self) -> usize;
 }
 
-impl BlockHeader for alloy_consensus::Header {
-    fn size(&self) -> usize {
-        self.size()
-    }
+impl<T> BlockHeader for T where
+    T: Send
+        + Sync
+        + Unpin
+        + Clone
+        + Default
+        + fmt::Debug
+        + PartialEq
+        + Eq
+        + serde::Serialize
+        + for<'de> serde::Deserialize<'de>
+        + alloy_rlp::Encodable
+        + alloy_rlp::Decodable
+        + alloy_consensus::BlockHeader
+        + Sealable
+        + InMemorySize
+{
 }

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -21,29 +21,17 @@ pub trait BlockHeader:
     + fmt::Debug
     + PartialEq
     + Eq
-    + serde::Serialize
-    + for<'de> serde::Deserialize<'de>
     + alloy_rlp::Encodable
     + alloy_rlp::Decodable
     + alloy_consensus::BlockHeader
     + Sealable
 {
+    /// Calculates a heuristic for the in-memory size of the [`BlockHeader`].
+    fn size(&self) -> usize;
 }
 
-impl<T> BlockHeader for T where
-    T: Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + serde::Serialize
-        + for<'de> serde::Deserialize<'de>
-        + alloy_rlp::Encodable
-        + alloy_rlp::Decodable
-        + alloy_consensus::BlockHeader
-        + Sealable
-{
+impl BlockHeader for alloy_consensus::Header {
+    fn size(&self) -> usize {
+        self.size()
+    }
 }

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -3,9 +3,9 @@
 pub mod body;
 pub mod header;
 
-use alloc::{fmt, vec::Vec};
+use alloc::fmt;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::B256;
 use reth_codecs::Compact;
 
 use crate::{BlockBody, BlockHeader, FullBlockHeader};
@@ -62,48 +62,6 @@ pub trait Block:
     // todo: can be default impl if sealed block type is made generic over header and body and
     // migrated to alloy
     fn seal(self, hash: B256) -> Self::SealedBlock<Self::Header, Self::Body>;
-
-    /// Expensive operation that recovers transaction signer. See
-    /// `SealedBlockWithSenders`.
-    fn senders(&self) -> Option<Vec<Address>> {
-        self.body().recover_signers()
-    }
-
-    /// Transform into a `BlockWithSenders`.
-    ///
-    /// # Panics
-    ///
-    /// If the number of senders does not match the number of transactions in the block
-    /// and the signer recovery for one of the transactions fails.
-    ///
-    /// Note: this is expected to be called with blocks read from disk.
-    #[track_caller]
-    fn with_senders_unchecked(self, senders: Vec<Address>) -> Self::BlockWithSenders<Self> {
-        self.try_with_senders_unchecked(senders).expect("stored block is valid")
-    }
-
-    /// Transform into a `BlockWithSenders` using the given senders.
-    ///
-    /// If the number of senders does not match the number of transactions in the block, this falls
-    /// back to manually recovery, but _without ensuring that the signature has a low `s` value_.
-    /// See also `SignedTransaction::recover_signer_unchecked`.
-    ///
-    /// Returns an error if a signature is invalid.
-    // todo: can be default impl if block with senders type is made generic over block and migrated
-    // to alloy
-    #[track_caller]
-    fn try_with_senders_unchecked(
-        self,
-        senders: Vec<Address>,
-    ) -> Result<Self::BlockWithSenders<Self>, Self>;
-
-    /// **Expensive**. Transform into a `BlockWithSenders` by recovering senders in the contained
-    /// transactions.
-    ///
-    /// Returns `None` if a transaction is invalid.
-    // todo: can be default impl if sealed block type is made generic over header and body and
-    // migrated to alloy
-    fn with_recovered_senders(self) -> Option<Self::BlockWithSenders<Self>>;
 
     /// Calculates a heuristic for the in-memory size of the [`Block`].
     fn size(&self) -> usize;

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -3,9 +3,9 @@
 pub mod body;
 pub mod header;
 
-use alloc::fmt;
+use alloc::{fmt, vec::Vec};
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use reth_codecs::Compact;
 
 use crate::{BlockBody, BlockHeader, FullBlockHeader};
@@ -62,6 +62,48 @@ pub trait Block:
     // todo: can be default impl if sealed block type is made generic over header and body and
     // migrated to alloy
     fn seal(self, hash: B256) -> Self::SealedBlock<Self::Header, Self::Body>;
+
+    /// Expensive operation that recovers transaction signer. See
+    /// `SealedBlockWithSenders`.
+    fn senders(&self) -> Option<Vec<Address>> {
+        self.body().recover_signers()
+    }
+
+    /// Transform into a `BlockWithSenders`.
+    ///
+    /// # Panics
+    ///
+    /// If the number of senders does not match the number of transactions in the block
+    /// and the signer recovery for one of the transactions fails.
+    ///
+    /// Note: this is expected to be called with blocks read from disk.
+    #[track_caller]
+    fn with_senders_unchecked(self, senders: Vec<Address>) -> Self::BlockWithSenders<Self> {
+        self.try_with_senders_unchecked(senders).expect("stored block is valid")
+    }
+
+    /// Transform into a `BlockWithSenders` using the given senders.
+    ///
+    /// If the number of senders does not match the number of transactions in the block, this falls
+    /// back to manually recovery, but _without ensuring that the signature has a low `s` value_.
+    /// See also `SignedTransaction::recover_signer_unchecked`.
+    ///
+    /// Returns an error if a signature is invalid.
+    // todo: can be default impl if block with senders type is made generic over block and migrated
+    // to alloy
+    #[track_caller]
+    fn try_with_senders_unchecked(
+        self,
+        senders: Vec<Address>,
+    ) -> Result<Self::BlockWithSenders<Self>, Self>;
+
+    /// **Expensive**. Transform into a `BlockWithSenders` by recovering senders in the contained
+    /// transactions.
+    ///
+    /// Returns `None` if a transaction is invalid.
+    // todo: can be default impl if sealed block type is made generic over header and body and
+    // migrated to alloy
+    fn with_recovered_senders(self) -> Option<Self::BlockWithSenders<Self>>;
 
     /// Calculates a heuristic for the in-memory size of the [`Block`].
     fn size(&self) -> usize;

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -56,10 +56,10 @@ impl<H> SealedHeader<H> {
     }
 }
 
-impl SealedHeader {
+impl<H: crate::BlockHeader> SealedHeader<H> {
     /// Return the number hash tuple.
     pub fn num_hash(&self) -> BlockNumHash {
-        BlockNumHash::new(self.number, self.hash)
+        BlockNumHash::new(self.number(), self.hash)
     }
 }
 

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -56,7 +56,7 @@ impl<H> SealedHeader<H> {
     }
 }
 
-impl<H: crate::BlockHeader> SealedHeader<H> {
+impl<H: alloy_consensus::BlockHeader> SealedHeader<H> {
     /// Return the number hash tuple.
     pub fn num_hash(&self) -> BlockNumHash {
         BlockNumHash::new(self.number(), self.hash)

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -21,7 +21,7 @@ impl NodePrimitives for () {
 /// Helper trait that sets trait bounds on [`NodePrimitives`].
 pub trait FullNodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
     /// Block primitive.
-    type Block: FullBlock<Body: BlockBody<Transaction = Self::SignedTx>>;
+    type Block: FullBlock<Body: BlockBody<SignedTransaction = Self::SignedTx>>;
     /// Signed version of the transaction type.
     type SignedTx: FullSignedTx;
     /// A receipt.

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -21,7 +21,7 @@ impl NodePrimitives for () {
 /// Helper trait that sets trait bounds on [`NodePrimitives`].
 pub trait FullNodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
     /// Block primitive.
-    type Block: FullBlock<Body: BlockBody<SignedTransaction = Self::SignedTx>>;
+    type Block: FullBlock<Body: BlockBody<Transaction = Self::SignedTx>>;
     /// Signed version of the transaction type.
     type SignedTx: FullSignedTx;
     /// A receipt.

--- a/crates/primitives-traits/src/size.rs
+++ b/crates/primitives-traits/src/size.rs
@@ -3,3 +3,9 @@ pub trait InMemorySize {
     /// Returns a heuristic for the in-memory size of a struct.
     fn size(&self) -> usize;
 }
+
+impl InMemorySize for alloy_consensus::Header {
+    fn size(&self) -> usize {
+        self.size()
+    }
+}

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -290,6 +290,13 @@ impl<H, B> SealedBlock<H, B> {
     }
 }
 
+impl<H: InMemorySize, B: InMemorySize> InMemorySize for SealedBlock<H, B> {
+    #[inline]
+    fn size(&self) -> usize {
+        self.header.size() + self.body.size()
+    }
+}
+
 impl SealedBlock {
     /// Splits the sealed block into underlying components
     #[inline]
@@ -425,14 +432,6 @@ impl SealedBlock {
     /// [`alloy_eips::eip2718::Encodable2718::encoded_2718`].
     pub fn raw_transactions(&self) -> Vec<Bytes> {
         self.body.transactions().map(|tx| tx.encoded_2718().into()).collect()
-    }
-}
-
-impl InMemorySize for SealedBlock {
-    /// Calculates a heuristic for the in-memory size of the [`SealedBlock`].
-    #[inline]
-    fn size(&self) -> usize {
-        self.header.size() + self.body.size()
     }
 }
 
@@ -643,6 +642,14 @@ impl InMemorySize for BlockBody {
             self.withdrawals
                 .as_ref()
                 .map_or(core::mem::size_of::<Option<Withdrawals>>(), Withdrawals::total_size)
+    }
+}
+
+impl reth_primitives_traits::BlockBody for BlockBody {
+    type Transaction = TransactionSigned;
+
+    fn transactions(&self) -> &[Self::Transaction] {
+        &self.transactions
     }
 }
 

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -290,13 +290,6 @@ impl<H, B> SealedBlock<H, B> {
     }
 }
 
-impl<H: InMemorySize, B: InMemorySize> InMemorySize for SealedBlock<H, B> {
-    #[inline]
-    fn size(&self) -> usize {
-        self.header.size() + self.body.size()
-    }
-}
-
 impl SealedBlock {
     /// Splits the sealed block into underlying components
     #[inline]
@@ -432,6 +425,13 @@ impl SealedBlock {
     /// [`alloy_eips::eip2718::Encodable2718::encoded_2718`].
     pub fn raw_transactions(&self) -> Vec<Bytes> {
         self.body.transactions().map(|tx| tx.encoded_2718().into()).collect()
+    }
+}
+
+impl<H: InMemorySize, B: InMemorySize> InMemorySize for SealedBlock<H, B> {
+    #[inline]
+    fn size(&self) -> usize {
+        self.header.size() + self.body.size()
     }
 }
 

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -645,14 +645,6 @@ impl InMemorySize for BlockBody {
     }
 }
 
-impl reth_primitives_traits::BlockBody for BlockBody {
-    type Transaction = TransactionSigned;
-
-    fn transactions(&self) -> &[Self::Transaction] {
-        &self.transactions
-    }
-}
-
 impl From<Block> for BlockBody {
     fn from(block: Block) -> Self {
         Self {

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -890,6 +890,8 @@ mod tests {
         }
 
         impl BodyDownloader for TestBodyDownloader {
+            type Body = BlockBody;
+
             fn set_download_range(
                 &mut self,
                 range: RangeInclusive<BlockNumber>,
@@ -910,7 +912,7 @@ mod tests {
         }
 
         impl Stream for TestBodyDownloader {
-            type Item = BodyDownloaderResult;
+            type Item = BodyDownloaderResult<BlockBody>;
             fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
                 let this = self.get_mut();
 

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -60,7 +60,7 @@ pub struct BodyStage<D: BodyDownloader> {
     /// The body downloader.
     downloader: D,
     /// Block response buffer.
-    buffer: Option<Vec<BlockResponse>>,
+    buffer: Option<Vec<BlockResponse<D::Body>>>,
 }
 
 impl<D: BodyDownloader> BodyStage<D> {
@@ -70,9 +70,10 @@ impl<D: BodyDownloader> BodyStage<D> {
     }
 }
 
-impl<Provider, D: BodyDownloader> Stage<Provider> for BodyStage<D>
+impl<Provider, D> Stage<Provider> for BodyStage<D>
 where
     Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + StatsReader + BlockReader,
+    D: BodyDownloader<Body = reth_primitives::BlockBody>,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -441,7 +441,9 @@ mod tests {
             }
         }
 
-        impl<D: HeaderDownloader + 'static> StageTestRunner for HeadersTestRunner<D> {
+        impl<D: HeaderDownloader<Header = reth_primitives::Header> + 'static> StageTestRunner
+            for HeadersTestRunner<D>
+        {
             type S = HeaderStage<ProviderFactory<MockNodeTypesWithDB>, D>;
 
             fn db(&self) -> &TestStageDB {
@@ -459,7 +461,9 @@ mod tests {
             }
         }
 
-        impl<D: HeaderDownloader + 'static> ExecuteStageTestRunner for HeadersTestRunner<D> {
+        impl<D: HeaderDownloader<Header = reth_primitives::Header> + 'static> ExecuteStageTestRunner
+            for HeadersTestRunner<D>
+        {
             type Seed = Vec<SealedHeader>;
 
             fn seed_execution(&mut self, input: ExecInput) -> Result<Self::Seed, TestRunnerError> {
@@ -537,7 +541,9 @@ mod tests {
             }
         }
 
-        impl<D: HeaderDownloader + 'static> UnwindStageTestRunner for HeadersTestRunner<D> {
+        impl<D: HeaderDownloader<Header = reth_primitives::Header> + 'static> UnwindStageTestRunner
+            for HeadersTestRunner<D>
+        {
             fn validate_unwind(&self, input: UnwindInput) -> Result<(), TestRunnerError> {
                 self.check_no_header_entry_above(input.unwind_to)
             }

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -194,7 +194,7 @@ where
 impl<Provider, P, D> Stage<Provider> for HeaderStage<P, D>
 where
     P: HeaderSyncGapProvider,
-    D: HeaderDownloader,
+    D: HeaderDownloader<Header = reth_primitives::Header>,
     Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory,
 {
     /// Return the id of the stage


### PR DESCRIPTION
- Makes some of the network types and components generic over `NetworkPrimitives` This includes `EthStream`, messages and fetcher
- Adds header and body AT to block clients/downloaders. For now the common implementations mostly rely on `alloy_consensus::BlockHeader` for header and `InMemorySize` for body which should allow to reuse those for most of the networks.
- More high-level consumers rely on `EthBlockClient` which restricts clients to Ethereum block parts