### PR TITLE
chore: move withencoded struct

### DIFF
--- a/crates/primitives-traits/src/encoded.rs
+++ b/crates/primitives-traits/src/encoded.rs
@@ -1,0 +1,55 @@
+use alloy_primitives::Bytes;
+
+/// Generic wrapper with encoded Bytes, such as transaction data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WithEncoded<T>(Bytes, pub T);
+
+impl<T> From<(Bytes, T)> for WithEncoded<T> {
+    fn from(value: (Bytes, T)) -> Self {
+        Self(value.0, value.1)
+    }
+}
+
+impl<T> WithEncoded<T> {
+    /// Wraps the value with the bytes.
+    pub const fn new(bytes: Bytes, value: T) -> Self {
+        Self(bytes, value)
+    }
+
+    /// Get the encoded bytes
+    pub fn encoded_bytes(&self) -> Bytes {
+        self.0.clone()
+    }
+
+    /// Get the underlying value
+    pub const fn value(&self) -> &T {
+        &self.1
+    }
+
+    /// Returns ownership of the underlying value.
+    pub fn into_value(self) -> T {
+        self.1
+    }
+
+    /// Transform the value
+    pub fn transform<F: From<T>>(self) -> WithEncoded<F> {
+        WithEncoded(self.0, self.1.into())
+    }
+
+    /// Split the wrapper into [`Bytes`] and value tuple
+    pub fn split(self) -> (Bytes, T) {
+        (self.0, self.1)
+    }
+
+    /// Maps the inner value to a new value using the given function.
+    pub fn map<U, F: FnOnce(T) -> U>(self, op: F) -> WithEncoded<U> {
+        WithEncoded(self.0, op(self.1))
+    }
+}
+
+impl<T> WithEncoded<Option<T>> {
+    /// returns `None` if the inner value is `None`, otherwise returns `Some(WithEncoded<T>)`.
+    pub fn transpose(self) -> Option<WithEncoded<T>> {
+        self.1.map(|v| WithEncoded(self.0, v))
+    }
+}

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -14,7 +14,6 @@ extern crate alloc;
 
 /// Common constants.
 pub mod constants;
-
 pub use constants::gas_units::{format_gas, format_gas_throughput};
 
 /// Minimal account
@@ -42,7 +41,9 @@ pub use block::{
     Block, FullBlock,
 };
 
+mod encoded;
 mod withdrawal;
+pub use encoded::WithEncoded;
 
 mod error;
 pub use error::{GotExpected, GotExpectedBoxed};

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -40,6 +40,7 @@ pub use error::{
 };
 pub use meta::TransactionMeta;
 pub use pooled::{PooledTransactionsElement, PooledTransactionsElementEcRecovered};
+pub use reth_primitives_traits::WithEncoded;
 pub use sidecar::BlobTransaction;
 pub use signature::{recover_signer, recover_signer_unchecked};
 pub use tx_type::TxType;
@@ -1721,60 +1722,6 @@ impl Decodable for TransactionSignedEcRecovered {
             .recover_signer()
             .ok_or(RlpError::Custom("Unable to recover decoded transaction signer."))?;
         Ok(Self { signer, signed_transaction })
-    }
-}
-
-/// Generic wrapper with encoded Bytes, such as transaction data.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WithEncoded<T>(Bytes, pub T);
-
-impl<T> From<(Bytes, T)> for WithEncoded<T> {
-    fn from(value: (Bytes, T)) -> Self {
-        Self(value.0, value.1)
-    }
-}
-
-impl<T> WithEncoded<T> {
-    /// Wraps the value with the bytes.
-    pub const fn new(bytes: Bytes, value: T) -> Self {
-        Self(bytes, value)
-    }
-
-    /// Get the encoded bytes
-    pub fn encoded_bytes(&self) -> Bytes {
-        self.0.clone()
-    }
-
-    /// Get the underlying value
-    pub const fn value(&self) -> &T {
-        &self.1
-    }
-
-    /// Returns ownership of the underlying value.
-    pub fn into_value(self) -> T {
-        self.1
-    }
-
-    /// Transform the value
-    pub fn transform<F: From<T>>(self) -> WithEncoded<F> {
-        WithEncoded(self.0, self.1.into())
-    }
-
-    /// Split the wrapper into [`Bytes`] and value tuple
-    pub fn split(self) -> (Bytes, T) {
-        (self.0, self.1)
-    }
-
-    /// Maps the inner value to a new value using the given function.
-    pub fn map<U, F: FnOnce(T) -> U>(self, op: F) -> WithEncoded<U> {
-        WithEncoded(self.0, op(self.1))
-    }
-}
-
-impl<T> WithEncoded<Option<T>> {
-    /// returns `None` if the inner value is `None`, otherwise returns `Some(WithEncoded<T>)`.
-    pub fn transpose(self) -> Option<WithEncoded<T>> {
-        self.1.map(|v| WithEncoded(self.0, v))
     }
 }
 


### PR DESCRIPTION
moves struct from primitives to primitives-traits to make reth-prim/tx leaner