### PR TITLE
fix: consume all payload variants

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -616,7 +616,7 @@ where
         if let Some(fut) = Pin::new(&mut this.maybe_better).as_pin_mut() {
             if let Poll::Ready(res) = fut.poll(cx) {
                 this.maybe_better = None;
-                if let Ok(BuildOutcome::Better { payload, .. }) = res {
+                if let Some(payload) = res.ok().and_then(|out| out.into_payload()) {
                     debug!(target: "payload_builder", "resolving better payload");
                     return Poll::Ready(Ok(payload))
                 }

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -616,7 +616,9 @@ where
         if let Some(fut) = Pin::new(&mut this.maybe_better).as_pin_mut() {
             if let Poll::Ready(res) = fut.poll(cx) {
                 this.maybe_better = None;
-                if let Some(payload) = res.ok().and_then(|out| out.into_payload()) {
+                if let Ok(Some(payload)) = res.map(|out| out.into_payload())
+                    .inspect_err(|err| debug!(target: "payload_builder", %err, "failed to resolve pending payload"))
+                {
                     debug!(target: "payload_builder", "resolving better payload");
                     return Poll::Ready(Ok(payload))
                 }

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -769,7 +769,7 @@ impl<Payload> BuildOutcome<Payload> {
     /// Consumes the type and returns the payload if the outcome is `Better`.
     pub fn into_payload(self) -> Option<Payload> {
         match self {
-            Self::Better { payload, .. } => Some(payload),
+            Self::Better { payload, .. } | Self::Freeze(payload) => Some(payload),
             _ => None,
         }
     }

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -617,7 +617,7 @@ where
             if let Poll::Ready(res) = fut.poll(cx) {
                 this.maybe_better = None;
                 if let Ok(Some(payload)) = res.map(|out| out.into_payload())
-                    .inspect_err(|err| debug!(target: "payload_builder", %err, "failed to resolve pending payload"))
+                    .inspect_err(|err| warn!(target: "payload_builder", %err, "failed to resolve pending payload"))
                 {
                     debug!(target: "payload_builder", "resolving better payload");
                     return Poll::Ready(Ok(payload))


### PR DESCRIPTION
we need to also consider the newly introduced `Freeze` variant, which is used by OP because if no_txpool then we can freeze the payload

closes https://github.com/paradigmxyz/reth/issues/12482
closes https://github.com/paradigmxyz/reth/issues/12470