### PR TITLE
chore(payload): fix withdrawals field pre-shanghai in Ethereum payload

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -440,14 +440,14 @@ where
         requests_hash,
     };
 
+    let withdrawals = chain_spec
+        .is_shanghai_active_at_timestamp(attributes.timestamp)
+        .then(|| attributes.withdrawals.clone());
+
     // seal the block
     let block = Block {
         header,
-        body: BlockBody {
-            transactions: executed_txs,
-            ommers: vec![],
-            withdrawals: Some(attributes.withdrawals.clone()),
-        },
+        body: BlockBody { transactions: executed_txs, ommers: vec![], withdrawals },
     };
 
     let sealed_block = Arc::new(block.seal_slow());


### PR DESCRIPTION
We were getting a hive error `Unexpected Failures: ['GetPayloadBodiesByRange (Empty Transactions/Withdrawals) (Paris) (reth)']` in the `ethereum-withdrawals` suite after https://github.com/paradigmxyz/reth/pull/12780, like in https://github.com/paradigmxyz/reth/actions/runs/11982076699/job/33409959229, `withdrawals` field should be `None` pre-shanghai

