### PR TITLE
chore: add encodable to pooled recovered

### DIFF
--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -739,6 +739,24 @@ impl TryFrom<TransactionSignedEcRecovered> for PooledTransactionsElementEcRecove
     }
 }
 
+impl Encodable2718 for PooledTransactionsElementEcRecovered {
+    fn type_flag(&self) -> Option<u8> {
+        self.transaction.type_flag()
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        self.transaction.encode_2718_len()
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.transaction.encode_2718(out)
+    }
+
+    fn trie_hash(&self) -> B256 {
+        self.transaction.trie_hash()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -947,7 +947,7 @@ pub trait PoolTransaction: fmt::Debug + Send + Sync + Clone {
     type Consensus: From<Self> + TryInto<Self, Error = Self::TryFromConsensusError>;
 
     /// Associated type representing the recovered pooled variant of the transaction.
-    type Pooled: Into<Self>;
+    type Pooled: Encodable2718 + Into<Self>;
 
     /// Define a method to convert from the `Consensus` type to `Self`
     fn try_from_consensus(tx: Self::Consensus) -> Result<Self, Self::TryFromConsensusError> {


### PR DESCRIPTION
adds encoable to the recovered variant.

this makes:

https://github.com/paradigmxyz/reth/blob/feb32a63b4b720157dbebed6f04e100c5de43724/crates/rpc/rpc-eth-api/src/helpers/transaction.rs#L105-L105

easier to use and we expect that this is an encodable type