### PR TITLE
perf(trie): avoid (de)allocating an extra prefix set

### DIFF
--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -43,6 +43,7 @@ impl<'a, TX: DbTx> DatabaseStorageRoot<'a, TX>
             DatabaseTrieCursorFactory::new(tx),
             DatabaseHashedCursorFactory::new(tx),
             address,
+            Default::default(),
             #[cfg(feature = "metrics")]
             TrieRootMetrics::new(TrieType::Storage),
         )
@@ -53,6 +54,7 @@ impl<'a, TX: DbTx> DatabaseStorageRoot<'a, TX>
             DatabaseTrieCursorFactory::new(tx),
             DatabaseHashedCursorFactory::new(tx),
             hashed_address,
+            Default::default(),
             #[cfg(feature = "metrics")]
             TrieRootMetrics::new(TrieType::Storage),
         )
@@ -70,10 +72,10 @@ impl<'a, TX: DbTx> DatabaseStorageRoot<'a, TX>
             DatabaseTrieCursorFactory::new(tx),
             HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
             address,
+            prefix_set,
             #[cfg(feature = "metrics")]
             TrieRootMetrics::new(TrieType::Storage),
         )
-        .with_prefix_set(prefix_set)
         .root()
     }
 }

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -115,10 +115,10 @@ where
                         trie_cursor_factory,
                         hashed_state,
                         hashed_address,
+                        prefix_set,
                         #[cfg(feature = "metrics")]
                         metrics,
                     )
-                    .with_prefix_set(prefix_set)
                     .calculate(retain_updates)?)
                 })();
                 let _ = tx.send(result);
@@ -173,6 +173,7 @@ where
                                 trie_cursor_factory.clone(),
                                 hashed_cursor_factory.clone(),
                                 hashed_address,
+                                Default::default(),
                                 #[cfg(feature = "metrics")]
                                 self.metrics.storage_trie.clone(),
                             )

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -202,15 +202,13 @@ where
                         self.trie_cursor_factory.clone(),
                         self.hashed_cursor_factory.clone(),
                         hashed_address,
-                        #[cfg(feature = "metrics")]
-                        self.metrics.storage_trie.clone(),
-                    )
-                    .with_prefix_set(
                         self.prefix_sets
                             .storage_prefix_sets
                             .get(&hashed_address)
                             .cloned()
                             .unwrap_or_default(),
+                        #[cfg(feature = "metrics")]
+                        self.metrics.storage_trie.clone(),
                     );
 
                     let storage_root = if retain_updates {
@@ -301,29 +299,32 @@ impl<T, H> StorageRoot<T, H> {
         trie_cursor_factory: T,
         hashed_cursor_factory: H,
         address: Address,
+        prefix_set: PrefixSet,
         #[cfg(feature = "metrics")] metrics: TrieRootMetrics,
     ) -> Self {
         Self::new_hashed(
             trie_cursor_factory,
             hashed_cursor_factory,
             keccak256(address),
+            prefix_set,
             #[cfg(feature = "metrics")]
             metrics,
         )
     }
 
     /// Creates a new storage root calculator given a hashed address.
-    pub fn new_hashed(
+    pub const fn new_hashed(
         trie_cursor_factory: T,
         hashed_cursor_factory: H,
         hashed_address: B256,
+        prefix_set: PrefixSet,
         #[cfg(feature = "metrics")] metrics: TrieRootMetrics,
     ) -> Self {
         Self {
             trie_cursor_factory,
             hashed_cursor_factory,
             hashed_address,
-            prefix_set: PrefixSet::default(),
+            prefix_set,
             #[cfg(feature = "metrics")]
             metrics,
         }


### PR DESCRIPTION
Previously we created `StorageRoot` with a `PrefixSet::Default` only to replace it immediately with `with_prefix_set`. This extra (de)allocation is not cheap as it has an `Arc` and is in the hot path of processing each leaf account node. We profiled live root calculation for new blocks with 10k-50k of account changes and `StateRoot::calculate` spent 1-2% of its time deallocating this extra prefix set. It is more expensive than RLP-encoding the accounts and ~25x more than #13004.  

<img width="870" alt="image" src="https://github.com/user-attachments/assets/bbc398ef-eec1-409a-874d-20ca8c2a80c1">
