### PR TITLE
perf(evm-config): return `&Arc<ChainSpec>`

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -55,7 +55,7 @@ impl EthEvmConfig {
     }
 
     /// Returns the chain spec associated with this configuration.
-    pub fn chain_spec(&self) -> &ChainSpec {
+    pub const fn chain_spec(&self) -> &Arc<ChainSpec> {
         &self.chain_spec
     }
 }

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -50,7 +50,7 @@ impl OpEvmConfig {
     }
 
     /// Returns the chain spec associated with this configuration.
-    pub fn chain_spec(&self) -> &OpChainSpec {
+    pub const fn chain_spec(&self) -> &Arc<OpChainSpec> {
         &self.chain_spec
     }
 }


### PR DESCRIPTION
Similar to https://github.com/paradigmxyz/reth/pull/12268/files#diff-e5e49f8eb6c0c2d8a4768b03ecb2966ca7d5679086fbc71e32b4cda348b84744R34.

This allows `*EvmConfig` users who need an `Arc<ChainSpec>` to clone the `Arc` directly from the `*EvmConfig`. Currently they would need to clone the chain spec then create a new `Arc` from it.