### PR TITLE
feat: add missing receipt fns

### DIFF
--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -31,4 +31,12 @@ pub trait Receipt:
 
     /// Calculates the receipts root of the given receipts.
     fn receipts_root(receipts: &[&Self]) -> B256;
+
+    /// Returns the cumulative gas used by the transaction.
+    fn cumulative_gas_used(&self) -> u64;
+
+    /// If transaction is executed successfully.
+    ///
+    /// This is euqivalent to `statusCode`
+    fn is_successful(&self) -> bool;
 }

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -101,6 +101,14 @@ impl reth_primitives_traits::Receipt for Receipt {
         #[cfg(not(feature = "optimism"))]
         crate::proofs::calculate_receipt_root_no_memo(_receipts)
     }
+
+    fn cumulative_gas_used(&self) -> u64 {
+        self.cumulative_gas_used
+    }
+
+    fn is_successful(&self) -> bool {
+        self.success
+    }
 }
 
 /// A collection of receipts organized as a two-dimensional vector.


### PR DESCRIPTION
we expect that these are always be part of the receipt