### PR TITLE
perf: use alloy hash map in trie related code

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -25,7 +25,11 @@ use alloy_eips::{
     eip4895::{Withdrawal, Withdrawals},
     BlockHashOrNumber,
 };
-use alloy_primitives::{keccak256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
+use alloy_primitives::{
+    keccak256,
+    map::{hash_map, HashMap, HashSet},
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
+};
 use itertools::Itertools;
 use rayon::slice::ParallelSliceMut;
 use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, EthereumHardforks};
@@ -71,7 +75,7 @@ use revm::{
 };
 use std::{
     cmp::Ordering,
-    collections::{hash_map, BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     fmt::Debug,
     ops::{Deref, DerefMut, Range, RangeBounds, RangeInclusive},
     sync::{mpsc, Arc},
@@ -2442,7 +2446,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HashingWriter for DatabaseProvi
 
         // Apply values to HashedState, and remove the account if it's None.
         let mut hashed_storage_keys: HashMap<B256, BTreeSet<B256>> =
-            HashMap::with_capacity(hashed_storages.len());
+            HashMap::with_capacity_and_hasher(hashed_storages.len(), Default::default());
         let mut hashed_storage = self.tx.cursor_dup_write::<tables::HashedStorages>()?;
         for (hashed_address, key, value) in hashed_storages.into_iter().rev() {
             hashed_storage_keys.entry(hashed_address).or_default().insert(key);

--- a/crates/storage/storage-api/src/hashing.rs
+++ b/crates/storage/storage-api/src/hashing.rs
@@ -1,10 +1,10 @@
-use alloy_primitives::{Address, BlockNumber, B256};
+use alloy_primitives::{map::HashMap, Address, BlockNumber, B256};
 use auto_impl::auto_impl;
 use reth_db::models::{AccountBeforeTx, BlockNumberAddress};
 use reth_primitives::{Account, StorageEntry};
 use reth_storage_errors::provider::ProviderResult;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     ops::{RangeBounds, RangeInclusive},
 };
 

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -114,7 +114,7 @@ pub trait StorageTrieWriter: Send + Sync {
     /// Returns the number of entries modified.
     fn write_storage_trie_updates(
         &self,
-        storage_tries: &std::collections::HashMap<B256, StorageTrieUpdates>,
+        storage_tries: &HashMap<B256, StorageTrieUpdates>,
     ) -> ProviderResult<usize>;
 
     /// Writes storage trie updates for the given hashed address.

--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -1,9 +1,9 @@
 use crate::Nibbles;
-use alloy_primitives::B256;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
+use alloy_primitives::{
+    map::{HashMap, HashSet},
+    B256,
 };
+use std::sync::Arc;
 
 /// Collection of mutable prefix sets.
 #[derive(Clone, Default, Debug)]

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -1,6 +1,8 @@
 use crate::{BranchNodeCompact, HashBuilder, Nibbles};
-use alloy_primitives::B256;
-use std::collections::{HashMap, HashSet};
+use alloy_primitives::{
+    map::{HashMap, HashSet},
+    B256,
+};
 
 /// The aggregation of trie updates.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
@@ -228,8 +230,8 @@ impl StorageTrieUpdates {
 #[cfg(any(test, feature = "serde"))]
 mod serde_nibbles_set {
     use crate::Nibbles;
+    use alloy_primitives::map::HashSet;
     use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-    use std::collections::HashSet;
 
     pub(super) fn serialize<S>(map: &HashSet<Nibbles>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -264,13 +266,13 @@ mod serde_nibbles_set {
 #[cfg(any(test, feature = "serde"))]
 mod serde_nibbles_map {
     use crate::Nibbles;
-    use alloy_primitives::hex;
+    use alloy_primitives::{hex, map::HashMap};
     use serde::{
         de::{Error, MapAccess, Visitor},
         ser::SerializeMap,
         Deserialize, Deserializer, Serialize, Serializer,
     };
-    use std::{collections::HashMap, marker::PhantomData};
+    use std::marker::PhantomData;
 
     pub(super) fn serialize<S, T>(
         map: &HashMap<Nibbles, T>,
@@ -314,7 +316,10 @@ mod serde_nibbles_map {
             where
                 A: MapAccess<'de>,
             {
-                let mut result = HashMap::with_capacity(map.size_hint().unwrap_or(0));
+                let mut result = HashMap::with_capacity_and_hasher(
+                    map.size_hint().unwrap_or(0),
+                    Default::default(),
+                );
 
                 while let Some((key, value)) = map.next_entry::<String, T>()? {
                     let decoded_key =
@@ -406,13 +411,13 @@ fn exclude_empty_from_pair<V>(
 #[cfg(feature = "serde-bincode-compat")]
 pub mod serde_bincode_compat {
     use crate::{BranchNodeCompact, Nibbles};
-    use alloy_primitives::B256;
+    use alloy_primitives::{
+        map::{HashMap, HashSet},
+        B256,
+    };
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
-    use std::{
-        borrow::Cow,
-        collections::{HashMap, HashSet},
-    };
+    use std::borrow::Cow;
 
     /// Bincode-compatible [`super::TrieUpdates`] serde implementation.
     ///

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -123,7 +123,7 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
         let prefix_set = storage.construct_prefix_set();
         let state_sorted = HashedPostStateSorted::new(
             Default::default(),
-            HashMap::from([(hashed_address, storage.into_sorted())]),
+            HashMap::from_iter([(hashed_address, storage.into_sorted())]),
         );
         Self::from_tx(tx, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
@@ -145,7 +145,7 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
         let prefix_set = storage.construct_prefix_set();
         let state_sorted = HashedPostStateSorted::new(
             Default::default(),
-            HashMap::from([(hashed_address, storage.into_sorted())]),
+            HashMap::from_iter([(hashed_address, storage.into_sorted())]),
         );
         Self::from_tx(tx, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -27,7 +27,7 @@ fn includes_empty_node_preimage() {
     assert_eq!(
         TrieWitness::from_tx(provider.tx_ref())
             .compute(HashedPostState {
-                accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
+                accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
                 storages: HashMap::default(),
             })
             .unwrap(),
@@ -44,8 +44,8 @@ fn includes_empty_node_preimage() {
 
     let witness = TrieWitness::from_tx(provider.tx_ref())
         .compute(HashedPostState {
-            accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
-            storages: HashMap::from([(
+            accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::from_iter([(
                 hashed_address,
                 HashedStorage::from_iter(false, [(hashed_slot, U256::from(1))]),
             )]),
@@ -80,12 +80,16 @@ fn includes_nodes_for_destroyed_storage_nodes() {
         .multiproof(HashMap::from_iter([(hashed_address, HashSet::from_iter([hashed_slot]))]))
         .unwrap();
 
-    let witness = TrieWitness::from_tx(provider.tx_ref())
-        .compute(HashedPostState {
-            accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
-            storages: HashMap::from([(hashed_address, HashedStorage::from_iter(true, []))]), // destroyed
-        })
-        .unwrap();
+    let witness =
+        TrieWitness::from_tx(provider.tx_ref())
+            .compute(HashedPostState {
+                accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+                storages: HashMap::from_iter([(
+                    hashed_address,
+                    HashedStorage::from_iter(true, []),
+                )]), // destroyed
+            })
+            .unwrap();
     assert!(witness.contains_key(&state_root));
     for node in multiproof.account_subtree.values() {
         assert_eq!(witness.get(&keccak256(node)), Some(node));
@@ -126,8 +130,8 @@ fn correctly_decodes_branch_node_values() {
 
     let witness = TrieWitness::from_tx(provider.tx_ref())
         .compute(HashedPostState {
-            accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
-            storages: HashMap::from([(
+            accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::from_iter([(
                 hashed_address,
                 HashedStorage::from_iter(
                     false,

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -3,10 +3,9 @@ use crate::{
     forward_cursor::ForwardInMemoryCursor, HashedAccountsSorted, HashedPostStateSorted,
     HashedStorageSorted,
 };
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{map::HashSet, B256, U256};
 use reth_primitives::Account;
 use reth_storage_errors::db::DatabaseError;
-use std::collections::HashSet;
 
 /// The hashed cursor factory for the post state.
 #[derive(Clone, Debug)]

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -3,10 +3,9 @@ use crate::{
     forward_cursor::ForwardInMemoryCursor,
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
 };
-use alloy_primitives::B256;
+use alloy_primitives::{map::HashSet, B256};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie_common::{BranchNodeCompact, Nibbles};
-use std::collections::HashSet;
 
 /// The trie cursor factory for the trie updates.
 #[derive(Debug, Clone)]

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -3,9 +3,8 @@ use crate::{
     trie_cursor::{CursorSubNode, TrieCursor},
     BranchNodeCompact, Nibbles,
 };
-use alloy_primitives::B256;
+use alloy_primitives::{map::HashSet, B256};
 use reth_storage_errors::db::DatabaseError;
-use std::collections::HashSet;
 
 #[cfg(feature = "metrics")]
 use crate::metrics::WalkerMetrics;


### PR DESCRIPTION
## Description

Use alloy hash map in all trie related code. This allows eliminating unnecessary conversions like below
https://github.com/paradigmxyz/reth/blob/cb31d347464c8ec48d9a1e67e2f747575c031576/crates/trie/sparse/src/state.rs#L263-L267