### PR TITLE
chore: rm unused codec derive

### DIFF
--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -22,8 +22,7 @@ use reth_db::{
 };
 use reth_fs_util as fs;
 use reth_primitives::{
-    Account, Log, LogData, Receipt, ReceiptWithBloom, StorageEntry, Transaction,
-    TransactionSignedNoHash, TxType,
+    Account, Log, LogData, Receipt, StorageEntry, Transaction, TransactionSignedNoHash, TxType,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode};
 use reth_stages_types::{
@@ -76,7 +75,6 @@ compact_types!(
         // reth-primitives
         Account,
         Receipt,
-        ReceiptWithBloom,
         // reth_codecs::alloy
         Authorization,
         GenesisAccount,

--- a/crates/optimism/storage/src/lib.rs
+++ b/crates/optimism/storage/src/lib.rs
@@ -16,7 +16,7 @@ mod tests {
         CompactClientVersion, CompactU256, CompactU64, StoredBlockBodyIndices, StoredBlockOmmers,
         StoredBlockWithdrawals,
     };
-    use reth_primitives::{Account, Receipt, ReceiptWithBloom};
+    use reth_primitives::{Account, Receipt};
     use reth_prune_types::{PruneCheckpoint, PruneMode, PruneSegment};
     use reth_stages_types::{
         AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint,
@@ -40,7 +40,6 @@ mod tests {
         assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
         assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
         assert_eq!(Receipt::bitflag_encoded_bytes(), 2);
-        assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
         assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
@@ -65,7 +64,6 @@ mod tests {
         validate_bitflag_backwards_compat!(PruneMode, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(PruneSegment, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(Receipt, UnusedBits::NotZero);
-        validate_bitflag_backwards_compat!(ReceiptWithBloom, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StageCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(StageUnitCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockBodyIndices, UnusedBits::Zero);

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -72,7 +72,6 @@ impl Receipt {
     }
 }
 
-// todo: replace with alloy receipt
 impl TxReceipt for Receipt {
     fn status_or_post_state(&self) -> Eip658Value {
         self.success.into()
@@ -191,8 +190,6 @@ impl From<Receipt> for ReceiptWithBloom {
 /// [`Receipt`] with calculated bloom filter.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct ReceiptWithBloom {
     /// Bloom filter build from logs.
     pub bloom: Bloom,

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -312,7 +312,7 @@ mod tests {
     fn test_ensure_backwards_compatibility() {
         use super::*;
         use reth_codecs::{test_utils::UnusedBits, validate_bitflag_backwards_compat};
-        use reth_primitives::{Account, Receipt, ReceiptWithBloom};
+        use reth_primitives::{Account, Receipt};
         use reth_prune_types::{PruneCheckpoint, PruneMode, PruneSegment};
         use reth_stages_types::{
             AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint,
@@ -333,7 +333,6 @@ mod tests {
         assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
         assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
         assert_eq!(Receipt::bitflag_encoded_bytes(), 1);
-        assert_eq!(ReceiptWithBloom::bitflag_encoded_bytes(), 0);
         assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
@@ -355,7 +354,6 @@ mod tests {
         validate_bitflag_backwards_compat!(PruneMode, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(PruneSegment, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(Receipt, UnusedBits::Zero);
-        validate_bitflag_backwards_compat!(ReceiptWithBloom, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StageCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(StageUnitCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockBodyIndices, UnusedBits::Zero);


### PR DESCRIPTION
we don't store this type as compact