### PR TITLE
fix: correctly poll `NetworkState`

### DIFF
--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -437,7 +437,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 }
             }
 
-            'inner: loop {
+            loop {
                 // need to buffer results here to make borrow checker happy
                 let mut closed_sessions = Vec::new();
                 let mut received_responses = Vec::new();
@@ -477,7 +477,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 }
 
                 if received_responses.is_empty() {
-                    break 'inner;
+                    break;
                 }
 
                 for (peer_id, resp) in received_responses {

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -385,10 +385,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
     }
 
     /// Handle the outcome of processed response, for example directly queue another request.
-    fn on_block_response_outcome(
-        &mut self,
-        outcome: BlockResponseOutcome,
-    ) -> Option<StateAction<N>> {
+    fn on_block_response_outcome(&mut self, outcome: BlockResponseOutcome) {
         match outcome {
             BlockResponseOutcome::Request(peer, request) => {
                 self.handle_block_request(peer, request);
@@ -397,7 +394,6 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 self.peers_manager.apply_reputation_change(&peer, reputation_change);
             }
         }
-        None
     }
 
     /// Invoked when received a response from a connected peer.
@@ -405,21 +401,19 @@ impl<N: NetworkPrimitives> NetworkState<N> {
     /// Delegates the response result to the fetcher which may return an outcome specific
     /// instruction that needs to be handled in [`Self::on_block_response_outcome`]. This could be
     /// a follow-up request or an instruction to slash the peer's reputation.
-    fn on_eth_response(
-        &mut self,
-        peer: PeerId,
-        resp: PeerResponseResult<N>,
-    ) -> Option<StateAction<N>> {
-        match resp {
+    fn on_eth_response(&mut self, peer: PeerId, resp: PeerResponseResult<N>) {
+        let outcome = match resp {
             PeerResponseResult::BlockHeaders(res) => {
-                let outcome = self.state_fetcher.on_block_headers_response(peer, res)?;
-                self.on_block_response_outcome(outcome)
+                self.state_fetcher.on_block_headers_response(peer, res)
             }
             PeerResponseResult::BlockBodies(res) => {
-                let outcome = self.state_fetcher.on_block_bodies_response(peer, res)?;
-                self.on_block_response_outcome(outcome)
+                self.state_fetcher.on_block_bodies_response(peer, res)
             }
             _ => None,
+        };
+
+        if let Some(outcome) = outcome {
+            self.on_block_response_outcome(outcome);
         }
     }
 
@@ -443,48 +437,51 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 }
             }
 
-            // need to buffer results here to make borrow checker happy
-            let mut closed_sessions = Vec::new();
-            let mut received_responses = Vec::new();
+            'inner: loop {
+                // need to buffer results here to make borrow checker happy
+                let mut closed_sessions = Vec::new();
+                let mut received_responses = Vec::new();
 
-            // poll all connected peers for responses
-            for (id, peer) in &mut self.active_peers {
-                if let Some(mut response) = peer.pending_response.take() {
-                    match response.poll(cx) {
-                        Poll::Ready(res) => {
-                            // check if the error is due to a closed channel to the session
-                            if res.err().is_some_and(|err| err.is_channel_closed()) {
-                                debug!(
-                                    target: "net",
-                                    ?id,
-                                    "Request canceled, response channel from session closed."
-                                );
-                                // if the channel is closed, this means the peer session is also
-                                // closed, in which case we can invoke the [Self::on_closed_session]
-                                // immediately, preventing followup requests and propagate the
-                                // connection dropped error
-                                closed_sessions.push(*id);
-                            } else {
-                                received_responses.push((*id, res));
+                // poll all connected peers for responses
+                for (id, peer) in &mut self.active_peers {
+                    if let Some(mut response) = peer.pending_response.take() {
+                        match response.poll(cx) {
+                            Poll::Ready(res) => {
+                                // check if the error is due to a closed channel to the session
+                                if res.err().is_some_and(|err| err.is_channel_closed()) {
+                                    debug!(
+                                        target: "net",
+                                        ?id,
+                                        "Request canceled, response channel from session closed."
+                                    );
+                                    // if the channel is closed, this means the peer session is also
+                                    // closed, in which case we can invoke the
+                                    // [Self::on_closed_session]
+                                    // immediately, preventing followup requests and propagate the
+                                    // connection dropped error
+                                    closed_sessions.push(*id);
+                                } else {
+                                    received_responses.push((*id, res));
+                                }
                             }
-                        }
-                        Poll::Pending => {
-                            // not ready yet, store again.
-                            peer.pending_response = Some(response);
-                        }
-                    };
+                            Poll::Pending => {
+                                // not ready yet, store again.
+                                peer.pending_response = Some(response);
+                            }
+                        };
+                    }
                 }
-            }
 
-            for peer in closed_sessions {
-                self.on_session_closed(peer)
-            }
+                for peer in closed_sessions {
+                    self.on_session_closed(peer)
+                }
 
-            let has_received_responses = !received_responses.is_empty();
+                if received_responses.is_empty() {
+                    break 'inner;
+                }
 
-            for (peer_id, resp) in received_responses {
-                if let Some(action) = self.on_eth_response(peer_id, resp) {
-                    self.queued_messages.push_back(action);
+                for (peer_id, resp) in received_responses {
+                    self.on_eth_response(peer_id, resp);
                 }
             }
 
@@ -495,7 +492,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
 
             // We need to poll again tn case we have received any responses because they may have
             // triggered follow-up requests.
-            if self.queued_messages.is_empty() && !has_received_responses {
+            if self.queued_messages.is_empty() {
                 return Poll::Pending
             }
         }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -480,6 +480,8 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 self.on_session_closed(peer)
             }
 
+            let mut has_received_responses = !received_responses.is_empty();
+
             for (peer_id, resp) in received_responses {
                 if let Some(action) = self.on_eth_response(peer_id, resp) {
                     self.queued_messages.push_back(action);
@@ -491,7 +493,9 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 self.on_peer_action(action);
             }
 
-            if self.queued_messages.is_empty() {
+            // We need to poll again tn case we have received any responses because they may have
+            // triggered follow-up requests.
+            if self.queued_messages.is_empty() && !has_received_responses {
                 return Poll::Pending
             }
         }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -480,7 +480,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 self.on_session_closed(peer)
             }
 
-            let mut has_received_responses = !received_responses.is_empty();
+            let has_received_responses = !received_responses.is_empty();
 
             for (peer_id, resp) in received_responses {
                 if let Some(action) = self.on_eth_response(peer_id, resp) {


### PR DESCRIPTION
When processing responses from peers, they might trigger follow-up requests (i.e header response followed by body request). Right now those might end up never polled if `queued_messages` are empty

I've encountered that when writing e2e tests, it was causing ~3s delay when receiving blocks during live sync