### PR TITLE
chore: group tx manager functions

### DIFF
--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -252,7 +252,7 @@ impl<N: NetworkPrimitives> PeersInfo for NetworkHandle<N> {
     }
 }
 
-impl Peers for NetworkHandle {
+impl<N: NetworkPrimitives> Peers for NetworkHandle<N> {
     fn add_trusted_peer_id(&self, peer: PeerId) {
         self.send_message(NetworkHandleMessage::AddTrustedPeerId(peer));
     }


### PR DESCRIPTION
moves functions around and puts those we can already satisfy on `N: NetworkPrimitives` in the corresponding impl block.

no functional changes