### PR TITLE
feat: make more network components generic over primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7349,6 +7349,7 @@ dependencies = [
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-primitives",
+ "reth-primitives-traits",
  "serde",
  "thiserror",
 ]
@@ -7784,6 +7785,7 @@ dependencies = [
  "reth-network-peers",
  "reth-network-types",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-storage-api",
  "reth-tasks",

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -16,9 +16,9 @@ workspace = true
 reth-chainspec.workspace = true
 reth-codecs-derive.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 
 # ethereum
-alloy-consensus.workspace = true
 alloy-chains = { workspace = true, features = ["rlp"] }
 alloy-eips.workspace = true
 alloy-primitives.workspace = true

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -54,7 +54,8 @@ arbitrary = [
 	"reth-chainspec/arbitrary",
 	"alloy-consensus/arbitrary",
 	"alloy-eips/arbitrary",
-	"alloy-primitives/arbitrary"
+	"alloy-primitives/arbitrary",
+    "reth-primitives-traits/arbitrary",
 ]
 serde = [
 	"dep:serde",

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -2,8 +2,8 @@
 
 use std::fmt::Debug;
 
-use alloy_consensus::BlockHeader;
 use alloy_rlp::{Decodable, Encodable};
+use reth_primitives_traits::{Block, BlockHeader};
 
 /// Abstraction over primitive types which might appear in network messages. See
 /// [`crate::EthMessage`] for more context.
@@ -34,7 +34,8 @@ pub trait NetworkPrimitives:
         + Eq
         + 'static;
     /// Full block type.
-    type Block: Encodable
+    type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody>
+        + Encodable
         + Decodable
         + Send
         + Sync

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -131,7 +131,8 @@ test-utils = [
 	"reth-discv4/test-utils",
 	"reth-network/test-utils",
 	"reth-network-p2p/test-utils",
-	"reth-primitives/test-utils"
+	"reth-primitives/test-utils",
+    "reth-primitives-traits/test-utils",
 ]
 
 [[bench]]

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 reth-chainspec.workspace = true
 reth-fs-util.workspace = true
 reth-primitives = { workspace = true, features = ["secp256k1"] }
+reth-primitives-traits.workspace = true
 reth-net-banlist.workspace = true
 reth-network-api.workspace = true
 reth-network-p2p.workspace = true

--- a/crates/net/network/src/import.rs
+++ b/crates/net/network/src/import.rs
@@ -7,7 +7,7 @@ use reth_network_peers::PeerId;
 use crate::message::NewBlockMessage;
 
 /// Abstraction over block import.
-pub trait BlockImport: std::fmt::Debug + Send + Sync {
+pub trait BlockImport<B = reth_primitives::Block>: std::fmt::Debug + Send + Sync {
     /// Invoked for a received `NewBlock` broadcast message from the peer.
     ///
     /// > When a `NewBlock` announcement message is received from a peer, the client first verifies
@@ -15,35 +15,35 @@ pub trait BlockImport: std::fmt::Debug + Send + Sync {
     ///
     /// This is supposed to start verification. The results are then expected to be returned via
     /// [`BlockImport::poll`].
-    fn on_new_block(&mut self, peer_id: PeerId, incoming_block: NewBlockMessage);
+    fn on_new_block(&mut self, peer_id: PeerId, incoming_block: NewBlockMessage<B>);
 
     /// Returns the results of a [`BlockImport::on_new_block`]
-    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<BlockImportOutcome>;
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<BlockImportOutcome<B>>;
 }
 
 /// Outcome of the [`BlockImport`]'s block handling.
 #[derive(Debug)]
-pub struct BlockImportOutcome {
+pub struct BlockImportOutcome<B = reth_primitives::Block> {
     /// Sender of the `NewBlock` message.
     pub peer: PeerId,
     /// The result after validating the block
-    pub result: Result<BlockValidation, BlockImportError>,
+    pub result: Result<BlockValidation<B>, BlockImportError>,
 }
 
 /// Represents the successful validation of a received `NewBlock` message.
 #[derive(Debug)]
-pub enum BlockValidation {
+pub enum BlockValidation<B> {
     /// Basic Header validity check, after which the block should be relayed to peers via a
     /// `NewBlock` message
     ValidHeader {
         /// received block
-        block: NewBlockMessage,
+        block: NewBlockMessage<B>,
     },
     /// Successfully imported: state-root matches after execution. The block should be relayed via
     /// `NewBlockHashes`
     ValidBlock {
         /// validated block.
-        block: NewBlockMessage,
+        block: NewBlockMessage<B>,
     },
 }
 
@@ -62,10 +62,10 @@ pub enum BlockImportError {
 #[non_exhaustive]
 pub struct ProofOfStakeBlockImport;
 
-impl BlockImport for ProofOfStakeBlockImport {
-    fn on_new_block(&mut self, _peer_id: PeerId, _incoming_block: NewBlockMessage) {}
+impl<B> BlockImport<B> for ProofOfStakeBlockImport {
+    fn on_new_block(&mut self, _peer_id: PeerId, _incoming_block: NewBlockMessage<B>) {}
 
-    fn poll(&mut self, _cx: &mut Context<'_>) -> Poll<BlockImportOutcome> {
+    fn poll(&mut self, _cx: &mut Context<'_>) -> Poll<BlockImportOutcome<B>> {
         Poll::Pending
     }
 }

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -11,16 +11,16 @@ use reth_eth_wire::{
     errors::EthStreamError,
     message::EthBroadcastMessage,
     multiplex::{ProtocolProxy, RlpxSatelliteStream},
-    EthMessage, EthStream, EthVersion, P2PStream,
+    EthMessage, EthNetworkPrimitives, EthStream, EthVersion, NetworkPrimitives, P2PStream,
 };
 use tokio::net::TcpStream;
 
 /// The type of the underlying peer network connection.
-pub type EthPeerConnection = EthStream<P2PStream<ECIESStream<TcpStream>>>;
+pub type EthPeerConnection<N> = EthStream<P2PStream<ECIESStream<TcpStream>>, N>;
 
 /// Various connection types that at least support the ETH protocol.
-pub type EthSatelliteConnection =
-    RlpxSatelliteStream<ECIESStream<TcpStream>, EthStream<ProtocolProxy>>;
+pub type EthSatelliteConnection<N = EthNetworkPrimitives> =
+    RlpxSatelliteStream<ECIESStream<TcpStream>, EthStream<ProtocolProxy, N>>;
 
 /// Connection types that support the ETH protocol.
 ///
@@ -30,14 +30,14 @@ pub type EthSatelliteConnection =
 // This type is boxed because the underlying stream is ~6KB,
 // mostly coming from `P2PStream`'s `snap::Encoder` (2072), and `ECIESStream` (3600).
 #[derive(Debug)]
-pub enum EthRlpxConnection {
+pub enum EthRlpxConnection<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// A connection that only supports the ETH protocol.
-    EthOnly(Box<EthPeerConnection>),
+    EthOnly(Box<EthPeerConnection<N>>),
     /// A connection that supports the ETH protocol and __at least one other__ `RLPx` protocol.
-    Satellite(Box<EthSatelliteConnection>),
+    Satellite(Box<EthSatelliteConnection<N>>),
 }
 
-impl EthRlpxConnection {
+impl<N: NetworkPrimitives> EthRlpxConnection<N> {
     /// Returns the negotiated ETH version.
     #[inline]
     pub(crate) const fn version(&self) -> EthVersion {
@@ -78,7 +78,7 @@ impl EthRlpxConnection {
     #[inline]
     pub fn start_send_broadcast(
         &mut self,
-        item: EthBroadcastMessage,
+        item: EthBroadcastMessage<N>,
     ) -> Result<(), EthStreamError> {
         match self {
             Self::EthOnly(conn) => conn.start_send_broadcast(item),
@@ -87,16 +87,16 @@ impl EthRlpxConnection {
     }
 }
 
-impl From<EthPeerConnection> for EthRlpxConnection {
+impl<N: NetworkPrimitives> From<EthPeerConnection<N>> for EthRlpxConnection<N> {
     #[inline]
-    fn from(conn: EthPeerConnection) -> Self {
+    fn from(conn: EthPeerConnection<N>) -> Self {
         Self::EthOnly(Box::new(conn))
     }
 }
 
-impl From<EthSatelliteConnection> for EthRlpxConnection {
+impl<N: NetworkPrimitives> From<EthSatelliteConnection<N>> for EthRlpxConnection<N> {
     #[inline]
-    fn from(conn: EthSatelliteConnection) -> Self {
+    fn from(conn: EthSatelliteConnection<N>) -> Self {
         Self::Satellite(Box::new(conn))
     }
 }
@@ -112,22 +112,22 @@ macro_rules! delegate_call {
     }
 }
 
-impl Stream for EthRlpxConnection {
-    type Item = Result<EthMessage, EthStreamError>;
+impl<N: NetworkPrimitives> Stream for EthRlpxConnection<N> {
+    type Item = Result<EthMessage<N>, EthStreamError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         delegate_call!(self.poll_next(cx))
     }
 }
 
-impl Sink<EthMessage> for EthRlpxConnection {
+impl<N: NetworkPrimitives> Sink<EthMessage<N>> for EthRlpxConnection<N> {
     type Error = EthStreamError;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         delegate_call!(self.poll_ready(cx))
     }
 
-    fn start_send(self: Pin<&mut Self>, item: EthMessage) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: EthMessage<N>) -> Result<(), Self::Error> {
         delegate_call!(self.start_send(item))
     }
 

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -5,7 +5,7 @@ use std::{io, net::SocketAddr, sync::Arc, time::Instant};
 use reth_ecies::ECIESError;
 use reth_eth_wire::{
     capability::CapabilityMessage, errors::EthStreamError, Capabilities, DisconnectReason,
-    EthVersion, Status,
+    EthVersion, NetworkPrimitives, Status,
 };
 use reth_network_api::PeerInfo;
 use reth_network_peers::{NodeRecord, PeerId};
@@ -54,7 +54,7 @@ impl PendingSessionHandle {
 /// Within an active session that supports the `Ethereum Wire Protocol `, three high-level tasks can
 /// be performed: chain synchronization, block propagation and transaction exchange.
 #[derive(Debug)]
-pub struct ActiveSessionHandle {
+pub struct ActiveSessionHandle<N: NetworkPrimitives> {
     /// The direction of the session
     pub(crate) direction: Direction,
     /// The assigned id for this session
@@ -68,7 +68,7 @@ pub struct ActiveSessionHandle {
     /// Announced capabilities of the peer.
     pub(crate) capabilities: Arc<Capabilities>,
     /// Sender half of the command channel used send commands _to_ the spawned session
-    pub(crate) commands_to_session: mpsc::Sender<SessionCommand>,
+    pub(crate) commands_to_session: mpsc::Sender<SessionCommand<N>>,
     /// The client's name and version
     pub(crate) client_version: Arc<str>,
     /// The address we're connected to
@@ -81,7 +81,7 @@ pub struct ActiveSessionHandle {
 
 // === impl ActiveSessionHandle ===
 
-impl ActiveSessionHandle {
+impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
     /// Sends a disconnect command to the session.
     pub fn disconnect(&self, reason: Option<DisconnectReason>) {
         // Note: we clone the sender which ensures the channel has capacity to send the message
@@ -93,7 +93,7 @@ impl ActiveSessionHandle {
     pub async fn try_disconnect(
         &self,
         reason: Option<DisconnectReason>,
-    ) -> Result<(), SendError<SessionCommand>> {
+    ) -> Result<(), SendError<SessionCommand<N>>> {
         self.commands_to_session.clone().send(SessionCommand::Disconnect { reason }).await
     }
 
@@ -162,7 +162,7 @@ impl ActiveSessionHandle {
 ///
 /// A session starts with a `Handshake`, followed by a `Hello` message which
 #[derive(Debug)]
-pub enum PendingSessionEvent {
+pub enum PendingSessionEvent<N: NetworkPrimitives> {
     /// Represents a successful `Hello` and `Status` exchange: <https://github.com/ethereum/devp2p/blob/6b0abc3d956a626c28dce1307ee9f546db17b6bd/rlpx.md#hello-0x00>
     Established {
         /// An internal identifier for the established session
@@ -179,7 +179,7 @@ pub enum PendingSessionEvent {
         status: Arc<Status>,
         /// The actual connection stream which can be used to send and receive `eth` protocol
         /// messages
-        conn: EthRlpxConnection,
+        conn: EthRlpxConnection<N>,
         /// The direction of the session, either `Inbound` or `Outgoing`
         direction: Direction,
         /// The remote node's user agent, usually containing the client name and version
@@ -222,20 +222,20 @@ pub enum PendingSessionEvent {
 
 /// Commands that can be sent to the spawned session.
 #[derive(Debug)]
-pub enum SessionCommand {
+pub enum SessionCommand<N: NetworkPrimitives> {
     /// Disconnect the connection
     Disconnect {
         /// Why the disconnect was initiated
         reason: Option<DisconnectReason>,
     },
     /// Sends a message to the peer
-    Message(PeerMessage),
+    Message(PeerMessage<N>),
 }
 
 /// Message variants an active session can produce and send back to the
 /// [`SessionManager`](crate::session::SessionManager)
 #[derive(Debug)]
-pub enum ActiveSessionMessage {
+pub enum ActiveSessionMessage<N: NetworkPrimitives> {
     /// Session was gracefully disconnected.
     Disconnected {
         /// The remote node's public key
@@ -257,7 +257,7 @@ pub enum ActiveSessionMessage {
         /// Identifier of the remote peer.
         peer_id: PeerId,
         /// Message received from the peer.
-        message: PeerMessage,
+        message: PeerMessage<N>,
     },
     /// Received a message that does not match the announced capabilities of the peer.
     InvalidMessage {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -28,11 +28,11 @@ use futures::{future::Either, io, FutureExt, StreamExt};
 use reth_ecies::{stream::ECIESStream, ECIESError};
 use reth_eth_wire::{
     capability::CapabilityMessage, errors::EthStreamError, multiplex::RlpxProtocolMultiplexer,
-    Capabilities, DisconnectReason, EthVersion, HelloMessageWithProtocols, Status,
-    UnauthedEthStream, UnauthedP2PStream,
+    Capabilities, DisconnectReason, EthVersion, HelloMessageWithProtocols, NetworkPrimitives,
+    Status, UnauthedEthStream, UnauthedP2PStream,
 };
 use reth_metrics::common::mpsc::MeteredPollSender;
-use reth_network_api::PeerRequestSender;
+use reth_network_api::{PeerRequest, PeerRequestSender};
 use reth_network_peers::PeerId;
 use reth_network_types::SessionsConfig;
 use reth_primitives::{ForkFilter, ForkId, ForkTransition, Head};
@@ -62,7 +62,7 @@ pub struct SessionId(usize);
 /// Manages a set of sessions.
 #[must_use = "Session Manager must be polled to process session events."]
 #[derive(Debug)]
-pub struct SessionManager {
+pub struct SessionManager<N: NetworkPrimitives> {
     /// Tracks the identifier for the next session.
     next_id: usize,
     /// Keeps track of all sessions
@@ -93,21 +93,21 @@ pub struct SessionManager {
     /// session is authenticated, it can be moved to the `active_session` set.
     pending_sessions: FxHashMap<SessionId, PendingSessionHandle>,
     /// All active sessions that are ready to exchange messages.
-    active_sessions: HashMap<PeerId, ActiveSessionHandle>,
+    active_sessions: HashMap<PeerId, ActiveSessionHandle<N>>,
     /// The original Sender half of the [`PendingSessionEvent`] channel.
     ///
     /// When a new (pending) session is created, the corresponding [`PendingSessionHandle`] will
     /// get a clone of this sender half.
-    pending_sessions_tx: mpsc::Sender<PendingSessionEvent>,
+    pending_sessions_tx: mpsc::Sender<PendingSessionEvent<N>>,
     /// Receiver half that listens for [`PendingSessionEvent`] produced by pending sessions.
-    pending_session_rx: ReceiverStream<PendingSessionEvent>,
+    pending_session_rx: ReceiverStream<PendingSessionEvent<N>>,
     /// The original Sender half of the [`ActiveSessionMessage`] channel.
     ///
     /// When active session state is reached, the corresponding [`ActiveSessionHandle`] will get a
     /// clone of this sender half.
-    active_session_tx: MeteredPollSender<ActiveSessionMessage>,
+    active_session_tx: MeteredPollSender<ActiveSessionMessage<N>>,
     /// Receiver half that listens for [`ActiveSessionMessage`] produced by pending sessions.
-    active_session_rx: ReceiverStream<ActiveSessionMessage>,
+    active_session_rx: ReceiverStream<ActiveSessionMessage<N>>,
     /// Additional `RLPx` sub-protocols to be used by the session manager.
     extra_protocols: RlpxSubProtocols,
     /// Tracks the ongoing graceful disconnections attempts for incoming connections.
@@ -118,7 +118,7 @@ pub struct SessionManager {
 
 // === impl SessionManager ===
 
-impl SessionManager {
+impl<N: NetworkPrimitives> SessionManager<N> {
     /// Creates a new empty [`SessionManager`].
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -182,7 +182,7 @@ impl SessionManager {
     }
 
     /// Returns a borrowed reference to the active sessions.
-    pub const fn active_sessions(&self) -> &HashMap<PeerId, ActiveSessionHandle> {
+    pub const fn active_sessions(&self) -> &HashMap<PeerId, ActiveSessionHandle<N>> {
         &self.active_sessions
     }
 
@@ -348,7 +348,7 @@ impl SessionManager {
     }
 
     /// Sends a message to the peer's session
-    pub fn send_message(&mut self, peer_id: &PeerId, msg: PeerMessage) {
+    pub fn send_message(&mut self, peer_id: &PeerId, msg: PeerMessage<N>) {
         if let Some(session) = self.active_sessions.get_mut(peer_id) {
             let _ = session.commands_to_session.try_send(SessionCommand::Message(msg)).inspect_err(
                 |e| {
@@ -373,7 +373,7 @@ impl SessionManager {
     }
 
     /// Removes the [`PendingSessionHandle`] if it exists.
-    fn remove_active_session(&mut self, id: &PeerId) -> Option<ActiveSessionHandle> {
+    fn remove_active_session(&mut self, id: &PeerId) -> Option<ActiveSessionHandle<N>> {
         let session = self.active_sessions.remove(id)?;
         self.counter.dec_active(&session.direction);
         Some(session)
@@ -411,7 +411,7 @@ impl SessionManager {
     /// This polls all the session handles and returns [`SessionEvent`].
     ///
     /// Active sessions are prioritized.
-    pub(crate) fn poll(&mut self, cx: &mut Context<'_>) -> Poll<SessionEvent> {
+    pub(crate) fn poll(&mut self, cx: &mut Context<'_>) -> Poll<SessionEvent<N>> {
         // Poll events from active sessions
         match self.active_session_rx.poll_next_unpin(cx) {
             Poll::Pending => {}
@@ -663,7 +663,7 @@ impl DisconnectionsCounter {
 
 /// Events produced by the [`SessionManager`]
 #[derive(Debug)]
-pub enum SessionEvent {
+pub enum SessionEvent<N: NetworkPrimitives> {
     /// A new session was successfully authenticated.
     ///
     /// This session is now able to exchange data.
@@ -681,7 +681,7 @@ pub enum SessionEvent {
         /// The Status message the peer sent during the `eth` handshake
         status: Arc<Status>,
         /// The channel for sending messages to the peer with the session
-        messages: PeerRequestSender,
+        messages: PeerRequestSender<PeerRequest<N>>,
         /// The direction of the session, either `Inbound` or `Outgoing`
         direction: Direction,
         /// The maximum time that the session waits for a response from the peer before timing out
@@ -702,7 +702,7 @@ pub enum SessionEvent {
         /// The remote node's public key
         peer_id: PeerId,
         /// Message received from the peer.
-        message: PeerMessage,
+        message: PeerMessage<N>,
     },
     /// Received a message that does not match the announced capabilities of the peer.
     InvalidMessage {
@@ -797,12 +797,12 @@ impl PendingSessionHandshakeError {
 pub struct ExceedsSessionLimit(pub(crate) u32);
 
 /// Starts a pending session authentication with a timeout.
-pub(crate) async fn pending_session_with_timeout<F>(
+pub(crate) async fn pending_session_with_timeout<F, N: NetworkPrimitives>(
     timeout: Duration,
     session_id: SessionId,
     remote_addr: SocketAddr,
     direction: Direction,
-    events: mpsc::Sender<PendingSessionEvent>,
+    events: mpsc::Sender<PendingSessionEvent<N>>,
     f: F,
 ) where
     F: Future<Output = ()>,
@@ -823,11 +823,11 @@ pub(crate) async fn pending_session_with_timeout<F>(
 ///
 /// This will wait for the _incoming_ handshake request and answer it.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn start_pending_incoming_session(
+pub(crate) async fn start_pending_incoming_session<N: NetworkPrimitives>(
     disconnect_rx: oneshot::Receiver<()>,
     session_id: SessionId,
     stream: TcpStream,
-    events: mpsc::Sender<PendingSessionEvent>,
+    events: mpsc::Sender<PendingSessionEvent<N>>,
     remote_addr: SocketAddr,
     secret_key: SecretKey,
     hello: HelloMessageWithProtocols,
@@ -854,9 +854,9 @@ pub(crate) async fn start_pending_incoming_session(
 /// Starts the authentication process for a connection initiated by a remote peer.
 #[instrument(skip_all, fields(%remote_addr, peer_id), target = "net")]
 #[allow(clippy::too_many_arguments)]
-async fn start_pending_outbound_session(
+async fn start_pending_outbound_session<N: NetworkPrimitives>(
     disconnect_rx: oneshot::Receiver<()>,
-    events: mpsc::Sender<PendingSessionEvent>,
+    events: mpsc::Sender<PendingSessionEvent<N>>,
     session_id: SessionId,
     remote_addr: SocketAddr,
     remote_peer_id: PeerId,
@@ -903,9 +903,9 @@ async fn start_pending_outbound_session(
 
 /// Authenticates a session
 #[allow(clippy::too_many_arguments)]
-async fn authenticate(
+async fn authenticate<N: NetworkPrimitives>(
     disconnect_rx: oneshot::Receiver<()>,
-    events: mpsc::Sender<PendingSessionEvent>,
+    events: mpsc::Sender<PendingSessionEvent<N>>,
     stream: TcpStream,
     session_id: SessionId,
     remote_addr: SocketAddr,
@@ -986,7 +986,7 @@ async fn get_ecies_stream<Io: AsyncRead + AsyncWrite + Unpin>(
 /// If additional [`RlpxSubProtocolHandlers`] are provided, the hello message will be updated to
 /// also negotiate the additional protocols.
 #[allow(clippy::too_many_arguments)]
-async fn authenticate_stream(
+async fn authenticate_stream<N: NetworkPrimitives>(
     stream: UnauthedP2PStream<ECIESStream<TcpStream>>,
     session_id: SessionId,
     remote_addr: SocketAddr,
@@ -996,7 +996,7 @@ async fn authenticate_stream(
     mut status: Status,
     fork_filter: ForkFilter,
     mut extra_handlers: RlpxSubProtocolHandlers,
-) -> PendingSessionEvent {
+) -> PendingSessionEvent<N> {
     // Add extra protocols to the hello message
     extra_handlers.retain(|handler| hello.try_add_protocol(handler.protocol()).is_ok());
 

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{BlockHeader, Transaction, TxType};
 use alloy_eips::{eip4895::Withdrawal, eip7685::Requests};
 use alloy_primitives::{Address, B256};
 
-use crate::{Block, InMemorySize};
+use crate::InMemorySize;
 
 /// Abstraction for block's body.
 pub trait BlockBody:
@@ -46,11 +46,6 @@ pub trait BlockBody:
 
     /// Returns [`Requests`] in block, if any.
     fn requests(&self) -> Option<&Requests>;
-
-    /// Create a [`Block`] from the body and its header.
-    fn into_block<T: Block<Header = Self::Header, Body = Self>>(self, header: Self::Header) -> T {
-        T::from((header, self))
-    }
 
     /// Calculate the transaction root for the block body.
     fn calculate_tx_root(&self) -> B256;

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -37,9 +37,9 @@ pub trait Block:
     /// The block's body contains the transactions in the block.
     type Body: Send + Sync + Unpin + 'static;
 
-    /// Returns reference to [`BlockHeader`] type.
+    /// Returns reference to block header.
     fn header(&self) -> &Self::Header;
 
-    /// Returns reference to [`BlockBody`] type.
+    /// Returns reference to block body.
     fn body(&self) -> &Self::Body;
 }

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -3,12 +3,11 @@
 pub mod body;
 pub mod header;
 
-use alloc::{fmt, vec::Vec};
+use alloc::fmt;
 
-use alloy_primitives::{Address, B256};
 use reth_codecs::Compact;
 
-use crate::{BlockBody, BlockHeader, FullBlockHeader, InMemorySize};
+use crate::{BlockHeader, FullBlockHeader, InMemorySize};
 
 /// Helper trait that unifies all behaviour required by block to support full node operations.
 pub trait FullBlock: Block<Header: Compact> + Compact {}
@@ -30,79 +29,17 @@ pub trait Block:
     + Eq
     + serde::Serialize
     + for<'a> serde::Deserialize<'a>
-    + From<(Self::Header, Self::Body)>
-    + Into<(Self::Header, Self::Body)>
     + InMemorySize
 {
     /// Header part of the block.
     type Header: BlockHeader;
 
     /// The block's body contains the transactions in the block.
-    type Body: BlockBody;
-
-    /// A block and block hash.
-    type SealedBlock<H, B>;
-
-    /// A block and addresses of senders of transactions in it.
-    type BlockWithSenders<T>;
+    type Body: Send + Sync + Unpin + 'static;
 
     /// Returns reference to [`BlockHeader`] type.
     fn header(&self) -> &Self::Header;
 
     /// Returns reference to [`BlockBody`] type.
     fn body(&self) -> &Self::Body;
-
-    /// Calculate the header hash and seal the block so that it can't be changed.
-    // todo: can be default impl if sealed block type is made generic over header and body and
-    // migrated to alloy
-    fn seal_slow(self) -> Self::SealedBlock<Self::Header, Self::Body>;
-
-    /// Seal the block with a known hash.
-    ///
-    /// WARNING: This method does not perform validation whether the hash is correct.
-    // todo: can be default impl if sealed block type is made generic over header and body and
-    // migrated to alloy
-    fn seal(self, hash: B256) -> Self::SealedBlock<Self::Header, Self::Body>;
-
-    /// Expensive operation that recovers transaction signer. See
-    /// `SealedBlockWithSenders`.
-    fn senders(&self) -> Option<Vec<Address>> {
-        self.body().recover_signers()
-    }
-
-    /// Transform into a `BlockWithSenders`.
-    ///
-    /// # Panics
-    ///
-    /// If the number of senders does not match the number of transactions in the block
-    /// and the signer recovery for one of the transactions fails.
-    ///
-    /// Note: this is expected to be called with blocks read from disk.
-    #[track_caller]
-    fn with_senders_unchecked(self, senders: Vec<Address>) -> Self::BlockWithSenders<Self> {
-        self.try_with_senders_unchecked(senders).expect("stored block is valid")
-    }
-
-    /// Transform into a `BlockWithSenders` using the given senders.
-    ///
-    /// If the number of senders does not match the number of transactions in the block, this falls
-    /// back to manually recovery, but _without ensuring that the signature has a low `s` value_.
-    /// See also `SignedTransaction::recover_signer_unchecked`.
-    ///
-    /// Returns an error if a signature is invalid.
-    // todo: can be default impl if block with senders type is made generic over block and migrated
-    // to alloy
-    #[track_caller]
-    fn try_with_senders_unchecked(
-        self,
-        senders: Vec<Address>,
-    ) -> Result<Self::BlockWithSenders<Self>, Self>;
-
-    /// **Expensive**. Transform into a `BlockWithSenders` by recovering senders in the contained
-    /// transactions.
-    ///
-    /// Returns `None` if a transaction is invalid.
-    // todo: can be default impl if sealed block type is made generic over header and body and
-    // migrated to alloy
-    fn with_recovered_senders(self) -> Option<Self::BlockWithSenders<Self>>;
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -87,6 +87,19 @@ impl Block {
     }
 }
 
+impl reth_primitives_traits::Block for Block {
+    type Header = Header;
+    type Body = BlockBody;
+
+    fn body(&self) -> &Self::Body {
+        &self.body
+    }
+
+    fn header(&self) -> &Self::Header {
+        &self.header
+    }
+}
+
 impl InMemorySize for Block {
     /// Calculates a heuristic for the in-memory size of the [`Block`].
     #[inline]


### PR DESCRIPTION
This PR trims `Block` trait to only keep header and body getters for now and implements the trait for `reth_primitives::Block`

Network components and their dependencies up to `Swarm` are made generic over `NetworkPrimitives`. The next step would be to make `NetworkManager` and `NetworkHandle` generic over it, exposing the primitives abstraction to network consumers