### PR TITLE
fix: remove redundant check in bodies stage

### DIFF
--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -1,5 +1,5 @@
 use crate::PipelineEvent;
-use alloy_primitives::{BlockNumber, TxNumber};
+use alloy_primitives::TxNumber;
 use reth_consensus::ConsensusError;
 use reth_errors::{BlockExecutionError, DatabaseError, RethError};
 use reth_network_p2p::error::DownloadError;
@@ -112,16 +112,6 @@ pub enum StageError {
         /// Expected static file transaction number.
         static_file: TxNumber,
     },
-    /// Unrecoverable inconsistency error related to a block number in a static file segment.
-    #[error("inconsistent block number for {segment}. db: {database}, static_file: {static_file}")]
-    InconsistentBlockNumber {
-        /// Static File segment where this error was encountered.
-        segment: StaticFileSegment,
-        /// Expected database block number.
-        database: BlockNumber,
-        /// Expected static file block number.
-        static_file: BlockNumber,
-    },
     /// The prune checkpoint for the given segment is missing.
     #[error("missing prune checkpoint for {0}")]
     MissingPruneCheckpoint(PruneSegment),
@@ -156,7 +146,6 @@ impl StageError {
                 Self::MissingDownloadBuffer |
                 Self::MissingSyncGap |
                 Self::ChannelClosed |
-                Self::InconsistentBlockNumber { .. } |
                 Self::InconsistentTxNumber { .. } |
                 Self::Internal(_) |
                 Self::Fatal(_)

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -176,17 +176,7 @@ where
 
             // Increment block on static file header.
             if block_number > 0 {
-                let appended_block_number = static_file_producer.increment_block(block_number)?;
-
-                if appended_block_number != block_number {
-                    // This scenario indicates a critical error in the logic of adding new
-                    // items. It should be treated as an `expect()` failure.
-                    return Err(StageError::InconsistentBlockNumber {
-                        segment: StaticFileSegment::Transactions,
-                        database: block_number,
-                        static_file: appended_block_number,
-                    })
-                }
+                static_file_producer.increment_block(block_number)?;
             }
 
             match response {

--- a/crates/static-file/static-file/src/segments/headers.rs
+++ b/crates/static-file/static-file/src/segments/headers.rs
@@ -46,9 +46,7 @@ impl<Provider: StaticFileProviderFactory + DBProvider> Segment<Provider> for Hea
             debug_assert_eq!(header_block, header_td_block);
             debug_assert_eq!(header_td_block, canonical_header_block);
 
-            let _static_file_block =
-                static_file_writer.append_header(&header, header_td.0, &canonical_header)?;
-            debug_assert_eq!(_static_file_block, header_block);
+            static_file_writer.append_header(&header, header_td.0, &canonical_header)?;
         }
 
         Ok(())

--- a/crates/static-file/static-file/src/segments/receipts.rs
+++ b/crates/static-file/static-file/src/segments/receipts.rs
@@ -30,8 +30,7 @@ impl<Provider: StaticFileProviderFactory + DBProvider + BlockReader> Segment<Pro
             static_file_provider.get_writer(*block_range.start(), StaticFileSegment::Receipts)?;
 
         for block in block_range {
-            let _static_file_block = static_file_writer.increment_block(block)?;
-            debug_assert_eq!(_static_file_block, block);
+            static_file_writer.increment_block(block)?;
 
             let block_body_indices = provider
                 .block_body_indices(block)?

--- a/crates/static-file/static-file/src/segments/transactions.rs
+++ b/crates/static-file/static-file/src/segments/transactions.rs
@@ -32,8 +32,7 @@ impl<Provider: StaticFileProviderFactory + DBProvider + BlockReader> Segment<Pro
             .get_writer(*block_range.start(), StaticFileSegment::Transactions)?;
 
         for block in block_range {
-            let _static_file_block = static_file_writer.increment_block(block)?;
-            debug_assert_eq!(_static_file_block, block);
+            static_file_writer.increment_block(block)?;
 
             let block_body_indices = provider
                 .block_body_indices(block)?

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -320,10 +320,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// and create the next one if we are past the end range.
     ///
     /// Returns the current [`BlockNumber`] as seen in the static file.
-    pub fn increment_block(
-        &mut self,
-        expected_block_number: BlockNumber,
-    ) -> ProviderResult<BlockNumber> {
+    pub fn increment_block(&mut self, expected_block_number: BlockNumber) -> ProviderResult<()> {
         let segment = self.writer.user_header().segment();
 
         self.check_next_block_number(expected_block_number)?;
@@ -350,7 +347,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             }
         }
 
-        let block = self.writer.user_header_mut().increment_block();
+        self.writer.user_header_mut().increment_block();
         if let Some(metrics) = &self.metrics {
             metrics.record_segment_operation(
                 segment,
@@ -359,7 +356,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             );
         }
 
-        Ok(block)
+        Ok(())
     }
 
     /// Verifies if the incoming block number matches the next expected block number
@@ -524,13 +521,13 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         header: &Header,
         total_difficulty: U256,
         hash: &BlockHash,
-    ) -> ProviderResult<BlockNumber> {
+    ) -> ProviderResult<()> {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;
 
         debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Headers);
 
-        let block_number = self.increment_block(header.number)?;
+        self.increment_block(header.number)?;
 
         self.append_column(header)?;
         self.append_column(CompactU256::from(total_difficulty))?;
@@ -544,7 +541,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             );
         }
 
-        Ok(block_number)
+        Ok(())
     }
 
     /// Appends transaction to static file.


### PR DESCRIPTION
Since https://github.com/paradigmxyz/reth/pull/7137 we now have the consistency check right in `increment_block`, so returned block number would always be equal to the `expected_block_number`.

This allows to remove redundant error variant

cc @joshieDo for sanity check