### PR TITLE
chore(sdk): Add blanket impls for refs to prim traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8582,6 +8582,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
+ "auto_impl",
  "bincode",
  "byteorder",
  "bytes",

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -27,6 +27,7 @@ byteorder = "1"
 derive_more.workspace = true
 roaring = "0.10.2"
 serde_with = { workspace = true, optional = true }
+auto_impl.workspace = true
 
 # required by reth-codecs
 bytes.workspace = true

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -5,6 +5,7 @@ use alloc::fmt;
 use alloy_consensus::Transaction;
 
 /// Abstraction for block's body.
+#[auto_impl::auto_impl(&, Arc)]
 pub trait BlockBody:
     Send
     + Sync
@@ -19,7 +20,6 @@ pub trait BlockBody:
     + alloy_rlp::Encodable
     + alloy_rlp::Decodable
     + InMemorySize
-    + 'static
 {
     /// Ordered list of signed transactions as committed in block.
     // todo: requires trait for signed transaction

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -26,7 +26,6 @@ pub trait BlockHeader:
     + alloy_consensus::BlockHeader
     + Sealable
     + InMemorySize
-    + 'static
 {
 }
 
@@ -46,6 +45,5 @@ impl<T> BlockHeader for T where
         + alloy_consensus::BlockHeader
         + Sealable
         + InMemorySize
-        + 'static
 {
 }

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -18,6 +18,7 @@ impl<T> FullBlock for T where T: Block<Header: FullBlockHeader> + Compact {}
 // todo: make sealable super-trait, depends on <https://github.com/paradigmxyz/reth/issues/11449>
 // todo: make with senders extension trait, so block can be impl by block type already containing
 // senders
+#[auto_impl::auto_impl(&, Arc)]
 pub trait Block:
     Send
     + Sync
@@ -32,7 +33,7 @@ pub trait Block:
     + InMemorySize
 {
     /// Header part of the block.
-    type Header: BlockHeader;
+    type Header: BlockHeader + 'static;
 
     /// The block's body contains the transactions in the block.
     type Body: Send + Sync + Unpin + 'static;

--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -10,9 +10,10 @@ use serde::{Deserialize, Serialize};
 /// Helper trait that unifies all behaviour required by receipt to support full node operations.
 pub trait FullReceipt: Receipt + Compact {}
 
-impl<T> FullReceipt for T where T: Receipt + Compact {}
+impl<T> FullReceipt for T where T: ReceiptExt + Compact {}
 
 /// Abstraction of a receipt.
+#[auto_impl::auto_impl(&, Arc)]
 pub trait Receipt:
     Send
     + Sync
@@ -28,7 +29,10 @@ pub trait Receipt:
 {
     /// Returns transaction type.
     fn tx_type(&self) -> u8;
+}
 
+/// Extension if [`Receipt`] used in block execution.
+pub trait ReceiptExt: Receipt {
     /// Calculates the receipts root of the given receipts.
     fn receipts_root(receipts: &[&Self]) -> B256;
 }

--- a/crates/primitives-traits/src/size.rs
+++ b/crates/primitives-traits/src/size.rs
@@ -1,4 +1,5 @@
 /// Trait for calculating a heuristic for the in-memory size of a struct.
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait InMemorySize {
     /// Returns a heuristic for the in-memory size of a struct.
     fn size(&self) -> usize;

--- a/crates/primitives-traits/src/transaction/mod.rs
+++ b/crates/primitives-traits/src/transaction/mod.rs
@@ -53,6 +53,7 @@ impl<T> Transaction for T where
 }
 
 /// Extension trait of [`alloy_consensus::Transaction`].
+#[auto_impl::auto_impl(&, Arc)]
 pub trait TransactionExt: alloy_consensus::Transaction {
     /// Transaction envelope type ID.
     type Type: TxType;

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -465,8 +465,8 @@ where
 
 impl<H, B> reth_primitives_traits::Block for SealedBlock<H, B>
 where
-    H: reth_primitives_traits::BlockHeader,
-    B: reth_primitives_traits::BlockBody,
+    H: reth_primitives_traits::BlockHeader + 'static,
+    B: reth_primitives_traits::BlockBody + 'static,
     Self: Serialize + for<'a> Deserialize<'a>,
 {
     type Header = H;

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -10,6 +10,7 @@ use alloy_primitives::{Bloom, Log, B256};
 use alloy_rlp::{length_of_length, Decodable, Encodable, RlpDecodable, RlpEncodable};
 use bytes::{Buf, BufMut};
 use derive_more::{DerefMut, From, IntoIterator};
+use reth_primitives_traits::receipt::ReceiptExt;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "reth-codec")]
@@ -97,7 +98,9 @@ impl reth_primitives_traits::Receipt for Receipt {
     fn tx_type(&self) -> u8 {
         self.tx_type as u8
     }
+}
 
+impl ReceiptExt for Receipt {
     fn receipts_root(_receipts: &[&Self]) -> B256 {
         #[cfg(feature = "optimism")]
         panic!("This should not be called in optimism mode. Use `optimism_receipts_root_slow` instead.");

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1367,12 +1367,6 @@ impl SignedTransaction for TransactionSigned {
         recover_signer_unchecked(&self.signature, signature_hash)
     }
 
-    fn from_transaction_and_signature(transaction: Transaction, signature: Signature) -> Self {
-        let mut initial_tx = Self { transaction, hash: Default::default(), signature };
-        initial_tx.hash = initial_tx.recalculate_hash();
-        initial_tx
-    }
-
     fn fill_tx_env(&self, tx_env: &mut TxEnv, sender: Address) {
         tx_env.caller = sender;
         match self.as_ref() {


### PR DESCRIPTION
A lot of places in the code take references to the primitive data types. For components to use these as generics, blanket impls of the data primitive traits for reference types, are needed.