### PR TITLE
feat: add Transaction AT to `TransactionsProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8655,6 +8655,7 @@ dependencies = [
 name = "reth-prune"
 version = "1.1.2"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "assert_matches",
  "itertools 0.13.0",
@@ -8988,6 +8989,7 @@ dependencies = [
  "reth-execution-types",
  "reth-metrics",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-server-types",
  "reth-rpc-types-compat",
@@ -9062,6 +9064,7 @@ name = "reth-stages"
 version = "1.1.2"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -238,3 +238,6 @@ pub type HeaderTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::BlockHe
 
 /// Helper adapter type for accessing [`NodePrimitives::BlockBody`] on [`NodeTypes`].
 pub type BodyTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::BlockBody;
+
+/// Helper adapter type for accessing [`NodePrimitives::SignedTx`] on [`NodeTypes`].
+pub type TxTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::SignedTx;

--- a/crates/optimism/cli/src/ovm_file_codec.rs
+++ b/crates/optimism/cli/src/ovm_file_codec.rs
@@ -254,10 +254,6 @@ impl Encodable2718 for TransactionSigned {
     fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
         self.transaction.eip2718_encode(&self.signature, out)
     }
-
-    fn trie_hash(&self) -> B256 {
-        self.ha()
-    }
 }
 
 impl Decodable2718 for TransactionSigned {

--- a/crates/optimism/cli/src/ovm_file_codec.rs
+++ b/crates/optimism/cli/src/ovm_file_codec.rs
@@ -250,8 +250,13 @@ impl Encodable2718 for TransactionSigned {
             Transaction::Deposit(deposit_tx) => deposit_tx.eip2718_encoded_length(),
         }
     }
+
     fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
         self.transaction.eip2718_encode(&self.signature, out)
+    }
+
+    fn trie_hash(&self) -> B256 {
+        self.ha()
     }
 }
 

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -11,7 +11,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::RethL1BlockInfo;
 use reth_optimism_forks::OpHardforks;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned, TxType};
-use reth_provider::ChainSpecProvider;
+use reth_provider::{ChainSpecProvider, TransactionsProvider};
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcReceipt};
 use reth_rpc_eth_types::{receipt::build_receipt, EthApiError};
 
@@ -21,6 +21,7 @@ impl<N> LoadReceipt for OpEthApi<N>
 where
     Self: Send + Sync,
     N: FullNodeComponents<Types: NodeTypes<ChainSpec = OpChainSpec>>,
+    Self::Provider: TransactionsProvider<Transaction = TransactionSigned>,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -58,6 +58,7 @@ impl<N> LoadTransaction for OpEthApi<N>
 where
     Self: SpawnBlocking + FullEthApiTypes,
     N: RpcNodeCore<Provider: TransactionsProvider, Pool: TransactionPool>,
+    Self::Pool: TransactionPool,
 {
 }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1624,6 +1624,10 @@ impl Encodable2718 for TransactionSigned {
     fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
         self.transaction.eip2718_encode(&self.signature, out)
     }
+
+    fn trie_hash(&self) -> B256 {
+        self.hash()
+    }
 }
 
 impl Decodable2718 for TransactionSigned {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1991,6 +1991,22 @@ pub mod serde_bincode_compat {
     }
 }
 
+/// Recovers a list of signers from a transaction list iterator.
+///
+/// Returns `None`, if some transaction's signature is invalid, see also
+/// [`Self::recover_signer`].
+pub fn recover_signers<'a, I, T>(txes: I, num_txes: usize) -> Option<Vec<Address>>
+where
+    T: SignedTransaction,
+    I: IntoParallelIterator<Item = &'a T> + IntoIterator<Item = &'a T> + Send,
+{
+    if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
+        txes.into_iter().map(|tx| tx.recover_signer()).collect()
+    } else {
+        txes.into_par_iter().map(|tx| tx.recover_signer()).collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1787,8 +1787,7 @@ impl<T: SignedTransaction> Decodable for TransactionSignedEcRecovered<T> {
     }
 }
 
-/// And extension trait for [`SignedTransaction`] to convert it into
-/// [`TransactionSignedEcRecovered`].
+/// Extension trait for [`SignedTransaction`] to convert it into [`TransactionSignedEcRecovered`].
 pub trait SignedTransactionIntoRecoveredExt: SignedTransaction {
     /// Consumes the type, recover signer and return [`TransactionSignedEcRecovered`] _without
     /// ensuring that the signature has a low `s` value_ (EIP-2).
@@ -2009,8 +2008,7 @@ pub mod serde_bincode_compat {
 
 /// Recovers a list of signers from a transaction list iterator.
 ///
-/// Returns `None`, if some transaction's signature is invalid, see also
-/// [`Self::recover_signer`].
+/// Returns `None`, if some transaction's signature is invalid
 pub fn recover_signers<'a, I, T>(txes: I, num_txes: usize) -> Option<Vec<Address>>
 where
     T: SignedTransaction,

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -24,6 +24,9 @@ reth-config.workspace = true
 reth-prune-types.workspace = true
 reth-static-file-types.workspace = true
 
+# ethereum
+alloy-eips.workspace = true
+
 # metrics
 reth-metrics.workspace = true
 metrics.workspace = true

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -3,6 +3,7 @@ use crate::{
     segments::{PruneInput, Segment, SegmentOutput},
     PrunerError,
 };
+use alloy_eips::eip2718::Encodable2718;
 use rayon::prelude::*;
 use reth_db::{tables, transaction::DbTxMut};
 use reth_provider::{BlockReader, DBProvider, TransactionsProvider};
@@ -58,7 +59,7 @@ where
         let hashes = provider
             .transactions_by_tx_range(tx_range.clone())?
             .into_par_iter()
-            .map(|transaction| transaction.hash())
+            .map(|transaction| transaction.trie_hash())
             .collect::<Vec<_>>();
 
         // Number of transactions retrieved from the database should match the tx range count

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -19,6 +19,7 @@
 //! use alloy_consensus::Header;
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_network_api::{NetworkInfo, Peers};
+//! use reth_primitives::TransactionSigned;
 //! use reth_provider::{AccountReader, CanonStateSubscriptions, ChangeSetReader, FullRpcProvider};
 //! use reth_rpc::EthApi;
 //! use reth_rpc_builder::{
@@ -36,7 +37,8 @@
 //!     block_executor: BlockExecutor,
 //!     consensus: Consensus,
 //! ) where
-//!     Provider: FullRpcProvider + AccountReader + ChangeSetReader,
+//!     Provider:
+//!         FullRpcProvider<Transaction = TransactionSigned> + AccountReader + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events: CanonStateSubscriptions + Clone + 'static,
@@ -77,6 +79,7 @@
 //! use reth_engine_primitives::EngineTypes;
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_network_api::{NetworkInfo, Peers};
+//! use reth_primitives::TransactionSigned;
 //! use reth_provider::{AccountReader, CanonStateSubscriptions, ChangeSetReader, FullRpcProvider};
 //! use reth_rpc::EthApi;
 //! use reth_rpc_api::EngineApiServer;
@@ -109,7 +112,8 @@
 //!     block_executor: BlockExecutor,
 //!     consensus: Consensus,
 //! ) where
-//!     Provider: FullRpcProvider + AccountReader + ChangeSetReader,
+//!     Provider:
+//!         FullRpcProvider<Transaction = TransactionSigned> + AccountReader + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events: CanonStateSubscriptions + Clone + 'static,

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -2,18 +2,21 @@
 //! loads receipt data w.r.t. network.
 
 use futures::Future;
-use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
+use reth_primitives::{Receipt, TransactionMeta};
+use reth_provider::TransactionsProvider;
 
 use crate::{EthApiTypes, RpcNodeCoreExt, RpcReceipt};
 
 /// Assembles transaction receipt data w.r.t to network.
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` receipts RPC methods.
-pub trait LoadReceipt: EthApiTypes + RpcNodeCoreExt + Send + Sync {
+pub trait LoadReceipt:
+    EthApiTypes + RpcNodeCoreExt<Provider: TransactionsProvider> + Send + Sync
+{
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.
     fn build_transaction_receipt(
         &self,
-        tx: TransactionSigned,
+        tx: <Self::Provider as TransactionsProvider>::Transaction,
         meta: TransactionMeta,
         receipt: Receipt,
     ) -> impl Future<Output = Result<RpcReceipt<Self::NetworkTypes>, Self::Error>> + Send;

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -19,6 +19,7 @@ reth-evm.workspace = true
 reth-execution-types.workspace = true
 reth-metrics.workspace = true
 reth-primitives = { workspace = true, features = ["secp256k1"] }
+reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-revm.workspace = true
 reth-rpc-server-types.workspace = true

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -2,7 +2,7 @@
 //!
 //! Log parsing for building filter.
 
-use alloy_eips::BlockNumHash;
+use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
 use alloy_primitives::TxHash;
 use alloy_rpc_types_eth::{FilteredParams, Log};
 use reth_chainspec::ChainInfo;
@@ -110,7 +110,7 @@ pub fn append_matching_block_logs<P: BlockReader>(
                                     ProviderError::TransactionNotFound(transaction_id.into())
                                 })?;
 
-                            Some(transaction.hash())
+                            Some(transaction.trie_hash())
                         }
                     };
                 }

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -4,7 +4,8 @@
 
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
-use reth_primitives::TransactionSignedEcRecovered;
+use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
+use reth_primitives_traits::SignedTransaction;
 use reth_rpc_types_compat::{
     transaction::{from_recovered, from_recovered_with_block_context},
     TransactionCompat,
@@ -12,15 +13,15 @@ use reth_rpc_types_compat::{
 
 /// Represents from where a transaction was fetched.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum TransactionSource {
+pub enum TransactionSource<T = TransactionSigned> {
     /// Transaction exists in the pool (Pending)
-    Pool(TransactionSignedEcRecovered),
+    Pool(TransactionSignedEcRecovered<T>),
     /// Transaction already included in a block
     ///
     /// This can be a historical block or a pending block (received from the CL)
     Block {
         /// Transaction fetched via provider
-        transaction: TransactionSignedEcRecovered,
+        transaction: TransactionSignedEcRecovered<T>,
         /// Index of the transaction in the block
         index: u64,
         /// Hash of the block.
@@ -34,22 +35,22 @@ pub enum TransactionSource {
 
 // === impl TransactionSource ===
 
-impl TransactionSource {
+impl<T: SignedTransaction> TransactionSource<T> {
     /// Consumes the type and returns the wrapped transaction.
-    pub fn into_recovered(self) -> TransactionSignedEcRecovered {
+    pub fn into_recovered(self) -> TransactionSignedEcRecovered<T> {
         self.into()
     }
 
     /// Conversion into network specific transaction type.
-    pub fn into_transaction<T: TransactionCompat>(
+    pub fn into_transaction<Builder: TransactionCompat<T>>(
         self,
-        resp_builder: &T,
-    ) -> Result<T::Transaction, T::Error> {
+        resp_builder: &Builder,
+    ) -> Result<Builder::Transaction, Builder::Error> {
         match self {
             Self::Pool(tx) => from_recovered(tx, resp_builder),
             Self::Block { transaction, index, block_hash, block_number, base_fee } => {
                 let tx_info = TransactionInfo {
-                    hash: Some(transaction.hash()),
+                    hash: Some(transaction.trie_hash()),
                     index: Some(index),
                     block_hash: Some(block_hash),
                     block_number: Some(block_number),
@@ -62,14 +63,14 @@ impl TransactionSource {
     }
 
     /// Returns the transaction and block related info, if not pending
-    pub fn split(self) -> (TransactionSignedEcRecovered, TransactionInfo) {
+    pub fn split(self) -> (TransactionSignedEcRecovered<T>, TransactionInfo) {
         match self {
             Self::Pool(tx) => {
-                let hash = tx.hash();
+                let hash = tx.trie_hash();
                 (tx, TransactionInfo { hash: Some(hash), ..Default::default() })
             }
             Self::Block { transaction, index, block_hash, block_number, base_fee } => {
-                let hash = transaction.hash();
+                let hash = transaction.trie_hash();
                 (
                     transaction,
                     TransactionInfo {
@@ -85,8 +86,8 @@ impl TransactionSource {
     }
 }
 
-impl From<TransactionSource> for TransactionSignedEcRecovered {
-    fn from(value: TransactionSource) -> Self {
+impl<T> From<TransactionSource<T>> for TransactionSignedEcRecovered<T> {
+    fn from(value: TransactionSource<T>) -> Self {
         match value {
             TransactionSource::Pool(tx) => tx,
             TransactionSource::Block { transaction, .. } => transaction,

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -7,7 +7,7 @@ use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{
     Block, BlockTransactions, BlockTransactionsKind, Header, TransactionInfo,
 };
-use reth_primitives::{Block as PrimitiveBlock, BlockWithSenders};
+use reth_primitives::{Block as PrimitiveBlock, BlockWithSenders, TransactionSigned};
 
 use crate::{transaction::from_recovered_with_block_context, TransactionCompat};
 
@@ -87,7 +87,11 @@ pub fn from_block_full<T: TransactionCompat>(
                 index: Some(idx as u64),
             };
 
-            from_recovered_with_block_context::<T>(signed_tx_ec_recovered, tx_info, tx_resp_builder)
+            from_recovered_with_block_context::<TransactionSigned, T>(
+                signed_tx_ec_recovered,
+                tx_info,
+                tx_resp_builder,
+            )
         })
         .collect::<Result<Vec<_>, T::Error>>()?;
 

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,6 +1,7 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
+use reth_provider::TransactionsProvider;
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 
@@ -8,7 +9,7 @@ use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> LoadReceipt for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: RpcNodeCoreExt,
+    Self: RpcNodeCoreExt<Provider: TransactionsProvider<Transaction = TransactionSigned>>,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -39,6 +39,7 @@ reth-trie-db = { workspace = true, features = ["metrics"] }
 
 reth-testing-utils = { workspace = true, optional = true }
 
+alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2246,9 +2246,7 @@ mod tests {
             (transactions_by_tx_range, |block: &SealedBlock, _: &Vec<Vec<Receipt>>| block
                 .body
                 .transactions
-                .iter()
-                .map(|tx| Into::<TransactionSignedNoHash>::into(tx.clone()))
-                .collect::<Vec<_>>()),
+                .clone()),
             (receipts_by_tx_range, |block: &SealedBlock, receipts: &Vec<Vec<Receipt>>| receipts
                 [block.number as usize]
                 .clone())
@@ -2593,9 +2591,7 @@ mod tests {
                 transaction_by_id_unhashed,
                 |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
                     tx_num,
-                    Some(Into::<TransactionSignedNoHash>::into(
-                        block.body.transactions[test_tx_index].clone()
-                    ))
+                    Some(block.body.transactions[test_tx_index].clone())
                 ),
                 u64::MAX
             ),

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -25,7 +25,7 @@ use reth_db::{models::BlockNumberAddress, transaction::DbTx, Database};
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_execution_types::ExecutionOutcome;
-use reth_node_types::NodeTypesWithDB;
+use reth_node_types::{NodeTypesWithDB, TxTy};
 use reth_primitives::{
     Account, Block, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
     StorageEntry, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
@@ -331,29 +331,31 @@ impl<N: ProviderNodeTypes> BlockReader for BlockchainProvider2<N> {
 }
 
 impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
+    type Transaction = TxTy<N>;
+
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.consistent_provider()?.transaction_id(tx_hash)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
         self.consistent_provider()?.transaction_by_id(id)
     }
 
     fn transaction_by_id_unhashed(
         &self,
         id: TxNumber,
-    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<Self::Transaction>> {
         self.consistent_provider()?.transaction_by_id_unhashed(id)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
         self.consistent_provider()?.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
         self.consistent_provider()?.transaction_by_hash_with_meta(tx_hash)
     }
 
@@ -364,21 +366,21 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
         self.consistent_provider()?.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
         self.consistent_provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<Self::Transaction>> {
         self.consistent_provider()?.transactions_by_tx_range(range)
     }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -21,7 +21,7 @@ use reth_execution_types::{BundleStateInit, ExecutionOutcome, RevertsInit};
 use reth_node_types::TxTy;
 use reth_primitives::{
     Account, Block, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
-    StorageEntry, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    StorageEntry, TransactionMeta,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -943,7 +943,14 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
             id.into(),
             |provider| provider.transaction_by_id(id),
             |tx_index, _, block_state| {
-                Ok(block_state.block_ref().block().body.transactions.get(tx_index).cloned())
+                Ok(block_state
+                    .block_ref()
+                    .block()
+                    .body
+                    .transactions
+                    .get(tx_index)
+                    .cloned()
+                    .map(Into::into))
             },
         )
     }
@@ -970,7 +977,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
         if let Some(tx) = self.head_block.as_ref().and_then(|b| b.transaction_on_chain(hash)) {
-            return Ok(Some(tx))
+            return Ok(Some(tx.into()))
         }
 
         self.storage_provider.transaction_by_hash(hash)
@@ -983,7 +990,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
         if let Some((tx, meta)) =
             self.head_block.as_ref().and_then(|b| b.transaction_meta_on_chain(tx_hash))
         {
-            return Ok(Some((tx, meta)))
+            return Ok(Some((tx.into(), meta)))
         }
 
         self.storage_provider.transaction_by_hash_with_meta(tx_hash)
@@ -1004,7 +1011,18 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
         self.get_in_memory_or_storage_by_block(
             id,
             |provider| provider.transactions_by_block(id),
-            |block_state| Ok(Some(block_state.block_ref().block().body.transactions.clone())),
+            |block_state| {
+                Ok(Some(
+                    block_state
+                        .block_ref()
+                        .block()
+                        .body
+                        .transactions
+                        .iter()
+                        .map(|tx| tx.clone().into())
+                        .collect(),
+                ))
+            },
         )
     }
 
@@ -1015,7 +1033,18 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
         self.get_in_memory_or_storage_by_block_range_while(
             range,
             |db_provider, range, _| db_provider.transactions_by_block_range(range),
-            |block_state, _| Some(block_state.block_ref().block().body.transactions.clone()),
+            |block_state, _| {
+                Some(
+                    block_state
+                        .block_ref()
+                        .block()
+                        .body
+                        .transactions
+                        .iter()
+                        .map(|tx| tx.clone().into())
+                        .collect(),
+                )
+            },
             |_| true,
         )
     }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -22,7 +22,7 @@ use reth_evm::ConfigureEvmEnv;
 use reth_node_types::{NodeTypesWithDB, TxTy};
 use reth_primitives::{
     Block, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
-    StaticFileSegment, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    StaticFileSegment, TransactionMeta,
 };
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -19,7 +19,7 @@ use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
 use reth_evm::ConfigureEvmEnv;
-use reth_node_types::NodeTypesWithDB;
+use reth_node_types::{NodeTypesWithDB, TxTy};
 use reth_primitives::{
     Block, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
     StaticFileSegment, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
@@ -420,11 +420,13 @@ impl<N: ProviderNodeTypes> BlockReader for ProviderFactory<N> {
 }
 
 impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
+    type Transaction = TxTy<N>;
+
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.provider()?.transaction_id(tx_hash)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Transactions,
             id,
@@ -436,7 +438,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
     fn transaction_by_id_unhashed(
         &self,
         id: TxNumber,
-    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<Self::Transaction>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Transactions,
             id,
@@ -445,14 +447,14 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
         )
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
         self.provider()?.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
         self.provider()?.transaction_by_hash_with_meta(tx_hash)
     }
 
@@ -463,21 +465,21 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
         self.provider()?.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
         self.provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<Self::Transaction>> {
         self.provider()?.transactions_by_tx_range(range)
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3,7 +3,7 @@ use crate::{
     providers::{
         database::{chain::ChainStorage, metrics},
         static_file::StaticFileWriter,
-        ProviderNodeTypes, StaticFileProvider,
+        NodeTypesForProvider, StaticFileProvider,
     },
     to_range,
     traits::{
@@ -243,7 +243,7 @@ impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
     }
 }
 
-impl<TX: DbTx + DbTxMut + 'static, N: ProviderNodeTypes> DatabaseProvider<TX, N> {
+impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
     /// Unwinds trie state for the given range.
     ///
     /// This includes calculating the resulted state root and comparing it with the parent block
@@ -374,7 +374,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
     }
 }
 
-impl<Tx: DbTx + DbTxMut + 'static, N: ProviderNodeTypes + 'static> DatabaseProvider<Tx, N> {
+impl<Tx: DbTx + DbTxMut + 'static, N: NodeTypesForProvider + 'static> DatabaseProvider<Tx, N> {
     // TODO: uncomment below, once `reth debug_cmd` has been feature gated with dev.
     // #[cfg(any(test, feature = "test-utils"))]
     /// Inserts an historical block. **Used for setting up test environments**
@@ -657,7 +657,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     }
 }
 
-impl<TX: DbTx + 'static, N: ProviderNodeTypes> DatabaseProvider<TX, N> {
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
     fn transactions_by_tx_range_with_cursor<C>(
         &self,
         range: impl RangeBounds<TxNumber>,
@@ -678,7 +678,7 @@ impl<TX: DbTx + 'static, N: ProviderNodeTypes> DatabaseProvider<TX, N> {
     fn block_with_senders<H, HF, B, BF>(
         &self,
         id: BlockHashOrNumber,
-        transaction_kind: TransactionVariant,
+        _transaction_kind: TransactionVariant,
         header_by_number: HF,
         construct_block: BF,
     ) -> ProviderResult<Option<B>>
@@ -1213,7 +1213,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> BlockNumReader for DatabaseProvider<TX, N
     }
 }
 
-impl<TX: DbTx + 'static, N: ProviderNodeTypes> BlockReader for DatabaseProvider<TX, N> {
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvider<TX, N> {
     fn find_block_by_hash(&self, hash: B256, source: BlockSource) -> ProviderResult<Option<Block>> {
         if source.is_canonical() {
             self.block(hash.into())
@@ -1388,7 +1388,9 @@ impl<TX: DbTx + 'static, N: ProviderNodeTypes> BlockReader for DatabaseProvider<
     }
 }
 
-impl<TX: DbTx + 'static, N: ProviderNodeTypes> TransactionsProviderExt for DatabaseProvider<TX, N> {
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProviderExt
+    for DatabaseProvider<TX, N>
+{
     /// Recovers transaction hashes by walking through `Transactions` table and
     /// calculating them in a parallel manner. Returned unsorted.
     fn transaction_hashes_by_range(
@@ -1456,7 +1458,7 @@ impl<TX: DbTx + 'static, N: ProviderNodeTypes> TransactionsProviderExt for Datab
 }
 
 // Calculates the hash of the given transaction
-impl<TX: DbTx + 'static, N: ProviderNodeTypes> TransactionsProvider for DatabaseProvider<TX, N> {
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for DatabaseProvider<TX, N> {
     type Transaction = TxTy<N>;
 
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
@@ -1600,7 +1602,7 @@ impl<TX: DbTx + 'static, N: ProviderNodeTypes> TransactionsProvider for Database
     }
 }
 
-impl<TX: DbTx + 'static, N: ProviderNodeTypes> ReceiptProvider for DatabaseProvider<TX, N> {
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabaseProvider<TX, N> {
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Receipts,
@@ -2694,7 +2696,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> StateReader for DatabaseProvider<TX, N> {
     }
 }
 
-impl<TX: DbTxMut + DbTx + 'static, N: ProviderNodeTypes + 'static> BlockExecutionWriter
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockExecutionWriter
     for DatabaseProvider<TX, N>
 {
     fn take_block_and_execution_above(
@@ -2744,7 +2746,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: ProviderNodeTypes + 'static> BlockExecutio
     }
 }
 
-impl<TX: DbTxMut + DbTx + 'static, N: ProviderNodeTypes + 'static> BlockWriter
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWriter
     for DatabaseProvider<TX, N>
 {
     type Body = <<N::Primitives as NodePrimitives>::Block as reth_primitives_traits::Block>::Body;

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -23,7 +23,7 @@ use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_db::table::Value;
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
-use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDB};
+use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDB, TxTy};
 use reth_primitives::{
     Account, Block, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
     TransactionMeta, TransactionSigned, TransactionSignedNoHash,
@@ -85,7 +85,7 @@ impl<T> NodeTypesForProvider for T where
     T: NodeTypes<
         ChainSpec: EthereumHardforks,
         Storage: ChainStorage<T::Primitives>,
-        Primitives: FullNodePrimitives<SignedTx: Value>,
+        Primitives: FullNodePrimitives<SignedTx: Value + Into<TransactionSigned>>,
     >
 {
 }
@@ -417,29 +417,31 @@ impl<N: ProviderNodeTypes> BlockReader for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
+    type Transaction = TxTy<N>;
+
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.database.transaction_id(tx_hash)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
         self.database.transaction_by_id(id)
     }
 
     fn transaction_by_id_unhashed(
         &self,
         id: TxNumber,
-    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<Self::Transaction>> {
         self.database.transaction_by_id_unhashed(id)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
         self.database.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
         self.database.transaction_by_hash_with_meta(tx_hash)
     }
 
@@ -450,21 +452,21 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
         self.database.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
         self.database.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<Self::Transaction>> {
         self.database.transactions_by_tx_range(range)
     }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -26,7 +26,7 @@ use reth_evm::ConfigureEvmEnv;
 use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDB, TxTy};
 use reth_primitives::{
     Account, Block, BlockWithSenders, Receipt, SealedBlock, SealedBlockWithSenders, SealedHeader,
-    TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    TransactionMeta, TransactionSigned,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
@@ -76,7 +76,7 @@ where
     Self: NodeTypes<
         ChainSpec: EthereumHardforks,
         Storage: ChainStorage<Self::Primitives>,
-        Primitives: FullNodePrimitives<SignedTx: Value>,
+        Primitives: FullNodePrimitives<SignedTx: Value + Into<TransactionSigned>>,
     >,
 {
 }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -76,7 +76,9 @@ where
     Self: NodeTypes<
         ChainSpec: EthereumHardforks,
         Storage: ChainStorage<Self::Primitives>,
-        Primitives: FullNodePrimitives<SignedTx: Value + Into<TransactionSigned>>,
+        Primitives: FullNodePrimitives<
+            SignedTx: Value + From<TransactionSigned> + Into<TransactionSigned>,
+        >,
     >,
 {
 }
@@ -85,7 +87,9 @@ impl<T> NodeTypesForProvider for T where
     T: NodeTypes<
         ChainSpec: EthereumHardforks,
         Storage: ChainStorage<T::Primitives>,
-        Primitives: FullNodePrimitives<SignedTx: Value + Into<TransactionSigned>>,
+        Primitives: FullNodePrimitives<
+            SignedTx: Value + From<TransactionSigned> + Into<TransactionSigned>,
+        >,
     >
 {
 }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -223,7 +223,7 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsPr
     }
 
     fn transaction_by_id(&self, num: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
-        Ok(self.cursor()?.get_one::<TransactionMask<Self::Transaction>>(num.into())?)
+        self.cursor()?.get_one::<TransactionMask<Self::Transaction>>(num.into())
     }
 
     fn transaction_by_id_unhashed(
@@ -234,7 +234,7 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsPr
     }
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
-        Ok(self.cursor()?.get_one::<TransactionMask<Self::Transaction>>((&hash).into())?)
+        self.cursor()?.get_one::<TransactionMask<Self::Transaction>>((&hash).into())
     }
 
     fn transaction_by_hash_with_meta(

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -415,7 +415,7 @@ mod tests {
 
         #[allow(clippy::too_many_arguments)]
         fn prune_and_validate(
-            sf_rw: &StaticFileProvider<()>,
+            sf_rw: &StaticFileProvider<EthPrimitives>,
             static_dir: impl AsRef<Path>,
             segment: StaticFileSegment,
             prune_count: u64,

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -23,7 +23,7 @@ use reth_errors::ProviderError;
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
     Account, Block, BlockWithSenders, Bytecode, Receipt, SealedBlock, SealedBlockWithSenders,
-    SealedHeader, TransactionMeta, TransactionSigned, TransactionSignedNoHash,
+    SealedHeader, TransactionMeta, TransactionSigned,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
@@ -192,29 +192,31 @@ impl BlockIdReader for NoopProvider {
 }
 
 impl TransactionsProvider for NoopProvider {
+    type Transaction = TransactionSigned;
+
     fn transaction_id(&self, _tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         Ok(None)
     }
 
-    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
         Ok(None)
     }
 
     fn transaction_by_id_unhashed(
         &self,
         _id: TxNumber,
-    ) -> ProviderResult<Option<TransactionSignedNoHash>> {
+    ) -> ProviderResult<Option<Self::Transaction>> {
         Ok(None)
     }
 
-    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
         Ok(None)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         _hash: TxHash,
-    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
         Ok(None)
     }
 
@@ -225,21 +227,21 @@ impl TransactionsProvider for NoopProvider {
     fn transactions_by_block(
         &self,
         _block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
         Ok(None)
     }
 
     fn transactions_by_block_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
         Ok(Vec::default())
     }
 
     fn transactions_by_tx_range(
         &self,
         _range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<reth_primitives::TransactionSignedNoHash>> {
+    ) -> ProviderResult<Vec<Self::Transaction>> {
         Ok(Vec::default())
     }
 

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -7,13 +7,13 @@ use crate::{
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
 use reth_chainspec::EthereumHardforks;
-use reth_node_types::NodeTypesWithDB;
+use reth_node_types::{NodeTypesWithDB, TxTy};
 
 /// Helper trait to unify all provider traits for simplicity.
 pub trait FullProvider<N: NodeTypesWithDB>:
     DatabaseProviderFactory<DB = N::DB>
-    + StaticFileProviderFactory
-    + BlockReaderIdExt
+    + StaticFileProviderFactory<Primitives = N::Primitives>
+    + BlockReaderIdExt<Transaction = TxTy<N>>
     + AccountReader
     + StateProviderFactory
     + EvmEnvProvider
@@ -30,8 +30,8 @@ pub trait FullProvider<N: NodeTypesWithDB>:
 
 impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
     T: DatabaseProviderFactory<DB = N::DB>
-        + StaticFileProviderFactory
-        + BlockReaderIdExt
+        + StaticFileProviderFactory<Primitives = N::Primitives>
+        + BlockReaderIdExt<Transaction = TxTy<N>>
         + AccountReader
         + StateProviderFactory
         + EvmEnvProvider

--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -1,7 +1,7 @@
 use crate::{BlockNumReader, BlockReader};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockNumber, TxHash, TxNumber};
-use reth_primitives::{TransactionMeta, TransactionSigned, TransactionSignedNoHash};
+use reth_primitives::TransactionMeta;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::ops::{Range, RangeBounds, RangeInclusive};
 
@@ -21,6 +21,9 @@ pub enum TransactionVariant {
 ///  Client trait for fetching [TransactionSigned] related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait TransactionsProvider: BlockNumReader + Send + Sync {
+    /// The transaction type this provider reads.
+    type Transaction;
+
     /// Get internal transaction identifier by transaction hash.
     ///
     /// This is the inverse of [TransactionsProvider::transaction_by_id].
@@ -28,23 +31,21 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>>;
 
     /// Get transaction by id, computes hash every time so more expensive.
-    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<TransactionSigned>>;
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>>;
 
     /// Get transaction by id without computing the hash.
-    fn transaction_by_id_unhashed(
-        &self,
-        id: TxNumber,
-    ) -> ProviderResult<Option<TransactionSignedNoHash>>;
+    fn transaction_by_id_unhashed(&self, id: TxNumber)
+        -> ProviderResult<Option<Self::Transaction>>;
 
     /// Get transaction by transaction hash.
-    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TransactionSigned>>;
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>>;
 
     /// Get transaction by transaction hash and additional metadata of the block the transaction was
     /// mined in
     fn transaction_by_hash_with_meta(
         &self,
         hash: TxHash,
-    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>>;
+    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>>;
 
     /// Get transaction block number
     fn transaction_block(&self, id: TxNumber) -> ProviderResult<Option<BlockNumber>>;
@@ -53,19 +54,19 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     fn transactions_by_block(
         &self,
         block: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionSigned>>>;
+    ) -> ProviderResult<Option<Vec<Self::Transaction>>>;
 
     /// Get transactions by block range.
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<TransactionSigned>>>;
+    ) -> ProviderResult<Vec<Vec<Self::Transaction>>>;
 
     /// Get transactions by tx range.
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionSignedNoHash>>;
+    ) -> ProviderResult<Vec<Self::Transaction>>;
 
     /// Get Senders from a tx range.
     fn senders_by_tx_range(

--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -19,7 +19,7 @@ pub enum TransactionVariant {
     WithHash,
 }
 
-///  Client trait for fetching [TransactionSigned] related data.
+///  Client trait for fetching transactions related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// The transaction type this provider reads.
@@ -84,7 +84,7 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
 /// A helper type alias to access [`TransactionsProvider::Transaction`].
 pub type ProviderTx<P> = <P as TransactionsProvider>::Transaction;
 
-///  Client trait for fetching additional [TransactionSigned] related data.
+///  Client trait for fetching additional transactions related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait TransactionsProviderExt: BlockReader + Send + Sync {
     /// Get transactions range by block range.

--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -2,6 +2,7 @@ use crate::{BlockNumReader, BlockReader};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockNumber, TxHash, TxNumber};
 use reth_primitives::TransactionMeta;
+use reth_primitives_traits::SignedTransaction;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::ops::{Range, RangeBounds, RangeInclusive};
 
@@ -22,7 +23,7 @@ pub enum TransactionVariant {
 #[auto_impl::auto_impl(&, Arc)]
 pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// The transaction type this provider reads.
-    type Transaction;
+    type Transaction: Send + Sync + SignedTransaction;
 
     /// Get internal transaction identifier by transaction hash.
     ///
@@ -79,6 +80,9 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
     /// Returns None if the transaction is not found.
     fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>>;
 }
+
+/// A helper type alias to access [`TransactionsProvider::Transaction`].
+pub type ProviderTx<P> = <P as TransactionsProvider>::Transaction;
 
 ///  Client trait for fetching additional [TransactionSigned] related data.
 #[auto_impl::auto_impl(&, Arc)]

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -4,7 +4,7 @@ use reth_chainspec::ChainSpecBuilder;
 use reth_db::{open_db_read_only, DatabaseEnv};
 use reth_node_ethereum::EthereumNode;
 use reth_node_types::NodeTypesWithDBAdapter;
-use reth_primitives::SealedHeader;
+use reth_primitives::{SealedHeader, TransactionSigned};
 use reth_provider::{
     providers::StaticFileProvider, AccountReader, BlockReader, BlockSource, HeaderProvider,
     ProviderFactory, ReceiptProvider, StateProvider, TransactionsProvider,
@@ -83,7 +83,9 @@ fn header_provider_example<T: HeaderProvider>(provider: T, number: u64) -> eyre:
 }
 
 /// The `TransactionsProvider` allows querying transaction-related information
-fn txs_provider_example<T: TransactionsProvider>(provider: T) -> eyre::Result<()> {
+fn txs_provider_example<T: TransactionsProvider<Transaction = TransactionSigned>>(
+    provider: T,
+) -> eyre::Result<()> {
     // Try the 5th tx
     let txid = 5;
 
@@ -160,7 +162,9 @@ fn block_provider_example<T: BlockReader>(provider: T, number: u64) -> eyre::Res
 }
 
 /// The `ReceiptProvider` allows querying the receipts tables.
-fn receipts_provider_example<T: ReceiptProvider + TransactionsProvider + HeaderProvider>(
+fn receipts_provider_example<
+    T: ReceiptProvider + TransactionsProvider<Transaction = TransactionSigned> + HeaderProvider,
+>(
     provider: T,
 ) -> eyre::Result<()> {
     let txid = 5;


### PR DESCRIPTION
This PR adds Transaction AT to `TransactionsProvider` trait making existing providers produce transactions based on configured `NodePrimitives`.

I was able to integrate this generic for all providers up to `ConsistentProvider` which is blocked by engine abstraction over blocks. Additionaly I've hit blockers for `DatabaseProvider` because we did not yet abstracted block bodies reading which I am planning to do next.

Above is the reason for those bouds:
https://github.com/paradigmxyz/reth/blob/31bf3f492d22a03473a9ac919d9103af1f534d40/crates/storage/provider/src/providers/mod.rs#L80

Additionally I've made some progress for consuming generic transaction from provider in RPC which is blocked by block reading abstraction as well.

This PR also changes all `TransactionsProvider` methods to return the `TransactionSigned` leaving hash calculation up for the caller
