### PR TITLE
feat(trie): validate sparse trie proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9467,6 +9467,7 @@ version = "1.1.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "arbitrary",
  "assert_matches",
  "criterion",

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -20,6 +20,7 @@ reth-trie-common.workspace = true
 # alloy
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
+alloy-trie.workspace = true
 
 # misc
 smallvec = { workspace = true, features = ["const_new"] }

--- a/crates/trie/sparse/src/errors.rs
+++ b/crates/trie/sparse/src/errors.rs
@@ -1,6 +1,7 @@
 //! Errors for sparse trie.
 
-use alloy_primitives::{Bytes, B256};
+use alloy_primitives::B256;
+use alloy_trie::nodes::TrieNode;
 use reth_trie_common::Nibbles;
 use thiserror::Error;
 
@@ -12,13 +13,29 @@ pub type SparseStateTrieResult<Ok> = Result<Ok, SparseStateTrieError>;
 /// Error encountered in [`crate::SparseStateTrie`].
 #[derive(Error, Debug)]
 pub enum SparseStateTrieError {
-    /// Encountered invalid root node.
+    /// Encountered invalid root node path.
     #[error("invalid root node at {path:?}: {node:?}")]
-    InvalidRootNode {
+    InvalidRootNodePath {
         /// Path to first proof node.
         path: Nibbles,
-        /// Encoded first proof node.
-        node: Bytes,
+        /// Decoded first proof node.
+        node: Box<TrieNode>,
+    },
+    /// Encountered unexpected node at path.
+    #[error("encountered unexpected node at path {path:?} when revealing: {node:?}")]
+    UnexpectedNode {
+        /// Path to the node.
+        path: Nibbles,
+        /// Node that was at the path when revealing.
+        node: Box<TrieNode>,
+    },
+    /// Encountered proof without leaf node.
+    #[error("proof without leaf node at {path:?}: {node:?}")]
+    ProofWithoutLeafNode {
+        /// Path to the leaf node.
+        path: Nibbles,
+        /// Decoded leaf node.
+        node: Box<TrieNode>,
     },
     /// Sparse trie error.
     #[error(transparent)]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -268,7 +268,7 @@ mod tests {
         ];
         assert_matches!(
             sparse.validate_proof(&mut proof.into_iter().peekable()),
-            Err(SparseStateTrieError::InvalidRootNodePath { .. })
+            Err(SparseStateTrieError::UnexpectedNode { .. })
         );
     }
 


### PR DESCRIPTION
Extend the validation to check that the last node of the leaf proof is indeed a leaf node.