### PR TITLE
fix(engine): remove sparse trie storage leaves in the state root task

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -524,11 +524,15 @@ fn update_sparse_trie(
 
         for (slot, value) in storage.storage {
             let slot_path = Nibbles::unpack(slot);
-            trie.update_storage_leaf(
-                address,
-                slot_path,
-                alloy_rlp::encode_fixed_size(&value).to_vec(),
-            )?;
+            if value.is_zero() {
+                trie.remove_storage_leaf(address, &slot_path)?;
+            } else {
+                trie.update_storage_leaf(
+                    address,
+                    slot_path,
+                    alloy_rlp::encode_fixed_size(&value).to_vec(),
+                )?;
+            }
         }
 
         storage_roots.insert(address, trie.storage_root(address).unwrap());


### PR DESCRIPTION
Zero-ed storage slots should result in removed storage trie leaves https://github.com/paradigmxyz/reth/blob/28ef5749e759a2b2c17260369fac2c6adb116bf9/crates/storage/provider/src/providers/database/provider.rs#L2450-L2460