### PR TITLE
ci: exclude more crates for op tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -35,11 +35,11 @@ jobs:
             partition: 2
             total_partitions: 2
           - type: optimism
-            args: --features "asm-keccak optimism" --locked --exclude reth --exclude "example-*"
+            args: --features "asm-keccak optimism" --locked --exclude reth --exclude reth-bench --exclude "example-*"
             partition: 1
             total_partitions: 2
           - type: optimism
-            args: --features "asm-keccak optimism" --locked --exclude reth --exclude "example-*"
+            args: --features "asm-keccak optimism" --locked --exclude reth --exclude reth-bench --exclude "example-*"
             partition: 2
             total_partitions: 2
           - type: book

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -35,11 +35,11 @@ jobs:
             partition: 2
             total_partitions: 2
           - type: optimism
-            args: --features "asm-keccak optimism" --locked
+            args: --features "asm-keccak optimism" --locked --exclude reth --exclude "example-*"
             partition: 1
             total_partitions: 2
           - type: optimism
-            args: --features "asm-keccak optimism" --locked
+            args: --features "asm-keccak optimism" --locked --exclude reth --exclude "example-*"
             partition: 2
             total_partitions: 2
           - type: book


### PR DESCRIPTION
the op unit tests occasionally run out of memory

this removes ~50crates, let's see if that's enough