### PR TITLE
feat: integrate node primitives in engine handler

### DIFF
--- a/crates/engine/local/src/service.rs
+++ b/crates/engine/local/src/service.rs
@@ -91,7 +91,7 @@ where
 
         let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();
 
-        let (to_tree_tx, from_tree) = EngineApiTreeHandler::spawn_new(
+        let (to_tree_tx, from_tree) = EngineApiTreeHandler::<N::Primitives, _, _, _, _>::spawn_new(
             blockchain_db.clone(),
             executor_factory,
             consensus,

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -92,7 +92,7 @@ where
 
         let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();
 
-        let (to_tree_tx, from_tree) = EngineApiTreeHandler::spawn_new(
+        let (to_tree_tx, from_tree) = EngineApiTreeHandler::<N::Primitives, _, _, _, _>::spawn_new(
             blockchain_db,
             executor_factory,
             consensus,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -82,6 +82,7 @@ pub mod serde_bincode_compat {
 
 /// Temp helper struct for integrating [`NodePrimitives`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub struct EthPrimitives;
 
 impl reth_primitives_traits::NodePrimitives for EthPrimitives {


### PR DESCRIPTION
integrates primitive types in engine handler, this will allow us to further integrate and enforce traits, such as engine validator