### PR TITLE
chore(ci): add reth-evm to wasm build exclusion list

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -36,6 +36,7 @@ exclude_crates=(
   reth-ethereum-payload-builder
   reth-etl
   reth-evm
+  reth-evm-ethereum
   reth-exex
   reth-exex-test-utils
   reth-ipc
@@ -49,6 +50,8 @@ exclude_crates=(
   reth-node-events
   reth-node-metrics
   reth-optimism-cli
+  reth-optimism-evm
+  reth-optimism-primitives
   reth-optimism-node
   reth-optimism-payload-builder
   reth-optimism-rpc

--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -35,6 +35,7 @@ exclude_crates=(
   reth-ethereum-engine-primitives
   reth-ethereum-payload-builder
   reth-etl
+  reth-evm
   reth-exex
   reth-exex-test-utils
   reth-ipc


### PR DESCRIPTION
In #12572 `reth-node-types` is added as dependency of `reth-evm` and `reth-optimism-primitives`, `reth-node-types` is in the exclusion list for wasm builds, this PR adds `reth-evm`, `reth-evm-ethereum`, `reth-optimism-evm` and `reth-optimism-primitives` to that list too.