### PR TITLE
Fix grammatical error in lib.rs

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -15,7 +15,7 @@
 //! - `min-error-logs`: Disables all logs below `error` level.
 //! - `min-warn-logs`: Disables all logs below `warn` level.
 //! - `min-info-logs`: Disables all logs below `info` level. This can speed up the node, since fewer
-//!   calls to the logging component is made.
+//!   calls to the logging component are made.
 //! - `min-debug-logs`: Disables all logs below `debug` level.
 //! - `min-trace-logs`: Disables all logs below `trace` level.
 


### PR DESCRIPTION
**Description**:  
This pull request corrects a grammatical error in the documentation for the `min-info-logs` feature flag. Specifically, the sentence:  

> This can speed up the node, since fewer calls to the logging component **is** made.  

has been corrected to:  

> This can speed up the node, since fewer calls to the logging component **are** made.  

### Importance of the fix:  
- **Improved readability**: Grammatical errors can distract readers and reduce the clarity of documentation. Fixing this ensures better comprehension for developers and users.  
- **Professionalism**: High-quality documentation reflects well on the project and fosters trust among contributors and users.  

This change is non-functional and affects only the documentation.