### PR TITLE
chore(trie): remove todo comment

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -176,7 +176,6 @@ impl RevealedSparseTrie {
 
     /// Reveal the trie node only if it was not known already.
     pub fn reveal_node(&mut self, path: Nibbles, node: TrieNode) -> SparseTrieResult<()> {
-        // TODO: revise all inserts to not overwrite existing entries
         match node {
             TrieNode::EmptyRoot => {
                 debug_assert!(path.is_empty());


### PR DESCRIPTION
## Description

Remove TODO comment as it is no longer relevant. The overwrite checks are present thanks to @shekhirin.