### PR TITLE
feat: add pending_transactions_max in trait TransactionPool

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -441,6 +441,13 @@ where
         self.pool.pending_transactions()
     }
 
+    fn pending_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.pending_transactions_max(max)
+    }
+
     fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.queued_transactions()
     }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -163,6 +163,13 @@ impl TransactionPool for NoopTransactionPool {
         vec![]
     }
 
+    fn pending_transactions_max(
+        &self,
+        _max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
     fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         vec![]
     }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -678,6 +678,14 @@ where
         self.get_pool_data().best_transactions_with_attributes(best_transactions_attributes)
     }
 
+    /// Returns only the first `max` transactions in the pending pool.
+    pub(crate) fn pending_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().pending_transactions_iter().take(max).collect()
+    }
+
     /// Returns all transactions from the pending sub-pool
     pub(crate) fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.get_pool_data().pending_transactions()

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -270,6 +270,15 @@ pub trait TransactionPool: Send + Sync + Clone {
     /// Consumer: RPC
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
+    /// Returns first `max` transactions that can be included in the next block.
+    ///
+    /// Consumer: Block production
+    /// See https://github.com/paradigmxyz/reth/issues/12767#issuecomment-2493223579
+    fn pending_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
     /// Returns all transactions that can be included in _future_ blocks.
     ///
     /// This and [Self::pending_transactions] are mutually exclusive.

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -271,9 +271,9 @@ pub trait TransactionPool: Send + Sync + Clone {
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
     /// Returns first `max` transactions that can be included in the next block.
+    /// See <https://github.com/paradigmxyz/reth/issues/12767#issuecomment-2493223579>
     ///
     /// Consumer: Block production
-    /// See https://github.com/paradigmxyz/reth/issues/12767#issuecomment-2493223579
     fn pending_transactions_max(
         &self,
         max: usize,


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/12767#issuecomment-2493223579

This PR adds fn `pending_transactions_max` in trait `TransactionPool`.