### PR TITLE
chore(sdk): make `BlockBody` and `BlockHeader` methods callable on `SealedBlock`

### DIFF
--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -13,9 +13,21 @@ use reth_codecs::Compact;
 use crate::{BlockBody, BlockHeader, Body, FullBlockBody, FullBlockHeader, Header, InMemorySize};
 
 /// Helper trait that unifies all behaviour required by block to support full node operations.
-pub trait FullBlock: Block<Header: FullBlockHeader, Body: FullBlockBody> + Compact {}
+pub trait FullBlock:
+    Block<Header: FullBlockHeader, Body: FullBlockBody>
+    + Compact
+    + alloy_rlp::Encodable
+    + alloy_rlp::Decodable
+{
+}
 
-impl<T> FullBlock for T where T: Block<Header: FullBlockHeader, Body: FullBlockBody> + Compact {}
+impl<T> FullBlock for T where
+    T: Block<Header: FullBlockHeader, Body: FullBlockBody>
+        + Compact
+        + alloy_rlp::Encodable
+        + alloy_rlp::Decodable
+{
+}
 
 /// Abstraction of block data type.
 // todo: make sealable super-trait, depends on <https://github.com/paradigmxyz/reth/issues/11449>
@@ -32,8 +44,6 @@ pub trait Block:
     + Eq
     + serde::Serialize
     + for<'a> serde::Deserialize<'a>
-    + alloy_rlp::Encodable
-    + alloy_rlp::Decodable
     + Header
     + Body<
         Self::Header,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -302,6 +302,23 @@ impl<H, B> SealedBlock<H, B> {
     }
 }
 
+impl<H, B> reth_primitives_traits::Block for SealedBlock<H, B>
+where
+    H: reth_primitives_traits::BlockHeader,
+    B: reth_primitives_traits::BlockBody<Header = H>,
+{
+    type Header = H;
+    type Body = B;
+
+    fn header(&self) -> &Self::Header {
+        self.header.header()
+    }
+
+    fn body(&self) -> &Self::Body {
+        &self.body
+    }
+}
+
 impl SealedBlock {
     /// Splits the sealed block into underlying components
     #[inline]

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -16,6 +16,7 @@ use reth_db_api::{
 };
 use reth_network_p2p::bodies::{downloader::BodyDownloader, response::BlockResponse};
 use reth_primitives::StaticFileSegment;
+use reth_primitives_traits::Body as _;
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileWriter},
     BlockReader, BlockWriter, DBProvider, ProviderError, StaticFileProviderFactory, StatsReader,
@@ -78,7 +79,7 @@ where
         + StatsReader
         + BlockReader
         + BlockWriter<Body = D::Body>,
-    D: BodyDownloader<Body: BlockBody<Transaction: Compact>>,
+    D: BodyDownloader<Body: BlockBody<Header = alloy_consensus::Header, Transaction: Compact>>,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -192,7 +193,7 @@ where
             match response {
                 BlockResponse::Full(block) => {
                     // Write transactions
-                    for transaction in block.body.transactions() {
+                    for transaction in block.transactions() {
                         let appended_tx_number =
                             static_file_producer.append_transaction(next_tx_num, transaction)?;
 


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/12450

Ref https://github.com/paradigmxyz/reth/issues/12454