### PR TITLE
perf: remove clone in trie walker

### DIFF
--- a/crates/trie/db/tests/walker.rs
+++ b/crates/trie/db/tests/walker.rs
@@ -63,13 +63,14 @@ where
 
     // We're traversing the path in lexicographical order.
     for expected in expected {
-        let got = walker.advance().unwrap();
+        walker.advance().unwrap();
+        let got = walker.key().cloned();
         assert_eq!(got.unwrap(), Nibbles::from_nibbles_unchecked(expected.clone()));
     }
 
     // There should be 8 paths traversed in total from 3 branches.
-    let got = walker.advance().unwrap();
-    assert!(got.is_none());
+    walker.advance().unwrap();
+    assert!(walker.key().is_none());
 }
 
 #[test]

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -145,11 +145,12 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Advances the walker to the next trie node and updates the skip node flag.
+    /// The new key can then be obtained via `key()`.
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Nibbles>, Error>` - The next key in the trie or an error.
-    pub fn advance(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+    /// * `Result<(), Error>` - Unit on success or an error.
+    pub fn advance(&mut self) -> Result<(), DatabaseError> {
         if let Some(last) = self.stack.last() {
             if !self.can_skip_current_node && self.children_are_in_trie() {
                 // If we can't skip the current node and the children are in the trie,
@@ -167,8 +168,7 @@ impl<C: TrieCursor> TrieWalker<C> {
             self.update_skip_node();
         }
 
-        // Return the current key.
-        Ok(self.key().cloned())
+        Ok(())
     }
 
     /// Retrieves the current root node from the DB, seeking either the exact node or the next one.


### PR DESCRIPTION
No one but a test is using the cloned return value. This is relatively cheap when compared to the whole state root calculation, but it's still copying 72 bytes in a hot path so...