### PR TITLE
chore(ci): debug logs on kurtosis-op client advance check failure

### DIFF
--- a/.github/assets/hive/Dockerfile
+++ b/.github/assets/hive/Dockerfile
@@ -5,4 +5,5 @@ COPY dist/reth /usr/local/bin
 COPY LICENSE-* ./
 
 EXPOSE 30303 30303/udp 9001 8545 8546
+ENV RUST_LOG=debug
 ENTRYPOINT ["/usr/local/bin/reth"]

--- a/.github/workflows/kurtosis-op.yml
+++ b/.github/workflows/kurtosis-op.yml
@@ -102,6 +102,8 @@ jobs:
             if [ $BLOCK_GETH -ge 100 ] && [ $BLOCK_RETH -ge 100 ] ; then exit 0; fi
             echo "Waiting for clients to advance..., Reth: $BLOCK_RETH Geth: $BLOCK_GETH"
           done
+          kurtosis service logs -a op-devnet op-el-2-op-reth-op-node-op-kurtosis
+          kurtosis service logs -a op-devnet op-cl-2-op-node-op-reth-op-kurtosis
           exit 1
 
 


### PR DESCRIPTION
Shows op-reth and op-node logs in case of client advance check failure. Also, increase log level defined in the hive Dockerfile to debug.