### PR TITLE
chore: Update Holocene timestamp for Sepolia

### DIFF
--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -577,7 +577,7 @@ mod tests {
                 ),
                 (
                     Head { number: 0, timestamp: 1732633200, ..Default::default() },
-                    ForkId { hash: ForkHash([0x98, 0x1c, 0x21, 0x69]), next: 0 },
+                    ForkId { hash: ForkHash([0x4a, 0x1c, 0x79, 0x2e]), next: 0 },
                 ),
             ],
         );
@@ -648,7 +648,7 @@ mod tests {
                 ),
                 (
                     Head { number: 0, timestamp: 1732633200, ..Default::default() },
-                    ForkId { hash: ForkHash([0x59, 0x5e, 0x2e, 0x6e]), next: 0 },
+                    ForkId { hash: ForkHash([0x8b, 0x5e, 0x76, 0x29]), next: 0 },
                 ),
             ],
         );

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -573,10 +573,10 @@ mod tests {
                 ),
                 (
                     Head { number: 0, timestamp: 1723478400, ..Default::default() },
-                    ForkId { hash: ForkHash([0x75, 0xde, 0xa4, 0x1e]), next: 1732201200 },
+                    ForkId { hash: ForkHash([0x75, 0xde, 0xa4, 0x1e]), next: 1732633200 },
                 ),
                 (
-                    Head { number: 0, timestamp: 1732201200, ..Default::default() },
+                    Head { number: 0, timestamp: 1732633200, ..Default::default() },
                     ForkId { hash: ForkHash([0x98, 0x1c, 0x21, 0x69]), next: 0 },
                 ),
             ],
@@ -644,10 +644,10 @@ mod tests {
                 ),
                 (
                     Head { number: 0, timestamp: 1723478400, ..Default::default() },
-                    ForkId { hash: ForkHash([0x5e, 0xdf, 0xa3, 0xb6]), next: 1732201200 },
+                    ForkId { hash: ForkHash([0x5e, 0xdf, 0xa3, 0xb6]), next: 1732633200 },
                 ),
                 (
-                    Head { number: 0, timestamp: 1732201200, ..Default::default() },
+                    Head { number: 0, timestamp: 1732633200, ..Default::default() },
                     ForkId { hash: ForkHash([0x59, 0x5e, 0x2e, 0x6e]), next: 0 },
                 ),
             ],

--- a/crates/optimism/hardforks/src/hardfork.rs
+++ b/crates/optimism/hardforks/src/hardfork.rs
@@ -158,7 +158,7 @@ impl OpHardfork {
                 Self::Ecotone => Some(1708534800),
                 Self::Fjord => Some(1716998400),
                 Self::Granite => Some(1723478400),
-                Self::Holocene => Some(1732201200),
+                Self::Holocene => Some(1732633200),
             },
         )
     }
@@ -257,7 +257,7 @@ impl OpHardfork {
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1708534800)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1716998400)),
             (Self::Granite.boxed(), ForkCondition::Timestamp(1723478400)),
-            (Self::Holocene.boxed(), ForkCondition::Timestamp(1732201200)),
+            (Self::Holocene.boxed(), ForkCondition::Timestamp(1732633200)),
         ])
     }
 
@@ -289,7 +289,7 @@ impl OpHardfork {
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1708534800)),
             (Self::Fjord.boxed(), ForkCondition::Timestamp(1716998400)),
             (Self::Granite.boxed(), ForkCondition::Timestamp(1723478400)),
-            (Self::Holocene.boxed(), ForkCondition::Timestamp(1732201200)),
+            (Self::Holocene.boxed(), ForkCondition::Timestamp(1732633200)),
         ])
     }
 

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -214,7 +214,7 @@ mod test {
     #[test]
     fn test_well_formed_attributes_pre_holocene() {
         let validator = OpEngineValidator::new(get_chainspec());
-        let attributes = get_attributes(None, 1732201199);
+        let attributes = get_attributes(None, 1732633199);
 
         let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
             OpEngineTypes,
@@ -227,7 +227,7 @@ mod test {
     #[test]
     fn test_well_formed_attributes_holocene_no_eip1559_params() {
         let validator = OpEngineValidator::new(get_chainspec());
-        let attributes = get_attributes(None, 1732201200);
+        let attributes = get_attributes(None, 1732633200);
 
         let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
             OpEngineTypes,
@@ -240,7 +240,7 @@ mod test {
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_denominator() {
         let validator = OpEngineValidator::new(get_chainspec());
-        let attributes = get_attributes(Some(b64!("0000000000000008")), 1732201200);
+        let attributes = get_attributes(Some(b64!("0000000000000008")), 1732633200);
 
         let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
             OpEngineTypes,
@@ -253,7 +253,7 @@ mod test {
     #[test]
     fn test_well_formed_attributes_holocene_valid() {
         let validator = OpEngineValidator::new(get_chainspec());
-        let attributes = get_attributes(Some(b64!("0000000800000008")), 1732201200);
+        let attributes = get_attributes(Some(b64!("0000000800000008")), 1732633200);
 
         let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
             OpEngineTypes,
@@ -266,7 +266,7 @@ mod test {
     #[test]
     fn test_well_formed_attributes_holocene_valid_all_zero() {
         let validator = OpEngineValidator::new(get_chainspec());
-        let attributes = get_attributes(Some(b64!("0000000000000000")), 1732201200);
+        let attributes = get_attributes(Some(b64!("0000000000000000")), 1732633200);
 
         let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
             OpEngineTypes,


### PR DESCRIPTION
## Overview

#12453 added the timestamps for {OP/Base} Sepolia activation, but they were changed to allow for RaaS providers to have a bit more time to prepare for the upgrade. See https://github.com/ethereum-optimism/superchain-registry/pull/677