### PR TITLE
perf(tx-pool): avoid copying tx cost

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -657,7 +657,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                     InsertErr::Overdraft { transaction } => Err(PoolError::new(
                         *transaction.hash(),
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Overdraft {
-                            cost: transaction.cost(),
+                            cost: *transaction.cost(),
                             balance: on_chain_balance,
                         }),
                     )),
@@ -1229,7 +1229,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     tx.state.insert(TxState::NO_NONCE_GAPS);
                     tx.state.insert(TxState::NO_PARKED_ANCESTORS);
                     tx.cumulative_cost = U256::ZERO;
-                    if tx.transaction.cost() > info.balance {
+                    if tx.transaction.cost() > &info.balance {
                         // sender lacks sufficient funds to pay for this transaction
                         tx.state.remove(TxState::ENOUGH_BALANCE);
                     } else {
@@ -1542,7 +1542,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     }
                 }
             }
-        } else if new_blob_tx.cost() > on_chain_balance {
+        } else if new_blob_tx.cost() > &on_chain_balance {
             // the transaction would go into overdraft
             return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
         }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -961,7 +961,7 @@ pub trait PoolTransaction: fmt::Debug + Send + Sync + Clone {
     /// For legacy transactions: `gas_price * gas_limit + tx_value`.
     /// For EIP-4844 blob transactions: `max_fee_per_gas * gas_limit + tx_value +
     /// max_blob_fee_per_gas * blob_gas_used`.
-    fn cost(&self) -> U256;
+    fn cost(&self) -> &U256;
 
     /// Amount of gas that should be used in executing this transaction. This is paid up-front.
     fn gas_limit(&self) -> u64;
@@ -1228,8 +1228,8 @@ impl PoolTransaction for EthPooledTransaction {
     /// For legacy transactions: `gas_price * gas_limit + tx_value`.
     /// For EIP-4844 blob transactions: `max_fee_per_gas * gas_limit + tx_value +
     /// max_blob_fee_per_gas * blob_gas_used`.
-    fn cost(&self) -> U256 {
-        self.cost
+    fn cost(&self) -> &U256 {
+        &self.cost
     }
 
     /// Amount of gas that should be used in executing this transaction. This is paid up-front.

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -384,11 +384,12 @@ where
         let cost = transaction.cost();
 
         // Checks for max cost
-        if cost > account.balance {
+        if cost > &account.balance {
+            let expected = *cost;
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::InsufficientFunds(
-                    GotExpected { got: account.balance, expected: cost }.into(),
+                    GotExpected { got: account.balance, expected }.into(),
                 )
                 .into(),
             )

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -312,7 +312,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     ///
     /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
     /// For legacy transactions: `gas_price * gas_limit + tx_value`.
-    pub fn cost(&self) -> U256 {
+    pub fn cost(&self) -> &U256 {
         self.transaction.cost()
     }
 

--- a/examples/network-txpool/src/main.rs
+++ b/examples/network-txpool/src/main.rs
@@ -82,7 +82,7 @@ impl TransactionValidator for OkValidator {
     ) -> TransactionValidationOutcome<Self::Transaction> {
         // Always return valid
         TransactionValidationOutcome::Valid {
-            balance: transaction.cost(),
+            balance: *transaction.cost(),
             state_nonce: transaction.nonce(),
             transaction: ValidTransaction::Valid(transaction),
             propagate: false,


### PR DESCRIPTION
Apparently, copying the 32-byte cost of existing mempool transactions can be a bottleneck when adding new ones. It is in the hot path when there are bots with many transactions such as popular delegated EIP-7702 addresses, AI agents, etc.

![Screenshot from 2024-11-18 19-22-15](https://github.com/user-attachments/assets/c8b1d62b-52ea-4a6e-8723-f8aa0dadee4b)

This PR makes `PoolTransaction::cost` return a reference to avoid a copy when we only compare `U256`s. This is similar to `PoolTransaction::hash` returning a `&TxHash` instead of a copied `TxHash`.