### PR TITLE
Fix Typo Update HARDFORK-CHECKLIST.md

### DIFF
--- a/HARDFORK-CHECKLIST.md
+++ b/HARDFORK-CHECKLIST.md
@@ -10,7 +10,7 @@
 ## Engine API
 
 - If there are changes to the engine API (e.g. a new `engine_newPayloadVx` and `engine_getPayloadVx` pair) add the new types to the `alloy-rpc-types-engine` crate.
-- If there are new parameters to the `engine_newPayloadVx` endpoint, add them to the `ExecutionPayloadSidecar` container type. This types contains all additional parameters that are required to convert an `ExecutionPayload` to an EL block.
+- If there are new parameters to the `engine_newPayloadVx` endpoint, add them to the `ExecutionPayloadSidecar` container type. This type contains all additional parameters that are required to convert an `ExecutionPayload` to an EL block.
 
 ## Reth changes
 


### PR DESCRIPTION
**Description**:  
This pull request corrects a typo in the documentation of the Engine API. Specifically, the sentence:

> _"This types contains all additional parameters that are required to convert an `ExecutionPayload` to an EL block."_

has been updated to:

> _"This type contains all additional parameters that are required to convert an `ExecutionPayload` to an EL block."_

**Issue**:  
The original sentence contained a grammatical error where "types" was used in place of the singular "type." This caused confusion regarding the subject-verb agreement, as "type" should be singular to match the verb "contains."

**Importance**:  
This change is important as it improves the clarity and accuracy of the documentation. A clear and correct description is crucial for users and developers who rely on the documentation to understand the API. Incorrect grammar, especially in technical documentation, can lead to misunderstandings and potential implementation issues.