### PR TITLE
feat(trie): short-circuit account/storage reveal in sparse trie

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -73,7 +73,7 @@ impl SparseStateTrie {
         slot: B256,
         proof: impl IntoIterator<Item = (Nibbles, Bytes)>,
     ) -> SparseStateTrieResult<()> {
-        if self.revealed.get(&account).map_or(false, |v| v.contains(&slot)) {
+        if self.revealed.get(&account).is_some_and(|v| v.contains(&slot)) {
             return Ok(());
         }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -73,7 +73,7 @@ impl SparseStateTrie {
         slot: B256,
         proof: impl IntoIterator<Item = (Nibbles, Bytes)>,
     ) -> SparseStateTrieResult<()> {
-        if self.revealed.get(&account).map(|v| v.contains(&slot)).unwrap_or(false) {
+        if self.revealed.get(&account).map_or(false, |v| v.contains(&slot)) {
             return Ok(());
         }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -42,6 +42,10 @@ impl SparseStateTrie {
         account: B256,
         proof: impl IntoIterator<Item = (Nibbles, Bytes)>,
     ) -> SparseStateTrieResult<()> {
+        if self.revealed.contains_key(&account) {
+            return Ok(());
+        }
+
         let mut proof = proof.into_iter().peekable();
 
         let Some(root_node) = self.validate_proof(&mut proof)? else { return Ok(()) };
@@ -69,6 +73,10 @@ impl SparseStateTrie {
         slot: B256,
         proof: impl IntoIterator<Item = (Nibbles, Bytes)>,
     ) -> SparseStateTrieResult<()> {
+        if self.revealed.get(&account).map(|v| v.contains(&slot)).unwrap_or(false) {
+            return Ok(());
+        }
+
         let mut proof = proof.into_iter().peekable();
 
         let Some(root_node) = self.validate_proof(&mut proof)? else { return Ok(()) };


### PR DESCRIPTION
Short-circuit `reveal_account` and `reveal_storage_slot` if the path has already been revealed.