### PR TITLE
feat: calculate state root in background

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -857,6 +857,16 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     pub fn trie_updates(&self) -> &TrieUpdates {
         &self.trie
     }
+
+    /// Returns a state root of the block.
+    pub fn state_root(&self) -> B256 {
+        self.block.header.header().state_root()
+    }
+
+    /// Sets the trie updates for the block.
+    pub fn set_trie_updates(&mut self, trie: TrieUpdates) {
+        self.trie = Arc::new(trie);
+    }
 }
 
 /// Non-empty chain of blocks.

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -110,6 +110,15 @@ pub struct NodeCommand<
     /// Additional cli arguments
     #[command(flatten, next_help_heading = "Extension")]
     pub ext: Ext,
+
+    /// Enables state root computation in the background with a persistent database.
+    ///
+    /// This option is intended for performance optimization when importing blocks
+    /// during live sync. It allows state root calculations to be performed
+    /// concurrently with other operations, potentially reducing overall
+    /// processing time.
+    #[arg(long = "compute-state-root-in-background", default_value_t = false)]
+    pub compute_state_root_in_background: bool,
 }
 
 impl<C: ChainSpecParser> NodeCommand<C> {
@@ -160,6 +169,7 @@ impl<
             dev,
             pruning,
             ext,
+            compute_state_root_in_background,
         } = self;
 
         // set up node config
@@ -177,6 +187,7 @@ impl<
             db,
             dev,
             pruning,
+            compute_state_root_in_background,
         };
 
         let data_dir = node_config.datadir();

--- a/crates/engine/tree/src/metrics.rs
+++ b/crates/engine/tree/src/metrics.rs
@@ -21,4 +21,6 @@ pub(crate) struct PersistenceMetrics {
     pub(crate) save_blocks_duration_seconds: Histogram,
     /// How long it took for blocks to be pruned
     pub(crate) prune_before_duration_seconds: Histogram,
+    /// The height of blocks was persisted
+    pub(crate) persistence_height: Gauge,
 }

--- a/crates/engine/tree/src/tree/config.rs
+++ b/crates/engine/tree/src/tree/config.rs
@@ -1,10 +1,10 @@
 //! Engine tree configuration.
 
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
-pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
+pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 16;
 
 /// How close to the canonical head we persist blocks.
-pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 2;
+pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 16;
 
 const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = 256;
 const DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH: u32 = 256;

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -215,6 +215,7 @@ where
                 Box::pin(consensus_engine_stream),
                 ctx.dev_mining_mode(ctx.components().pool()),
                 LocalPayloadAttributesBuilder::new(ctx.chain_spec()),
+                ctx.node_config().compute_state_root_in_background,
             );
 
             Either::Left(eth_service)
@@ -234,6 +235,7 @@ where
                 engine_tree_config,
                 ctx.invalid_block_hook()?,
                 ctx.sync_metrics_tx(),
+                ctx.node_config().compute_state_root_in_background,
             );
 
             Either::Right(eth_service)

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -129,6 +129,9 @@ pub struct NodeConfig<ChainSpec> {
 
     /// All pruning related arguments
     pub pruning: PruningArgs,
+
+    /// Compute state root in background
+    pub compute_state_root_in_background: bool,
 }
 
 impl NodeConfig<ChainSpec> {
@@ -157,6 +160,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             dev: DevArgs::default(),
             pruning: PruningArgs::default(),
             datadir: DatadirArgs::default(),
+            compute_state_root_in_background: false,
         }
     }
 
@@ -445,6 +449,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             db: self.db,
             dev: self.dev,
             pruning: self.pruning,
+            compute_state_root_in_background: self.compute_state_root_in_background,
         }
     }
 }
@@ -471,6 +476,7 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             dev: self.dev,
             pruning: self.pruning.clone(),
             datadir: self.datadir.clone(),
+            compute_state_root_in_background: false,
         }
     }
 }


### PR DESCRIPTION
### Description

This PR adds an option to calculate the state root in the background, improving block insertion performance during live sync.

### Rationale

Calculating the state root during live sync takes a lot of time, resulting in poor performance. This feature allows for background calculation of the state root and merges calculations for multiple blocks to update the trie simultaneously. Our tests show that enabling this feature can improve performance from 50 mgasps to 400 mgasps.

**Without this feature:**
![image](https://github.com/user-attachments/assets/14e0c34f-44d7-4bf2-b8d0-90272603f6dc)

**With this feature enabled:**
![image](https://github.com/user-attachments/assets/592e60c1-2525-4d66-b56c-7932bd57a209)

### Example

NA

### Changes

Notable changes: 
* Calculate the state root in the background.  
*  Merge the calculation of the state root for multiple blocks.

### Potential Impacts
* The persistent database should align with the background calculation of the state root.  
*  When unwinding blocks, you can only unwind to the block where the state root has been calculated.
