### PR TITLE
feat: generic static file masks

### DIFF
--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -2,10 +2,7 @@
 
 use alloy_primitives::{BlockHash, BlockNumber};
 use reth_consensus::Consensus;
-use reth_db::{
-    static_file::{BlockHashMask, HeaderMask},
-    tables,
-};
+use reth_db::{static_file::BlockHashMask, tables};
 use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
 use reth_node_types::{FullNodePrimitives, NodeTypesWithDB};
 use reth_primitives::{BlockBody, StaticFileSegment};

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{BlockHash, BlockNumber};
 use reth_consensus::Consensus;
-use reth_db::{static_file::HeaderMask, tables};
+use reth_db::{static_file::{BlockHashMask, HeaderMask}, tables};
 use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
 use reth_node_types::{FullNodePrimitives, NodeTypesWithDB};
 use reth_primitives::{BlockBody, StaticFileSegment};
@@ -85,7 +85,7 @@ impl<N: ProviderNodeTypes, E> TreeExternals<N, E> {
             hashes.extend(range.clone().zip(static_file_provider.fetch_range_with_predicate(
                 StaticFileSegment::Headers,
                 range,
-                |cursor, number| cursor.get_one::<HeaderMask<BlockHash>>(number.into()),
+                |cursor, number| cursor.get_one::<BlockHashMask>(number.into()),
                 |_| true,
             )?));
         }

--- a/crates/blockchain-tree/src/externals.rs
+++ b/crates/blockchain-tree/src/externals.rs
@@ -2,7 +2,10 @@
 
 use alloy_primitives::{BlockHash, BlockNumber};
 use reth_consensus::Consensus;
-use reth_db::{static_file::{BlockHashMask, HeaderMask}, tables};
+use reth_db::{
+    static_file::{BlockHashMask, HeaderMask},
+    tables,
+};
 use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
 use reth_node_types::{FullNodePrimitives, NodeTypesWithDB};
 use reth_primitives::{BlockBody, StaticFileSegment};

--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -2,7 +2,9 @@ use alloy_consensus::Header;
 use alloy_primitives::{hex, BlockHash};
 use clap::Parser;
 use reth_db::{
-    static_file::{ColumnSelectorOne, ColumnSelectorTwo, HeaderMask, ReceiptMask, TransactionMask},
+    static_file::{
+        ColumnSelectorOne, ColumnSelectorTwo, HeaderWithHashMask, ReceiptMask, TransactionMask,
+    },
     tables, RawKey, RawTable, Receipts, TableViewer, Transactions,
 };
 use reth_db_api::table::{Decompress, DupSort, Table};
