### PR TITLE
fix(discv5): warning discv5 config socket override

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -412,11 +412,13 @@ pub fn discv5_sockets_wrt_rlpx_addr(
                 discv5_addr_ipv6.map(|ip| SocketAddrV6::new(ip, discv5_port_ipv6, 0, 0));
 
             if let Some(discv5_addr) = discv5_addr_ipv4 {
-                warn!(target: "net::discv5",
-                    %discv5_addr,
-                    %rlpx_addr,
-                    "Overwriting discv5 IPv4 address with RLPx IPv4 address, limited to one advertised IP address per IP version"
-                );
+                if discv5_addr != rlpx_addr {
+                    warn!(target: "net::discv5",
+                        %discv5_addr,
+                        %rlpx_addr,
+                        "Overwriting discv5 IPv4 address with RLPx IPv4 address, limited to one advertised IP address per IP version"
+                    );
+                }
             }
 
             // overwrite discv5 ipv4 addr with RLPx address. this is since there is no
@@ -429,11 +431,13 @@ pub fn discv5_sockets_wrt_rlpx_addr(
                 discv5_addr_ipv4.map(|ip| SocketAddrV4::new(ip, discv5_port_ipv4));
 
             if let Some(discv5_addr) = discv5_addr_ipv6 {
-                warn!(target: "net::discv5",
-                    %discv5_addr,
-                    %rlpx_addr,
-                    "Overwriting discv5 IPv6 address with RLPx IPv6 address, limited to one advertised IP address per IP version"
-                );
+                if discv5_addr != rlpx_addr {
+                    warn!(target: "net::discv5",
+                        %discv5_addr,
+                        %rlpx_addr,
+                        "Overwriting discv5 IPv6 address with RLPx IPv6 address, limited to one advertised IP address per IP version"
+                    );
+                }
             }
 
             // overwrite discv5 ipv6 addr with RLPx address. this is since there is no


### PR DESCRIPTION
Bug: warning is logged when same discv5 and rlpx address are used.

Fix: check if rlpx address and discv5 address are equal, if discv5 address is set.