### PR TITLE
refactor: unify logic for writing headers

### DIFF
--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -68,10 +68,13 @@ pub trait BlockWriter: Send + Sync {
     ///
     /// Return [StoredBlockBodyIndices] that contains indices of the first and last transactions and
     /// transition in the block.
+    ///
+    /// Accepts [`StorageLocation`] value which specifies where should transactions and headers be
+    /// written.
     fn insert_block(
         &self,
         block: SealedBlockWithSenders<Self::Block>,
-        write_transactions_to: StorageLocation,
+        write_to: StorageLocation,
     ) -> ProviderResult<StoredBlockBodyIndices>;
 
     /// Appends a batch of block bodies extending the canonical chain. This is invoked during

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -69,7 +69,7 @@ pub trait BlockWriter: Send + Sync {
     /// Return [StoredBlockBodyIndices] that contains indices of the first and last transactions and
     /// transition in the block.
     ///
-    /// Accepts [`StorageLocation`] value which specifies where should transactions and headers be
+    /// Accepts [`StorageLocation`] value which specifies where transactions and headers should be
     /// written.
     fn insert_block(
         &self,


### PR DESCRIPTION
Simialrly to https://github.com/paradigmxyz/reth/pull/12694 uses `StorageLocation` value to determine where to write headers.