### PR TITLE
Grammar and Typo Fixes in Documentation

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
@@ -136,7 +136,7 @@ are only a few cases of changing data.
 | _DELETING_|||
 |Key is absent → Error since no such key      |\ref mdbx_del() or \ref mdbx_replace()|Error \ref MDBX_NOTFOUND|
 |Key exist → Delete by key                    |\ref mdbx_del() with the parameter `data = NULL`|Deletion|
-|Key exist → Delete by key with with data matching check|\ref mdbx_del() with the parameter `data` filled with the value which should be match for deletion|Deletion or \ref MDBX_NOTFOUND if the value does not match|
+|Key exist → Delete by key with data matching check|\ref mdbx_del() with the parameter `data` filled with the value which should be match for deletion|Deletion or \ref MDBX_NOTFOUND if the value does not match|
 |Delete at the current cursor position        |\ref mdbx_cursor_del() with \ref MDBX_CURRENT flag|Deletion|
 |Extract (read & delete) value by the key     |\ref mdbx_replace() with zero flag and parameter `new_data = NULL`|Returning a deleted value|
 
@@ -5264,7 +5264,7 @@ LIBMDBX_API int mdbx_dbi_sequence(MDBX_txn *txn, MDBX_dbi dbi, uint64_t *result,
  * This returns a comparison as if the two data items were keys in the
  * specified database.
  *
- * \warning There ss a Undefined behavior if one of arguments is invalid.
+ * \warning There is a Undefined behavior if one of arguments is invalid.
  *
  * \param [in] txn   A transaction handle returned by \ref mdbx_txn_begin().
  * \param [in] dbi   A database handle returned by \ref mdbx_dbi_open().

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -42,7 +42,7 @@ There will only ever exist one description per metric `KeyName`; it is not possi
 The `metrics` crate provides three macros per metric variant: `register_<metric>!`, `<metric>!`, and `describe_<metric>!`. Prefer to use these where possible, since they generate the code necessary to register and update metrics under various conditions.
 
 - The `register_<metric>!` macro simply creates the metric and returns a handle to it (e.g. a `Counter`). These metric structs are thread-safe and cheap to clone.
-- The `<metric>!` macro registers the metric if it does not exist, and updates it's value.
+- The `<metric>!` macro registers the metric if it does not exist, and updates its value.
 - The `describe_<metric>!` macro adds an end-user description for the metric.
 
 How the metrics are exposed to the end-user is determined by the CLI.


### PR DESCRIPTION
🔍 Changes Overview
1. docs/design/metrics.md
-  and updates it's value.
+ and updates its value.
Reason: Fixed possessive pronoun usage. "it's" is a contraction of "it is", while "its" is the correct possessive form.

2. crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
-   warning There ss a Undefined 
+  warning There is a Undefined
Reason: Fixed typo in warning message. "ss" was a typographical error that should be "is".

-   |Key exist → Delete by key with with data matching check|
+  |Key exist → Delete by key with data matching check|
Reason: Removed duplicate word "with" to improve readability and correctness of the documentation.