### PR TITLE
chore: add default for 2718 transactions

### DIFF
--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -1,13 +1,13 @@
 //! Block body abstraction.
 
-use alloc::{fmt, vec::Vec};
-use alloy_consensus::Transaction;
-use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip4895::Withdrawals};
-
 use crate::{
     FullSignedTx, InMemorySize, MaybeArbitrary, MaybeSerde, MaybeSerdeBincodeCompat,
     SignedTransaction,
 };
+use alloc::{fmt, vec::Vec};
+use alloy_consensus::Transaction;
+use alloy_eips::{eip2718::Encodable2718, eip4844::DATA_GAS_PER_BLOB, eip4895::Withdrawals};
+use alloy_primitives::Bytes;
 
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
 pub trait FullBlockBody: BlockBody<Transaction: FullSignedTx> {}
@@ -58,5 +58,25 @@ pub trait BlockBody:
             .filter_map(|tx| tx.blob_versioned_hashes())
             .map(|hashes| hashes.len() as u64 * DATA_GAS_PER_BLOB)
             .sum()
+    }
+
+    /// Returns an iterator over the encoded 2718 transactions.
+    ///
+    /// This is also known as `raw transactions`.
+    ///
+    /// See also [`Encodable2718`].
+    #[doc(alias = "raw_transactions_iter")]
+    fn encoded_2718_transactions_iter(&self) -> impl Iterator<Item = Vec<u8>> + '_ {
+        self.transactions().iter().map(|tx| tx.encoded_2718())
+    }
+
+    /// Returns a vector of encoded 2718 transactions.
+    ///
+    /// This is also known as `raw transactions`.
+    ///
+    /// See also [`Encodable2718`].
+    #[doc(alias = "raw_transactions")]
+    fn encoded_2718_transactions(&self) -> Vec<Bytes> {
+        self.encoded_2718_transactions_iter().map(Into::into).collect()
     }
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -417,13 +417,14 @@ where
         Ok(())
     }
 
-    /// Returns a vector of transactions RLP encoded with
-    /// [`alloy_eips::eip2718::Encodable2718::encoded_2718`].
-    pub fn raw_transactions(&self) -> Vec<Bytes>
-    where
-        B::Transaction: Encodable2718,
-    {
-        self.body.transactions().iter().map(|tx| tx.encoded_2718().into()).collect()
+    /// Returns a vector of encoded 2718 transactions.
+    ///
+    /// This is also known as `raw transactions`.
+    ///
+    /// See also [`Encodable2718`].
+    #[doc(alias = "raw_transactions")]
+    pub fn encoded_2718_transactions(&self) -> Vec<Bytes> {
+        self.body.encoded_2718_transactions()
     }
 }
 

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -124,7 +124,7 @@ pub fn block_to_payload(value: SealedBlock) -> ExecutionPayload {
 
 /// Converts [`SealedBlock`] to [`ExecutionPayloadV1`]
 pub fn block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
-    let transactions = value.raw_transactions();
+    let transactions = value.encoded_2718_transactions();
     ExecutionPayloadV1 {
         parent_hash: value.parent_hash,
         fee_recipient: value.beneficiary,
@@ -145,7 +145,7 @@ pub fn block_to_payload_v1(value: SealedBlock) -> ExecutionPayloadV1 {
 
 /// Converts [`SealedBlock`] to [`ExecutionPayloadV2`]
 pub fn block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
-    let transactions = value.raw_transactions();
+    let transactions = value.encoded_2718_transactions();
 
     ExecutionPayloadV2 {
         payload_inner: ExecutionPayloadV1 {
@@ -170,7 +170,7 @@ pub fn block_to_payload_v2(value: SealedBlock) -> ExecutionPayloadV2 {
 
 /// Converts [`SealedBlock`] to [`ExecutionPayloadV3`], and returns the parent beacon block root.
 pub fn block_to_payload_v3(value: SealedBlock) -> ExecutionPayloadV3 {
-    let transactions = value.raw_transactions();
+    let transactions = value.encoded_2718_transactions();
     ExecutionPayloadV3 {
         blob_gas_used: value.blob_gas_used.unwrap_or_default(),
         excess_blob_gas: value.excess_blob_gas.unwrap_or_default(),
@@ -334,7 +334,7 @@ pub fn convert_to_payload_body_v1(value: Block) -> ExecutionPayloadBodyV1 {
 
 /// Transforms a [`SealedBlock`] into a [`ExecutionPayloadV1`]
 pub fn execution_payload_from_sealed_block(value: SealedBlock) -> ExecutionPayloadV1 {
-    let transactions = value.raw_transactions();
+    let transactions = value.encoded_2718_transactions();
     ExecutionPayloadV1 {
         parent_hash: value.parent_hash,
         fee_recipient: value.beneficiary,


### PR DESCRIPTION
added this to the `Body` trait

we could also add this to `Block` with a default delegate or move to block entirely.

I also want to retire `raw_transactions` terminology in favor of 2718, but open to naming suggestions here