### PR TITLE
feat: add EthereumEthApiTypes

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -4,11 +4,27 @@ use alloy_consensus::{Signed, Transaction as _, TxEip4844Variant, TxEnvelope};
 use alloy_network::{Ethereum, Network};
 use alloy_rpc_types_eth::{Transaction, TransactionInfo};
 use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
+use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::TransactionCompat;
 
+/// A standalone [`EthApiTypes`] implementation for Ethereum.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EthereumEthApiTypes(EthTxBuilder);
+
+impl EthApiTypes for EthereumEthApiTypes {
+    type Error = EthApiError;
+    type NetworkTypes = Ethereum;
+    type TransactionCompat = EthTxBuilder;
+
+    fn tx_resp_builder(&self) -> &Self::TransactionCompat {
+        &self.0
+    }
+}
+
 /// Builds RPC transaction response for l1.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
 pub struct EthTxBuilder;
 
 impl TransactionCompat for EthTxBuilder

--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -13,6 +13,9 @@ pub use core::EthApi;
 pub use filter::EthFilter;
 pub use pubsub::EthPubSub;
 
-pub use helpers::{signer::DevSigner, types::EthTxBuilder};
+pub use helpers::{
+    signer::DevSigner,
+    types::{EthTxBuilder, EthereumEthApiTypes},
+};
 
 pub use reth_rpc_eth_api::{EthApiServer, EthApiTypes, FullEthApiServer, RpcNodeCore};


### PR DESCRIPTION
adds a standalone `EthApiType` implementation for ethereum.

this makes it easier to create things like:

https://github.com/paradigmxyz/reth/blob/722fdbbbccc97d070a3018a6871f5155544bcedc/crates/rpc/rpc/src/eth/filter.rs#L43-L48

that need the compat