### PR TITLE
feat: install op debug exeuction witness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8335,6 +8335,7 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-revm",
+ "reth-rpc-server-types",
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -29,6 +29,7 @@ reth-evm.workspace = true
 reth-revm = { workspace = true, features = ["std"] }
 reth-beacon-consensus.workspace = true
 reth-trie-db.workspace = true
+reth-rpc-server-types.workspace = true
 
 # op-reth
 reth-optimism-payload-builder.workspace = true

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -11,7 +11,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_payload_builder::OpPayloadBuilder;
 use reth_primitives::SealedHeader;
 use reth_provider::{BlockReaderIdExt, ProviderError, ProviderResult, StateProviderFactory};
-use reth_rpc_api::DebugExecutionWitnessApiServer;
+pub use reth_rpc_api::DebugExecutionWitnessApiServer;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use std::{fmt::Debug, sync::Arc};
 


### PR DESCRIPTION
completes https://github.com/paradigmxyz/reth/pull/12238

by adding `launch_add_ons_with` as a workaround which makes it easy to extend modules, this can be improved but for now does the job.