### PR TITLE
chore: remove txext trait

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -49,7 +49,7 @@ use reth_network_p2p::{
 use reth_network_peers::PeerId;
 use reth_network_types::ReputationChangeKind;
 use reth_primitives::{PooledTransactionsElement, TransactionSigned};
-use reth_primitives_traits::{SignedTransaction, TransactionExt, TxType};
+use reth_primitives_traits::{SignedTransaction, TxType};
 use reth_tokio_util::EventStream;
 use reth_transaction_pool::{
     error::{PoolError, PoolResult},
@@ -1617,7 +1617,7 @@ impl<T: SignedTransaction> FullTransactionsBuilder<T> {
         //  via `GetPooledTransactions`.
         //
         // From: <https://eips.ethereum.org/EIPS/eip-4844#networking>
-        if !transaction.transaction.transaction().tx_type().is_broadcastable_in_full() {
+        if !transaction.transaction.tx_type().is_broadcastable_in_full() {
             self.pooled.push(transaction);
             return
         }
@@ -1683,7 +1683,7 @@ impl PooledTransactionsHashesBuilder {
             Self::Eth68(msg) => {
                 msg.hashes.push(*tx.tx_hash());
                 msg.sizes.push(tx.size);
-                msg.types.push(tx.transaction.transaction().tx_type().into());
+                msg.types.push(tx.transaction.tx_type().into());
             }
         }
     }

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -29,7 +29,7 @@ pub use transaction::{
     execute::FillTxEnv,
     signed::{FullSignedTx, SignedTransaction},
     tx_type::{FullTxType, TxType},
-    FullTransaction, Transaction, TransactionExt,
+    FullTransaction, Transaction,
 };
 
 mod integer_list;

--- a/crates/primitives-traits/src/transaction/mod.rs
+++ b/crates/primitives-traits/src/transaction/mod.rs
@@ -4,16 +4,13 @@ pub mod execute;
 pub mod signed;
 pub mod tx_type;
 
+use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
 use core::{fmt, hash::Hash};
 
-use alloy_primitives::B256;
-
-use crate::{FullTxType, InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde, TxType};
-
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
-pub trait FullTransaction: Transaction<Type: FullTxType> + MaybeCompact {}
+pub trait FullTransaction: Transaction + MaybeCompact {}
 
-impl<T> FullTransaction for T where T: Transaction<Type: FullTxType> + MaybeCompact {}
+impl<T> FullTransaction for T where T: Transaction + MaybeCompact {}
 
 /// Abstraction of a transaction.
 pub trait Transaction:
@@ -26,7 +23,7 @@ pub trait Transaction:
     + Eq
     + PartialEq
     + Hash
-    + TransactionExt
+    + alloy_consensus::Transaction
     + InMemorySize
     + MaybeSerde
     + MaybeArbitrary
@@ -43,25 +40,9 @@ impl<T> Transaction for T where
         + Eq
         + PartialEq
         + Hash
-        + TransactionExt
+        + alloy_consensus::Transaction
         + InMemorySize
         + MaybeSerde
         + MaybeArbitrary
 {
-}
-
-/// Extension trait of [`alloy_consensus::Transaction`].
-#[auto_impl::auto_impl(&, Arc)]
-pub trait TransactionExt: alloy_consensus::Transaction {
-    /// Transaction envelope type ID.
-    type Type: TxType;
-
-    /// Heavy operation that return signature hash over rlp encoded transaction.
-    /// It is only for signature signing or signer recovery.
-    fn signature_hash(&self) -> B256;
-
-    /// Returns the transaction type.
-    fn tx_type(&self) -> Self::Type {
-        Self::Type::try_from(self.ty()).expect("should decode tx type id")
-    }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -21,6 +21,8 @@ use once_cell as _;
 use once_cell::sync::Lazy as LazyLock;
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::DepositTransaction;
+#[cfg(feature = "optimism")]
+use op_alloy_consensus::TxDeposit;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
 use revm_primitives::{AuthorizationList, TxEnv};

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,5 +1,6 @@
 //! Transaction types.
 
+use alloc::vec::Vec;
 use alloy_consensus::{
     transaction::RlpEcdsaTx, SignableTransaction, Transaction as _, TxEip1559, TxEip2930,
     TxEip4844, TxEip7702, TxLegacy,


### PR DESCRIPTION
consolidate TransactionExt into SignedTx.

the AT on SignedTx isn't very convenient because a SignedTx should always be a tx itself.

now the Transaction and SignedTx aren't so different, so perhaps we can try to unify those, because we only ever use a tx with the sig (excluding special eth_sendTx endpoint)
