### PR TITLE
fix(ci): warn instead of failing no tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
-            ${{ matrix.args }} --workspace --exclude ef-tests \
+            ${{ matrix.args }} --workspace \
+            --exclude ef-tests --no-tests=warn \
             --partition hash:${{ matrix.partition }}/2 \
             -E "!kind(test)"
 


### PR DESCRIPTION
This is for `--manifest-path book/sources/Cargo.toml`.

[Previously](https://github.com/paradigmxyz/reth/actions/runs/12037854438/job/33562218674):
![image](https://github.com/user-attachments/assets/5d8ad852-bd8e-41fd-983c-2c7373f0afec)

[Today](https://github.com/paradigmxyz/reth/actions/runs/12042599246/job/33576538087?pr=12870):
![image](https://github.com/user-attachments/assets/7596b3ab-1361-494c-b209-3d4e1734c820)

Alternatively, we can add a few tests to `book` :thinking:. 