### PR TITLE
fix: add additional op checks for chain specific check

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -819,7 +819,10 @@ where
     /// This checks for OP-Mainnet and ensures we have all the necessary data to progress (past
     /// bedrock height)
     fn ensure_chain_specific_db_checks(&self) -> ProviderResult<()> {
-        if self.chain_spec().is_optimism() && self.chain_id() == Chain::optimism_mainnet() {
+        if self.chain_spec().is_optimism() &&
+            !self.is_dev() &&
+            self.chain_id() == Chain::optimism_mainnet()
+        {
             let latest = self.blockchain_db().last_block_number()?;
             // bedrock height
             if latest < 105235063 {

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -819,7 +819,7 @@ where
     /// This checks for OP-Mainnet and ensures we have all the necessary data to progress (past
     /// bedrock height)
     fn ensure_chain_specific_db_checks(&self) -> ProviderResult<()> {
-        if self.chain_id() == Chain::optimism_mainnet() {
+        if self.chain_spec().is_optimism() && self.chain_id() == Chain::optimism_mainnet() {
             let latest = self.blockchain_db().last_block_number()?;
             // bedrock height
             if latest < 105235063 {


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/pull/12621

closes #12620

also, enforces that the chainspec is optimism and non dev, this should fix hive tests that use op mainnet chainid but with ethereum chainspec