### PR TITLE
fix: do not delegate is_optimism check for Ethereum ChainSpec

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -109,6 +109,6 @@ impl EthChainSpec for ChainSpec {
     }
 
     fn is_optimism(&self) -> bool {
-        self.chain.is_optimism()
+        false
     }
 }


### PR DESCRIPTION
`is_optimism` should always be false for Ethereum's `ChainSpec`, otherwise it could return true for an Ethereum chain spec if the chain id is one of Optimism's chains. 

This was causing hive tests to fail https://github.com/paradigmxyz/reth/actions/runs/11903470318/job/33171134482 will retrigger on this branch.