### PR TITLE
chore(trie): log proof result send error

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -22,7 +22,7 @@ use reth_trie::{
 use reth_trie_common::proof::ProofRetainer;
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, error};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::ParallelStateRootMetrics;
@@ -126,7 +126,9 @@ where
                         ))
                     })
                 })();
-                let _ = tx.send(result);
+                if let Err(err) = tx.send(result) {
+                    error!(target: "trie::parallel", ?hashed_address, err_content = ?err.0,  "Failed to send proof result");
+                }
             });
             storage_proofs.insert(hashed_address, rx);
         }


### PR DESCRIPTION
The log entries would look like this:
```
Nov 21 16:29:07 229S604122 reth-mainnet[2236184]: 2024-11-21T16:29:07.235068Z ERROR trie::parallel: Failed to send proof result hashed_address=0x70d8cd57c4a2a6d811f902570becb4a0d86102a774b019b4d1513fe628d7daae err_content=Ok(StorageMultiProof { root: 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, subtree: ProofNodes({Nibbles(""): 0x80}) })
```