### PR TITLE
perf(trie): avoid update reallocation & track wiped

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1,9 +1,5 @@
 use crate::{SparseTrieError, SparseTrieResult};
-use alloy_primitives::{
-    hex, keccak256,
-    map::{HashMap, HashSet},
-    B256,
-};
+use alloy_primitives::{hex, keccak256, map::HashMap, B256};
 use alloy_rlp::Decodable;
 use reth_tracing::tracing::debug;
 use reth_trie_common::{
@@ -111,6 +107,7 @@ pub struct RevealedSparseTrie {
     prefix_set: PrefixSetMut,
     /// Reusable buffer for RLP encoding of nodes.
     rlp_buf: Vec<u8>,
+    /// Retained trie updates.
     updates: Option<SparseTrieUpdates>,
 }
 
@@ -607,8 +604,10 @@ impl RevealedSparseTrie {
 
     /// Wipe the trie, removing all values and nodes, and replacing the root with an empty node.
     pub fn wipe(&mut self) {
+        let updates_retained = self.updates.is_some();
         *self = Self::default();
         self.prefix_set = PrefixSetMut::all();
+        self.updates = updates_retained.then(SparseTrieUpdates::wiped);
     }
 
     /// Return the root of the sparse trie.
@@ -1030,12 +1029,18 @@ impl RlpNodeBuffers {
 pub struct SparseTrieUpdates {
     pub(crate) updated_nodes: HashMap<Nibbles, BranchNodeCompact>,
     pub(crate) removed_nodes: HashSet<Nibbles>,
+    pub(crate) wiped: bool,
+}
+
+impl SparseTrieUpdates {
+    /// Create new wiped sparse trie updates.
+    pub fn wiped() -> Self {
+        Self { wiped: true, ..Default::default() }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use super::*;
     use alloy_primitives::{map::HashSet, U256};
     use alloy_rlp::Encodable;
@@ -1057,6 +1062,7 @@ mod tests {
         proof::{ProofNodes, ProofRetainer},
         HashBuilder,
     };
+    use std::collections::BTreeMap;
 
     /// Pad nibbles to the length of a B256 hash with zeros on the left.
     fn pad_nibbles_left(nibbles: Nibbles) -> Nibbles {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1,5 +1,9 @@
 use crate::{SparseTrieError, SparseTrieResult};
-use alloy_primitives::{hex, keccak256, map::HashMap, B256};
+use alloy_primitives::{
+    hex, keccak256,
+    map::{HashMap, HashSet},
+    B256,
+};
 use alloy_rlp::Decodable;
 use reth_tracing::tracing::debug;
 use reth_trie_common::{


### PR DESCRIPTION
## Description

Use std collections for `SparseTrieUpdates` to avoid reallocations.

Nit: track `wiped` flag inside `SparseTrieUpdates`. 