### PR TITLE
chore: add DUPSORT trait const

### DIFF
--- a/crates/storage/db-api/src/table.rs
+++ b/crates/storage/db-api/src/table.rs
@@ -88,6 +88,9 @@ pub trait Table: Send + Sync + Debug + 'static {
     /// The table's name.
     const NAME: &'static str;
 
+    /// Whether the table is also a `DUPSORT` table.
+    const DUPSORT: bool;
+
     /// Key element of `Table`.
     ///
     /// Sorting should be taken into account when encoding this.

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -140,6 +140,7 @@ macro_rules! tables {
                 $value: reth_db_api::table::Value + 'static
             {
                 const NAME: &'static str = table_names::$name;
+                const DUPSORT: bool = tables!(@bool $($subkey)?);
 
                 type Key = $key;
                 type Value = $value;

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -14,6 +14,7 @@ pub struct RawTable<T: Table> {
 
 impl<T: Table> Table for RawTable<T> {
     const NAME: &'static str = T::NAME;
+    const DUPSORT: bool = false;
 
     type Key = RawKey<T::Key>;
     type Value = RawValue<T::Value>;
@@ -28,6 +29,7 @@ pub struct RawDupSort<T: DupSort> {
 
 impl<T: DupSort> Table for RawDupSort<T> {
     const NAME: &'static str = T::NAME;
+    const DUPSORT: bool = true;
 
     type Key = RawKey<T::Key>;
     type Value = RawValue<T::Value>;


### PR DESCRIPTION
towards #12386

we need to so that we can derive the initializer logic from the table trait