### PR TITLE
fix(engine): get_proof_targets only add fetched accounts if they have new storage

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -13,7 +13,7 @@ use reth_trie_parallel::root::ParallelStateRootError;
 use reth_trie_sparse::{SparseStateTrie, SparseStateTrieResult, SparseTrieError};
 use revm_primitives::{keccak256, EvmState, B256};
 use std::{
-    collections::{hash_map::Entry, BTreeMap},
+    collections::BTreeMap,
     sync::{
         mpsc::{self, Receiver, Sender},
         Arc,
@@ -216,7 +216,7 @@ where
         view: ConsistentDbView<Factory>,
         input: Arc<TrieInput>,
         update: EvmState,
-        fetched_proof_targets: &mut HashMap<B256, HashSet<B256>>,
+        fetched_proof_targets: &HashMap<B256, HashSet<B256>>,
         proof_sequence_number: u64,
         state_root_message_sender: Sender<StateRootMessage>,
     ) -> HashMap<B256, HashSet<B256>> {
@@ -318,7 +318,7 @@ where
         );
 
         // TODO(alexey): store proof targets in `ProofSequecner` to avoid recomputing them
-        let targets = get_proof_targets(&state, &mut HashMap::default());
+        let targets = get_proof_targets(&state, &HashMap::default());
 
         let tx = self.tx.clone();
         rayon::spawn(move || {
@@ -361,7 +361,7 @@ where
                             self.config.consistent_view.clone(),
                             self.config.input.clone(),
                             update,
-                            &mut self.fetched_proof_targets,
+                            &self.fetched_proof_targets,
                             self.proof_sequencer.next_sequence(),
                             self.tx.clone(),
                         );
@@ -469,7 +469,7 @@ where
 /// account shouldn't be included.
 fn get_proof_targets(
     state_update: &HashedPostState,
-    fetched_proof_targets: &mut HashMap<B256, HashSet<B256>>,
+    fetched_proof_targets: &HashMap<B256, HashSet<B256>>,
 ) -> HashMap<B256, HashSet<B256>> {
     let mut targets = HashMap::default();
 
@@ -821,9 +821,9 @@ mod tests {
     #[test]
     fn test_get_proof_targets_new_account_targets() {
         let state = create_get_proof_targets_state();
-        let mut fetched = HashMap::default();
+        let fetched = HashMap::default();
 
-        let targets = get_proof_targets(&state, &mut fetched);
+        let targets = get_proof_targets(&state, &fetched);
 
         // should return all accounts as targets since nothing was fetched before
         assert_eq!(targets.len(), state.accounts.len());
@@ -835,9 +835,9 @@ mod tests {
     #[test]
     fn test_get_proof_targets_new_storage_targets() {
         let state = create_get_proof_targets_state();
-        let mut fetched = HashMap::default();
+        let fetched = HashMap::default();
 
-        let targets = get_proof_targets(&state, &mut fetched);
+        let targets = get_proof_targets(&state, &fetched);
 
         // verify storage slots are included for accounts with storage
         for (addr, storage) in &state.storages {
@@ -865,7 +865,7 @@ mod tests {
         // mark the account as already fetched
         fetched.insert(*fetched_addr, HashSet::default());
 
-        let targets = get_proof_targets(&state, &mut fetched);
+        let targets = get_proof_targets(&state, &fetched);
 
         // should not include the already fetched account since it has no storage updates
         assert!(!targets.contains_key(fetched_addr));
@@ -885,7 +885,7 @@ mod tests {
         fetched_slots.insert(fetched_slot);
         fetched.insert(*addr, fetched_slots);
 
-        let targets = get_proof_targets(&state, &mut fetched);
+        let targets = get_proof_targets(&state, &fetched);
 
         // should not include the already fetched storage slot
         let target_slots = &targets[addr];
@@ -896,9 +896,9 @@ mod tests {
     #[test]
     fn test_get_proof_targets_empty_state() {
         let state = HashedPostState::default();
-        let mut fetched = HashMap::default();
+        let fetched = HashMap::default();
 
-        let targets = get_proof_targets(&state, &mut fetched);
+        let targets = get_proof_targets(&state, &fetched);
 
         assert!(targets.is_empty());
     }
@@ -925,7 +925,7 @@ mod tests {
         fetched_slots.insert(slot1);
         fetched.insert(addr1, fetched_slots);
 
-        let targets = get_proof_targets(&state, &mut fetched);
+        let targets = get_proof_targets(&state, &fetched);
 
         assert!(targets.contains_key(&addr2));
         assert!(!targets[&addr1].contains(&slot1));
@@ -935,7 +935,7 @@ mod tests {
     #[test]
     fn test_get_proof_targets_unmodified_account_with_storage() {
         let mut state = HashedPostState::default();
-        let mut fetched = HashMap::default();
+        let fetched = HashMap::default();
 
         let addr = B256::random();
         let slot1 = B256::random();
@@ -951,7 +951,7 @@ mod tests {
         assert!(!state.accounts.contains_key(&addr));
         assert!(!fetched.contains_key(&addr));
 
-        let targets = get_proof_targets(&state, &mut fetched);
+        let targets = get_proof_targets(&state, &fetched);
 
         // verify that we still get the storage slots for the unmodified account
         assert!(targets.contains_key(&addr));

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -475,7 +475,7 @@ fn get_proof_targets(
 
     // first collect all new accounts (not previously fetched)
     for &hashed_address in state_update.accounts.keys() {
-        if fetched_proof_targets.contains_key(&hashed_address) {
+        if !fetched_proof_targets.contains_key(&hashed_address) {
             targets.insert(hashed_address, HashSet::default());
         }
     }

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -13,7 +13,7 @@ use reth_trie_parallel::root::ParallelStateRootError;
 use reth_trie_sparse::{SparseStateTrie, SparseStateTrieResult, SparseTrieError};
 use revm_primitives::{keccak256, EvmState, B256};
 use std::{
-    collections::BTreeMap,
+    collections::{hash_map::Entry, BTreeMap},
     sync::{
         mpsc::{self, Receiver, Sender},
         Arc,
@@ -216,7 +216,7 @@ where
         view: ConsistentDbView<Factory>,
         input: Arc<TrieInput>,
         update: EvmState,
-        fetched_proof_targets: &HashMap<B256, HashSet<B256>>,
+        fetched_proof_targets: &mut HashMap<B256, HashSet<B256>>,
         proof_sequence_number: u64,
         state_root_message_sender: Sender<StateRootMessage>,
     ) -> HashMap<B256, HashSet<B256>> {
@@ -318,7 +318,7 @@ where
         );
 
         // TODO(alexey): store proof targets in `ProofSequecner` to avoid recomputing them
-        let targets = get_proof_targets(&state, &HashMap::default());
+        let targets = get_proof_targets(&state, &mut HashMap::default());
 
         let tx = self.tx.clone();
         rayon::spawn(move || {
@@ -361,7 +361,7 @@ where
                             self.config.consistent_view.clone(),
                             self.config.input.clone(),
                             update,
-                            &self.fetched_proof_targets,
+                            &mut self.fetched_proof_targets,
                             self.proof_sequencer.next_sequence(),
                             self.tx.clone(),
                         );
@@ -469,13 +469,13 @@ where
 /// account shouldn't be included.
 fn get_proof_targets(
     state_update: &HashedPostState,
-    fetched_proof_targets: &HashMap<B256, HashSet<B256>>,
+    fetched_proof_targets: &mut HashMap<B256, HashSet<B256>>,
 ) -> HashMap<B256, HashSet<B256>> {
     let mut targets = HashMap::default();
 
     // first collect all new accounts (not previously fetched)
     for &hashed_address in state_update.accounts.keys() {
-        if !fetched_proof_targets.contains_key(&hashed_address) {
+        if let Entry::Vacant(_) = fetched_proof_targets.entry(hashed_address) {
             targets.insert(hashed_address, HashSet::default());
         }
     }
@@ -838,9 +838,9 @@ mod tests {
     #[test]
     fn test_get_proof_targets_new_account_targets() {
         let state = create_get_proof_targets_state();
-        let fetched = HashMap::default();
+        let mut fetched = HashMap::default();
 
-        let targets = get_proof_targets(&state, &fetched);
+        let targets = get_proof_targets(&state, &mut fetched);
 
         // should return all accounts as targets since nothing was fetched before
         assert_eq!(targets.len(), state.accounts.len());
@@ -852,9 +852,9 @@ mod tests {
     #[test]
     fn test_get_proof_targets_new_storage_targets() {
         let state = create_get_proof_targets_state();
-        let fetched = HashMap::default();
+        let mut fetched = HashMap::default();
 
-        let targets = get_proof_targets(&state, &fetched);
+        let targets = get_proof_targets(&state, &mut fetched);
 
         // verify storage slots are included for accounts with storage
         for (addr, storage) in &state.storages {
@@ -882,7 +882,7 @@ mod tests {
         // mark the account as already fetched
         fetched.insert(*fetched_addr, HashSet::default());
 
-        let targets = get_proof_targets(&state, &fetched);
+        let targets = get_proof_targets(&state, &mut fetched);
 
         // should not include the already fetched account since it has no storage updates
         assert!(!targets.contains_key(fetched_addr));
@@ -902,7 +902,7 @@ mod tests {
         fetched_slots.insert(fetched_slot);
         fetched.insert(*addr, fetched_slots);
 
-        let targets = get_proof_targets(&state, &fetched);
+        let targets = get_proof_targets(&state, &mut fetched);
 
         // should not include the already fetched storage slot
         let target_slots = &targets[addr];
@@ -913,9 +913,9 @@ mod tests {
     #[test]
     fn test_get_proof_targets_empty_state() {
         let state = HashedPostState::default();
-        let fetched = HashMap::default();
+        let mut fetched = HashMap::default();
 
-        let targets = get_proof_targets(&state, &fetched);
+        let targets = get_proof_targets(&state, &mut fetched);
 
         assert!(targets.is_empty());
     }
@@ -942,7 +942,7 @@ mod tests {
         fetched_slots.insert(slot1);
         fetched.insert(addr1, fetched_slots);
 
-        let targets = get_proof_targets(&state, &fetched);
+        let targets = get_proof_targets(&state, &mut fetched);
 
         assert!(targets.contains_key(&addr2));
         assert!(!targets[&addr1].contains(&slot1));

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -482,34 +482,25 @@ fn get_proof_targets(
 
     // then process storage slots for all accounts in the state update
     for (hashed_address, storage) in &state_update.storages {
-        // only process storage if account:
-        // 1. is new (in targets), or
-        // 2. was previously fetched (in fetched_proof_targets), or
-        // 3. has storage updates even if not modified
-        if targets.contains_key(hashed_address) ||
-            fetched_proof_targets.contains_key(hashed_address) ||
-            state_update.storages.contains_key(hashed_address)
-        {
-            let target_slots = targets.entry(*hashed_address).or_default();
-            if let Some(fetched_storage_slots) = fetched_proof_targets.get(hashed_address) {
-                // We have previously fetched slots for this address
-                // Only add slots that haven't been fetched yet
-                for slot in storage.storage.keys() {
-                    if !fetched_storage_slots.contains(slot) {
-                        target_slots.insert(*slot);
-                    }
+        let target_slots = targets.entry(*hashed_address).or_default();
+        if let Some(fetched_storage_slots) = fetched_proof_targets.get(hashed_address) {
+            // We have previously fetched slots for this address
+            // Only add slots that haven't been fetched yet
+            for slot in storage.storage.keys() {
+                if !fetched_storage_slots.contains(slot) {
+                    target_slots.insert(*slot);
                 }
-            } else {
-                // No slots have been fetched for this address yet
-                // Add all slots from the storage
-                target_slots.extend(storage.storage.keys().copied());
             }
+        } else {
+            // No slots have been fetched for this address yet
+            // Add all slots from the storage
+            target_slots.extend(storage.storage.keys().copied());
+        }
 
-            // if we didn't find any new storage slots and this account was previously fetched,
-            // remove it from targets
-            if target_slots.is_empty() && fetched_proof_targets.contains_key(hashed_address) {
-                targets.remove(hashed_address);
-            }
+        // if we didn't find any new storage slots and this account was previously fetched,
+        // remove it from targets
+        if target_slots.is_empty() && fetched_proof_targets.contains_key(hashed_address) {
+            targets.remove(hashed_address);
         }
     }
 

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -475,7 +475,7 @@ fn get_proof_targets(
 
     // first collect all new accounts (not previously fetched)
     for &hashed_address in state_update.accounts.keys() {
-        if let Entry::Vacant(_) = fetched_proof_targets.entry(hashed_address) {
+        if fetched_proof_targets.contains_key(&hashed_address) {
             targets.insert(hashed_address, HashSet::default());
         }
     }

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -489,14 +489,18 @@ fn get_proof_targets(
             fetched_proof_targets.contains_key(hashed_address)
         {
             let target_slots = targets.entry(*hashed_address).or_default();
-            let fetched_storage_slots = fetched_proof_targets.get(hashed_address);
-
-            // add only storage slots that haven't been fetched yet
-            for slot in storage.storage.keys() {
-                if !fetched_storage_slots.is_some_and(|fetched_slots| fetched_slots.contains(slot))
-                {
-                    target_slots.insert(*slot);
+            if let Some(fetched_storage_slots) = fetched_proof_targets.get(hashed_address) {
+                // We have previously fetched slots for this address
+                // Only add slots that haven't been fetched yet
+                for slot in storage.storage.keys() {
+                    if !fetched_storage_slots.contains(slot) {
+                        target_slots.insert(*slot);
+                    }
                 }
+            } else {
+                // No slots have been fetched for this address yet
+                // Add all slots from the storage
+                target_slots.extend(storage.storage.keys().copied());
             }
 
             // if we didn't find any new storage slots and this account was previously fetched,

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -481,7 +481,7 @@ fn get_proof_targets(
     }
 
     // then process storage slots for all accounts in the state update
-    for (hashed_address, storage) in state_update.storages.iter() {
+    for (hashed_address, storage) in &state_update.storages {
         // only process storage if we either:
         // 1. haven't fetched this account at all (it's in our targets), or
         // 2. have fetched the account but need new storage slots

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -862,7 +862,7 @@ mod tests {
         assert!(!targets.contains_key(&new_addr));
 
         // should include accounts with storage even if fetched
-        for (addr, _) in state.storages.iter() {
+        for addr in state.storages.keys() {
             assert!(targets.contains_key(addr));
         }
     }


### PR DESCRIPTION
follow-up of #12983

The tests brought up an issue in `get_proof_targets`, accounts were always added to the output if they had any storage, no matter if they were already fetched. Now, if they are present in fetched, they are only added if they have new storage.