### PR TITLE
Do not print whole block in `debug!` logs

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -447,7 +447,7 @@ where
     };
 
     let sealed_block = Arc::new(block.seal_slow());
-    debug!(target: "payload_builder", ?sealed_block, "sealed built block");
+    debug!(target: "payload_builder", sealed_block_header = ?sealed_block.header, "sealed built block");
 
     // create the executed block data
     let executed = ExecutedBlock {

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -424,7 +424,7 @@ where
         };
 
         let sealed_block = Arc::new(block.seal_slow());
-        debug!(target: "payload_builder", ?sealed_block, "sealed built block");
+        debug!(target: "payload_builder", sealed_block_header = ?sealed_block.header, "sealed built block");
 
         // create the executed block data
         let executed = ExecutedBlock {


### PR DESCRIPTION
This pr prints only block's number and hash instead of the whole sealed blocked, once it is produced.

I've discovered that once you enable debug logs, payload builder prints the whole block with a bunch of random hashes very unrelevant to debuging. Something like this:

<details>
  <summary>Logs before</summary>

This is for an empty block, btw.
```sh
2024-11-20T10:15:17.952145Z DEBUG reth_ethereum_payload_builder: sealed built block sealed_block=SealedBlock { header: SealedHeader { hash: 0x8c82e84a179775e8f017e2301e2f1fd0277a940e6bdf929a7278a3f826e2447b, header: Header { parent_hash: 0x6d288f2cae2ffcf55de32cd8d01cee552ee95feee942032d79eb1320ad89802f, ommers_hash: 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347, beneficiary: 0x4200000000000000000000000000000000000011, state_root: 0x6816c9559561925ec4c375332de4f0fbd4b12cda17c6a1f7b2910287e66e0c7b, transactions_root: 0x5a95dffd9d4c859c3318b12378d5d2dd21da8206a2e43c43c6e67024e18dee4f, receipts_root: 0xed2b8a32ead938bf1cfeb1f3e2038f7854391e5aa18cdd6ad60a2f62ee19da56, withdrawals_root: Some(0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421), logs_bloom: 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, difficulty: 0, number: 70169, gas_limit: 18446744073709551615, gas_used: 43794, timestamp: 1732097718, mix_hash: 0xdd8d0be8a9333e7e571ce0e32d4a162f8e370336e5473c5e6829839c2fd5a893, nonce: 0x0000000000000000, base_fee_per_gas: Some(7), blob_gas_used: Some(0), excess_blob_gas: Some(0), parent_beacon_block_root: Some(0xb14907e85c731958dc8154a5e6dbb353d0a84a02d6b0393c083da30e62267de5), requests_hash: None, extra_data: 0x } }, body: BlockBody { transactions: [TransactionSigned { hash: 0x340bdb38033ac4c5a1a9803174d813a84702b0a172164f793c6bf3d2d97c823d, signature: Signature { v: Parity(false), r: 0, s: 0 }, transaction: Deposit(TxDeposit { source_hash: 0x6bbf93602afa2d99cc17faf4b631c3c83624c494ddc05efb244dbbed44e1cfe7, from: 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001, to: Call(0x4200000000000000000000000000000000000015), mint: None, value: 0, gas_limit: 1000000, is_system_transaction: false, input: 0x440a5e20000f424000000000000000000000000300000000673db6b1000000000000161900000000000000000000000000000000000000000000000000000000000000070000000000000000000000000000000000000000000000000000000000000001ab5b8ad9ec90afefc278c63b9be85acf872f8cf6c84d45cec2e116edce96deb00000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc }) }], ommers: [], withdrawals: Some(Withdrawals([])) } }
```
</details>