### PR TITLE
chore: use keccak256 from alloy

### DIFF
--- a/crates/trie/common/src/key.rs
+++ b/crates/trie/common/src/key.rs
@@ -1,5 +1,4 @@
-use alloy_primitives::B256;
-use revm_primitives::keccak256;
+use alloy_primitives::{keccak256, B256};
 
 /// Trait for hashing keys in state.
 pub trait KeyHasher: Default + Clone + Send + Sync + 'static {


### PR DESCRIPTION
A minor nit on a recently merged PR. I think LSP's have a tendency to prefer the `revm_primitives` keccak over `alloy_primitives` for whatever reason