### PR TITLE
feat: make `StaticFileProvider` generic over `NodePrimitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8134,6 +8134,7 @@ dependencies = [
  "reqwest",
  "reth-db-api",
  "reth-metrics",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-tasks",
  "socket2",

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -109,7 +109,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Environmen
         &self,
         config: &Config,
         db: Arc<DatabaseEnv>,
-        static_file_provider: StaticFileProvider,
+        static_file_provider: StaticFileProvider<N::Primitives>,
     ) -> eyre::Result<ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>> {
         let has_receipt_pruning = config.prune.as_ref().map_or(false, |a| a.has_receipts_pruning());
         let prune_modes =

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -9,7 +9,9 @@ use reth_db::{mdbx, static_file::iter_static_files, DatabaseEnv, TableViewer, Ta
 use reth_db_api::database::Database;
 use reth_db_common::DbTool;
 use reth_fs_util as fs;
-use reth_node_builder::{NodeTypesWithDB, NodeTypesWithDBAdapter, NodeTypesWithEngine};
+use reth_node_builder::{
+    NodePrimitives, NodeTypesWithDB, NodeTypesWithDBAdapter, NodeTypesWithEngine,
+};
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::providers::{ProviderNodeTypes, StaticFileProvider};
 use reth_static_file_types::SegmentRangeInclusive;
@@ -49,7 +51,7 @@ impl Command {
             println!("\n");
         }
 
-        let static_files_stats_table = self.static_files_stats_table(data_dir)?;
+        let static_files_stats_table = self.static_files_stats_table::<N::Primitives>(data_dir)?;
         println!("{static_files_stats_table}");
 
         println!("\n");
@@ -143,7 +145,7 @@ impl Command {
         Ok(table)
     }
 
-    fn static_files_stats_table(
+    fn static_files_stats_table<N: NodePrimitives>(
         &self,
         data_dir: ChainPath<DataDirPath>,
     ) -> eyre::Result<ComfyTable> {
@@ -173,7 +175,8 @@ impl Command {
         }
 
         let static_files = iter_static_files(data_dir.static_files())?;
-        let static_file_provider = StaticFileProvider::read_only(data_dir.static_files(), false)?;
+        let static_file_provider =
+            StaticFileProvider::<N>::read_only(data_dir.static_files(), false)?;
 
         let mut total_data_size = 0;
         let mut total_index_size = 0;

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -97,7 +97,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateC
             if last_block_number == 0 {
                 without_evm::setup_without_evm(
                     &provider_rw,
-                    &static_file_provider,
                     // &header,
                     // header_hash,
                     SealedHeader::new(header, header_hash),

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -329,10 +329,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
                 }
 
                 if self.commit {
-                    UnifiedStorageWriter::commit_unwind(
-                        provider_rw,
-                        provider_factory.static_file_provider(),
-                    )?;
+                    UnifiedStorageWriter::commit_unwind(provider_rw)?;
                     provider_rw = provider_factory.database_provider_rw()?;
                 }
             }
@@ -355,7 +352,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
                 provider_rw.save_stage_checkpoint(exec_stage.id(), checkpoint)?;
             }
             if self.commit {
-                UnifiedStorageWriter::commit(provider_rw, provider_factory.static_file_provider())?;
+                UnifiedStorageWriter::commit(provider_rw)?;
                 provider_rw = provider_factory.database_provider_rw()?;
             }
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -120,7 +120,7 @@ impl<N: ProviderNodeTypes> PersistenceService<N> {
 
         let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
         UnifiedStorageWriter::from(&provider_rw, &sf_provider).remove_blocks_above(new_tip_num)?;
-        UnifiedStorageWriter::commit_unwind(provider_rw, sf_provider)?;
+        UnifiedStorageWriter::commit_unwind(provider_rw)?;
 
         debug!(target: "engine::persistence", ?new_tip_num, ?new_tip_hash, "Removed blocks from disk");
         self.metrics.remove_blocks_above_duration_seconds.record(start_time.elapsed());
@@ -142,7 +142,7 @@ impl<N: ProviderNodeTypes> PersistenceService<N> {
             let static_file_provider = self.provider.static_file_provider();
 
             UnifiedStorageWriter::from(&provider_rw, &static_file_provider).save_blocks(&blocks)?;
-            UnifiedStorageWriter::commit(provider_rw, static_file_provider)?;
+            UnifiedStorageWriter::commit(provider_rw)?;
         }
         self.metrics.save_blocks_duration_seconds.record(start_time.elapsed());
         Ok(last_block_hash_num)

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -495,7 +495,7 @@ where
     }
 
     /// Returns the static file provider to interact with the static files.
-    pub fn static_file_provider(&self) -> StaticFileProvider {
+    pub fn static_file_provider(&self) -> StaticFileProvider<T::Primitives> {
         self.right().static_file_provider()
     }
 
@@ -766,7 +766,7 @@ where
     }
 
     /// Returns the static file provider to interact with the static files.
-    pub fn static_file_provider(&self) -> StaticFileProvider {
+    pub fn static_file_provider(&self) -> StaticFileProvider<<T::Types as NodeTypes>::Primitives> {
         self.provider_factory().static_file_provider()
     }
 

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 reth-db-api.workspace = true
+reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-metrics.workspace = true
 reth-tasks.workspace = true

--- a/crates/node/metrics/src/hooks.rs
+++ b/crates/node/metrics/src/hooks.rs
@@ -1,7 +1,12 @@
 use metrics_process::Collector;
 use reth_db_api::database_metrics::DatabaseMetrics;
+use reth_primitives_traits::NodePrimitives;
 use reth_provider::providers::StaticFileProvider;
-use std::{fmt, sync::Arc};
+use std::{
+    fmt::{self},
+    sync::Arc,
+};
+
 pub(crate) trait Hook: Fn() + Send + Sync {}
 impl<T: Fn() + Send + Sync> Hook for T {}
 
@@ -22,10 +27,11 @@ pub struct Hooks {
 
 impl Hooks {
     /// Create a new set of hooks
-    pub fn new<Metrics: DatabaseMetrics + 'static + Send + Sync>(
-        db: Metrics,
-        static_file_provider: StaticFileProvider,
-    ) -> Self {
+    pub fn new<Metrics, N>(db: Metrics, static_file_provider: StaticFileProvider<N>) -> Self
+    where
+        Metrics: DatabaseMetrics + 'static + Send + Sync,
+        N: NodePrimitives,
+    {
         let hooks: Vec<Box<dyn Hook<Output = ()>>> = vec![
             Box::new(move || db.report_metrics()),
             Box::new(move || {

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -150,7 +150,7 @@ where
         }
     }
 
-    let provider = provider_factory.provider_rw()?;
+    let provider = provider_factory.database_provider_rw()?;
     let mut total_decoded_receipts = 0;
     let mut total_receipts = 0;
     let mut total_filtered_out_dup_txns = 0;
@@ -247,7 +247,7 @@ where
     provider
         .save_stage_checkpoint(StageId::Execution, StageCheckpoint::new(highest_block_receipts))?;
 
-    UnifiedStorageWriter::commit(provider, static_file_provider)?;
+    UnifiedStorageWriter::commit(provider)?;
 
     Ok(ImportReceiptsResult { total_decoded_receipts, total_filtered_out_dup_txns })
 }

--- a/crates/optimism/cli/src/commands/init_state.rs
+++ b/crates/optimism/cli/src/commands/init_state.rs
@@ -54,7 +54,6 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitStateCommandOp<C> {
             if last_block_number == 0 {
                 reth_cli_commands::init_state::without_evm::setup_without_evm(
                     &provider_rw,
-                    &static_file_provider,
                     SealedHeader::new(BEDROCK_HEADER, BEDROCK_HEADER_HASH),
                     BEDROCK_HEADER_TTD,
                 )?;

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use crate::{BlockBody, FullBlock, FullReceipt, FullSignedTx, FullTxType};
 
 /// Configures all the primitive types of the node.
-pub trait NodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
+pub trait NodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static {
     /// Block primitive.
     type Block: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static;
     /// Signed version of the transaction type.
@@ -22,7 +22,7 @@ impl NodePrimitives for () {
 }
 
 /// Helper trait that sets trait bounds on [`NodePrimitives`].
-pub trait FullNodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug {
+pub trait FullNodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug + 'static {
     /// Block primitive.
     type Block: FullBlock<Body: BlockBody<Transaction = Self::SignedTx>>;
     /// Signed version of the transaction type.

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -5,7 +5,7 @@ use crate::segments::{
 use reth_db::transaction::DbTxMut;
 use reth_provider::{
     providers::StaticFileProvider, BlockReader, DBProvider, PruneCheckpointWriter,
-    TransactionsProvider,
+    StaticFileProviderFactory, TransactionsProvider,
 };
 use reth_prune_types::PruneModes;
 
@@ -45,12 +45,16 @@ impl<Provider> SegmentSet<Provider> {
 
 impl<Provider> SegmentSet<Provider>
 where
-    Provider: DBProvider<Tx: DbTxMut> + TransactionsProvider + PruneCheckpointWriter + BlockReader,
+    Provider: StaticFileProviderFactory
+        + DBProvider<Tx: DbTxMut>
+        + TransactionsProvider
+        + PruneCheckpointWriter
+        + BlockReader,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and
     /// [`PruneModes`].
     pub fn from_components(
-        static_file_provider: StaticFileProvider,
+        static_file_provider: StaticFileProvider<Provider::Primitives>,
         prune_modes: PruneModes,
     ) -> Self {
         let PruneModes {

--- a/crates/prune/prune/src/segments/static_file/headers.rs
+++ b/crates/prune/prune/src/segments/static_file/headers.rs
@@ -12,7 +12,7 @@ use reth_db::{
     tables,
     transaction::DbTxMut,
 };
-use reth_provider::{providers::StaticFileProvider, DBProvider};
+use reth_provider::{providers::StaticFileProvider, DBProvider, StaticFileProviderFactory};
 use reth_prune_types::{
     PruneLimiter, PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput,
     SegmentOutputCheckpoint,
@@ -24,17 +24,19 @@ use tracing::trace;
 const HEADER_TABLES_TO_PRUNE: usize = 3;
 
 #[derive(Debug)]
-pub struct Headers {
-    static_file_provider: StaticFileProvider,
+pub struct Headers<N> {
+    static_file_provider: StaticFileProvider<N>,
 }
 
-impl Headers {
-    pub const fn new(static_file_provider: StaticFileProvider) -> Self {
+impl<N> Headers<N> {
+    pub const fn new(static_file_provider: StaticFileProvider<N>) -> Self {
         Self { static_file_provider }
     }
 }
 
-impl<Provider: DBProvider<Tx: DbTxMut>> Segment<Provider> for Headers {
+impl<Provider: StaticFileProviderFactory + DBProvider<Tx: DbTxMut>> Segment<Provider>
+    for Headers<Provider::Primitives>
+{
     fn segment(&self) -> PruneSegment {
         PruneSegment::Headers
     }

--- a/crates/prune/prune/src/segments/static_file/receipts.rs
+++ b/crates/prune/prune/src/segments/static_file/receipts.rs
@@ -5,25 +5,29 @@ use crate::{
 use reth_db::transaction::DbTxMut;
 use reth_provider::{
     errors::provider::ProviderResult, providers::StaticFileProvider, BlockReader, DBProvider,
-    PruneCheckpointWriter, TransactionsProvider,
+    PruneCheckpointWriter, StaticFileProviderFactory, TransactionsProvider,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 use reth_static_file_types::StaticFileSegment;
 
 #[derive(Debug)]
-pub struct Receipts {
-    static_file_provider: StaticFileProvider,
+pub struct Receipts<N> {
+    static_file_provider: StaticFileProvider<N>,
 }
 
-impl Receipts {
-    pub const fn new(static_file_provider: StaticFileProvider) -> Self {
+impl<N> Receipts<N> {
+    pub const fn new(static_file_provider: StaticFileProvider<N>) -> Self {
         Self { static_file_provider }
     }
 }
 
-impl<Provider> Segment<Provider> for Receipts
+impl<Provider> Segment<Provider> for Receipts<Provider::Primitives>
 where
-    Provider: DBProvider<Tx: DbTxMut> + PruneCheckpointWriter + TransactionsProvider + BlockReader,
+    Provider: StaticFileProviderFactory
+        + DBProvider<Tx: DbTxMut>
+        + PruneCheckpointWriter
+        + TransactionsProvider
+        + BlockReader,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::Receipts

--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -4,7 +4,10 @@ use crate::{
     PrunerError,
 };
 use reth_db::{tables, transaction::DbTxMut};
-use reth_provider::{providers::StaticFileProvider, BlockReader, DBProvider, TransactionsProvider};
+use reth_provider::{
+    providers::StaticFileProvider, BlockReader, DBProvider, StaticFileProviderFactory,
+    TransactionsProvider,
+};
 use reth_prune_types::{
     PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
 };
@@ -12,19 +15,20 @@ use reth_static_file_types::StaticFileSegment;
 use tracing::trace;
 
 #[derive(Debug)]
-pub struct Transactions {
-    static_file_provider: StaticFileProvider,
+pub struct Transactions<N> {
+    static_file_provider: StaticFileProvider<N>,
 }
 
-impl Transactions {
-    pub const fn new(static_file_provider: StaticFileProvider) -> Self {
+impl<N> Transactions<N> {
+    pub const fn new(static_file_provider: StaticFileProvider<N>) -> Self {
         Self { static_file_provider }
     }
 }
 
-impl<Provider> Segment<Provider> for Transactions
+impl<Provider> Segment<Provider> for Transactions<Provider::Primitives>
 where
-    Provider: DBProvider<Tx: DbTxMut> + TransactionsProvider + BlockReader,
+    Provider:
+        DBProvider<Tx: DbTxMut> + TransactionsProvider + BlockReader + StaticFileProviderFactory,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::Transactions

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -9,7 +9,7 @@ use reth_primitives_traits::constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH;
 use reth_provider::{
     providers::ProviderNodeTypes, writer::UnifiedStorageWriter, ChainStateBlockReader,
     ChainStateBlockWriter, DatabaseProviderFactory, ProviderFactory, StageCheckpointReader,
-    StageCheckpointWriter, StaticFileProviderFactory,
+    StageCheckpointWriter,
 };
 use reth_prune::PrunerBuilder;
 use reth_static_file::StaticFileProducer;
@@ -358,10 +358,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             ))?;
                         }
 
-                        UnifiedStorageWriter::commit_unwind(
-                            provider_rw,
-                            self.provider_factory.static_file_provider(),
-                        )?;
+                        UnifiedStorageWriter::commit_unwind(provider_rw)?;
 
                         stage.post_unwind_commit()?;
 
@@ -469,10 +466,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                         result: out.clone(),
                     });
 
-                    UnifiedStorageWriter::commit(
-                        provider_rw,
-                        self.provider_factory.static_file_provider(),
-                    )?;
+                    UnifiedStorageWriter::commit(provider_rw)?;
 
                     stage.post_execute_commit()?;
 
@@ -533,7 +527,7 @@ fn on_stage_error<N: ProviderNodeTypes>(
                     prev_checkpoint.unwrap_or_default(),
                 )?;
 
-                UnifiedStorageWriter::commit(provider_rw, factory.static_file_provider())?;
+                UnifiedStorageWriter::commit(provider_rw)?;
 
                 // We unwind because of a validation error. If the unwind itself
                 // fails, we bail entirely,

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -311,11 +311,11 @@ where
 
 fn missing_static_data_error<Provider>(
     last_tx_num: TxNumber,
-    static_file_provider: &StaticFileProvider,
+    static_file_provider: &StaticFileProvider<Provider::Primitives>,
     provider: &Provider,
 ) -> Result<StageError, ProviderError>
 where
-    Provider: BlockReader,
+    Provider: BlockReader + StaticFileProviderFactory,
 {
     let mut last_block = static_file_provider
         .get_highest_static_file_block(StaticFileSegment::Transactions)

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -12,7 +12,7 @@ use reth_evm::{
 use reth_execution_types::Chain;
 use reth_exex::{ExExManagerHandle, ExExNotification, ExExNotificationSource};
 use reth_primitives::{SealedHeader, StaticFileSegment};
-use reth_primitives_traits::format_gas_throughput;
+use reth_primitives_traits::{format_gas_throughput, NodePrimitives};
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileProviderRWRefMut, StaticFileWriter},
     writer::UnifiedStorageWriter,
@@ -181,7 +181,8 @@ where
         + StatsReader
         + StateChangeWriter
         + BlockHashReader,
-    for<'a> UnifiedStorageWriter<'a, Provider, StaticFileProviderRWRefMut<'a>>: StateWriter,
+    for<'a> UnifiedStorageWriter<'a, Provider, StaticFileProviderRWRefMut<'a, Provider::Primitives>>:
+        StateWriter,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -485,8 +486,8 @@ where
     }
 }
 
-fn execution_checkpoint(
-    provider: &StaticFileProvider,
+fn execution_checkpoint<N: NodePrimitives>(
+    provider: &StaticFileProvider<N>,
     start_block: BlockNumber,
     max_block: BlockNumber,
     checkpoint: StageCheckpoint,
@@ -552,8 +553,8 @@ fn execution_checkpoint(
     })
 }
 
-fn calculate_gas_used_from_headers(
-    provider: &StaticFileProvider,
+fn calculate_gas_used_from_headers<N: NodePrimitives>(
+    provider: &StaticFileProvider<N>,
     range: RangeInclusive<BlockNumber>,
 ) -> Result<u64, ProviderError> {
     debug!(target: "sync::stages::execution", ?range, "Calculating gas used from headers");
@@ -587,11 +588,11 @@ fn calculate_gas_used_from_headers(
 /// (by returning [`StageError`]) until the heights in both the database and static file match.
 fn prepare_static_file_producer<'a, 'b, Provider>(
     provider: &'b Provider,
-    static_file_provider: &'a StaticFileProvider,
+    static_file_provider: &'a StaticFileProvider<Provider::Primitives>,
     start_block: u64,
-) -> Result<StaticFileProviderRWRefMut<'a>, StageError>
+) -> Result<StaticFileProviderRWRefMut<'a, Provider::Primitives>, StageError>
 where
-    Provider: DBProvider + BlockReader + HeaderProvider,
+    Provider: StaticFileProviderFactory + DBProvider + BlockReader + HeaderProvider,
     'b: 'a,
 {
     // Get next expected receipt number

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -296,8 +296,8 @@ mod tests {
     ) {
         // We recreate the static file provider, since consistency heals are done on fetching the
         // writer for the first time.
-        let static_file_provider =
-            StaticFileProvider::read_write(db.factory.static_file_provider().path()).unwrap();
+        let mut static_file_provider = db.factory.static_file_provider();
+        static_file_provider = StaticFileProvider::read_write(static_file_provider.path()).unwrap();
 
         // Simulate corruption by removing `prune_count` rows from the data file without updating
         // its offset list and configuration.
@@ -314,9 +314,10 @@ mod tests {
 
         // We recreate the static file provider, since consistency heals are done on fetching the
         // writer for the first time.
+        let mut static_file_provider = db.factory.static_file_provider();
+        static_file_provider = StaticFileProvider::read_write(static_file_provider.path()).unwrap();
         assert_eq!(
-            StaticFileProvider::read_write(db.factory.static_file_provider().path())
-                .unwrap()
+            static_file_provider
                 .check_consistency(&db.factory.database_provider_ro().unwrap(), is_full_node,),
             Ok(expected)
         );

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -24,7 +24,7 @@ use reth_provider::{
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_testing_utils::generators::ChangeSet;
-use std::{collections::BTreeMap, path::Path};
+use std::{collections::BTreeMap, fmt::Debug, path::Path};
 use tempfile::TempDir;
 
 /// Test database that is used for testing stage implementations.
@@ -142,7 +142,7 @@ impl TestStageDB {
 
     /// Insert header to static file if `writer` exists, otherwise to DB.
     pub fn insert_header<TX: DbTx + DbTxMut>(
-        writer: Option<&mut StaticFileProviderRWRefMut<'_>>,
+        writer: Option<&mut StaticFileProviderRWRefMut<'_, ()>>,
         tx: &TX,
         header: &SealedHeader,
         td: U256,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -163,7 +163,9 @@ impl<N: ProviderNodeTypes> DatabaseProviderFactory for BlockchainProvider2<N> {
 }
 
 impl<N: ProviderNodeTypes> StaticFileProviderFactory for BlockchainProvider2<N> {
-    fn static_file_provider(&self) -> StaticFileProvider {
+    type Primitives = N::Primitives;
+
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         self.database.static_file_provider()
     }
 }
@@ -911,7 +913,7 @@ mod tests {
         )?;
 
         // Commit to both storages: database and static files
-        UnifiedStorageWriter::commit(provider_rw, factory.static_file_provider())?;
+        UnifiedStorageWriter::commit(provider_rw)?;
 
         let provider = BlockchainProvider2::new(factory)?;
 
@@ -999,8 +1001,7 @@ mod tests {
                     UnifiedStorageWriter::from(&provider_rw, &hook_provider.static_file_provider())
                         .save_blocks(&[lowest_memory_block])
                         .unwrap();
-                    UnifiedStorageWriter::commit(provider_rw, hook_provider.static_file_provider())
-                        .unwrap();
+                    UnifiedStorageWriter::commit(provider_rw).unwrap();
 
                     // Remove from memory
                     hook_provider.canonical_in_memory_state.remove_persisted_blocks(num_hash);

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -612,7 +612,9 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> StaticFileProviderFactory for ConsistentProvider<N> {
-    fn static_file_provider(&self) -> StaticFileProvider {
+    type Primitives = N::Primitives;
+
+    fn static_file_provider(&self) -> StaticFileProvider<N::Primitives> {
         self.storage_provider.static_file_provider()
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -53,7 +53,7 @@ pub struct ProviderFactory<N: NodeTypesWithDB> {
     /// Chain spec
     chain_spec: Arc<N::ChainSpec>,
     /// Static File Provider
-    static_file_provider: StaticFileProvider,
+    static_file_provider: StaticFileProvider<N::Primitives>,
     /// Optional pruning configuration
     prune_modes: PruneModes,
 }
@@ -78,7 +78,7 @@ impl<N: NodeTypesWithDB> ProviderFactory<N> {
     pub fn new(
         db: N::DB,
         chain_spec: Arc<N::ChainSpec>,
-        static_file_provider: StaticFileProvider,
+        static_file_provider: StaticFileProvider<N::Primitives>,
     ) -> Self {
         Self { db, chain_spec, static_file_provider, prune_modes: PruneModes::none() }
     }
@@ -114,7 +114,7 @@ impl<N: NodeTypesWithDB<DB = Arc<DatabaseEnv>>> ProviderFactory<N> {
         path: P,
         chain_spec: Arc<N::ChainSpec>,
         args: DatabaseArguments,
-        static_file_provider: StaticFileProvider,
+        static_file_provider: StaticFileProvider<N::Primitives>,
     ) -> RethResult<Self> {
         Ok(Self {
             db: Arc::new(init_db(path, args).map_err(RethError::msg)?),
@@ -202,8 +202,10 @@ impl<N: ProviderNodeTypes> DatabaseProviderFactory for ProviderFactory<N> {
 }
 
 impl<N: NodeTypesWithDB> StaticFileProviderFactory for ProviderFactory<N> {
+    type Primitives = N::Primitives;
+
     /// Returns static file provider
-    fn static_file_provider(&self) -> StaticFileProvider {
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         self.static_file_provider.clone()
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -135,7 +135,7 @@ pub struct DatabaseProvider<TX, N: NodeTypes> {
     /// Chain spec
     chain_spec: Arc<N::ChainSpec>,
     /// Static File provider
-    static_file_provider: StaticFileProvider,
+    static_file_provider: StaticFileProvider<N::Primitives>,
     /// Pruning configuration
     prune_modes: PruneModes,
 }
@@ -199,8 +199,10 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
 }
 
 impl<TX, N: NodeTypes> StaticFileProviderFactory for DatabaseProvider<TX, N> {
+    type Primitives = N::Primitives;
+
     /// Returns a static file provider
-    fn static_file_provider(&self) -> StaticFileProvider {
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         self.static_file_provider.clone()
     }
 }
@@ -220,7 +222,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
     pub const fn new_rw(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,
-        static_file_provider: StaticFileProvider,
+        static_file_provider: StaticFileProvider<N::Primitives>,
         prune_modes: PruneModes,
     ) -> Self {
         Self { tx, chain_spec, static_file_provider, prune_modes }
@@ -363,7 +365,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     pub const fn new(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,
-        static_file_provider: StaticFileProvider,
+        static_file_provider: StaticFileProvider<N::Primitives>,
         prune_modes: PruneModes,
     ) -> Self {
         Self { tx, chain_spec, static_file_provider, prune_modes }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -204,7 +204,9 @@ impl<N: ProviderNodeTypes> DatabaseProviderFactory for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> StaticFileProviderFactory for BlockchainProvider<N> {
-    fn static_file_provider(&self) -> StaticFileProvider {
+    type Primitives = N::Primitives;
+
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         self.database.static_file_provider()
     }
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -556,7 +556,9 @@ impl PruneCheckpointReader for NoopProvider {
 }
 
 impl StaticFileProviderFactory for NoopProvider {
-    fn static_file_provider(&self) -> StaticFileProvider {
+    type Primitives = ();
+
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         StaticFileProvider::read_only(PathBuf::default(), false).unwrap()
     }
 }

--- a/crates/storage/provider/src/traits/static_file_provider.rs
+++ b/crates/storage/provider/src/traits/static_file_provider.rs
@@ -1,7 +1,12 @@
+use reth_node_types::NodePrimitives;
+
 use crate::providers::StaticFileProvider;
 
 /// Static file provider factory.
 pub trait StaticFileProviderFactory {
+    /// The network primitives type [`StaticFileProvider`] is using.
+    type Primitives: NodePrimitives;
+
     /// Create new instance of static file provider.
-    fn static_file_provider(&self) -> StaticFileProvider;
+    fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives>;
 }

--- a/crates/storage/provider/src/writer/static_file.rs
+++ b/crates/storage/provider/src/writer/static_file.rs
@@ -1,12 +1,13 @@
 use crate::providers::StaticFileProviderRWRefMut;
 use alloy_primitives::{BlockNumber, TxNumber};
 use reth_errors::ProviderResult;
+use reth_node_types::NodePrimitives;
 use reth_primitives::Receipt;
 use reth_storage_api::ReceiptWriter;
 
 pub(crate) struct StaticFileWriter<'a, W>(pub(crate) &'a mut W);
 
-impl ReceiptWriter for StaticFileWriter<'_, StaticFileProviderRWRefMut<'_>> {
+impl<N: NodePrimitives> ReceiptWriter for StaticFileWriter<'_, StaticFileProviderRWRefMut<'_, N>> {
     fn append_block_receipts(
         &mut self,
         first_tx_index: TxNumber,


### PR DESCRIPTION
Adds `NodePrimitives` generic to types reading or writing to staticfiles. We are still reading/writing concrete types but this should unblock turning those into generics