### PR TITLE
chore(net): downgrade pending sesion timeout log to trace

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -807,7 +807,7 @@ pub(crate) async fn pending_session_with_timeout<F, N: NetworkPrimitives>(
     F: Future<Output = ()>,
 {
     if tokio::time::timeout(timeout, f).await.is_err() {
-        debug!(target: "net::session", ?remote_addr, ?direction, "pending session timed out");
+        trace!(target: "net::session", ?remote_addr, ?direction, "pending session timed out");
         let event = PendingSessionEvent::Disconnected {
             remote_addr,
             session_id,


### PR DESCRIPTION
Too noisy 

![image](https://github.com/user-attachments/assets/4831ff9c-c856-4239-bf65-b8f90ccee3dd)
