### PR TITLE
fix(trie): always create empty storage multiproofs

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -2,7 +2,11 @@
 
 use crate::{Nibbles, TrieAccount};
 use alloy_consensus::constants::KECCAK_EMPTY;
-use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_primitives::{
+    keccak256,
+    map::{hash_map, HashMap},
+    Address, Bytes, B256, U256,
+};
 use alloy_rlp::{encode_fixed_size, Decodable, EMPTY_STRING_CODE};
 use alloy_trie::{
     nodes::TrieNode,
@@ -11,7 +15,6 @@ use alloy_trie::{
 };
 use itertools::Itertools;
 use reth_primitives_traits::Account;
-use std::collections::{hash_map, HashMap};
 
 /// The state multiproof of target accounts and multiproofs of their storage tries.
 /// Multiproof is effectively a state subtrie that only contains the nodes

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -103,7 +103,10 @@ where
         let retainer = targets.keys().map(Nibbles::unpack).collect();
         let mut hash_builder = HashBuilder::default().with_proof_retainer(retainer);
 
-        let mut storages = HashMap::default();
+        // Initialize all storage multiproofs as empty.
+        // Storage multiproofs for non empty tries will be overwritten if necessary.
+        let mut storages =
+            HashMap::from_iter(targets.keys().map(|key| (*key, StorageMultiProof::empty())));
         let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
         let mut account_node_iter = TrieNodeIter::new(walker, hashed_account_cursor);
         while let Some(account_node) = account_node_iter.try_next()? {
@@ -132,6 +135,8 @@ where
                     account.encode(&mut account_rlp as &mut dyn BufMut);
 
                     hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
+
+                    // Overwrite storage multiproof.
                     storages.insert(hashed_address, storage_multiproof);
                 }
             }

--- a/crates/trie/trie/src/proof.rs
+++ b/crates/trie/trie/src/proof.rs
@@ -105,8 +105,8 @@ where
 
         // Initialize all storage multiproofs as empty.
         // Storage multiproofs for non empty tries will be overwritten if necessary.
-        let mut storages =
-            HashMap::from_iter(targets.keys().map(|key| (*key, StorageMultiProof::empty())));
+        let mut storages: HashMap<_, _> =
+            targets.keys().map(|key| (*key, StorageMultiProof::empty())).collect();
         let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
         let mut account_node_iter = TrieNodeIter::new(walker, hashed_account_cursor);
         while let Some(account_node) = account_node_iter.try_next()? {


### PR DESCRIPTION
## Description

Always make sure there is a storage multiproof entry for all requested accounts.