### PR TITLE
feat: add support for `eth_signTransaction`

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -278,7 +278,13 @@ where
     .await
     .unwrap();
     EthApiClient::<Transaction, Block, Receipt>::syncing(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::send_transaction(client, transaction_request)
+    EthApiClient::<Transaction, Block, Receipt>::send_transaction(
+        client,
+        transaction_request.clone(),
+    )
+    .await
+    .unwrap_err();
+    EthApiClient::<Transaction, Block, Receipt>::sign_transaction(client, transaction_request)
         .await
         .unwrap_err();
     EthApiClient::<Transaction, Block, Receipt>::hashrate(client).await.unwrap();
@@ -317,12 +323,6 @@ where
         .await
         .err()
         .unwrap()
-    ));
-    assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt>::sign_transaction(client, call_request.clone())
-            .await
-            .err()
-            .unwrap()
     ));
 }
 

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -780,8 +780,9 @@ where
     }
 
     /// Handler for: `eth_signTransaction`
-    async fn sign_transaction(&self, _transaction: TransactionRequest) -> RpcResult<Bytes> {
-        Err(internal_rpc_err("unimplemented"))
+    async fn sign_transaction(&self, request: TransactionRequest) -> RpcResult<Bytes> {
+        trace!(target: "rpc::eth", ?request, "Serving eth_signTransaction");
+        Ok(EthTransactions::sign_transaction(self, request).await?)
     }
 
     /// Handler for: `eth_signTypedData`

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -400,16 +400,10 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         txn: TransactionRequest,
     ) -> impl Future<Output = Result<TransactionSigned, Self::Error>> + Send {
         async move {
-            let signers: Vec<_> = self.signers().read().iter().cloned().collect();
-            for signer in signers {
-                if signer.is_signer_for(from) {
-                    return match signer.sign_transaction(txn, from).await {
-                        Ok(tx) => Ok(tx),
-                        Err(e) => Err(e.into_eth_err()),
-                    }
-                }
-            }
-            Err(EthApiError::InvalidTransactionSignature.into())
+            self.find_signer(from)?
+                .sign_transaction(txn, from)
+                .await
+                .map_err(Self::Error::from_eth_err)
         }
     }
 
@@ -427,6 +421,22 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 .map_err(Self::Error::from_eth_err)?
                 .as_bytes()
                 .into())
+        }
+    }
+
+    /// Signs a transaction request using the given account in request
+    /// Returns the EIP-2718 encoded signed transaction.
+    fn sign_transaction(
+        &self,
+        request: TransactionRequest,
+    ) -> impl Future<Output = Result<Bytes, Self::Error>> + Send {
+        async move {
+            let from = match request.from {
+                Some(from) => from,
+                None => return Err(SignError::NoAccount.into_eth_err()),
+            };
+
+            Ok(self.sign_request(&from, request).await?.encoded_2718().into())
         }
     }
 


### PR DESCRIPTION
### Summary
Adding support for `eth_signTransaction` RPC. The building blocks were already in place for other `sign_*` methods.

**Note for reviewer**
I couldn't find where to add tests for RPC call or it it required or not. There seem to be no additional tests for other sign methods except the `test_basic_eth_calls`. The underlying `send_transaction` helper method has unit tests though