### PR TITLE
feat: move body writing to `BlockWriter` trait

### DIFF
--- a/crates/net/p2p/src/bodies/response.rs
+++ b/crates/net/p2p/src/bodies/response.rs
@@ -32,6 +32,14 @@ impl<B> BlockResponse<B> {
             Self::Empty(header) => header.difficulty,
         }
     }
+
+    /// Return the reference to the response body
+    pub fn into_body(self) -> Option<B> {
+        match self {
+            Self::Full(block) => Some(block.body),
+            Self::Empty(_) => None,
+        }
+    }
 }
 
 impl<B: InMemorySize> InMemorySize for BlockResponse<B> {

--- a/crates/storage/db-models/src/blocks.rs
+++ b/crates/storage/db-models/src/blocks.rs
@@ -12,7 +12,7 @@ pub type NumTransactions = u64;
 ///
 /// It has the pointer to the transaction Number of the first
 /// transaction in the block and the total number of transactions.
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, Compact)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Copy, Serialize, Deserialize, Compact)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[add_arbitrary_tests(compact)]
 pub struct StoredBlockBodyIndices {


### PR DESCRIPTION
Moves logic for writing bodies to database from `BodyStage` to `BlockWriter::append_block_bodies`. This will allow us to make `BlockWriter` generic over block body as we now don't have chain-specific persistence logic in there.

Initially I've tried to unify persistence code paths for live sync and backfill sync but this doesn't seem feasible/doesn't make much sense because during backfill sync we write in batches and to different tables

