### PR TITLE
Improve clarity and readability in bandwidth requirements section

### DIFF
--- a/book/installation/installation.md
+++ b/book/installation/installation.md
@@ -70,7 +70,7 @@ Higher memory is generally better as it allows for better caching, resulting in 
 
 A stable and dependable internet connection is crucial for both syncing a node from genesis and for keeping up with the chain's tip.
 
-Note that due to Reth's staged sync, you only need an internet connection for the Headers and Bodies stages. This means that the first 1-3 hours (depending on your internet connection) will be online, downloading all necessary data, and the rest will be done offline and does not require an internet connection.
+Due to Reth's staged sync, an internet connection is needed only for the Headers and Bodies stages. This means that the first 1-3 hours (depending on your internet connection) will be online, downloading all necessary data, and the rest will be done offline and does not require an internet connection.
 
 Once you're synced to the tip you will need a reliable connection, especially if you're operating a validator. A 24Mbps connection is recommended, but you can probably get away with less. Make sure your ISP does not cap your bandwidth.
 


### PR DESCRIPTION
This update enhances the clarity and readability of a sentence in the "Bandwidth" section. The original sentence:  

> "Note that due to Reth's staged sync, you only need an internet connection for the Headers and Bodies stages."  

has been rephrased for conciseness and improved flow:  

> "Due to Reth's staged sync, an internet connection is needed only for the Headers and Bodies stages."  

This small change makes the doc more polished and professional, ensuring a smoother reading experience for users. While the original sentence was understandable, this revision removes redundancy and aligns with the consistent, clear tone used throughout the rest of the doc.  

Let me know if further adjustments are needed! 😊