### PR TITLE
chore(util): Add reth payload util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8360,6 +8360,7 @@ dependencies = [
  "reth-optimism-forks",
  "reth-payload-builder",
  "reth-payload-primitives",
+ "reth-payload-util",
  "reth-primitives",
  "reth-provider",
  "reth-revm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8324,6 +8324,7 @@ dependencies = [
  "reth-optimism-payload-builder",
  "reth-optimism-rpc",
  "reth-payload-builder",
+ "reth-payload-util",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
@@ -8479,6 +8480,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "reth-payload-util"
+version = "1.1.1"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "reth-primitives",
 ]
 
 [[package]]
@@ -9260,6 +9270,7 @@ dependencies = [
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
+ "reth-payload-util",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
     "crates/payload/builder/",
     "crates/payload/primitives/",
     "crates/payload/validator/",
+    "crates/payload/util/",
     "crates/primitives-traits/",
     "crates/primitives/",
     "crates/prune/prune",
@@ -381,6 +382,7 @@ reth-optimism-storage = { path = "crates/optimism/storage" }
 reth-payload-builder = { path = "crates/payload/builder" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
+reth-payload-util = { path = "crates/payload/util" }
 reth-primitives = { path = "crates/primitives", default-features = false, features = [
     "std",
 ] }

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -16,6 +16,7 @@ reth-chainspec.workspace = true
 reth-engine-local.workspace = true
 reth-primitives.workspace = true
 reth-payload-builder.workspace = true
+reth-payload-util.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-consensus.workspace = true
 reth-node-api.workspace = true

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -25,12 +25,10 @@ use reth_optimism_node::{
     OpEngineTypes, OpNode,
 };
 use reth_optimism_payload_builder::builder::OpPayloadTransactions;
+use reth_payload_util::{PayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
 use reth_primitives::{SealedBlock, Transaction, TransactionSigned, TransactionSignedEcRecovered};
 use reth_provider::providers::BlockchainProvider2;
-use reth_transaction_pool::{
-    pool::{BestPayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed},
-    PayloadTransactions,
-};
+use reth_transaction_pool::BestPayloadTransactions;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -28,7 +28,7 @@ use reth_optimism_payload_builder::builder::OpPayloadTransactions;
 use reth_payload_util::{PayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
 use reth_primitives::{SealedBlock, Transaction, TransactionSigned, TransactionSignedEcRecovered};
 use reth_provider::providers::BlockchainProvider2;
-use reth_transaction_pool::BestPayloadTransactions;
+use reth_transaction_pool::pool::BestPayloadTransactions;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -22,6 +22,7 @@ reth-rpc-types-compat.workspace = true
 reth-evm.workspace = true
 reth-execution-types.workspace = true
 reth-payload-builder.workspace = true
+reth-payload-util.workspace = true
 reth-payload-primitives = { workspace = true, features = ["op"] }
 reth-basic-payload-builder.workspace = true
 reth-trie.workspace = true

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -16,6 +16,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;
 use reth_optimism_forks::OpHardforks;
 use reth_payload_primitives::{PayloadBuilderAttributes, PayloadBuilderError};
+use reth_payload_util::PayloadTransactions;
 use reth_primitives::{
     proofs,
     revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg},
@@ -24,7 +25,7 @@ use reth_primitives::{
 use reth_provider::{ProviderError, StateProofProvider, StateProviderFactory, StateRootProvider};
 use reth_revm::database::StateProviderDatabase;
 use reth_transaction_pool::{
-    noop::NoopTransactionPool, BestTransactionsAttributes, PayloadTransactions, TransactionPool,
+    noop::NoopTransactionPool, BestTransactionsAttributes, TransactionPool,
 };
 use reth_trie::HashedPostState;
 use revm::{

--- a/crates/payload/util/Cargo.toml
+++ b/crates/payload/util/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "reth-payload-util"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "reth payload utilities"
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-primitives.workspace = true
+
+# alloy
+alloy-primitives.workspace = true
+alloy-consensus.workspace = true

--- a/crates/payload/util/src/lib.rs
+++ b/crates/payload/util/src/lib.rs
@@ -1,0 +1,15 @@
+//! payload utils.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+mod traits;
+mod transaction;
+
+pub use traits::PayloadTransactions;
+pub use transaction::{PayloadTransactionsChain, PayloadTransactionsFixed};

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -1,0 +1,20 @@
+use alloy_primitives::Address;
+use reth_primitives::TransactionSignedEcRecovered;
+
+/// Iterator that returns transactions for the block building process in the order they should be
+/// included in the block.
+///
+/// Can include transactions from the pool and other sources (alternative pools,
+/// sequencer-originated transactions, etc.).
+pub trait PayloadTransactions {
+    /// Returns the next transaction to include in the block.
+    fn next(
+        &mut self,
+        // In the future, `ctx` can include access to state for block building purposes.
+        ctx: (),
+    ) -> Option<TransactionSignedEcRecovered>;
+
+    /// Exclude descendants of the transaction with given sender and nonce from the iterator,
+    /// because this transaction won't be included in the block.
+    fn mark_invalid(&mut self, sender: Address, nonce: u64);
+}

--- a/crates/payload/util/src/transaction.rs
+++ b/crates/payload/util/src/transaction.rs
@@ -1,0 +1,128 @@
+use crate::PayloadTransactions;
+use alloy_consensus::Transaction;
+use alloy_primitives::Address;
+use reth_primitives::TransactionSignedEcRecovered;
+
+/// An implementation of [`crate::traits::PayloadTransactions`] that yields
+/// a pre-defined set of transactions.
+///
+/// This is useful to put a sequencer-specified set of transactions into the block
+/// and compose it with the rest of the transactions.
+#[derive(Debug)]
+pub struct PayloadTransactionsFixed<T> {
+    transactions: Vec<T>,
+    index: usize,
+}
+
+impl<T> PayloadTransactionsFixed<T> {
+    /// Constructs a new [`PayloadTransactionsFixed`].
+    pub fn new(transactions: Vec<T>) -> Self {
+        Self { transactions, index: Default::default() }
+    }
+
+    /// Constructs a new [`PayloadTransactionsFixed`] with a single transaction.
+    pub fn single(transaction: T) -> Self {
+        Self { transactions: vec![transaction], index: Default::default() }
+    }
+}
+
+impl PayloadTransactions for PayloadTransactionsFixed<TransactionSignedEcRecovered> {
+    fn next(&mut self, _ctx: ()) -> Option<TransactionSignedEcRecovered> {
+        (self.index < self.transactions.len()).then(|| {
+            let tx = self.transactions[self.index].clone();
+            self.index += 1;
+            tx
+        })
+    }
+
+    fn mark_invalid(&mut self, _sender: Address, _nonce: u64) {}
+}
+
+/// Wrapper over [`crate::traits::PayloadTransactions`] that combines transactions from multiple
+/// `PayloadTransactions` iterators and keeps track of the gas for both of iterators.
+///
+/// We can't use [`Iterator::chain`], because:
+/// (a) we need to propagate the `mark_invalid` and `no_updates`
+/// (b) we need to keep track of the gas
+///
+/// Notes that [`PayloadTransactionsChain`] fully drains the first iterator
+/// before moving to the second one.
+///
+/// If the `before` iterator has transactions that are not fitting into the block,
+/// the after iterator will get propagated a `mark_invalid` call for each of them.
+#[derive(Debug)]
+pub struct PayloadTransactionsChain<B: PayloadTransactions, A: PayloadTransactions> {
+    /// Iterator that will be used first
+    before: B,
+    /// Allowed gas for the transactions from `before` iterator. If `None`, no gas limit is
+    /// enforced.
+    before_max_gas: Option<u64>,
+    /// Gas used by the transactions from `before` iterator
+    before_gas: u64,
+    /// Iterator that will be used after `before` iterator
+    after: A,
+    /// Allowed gas for the transactions from `after` iterator. If `None`, no gas limit is
+    /// enforced.
+    after_max_gas: Option<u64>,
+    /// Gas used by the transactions from `after` iterator
+    after_gas: u64,
+}
+
+impl<B: PayloadTransactions, A: PayloadTransactions> PayloadTransactionsChain<B, A> {
+    /// Constructs a new [`PayloadTransactionsChain`].
+    pub fn new(
+        before: B,
+        before_max_gas: Option<u64>,
+        after: A,
+        after_max_gas: Option<u64>,
+    ) -> Self {
+        Self {
+            before,
+            before_max_gas,
+            before_gas: Default::default(),
+            after,
+            after_max_gas,
+            after_gas: Default::default(),
+        }
+    }
+}
+
+impl<B, A> PayloadTransactions for PayloadTransactionsChain<B, A>
+where
+    B: PayloadTransactions,
+    A: PayloadTransactions,
+{
+    fn next(&mut self, ctx: ()) -> Option<TransactionSignedEcRecovered> {
+        while let Some(tx) = self.before.next(ctx) {
+            if let Some(before_max_gas) = self.before_max_gas {
+                if self.before_gas + tx.transaction.gas_limit() <= before_max_gas {
+                    self.before_gas += tx.transaction.gas_limit();
+                    return Some(tx);
+                }
+                self.before.mark_invalid(tx.signer(), tx.transaction.nonce());
+                self.after.mark_invalid(tx.signer(), tx.transaction.nonce());
+            } else {
+                return Some(tx);
+            }
+        }
+
+        while let Some(tx) = self.after.next(ctx) {
+            if let Some(after_max_gas) = self.after_max_gas {
+                if self.after_gas + tx.transaction.gas_limit() <= after_max_gas {
+                    self.after_gas += tx.transaction.gas_limit();
+                    return Some(tx);
+                }
+                self.after.mark_invalid(tx.signer(), tx.transaction.nonce());
+            } else {
+                return Some(tx);
+            }
+        }
+
+        None
+    }
+
+    fn mark_invalid(&mut self, sender: Address, nonce: u64) {
+        self.before.mark_invalid(sender, nonce);
+        self.after.mark_invalid(sender, nonce);
+    }
+}

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -18,6 +18,7 @@ reth-chainspec.workspace = true
 reth-eth-wire-types.workspace = true
 reth-primitives = { workspace = true, features = ["c-kzg", "secp256k1"] }
 reth-primitives-traits.workspace = true
+reth-payload-util.workspace = true
 reth-execution-types.workspace = true
 reth-fs-util.workspace = true
 reth-storage-api.workspace = true

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -108,7 +108,6 @@ use crate::{
 };
 pub use best::{
     BestPayloadTransactions, BestTransactionFilter, BestTransactionsWithPrioritizedSenders,
-    PayloadTransactionsChain, PayloadTransactionsFixed,
 };
 pub use blob::{blob_tx_priority, fee_delta};
 pub use events::{FullTransactionEvent, TransactionEvent};

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -886,7 +886,7 @@ impl<T> TransactionFilter for NoopTransactionFilter<T> {
     }
 }
 
-/// A Helper type that bundles the best transactions attributes together.
+/// A Helper type thaPayloadTransactionst bundles the best transactions attributes together.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BestTransactionsAttributes {
     /// The base fee attribute for best transactions.
@@ -1508,24 +1508,6 @@ impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
             }
         }
     }
-}
-
-/// Iterator that returns transactions for the block building process in the order they should be
-/// included in the block.
-///
-/// Can include transactions from the pool and other sources (alternative pools,
-/// sequencer-originated transactions, etc.).
-pub trait PayloadTransactions {
-    /// Returns the next transaction to include in the block.
-    fn next(
-        &mut self,
-        // In the future, `ctx` can include access to state for block building purposes.
-        ctx: (),
-    ) -> Option<TransactionSignedEcRecovered>;
-
-    /// Exclude descendants of the transaction with given sender and nonce from the iterator,
-    /// because this transaction won't be included in the block.
-    fn mark_invalid(&mut self, sender: Address, nonce: u64);
 }
 
 #[cfg(test)]

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -886,7 +886,7 @@ impl<T> TransactionFilter for NoopTransactionFilter<T> {
     }
 }
 
-/// A Helper type thaPayloadTransactionst bundles the best transactions attributes together.
+/// A Helper type that bundles the best transactions attributes together.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BestTransactionsAttributes {
     /// The base fee attribute for best transactions.


### PR DESCRIPTION
Resolves: https://github.com/paradigmxyz/reth/issues/12533

- Added a new `reth-payload-util` crate within the payload module that contains shared utilities, allowing `transaction-pool` to use these utilities without creating dependency cycles.
- I also discovered that many components are tightly coupled with the transaction pool module, which explains the concentration of changes there. We should consider refactoring the transaction pool to better separate concerns, especially for functionality that could be reused elsewhere without creating dependency cycles.

For example, this code remains in transaction pool due to its dependencies:
https://github.com/paradigmxyz/reth/blob/7bd7c37b13960cb5c04b46ec678234596db299d6/crates/transaction-pool/src/pool/best.rs#L213