### PR TITLE
chore: lower tmp ban duration for trusted or static peers

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -375,7 +375,7 @@ impl PeersManager {
             if peer.is_trusted() || peer.is_static() {
                 // For misbehaving trusted or static peers, we provide a bit more leeway when
                 // penalizing them.
-                ban_duration = self.backoff_durations.medium;
+                ban_duration = self.backoff_durations.low / 2;
             }
         }
 


### PR DESCRIPTION
this was previously 3mins which is quite long, we can lower this because odds are this happens during ramp up where one client is still offline
set it to 15s by default