@@ -61,7 +63,7 @@ impl Command {
             Subcommand::StaticFile { segment, key, raw } => {
                 let (key, mask): (u64, _) = match segment {
                     StaticFileSegment::Headers => {
-                        (table_key::<tables::Headers>(&key)?, <HeaderMask<Header, BlockHash>>::MASK)
+                        (table_key::<tables::Headers>(&key)?, <HeaderWithHashMask<Header>>::MASK)
                     }
                     StaticFileSegment::Transactions => (
                         table_key::<tables::Transactions>(&key)?,

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -523,9 +523,9 @@ mod tests {
             },
         };
         use alloy_consensus::Header;
-        use alloy_primitives::{BlockHash, BlockNumber, TxNumber, B256};
+        use alloy_primitives::{BlockNumber, TxNumber, B256};
         use futures_util::Stream;
-        use reth_db::{static_file::HeaderMask, tables};
+        use reth_db::{static_file::HeaderWithHashMask, tables};
         use reth_db_api::{
             cursor::DbCursorRO,
             models::{StoredBlockBodyIndices, StoredBlockOmmers},
@@ -813,7 +813,7 @@ mod tests {
                 for header in static_file_provider.fetch_range_iter(
                     StaticFileSegment::Headers,
                     *range.start()..*range.end() + 1,
-                    |cursor, number| cursor.get_two::<HeaderMask<Header, BlockHash>>(number.into()),
+                    |cursor, number| cursor.get_two::<HeaderWithHashMask<Header>>(number.into()),
                 )? {
                     let (header, hash) = header?;
                     self.headers.push_back(SealedHeader::new(header, hash));

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -48,7 +48,6 @@ page_size = { version = "0.6.0", optional = true }
 thiserror.workspace = true
 tempfile = { workspace = true, optional = true }
 derive_more.workspace = true
-paste.workspace = true
 rustc-hash = { workspace = true, optional = true }
 sysinfo = { version = "0.31", default-features = false, features = ["system"] }
 parking_lot = { workspace = true, optional = true }

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -1,23 +1,44 @@
-use super::{ReceiptMask, TransactionMask};
 use crate::{
     add_static_file_mask,
-    static_file::mask::{ColumnSelectorOne, ColumnSelectorTwo, HeaderMask},
-    HeaderTerminalDifficulties, RawValue, Receipts, Transactions,
+    static_file::mask::{ColumnSelectorOne, ColumnSelectorTwo},
+    HeaderTerminalDifficulties,
 };
-use alloy_consensus::Header;
 use alloy_primitives::BlockHash;
 use reth_db_api::table::Table;
 
 // HEADER MASKS
-add_static_file_mask!(HeaderMask, Header, 0b001);
-add_static_file_mask!(HeaderMask, <HeaderTerminalDifficulties as Table>::Value, 0b010);
-add_static_file_mask!(HeaderMask, BlockHash, 0b100);
-add_static_file_mask!(HeaderMask, Header, BlockHash, 0b101);
-add_static_file_mask!(HeaderMask, <HeaderTerminalDifficulties as Table>::Value, BlockHash, 0b110);
+add_static_file_mask! {
+    #[doc = "Mask for selecting a single header from Headers static file segment"]
+    HeaderMask<H>, H, 0b001
+}
+add_static_file_mask! {
+    #[doc = "Mask for selecting a total difficulty value from Headers static file segment"]
+    TotalDifficultyMask, <HeaderTerminalDifficulties as Table>::Value, 0b010
+}
+add_static_file_mask! {
+    #[doc = "Mask for selecting a block hash value from Headers static file segment"]
+    BlockHashMask, BlockHash, 0b100
+}
+add_static_file_mask! {
+    #[doc = "Mask for selecting a header along with block hash from Headers static file segment"]
+    HeaderWithHashMask<H>, H, BlockHash, 0b101
+}
+add_static_file_mask! {
+    #[doc = "Mask for selecting a total difficulty along with block hash from Headers static file segment"]
+    TDWithHashMask,
+    <HeaderTerminalDifficulties as Table>::Value,
+    BlockHash,
+    0b110
+}
 
 // RECEIPT MASKS
-add_static_file_mask!(ReceiptMask, <Receipts as Table>::Value, 0b1);
+add_static_file_mask! {
+    #[doc = "Mask for selecting a single receipt from Receipts static file segment"]
+    ReceiptMask<R>, R, 0b1
+}
 
 // TRANSACTION MASKS
-add_static_file_mask!(TransactionMask, <Transactions as Table>::Value, 0b1);
-add_static_file_mask!(TransactionMask, RawValue<<Transactions as Table>::Value>, 0b1);
+add_static_file_mask! {
+    #[doc = "Mask for selecting a single transaction from Transactions static file segment"]
+    TransactionMask<T>, T, 0b1
+}

--- a/crates/storage/db/src/static_file/mod.rs
+++ b/crates/storage/db/src/static_file/mod.rs
@@ -17,6 +17,7 @@ use reth_primitives::{
 };
 
 mod masks;
+pub use masks::*;
 
 /// Alias type for a map of [`StaticFileSegment`] and sorted lists of existing static file ranges.
 type SortedStaticFiles =

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -14,7 +14,6 @@ use reth_db::static_file::{
     BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TDWithHashMask,
     TotalDifficultyMask, TransactionMask,
 };
-use reth_db_api::models::CompactU256;
 use reth_node_types::NodePrimitives;
 use reth_primitives::{
     Receipt, SealedHeader, TransactionMeta, TransactionSigned, TransactionSignedNoHash,

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -11,7 +11,8 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use reth_chainspec::ChainInfo;
 use reth_db::static_file::{
-    HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TDWithHashMask, TransactionMask,
+    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TDWithHashMask,
+    TotalDifficultyMask, TransactionMask,
 };
 use reth_db_api::models::CompactU256;
 use reth_node_types::NodePrimitives;
@@ -110,7 +111,7 @@ impl<N: NodePrimitives> HeaderProvider for StaticFileJarProvider<'_, N> {
     }
 
     fn header_td_by_number(&self, num: BlockNumber) -> ProviderResult<Option<U256>> {
-        Ok(self.cursor()?.get_one::<HeaderMask<CompactU256>>(num.into())?.map(Into::into))
+        Ok(self.cursor()?.get_one::<TotalDifficultyMask>(num.into())?.map(Into::into))
     }
 
     fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
@@ -162,7 +163,7 @@ impl<N: NodePrimitives> HeaderProvider for StaticFileJarProvider<'_, N> {
 
 impl<N: NodePrimitives> BlockHashReader for StaticFileJarProvider<'_, N> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
-        self.cursor()?.get_one::<HeaderMask<BlockHash>>(number.into())
+        self.cursor()?.get_one::<BlockHashMask>(number.into())
     }
 
     fn canonical_hashes_range(
@@ -174,7 +175,7 @@ impl<N: NodePrimitives> BlockHashReader for StaticFileJarProvider<'_, N> {
         let mut hashes = Vec::with_capacity((end - start) as usize);
 
         for number in start..end {
-            if let Some(hash) = cursor.get_one::<HeaderMask<BlockHash>>(number.into())? {
+            if let Some(hash) = cursor.get_one::<BlockHashMask>(number.into())? {
                 hashes.push(hash)
             }
         }
@@ -202,7 +203,7 @@ impl<N: NodePrimitives> BlockNumReader for StaticFileJarProvider<'_, N> {
         let mut cursor = self.cursor()?;
 
         Ok(cursor
-            .get_one::<HeaderMask<BlockHash>>((&hash).into())?
+            .get_one::<BlockHashMask>((&hash).into())?
             .and_then(|res| (res == hash).then(|| cursor.number()).flatten()))
     }
 }


### PR DESCRIPTION
This changes the way we handle masks in static files and allows them to be generic over primitive types.

Right now we reuse the `Header` mask for fetching headers as well as different combinations of other columns. e.g to fetch Header and hash we need to use `Header<Header, BlockHash>`, for TD and hash — `Header<U256, Hash>`, etc.

With current approach adding generics is not possible because we rely on `ColumnSelector` implementations for concrete types. i.e we have concrete implementation of `ColumnSelectorTwo for HeaderMask<Header, BlockHash>` which selects header+hash and a concrete implementation `ColumnSelectorTwo for HeaderMask<U256, BlockHash>`  which selects TD+Hash, thus we can't have a another implementation abstracted over first generic.

This PR changes the way we operate on masks and introduces separate masks for different sets of columns. We now have a separate `HeaderMask<H>` which selects a header, `HeaderWithHash<H>` mask which selects header and hash, etc.

This allows us to have generic impls for separate masks and also removed some redundancy in static files code — instead of `HeaderMask<CompactU256, BlockHash>` we now can just write `TDWithHashMask`