### PR TITLE
chore(exex): emit warn log when WAL grows beyond a certain number of blocks

### DIFF
--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -35,11 +35,11 @@ use tokio_util::sync::{PollSendError, PollSender, ReusableBoxFuture};
 /// or 17 minutes of 1-second blocks.
 pub const DEFAULT_EXEX_MANAGER_CAPACITY: usize = 1024;
 
-/// The default maximum number of blocks allowed in the WAL before emitting a warning.
+/// The maximum number of blocks allowed in the WAL before emitting a warning.
 ///
 /// This constant defines the threshold for the Write-Ahead Log (WAL) size. If the number of blocks
 /// in the WAL exceeds this limit, a warning is logged to indicate potential issues.
-pub const DEFAULT_MAX_WAL_BLOCKS_WARNING: usize = 128;
+pub const WAL_BLOCKS_WARNING: usize = 128;
 
 /// The source of the notification.
 ///
@@ -383,12 +383,12 @@ where
                 .unwrap();
 
             self.wal.finalize(lowest_finished_height)?;
-            if self.wal.num_blocks() > (DEFAULT_MAX_WAL_BLOCKS_WARNING as u64) {
+            if self.wal.num_blocks() > (WAL_BLOCKS_WARNING as u64) {
                 warn!(
                     target: "exex::manager",
                     "WAL contains {} blocks, exceeding the limit of {}",
                     self.wal.num_blocks(),
-                    DEFAULT_MAX_WAL_BLOCKS_WARNING,
+                    WAL_BLOCKS_WARNING,
                 );
             }
         } else {

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -10,7 +10,7 @@ use reth_chainspec::Head;
 use reth_metrics::{metrics::Counter, Metrics};
 use reth_primitives::SealedHeader;
 use reth_provider::HeaderProvider;
-use reth_tracing::tracing::debug;
+use reth_tracing::tracing::{debug, warn};
 use std::{
     collections::VecDeque,
     fmt::Debug,
@@ -34,6 +34,12 @@ use tokio_util::sync::{PollSendError, PollSender, ReusableBoxFuture};
 /// 1024 notifications in the buffer is 3.5 hours of mainnet blocks,
 /// or 17 minutes of 1-second blocks.
 pub const DEFAULT_EXEX_MANAGER_CAPACITY: usize = 1024;
+
+/// The default maximum number of blocks allowed in the WAL before emitting a warning.
+///
+/// This constant defines the threshold for the Write-Ahead Log (WAL) size. If the number of blocks
+/// in the WAL exceeds this limit, a warning is logged to indicate potential issues.
+pub const DEFAULT_MAX_WAL_BLOCKS_WARNING: usize = 128;
 
 /// The source of the notification.
 ///
@@ -377,6 +383,14 @@ where
                 .unwrap();
 
             self.wal.finalize(lowest_finished_height)?;
+            if self.wal.num_blocks() > (DEFAULT_MAX_WAL_BLOCKS_WARNING as u64) {
+                warn!(
+                    target: "exex::manager",
+                    "WAL contains {} blocks, exceeding the limit of {}",
+                    self.wal.num_blocks(),
+                    DEFAULT_MAX_WAL_BLOCKS_WARNING,
+                );
+            }
         } else {
             let unfinalized_exexes = exex_finished_heights
                 .into_iter()

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -383,7 +383,7 @@ where
                 .unwrap();
 
             self.wal.finalize(lowest_finished_height)?;
-            if self.wal.num_blocks() > (WAL_BLOCKS_WARNING as u64) {
+            if self.wal.num_blocks() > WAL_BLOCKS_WARNING {
                 warn!(
                     target: "exex::manager",
                     blocks = ?self.wal.num_blocks(),

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -386,9 +386,8 @@ where
             if self.wal.num_blocks() > (WAL_BLOCKS_WARNING as u64) {
                 warn!(
                     target: "exex::manager",
-                    "WAL contains {} blocks, exceeding the limit of {}",
-                    self.wal.num_blocks(),
-                    WAL_BLOCKS_WARNING,
+                    blocks = ?self.wal.num_blocks(),
+                    "WAL contains too many blocks and is not getting cleared. That will lead to increased disk space usage. Check that you emit the FinishedHeight event from your ExExes."
                 );
             }
         } else {

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -35,6 +35,11 @@ impl BlockCache {
         self.notification_max_blocks.is_empty()
     }
 
+    /// Returns the number of blocks in the cache.
+    pub (super) fn num_blocks(&self) -> u64 {
+        self.committed_blocks.len() as u64
+    }
+
     /// Removes all files from the cache that has notifications with a tip block less than or equal
     /// to the given block number.
     ///

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -36,8 +36,8 @@ impl BlockCache {
     }
 
     /// Returns the number of blocks in the cache.
-    pub(super) fn num_blocks(&self) -> u64 {
-        self.committed_blocks.len() as u64
+    pub(super) fn num_blocks(&self) -> usize {
+        self.committed_blocks.len()
     }
 
     /// Removes all files from the cache that has notifications with a tip block less than or equal

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -36,7 +36,7 @@ impl BlockCache {
     }
 
     /// Returns the number of blocks in the cache.
-    pub (super) fn num_blocks(&self) -> u64 {
+    pub(super) fn num_blocks(&self) -> u64 {
         self.committed_blocks.len() as u64
     }
 

--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -71,7 +71,6 @@ impl Wal {
     pub fn num_blocks(&self) -> u64 {
         self.inner.block_cache().num_blocks()
     }
-
 }
 
 /// Inner type for the WAL.

--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -68,7 +68,7 @@ impl Wal {
     }
 
     /// Returns the number of blocks in the WAL.
-    pub fn num_blocks(&self) -> u64 {
+    pub fn num_blocks(&self) -> usize {
         self.inner.block_cache().num_blocks()
     }
 }

--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -66,6 +66,12 @@ impl Wal {
     ) -> eyre::Result<Box<dyn Iterator<Item = eyre::Result<ExExNotification>> + '_>> {
         self.inner.iter_notifications()
     }
+
+    /// Returns the number of blocks in the WAL.
+    pub fn num_blocks(&self) -> u64 {
+        self.inner.block_cache().num_blocks()
+    }
+
 }
 
 /// Inner type for the WAL.


### PR DESCRIPTION
Closes #12626.