### PR TITLE
refactor: simplify withdrawals outcome

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -14,7 +14,7 @@ use alloy_eips::{eip4844::MAX_DATA_GAS_PER_BLOCK, eip7685::Requests, merge::BEAC
 use alloy_primitives::U256;
 use reth_basic_payload_builder::{
     commit_withdrawals, is_better_payload, BuildArguments, BuildOutcome, PayloadBuilder,
-    PayloadConfig, WithdrawalsOutcome,
+    PayloadConfig,
 };
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::ChainSpec;
@@ -356,8 +356,8 @@ where
         None
     };
 
-    let WithdrawalsOutcome { withdrawals_root, withdrawals } =
-        commit_withdrawals(&mut db, &chain_spec, attributes.timestamp, attributes.withdrawals)?;
+    let withdrawals_root =
+        commit_withdrawals(&mut db, &chain_spec, attributes.timestamp, &attributes.withdrawals)?;
 
     // merge all transitions into bundle state, this would apply the withdrawal balance changes
     // and 4788 contract call
@@ -443,7 +443,11 @@ where
     // seal the block
     let block = Block {
         header,
-        body: BlockBody { transactions: executed_txs, ommers: vec![], withdrawals },
+        body: BlockBody {
+            transactions: executed_txs,
+            ommers: vec![],
+            withdrawals: Some(attributes.withdrawals.clone()),
+        },
     };
 
     let sealed_block = Arc::new(block.seal_slow());


### PR DESCRIPTION
It was possible to construct a `WithdrawalsOutcome` with a `None` `withdrawals` but a `Some` `withdrawals_root` and vice-versa. `commit_withdrawals` also only needs `&Withdrawals` so taking in a full one just to return it in `Some` wasn't very clean.