### PR TITLE
perf(tree): keep storage trie around for updates

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -10,7 +10,7 @@ use reth_trie::{
 };
 use reth_trie_db::DatabaseProof;
 use reth_trie_parallel::root::ParallelStateRootError;
-use reth_trie_sparse::{SparseStateTrie, SparseStateTrieResult};
+use reth_trie_sparse::{SparseStateTrie, SparseStateTrieResult, SparseTrieError};
 use revm_primitives::{keccak256, EvmState, B256};
 use std::{
     collections::BTreeMap,
@@ -489,7 +489,7 @@ fn update_sparse_trie(
 
     // Update storage slots with new values and calculate storage roots.
     for (address, storage) in state.storages {
-        let storage_trie = trie.revealed_storage_trie_mut(&address)?;
+        let storage_trie = trie.storage_trie_mut(&address).ok_or(SparseTrieError::Blind)?;
 
         if storage.wiped {
             storage_trie.wipe();

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -489,25 +489,24 @@ fn update_sparse_trie(
 
     // Update storage slots with new values and calculate storage roots.
     for (address, storage) in state.storages {
+        let storage_trie = trie.revealed_storage_trie_mut(&address)?;
+
         if storage.wiped {
-            trie.wipe_storage(address)?;
+            storage_trie.wipe();
         }
 
         for (slot, value) in storage.storage {
             let slot_nibbles = Nibbles::unpack(slot);
             if value.is_zero() {
                 // TODO: handle blinded node error
-                trie.remove_storage_leaf(address, &slot_nibbles)?;
+                storage_trie.remove_leaf(&slot_nibbles)?;
             } else {
-                trie.update_storage_leaf(
-                    address,
-                    slot_nibbles,
-                    alloy_rlp::encode_fixed_size(&value).to_vec(),
-                )?;
+                storage_trie
+                    .update_leaf(slot_nibbles, alloy_rlp::encode_fixed_size(&value).to_vec())?;
             }
         }
 
-        trie.storage_root(address).unwrap();
+        storage_trie.root();
     }
 
     // Update accounts with new values

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -62,9 +62,17 @@ impl SparseStateTrie {
         self.revealed.get(account).is_some_and(|slots| slots.contains(slot))
     }
 
-    /// Returned mutable reference to storage sparse trie if it was revealed.
+    /// Returns mutable reference to storage sparse trie if it was revealed.
     pub fn storage_trie_mut(&mut self, account: &B256) -> Option<&mut RevealedSparseTrie> {
         self.storages.get_mut(account).and_then(|e| e.as_revealed_mut())
+    }
+
+    /// Returns mutable reference to storage sparse trie that is expected to have been revealed.
+    pub fn revealed_storage_trie_mut(
+        &mut self,
+        account: &B256,
+    ) -> SparseStateTrieResult<&mut RevealedSparseTrie> {
+        Ok(self.storage_trie_mut(account).ok_or(SparseTrieError::Blind)?)
     }
 
     /// Reveal unknown trie paths from provided leaf path and its proof for the account.

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -67,14 +67,6 @@ impl SparseStateTrie {
         self.storages.get_mut(account).and_then(|e| e.as_revealed_mut())
     }
 
-    /// Returns mutable reference to storage sparse trie that is expected to have been revealed.
-    pub fn revealed_storage_trie_mut(
-        &mut self,
-        account: &B256,
-    ) -> SparseStateTrieResult<&mut RevealedSparseTrie> {
-        Ok(self.storage_trie_mut(account).ok_or(SparseTrieError::Blind)?)
-    }
-
     /// Reveal unknown trie paths from provided leaf path and its proof for the account.
     /// NOTE: This method does not extensively validate the proof.
     pub fn reveal_account(


### PR DESCRIPTION
## Description

Keep reference to storage trie around for all updates. This prevents redundant storage trie fetches from the hashmap.