### PR TITLE
feat: add is_broadcastable_in_full to txtype

### DIFF
--- a/crates/primitives-traits/src/transaction/tx_type.rs
+++ b/crates/primitives-traits/src/transaction/tx_type.rs
@@ -49,4 +49,14 @@ pub trait TxType:
 
     /// Returns `true` if this is an eip-7702 transaction.
     fn is_eip7702(&self) -> bool;
+
+    /// Returns whether this transaction type can be __broadcasted__ as full transaction over the
+    /// network.
+    ///
+    /// Some transactions are not broadcastable as objects and only allowed to be broadcasted as
+    /// hashes, e.g. because they missing context (e.g. blob sidecar).
+    fn is_broadcastable_in_full(&self) -> bool {
+        // EIP-4844 transactions are not broadcastable in full, only hashes are allowed.
+        !self.is_eip4844()
+    }
 }

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -257,7 +257,15 @@ mod tests {
     use super::*;
     use alloy_primitives::hex;
     use reth_codecs::{txtype::*, Compact};
+    use reth_primitives_traits::TxType as _;
     use rstest::rstest;
+
+    #[test]
+    fn is_broadcastable() {
+        assert!(TxType::Legacy.is_broadcastable_in_full());
+        assert!(TxType::Eip1559.is_broadcastable_in_full());
+        assert!(!TxType::Eip4844.is_broadcastable_in_full());
+    }
 
     #[rstest]
     #[case(U64::from(LEGACY_TX_TYPE_ID), Ok(TxType::Legacy))]


### PR DESCRIPTION
adds a helper to txtype to determine whether a txtype can be broadcasted as full object

this is intended to be used in p2p where we need to ensure only 4844 hashes are broadcasted.

we can ignore deposit txs here because those are never pooled.