### PR TITLE
Fix Minor Documentation Errors

### DIFF
--- a/book/run/config.md
+++ b/book/run/config.md
@@ -36,7 +36,7 @@ The defaults shipped with Reth try to be relatively reasonable, but may not be o
 
 ### `headers`
 
-The headers section controls both the behavior of the header stage, which download historical headers, as well as the primary downloader that fetches headers over P2P.
+The headers section controls both the behavior of the header stage, which downloads historical headers, as well as the primary downloader that fetches headers over P2P.
 
 ```toml
 [stages.headers]
@@ -65,7 +65,7 @@ commit_threshold = 10000
 
 ### `bodies`
 
-The bodies section controls both the behavior of the bodies stage, which download historical block bodies, as well as the primary downloader that fetches block bodies over P2P.
+The bodies section controls both the behavior of the bodies stage, which downloads historical block bodies, as well as the primary downloader that fetches block bodies over P2P.
 
 ```toml
 [stages.bodies]
@@ -102,7 +102,7 @@ The sender recovery stage recovers the address of transaction senders using tran
 
 ```toml
 [stages.sender_recovery]
-# The amount of transactions to recover senders for before
+# The number of transactions to recover senders for before
 # writing the results to disk.
 #
 # Lower thresholds correspond to more frequent disk I/O (writes),

--- a/book/run/sync-op-mainnet.md
+++ b/book/run/sync-op-mainnet.md
@@ -1,6 +1,6 @@
 # Sync OP Mainnet
 
-To sync OP mainnet, bedrock state needs to be imported as a starting point. There are currently two ways:
+To sync OP mainnet, Bedrock state needs to be imported as a starting point. There are currently two ways:
 
 * Minimal bootstrap **(recommended)**: only state snapshot at Bedrock block is imported without any OVM historical data.
 * Full bootstrap **(not recommended)**: state, blocks and receipts are imported. *Not recommended for now: [storage consistency issue](https://github.com/paradigmxyz/reth/pull/11099) tldr: sudden crash may break the node

--- a/book/run/transactions.md
+++ b/book/run/transactions.md
@@ -38,7 +38,7 @@ Alongside the `accessList` parameter and legacy parameters (except `gasPrice`), 
 
 The base fee is burned, while the priority fee is paid to the miner who includes the transaction, incentivizing miners to include transactions with higher priority fees per gas.
 
-## EIP-4844 Transaction
+## EIP-4844 Transactions
 
 [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) transactions (type `0x3`) was introduced in Ethereum's Dencun fork. This provides a temporary but significant scaling relief for rollups by allowing them to initially scale to 0.375 MB per slot, with a separate fee market allowing fees to be very low while usage of this system is limited.
 


### PR DESCRIPTION
### Changes made

1. **book/run/config.md**:
   - **"which download historical headers"** has been corrected to **"which downloads historical headers"**. This correction is necessary because the context implies an ongoing action, so the verb should be in the singular present form.
   - **"which download historical block bodies"** has also been corrected to **"which downloads historical block bodies"** for consistency with the previous fix.
   - **"The amount of transactions"** has been corrected to **"The number of transactions"**. This change ensures grammatical accuracy, as "amount" is typically used for uncountable nouns, while "number" should be used with countable nouns like "transactions".

2. **book/run/sync-op-mainnet.md**:
   - **"bedrock state"** has been updated to **"Bedrock state"** to properly capitalize the term, which refers to a specific technology or state related to OP mainnet.

3. **book/run/transactions.md**:
   - **"EIP-4844 Transaction"** has been changed to **"EIP-4844 Transactions"**. The plural form is required here, as the documentation refers to the general category of transactions, not just a single transaction.

### Importance
The changes in this PR are critical for ensuring that the documentation is clear, accurate, and professionally written. Correct grammatical usage helps prevent confusion for users and contributors who rely on the documentation for accurate information. The specific terminology changes also make sure that the technical terms and concepts are presented properly, aligning with industry standards and best practices.

**Thank you for reviewing this PR!**