### PR TITLE
Use `adjust_index_for_rlp` from alloy

### DIFF
--- a/crates/trie/common/src/root.rs
+++ b/crates/trie/common/src/root.rs
@@ -7,17 +7,6 @@ use alloy_trie::HashBuilder;
 use itertools::Itertools;
 use nybbles::Nibbles;
 
-/// Adjust the index of an item for rlp encoding.
-pub const fn adjust_index_for_rlp(i: usize, len: usize) -> usize {
-    if i > 0x7f {
-        i
-    } else if i == 0x7f || i + 1 == len {
-        0
-    } else {
-        i + 1
-    }
-}
-
 /// Hashes and sorts account keys, then proceeds to calculating the root hash of the state
 /// represented as MPT.
 /// See [`state_root_unsorted`] for more info.

--- a/crates/trie/trie/benches/trie_root.rs
+++ b/crates/trie/trie/benches/trie_root.rs
@@ -44,7 +44,8 @@ criterion_main!(benches);
 mod implementations {
     use super::*;
     use alloy_rlp::Encodable;
-    use reth_trie_common::{root::adjust_index_for_rlp, HashBuilder, Nibbles};
+    use alloy_trie::root::adjust_index_for_rlp;
+    use reth_trie_common::{HashBuilder, Nibbles};
 
     pub fn trie_hash_ordered_trie_root(receipts: &[ReceiptWithBloom]) -> B256 {
         triehash::ordered_trie_root::<KeccakHasher, _>(receipts.iter().map(|receipt| {


### PR DESCRIPTION
Use `adjust_index_for_rlp` from alloy since it was migrated to alloy in https://github.com/alloy-rs/trie/pull/55