### PR TITLE
chore: rm reth testing utils dep from reth-primitives-traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8536,7 +8536,6 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rand 0.8.5",
  "reth-codecs",
- "reth-testing-utils",
  "revm-primitives",
  "roaring",
  "serde",

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -39,8 +39,6 @@ proptest = { workspace = true, optional = true }
 proptest-arbitrary-interop = { workspace = true, optional = true }
 
 [dev-dependencies]
-reth-testing-utils.workspace = true
-
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
 alloy-consensus = { workspace = true, features = ["arbitrary"] }
 

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -219,10 +219,8 @@ pub(super) mod serde_bincode_compat {
     #[cfg(test)]
     mod tests {
         use super::super::{serde_bincode_compat, SealedHeader};
-
         use arbitrary::Arbitrary;
         use rand::Rng;
-        use reth_testing_utils::generators;
         use serde::{Deserialize, Serialize};
         use serde_with::serde_as;
 
@@ -236,7 +234,7 @@ pub(super) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            generators::rng().fill(bytes.as_mut_slice());
+            rand::thread_rng().fill(&mut bytes[..]);
             let data = Data {
                 transaction: SealedHeader::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
                     .unwrap(),


### PR DESCRIPTION
replace reth-testing-utils with rand because reth-testing-utils depends on reth-primitives resulting in a weird dep tree