### PR TITLE
chore(sdk): limit `FillTxEnv` to super trait of `FullSignedTx`

### DIFF
--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -7,7 +7,7 @@ use alloy_eips::{
 use alloy_primitives::{keccak256, Address, Bytes, B256, B64, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1, PayloadId};
-use op_alloy_consensus::eip1559::{decode_holocene_extra_data, EIP1559ParamError};
+use op_alloy_consensus::{decode_holocene_extra_data, EIP1559ParamError};
 /// Re-export for use in downstream arguments.
 pub use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4};

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -26,6 +26,7 @@ pub use receipt::{FullReceipt, Receipt};
 
 pub mod transaction;
 pub use transaction::{
+    execute::FillTxEnv,
     signed::{FullSignedTx, SignedTransaction},
     FullTransaction, Transaction, TransactionExt,
 };

--- a/crates/primitives-traits/src/transaction/execute.rs
+++ b/crates/primitives-traits/src/transaction/execute.rs
@@ -1,0 +1,10 @@
+//! Abstraction of an executable transaction.
+
+use alloy_primitives::Address;
+use revm_primitives::TxEnv;
+
+/// Loads transaction into execution environment.
+pub trait FillTxEnv {
+    /// Fills [`TxEnv`] with an [`Address`] and transaction.
+    fn fill_tx_env(&self, tx_env: &mut TxEnv, sender: Address);
+}

--- a/crates/primitives-traits/src/transaction/mod.rs
+++ b/crates/primitives-traits/src/transaction/mod.rs
@@ -1,5 +1,6 @@
 //! Transaction abstraction
 
+pub mod execute;
 pub mod signed;
 
 use core::{fmt, hash::Hash};

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -6,14 +6,19 @@ use core::hash::Hash;
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{keccak256, Address, PrimitiveSignature, TxHash, B256};
 use reth_codecs::Compact;
-use revm_primitives::TxEnv;
 
-use crate::{transaction::TransactionExt, FullTransaction, MaybeArbitrary, Transaction};
+use crate::{transaction::TransactionExt, FillTxEnv, FullTransaction, MaybeArbitrary, Transaction};
 
 /// Helper trait that unifies all behaviour required by block to support full node operations.
-pub trait FullSignedTx: SignedTransaction<Transaction: FullTransaction> + Compact {}
+pub trait FullSignedTx:
+    SignedTransaction<Transaction: FullTransaction> + FillTxEnv + Compact
+{
+}
 
-impl<T> FullSignedTx for T where T: SignedTransaction<Transaction: FullTransaction> + Compact {}
+impl<T> FullSignedTx for T where
+    T: SignedTransaction<Transaction: FullTransaction> + FillTxEnv + Compact
+{
+}
 
 /// A signed transaction.
 pub trait SignedTransaction:
@@ -78,9 +83,6 @@ pub trait SignedTransaction:
     fn recalculate_hash(&self) -> B256 {
         keccak256(self.encoded_2718())
     }
-
-    /// Fills [`TxEnv`] with an [`Address`] and transaction.
-    fn fill_tx_env(&self, tx_env: &mut TxEnv, sender: Address);
 }
 
 impl<T: SignedTransaction> TransactionExt for T {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1372,7 +1372,79 @@ impl SignedTransaction for TransactionSigned {
         initial_tx.hash = initial_tx.recalculate_hash();
         initial_tx
     }
+}
 
+impl alloy_consensus::Transaction for TransactionSigned {
+    fn chain_id(&self) -> Option<ChainId> {
+        self.deref().chain_id()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.deref().nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.deref().gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        self.deref().gas_price()
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.deref().max_fee_per_gas()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.deref().max_priority_fee_per_gas()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.deref().max_fee_per_blob_gas()
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.deref().priority_fee_or_price()
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.deref().effective_gas_price(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.deref().is_dynamic_fee()
+    }
+
+    fn kind(&self) -> TxKind {
+        self.deref().kind()
+    }
+
+    fn value(&self) -> U256 {
+        self.deref().value()
+    }
+
+    fn input(&self) -> &Bytes {
+        self.deref().input()
+    }
+
+    fn ty(&self) -> u8 {
+        self.deref().ty()
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        self.deref().access_list()
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        alloy_consensus::Transaction::blob_versioned_hashes(self.deref())
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.deref().authorization_list()
+    }
+}
+
+impl reth_primitives_traits::FillTxEnv for TransactionSigned {
     fn fill_tx_env(&self, tx_env: &mut TxEnv, sender: Address) {
         tx_env.caller = sender;
         match self.as_ref() {
@@ -1450,76 +1522,6 @@ impl SignedTransaction for TransactionSigned {
             #[cfg(feature = "optimism")]
             Transaction::Deposit(_) => {}
         }
-    }
-}
-
-impl alloy_consensus::Transaction for TransactionSigned {
-    fn chain_id(&self) -> Option<ChainId> {
-        self.deref().chain_id()
-    }
-
-    fn nonce(&self) -> u64 {
-        self.deref().nonce()
-    }
-
-    fn gas_limit(&self) -> u64 {
-        self.deref().gas_limit()
-    }
-
-    fn gas_price(&self) -> Option<u128> {
-        self.deref().gas_price()
-    }
-
-    fn max_fee_per_gas(&self) -> u128 {
-        self.deref().max_fee_per_gas()
-    }
-
-    fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        self.deref().max_priority_fee_per_gas()
-    }
-
-    fn max_fee_per_blob_gas(&self) -> Option<u128> {
-        self.deref().max_fee_per_blob_gas()
-    }
-
-    fn priority_fee_or_price(&self) -> u128 {
-        self.deref().priority_fee_or_price()
-    }
-
-    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        self.deref().effective_gas_price(base_fee)
-    }
-
-    fn is_dynamic_fee(&self) -> bool {
-        self.deref().is_dynamic_fee()
-    }
-
-    fn kind(&self) -> TxKind {
-        self.deref().kind()
-    }
-
-    fn value(&self) -> U256 {
-        self.deref().value()
-    }
-
-    fn input(&self) -> &Bytes {
-        self.deref().input()
-    }
-
-    fn ty(&self) -> u8 {
-        self.deref().ty()
-    }
-
-    fn access_list(&self) -> Option<&AccessList> {
-        self.deref().access_list()
-    }
-
-    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
-        alloy_consensus::Transaction::blob_versioned_hashes(self.deref())
-    }
-
-    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
-        self.deref().authorization_list()
     }
 }
 


### PR DESCRIPTION
`FillTxEnv` is only necessary in rpc (tracing) and execution components