### PR TITLE
chore: make cargo t compile for reth-trie-common

### DIFF
--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -31,6 +31,8 @@ nybbles = { workspace = true, features = ["rlp"] }
 # `serde` feature
 serde = { workspace = true, optional = true }
 
+serde_with = { workspace = true, optional = true }
+
 # `test-utils` feature
 hash-db = { version = "=0.15.2", optional = true }
 plain_hasher = { version = "0.2", optional = true }
@@ -65,7 +67,8 @@ serde = [
 ]
 serde-bincode-compat = [
 	"reth-primitives-traits/serde-bincode-compat",
-	"alloy-consensus/serde-bincode-compat"
+	"alloy-consensus/serde-bincode-compat",
+    "dep:serde_with"
 ]
 test-utils = [
     "dep:plain_hasher",

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -31,25 +31,25 @@ nybbles = { workspace = true, features = ["rlp"] }
 # `serde` feature
 serde = { workspace = true, optional = true }
 
-# `serde-bincode-compat` feature
-serde_with = { workspace = true, optional = true }
-
 # `test-utils` feature
 hash-db = { version = "=0.15.2", optional = true }
 plain_hasher = { version = "0.2", optional = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
+reth-primitives-traits = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["getrandom"] }
-alloy-trie = { workspace = true, features = ["arbitrary"] }
+alloy-trie = { workspace = true, features = ["arbitrary", "serde"] }
 hash-db = "=0.15.2"
 plain_hasher = "0.2"
-serde_json.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 criterion.workspace = true
 bincode.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
 
 [features]
 serde = [
@@ -64,7 +64,6 @@ serde = [
     "reth-codecs/serde"
 ]
 serde-bincode-compat = [
-	"serde_with",
 	"reth-primitives-traits/serde-bincode-compat",
 	"alloy-consensus/serde-bincode-compat"
 ]

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -66,6 +66,7 @@ serde = [
     "reth-codecs/serde"
 ]
 serde-bincode-compat = [
+    "serde",
 	"reth-primitives-traits/serde-bincode-compat",
 	"alloy-consensus/serde-bincode-compat",
     "dep:serde_with"

--- a/crates/trie/common/src/hash_builder/state.rs
+++ b/crates/trie/common/src/hash_builder/state.rs
@@ -7,7 +7,7 @@ use reth_codecs::Compact;
 /// The hash builder state for storing in the database.
 /// Check the `reth-trie` crate for more info on hash builder.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),

--- a/crates/trie/common/src/nibbles.rs
+++ b/crates/trie/common/src/nibbles.rs
@@ -6,7 +6,7 @@ pub use nybbles::Nibbles;
 
 /// The representation of nibbles of the merkle trie stored in the database.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::Index)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "test-utils", derive(arbitrary::Arbitrary))]
 pub struct StoredNibbles(pub Nibbles);
 
@@ -63,7 +63,7 @@ impl Compact for StoredNibbles {
 
 /// The representation of nibbles of the merkle trie stored in the database.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deref)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "test-utils", derive(arbitrary::Arbitrary))]
 pub struct StoredNibblesSubKey(pub Nibbles);
 

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -171,8 +171,8 @@ impl StorageMultiProof {
 
 /// The merkle proof with the relevant account info.
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), serde(rename_all = "camelCase"))]
 pub struct AccountProof {
     /// The address associated with the account.
     pub address: Address,
@@ -228,7 +228,7 @@ impl AccountProof {
 
 /// The merkle proof of the storage entry.
 #[derive(Clone, PartialEq, Eq, Default, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageProof {
     /// The raw storage key.
     pub key: B256,

--- a/crates/trie/common/src/storage.rs
+++ b/crates/trie/common/src/storage.rs
@@ -3,7 +3,7 @@ use reth_codecs::Compact;
 
 /// Account storage trie node.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageTrieEntry {
     /// The nibbles of the intermediate node
     pub nibbles: StoredNibblesSubKey,

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -4,13 +4,13 @@ use std::collections::{HashMap, HashSet};
 
 /// The aggregation of trie updates.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 pub struct TrieUpdates {
     /// Collection of updated intermediate account nodes indexed by full path.
-    #[cfg_attr(feature = "serde", serde(with = "serde_nibbles_map"))]
+    #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_map"))]
     pub account_nodes: HashMap<Nibbles, BranchNodeCompact>,
     /// Collection of removed intermediate account nodes indexed by full path.
-    #[cfg_attr(feature = "serde", serde(with = "serde_nibbles_set"))]
+    #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_set"))]
     pub removed_nodes: HashSet<Nibbles>,
     /// Collection of updated storage tries indexed by the hashed address.
     pub storage_tries: HashMap<B256, StorageTrieUpdates>,
@@ -112,15 +112,15 @@ impl TrieUpdates {
 
 /// Trie updates for storage trie of a single account.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageTrieUpdates {
     /// Flag indicating whether the trie was deleted.
     pub is_deleted: bool,
     /// Collection of updated storage trie nodes.
-    #[cfg_attr(feature = "serde", serde(with = "serde_nibbles_map"))]
+    #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_map"))]
     pub storage_nodes: HashMap<Nibbles, BranchNodeCompact>,
     /// Collection of removed storage trie nodes.
-    #[cfg_attr(feature = "serde", serde(with = "serde_nibbles_set"))]
+    #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_set"))]
     pub removed_nodes: HashSet<Nibbles>,
 }
 
@@ -225,7 +225,7 @@ impl StorageTrieUpdates {
 /// hex-encoded packed representation.
 ///
 /// This also sorts the set before serializing.
-#[cfg(feature = "serde")]
+#[cfg(any(test, feature = "serde"))]
 mod serde_nibbles_set {
     use crate::Nibbles;
     use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -261,7 +261,7 @@ mod serde_nibbles_set {
 /// hex-encoded packed representation.
 ///
 /// This also sorts the map's keys before encoding and serializing.
-#[cfg(feature = "serde")]
+#[cfg(any(test, feature = "serde"))]
 mod serde_nibbles_map {
     use crate::Nibbles;
     use alloy_primitives::hex;

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -403,7 +403,7 @@ fn exclude_empty_from_pair<V>(
 }
 
 /// Bincode-compatible trie updates type serde implementations.
-#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+#[cfg(feature = "serde-bincode-compat")]
 pub mod serde_bincode_compat {
     use crate::{BranchNodeCompact, Nibbles};
     use alloy_primitives::B256;


### PR DESCRIPTION
removes unused dep warning and fixes cargo t build