### PR TITLE
Fix grammar in MDBX documentation

### DIFF
--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 pub use crate::implementation::mdbx::*;
 pub use reth_libmdbx::*;
 
-/// Creates a new database at the specified path if it doesn't exist. Does NOT create tables. Check
+/// Creates the new database at the specified path if it doesn't exist. Does NOT create tables. Check
 /// [`init_db`].
 pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
     use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 pub use crate::implementation::mdbx::*;
 pub use reth_libmdbx::*;
 
-/// Creates the new database at the specified path if it doesn't exist. Does NOT create tables. Check
+/// Creates a new database at the specified path if it doesn't exist. Does NOT create tables. Check
 /// [`init_db`].
 pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
     use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/man1/mdbx_chk.1
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/man1/mdbx_chk.1
@@ -27,7 +27,7 @@ mdbx_chk \- MDBX checking tool
 .SH DESCRIPTION
 The
 .B mdbx_chk
-utility intended to check an MDBX database file.
+utility is intended to check an MDBX database file.
 .SH OPTIONS
 .TP
 .BR \-V
@@ -55,7 +55,7 @@ check, including full check of all meta-pages and actual size of database file.
 .BR \-w
 Open environment in read-write mode and lock for writing while checking.
 This could be impossible if environment already used by another process(s)
-in an incompatible read-write mode. This allow rollback to last steady commit
+in an incompatible read-write mode. This allows rollback to last steady commit
 (in case environment was not closed properly) and then check transaction IDs
 of meta-pages. Otherwise, without \fB\-w\fP option environment will be
 opened in read-only mode.
@@ -90,7 +90,7 @@ then forcibly loads ones by sequential access and tries to lock database pages i
 .TP
 .BR \-n
 Open MDBX environment(s) which do not use subdirectories.
-This is legacy option. For now MDBX handles this automatically.
+This is a legacy option. For now MDBX handles this automatically.
 
 .SH DIAGNOSTICS
 Exit status is zero if no errors occur. Errors result in a non-zero exit status


### PR DESCRIPTION
Fix several grammatical issues:
- "Creates a new database" -> "Creates the new database"
- Add missing "is" in utility description
- Fix verb form: "allow" -> "allows"
- Add missing article: "This is legacy option" -> "This is a legacy option"