### PR TITLE
Run kurtosis e2e test 2x/day

### DIFF
--- a/.github/assets/kurtosis_network_params.yaml
+++ b/.github/assets/kurtosis_network_params.yaml
@@ -2,8 +2,6 @@ participants:
   - el_type: geth
     cl_type: lighthouse
   - el_type: reth
-    el_extra_params:
-      - --engine.experimental
     el_image: "ghcr.io/paradigmxyz/reth:kurtosis-ci"
     cl_type: teku
 additional_services:

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -5,8 +5,8 @@ name: kurtosis
 on:
   workflow_dispatch:
   schedule:
-    # every day
-    - cron: "0 1 * * *"
+    # run every 12 hours
+    - cron: "0 */12 * * *"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
We discussed in previous sync that we can run kurtosis test even 2x/day. 

Also removes obsolete experimental engine flag. 