### PR TITLE
feat: add try_into_pooled_eip4844

### DIFF
--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -770,6 +770,14 @@ impl EthPoolTransaction for MockTransaction {
         }
     }
 
+    fn try_into_pooled_eip4844(self, sidecar: Arc<BlobTransactionSidecar>) -> Option<Self::Pooled> {
+        Self::Pooled::try_from_blob_transaction(
+            self.into_consensus(),
+            Arc::unwrap_or_clone(sidecar),
+        )
+        .ok()
+    }
+
     fn validate_blob(
         &self,
         _blob: &BlobTransactionSidecar,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1093,6 +1093,13 @@ pub trait EthPoolTransaction:
     /// Returns the number of blobs this transaction has.
     fn blob_count(&self) -> usize;
 
+    /// A specialization for the EIP-4844 transaction type.
+    /// Tries to reattach the blob sidecar to the transaction.
+    ///
+    /// This returns an option, but callers should ensure that the transaction is an EIP-4844
+    /// transaction: [`PoolTransaction::is_eip4844`].
+    fn try_into_pooled_eip4844(self, sidecar: Arc<BlobTransactionSidecar>) -> Option<Self::Pooled>;
+
     /// Validates the blob sidecar of the transaction with the given settings.
     fn validate_blob(
         &self,
@@ -1337,6 +1344,14 @@ impl EthPoolTransaction for EthPooledTransaction {
             Transaction::Eip4844(tx) => tx.blob_versioned_hashes.len(),
             _ => 0,
         }
+    }
+
+    fn try_into_pooled_eip4844(self, sidecar: Arc<BlobTransactionSidecar>) -> Option<Self::Pooled> {
+        PooledTransactionsElementEcRecovered::try_from_blob_transaction(
+            self.into_consensus(),
+            Arc::unwrap_or_clone(sidecar),
+        )
+        .ok()
     }
 
     fn validate_blob(


### PR DESCRIPTION
in order to support arbitrary pooled variants, we need a helper for 4844 because support for 4844 is baked into the pool.

for p2p we need to reattach the sidecar to the tx object we keep in the pool.
This introduces a trait function that takes care of this.

this will allows us to change the pool's trait function to `Transaction::Pooled`

https://github.com/paradigmxyz/reth/blob/3bcc4c83143f58cdaf313c098d3699e0e5e3d403/crates/transaction-pool/src/traits.rs#L230-L234