### PR TITLE
chore(sdk): add adapters for header and body to `NodeTypes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4590,7 +4590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11181,7 +11181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3637e734239e12ab152cd269302500bd063f37624ee210cd04b4936ed671f3b1"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11672,7 +11672,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -232,3 +232,9 @@ where
 {
     type Engine = E;
 }
+
+/// Helper adapter type for accessing [`NodePrimitives::BlockHeader`] on [`NodeTypes`].
+pub type HeaderTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::BlockHeader;
+
+/// Helper adapter type for accessing [`NodePrimitives::BlockBody`] on [`NodeTypes`].
+pub type BodyTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::BlockBody;


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/12647

Ref https://github.com/paradigmxyz/reth/issues/12454