### PR TITLE
Typo Update profiling.md

### DIFF
--- a/book/developers/profiling.md
+++ b/book/developers/profiling.md
@@ -25,7 +25,7 @@ In this tutorial, we will be reviewing:
 
 [Jemalloc](https://jemalloc.net/) is a general-purpose allocator that is used [across the industry in production](https://engineering.fb.com/2011/01/03/core-data/scalable-memory-allocation-using-jemalloc/), well known for its performance benefits, predictability, and profiling capabilities.
 We've seen significant performance benefits in reth when using jemalloc, but will be primarily focusing on its profiling capabilities.
-Jemalloc also provides tools for analyzing and visualizing its the allocation profiles it generates, notably `jeprof`.
+Jemalloc also provides tools for analyzing and visualizing its allocation profiles it generates, notably `jeprof`.
 
 
 #### Enabling jemalloc in reth


### PR DESCRIPTION
### Description:

This PR fixes a minor but important typo in the **Jemalloc** section of the profiling documentation.

#### Before:
> Jemalloc also provides tools for analyzing and visualizing **its the allocation profiles** it generates, notably `jeprof`.

#### After:
> Jemalloc also provides tools for analyzing and visualizing **its allocation profiles** it generates, notably `jeprof`.

### Importance of the Fix:

The typo introduces a grammatical issue that can distract readers and reduce the perceived professionalism of the documentation. While small, such errors can impact readability and comprehension, especially for non-native English speakers. Correcting this ensures the documentation maintains its clarity and quality.