### PR TITLE
fix: add senders in cache if not present

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -474,7 +474,7 @@ where
                         CacheAction::CacheNewCanonicalChain { chain_change } => {
                             for mut block in chain_change.blocks {
                                 if block.senders.len() != block.body.transactions.len() {
-                                    if let Some(senders) = block.body.recover_signers() {
+                                    if let Some(senders) = block.body.recover_signers_unchecked() {
                                         block.senders = senders;
                                     }
                                 }

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -472,7 +472,12 @@ where
                             }
                         }
                         CacheAction::CacheNewCanonicalChain { chain_change } => {
-                            for block in chain_change.blocks {
+                            for mut block in chain_change.blocks {
+                                if block.senders.len() != block.body.transactions.len() {
+                                    if let Some(senders) = block.body.recover_signers() {
+                                        block.senders = senders;
+                                    }
+                                }
                                 this.on_new_block(block.hash(), Ok(Some(Arc::new(block))));
                             }
 


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/12659

Supersedes https://github.com/paradigmxyz/reth/pull/12666

Basically what happens to me is that if I use the new engine, when blocks get saved in the cache, senders is empty even though there is a transaction in the block. In fact, senders is empty only in the cache, while in the db senders is already populated correctly.

@joshieDo @mattsse what do you think of this solution?