### PR TITLE
feat: add `Receipt` AT to `ReceiptProvider`

### DIFF
--- a/crates/e2e-test-utils/src/rpc.rs
+++ b/crates/e2e-test-utils/src/rpc.rs
@@ -26,7 +26,7 @@ where
     Node: FullNodeComponents<
         Types: NodeTypes<
             ChainSpec: EthereumHardforks,
-            Primitives: NodePrimitives<Block: Encodable>,
+            Primitives: NodePrimitives<Block: Encodable, Receipt = reth_primitives::Receipt>,
         >,
     >,
     EthApi: EthApiSpec + EthTransactions + TraceExt,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -539,7 +539,7 @@ where
     P: DatabaseProviderFactory
         + BlockReader<Block = reth_primitives::Block>
         + StateProviderFactory
-        + StateReader
+        + StateReader<Receipt = reth_primitives::Receipt>
         + Clone
         + 'static,
     <P as DatabaseProviderFactory>::Provider: BlockReader,

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -147,7 +147,11 @@ where
 
 impl<C> NetworkConfig<C>
 where
-    C: BlockReader<Block = reth_primitives::Block> + HeaderProvider + Clone + Unpin + 'static,
+    C: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
+        + HeaderProvider
+        + Clone
+        + Unpin
+        + 'static,
 {
     /// Starts the networking stack given a [`NetworkConfig`] and returns a handle to the network.
     pub async fn start_network(self) -> Result<NetworkHandle, NetworkError> {

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -80,7 +80,7 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
 
 impl<C> EthRequestHandler<C>
 where
-    C: BlockReader + HeaderProvider + ReceiptProvider,
+    C: BlockReader + HeaderProvider + ReceiptProvider<Receipt = reth_primitives::Receipt>,
 {
     /// Returns the list of requested headers
     fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<Header> {
@@ -224,7 +224,9 @@ where
 /// This should be spawned or used as part of `tokio::select!`.
 impl<C> Future for EthRequestHandler<C>
 where
-    C: BlockReader<Block = reth_primitives::Block> + HeaderProvider + Unpin,
+    C: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
+        + HeaderProvider
+        + Unpin,
 {
     type Output = ();
 

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -194,7 +194,11 @@ where
 
 impl<C, Pool> Testnet<C, Pool>
 where
-    C: BlockReader<Block = reth_primitives::Block> + HeaderProvider + Clone + Unpin + 'static,
+    C: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
+        + HeaderProvider
+        + Clone
+        + Unpin
+        + 'static,
     Pool: TransactionPool + Unpin + 'static,
 {
     /// Spawns the testnet to a separate task
@@ -253,7 +257,10 @@ impl<C, Pool> fmt::Debug for Testnet<C, Pool> {
 
 impl<C, Pool> Future for Testnet<C, Pool>
 where
-    C: BlockReader<Block = reth_primitives::Block> + HeaderProvider + Unpin + 'static,
+    C: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
+        + HeaderProvider
+        + Unpin
+        + 'static,
     Pool: TransactionPool + Unpin + 'static,
 {
     type Output = ();
@@ -448,7 +455,10 @@ where
 
 impl<C, Pool> Future for Peer<C, Pool>
 where
-    C: BlockReader<Block = reth_primitives::Block> + HeaderProvider + Unpin + 'static,
+    C: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
+        + HeaderProvider
+        + Unpin
+        + 'static,
     Pool: TransactionPool + Unpin + 'static,
 {
     type Output = ();

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -651,7 +651,8 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     pub fn start_network<Pool>(&self, builder: NetworkBuilder<(), ()>, pool: Pool) -> NetworkHandle
     where
         Pool: TransactionPool + Unpin + 'static,
-        Node::Provider: BlockReader<Block = reth_primitives::Block>,
+        Node::Provider:
+            BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>,
     {
         self.start_network_with(builder, pool, Default::default())
     }
@@ -670,7 +671,8 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     ) -> NetworkHandle
     where
         Pool: TransactionPool + Unpin + 'static,
-        Node::Provider: BlockReader<Block = reth_primitives::Block>,
+        Node::Provider:
+            BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>,
     {
         let (handle, network, txpool, eth) = builder
             .transactions(pool, tx_config)

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -244,3 +244,6 @@ pub type BodyTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::BlockBody
 
 /// Helper adapter type for accessing [`NodePrimitives::SignedTx`] on [`NodeTypes`].
 pub type TxTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::SignedTx;
+
+/// Helper adapter type for accessing [`NodePrimitives::Receipt`] on [`NodeTypes`].
+pub type ReceiptTy<N> = <<N as NodeTypes>::Primitives as NodePrimitives>::Receipt;

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -24,8 +24,10 @@ impl<N> LoadPendingBlock for OpEthApi<N>
 where
     Self: SpawnBlocking,
     N: RpcNodeCore<
-        Provider: BlockReaderIdExt<Block = reth_primitives::Block>
-                      + EvmEnvProvider
+        Provider: BlockReaderIdExt<
+            Block = reth_primitives::Block,
+            Receipt = reth_primitives::Receipt,
+        > + EvmEnvProvider
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool,

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -11,7 +11,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::RethL1BlockInfo;
 use reth_optimism_forks::OpHardforks;
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned, TxType};
-use reth_provider::{ChainSpecProvider, TransactionsProvider};
+use reth_provider::{ChainSpecProvider, ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcReceipt};
 use reth_rpc_eth_types::{receipt::build_receipt, EthApiError};
 
@@ -21,7 +21,8 @@ impl<N> LoadReceipt for OpEthApi<N>
 where
     Self: Send + Sync,
     N: FullNodeComponents<Types: NodeTypes<ChainSpec = OpChainSpec>>,
-    Self::Provider: TransactionsProvider<Transaction = TransactionSigned>,
+    Self::Provider:
+        TransactionsProvider<Transaction = TransactionSigned> + ReceiptProvider<Receipt = Receipt>,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -74,7 +74,7 @@ where
 
 impl<N> TransactionCompat for OpEthApi<N>
 where
-    N: FullNodeComponents,
+    N: FullNodeComponents<Provider: ReceiptProvider<Receipt = reth_primitives::Receipt>>,
 {
     type Transaction = Transaction;
     type Error = OpEthApiError;

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -29,7 +29,7 @@ pub struct EthHandlers<Provider, Pool, Network, Events, EthApi: EthApiTypes> {
 impl<Provider, Pool, Network, Events, EthApi> EthHandlers<Provider, Pool, Network, Events, EthApi>
 where
     Provider: StateProviderFactory
-        + BlockReader<Block = reth_primitives::Block>
+        + BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
         + EvmEnvProvider
         + Clone
         + Unpin

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -37,8 +37,11 @@
 //!     block_executor: BlockExecutor,
 //!     consensus: Consensus,
 //! ) where
-//!     Provider: FullRpcProvider<Transaction = TransactionSigned, Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
-//!         + AccountReader
+//!     Provider: FullRpcProvider<
+//!             Transaction = TransactionSigned,
+//!             Block = reth_primitives::Block,
+//!             Receipt = reth_primitives::Receipt,
+//!         > + AccountReader
 //!         + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
@@ -114,8 +117,11 @@
 //!     block_executor: BlockExecutor,
 //!     consensus: Consensus,
 //! ) where
-//!     Provider: FullRpcProvider<Transaction = TransactionSigned, Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
-//!         + AccountReader
+//!     Provider: FullRpcProvider<
+//!             Transaction = TransactionSigned,
+//!             Block = reth_primitives::Block,
+//!             Receipt = reth_primitives::Receipt,
+//!         > + AccountReader
 //!         + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -37,7 +37,7 @@
 //!     block_executor: BlockExecutor,
 //!     consensus: Consensus,
 //! ) where
-//!     Provider: FullRpcProvider<Transaction = TransactionSigned, Block = reth_primitives::Block>
+//!     Provider: FullRpcProvider<Transaction = TransactionSigned, Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
 //!         + AccountReader
 //!         + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
@@ -114,7 +114,7 @@
 //!     block_executor: BlockExecutor,
 //!     consensus: Consensus,
 //! ) where
-//!     Provider: FullRpcProvider<Transaction = TransactionSigned, Block = reth_primitives::Block>
+//!     Provider: FullRpcProvider<Transaction = TransactionSigned, Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
 //!         + AccountReader
 //!         + ChangeSetReader,
 //!     Pool: TransactionPool + Unpin + 'static,
@@ -195,7 +195,7 @@ use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives::EthPrimitives;
 use reth_provider::{
     AccountReader, BlockReader, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
-    EvmEnvProvider, FullRpcProvider, StateProviderFactory,
+    EvmEnvProvider, FullRpcProvider, ReceiptProvider, StateProviderFactory,
 };
 use reth_rpc::{
     AdminApi, DebugApi, EngineEthApi, EthBundle, NetApi, OtterscanApi, RPCApi, RethApi, TraceApi,
@@ -263,7 +263,9 @@ pub async fn launch<Provider, Pool, Network, Tasks, Events, EvmConfig, EthApi, B
     consensus: Arc<dyn Consensus>,
 ) -> Result<RpcServerHandle, RpcError>
 where
-    Provider: FullRpcProvider<Block = reth_primitives::Block> + AccountReader + ChangeSetReader,
+    Provider: FullRpcProvider<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
+        + AccountReader
+        + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
@@ -646,7 +648,10 @@ where
         EngineT: EngineTypes,
         EngineApi: EngineApiServer<EngineT>,
         EthApi: FullEthApiServer,
-        Provider: BlockReader<Block = <EthApi::Provider as BlockReader>::Block>,
+        Provider: BlockReader<
+            Block = <EthApi::Provider as BlockReader>::Block,
+            Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
+        >,
     {
         let Self {
             provider,
@@ -722,7 +727,7 @@ where
     ) -> RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
     where
         EthApi: EthApiTypes + 'static,
-        Provider: BlockReader<Block = reth_primitives::Block>,
+        Provider: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>,
     {
         let Self {
             provider,
@@ -757,7 +762,10 @@ where
     ) -> TransportRpcModules<()>
     where
         EthApi: FullEthApiServer,
-        Provider: BlockReader<Block = <EthApi::Provider as BlockReader>::Block>,
+        Provider: BlockReader<
+            Block = <EthApi::Provider as BlockReader>::Block,
+            Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
+        >,
     {
         let mut modules = TransportRpcModules::default();
 
@@ -916,7 +924,7 @@ impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
     RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
 where
     Provider: StateProviderFactory
-        + BlockReader<Block = reth_primitives::Block>
+        + BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
         + EvmEnvProvider
         + Clone
         + Unpin
@@ -1125,7 +1133,10 @@ where
     pub fn register_debug(&mut self) -> &mut Self
     where
         EthApi: EthApiSpec + EthTransactions + TraceExt,
-        Provider: BlockReader<Block = <EthApi::Provider as BlockReader>::Block>,
+        Provider: BlockReader<
+            Block = <EthApi::Provider as BlockReader>::Block,
+            Receipt = reth_primitives::Receipt,
+        >,
     {
         let debug_api = self.debug_api();
         self.modules.insert(RethRpcModule::Debug, debug_api.into_rpc().into());
@@ -1279,8 +1290,10 @@ where
 impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
     RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
 where
-    Provider: FullRpcProvider<Block = <EthApi::Provider as BlockReader>::Block>
-        + AccountReader
+    Provider: FullRpcProvider<
+            Block = <EthApi::Provider as BlockReader>::Block,
+            Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
+        > + AccountReader
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -7,8 +7,10 @@ use alloy_eips::BlockId;
 use alloy_rpc_types_eth::{Block, Header, Index};
 use futures::Future;
 use reth_node_api::BlockBody;
-use reth_primitives::{Receipt, SealedBlockFor, SealedBlockWithSenders};
-use reth_provider::{BlockIdReader, BlockReader, BlockReaderIdExt, HeaderProvider};
+use reth_primitives::{SealedBlockFor, SealedBlockWithSenders};
+use reth_provider::{
+    BlockIdReader, BlockReader, BlockReaderIdExt, HeaderProvider, ProviderReceipt,
+};
 use reth_rpc_types_compat::block::from_block;
 
 use crate::{
@@ -24,7 +26,7 @@ pub type BlockReceiptsResult<N, E> = Result<Option<Vec<RpcReceipt<N>>>, E>;
 pub type BlockAndReceiptsResult<Eth> = Result<
     Option<(
         SealedBlockFor<<<Eth as RpcNodeCore>::Provider as BlockReader>::Block>,
-        Arc<Vec<Receipt>>,
+        Arc<Vec<ProviderReceipt<<Eth as RpcNodeCore>::Provider>>>,
     )>,
     <Eth as EthApiTypes>::Error,
 >;

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -22,7 +22,7 @@ use reth_primitives::{
 };
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderError,
-    ReceiptProvider, StateProviderFactory,
+    ProviderReceipt, ReceiptProvider, StateProviderFactory,
 };
 use reth_revm::{
     database::StateProviderDatabase,
@@ -45,8 +45,10 @@ use tracing::debug;
 pub trait LoadPendingBlock:
     EthApiTypes
     + RpcNodeCore<
-        Provider: BlockReaderIdExt<Block = reth_primitives::Block>
-                      + EvmEnvProvider
+        Provider: BlockReaderIdExt<
+            Block = reth_primitives::Block,
+            Receipt = reth_primitives::Receipt,
+        > + EvmEnvProvider
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool,
@@ -119,7 +121,10 @@ pub trait LoadPendingBlock:
         &self,
     ) -> impl Future<
         Output = Result<
-            Option<(SealedBlockWithSenders<<Self::Provider as BlockReader>::Block>, Vec<Receipt>)>,
+            Option<(
+                SealedBlockWithSenders<<Self::Provider as BlockReader>::Block>,
+                Vec<ProviderReceipt<Self::Provider>>,
+            )>,
             Self::Error,
         >,
     > + Send

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -2,8 +2,8 @@
 //! loads receipt data w.r.t. network.
 
 use futures::Future;
-use reth_primitives::{Receipt, TransactionMeta};
-use reth_provider::TransactionsProvider;
+use reth_primitives::TransactionMeta;
+use reth_provider::{ProviderReceipt, ProviderTx, ReceiptProvider, TransactionsProvider};
 
 use crate::{EthApiTypes, RpcNodeCoreExt, RpcReceipt};
 
@@ -11,13 +11,13 @@ use crate::{EthApiTypes, RpcNodeCoreExt, RpcReceipt};
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` receipts RPC methods.
 pub trait LoadReceipt:
-    EthApiTypes + RpcNodeCoreExt<Provider: TransactionsProvider> + Send + Sync
+    EthApiTypes + RpcNodeCoreExt<Provider: TransactionsProvider + ReceiptProvider> + Send + Sync
 {
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.
     fn build_transaction_receipt(
         &self,
-        tx: <Self::Provider as TransactionsProvider>::Transaction,
+        tx: ProviderTx<Self::Provider>,
         meta: TransactionMeta,
-        receipt: Receipt,
+        receipt: ProviderReceipt<Self::Provider>,
     ) -> impl Future<Output = Result<RpcReceipt<Self::NetworkTypes>, Self::Error>> + Send;
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -8,9 +8,10 @@ use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, Bytes, TxHash, B256};
 use alloy_rpc_types_eth::{transaction::TransactionRequest, BlockNumberOrTag, TransactionInfo};
 use futures::Future;
-use reth_primitives::{Receipt, SealedBlockWithSenders, TransactionMeta, TransactionSigned};
+use reth_primitives::{SealedBlockWithSenders, TransactionMeta, TransactionSigned};
 use reth_provider::{
-    BlockNumReader, BlockReaderIdExt, ProviderTx, ReceiptProvider, TransactionsProvider,
+    BlockNumReader, BlockReaderIdExt, ProviderReceipt, ProviderTx, ReceiptProvider,
+    TransactionsProvider,
 };
 use reth_rpc_eth_types::{
     utils::{binary_search, recover_raw_transaction},
@@ -159,7 +160,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         hash: TxHash,
     ) -> impl Future<
         Output = Result<
-            Option<(ProviderTx<Self::Provider>, TransactionMeta, Receipt)>,
+            Option<(ProviderTx<Self::Provider>, TransactionMeta, ProviderReceipt<Self::Provider>)>,
             Self::Error,
         >,
     > + Send

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -8,7 +8,7 @@ use std::{
 use alloy_network::Network;
 use alloy_rpc_types_eth::Block;
 use reth_primitives::TransactionSigned;
-use reth_provider::TransactionsProvider;
+use reth_provider::{ReceiptProvider, TransactionsProvider};
 use reth_rpc_types_compat::TransactionCompat;
 
 use crate::{AsEthApiError, FromEthApiError, FromEvmError, RpcNodeCore};
@@ -47,8 +47,10 @@ pub type RpcError<T> = <T as EthApiTypes>::Error;
 /// Helper trait holds necessary trait bounds on [`EthApiTypes`] to implement `eth` API.
 pub trait FullEthApiTypes
 where
-    Self: RpcNodeCore<Provider: TransactionsProvider<Transaction = TransactionSigned>>
-        + EthApiTypes<
+    Self: RpcNodeCore<
+            Provider: TransactionsProvider<Transaction = TransactionSigned>
+                          + ReceiptProvider<Receipt = reth_primitives::Receipt>,
+        > + EthApiTypes<
             TransactionCompat: TransactionCompat<
                 <Self::Provider as TransactionsProvider>::Transaction,
                 Transaction = RpcTransaction<Self::NetworkTypes>,
@@ -59,8 +61,10 @@ where
 }
 
 impl<T> FullEthApiTypes for T where
-    T: RpcNodeCore<Provider: TransactionsProvider<Transaction = TransactionSigned>>
-        + EthApiTypes<
+    T: RpcNodeCore<
+            Provider: TransactionsProvider<Transaction = TransactionSigned>
+                          + ReceiptProvider<Receipt = reth_primitives::Receipt>,
+        > + EthApiTypes<
             TransactionCompat: TransactionCompat<
                 <Self::Provider as TransactionsProvider>::Transaction,
                 Transaction = RpcTransaction<T::NetworkTypes>,

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -106,7 +106,7 @@ impl EthStateCache {
     ) -> Self
     where
         Provider: StateProviderFactory
-            + BlockReader<Block = reth_primitives::Block>
+            + BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
             + EvmEnvProvider
             + Clone
             + Unpin
@@ -128,7 +128,7 @@ impl EthStateCache {
     ) -> Self
     where
         Provider: StateProviderFactory
-            + BlockReader<Block = reth_primitives::Block>
+            + BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
             + EvmEnvProvider
             + Clone
             + Unpin
@@ -348,7 +348,7 @@ where
 impl<Provider, Tasks, EvmConfig> Future for EthStateCacheService<Provider, Tasks, EvmConfig>
 where
     Provider: StateProviderFactory
-        + BlockReader<Block = reth_primitives::Block>
+        + BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
         + EvmEnvProvider
         + Clone
         + Unpin

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -794,7 +794,7 @@ where
 #[async_trait]
 impl<Provider, Eth, BlockExecutor> DebugApiServer for DebugApi<Provider, Eth, BlockExecutor>
 where
-    Provider: BlockReaderIdExt<Block: Encodable>
+    Provider: BlockReaderIdExt<Block: Encodable, Receipt = reth_primitives::Receipt>
         + HeaderProvider
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -438,7 +438,7 @@ mod tests {
     use crate::EthApi;
 
     fn build_test_eth_api<
-        P: BlockReaderIdExt<Block = reth_primitives::Block>
+        P: BlockReaderIdExt<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>
             + BlockReader
             + ChainSpecProvider<ChainSpec = ChainSpec>
             + EvmEnvProvider

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -18,8 +18,10 @@ impl<Provider, Pool, Network, EvmConfig> LoadPendingBlock
 where
     Self: SpawnBlocking
         + RpcNodeCore<
-            Provider: BlockReaderIdExt<Block = reth_primitives::Block>
-                          + EvmEnvProvider
+            Provider: BlockReaderIdExt<
+                Block = reth_primitives::Block,
+                Receipt = reth_primitives::Receipt,
+            > + EvmEnvProvider
                           + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                           + StateProviderFactory,
             Pool: TransactionPool,

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,7 +1,7 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
-use reth_provider::TransactionsProvider;
+use reth_provider::{ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 
@@ -9,7 +9,10 @@ use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> LoadReceipt for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: RpcNodeCoreExt<Provider: TransactionsProvider<Transaction = TransactionSigned>>,
+    Self: RpcNodeCoreExt<
+        Provider: TransactionsProvider<Transaction = TransactionSigned>
+                      + ReceiptProvider<Receipt = reth_primitives::Receipt>,
+    >,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -288,7 +288,7 @@ impl<N: ProviderNodeTypes> BlockReader for BlockchainProvider2<N> {
 
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>> {
         Ok(self.canonical_in_memory_state.pending_block_and_receipts())
     }
 
@@ -764,6 +764,8 @@ impl<N: ProviderNodeTypes> AccountReader for BlockchainProvider2<N> {
 }
 
 impl<N: ProviderNodeTypes> StateReader for BlockchainProvider2<N> {
+    type Receipt = ReceiptTy<N>;
+
     /// Re-constructs the [`ExecutionOutcome`] from in-memory and database state, if necessary.
     ///
     /// If data for the block does not exist, this will return [`None`].
@@ -773,7 +775,10 @@ impl<N: ProviderNodeTypes> StateReader for BlockchainProvider2<N> {
     /// inconsistent. Currently this can safely be called within the blockchain tree thread,
     /// because the tree thread is responsible for modifying the [`CanonicalInMemoryState`] in the
     /// first place.
-    fn get_state(&self, block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>> {
+    fn get_state(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
         StateReader::get_state(&self.consistent_provider()?, block)
     }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -25,7 +25,7 @@ use reth_db::{models::BlockNumberAddress, transaction::DbTx, Database};
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
 use reth_execution_types::ExecutionOutcome;
-use reth_node_types::{BlockTy, NodeTypesWithDB, TxTy};
+use reth_node_types::{BlockTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives::{
     Account, Block, BlockWithSenders, EthPrimitives, NodePrimitives, Receipt, SealedBlock,
     SealedBlockFor, SealedBlockWithSenders, SealedHeader, StorageEntry, TransactionMeta,
@@ -411,28 +411,33 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider2<N> {
 }
 
 impl<N: ProviderNodeTypes> ReceiptProvider for BlockchainProvider2<N> {
-    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
+    type Receipt = ReceiptTy<N>;
+
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.consistent_provider()?.receipt(id)
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
         self.consistent_provider()?.receipt_by_hash(hash)
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         self.consistent_provider()?.receipts_by_block(block)
     }
 
     fn receipts_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>> {
+    ) -> ProviderResult<Vec<Self::Receipt>> {
         self.consistent_provider()?.receipts_by_tx_range(range)
     }
 }
 
 impl<N: ProviderNodeTypes> ReceiptProviderIdExt for BlockchainProvider2<N> {
-    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         self.consistent_provider()?.receipts_by_block_id(block)
     }
 }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -21,8 +21,8 @@ use reth_evm::ConfigureEvmEnv;
 use reth_execution_types::{BundleStateInit, ExecutionOutcome, RevertsInit};
 use reth_node_types::{BlockTy, ReceiptTy, TxTy};
 use reth_primitives::{
-    Account, BlockWithSenders, Receipt, SealedBlockFor, SealedBlockWithSenders, SealedHeader,
-    StorageEntry, TransactionMeta,
+    Account, BlockWithSenders, SealedBlockFor, SealedBlockWithSenders, SealedHeader, StorageEntry,
+    TransactionMeta,
 };
 use reth_primitives_traits::{Block, BlockBody};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
@@ -151,7 +151,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     pub fn get_state(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Option<ExecutionOutcome>> {
+    ) -> ProviderResult<Option<ExecutionOutcome<ReceiptTy<N>>>> {
         if range.is_empty() {
             return Ok(None)
         }
@@ -828,7 +828,7 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
 
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>> {
         Ok(self.canonical_in_memory_state.pending_block_and_receipts())
     }
 
@@ -1501,6 +1501,8 @@ impl<N: ProviderNodeTypes> AccountReader for ConsistentProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> StateReader for ConsistentProvider<N> {
+    type Receipt = ReceiptTy<N>;
+
     /// Re-constructs the [`ExecutionOutcome`] from in-memory and database state, if necessary.
     ///
     /// If data for the block does not exist, this will return [`None`].

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -19,7 +19,7 @@ use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
 use reth_evm::ConfigureEvmEnv;
-use reth_node_types::{BlockTy, NodeTypesWithDB, TxTy};
+use reth_node_types::{BlockTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives::{
     BlockWithSenders, Receipt, SealedBlockFor, SealedBlockWithSenders, SealedHeader,
     StaticFileSegment, TransactionMeta,
@@ -508,7 +508,8 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
 }
 
 impl<N: ProviderNodeTypes> ReceiptProvider for ProviderFactory<N> {
-    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
+    type Receipt = ReceiptTy<N>;
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Receipts,
             id,
@@ -517,18 +518,21 @@ impl<N: ProviderNodeTypes> ReceiptProvider for ProviderFactory<N> {
         )
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
         self.provider()?.receipt_by_hash(hash)
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         self.provider()?.receipts_by_block(block)
     }
 
     fn receipts_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>> {
+    ) -> ProviderResult<Vec<Self::Receipt>> {
         self.static_file_provider.get_range_with_static_file_or_database(
             StaticFileSegment::Receipts,
             to_range(range),

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -21,8 +21,8 @@ use reth_errors::{RethError, RethResult};
 use reth_evm::ConfigureEvmEnv;
 use reth_node_types::{BlockTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives::{
-    BlockWithSenders, Receipt, SealedBlockFor, SealedBlockWithSenders, SealedHeader,
-    StaticFileSegment, TransactionMeta,
+    BlockWithSenders, SealedBlockFor, SealedBlockWithSenders, SealedHeader, StaticFileSegment,
+    TransactionMeta,
 };
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
@@ -381,7 +381,7 @@ impl<N: ProviderNodeTypes> BlockReader for ProviderFactory<N> {
 
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>> {
         self.provider()?.pending_block_and_receipts()
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -46,7 +46,7 @@ use reth_db_api::{
 use reth_evm::ConfigureEvmEnv;
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_network_p2p::headers::downloader::SyncTarget;
-use reth_node_types::{BlockTy, BodyTy, NodeTypes, TxTy};
+use reth_node_types::{BlockTy, BodyTy, NodeTypes, ReceiptTy, TxTy};
 use reth_primitives::{
     Account, BlockExt, BlockWithSenders, Bytecode, GotExpected, Receipt, SealedBlock,
     SealedBlockFor, SealedBlockWithSenders, SealedHeader, StaticFileSegment, StorageEntry,
@@ -1529,7 +1529,9 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
 }
 
 impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabaseProvider<TX, N> {
-    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
+    type Receipt = ReceiptTy<N>;
+
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Receipts,
             id,
@@ -1538,7 +1540,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
         )
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
         if let Some(id) = self.transaction_id(hash)? {
             self.receipt(id)
         } else {
@@ -1546,7 +1548,10 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
         }
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         if let Some(number) = self.convert_hash_or_number(block)? {
             if let Some(body) = self.block_body_indices(number)? {
                 let tx_range = body.tx_num_range();
@@ -1563,7 +1568,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
     fn receipts_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>> {
+    ) -> ProviderResult<Vec<Self::Receipt>> {
         self.static_file_provider.get_range_with_static_file_or_database(
             StaticFileSegment::Receipts,
             to_range(range),

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -48,9 +48,9 @@ use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_network_p2p::headers::downloader::SyncTarget;
 use reth_node_types::{BlockTy, BodyTy, NodeTypes, ReceiptTy, TxTy};
 use reth_primitives::{
-    Account, BlockExt, BlockWithSenders, Bytecode, GotExpected, Receipt, SealedBlock,
-    SealedBlockFor, SealedBlockWithSenders, SealedHeader, StaticFileSegment, StorageEntry,
-    TransactionMeta, TransactionSignedNoHash,
+    Account, BlockExt, BlockWithSenders, Bytecode, GotExpected, SealedBlock, SealedBlockFor,
+    SealedBlockWithSenders, SealedHeader, StaticFileSegment, StorageEntry, TransactionMeta,
+    TransactionSignedNoHash,
 };
 use reth_primitives_traits::{Block as _, BlockBody as _, SignedTransaction};
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
@@ -1199,7 +1199,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
 
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>> {
         Ok(None)
     }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -24,7 +24,7 @@ use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_db::table::Value;
 use reth_db_api::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_evm::ConfigureEvmEnv;
-use reth_node_types::{BlockTy, FullNodePrimitives, NodeTypes, NodeTypesWithDB, TxTy};
+use reth_node_types::{BlockTy, FullNodePrimitives, NodeTypes, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives::{
     Account, BlockWithSenders, EthPrimitives, Receipt, SealedBlock, SealedBlockFor,
     SealedBlockWithSenders, SealedHeader, TransactionMeta,
@@ -516,22 +516,27 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> ReceiptProvider for BlockchainProvider<N> {
-    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>> {
+    type Receipt = ReceiptTy<N>;
+
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.database.receipt(id)
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
         self.database.receipt_by_hash(hash)
     }
 
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         self.database.receipts_by_block(block)
     }
 
     fn receipts_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>> {
+    ) -> ProviderResult<Vec<Self::Receipt>> {
         self.database.receipts_by_tx_range(range)
     }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1341,10 +1341,12 @@ impl<N: NodePrimitives> BlockHashReader for StaticFileProvider<N> {
     }
 }
 
-impl<N: NodePrimitives<SignedTx: Value + SignedTransaction>> ReceiptProvider
+impl<N: NodePrimitives<SignedTx: Value + SignedTransaction, Receipt: Value>> ReceiptProvider
     for StaticFileProvider<N>
 {
-    fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Receipt>> {
+    type Receipt = N::Receipt;
+
+    fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.get_segment_provider_from_transaction(StaticFileSegment::Receipts, num, None)
             .and_then(|provider| provider.receipt(num))
             .or_else(|err| {
@@ -1356,31 +1358,36 @@ impl<N: NodePrimitives<SignedTx: Value + SignedTransaction>> ReceiptProvider
             })
     }
 
-    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
         if let Some(num) = self.transaction_id(hash)? {
             return self.receipt(num)
         }
         Ok(None)
     }
 
-    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        _block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         unreachable!()
     }
 
     fn receipts_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>> {
+    ) -> ProviderResult<Vec<Self::Receipt>> {
         self.fetch_range_with_predicate(
             StaticFileSegment::Receipts,
             to_range(range),
-            |cursor, number| cursor.get_one::<ReceiptMask<Receipt>>(number.into()),
+            |cursor, number| cursor.get_one::<ReceiptMask<Self::Receipt>>(number.into()),
             |_| true,
         )
     }
 }
 
-impl<N: FullNodePrimitives<SignedTx: Value>> TransactionsProviderExt for StaticFileProvider<N> {
+impl<N: FullNodePrimitives<SignedTx: Value, Receipt: Value>> TransactionsProviderExt
+    for StaticFileProvider<N>
+{
     fn transaction_hashes_by_range(
         &self,
         tx_range: Range<TxNumber>,
@@ -1575,7 +1582,7 @@ impl<N: NodePrimitives> BlockNumReader for StaticFileProvider<N> {
     }
 }
 
-impl<N: FullNodePrimitives<SignedTx: Value>> BlockReader for StaticFileProvider<N> {
+impl<N: FullNodePrimitives<SignedTx: Value, Receipt: Value>> BlockReader for StaticFileProvider<N> {
     type Block = N::Block;
 
     fn find_block_by_hash(

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -38,8 +38,8 @@ use reth_primitives::{
         DEFAULT_BLOCKS_PER_STATIC_FILE,
     },
     transaction::recover_signers,
-    BlockWithSenders, Receipt, SealedBlockFor, SealedBlockWithSenders, SealedHeader,
-    StaticFileSegment, TransactionMeta, TransactionSignedNoHash,
+    BlockWithSenders, SealedBlockFor, SealedBlockWithSenders, SealedHeader, StaticFileSegment,
+    TransactionMeta, TransactionSignedNoHash,
 };
 use reth_primitives_traits::SignedTransaction;
 use reth_stages_types::{PipelineTarget, StageId};
@@ -1613,7 +1613,7 @@ impl<N: FullNodePrimitives<SignedTx: Value, Receipt: Value>> BlockReader for Sta
 
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>> {
         // Required data not present in static_files
         Err(ProviderError::UnsupportedProvider)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -830,6 +830,8 @@ impl ChangeSetReader for MockEthProvider {
 }
 
 impl StateReader for MockEthProvider {
+    type Receipt = Receipt;
+
     fn get_state(&self, _block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -379,6 +379,8 @@ impl TransactionsProvider for MockEthProvider {
 }
 
 impl ReceiptProvider for MockEthProvider {
+    type Receipt = Receipt;
+
     fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -260,6 +260,7 @@ impl TransactionsProvider for NoopProvider {
 }
 
 impl ReceiptProvider for NoopProvider {
+    type Receipt = Receipt;
     fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -80,8 +80,14 @@ impl<T: BlockExecutionWriter> BlockExecutionWriter for &T {
 /// This just receives state, or [`ExecutionOutcome`], from the provider
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait StateReader: Send + Sync {
+    /// Receipt type in [`ExecutionOutcome`].
+    type Receipt: Send + Sync;
+
     /// Get the [`ExecutionOutcome`] for the given block
-    fn get_state(&self, block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>>;
+    fn get_state(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>>;
 }
 
 /// Block Writer

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -7,19 +7,21 @@ use crate::{
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
 use reth_chainspec::EthereumHardforks;
-use reth_node_types::{BlockTy, NodeTypesWithDB, TxTy};
+use reth_node_types::{BlockTy, NodeTypesWithDB, ReceiptTy, TxTy};
+use reth_storage_api::NodePrimitivesProvider;
 
 /// Helper trait to unify all provider traits for simplicity.
 pub trait FullProvider<N: NodeTypesWithDB>:
     DatabaseProviderFactory<DB = N::DB>
-    + StaticFileProviderFactory<Primitives = N::Primitives>
-    + BlockReaderIdExt<Transaction = TxTy<N>, Block = BlockTy<N>>
+    + NodePrimitivesProvider<Primitives = N::Primitives>
+    + StaticFileProviderFactory
+    + BlockReaderIdExt<Transaction = TxTy<N>, Block = BlockTy<N>, Receipt = ReceiptTy<N>>
     + AccountReader
     + StateProviderFactory
     + EvmEnvProvider
     + ChainSpecProvider<ChainSpec = N::ChainSpec>
     + ChangeSetReader
-    + CanonStateSubscriptions<Primitives = N::Primitives>
+    + CanonStateSubscriptions
     + ForkChoiceSubscriptions
     + StageCheckpointReader
     + Clone
@@ -30,14 +32,15 @@ pub trait FullProvider<N: NodeTypesWithDB>:
 
 impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
     T: DatabaseProviderFactory<DB = N::DB>
-        + StaticFileProviderFactory<Primitives = N::Primitives>
-        + BlockReaderIdExt<Transaction = TxTy<N>, Block = BlockTy<N>>
+        + NodePrimitivesProvider<Primitives = N::Primitives>
+        + StaticFileProviderFactory
+        + BlockReaderIdExt<Transaction = TxTy<N>, Block = BlockTy<N>, Receipt = ReceiptTy<N>>
         + AccountReader
         + StateProviderFactory
         + EvmEnvProvider
         + ChainSpecProvider<ChainSpec = N::ChainSpec>
         + ChangeSetReader
-        + CanonStateSubscriptions<Primitives = N::Primitives>
+        + CanonStateSubscriptions
         + ForkChoiceSubscriptions
         + StageCheckpointReader
         + Clone

--- a/crates/storage/storage-api/src/block.rs
+++ b/crates/storage/storage-api/src/block.rs
@@ -6,9 +6,7 @@ use alloy_consensus::Header;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{BlockNumber, B256};
 use reth_db_models::StoredBlockBodyIndices;
-use reth_primitives::{
-    BlockWithSenders, Receipt, SealedBlockFor, SealedBlockWithSenders, SealedHeader,
-};
+use reth_primitives::{BlockWithSenders, SealedBlockFor, SealedBlockWithSenders, SealedHeader};
 use reth_storage_errors::provider::ProviderResult;
 use std::ops::RangeInclusive;
 
@@ -95,7 +93,7 @@ pub trait BlockReader:
     #[allow(clippy::type_complexity)]
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>>;
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>>;
 
     /// Returns the ommers/uncle headers of the given block from the database.
     ///
@@ -186,7 +184,7 @@ impl<T: BlockReader> BlockReader for std::sync::Arc<T> {
     }
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>> {
         T::pending_block_and_receipts(self)
     }
     fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {
@@ -255,7 +253,7 @@ impl<T: BlockReader> BlockReader for &T {
     }
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(SealedBlockFor<Self::Block>, Vec<Self::Receipt>)>> {
         T::pending_block_and_receipts(self)
     }
     fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Header>>> {

--- a/crates/storage/storage-api/src/receipts.rs
+++ b/crates/storage/storage-api/src/receipts.rs
@@ -1,33 +1,38 @@
 use crate::BlockIdReader;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{TxHash, TxNumber};
-use reth_primitives::Receipt;
 use reth_storage_errors::provider::ProviderResult;
 use std::ops::RangeBounds;
 
 /// Client trait for fetching [Receipt] data .
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ReceiptProvider: Send + Sync {
+    /// The receipt type.
+    type Receipt: Send + Sync;
+
     /// Get receipt by transaction number
     ///
     /// Returns `None` if the transaction is not found.
-    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Receipt>>;
+    fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>>;
 
     /// Get receipt by transaction hash.
     ///
     /// Returns `None` if the transaction is not found.
-    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>>;
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>>;
 
     /// Get receipts by block num or hash.
     ///
     /// Returns `None` if the block is not found.
-    fn receipts_by_block(&self, block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>>;
+    fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>>;
 
     /// Get receipts by tx range.
     fn receipts_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>>;
+    ) -> ProviderResult<Vec<Self::Receipt>>;
 }
 
 /// Trait extension for `ReceiptProvider`, for types that implement `BlockId` conversion.
@@ -40,10 +45,9 @@ pub trait ReceiptProvider: Send + Sync {
 /// so this trait can only be implemented for types that implement `BlockIdReader`. The
 /// `BlockIdReader` methods should be used to resolve `BlockId`s to block numbers or hashes, and
 /// retrieving the receipts should be done using the type's `ReceiptProvider` methods.
-#[auto_impl::auto_impl(&, Arc)]
 pub trait ReceiptProviderIdExt: ReceiptProvider + BlockIdReader {
     /// Get receipt by block id
-    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block_id(&self, block: BlockId) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         let id = match block {
             BlockId::Hash(hash) => BlockHashOrNumber::Hash(hash.block_hash),
             BlockId::Number(num_tag) => {
@@ -64,7 +68,7 @@ pub trait ReceiptProviderIdExt: ReceiptProvider + BlockIdReader {
     fn receipts_by_number_or_tag(
         &self,
         number_or_tag: BlockNumberOrTag,
-    ) -> ProviderResult<Option<Vec<Receipt>>> {
+    ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
         self.receipts_by_block_id(number_or_tag.into())
     }
 }

--- a/crates/storage/storage-api/src/receipts.rs
+++ b/crates/storage/storage-api/src/receipts.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{TxHash, TxNumber};
 use reth_storage_errors::provider::ProviderResult;
 use std::ops::RangeBounds;
 
-/// Client trait for fetching [Receipt] data .
+/// Client trait for fetching receipt data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ReceiptProvider: Send + Sync {
     /// The receipt type.

--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -1,4 +1,4 @@
-use crate::{BlockNumReader, BlockReader};
+use crate::{BlockNumReader, BlockReader, ReceiptProvider};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockNumber, TxHash, TxNumber};
 use reth_primitives::TransactionMeta;
@@ -83,6 +83,9 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
 
 /// A helper type alias to access [`TransactionsProvider::Transaction`].
 pub type ProviderTx<P> = <P as TransactionsProvider>::Transaction;
+
+/// A helper type alias to access [`ReceiptProvider::Receipt`].
+pub type ProviderReceipt<P> = <P as ReceiptProvider>::Receipt;
 
 ///  Client trait for fetching additional transactions related data.
 #[auto_impl::auto_impl(&, Arc)]

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -166,7 +166,9 @@ fn block_provider_example<T: BlockReader<Block = reth_primitives::Block>>(
 
 /// The `ReceiptProvider` allows querying the receipts tables.
 fn receipts_provider_example<
-    T: ReceiptProvider + TransactionsProvider<Transaction = TransactionSigned> + HeaderProvider,
+    T: ReceiptProvider<Receipt = reth_primitives::Receipt>
+        + TransactionsProvider<Transaction = TransactionSigned>
+        + HeaderProvider,
 >(
     provider: T,
 ) -> eyre::Result<()> {


### PR DESCRIPTION
Based on #12887 

Adds `Receipt` AT to `ReceiptProvider`, for now Receipts are still bounded to `reth_primitives::Receipt`