### PR TITLE
chore: remove duplicated functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 name = "example-beacon-api-sidecar-fetcher"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-beacon",
  "clap",

--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -2,6 +2,7 @@
 
 use crate::OpBlockExecutionError;
 use alloc::{string::ToString, sync::Arc};
+use alloy_consensus::Transaction;
 use alloy_primitives::{address, b256, hex, Address, Bytes, B256, U256};
 use reth_chainspec::ChainSpec;
 use reth_execution_errors::BlockExecutionError;

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -222,29 +222,6 @@ impl Transaction {
         }
     }
 
-    /// Gets the transaction's [`TxKind`], which is the address of the recipient or
-    /// [`TxKind::Create`] if the transaction is a contract creation.
-    pub const fn kind(&self) -> TxKind {
-        match self {
-            Self::Legacy(TxLegacy { to, .. }) |
-            Self::Eip2930(TxEip2930 { to, .. }) |
-            Self::Eip1559(TxEip1559 { to, .. }) => *to,
-            Self::Eip4844(TxEip4844 { to, .. }) | Self::Eip7702(TxEip7702 { to, .. }) => {
-                TxKind::Call(*to)
-            }
-            #[cfg(feature = "optimism")]
-            Self::Deposit(TxDeposit { to, .. }) => *to,
-        }
-    }
-
-    /// Get the transaction's address of the contract that will be called, or the address that will
-    /// receive the transfer.
-    ///
-    /// Returns `None` if this is a `CREATE` transaction.
-    pub fn to(&self) -> Option<Address> {
-        self.kind().to().copied()
-    }
-
     /// Get the transaction's type
     pub const fn tx_type(&self) -> TxType {
         match self {
@@ -255,56 +232,6 @@ impl Transaction {
             Self::Eip7702(_) => TxType::Eip7702,
             #[cfg(feature = "optimism")]
             Self::Deposit(_) => TxType::Deposit,
-        }
-    }
-
-    /// Returns the [`AccessList`] of the transaction.
-    ///
-    /// Returns `None` for legacy transactions.
-    pub const fn access_list(&self) -> Option<&AccessList> {
-        match self {
-            Self::Legacy(_) => None,
-            Self::Eip2930(tx) => Some(&tx.access_list),
-            Self::Eip1559(tx) => Some(&tx.access_list),
-            Self::Eip4844(tx) => Some(&tx.access_list),
-            Self::Eip7702(tx) => Some(&tx.access_list),
-            #[cfg(feature = "optimism")]
-            Self::Deposit(_) => None,
-        }
-    }
-
-    /// Returns the [`SignedAuthorization`] list of the transaction.
-    ///
-    /// Returns `None` if this transaction is not EIP-7702.
-    pub fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
-        match self {
-            Self::Eip7702(tx) => Some(&tx.authorization_list),
-            _ => None,
-        }
-    }
-
-    /// Returns true if the tx supports dynamic fees
-    pub const fn is_dynamic_fee(&self) -> bool {
-        match self {
-            Self::Legacy(_) | Self::Eip2930(_) => false,
-            Self::Eip1559(_) | Self::Eip4844(_) | Self::Eip7702(_) => true,
-            #[cfg(feature = "optimism")]
-            Self::Deposit(_) => false,
-        }
-    }
-
-    /// Blob versioned hashes for eip4844 transaction, for legacy, eip1559, eip2930 and eip7702
-    /// transactions this is `None`
-    ///
-    /// This is also commonly referred to as the "blob versioned hashes" (`BlobVersionedHashes`).
-    pub fn blob_versioned_hashes(&self) -> Option<Vec<B256>> {
-        match self {
-            Self::Legacy(_) | Self::Eip2930(_) | Self::Eip1559(_) | Self::Eip7702(_) => None,
-            Self::Eip4844(TxEip4844 { blob_versioned_hashes, .. }) => {
-                Some(blob_versioned_hashes.clone())
-            }
-            #[cfg(feature = "optimism")]
-            Self::Deposit(_) => None,
         }
     }
 
@@ -345,19 +272,6 @@ impl Transaction {
             Some(fee.min(priority_fee))
         } else {
             Some(fee)
-        }
-    }
-
-    /// Get the transaction's input field.
-    pub const fn input(&self) -> &Bytes {
-        match self {
-            Self::Legacy(TxLegacy { input, .. }) |
-            Self::Eip2930(TxEip2930 { input, .. }) |
-            Self::Eip1559(TxEip1559 { input, .. }) |
-            Self::Eip4844(TxEip4844 { input, .. }) |
-            Self::Eip7702(TxEip7702 { input, .. }) => input,
-            #[cfg(feature = "optimism")]
-            Self::Deposit(TxDeposit { input, .. }) => input,
         }
     }
 
@@ -2100,13 +2014,15 @@ mod tests {
 
         assert_eq!(
             tx.blob_versioned_hashes(),
-            Some(vec![
-                b256!("012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921a"),
-                b256!("0152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4"),
-                b256!("013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7"),
-                b256!("01148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1"),
-                b256!("011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e6549"),
-            ])
+            Some(
+                &[
+                    b256!("012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921a"),
+                    b256!("0152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4"),
+                    b256!("013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7"),
+                    b256!("01148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1"),
+                    b256!("011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e6549"),
+                ][..]
+            )
         );
     }
 

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -690,6 +690,7 @@ impl TryFrom<TransactionSignedEcRecovered> for PooledTransactionsElementEcRecove
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::Transaction as _;
     use alloy_primitives::{address, hex};
     use assert_matches::assert_matches;
     use bytes::Bytes;

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -75,7 +75,7 @@ pub fn transaction_to_call_request(tx: TransactionSignedEcRecovered) -> Transact
     let access_list = tx.transaction.access_list().cloned();
     let max_fee_per_blob_gas = tx.transaction.max_fee_per_blob_gas();
     let authorization_list = tx.transaction.authorization_list().map(|l| l.to_vec());
-    let blob_versioned_hashes = tx.transaction.blob_versioned_hashes();
+    let blob_versioned_hashes = tx.transaction.blob_versioned_hashes().map(Vec::from);
     let tx_type = tx.transaction.tx_type();
 
     // fees depending on the transaction type

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -109,6 +109,7 @@ impl EthSigner for DevSigner {
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::Transaction;
     use alloy_primitives::{Bytes, U256};
     use alloy_rpc_types_eth::TransactionInput;
     use revm_primitives::TxKind;

--- a/examples/beacon-api-sidecar-fetcher/Cargo.toml
+++ b/examples/beacon-api-sidecar-fetcher/Cargo.toml
@@ -11,6 +11,7 @@ reth-node-ethereum.workspace = true
 
 alloy-rpc-types-beacon.workspace = true
 alloy-primitives.workspace = true
+alloy-consensus.workspace = true
 
 clap.workspace = true
 eyre.workspace = true

--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -1,4 +1,5 @@
 use crate::BeaconSidecarConfig;
+use alloy_consensus::Transaction as _;
 use alloy_primitives::B256;
 use alloy_rpc_types_beacon::sidecar::{BeaconBlobBundle, SidecarIterator};
 use eyre::Result;


### PR DESCRIPTION
removes functions that are already available via transaction trait.