### PR TITLE
chore: add SealedHeader::seal

### DIFF
--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -56,6 +56,14 @@ impl<H> SealedHeader<H> {
     }
 }
 
+impl<H: Sealable> SealedHeader<H> {
+    /// Hashes the header and creates a sealed header.
+    pub fn seal(header: H) -> Self {
+        let hash = header.hash_slow();
+        Self::new(header, hash)
+    }
+}
+
 impl<H: alloy_consensus::BlockHeader> SealedHeader<H> {
     /// Return the number hash tuple.
     pub fn num_hash(&self) -> BlockNumHash {


### PR DESCRIPTION
currently we can only create this by providing the hash this introduces seal.

in a followup, we should rename the functions so that they mirror alloy's Sealed type