### PR TITLE
chore: rm cfg imports

### DIFF
--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -1,11 +1,8 @@
-use crate::InMemorySize;
-
 use super::Header;
+use crate::InMemorySize;
 use alloy_consensus::Sealed;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{keccak256, BlockHash, Sealable};
-#[cfg(any(test, feature = "test-utils"))]
-use alloy_primitives::{BlockNumber, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
 use bytes::BufMut;
 use core::mem;
@@ -130,17 +127,17 @@ impl SealedHeader {
     }
 
     /// Updates the block number.
-    pub fn set_block_number(&mut self, number: BlockNumber) {
+    pub fn set_block_number(&mut self, number: alloy_primitives::BlockNumber) {
         self.header.number = number;
     }
 
     /// Updates the block state root.
-    pub fn set_state_root(&mut self, state_root: B256) {
+    pub fn set_state_root(&mut self, state_root: alloy_primitives::B256) {
         self.header.state_root = state_root;
     }
 
     /// Updates the block difficulty.
-    pub fn set_difficulty(&mut self, difficulty: U256) {
+    pub fn set_difficulty(&mut self, difficulty: alloy_primitives::U256) {
         self.header.difficulty = difficulty;
     }
 }


### PR DESCRIPTION
use full paths instead