### PR TITLE
feat(engine): use non-parallel multiproof for state root task

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -279,6 +279,7 @@ where
                 }
             };
 
+            // TODO: replace with parallel proof
             let result =
                 Proof::overlay_multiproof(provider.tx_ref(), input.as_ref().clone(), targets);
             match result {

--- a/crates/trie/trie/src/input.rs
+++ b/crates/trie/trie/src/input.rs
@@ -1,7 +1,7 @@
 use crate::{prefix_set::TriePrefixSetsMut, updates::TrieUpdates, HashedPostState};
 
 /// Inputs for trie-related computations.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct TrieInput {
     /// The collection of cached in-memory intermediate trie nodes that
     /// can be reused for computation.


### PR DESCRIPTION
We currently have an issue with calculating the multiproof using `ParallelProof`. This PR makes the multiproof calculation single-threaded, so that we can merge the base PR and investigate the parallel multiproof issue separately.