### PR TITLE
feat: enforce relations between block parts on NodePrimitives

### DIFF
--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -1,7 +1,8 @@
 use core::fmt;
 
 use crate::{
-    FullBlock, FullBlockBody, FullBlockHeader, FullReceipt, FullSignedTx, FullTxType, MaybeSerde,
+    Block, BlockBody, BlockHeader, FullBlock, FullBlockBody, FullBlockHeader, FullReceipt,
+    FullSignedTx, FullTxType, MaybeSerde,
 };
 
 /// Configures all the primitive types of the node.
@@ -9,38 +10,11 @@ pub trait NodePrimitives:
     Send + Sync + Unpin + Clone + Default + fmt::Debug + PartialEq + Eq + 'static
 {
     /// Block primitive.
-    type Block: Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + MaybeSerde
-        + 'static;
+    type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody>;
     /// Block header primitive.
-    type BlockHeader: Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + MaybeSerde
-        + 'static;
+    type BlockHeader: BlockHeader;
     /// Block body primitive.
-    type BlockBody: Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + MaybeSerde
-        + 'static;
+    type BlockBody: BlockBody<Transaction = Self::SignedTx>;
     /// Signed version of the transaction type.
     type SignedTx: Send + Sync + Unpin + Clone + fmt::Debug + PartialEq + Eq + MaybeSerde + 'static;
     /// Transaction envelope type ID.
@@ -57,16 +31,6 @@ pub trait NodePrimitives:
         + MaybeSerde
         + 'static;
 }
-
-impl NodePrimitives for () {
-    type Block = ();
-    type BlockHeader = ();
-    type BlockBody = ();
-    type SignedTx = ();
-    type TxType = ();
-    type Receipt = ();
-}
-
 /// Helper trait that sets trait bounds on [`NodePrimitives`].
 pub trait FullNodePrimitives
 where

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -172,7 +172,7 @@ mod tests {
 
         // [ Headers Creation and Commit ]
         {
-            let sf_rw = StaticFileProvider::<()>::read_write(&static_dir)
+            let sf_rw = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)
                 .expect("Failed to create static file provider")
                 .with_custom_blocks_per_file(blocks_per_file);
 
@@ -191,8 +191,8 @@ mod tests {
 
         // Helper function to prune headers and validate truncation results
         fn prune_and_validate(
-            writer: &mut StaticFileProviderRWRefMut<'_, ()>,
-            sf_rw: &StaticFileProvider<()>,
+            writer: &mut StaticFileProviderRWRefMut<'_, EthPrimitives>,
+            sf_rw: &StaticFileProvider<EthPrimitives>,
             static_dir: impl AsRef<Path>,
             prune_count: u64,
             expected_tip: Option<u64>,

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -22,8 +22,8 @@ use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_errors::ProviderError;
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives::{
-    Account, Block, BlockWithSenders, Bytecode, Receipt, SealedBlock, SealedBlockWithSenders,
-    SealedHeader, TransactionMeta, TransactionSigned,
+    Account, Block, BlockWithSenders, Bytecode, EthPrimitives, Receipt, SealedBlock,
+    SealedBlockWithSenders, SealedHeader, TransactionMeta, TransactionSigned,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
@@ -558,7 +558,7 @@ impl PruneCheckpointReader for NoopProvider {
 }
 
 impl StaticFileProviderFactory for NoopProvider {
-    type Primitives = ();
+    type Primitives = EthPrimitives;
 
     fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         StaticFileProvider::read_only(PathBuf::default(), false).unwrap()


### PR DESCRIPTION
`NodePrimitives` is pretty much useless without those bounds which are not very restrictive
