### PR TITLE
chore: move txtype constants to codecs

### DIFF
--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -393,7 +393,7 @@ impl Decodable for ReceiptWithBloom {
                         Self::decode_receipt(buf, TxType::Eip7702)
                     }
                     #[cfg(feature = "optimism")]
-                    crate::transaction::DEPOSIT_TX_TYPE_ID => {
+                    op_alloy_consensus::DEPOSIT_TX_TYPE_ID => {
                         buf.advance(1);
                         Self::decode_receipt(buf, TxType::Deposit)
                     }
@@ -529,7 +529,7 @@ impl ReceiptWithBloomEncoder<'_> {
             }
             #[cfg(feature = "optimism")]
             TxType::Deposit => {
-                out.put_u8(crate::transaction::DEPOSIT_TX_TYPE_ID);
+                out.put_u8(op_alloy_consensus::DEPOSIT_TX_TYPE_ID);
             }
         }
         out.put_slice(payload.as_ref());

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -57,17 +57,9 @@ pub mod signature;
 pub(crate) mod util;
 mod variant;
 
+use alloc::vec::Vec;
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::TxDeposit;
-#[cfg(feature = "optimism")]
-pub use tx_type::DEPOSIT_TX_TYPE_ID;
-#[cfg(any(test, feature = "reth-codec"))]
-pub use tx_type::{
-    COMPACT_EXTENDED_IDENTIFIER_FLAG, COMPACT_IDENTIFIER_EIP1559, COMPACT_IDENTIFIER_EIP2930,
-    COMPACT_IDENTIFIER_LEGACY,
-};
-
-use alloc::vec::Vec;
 use reth_primitives_traits::{transaction::TransactionExt, SignedTransaction};
 use revm_primitives::{AuthorizationList, TxEnv};
 
@@ -594,19 +586,19 @@ impl reth_codecs::Compact for Transaction {
         use bytes::Buf;
 
         match identifier {
-            COMPACT_IDENTIFIER_LEGACY => {
+            reth_codecs::txtype::COMPACT_IDENTIFIER_LEGACY => {
                 let (tx, buf) = TxLegacy::from_compact(buf, buf.len());
                 (Self::Legacy(tx), buf)
             }
-            COMPACT_IDENTIFIER_EIP2930 => {
+            reth_codecs::txtype::COMPACT_IDENTIFIER_EIP2930 => {
                 let (tx, buf) = TxEip2930::from_compact(buf, buf.len());
                 (Self::Eip2930(tx), buf)
             }
-            COMPACT_IDENTIFIER_EIP1559 => {
+            reth_codecs::txtype::COMPACT_IDENTIFIER_EIP1559 => {
                 let (tx, buf) = TxEip1559::from_compact(buf, buf.len());
                 (Self::Eip1559(tx), buf)
             }
-            COMPACT_EXTENDED_IDENTIFIER_FLAG => {
+            reth_codecs::txtype::COMPACT_EXTENDED_IDENTIFIER_FLAG => {
                 // An identifier of 3 indicates that the transaction type did not fit into
                 // the backwards compatible 2 bit identifier, their transaction types are
                 // larger than 2 bits (eg. 4844 and Deposit Transactions). In this case,
@@ -623,7 +615,7 @@ impl reth_codecs::Compact for Transaction {
                         (Self::Eip7702(tx), buf)
                     }
                     #[cfg(feature = "optimism")]
-                    DEPOSIT_TX_TYPE_ID => {
+                    op_alloy_consensus::DEPOSIT_TX_TYPE_ID => {
                         let (tx, buf) = TxDeposit::from_compact(buf, buf.len());
                         (Self::Deposit(tx), buf)
                     }

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -17,13 +17,14 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 pub use reth_codecs_derive::*;
 use serde as _;
 
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U256};
 use bytes::{Buf, BufMut};
 
-extern crate alloc;
 use alloc::vec::Vec;
 
 #[cfg(feature = "test-utils")]
@@ -32,6 +33,8 @@ pub mod alloy;
 #[cfg(not(feature = "test-utils"))]
 #[cfg(any(test, feature = "alloy"))]
 mod alloy;
+
+pub mod txtype;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/storage/codecs/src/txtype.rs
+++ b/crates/storage/codecs/src/txtype.rs
@@ -1,0 +1,15 @@
+//! Commonly used constants for transaction types.
+
+/// Identifier parameter for legacy transaction
+pub const COMPACT_IDENTIFIER_LEGACY: usize = 0;
+
+/// Identifier parameter for EIP-2930 transaction
+pub const COMPACT_IDENTIFIER_EIP2930: usize = 1;
+
+/// Identifier parameter for EIP-1559 transaction
+pub const COMPACT_IDENTIFIER_EIP1559: usize = 2;
+
+/// For backwards compatibility purposes only 2 bits of the type are encoded in the identifier
+/// parameter. In the case of a [`COMPACT_EXTENDED_IDENTIFIER_FLAG`], the full transaction type is
+/// read from the buffer as a single byte.
+pub const COMPACT_EXTENDED_IDENTIFIER_FLAG: usize = 3;


### PR DESCRIPTION
moves the constants we use for compact encoding to the codecs crate.

we need to move them out of reth-primitives because we need to use them for the network specific txtypes