### PR TITLE
feat(rpc): Add coinbase support to eth_callBundle; limit gas

### DIFF
--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -1,6 +1,6 @@
 //! `Eth` bundle implementation and helpers.
 
-use alloy_primitives::{Address, Keccak256, U256};
+use alloy_primitives::{Keccak256, U256};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthChainSpec;
@@ -54,14 +54,14 @@ where
         let EthCallBundle {
             txs,
             block_number,
+            coinbase,
             state_block_number,
+            timeout: _,
             timestamp,
             gas_limit,
             difficulty,
             base_fee,
         } = bundle;
-        // TODO: pull from bundle args once we update alloy (or copy/paste struct for now)
-        let coinbase: Option<Address> = None;
         if txs.is_empty() {
             return Err(EthApiError::InvalidParams(
                 EthBundleError::EmptyBundleTransactions.to_string(),

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -1,6 +1,6 @@
 //! `Eth` bundle implementation and helpers.
 
-use alloy_primitives::{Keccak256, U256};
+use alloy_primitives::{Address, Keccak256, U256};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthChainSpec;
@@ -60,6 +60,8 @@ where
             difficulty,
             base_fee,
         } = bundle;
+        // TODO: pull from bundle args once we update alloy (or copy/paste struct for now)
+        let coinbase: Option<Address> = None;
         if txs.is_empty() {
             return Err(EthApiError::InvalidParams(
                 EthBundleError::EmptyBundleTransactions.to_string(),
@@ -105,6 +107,10 @@ where
         // Note: the block number is considered the `parent` block: <https://github.com/flashbots/mev-geth/blob/fddf97beec5877483f879a77b7dea2e58a58d653/internal/ethapi/api.go#L2104>
         let (cfg, mut block_env, at) = self.eth_api().evm_env_at(block_id).await?;
 
+        if let Some(coinbase) = coinbase {
+            block_env.coinbase = coinbase;
+        }
+
         // need to adjust the timestamp for the next block
         if let Some(timestamp) = timestamp {
             block_env.timestamp = U256::from(timestamp);
@@ -116,8 +122,16 @@ where
             block_env.difficulty = U256::from(difficulty);
         }
 
+        // default to call gas limit unless user requests a smaller limit
+        block_env.gas_limit = U256::from(self.inner.eth_api.call_gas_limit());
         if let Some(gas_limit) = gas_limit {
-            block_env.gas_limit = U256::from(gas_limit);
+            let gas_limit = U256::from(gas_limit);
+            if gas_limit > block_env.gas_limit {
+                return Err(
+                    EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
+                )
+            }
+            block_env.gas_limit = gas_limit;
         }
 
         if let Some(base_fee) = base_fee {


### PR DESCRIPTION
Requires new alloy with : https://github.com/alloy-rs/alloy/pull/1667

- [ ] import new alloy or copy/paste `EthCallBundle` struct?

Tested on mekong:

- patched alloy crates to `9ecb8a6d7e85af34853290bc4b6dcac5a908a8ae` (main w/ my change)
- With help from @klkvr fixed a small lifetime issue related to https://github.com/alloy-rs/alloy/pull/1657

```diff
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -274,7 +274,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                     block
                         .transactions_with_sender()
                         .enumerate()
-                        .find(|(_, (signer, tx))| **signer == sender && tx.nonce() == nonce)
+                        .find(|(_, (signer, tx))| **signer == sender && (*tx).nonce() == nonce)
                         .map(|(index, (signer, tx))| {
                             let tx_info = TransactionInfo {
                                 hash: Some(tx.hash()),
```

Can now confirm that including a tx which sends eth to the target coinbase works.  Below I send a tx which sends 1eth to `0x4bE0Cd2553356b4ABb8b6a1882325dAbC8d3013D` and then set the coinbase to that address, and `ethSentToCoinbase` correctly shows 1eth in the result:

```
> cast rpc eth_callBundle '{"txs":["0x02f8778501a5ee289c80840e078998840e0789a6825208944be0cd2553356b4abb8b6a1882325dabc8d3013d880de0b6b3a764000080c080a0c3b6de99450a27e5bd1c4503d657e7725037e37f01ea95570545f1bb1d5ac77fa079100f752ac8ebeea043acce8f6fb37f4fa3714debeac4e3278aa2a3bf93ea4f"],"blockNumber":"'$(cast --to-hex $(cast block-number))'","stateBlockNumber":"'$(cast --to-hex $(cast block-number))'","coinbase":"0x4bE0Cd2553356b4ABb8b6a1882325dAbC8d3013D"}' | jq .

{
  "bundleHash": "0x9e1a23066a4feda73b2bf3ae946aadd3231a7a2c3e5fd2b13752ef7bb3d7e486",
  "bundleGasPrice": "47619282994047",
  "coinbaseDiff": "1000004942875000000",
  "ethSentToCoinbase": "1000000000000000000",
  "gasFees": "4942875000000",
  "results": [
    {
      "coinbaseDiff": "1000004942875000000",
      "ethSentToCoinbase": "1000000000000000000",
      "fromAddress": "0x1b57edab586cbdabd4d914869ae8bb78dbc05571",
      "gasFees": "4942875000000",
      "gasPrice": "235375000",
      "gasUsed": "0x5208",
      "toAddress": "0x4be0cd2553356b4abb8b6a1882325dabc8d3013d",
      "txHash": "0x3fe98324bab379e12a757059b677ccf5a942a612d4d2f936f6f872a4a00a2738",
      "value": "0x"
    }
  ],
  "stateBlockNumber": "0x17705",
  "totalGasUsed": "0x5208"
}
```

