### PR TITLE
fix: typos in documentation files

### DIFF
--- a/book/run/pruning.md
+++ b/book/run/pruning.md
@@ -18,7 +18,7 @@ the steps for running Reth as a full node, what caveats to expect and how to con
 - Full Node – Reth node that has the latest state and historical data for only the last 10064 blocks available
   for querying in the same way as an archive node.
 
-The node type that was chosen when first [running a node](./run-a-node.md) **can not** be changed after
+The node type that was chosen when first [running a node](./run-a-node.md) **cannot** be changed after
 the initial sync. Turning Archive into Pruned, or Pruned into Full is not supported.
 
 ## Modes

--- a/docs/crates/stages.md
+++ b/docs/crates/stages.md
@@ -43,7 +43,7 @@ pub trait Stage<DB: Database>: Send + Sync {
 }
 ```
 
-To get a better idea of what is happening at each part of the pipeline, lets walk through what is going on under the hood within the `execute()` function at each stage, starting with `HeaderStage`.
+To get a better idea of what is happening at each part of the pipeline, let's walk through what is going on under the hood within the `execute()` function at each stage, starting with `HeaderStage`.
 
 <br>
 

--- a/docs/repo/labels.md
+++ b/docs/repo/labels.md
@@ -30,7 +30,7 @@ For easier at-a-glance communication of the status of issues and PRs the followi
 - https://github.com/paradigmxyz/reth/labels/S-duplicate
 - https://github.com/paradigmxyz/reth/labels/S-wontfix
 
-**Misc.**
+**Miscellaneous**
 
 - https://github.com/paradigmxyz/reth/labels/S-needs-triage
 - https://github.com/paradigmxyz/reth/labels/S-controversial


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "can not" to "cannot".
Corrected "lets" to "let's".
Corrected "Misc." to "Miscellaneous".

Please review the changes and let me know if any additional changes are needed.

