### PR TITLE
chore: replace blobtx fields with signed

### DIFF
--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -87,7 +87,7 @@ where
             .iter()
             .filter_map(|(tx, _)| {
                 if let PooledTransactionsElement::BlobTransaction(tx) = tx {
-                    Some(tx.transaction.tx.blob_gas())
+                    Some(tx.tx().tx().blob_gas())
                 } else {
                     None
                 }


### PR DESCRIPTION
replaces the fields of `Blobtransaction` with `Signed`, we still need a new type but I think we could upstream all of these functions to alloy for `Signed<TxEip4844WithSidecar>` @klkvr ?

driveby fixes a wrong arbitrary impl