### PR TITLE
test: enable op prim arbitrary in e2e test-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7112,6 +7112,7 @@ dependencies = [
  "reth-network-peers",
  "reth-node-api",
  "reth-node-builder",
+ "reth-optimism-primitives",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -28,6 +28,9 @@ reth-stages-types.workspace = true
 reth-network-peers.workspace = true
 reth-engine-local.workspace = true
 
+# currently need to enable this for workspace level
+reth-optimism-primitives  = { workspace = true, features = ["arbitrary"] }
+
 # rpc
 jsonrpsee.workspace = true
 url.workspace = true


### PR DESCRIPTION
otherwise --workspace target currently fails.

we could perhaps exclude this crate from workspace