### PR TITLE
feat: `SerdeBincodeCompat` trait

### DIFF
--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -528,7 +528,6 @@ pub(super) mod serde_bincode_compat {
     use reth_primitives::{
         serde_bincode_compat::SealedBlockWithSenders, EthPrimitives, NodePrimitives,
     };
-    use reth_primitives_traits::serde_bincode_compat::SerdeBincodeCompat;
     use reth_trie_common::serde_bincode_compat::updates::TrieUpdates;
     use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
@@ -552,7 +551,7 @@ pub(super) mod serde_bincode_compat {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct Chain<'a, N = EthPrimitives>
     where
-        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+        N: NodePrimitives,
     {
         blocks: SealedBlocksWithSenders<'a, N::Block>,
         execution_outcome: Cow<'a, ExecutionOutcome<N::Receipt>>,
@@ -566,7 +565,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<B> Serialize for SealedBlocksWithSenders<'_, B>
     where
-        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
+        B: reth_primitives_traits::Block,
     {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -584,7 +583,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'de, B> Deserialize<'de> for SealedBlocksWithSenders<'_, B>
     where
-        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
+        B: reth_primitives_traits::Block,
     {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
@@ -599,7 +598,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, N> From<&'a super::Chain<N>> for Chain<'a, N>
     where
-        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+        N: NodePrimitives,
     {
         fn from(value: &'a super::Chain<N>) -> Self {
             Self {
@@ -612,7 +611,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, N> From<Chain<'a, N>> for super::Chain<N>
     where
-        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+        N: NodePrimitives,
     {
         fn from(value: Chain<'a, N>) -> Self {
             Self {

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -525,7 +525,10 @@ pub(super) mod serde_bincode_compat {
     use crate::ExecutionOutcome;
     use alloc::borrow::Cow;
     use alloy_primitives::BlockNumber;
-    use reth_primitives::serde_bincode_compat::SealedBlockWithSenders;
+    use reth_primitives::{
+        serde_bincode_compat::SealedBlockWithSenders, EthPrimitives, NodePrimitives,
+    };
+    use reth_primitives_traits::serde_bincode_compat::SerdeBincodeCompat;
     use reth_trie_common::serde_bincode_compat::updates::TrieUpdates;
     use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
@@ -547,18 +550,24 @@ pub(super) mod serde_bincode_compat {
     /// }
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct Chain<'a> {
-        blocks: SealedBlocksWithSenders<'a>,
-        execution_outcome: Cow<'a, ExecutionOutcome>,
+    pub struct Chain<'a, N = EthPrimitives>
+    where
+        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+    {
+        blocks: SealedBlocksWithSenders<'a, N::Block>,
+        execution_outcome: Cow<'a, ExecutionOutcome<N::Receipt>>,
         trie_updates: Option<TrieUpdates<'a>>,
     }
 
     #[derive(Debug)]
-    struct SealedBlocksWithSenders<'a>(
-        Cow<'a, BTreeMap<BlockNumber, reth_primitives::SealedBlockWithSenders>>,
+    struct SealedBlocksWithSenders<'a, B: reth_primitives_traits::Block>(
+        Cow<'a, BTreeMap<BlockNumber, reth_primitives::SealedBlockWithSenders<B>>>,
     );
 
-    impl Serialize for SealedBlocksWithSenders<'_> {
+    impl<B> Serialize for SealedBlocksWithSenders<'_, B>
+    where
+        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
+    {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -573,20 +582,26 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'de> Deserialize<'de> for SealedBlocksWithSenders<'_> {
+    impl<'de, B> Deserialize<'de> for SealedBlocksWithSenders<'_, B>
+    where
+        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
+    {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
             Ok(Self(Cow::Owned(
-                BTreeMap::<BlockNumber, SealedBlockWithSenders<'_>>::deserialize(deserializer)
+                BTreeMap::<BlockNumber, SealedBlockWithSenders<'_, B>>::deserialize(deserializer)
                     .map(|blocks| blocks.into_iter().map(|(n, b)| (n, b.into())).collect())?,
             )))
         }
     }
 
-    impl<'a> From<&'a super::Chain> for Chain<'a> {
-        fn from(value: &'a super::Chain) -> Self {
+    impl<'a, N> From<&'a super::Chain<N>> for Chain<'a, N>
+    where
+        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+    {
+        fn from(value: &'a super::Chain<N>) -> Self {
             Self {
                 blocks: SealedBlocksWithSenders(Cow::Borrowed(&value.blocks)),
                 execution_outcome: Cow::Borrowed(&value.execution_outcome),
@@ -595,8 +610,11 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> From<Chain<'a>> for super::Chain {
-        fn from(value: Chain<'a>) -> Self {
+    impl<'a, N> From<Chain<'a, N>> for super::Chain<N>
+    where
+        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+    {
+        fn from(value: Chain<'a, N>) -> Self {
             Self {
                 blocks: value.blocks.0.into_owned(),
                 execution_outcome: value.execution_outcome.into_owned(),

--- a/crates/exex/types/Cargo.toml
+++ b/crates/exex/types/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # reth
 reth-chain-state.workspace = true
 reth-execution-types.workspace = true
+reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
 
 # reth

--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -98,6 +98,7 @@ pub(super) mod serde_bincode_compat {
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
     #[allow(missing_docs)]
+    #[serde(bound = "")]
     pub enum ExExNotification<'a, N = EthPrimitives>
     where
         N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,

--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -76,6 +76,8 @@ pub(super) mod serde_bincode_compat {
     use std::sync::Arc;
 
     use reth_execution_types::serde_bincode_compat::Chain;
+    use reth_primitives::{EthPrimitives, NodePrimitives};
+    use reth_primitives_traits::serde_bincode_compat::SerdeBincodeCompat;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
@@ -96,14 +98,20 @@ pub(super) mod serde_bincode_compat {
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
     #[allow(missing_docs)]
-    pub enum ExExNotification<'a> {
-        ChainCommitted { new: Chain<'a> },
-        ChainReorged { old: Chain<'a>, new: Chain<'a> },
-        ChainReverted { old: Chain<'a> },
+    pub enum ExExNotification<'a, N = EthPrimitives>
+    where
+        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+    {
+        ChainCommitted { new: Chain<'a, N> },
+        ChainReorged { old: Chain<'a, N>, new: Chain<'a, N> },
+        ChainReverted { old: Chain<'a, N> },
     }
 
-    impl<'a> From<&'a super::ExExNotification> for ExExNotification<'a> {
-        fn from(value: &'a super::ExExNotification) -> Self {
+    impl<'a, N> From<&'a super::ExExNotification<N>> for ExExNotification<'a, N>
+    where
+        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+    {
+        fn from(value: &'a super::ExExNotification<N>) -> Self {
             match value {
                 super::ExExNotification::ChainCommitted { new } => {
                     ExExNotification::ChainCommitted { new: Chain::from(new.as_ref()) }
@@ -121,8 +129,11 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'a> From<ExExNotification<'a>> for super::ExExNotification {
-        fn from(value: ExExNotification<'a>) -> Self {
+    impl<'a, N> From<ExExNotification<'a, N>> for super::ExExNotification<N>
+    where
+        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+    {
+        fn from(value: ExExNotification<'a, N>) -> Self {
             match value {
                 ExExNotification::ChainCommitted { new } => {
                     Self::ChainCommitted { new: Arc::new(new.into()) }

--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -77,7 +77,6 @@ pub(super) mod serde_bincode_compat {
 
     use reth_execution_types::serde_bincode_compat::Chain;
     use reth_primitives::{EthPrimitives, NodePrimitives};
-    use reth_primitives_traits::serde_bincode_compat::SerdeBincodeCompat;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
@@ -101,7 +100,7 @@ pub(super) mod serde_bincode_compat {
     #[serde(bound = "")]
     pub enum ExExNotification<'a, N = EthPrimitives>
     where
-        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+        N: NodePrimitives,
     {
         ChainCommitted { new: Chain<'a, N> },
         ChainReorged { old: Chain<'a, N>, new: Chain<'a, N> },
@@ -110,7 +109,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, N> From<&'a super::ExExNotification<N>> for ExExNotification<'a, N>
     where
-        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+        N: NodePrimitives,
     {
         fn from(value: &'a super::ExExNotification<N>) -> Self {
             match value {
@@ -132,7 +131,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, N> From<ExExNotification<'a, N>> for super::ExExNotification<N>
     where
-        N: NodePrimitives<BlockHeader: SerdeBincodeCompat, BlockBody: SerdeBincodeCompat>,
+        N: NodePrimitives,
     {
         fn from(value: ExExNotification<'a, N>) -> Self {
             match value {

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -4,7 +4,10 @@ use alloc::{fmt, vec::Vec};
 
 use alloy_eips::eip4895::Withdrawals;
 
-use crate::{FullSignedTx, InMemorySize, MaybeArbitrary, MaybeSerde, SignedTransaction};
+use crate::{
+    FullSignedTx, InMemorySize, MaybeArbitrary, MaybeSerde, MaybeSerdeBincodeCompat,
+    SignedTransaction,
+};
 
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
 pub trait FullBlockBody: BlockBody<Transaction: FullSignedTx> {}
@@ -26,6 +29,7 @@ pub trait BlockBody:
     + InMemorySize
     + MaybeSerde
     + MaybeArbitrary
+    + MaybeSerdeBincodeCompat
 {
     /// Ordered list of signed transactions as committed in block.
     type Transaction: SignedTransaction;

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -49,5 +49,6 @@ impl<T> BlockHeader for T where
         + InMemorySize
         + MaybeSerde
         + MaybeArbitrary
+        + MaybeSerdeBincodeCompat
 {
 }

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -4,7 +4,7 @@ use core::fmt;
 
 use alloy_primitives::Sealable;
 
-use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
+use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde, MaybeSerdeBincodeCompat};
 
 /// Helper trait that unifies all behaviour required by block header to support full node
 /// operations.
@@ -29,6 +29,7 @@ pub trait BlockHeader:
     + InMemorySize
     + MaybeSerde
     + MaybeArbitrary
+    + MaybeSerdeBincodeCompat
 {
 }
 

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -213,11 +213,8 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<H: SerdeBincodeCompat> SerializeAs<super::SealedHeader<H>> for SealedHeader<'_, H> {
-        fn serialize_as<S>(
-            source: &super::SealedHeader<H>,
-            serializer: S,
-        ) -> Result<S::Ok, S::Error>
+    impl SerializeAs<super::SealedHeader> for SealedHeader<'_> {
+        fn serialize_as<S>(source: &super::SealedHeader, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
@@ -225,10 +222,8 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
-    impl<'de, H: SerdeBincodeCompat> DeserializeAs<'de, super::SealedHeader<H>>
-        for SealedHeader<'de, H>
-    {
-        fn deserialize_as<D>(deserializer: D) -> Result<super::SealedHeader<H>, D::Error>
+    impl<'de> DeserializeAs<'de, super::SealedHeader> for SealedHeader<'de> {
+        fn deserialize_as<D>(deserializer: D) -> Result<super::SealedHeader, D::Error>
         where
             D: Deserializer<'de>,
         {

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -68,9 +68,7 @@ pub use header::{BlockWithParent, Header, HeaderError, SealedHeader};
 ///
 /// Read more: <https://github.com/bincode-org/bincode/issues/326>
 #[cfg(feature = "serde-bincode-compat")]
-pub mod serde_bincode_compat {
-    pub use super::header::{serde_bincode_compat as header, serde_bincode_compat::*};
-}
+pub mod serde_bincode_compat;
 
 /// Heuristic size trait
 pub mod size;

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -116,3 +116,16 @@ pub trait MaybeCompact {}
 impl<T> MaybeCompact for T where T: reth_codecs::Compact {}
 #[cfg(not(feature = "reth-codec"))]
 impl<T> MaybeCompact for T {}
+
+/// Helper trait that requires serde bincode compatibility implementation.
+#[cfg(feature = "serde-bincode-compat")]
+pub trait MaybeSerdeBincodeCompat: crate::serde_bincode_compat::SerdeBincodeCompat {}
+/// Noop. Helper trait that would require serde bincode compatibility implementation if
+/// `serde-bincode-compat` feature were enabled.
+#[cfg(not(feature = "serde-bincode-compat"))]
+pub trait MaybeSerdeBincodeCompat {}
+
+#[cfg(feature = "serde-bincode-compat")]
+impl<T> MaybeSerdeBincodeCompat for T where T: crate::serde_bincode_compat::SerdeBincodeCompat {}
+#[cfg(not(feature = "serde-bincode-compat"))]
+impl<T> MaybeSerdeBincodeCompat for T {}

--- a/crates/primitives-traits/src/serde_bincode_compat.rs
+++ b/crates/primitives-traits/src/serde_bincode_compat.rs
@@ -1,0 +1,14 @@
+use core::fmt::Debug;
+
+pub use super::header::{serde_bincode_compat as header, serde_bincode_compat::*};
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Trait for types that can be serialized and deserialized using bincode.
+pub trait SerdeBincodeCompat: Sized + 'static {
+    /// Serde representation of the type for bincode serialization.
+    type BincodeRepr<'a>: Debug + Serialize + DeserializeOwned + From<&'a Self> + Into<Self>;
+}
+
+impl SerdeBincodeCompat for alloy_consensus::Header {
+    type BincodeRepr<'a> = alloy_consensus::serde_bincode_compat::Header<'a>;
+}

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -744,7 +744,7 @@ pub(super) mod serde_bincode_compat {
     use alloy_consensus::serde_bincode_compat::Header;
     use alloy_eips::eip4895::Withdrawals;
     use alloy_primitives::Address;
-    use reth_primitives_traits::serde_bincode_compat::SealedHeader;
+    use reth_primitives_traits::serde_bincode_compat::{SealedHeader, SerdeBincodeCompat};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
@@ -810,6 +810,10 @@ pub(super) mod serde_bincode_compat {
         }
     }
 
+    impl SerdeBincodeCompat for super::BlockBody {
+        type BincodeRepr<'a> = BlockBody<'a>;
+    }
+
     /// Bincode-compatible [`super::SealedBlock`] serde implementation.
     ///
     /// Intended to use with the [`serde_with::serde_as`] macro in the following way:
@@ -826,19 +830,34 @@ pub(super) mod serde_bincode_compat {
     /// }
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct SealedBlock<'a> {
-        header: SealedHeader<'a>,
-        body: BlockBody<'a>,
+    pub struct SealedBlock<
+        'a,
+        H: SerdeBincodeCompat = super::Header,
+        B: SerdeBincodeCompat = super::BlockBody,
+    > {
+        header: SealedHeader<'a, H>,
+        body: B::BincodeRepr<'a>,
     }
 
-    impl<'a> From<&'a super::SealedBlock> for SealedBlock<'a> {
-        fn from(value: &'a super::SealedBlock) -> Self {
-            Self { header: SealedHeader::from(&value.header), body: BlockBody::from(&value.body) }
+    impl<'a, H, B> From<&'a super::SealedBlock<H, B>> for SealedBlock<'a, H, B>
+    where
+        H: SerdeBincodeCompat,
+        B: SerdeBincodeCompat,
+    {
+        fn from(value: &'a super::SealedBlock<H, B>) -> Self {
+            Self {
+                header: SealedHeader::from(&value.header),
+                body: B::BincodeRepr::from(&value.body),
+            }
         }
     }
 
-    impl<'a> From<SealedBlock<'a>> for super::SealedBlock {
-        fn from(value: SealedBlock<'a>) -> Self {
+    impl<'a, H, B> From<SealedBlock<'a, H, B>> for super::SealedBlock<H, B>
+    where
+        H: SerdeBincodeCompat,
+        B: SerdeBincodeCompat,
+    {
+        fn from(value: SealedBlock<'a, H, B>) -> Self {
             Self { header: value.header.into(), body: value.body.into() }
         }
     }
@@ -877,19 +896,33 @@ pub(super) mod serde_bincode_compat {
     /// }
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct SealedBlockWithSenders<'a> {
-        block: SealedBlock<'a>,
+    pub struct SealedBlockWithSenders<'a, B: reth_primitives_traits::Block = super::Block>
+    where
+        B::Header: SerdeBincodeCompat,
+        B::Body: SerdeBincodeCompat,
+    {
+        block: SealedBlock<'a, B::Header, B::Body>,
         senders: Cow<'a, Vec<Address>>,
     }
 
-    impl<'a> From<&'a super::SealedBlockWithSenders> for SealedBlockWithSenders<'a> {
-        fn from(value: &'a super::SealedBlockWithSenders) -> Self {
+    impl<'a, B: reth_primitives_traits::Block> From<&'a super::SealedBlockWithSenders<B>>
+        for SealedBlockWithSenders<'a, B>
+    where
+        B::Header: SerdeBincodeCompat,
+        B::Body: SerdeBincodeCompat,
+    {
+        fn from(value: &'a super::SealedBlockWithSenders<B>) -> Self {
             Self { block: SealedBlock::from(&value.block), senders: Cow::Borrowed(&value.senders) }
         }
     }
 
-    impl<'a> From<SealedBlockWithSenders<'a>> for super::SealedBlockWithSenders {
-        fn from(value: SealedBlockWithSenders<'a>) -> Self {
+    impl<'a, B: reth_primitives_traits::Block> From<SealedBlockWithSenders<'a, B>>
+        for super::SealedBlockWithSenders<B>
+    where
+        B::Header: SerdeBincodeCompat,
+        B::Body: SerdeBincodeCompat,
+    {
+        fn from(value: SealedBlockWithSenders<'a, B>) -> Self {
             Self { block: value.block.into(), senders: value.senders.into_owned() }
         }
     }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -898,7 +898,7 @@ pub(super) mod serde_bincode_compat {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct SealedBlockWithSenders<'a, B = super::Block>
     where
-        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
+        B: reth_primitives_traits::Block,
     {
         block: SealedBlock<'a, B::Header, B::Body>,
         senders: Cow<'a, Vec<Address>>,
@@ -906,7 +906,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, B> From<&'a super::SealedBlockWithSenders<B>> for SealedBlockWithSenders<'a, B>
     where
-        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
+        B: reth_primitives_traits::Block,
     {
         fn from(value: &'a super::SealedBlockWithSenders<B>) -> Self {
             Self { block: SealedBlock::from(&value.block), senders: Cow::Borrowed(&value.senders) }
@@ -915,7 +915,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, B> From<SealedBlockWithSenders<'a, B>> for super::SealedBlockWithSenders<B>
     where
-        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
+        B: reth_primitives_traits::Block,
     {
         fn from(value: SealedBlockWithSenders<'a, B>) -> Self {
             Self { block: value.block.into(), senders: value.senders.into_owned() }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -830,11 +830,11 @@ pub(super) mod serde_bincode_compat {
     /// }
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct SealedBlock<
-        'a,
-        H: SerdeBincodeCompat = super::Header,
-        B: SerdeBincodeCompat = super::BlockBody,
-    > {
+    pub struct SealedBlock<'a, H = super::Header, B = super::BlockBody>
+    where
+        H: SerdeBincodeCompat,
+        B: SerdeBincodeCompat,
+    {
         header: SealedHeader<'a, H>,
         body: B::BincodeRepr<'a>,
     }
@@ -896,31 +896,26 @@ pub(super) mod serde_bincode_compat {
     /// }
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct SealedBlockWithSenders<'a, B: reth_primitives_traits::Block = super::Block>
+    pub struct SealedBlockWithSenders<'a, B = super::Block>
     where
-        B::Header: SerdeBincodeCompat,
-        B::Body: SerdeBincodeCompat,
+        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         block: SealedBlock<'a, B::Header, B::Body>,
         senders: Cow<'a, Vec<Address>>,
     }
 
-    impl<'a, B: reth_primitives_traits::Block> From<&'a super::SealedBlockWithSenders<B>>
-        for SealedBlockWithSenders<'a, B>
+    impl<'a, B> From<&'a super::SealedBlockWithSenders<B>> for SealedBlockWithSenders<'a, B>
     where
-        B::Header: SerdeBincodeCompat,
-        B::Body: SerdeBincodeCompat,
+        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         fn from(value: &'a super::SealedBlockWithSenders<B>) -> Self {
             Self { block: SealedBlock::from(&value.block), senders: Cow::Borrowed(&value.senders) }
         }
     }
 
-    impl<'a, B: reth_primitives_traits::Block> From<SealedBlockWithSenders<'a, B>>
-        for super::SealedBlockWithSenders<B>
+    impl<'a, B> From<SealedBlockWithSenders<'a, B>> for super::SealedBlockWithSenders<B>
     where
-        B::Header: SerdeBincodeCompat,
-        B::Body: SerdeBincodeCompat,
+        B: reth_primitives_traits::Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         fn from(value: SealedBlockWithSenders<'a, B>) -> Self {
             Self { block: value.block.into(), senders: value.senders.into_owned() }


### PR DESCRIPTION
For integration into ExExes and HeaderStage, we need a separate serde impls appropriate for bincode serialization. Right now this is solved with helper modules but this approach doesn't work for generic primitives

This PR introduces `SerdeBincodeCompat` which allows to specify a type representation which can be serialized using bincode.