### PR TITLE
chore: relax block impl bounds

### DIFF
--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -30,6 +30,7 @@ pub trait BlockBody:
     + MaybeSerde
     + MaybeArbitrary
     + MaybeSerdeBincodeCompat
+    + 'static
 {
     /// Ordered list of signed transactions as committed in block.
     type Transaction: SignedTransaction;

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -30,6 +30,7 @@ pub trait BlockHeader:
     + MaybeSerde
     + MaybeArbitrary
     + MaybeSerdeBincodeCompat
+    + 'static
 {
 }
 
@@ -50,5 +51,6 @@ impl<T> BlockHeader for T where
         + MaybeSerde
         + MaybeArbitrary
         + MaybeSerdeBincodeCompat
+        + 'static
 {
 }

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -41,10 +41,10 @@ pub trait Block:
     + MaybeArbitrary
 {
     /// Header part of the block.
-    type Header: BlockHeader + 'static;
+    type Header: BlockHeader;
 
     /// The block's body contains the transactions in the block.
-    type Body: BlockBody<OmmerHeader = Self::Header> + Send + Sync + Unpin + 'static;
+    type Body: BlockBody<OmmerHeader = Self::Header>;
 
     /// Create new block instance.
     fn new(header: Self::Header, body: Self::Body) -> Self;

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -457,9 +457,8 @@ where
 
 impl<H, B> reth_primitives_traits::Block for SealedBlock<H, B>
 where
-    H: reth_primitives_traits::BlockHeader + 'static,
-    B: reth_primitives_traits::BlockBody<OmmerHeader = H> + 'static,
-    Self: Serialize + for<'a> Deserialize<'a>,
+    H: reth_primitives_traits::BlockHeader,
+    B: reth_primitives_traits::BlockBody<OmmerHeader = H>,
 {
     type Header = H;
     type Body = B;


### PR DESCRIPTION
encountered in https://github.com/paradigmxyz/reth/pull/13012

we can relax this, will help transitioning more consensus impls

I've moved the 'static bound to the trait itself because we can assume that this will always be a static type