### PR TITLE
chore(sdk): define helper trait `BlockPrimitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6479,6 +6479,7 @@ dependencies = [
  "reth-payload-primitives",
  "reth-payload-validator",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-prune-types",

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -32,6 +32,7 @@ reth-engine-primitives.workspace = true
 reth-network-p2p.workspace = true
 reth-node-types.workspace = true
 reth-chainspec = { workspace = true, optional = true }
+reth-primitives-traits.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -27,6 +27,7 @@ use reth_payload_builder_primitives::PayloadBuilder;
 use reth_payload_primitives::{PayloadAttributes, PayloadBuilderAttributes};
 use reth_payload_validator::ExecutionPayloadValidator;
 use reth_primitives::{Head, SealedBlock, SealedHeader};
+use reth_primitives_traits::BlockPrimitives;
 use reth_provider::{
     providers::ProviderNodeTypes, BlockIdReader, BlockReader, BlockSource, CanonChainTracker,
     ChainSpecProvider, ProviderError, StageCheckpointReader,
@@ -226,7 +227,7 @@ where
 
 impl<N, BT, Client> BeaconConsensusEngine<N, BT, Client>
 where
-    N: EngineNodeTypes,
+    N: EngineNodeTypes<Primitives: BlockPrimitives>,
     BT: BlockchainTreeEngine
         + BlockReader
         + BlockIdReader
@@ -1795,7 +1796,7 @@ where
 /// receiver and forwarding them to the blockchain tree.
 impl<N, BT, Client> Future for BeaconConsensusEngine<N, BT, Client>
 where
-    N: EngineNodeTypes,
+    N: EngineNodeTypes<Primitives: BlockPrimitives>,
     Client: EthBlockClient + 'static,
     BT: BlockchainTreeEngine
         + BlockReader

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -87,9 +87,7 @@ pub fn build_pipeline<N, H, B, Executor>(
 where
     N: ProviderNodeTypes,
     H: HeaderDownloader<Header = alloy_consensus::Header> + 'static,
-    B: BodyDownloader<
-            Body = <<N::Primitives as NodePrimitives>::Block as reth_node_api::Block>::Body,
-        > + 'static,
+    B: BodyDownloader<Body = <N::Primitives as NodePrimitives>::BlockBody> + 'static,
     Executor: BlockExecutorProvider,
     N::Primitives: FullNodePrimitives<BlockBody = reth_primitives::BlockBody>,
 {

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -2,9 +2,7 @@
 
 use alloc::fmt;
 
-use alloy_consensus::Transaction;
-
-use crate::{FullSignedTx, InMemorySize, MaybeArbitrary, MaybeSerde};
+use crate::{FullSignedTx, InMemorySize, MaybeArbitrary, MaybeSerde, SignedTransaction};
 
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
 pub trait FullBlockBody: BlockBody<Transaction: FullSignedTx> {}
@@ -28,8 +26,8 @@ pub trait BlockBody:
     + MaybeSerde
     + MaybeArbitrary
 {
-    /// Ordered list of signed transactions as committed in block.
-    type Transaction: Transaction;
+    /// Signed transaction.
+    type Transaction: SignedTransaction;
 
     /// Returns reference to transactions in block.
     fn transactions(&self) -> &[Self::Transaction];

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -78,7 +78,9 @@ pub use size::InMemorySize;
 
 /// Node traits
 pub mod node;
-pub use node::{FullNodePrimitives, NodePrimitives, ReceiptTy};
+pub use node::{
+    BlockPrimitives, FullBlockPrimitives, FullNodePrimitives, NodePrimitives, ReceiptTy,
+};
 
 /// Helper trait that requires arbitrary implementation if the feature is enabled.
 #[cfg(any(feature = "test-utils", feature = "arbitrary"))]

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -1,7 +1,8 @@
 use core::fmt;
 
 use crate::{
-    FullBlock, FullBlockBody, FullBlockHeader, FullReceipt, FullSignedTx, FullTxType, MaybeSerde,
+    Block, BlockBody, BlockHeader, FullBlock, FullBlockBody, FullBlockHeader, FullReceipt,
+    FullSignedTx, FullTxType, MaybeSerde, SignedTransaction,
 };
 
 /// Configures all the primitive types of the node.
@@ -77,46 +78,74 @@ impl NodePrimitives for () {
 }
 
 /// Helper trait that sets trait bounds on [`NodePrimitives`].
-pub trait FullNodePrimitives
-where
-    Self: NodePrimitives<
-            Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>,
-            BlockHeader: FullBlockHeader,
-            BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
-            SignedTx: FullSignedTx,
-            TxType: FullTxType,
-            Receipt: FullReceipt,
-        > + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + 'static,
+pub trait FullNodePrimitives:
+    NodePrimitives<
+    Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody> + 'static,
+    BlockHeader: FullBlockHeader + 'static,
+    BlockBody: FullBlockBody<Transaction = Self::SignedTx> + 'static,
+    SignedTx: FullSignedTx + 'static,
+    TxType: FullTxType + 'static,
+    Receipt: FullReceipt + 'static,
+>
 {
 }
 
 impl<T> FullNodePrimitives for T where
     T: NodePrimitives<
-            Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>,
-            BlockHeader: FullBlockHeader,
-            BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
-            SignedTx: FullSignedTx,
-            TxType: FullTxType,
-            Receipt: FullReceipt,
-        > + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + 'static
+        Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody> + 'static,
+        BlockHeader: FullBlockHeader + 'static,
+        BlockBody: FullBlockBody<Transaction = Self::SignedTx> + 'static,
+        SignedTx: FullSignedTx + 'static,
+        TxType: FullTxType + 'static,
+        Receipt: FullReceipt + 'static,
+    >
 {
 }
 
 /// Helper adapter type for accessing [`NodePrimitives`] receipt type.
 pub type ReceiptTy<N> = <N as NodePrimitives>::Receipt;
+
+/// Helper trait that links [`NodePrimitives::Block`] to [`NodePrimitives::BlockHeader`],
+/// [`NodePrimitives::BlockBody`] and [`NodePrimitives::SignedTx`].
+pub trait BlockPrimitives:
+    NodePrimitives<
+    Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody>,
+    BlockHeader: BlockHeader,
+    BlockBody: BlockBody<Transaction = Self::SignedTx>,
+    SignedTx: SignedTransaction,
+>
+{
+}
+
+impl<T> BlockPrimitives for T where
+    T: NodePrimitives<
+        Block: Block<Header = T::BlockHeader, Body = T::BlockBody>,
+        BlockHeader: BlockHeader,
+        BlockBody: BlockBody<Transaction = T::SignedTx>,
+        SignedTx: SignedTransaction,
+    >
+{
+}
+
+/// Helper trait like [`BlockPrimitives`], but with encoding trait bounds on
+/// [`NodePrimitives::Block`], [`NodePrimitives::BlockHeader`], [`NodePrimitives::BlockBody`] and
+/// [`NodePrimitives::SignedTx`].
+pub trait FullBlockPrimitives:
+    NodePrimitives<
+    Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>,
+    BlockHeader: FullBlockHeader,
+    BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
+    SignedTx: FullSignedTx,
+>
+{
+}
+
+impl<T> FullBlockPrimitives for T where
+    T: NodePrimitives<
+        Block: FullBlock<Header = T::BlockHeader, Body = T::BlockBody>,
+        BlockHeader: FullBlockHeader,
+        BlockBody: FullBlockBody<Transaction = T::SignedTx>,
+        SignedTx: FullSignedTx,
+    >
+{
+}

--- a/crates/primitives-traits/src/transaction/mod.rs
+++ b/crates/primitives-traits/src/transaction/mod.rs
@@ -4,8 +4,9 @@ pub mod execute;
 pub mod signed;
 pub mod tx_type;
 
-use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
 use core::{fmt, hash::Hash};
+
+use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
 
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
 pub trait FullTransaction: Transaction + MaybeCompact {}

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -1,15 +1,26 @@
 //! API of a signed transaction.
 
-use crate::{FillTxEnv, InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde, TxType};
 use alloc::fmt;
-use alloy_eips::eip2718::{Decodable2718, Encodable2718};
-use alloy_primitives::{keccak256, Address, PrimitiveSignature, TxHash, B256};
 use core::hash::Hash;
 
-/// Helper trait that unifies all behaviour required by block to support full node operations.
-pub trait FullSignedTx: SignedTransaction + FillTxEnv + MaybeCompact {}
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_primitives::{keccak256, Address, PrimitiveSignature, TxHash, B256};
 
-impl<T> FullSignedTx for T where T: SignedTransaction + FillTxEnv + MaybeCompact {}
+use crate::{
+    FillTxEnv, FullTransaction, FullTxType, InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde,
+    Transaction, TxType,
+};
+
+/// Helper trait that unifies all behaviour required by block to support full node operations.
+pub trait FullSignedTx:
+    SignedTransaction<Transaction: FullTransaction, Type: FullTxType> + FillTxEnv + MaybeCompact
+{
+}
+
+impl<T> FullSignedTx for T where
+    T: SignedTransaction<Transaction: FullTransaction, Type: FullTxType> + FillTxEnv + MaybeCompact
+{
+}
 
 /// A signed transaction.
 #[auto_impl::auto_impl(&, Arc)]
@@ -32,6 +43,9 @@ pub trait SignedTransaction:
     + MaybeArbitrary
     + InMemorySize
 {
+    /// Unsigned transaction type.
+    type Transaction: Transaction;
+
     /// Transaction envelope type ID.
     type Type: TxType;
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1265,6 +1265,7 @@ impl TransactionSigned {
 
 impl SignedTransaction for TransactionSigned {
     type Type = TxType;
+    type Transaction = Transaction;
 
     fn tx_hash(&self) -> &TxHash {
         self.hash_ref()

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -579,6 +579,7 @@ impl alloy_consensus::Transaction for PooledTransactionsElement {
 }
 
 impl SignedTransaction for PooledTransactionsElement {
+    type Transaction = Transaction;
     type Type = TxType;
 
     fn tx_hash(&self) -> &TxHash {

--- a/crates/storage/provider/src/providers/database/chain.rs
+++ b/crates/storage/provider/src/providers/database/chain.rs
@@ -1,11 +1,11 @@
 use crate::{providers::NodeTypes, DatabaseProvider};
 use reth_db::transaction::{DbTx, DbTxMut};
-use reth_node_types::FullNodePrimitives;
 use reth_primitives::EthPrimitives;
+use reth_primitives_traits::BlockPrimitives;
 use reth_storage_api::{ChainStorageWriter, EthStorage};
 
 /// Trait that provides access to implementations of [`ChainStorage`]
-pub trait ChainStorage<Primitives: FullNodePrimitives>: Send + Sync {
+pub trait ChainStorage<Primitives: BlockPrimitives>: Send + Sync {
     /// Provides access to the chain writer.
     fn writer<TX, Types>(&self) -> impl ChainStorageWriter<DatabaseProvider<TX, Types>, Primitives>
     where

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -48,11 +48,11 @@ use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_network_p2p::headers::downloader::SyncTarget;
 use reth_node_types::{NodeTypes, TxTy};
 use reth_primitives::{
-    Account, Block, BlockBody, BlockWithSenders, Bytecode, GotExpected, NodePrimitives, Receipt,
-    SealedBlock, SealedBlockWithSenders, SealedHeader, StaticFileSegment, StorageEntry,
-    TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    Account, Block, BlockBody, BlockWithSenders, Bytecode, GotExpected, Receipt, SealedBlock,
+    SealedBlockWithSenders, SealedHeader, StaticFileSegment, StorageEntry, TransactionMeta,
+    TransactionSigned, TransactionSignedNoHash,
 };
-use reth_primitives_traits::{BlockBody as _, SignedTransaction};
+use reth_primitives_traits::{BlockBody as _, NodePrimitives, SignedTransaction};
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{StateProvider, StorageChangeSetReader, TryIntoHistoricalStateProvider};
@@ -2751,7 +2751,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockExecu
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWriter
     for DatabaseProvider<TX, N>
 {
-    type Body = <<N::Primitives as NodePrimitives>::Block as reth_primitives_traits::Block>::Body;
+    type Body = <N::Primitives as NodePrimitives>::BlockBody;
 
     /// Inserts the block into the database, always modifying the following tables:
     /// * [`CanonicalHeaders`](tables::CanonicalHeaders)

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -7,7 +7,7 @@ use reth_db::{
     transaction::DbTxMut,
     DbTxUnwindExt,
 };
-use reth_primitives_traits::{Block, BlockBody, FullNodePrimitives};
+use reth_primitives_traits::{BlockBody, BlockPrimitives};
 use reth_storage_errors::provider::ProviderResult;
 
 /// Trait that implements how block bodies are written to the storage.
@@ -32,12 +32,12 @@ pub trait BlockBodyWriter<Provider, Body: BlockBody> {
 }
 
 /// Trait that implements how chain-specific types are written to the storage.
-pub trait ChainStorageWriter<Provider, Primitives: FullNodePrimitives>:
-    BlockBodyWriter<Provider, <Primitives::Block as Block>::Body>
+pub trait ChainStorageWriter<Provider, Primitives: BlockPrimitives>:
+    BlockBodyWriter<Provider, Primitives::BlockBody>
 {
 }
-impl<T, Provider, Primitives: FullNodePrimitives> ChainStorageWriter<Provider, Primitives> for T where
-    T: BlockBodyWriter<Provider, <Primitives::Block as Block>::Body>
+impl<T, Provider, Primitives: BlockPrimitives> ChainStorageWriter<Provider, Primitives> for T where
+    T: BlockBodyWriter<Provider, Primitives::BlockBody>
 {
 }
 


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/12647

- Defines helper trait `BlockPrimitives`, which links `NodePrimitives::Block` to `NodePrimitives::BlockHeader`,  `NodePrimitives::BlockBody` and `NodePrimitives::SignedTransaction`. This makes the trait bounds necessary on impl bodies much less verbose!
- Makes `NodePrimitives` super trait of `FullNodePrimitives`, as it allows for the transition `FullNodePrimitives` -> `BlockPrimitives` -> `NodePrimitives`.
NOTE: the reason I didn't do this in the first place is because I copied the pattern of `FullNodeComponents` -> `RpcNodeCore` used to simplify type definitions, introduced because `FullNodeComponents` wasn't built from a base trait without trait bounds (and re-writing that would have been a too big change for the task). Here we have the opportunity to have a plain (trait unbound) super trait though since we're writing primitives from scratch.