### PR TITLE
feat: relax more tx manager bounds

### DIFF
--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -142,10 +142,8 @@ where
             let l1_block_info = self.block_info.l1_block_info.read().clone();
 
             let mut encoded = Vec::with_capacity(valid_tx.transaction().encoded_length());
-            <<Tx as reth_transaction_pool::PoolTransaction>::Consensus as Into<
-                TransactionSigned,
-            >>::into(valid_tx.transaction().clone().into_consensus())
-            .encode_2718(&mut encoded);
+            let tx: TransactionSigned = valid_tx.transaction().clone().into_consensus().into();
+            tx.encode_2718(&mut encoded);
 
             let cost_addition = match l1_block_info.l1_tx_data_fee(
                 &self.chain_spec(),

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -3,7 +3,9 @@ use alloy_eips::eip2718::Encodable2718;
 use parking_lot::RwLock;
 use reth_chainspec::ChainSpec;
 use reth_optimism_evm::RethL1BlockInfo;
-use reth_primitives::{Block, GotExpected, InvalidTransactionError, SealedBlock};
+use reth_primitives::{
+    Block, GotExpected, InvalidTransactionError, SealedBlock, TransactionSigned,
+};
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use reth_revm::L1BlockInfo;
 use reth_transaction_pool::{
@@ -140,7 +142,10 @@ where
             let l1_block_info = self.block_info.l1_block_info.read().clone();
 
             let mut encoded = Vec::with_capacity(valid_tx.transaction().encoded_length());
-            valid_tx.transaction().clone().into_consensus().into().encode_2718(&mut encoded);
+            <<Tx as reth_transaction_pool::PoolTransaction>::Consensus as Into<
+                TransactionSigned,
+            >>::into(valid_tx.transaction().clone().into_consensus())
+            .encode_2718(&mut encoded);
 
             let cost_addition = match l1_block_info.l1_tx_data_fee(
                 &self.chain_spec(),

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -20,7 +20,8 @@ use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
 use reth_primitives::{
     kzg::KzgSettings, transaction::TryFromRecoveredTransactionError, PooledTransactionsElement,
-    PooledTransactionsElementEcRecovered, SealedBlock, Transaction, TransactionSignedEcRecovered,
+    PooledTransactionsElementEcRecovered, SealedBlock, Transaction,
+    TransactionSignedEcRecovered,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -1068,7 +1069,9 @@ pub trait PoolTransaction: fmt::Debug + Send + Sync + Clone {
 /// Super trait for transactions that can be converted to and from Eth transactions
 pub trait EthPoolTransaction:
     PoolTransaction<
-    Consensus: From<TransactionSignedEcRecovered> + Into<TransactionSignedEcRecovered>,
+    Consensus: From<TransactionSignedEcRecovered>
+                   + Into<TransactionSignedEcRecovered>,
+                   // + Into<TransactionSigned>,
     Pooled: From<PooledTransactionsElementEcRecovered> + Into<PooledTransactionsElementEcRecovered>,
 >
 {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -20,7 +20,7 @@ use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
 use reth_primitives::{
     kzg::KzgSettings, transaction::TryFromRecoveredTransactionError, PooledTransactionsElement,
-    PooledTransactionsElementEcRecovered, SealedBlock, Transaction,
+    PooledTransactionsElementEcRecovered, SealedBlock, Transaction, TransactionSigned,
     TransactionSignedEcRecovered,
 };
 #[cfg(feature = "serde")]
@@ -1070,8 +1070,8 @@ pub trait PoolTransaction: fmt::Debug + Send + Sync + Clone {
 pub trait EthPoolTransaction:
     PoolTransaction<
     Consensus: From<TransactionSignedEcRecovered>
-                   + Into<TransactionSignedEcRecovered>,
-                   // + Into<TransactionSigned>,
+                   + Into<TransactionSignedEcRecovered>
+                   + Into<TransactionSigned>,
     Pooled: From<PooledTransactionsElementEcRecovered> + Into<PooledTransactionsElementEcRecovered>,
 >
 {


### PR DESCRIPTION
relaxes more trait bounds in txmanager

since `TxSignedRecovered != TxSigned` I had to add an additional Into bound.

this will suck for a bit, but next step would be to gradually remove this, this will require some additional changes first.

no functional changes