### PR TITLE
fix(rpc): remove reference to preimage bool in debug_executionWitness

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -136,8 +136,7 @@ pub trait DebugApi {
     /// to their preimages that were required during the execution of the block, including during
     /// state root recomputation.
     ///
-    /// The first argument is the block number or block hash. The second argument is a boolean
-    /// indicating whether to include the preimages of keys in the response.
+    /// The first argument is the block number or block hash.
     #[method(name = "executionWitness")]
     async fn debug_execution_witness(&self, block: BlockNumberOrTag)
         -> RpcResult<ExecutionWitness>;


### PR DESCRIPTION
These docs still had the reference to `include_preimages`, we have since removed the flag. This removes those docs