### PR TITLE
feat: add tx_number consistency check to StaticFileProviderRW

### DIFF
--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -1,5 +1,5 @@
 use crate::PipelineEvent;
-use alloy_primitives::{BlockNumber, TxNumber};
+use alloy_primitives::BlockNumber;
 use reth_consensus::ConsensusError;
 use reth_errors::{BlockExecutionError, DatabaseError, RethError};
 use reth_network_p2p::error::DownloadError;
@@ -100,18 +100,6 @@ pub enum StageError {
         /// Static File segment
         segment: StaticFileSegment,
     },
-    /// Unrecoverable inconsistency error related to a transaction number in a static file segment.
-    #[error(
-        "inconsistent transaction number for {segment}. db: {database}, static_file: {static_file}"
-    )]
-    InconsistentTxNumber {
-        /// Static File segment where this error was encountered.
-        segment: StaticFileSegment,
-        /// Expected database transaction number.
-        database: TxNumber,
-        /// Expected static file transaction number.
-        static_file: TxNumber,
-    },
     /// Unrecoverable inconsistency error related to a block number in a static file segment.
     #[error("inconsistent block number for {segment}. db: {database}, static_file: {static_file}")]
     InconsistentBlockNumber {
@@ -157,7 +145,6 @@ impl StageError {
                 Self::MissingSyncGap |
                 Self::ChannelClosed |
                 Self::InconsistentBlockNumber { .. } |
-                Self::InconsistentTxNumber { .. } |
                 Self::Internal(_) |
                 Self::Fatal(_)
         )

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -193,18 +193,7 @@ where
                 BlockResponse::Full(block) => {
                     // Write transactions
                     for transaction in block.body.transactions() {
-                        let appended_tx_number =
-                            static_file_producer.append_transaction(next_tx_num, transaction)?;
-
-                        if appended_tx_number != next_tx_num {
-                            // This scenario indicates a critical error in the logic of adding new
-                            // items. It should be treated as an `expect()` failure.
-                            return Err(StageError::InconsistentTxNumber {
-                                segment: StaticFileSegment::Transactions,
-                                database: next_tx_num,
-                                static_file: appended_tx_number,
-                            })
-                        }
+                        static_file_producer.append_transaction(next_tx_num, transaction)?;
 
                         // Increment transaction id for each transaction.
                         next_tx_num += 1;

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -133,6 +133,9 @@ pub enum ProviderError {
     /// Trying to insert data from an unexpected block number.
     #[display("trying to append data to {_0} as block #{_1} but expected block #{_2}")]
     UnexpectedStaticFileBlockNumber(StaticFileSegment, BlockNumber, BlockNumber),
+    /// Trying to insert data from an unexpected block number.
+    #[display("trying to append row to {_0} at index #{_1} but expected index #{_2}")]
+    UnexpectedStaticFileTxNumber(StaticFileSegment, TxNumber, TxNumber),
     /// Static File Provider was initialized as read-only.
     #[display("cannot get a writer on a read-only environment.")]
     ReadOnlyStaticFileAccess,

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -501,16 +501,24 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         &mut self,
         tx_num: TxNumber,
         value: V,
-    ) -> ProviderResult<TxNumber> {
-        if self.writer.user_header().tx_range().is_none() {
-            self.writer.user_header_mut().set_tx_range(tx_num, tx_num);
-        } else {
+    ) -> ProviderResult<()> {
+        if let Some(range) = self.writer.user_header().tx_range() {
+            let next_tx = range.end() + 1;
+            if next_tx != tx_num {
+                return Err(ProviderError::UnexpectedStaticFileTxNumber(
+                    self.writer.user_header().segment(),
+                    tx_num,
+                    next_tx,
+                ))
+            }
             self.writer.user_header_mut().increment_tx();
+        } else {
+            self.writer.user_header_mut().set_tx_range(tx_num, tx_num);
         }
 
         self.append_column(value)?;
 
-        Ok(self.writer.user_header().tx_end().expect("qed"))
+        Ok(())
     }
 
     /// Appends header to static file.
@@ -553,16 +561,12 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// empty blocks and this function wouldn't be called.
     ///
     /// Returns the current [`TxNumber`] as seen in the static file.
-    pub fn append_transaction(
-        &mut self,
-        tx_num: TxNumber,
-        tx: impl Compact,
-    ) -> ProviderResult<TxNumber> {
+    pub fn append_transaction(&mut self, tx_num: TxNumber, tx: impl Compact) -> ProviderResult<()> {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;
 
         debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Transactions);
-        let result = self.append_with_tx_number(tx_num, tx)?;
+        self.append_with_tx_number(tx_num, tx)?;
 
         if let Some(metrics) = &self.metrics {
             metrics.record_segment_operation(
@@ -572,7 +576,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             );
         }
 
-        Ok(result)
+        Ok(())
     }
 
     /// Appends receipt to static file.
@@ -581,16 +585,12 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// empty blocks and this function wouldn't be called.
     ///
     /// Returns the current [`TxNumber`] as seen in the static file.
-    pub fn append_receipt(
-        &mut self,
-        tx_num: TxNumber,
-        receipt: &Receipt,
-    ) -> ProviderResult<TxNumber> {
+    pub fn append_receipt(&mut self, tx_num: TxNumber, receipt: &Receipt) -> ProviderResult<()> {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;
 
         debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Receipts);
-        let result = self.append_with_tx_number(tx_num, receipt)?;
+        self.append_with_tx_number(tx_num, receipt)?;
 
         if let Some(metrics) = &self.metrics {
             metrics.record_segment_operation(
@@ -600,7 +600,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             );
         }
 
-        Ok(result)
+        Ok(())
     }
 
     /// Appends multiple receipts to the static file.
@@ -628,7 +628,8 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
 
         for receipt_result in receipts_iter {
             let (tx_num, receipt) = receipt_result?;
-            tx_number = self.append_with_tx_number(tx_num, receipt.borrow())?;
+            self.append_with_tx_number(tx_num, receipt.borrow())?;
+            tx_number = tx_num;
             count += 1;
         }
 


### PR DESCRIPTION
Adds similar check as https://github.com/paradigmxyz/reth/pull/7137 but for transaction index and removes redundant `StageError` variant simialrly to https://github.com/paradigmxyz/reth/pull/12569