### PR TITLE
feat: add clone into consensus

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1489,7 +1489,7 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
         P: PoolTransaction<Consensus: Into<T>>,
     {
         let size = tx.encoded_length();
-        let transaction = tx.transaction.clone().into_consensus().into();
+        let transaction = tx.transaction.clone_into_consensus().into();
         let transaction = Arc::new(transaction);
         Self { size, transaction }
     }

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -142,7 +142,7 @@ where
             let l1_block_info = self.block_info.l1_block_info.read().clone();
 
             let mut encoded = Vec::with_capacity(valid_tx.transaction().encoded_length());
-            let tx: TransactionSigned = valid_tx.transaction().clone().into_consensus().into();
+            let tx: TransactionSigned = valid_tx.transaction().clone_into_consensus().into();
             tx.encode_2718(&mut encoded);
 
             let cost_addition = match l1_block_info.l1_tx_data_fee(

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -239,7 +239,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 if let Some(tx) =
                     RpcNodeCore::pool(self).get_transaction_by_sender_and_nonce(sender, nonce)
                 {
-                    let transaction = tx.transaction.clone().into_consensus();
+                    let transaction = tx.transaction.clone_into_consensus();
                     return Ok(Some(from_recovered(transaction.into(), self.tx_resp_builder())?));
                 }
             }

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -49,7 +49,7 @@ where
         {
             content.entry(tx.sender()).or_default().insert(
                 tx.nonce().to_string(),
-                from_recovered(tx.clone().into_consensus().into(), resp_builder)?,
+                from_recovered(tx.clone_into_consensus().into(), resp_builder)?,
             );
 
             Ok(())
@@ -101,7 +101,7 @@ where
             inspect: &mut BTreeMap<Address, BTreeMap<String, TxpoolInspectSummary>>,
         ) {
             let entry = inspect.entry(tx.sender()).or_default();
-            let tx: TransactionSignedEcRecovered = tx.clone().into_consensus().into();
+            let tx: TransactionSignedEcRecovered = tx.clone_into_consensus().into();
             entry.insert(
                 tx.nonce().to_string(),
                 TxpoolInspectSummary {

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -602,7 +602,7 @@ where
         .into_iter()
         .map(|tx| {
             let recovered: TransactionSignedEcRecovered =
-                tx.transaction.clone().into_consensus().into();
+                tx.transaction.clone_into_consensus().into();
             recovered.into_signed()
         })
         .collect::<Vec<_>>();

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -979,6 +979,13 @@ pub trait PoolTransaction: fmt::Debug + Send + Sync + Clone {
         tx.try_into()
     }
 
+    /// Clone the transaction into a consensus variant.
+    ///
+    /// This method is preferred when the [`PoolTransaction`] already wraps the consensus variant.
+    fn clone_into_consensus(&self) -> Self::Consensus {
+        self.clone().into_consensus()
+    }
+
     /// Define a method to convert from the `Self` type to `Consensus`
     fn into_consensus(self) -> Self::Consensus {
         self.into()
@@ -1236,6 +1243,10 @@ impl PoolTransaction for EthPooledTransaction {
     type Consensus = TransactionSignedEcRecovered;
 
     type Pooled = PooledTransactionsElementEcRecovered;
+
+    fn clone_into_consensus(&self) -> Self::Consensus {
+        self.transaction().clone()
+    }
 
     fn try_consensus_into_pooled(
         tx: Self::Consensus,

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -375,6 +375,13 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         self.is_eip4844() != other.is_eip4844()
     }
 
+    /// Converts to this type into the consensus transaction of the pooled transaction.
+    ///
+    /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
+    pub fn to_consensus(&self) -> T::Consensus {
+        self.transaction.clone_into_consensus()
+    }
+
     /// Determines whether a candidate transaction (`maybe_replacement`) is underpriced compared to
     /// an existing transaction in the pool.
     ///
@@ -433,7 +440,7 @@ impl<T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>> ValidPoo
     ///
     /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
     pub fn to_recovered_transaction(&self) -> TransactionSignedEcRecovered {
-        self.transaction.clone().into_consensus().into()
+        self.to_consensus().into()
     }
 }
 


### PR DESCRIPTION
we expect that the pool tx wraps the consensus format, so we can make  `tx.clone().into_consensus` a bit more efficient