### PR TITLE
feat: use pooled AT for get_pooled_transactions

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -156,7 +156,6 @@ use alloy_primitives::{Address, TxHash, B256, U256};
 use aquamarine as _;
 use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
-use reth_primitives::PooledTransactionsElement;
 use reth_storage_api::StateProviderFactory;
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::mpsc::Receiver;
@@ -416,8 +415,19 @@ where
         &self,
         tx_hashes: Vec<TxHash>,
         limit: GetPooledTransactionLimit,
-    ) -> Vec<PooledTransactionsElement> {
+    ) -> Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled> {
         self.pool.get_pooled_transaction_elements(tx_hashes, limit)
+    }
+
+    fn get_pooled_transactions_as<P>(
+        &self,
+        tx_hashes: Vec<TxHash>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<P>
+    where
+        <Self::Transaction as PoolTransaction>::Pooled: Into<P>,
+    {
+        self.pool.get_pooled_transactions_as(tx_hashes, limit)
     }
 
     fn get_pooled_transaction_element(

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -13,8 +13,8 @@ use crate::{
     validate::ValidTransaction,
     AllPoolTransactions, AllTransactionsEvents, BestTransactions, BlockInfo, EthPoolTransaction,
     EthPooledTransaction, NewTransactionEvent, PoolResult, PoolSize, PoolTransaction,
-    PooledTransactionsElement, PropagatedTransactions, TransactionEvents, TransactionOrigin,
-    TransactionPool, TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
+    PropagatedTransactions, TransactionEvents, TransactionOrigin, TransactionPool,
+    TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
 };
 use alloy_eips::{
     eip1559::ETHEREUM_BLOCK_GAS_LIMIT,
@@ -135,7 +135,18 @@ impl TransactionPool for NoopTransactionPool {
         &self,
         _tx_hashes: Vec<TxHash>,
         _limit: GetPooledTransactionLimit,
-    ) -> Vec<PooledTransactionsElement> {
+    ) -> Vec<<Self::Transaction as PoolTransaction>::Pooled> {
+        vec![]
+    }
+
+    fn get_pooled_transactions_as<T>(
+        &self,
+        _tx_hashes: Vec<TxHash>,
+        _limit: GetPooledTransactionLimit,
+    ) -> Vec<T>
+    where
+        <Self::Transaction as PoolTransaction>::Pooled: Into<T>,
+    {
         vec![]
     }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -88,7 +88,6 @@ use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
 
 use alloy_eips::eip4844::BlobTransactionSidecar;
-use reth_primitives::PooledTransactionsElement;
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -340,14 +339,27 @@ where
         }
     }
 
-    /// Returns converted [`PooledTransactionsElement`] for the given transaction hashes.
+    /// Returns pooled transactions for the given transaction hashes.
     pub(crate) fn get_pooled_transaction_elements(
         &self,
         tx_hashes: Vec<TxHash>,
         limit: GetPooledTransactionLimit,
-    ) -> Vec<PooledTransactionsElement>
+    ) -> Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>
     where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    {
+        self.get_pooled_transactions_as(tx_hashes, limit)
+    }
+
+    /// Returns pooled transactions for the given transaction hashes as the requested type.
+    pub(crate) fn get_pooled_transactions_as<P>(
+        &self,
+        tx_hashes: Vec<TxHash>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<P>
+    where
+        <V as TransactionValidator>::Transaction: EthPoolTransaction,
+        <<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled: Into<P>,
     {
         let transactions = self.get_all(tx_hashes);
         let mut elements = Vec::with_capacity(transactions.len());

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -381,7 +381,7 @@ where
         elements
     }
 
-    /// Returns converted [`PooledTransactionsElement`] for the given transaction hash.
+    /// Returns converted pooled transaction for the given transaction hash.
     pub(crate) fn get_pooled_transaction_element(
         &self,
         tx_hash: TxHash,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -231,7 +231,16 @@ pub trait TransactionPool: Send + Sync + Clone {
         &self,
         tx_hashes: Vec<TxHash>,
         limit: GetPooledTransactionLimit,
-    ) -> Vec<PooledTransactionsElement>;
+    ) -> Vec<<Self::Transaction as PoolTransaction>::Pooled>;
+
+    /// Returns the pooled transaction variant for the given transaction hash as the requested type.
+    fn get_pooled_transactions_as<T>(
+        &self,
+        tx_hashes: Vec<TxHash>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<T>
+    where
+        <Self::Transaction as PoolTransaction>::Pooled: Into<T>;
 
     /// Returns the pooled transaction variant for the given transaction hash.
     ///


### PR DESCRIPTION
removes hardcoded `PooledTransactionElement` from pool trait and replace with AT Pooled type

adds a helpter that applies an `Into` because the network operates on the unrecovered variant.

this should unblock more generalization on `TransactionManager`