### PR TITLE
feat: allow passing generic block to `Consensus::validate_post_execution`

### DIFF
--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -211,8 +211,8 @@ impl AppendableChain {
 
         let state = executor.execute((&block, U256::MAX).into())?;
         externals.consensus.validate_block_post_execution(
-            &block,
-            PostExecutionInput::new(&state.receipts, &state.requests),
+            &block.block,
+            PostExecutionInput::new(&block.senders, &state.receipts, &state.requests),
         )?;
 
         let initial_execution_outcome = ExecutionOutcome::from((state, block.number));

--- a/crates/consensus/consensus/src/noop.rs
+++ b/crates/consensus/consensus/src/noop.rs
@@ -1,6 +1,6 @@
 use crate::{Consensus, ConsensusError, HeaderValidator, PostExecutionInput};
 use alloy_primitives::U256;
-use reth_primitives::{BlockWithSenders, SealedBlock, SealedHeader};
+use reth_primitives::{SealedBlock, SealedHeader};
 
 /// A Consensus implementation that does nothing.
 #[derive(Debug, Copy, Clone, Default)]
@@ -45,9 +45,10 @@ impl<H, B> Consensus<H, B> for NoopConsensus {
         Ok(())
     }
 
-    fn validate_block_post_execution(
+    fn validate_post_execution(
         &self,
-        _block: &BlockWithSenders,
+        _header: &H,
+        _body: &B,
         _input: PostExecutionInput<'_>,
     ) -> Result<(), ConsensusError> {
         Ok(())

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::{Consensus, ConsensusError, HeaderValidator, PostExecutionInput};
 use alloy_primitives::U256;
 use core::sync::atomic::{AtomicBool, Ordering};
-use reth_primitives::{BlockWithSenders, SealedBlock, SealedHeader};
+use reth_primitives::{SealedBlock, SealedHeader};
 
 /// Consensus engine implementation for testing
 #[derive(Debug)]
@@ -70,9 +70,10 @@ impl<H, B> Consensus<H, B> for TestConsensus {
         }
     }
 
-    fn validate_block_post_execution(
+    fn validate_post_execution(
         &self,
-        _block: &BlockWithSenders,
+        _header: &H,
+        _body: &B,
         _input: PostExecutionInput<'_>,
     ) -> Result<(), ConsensusError> {
         if self.fail_validation() {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2222,8 +2222,8 @@ where
         trace!(target: "engine::tree", elapsed=?exec_time.elapsed(), ?block_number, "Executed block");
 
         if let Err(err) = self.consensus.validate_block_post_execution(
-            &block,
-            PostExecutionInput::new(&output.receipts, &output.requests),
+            &block.block,
+            PostExecutionInput::new(&block.senders, &output.receipts, &output.requests),
         ) {
             // call post-block hook
             self.invalid_block_hook.on_invalid_block(

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -18,7 +18,7 @@ use reth_consensus_common::validation::{
     validate_against_parent_timestamp, validate_block_pre_execution, validate_body_against_header,
     validate_header_base_fee, validate_header_extradata, validate_header_gas,
 };
-use reth_primitives::{BlockBody, BlockWithSenders, SealedBlock, SealedHeader};
+use reth_primitives::{BlockBody, SealedBlock, SealedHeader};
 use reth_primitives_traits::constants::MINIMUM_GAS_LIMIT;
 use std::{fmt::Debug, sync::Arc, time::SystemTime};
 
@@ -26,7 +26,7 @@ use std::{fmt::Debug, sync::Arc, time::SystemTime};
 pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 
 mod validation;
-pub use validation::validate_block_post_execution;
+pub use validation::validate_post_execution;
 
 /// Ethereum beacon consensus
 ///
@@ -105,12 +105,13 @@ impl<ChainSpec: Send + Sync + EthChainSpec + EthereumHardforks + Debug> Consensu
         validate_block_pre_execution(block, &self.chain_spec)
     }
 
-    fn validate_block_post_execution(
+    fn validate_post_execution(
         &self,
-        block: &BlockWithSenders,
+        header: &Header,
+        _body: &BlockBody,
         input: PostExecutionInput<'_>,
     ) -> Result<(), ConsensusError> {
-        validate_block_post_execution(block, &self.chain_spec, input.receipts, input.requests)
+        validate_post_execution(header, &self.chain_spec, input.receipts, input.requests)
     }
 }
 

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -1,25 +1,26 @@
+use alloy_consensus::BlockHeader;
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::{Bloom, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::ConsensusError;
-use reth_primitives::{gas_spent_by_transactions, BlockWithSenders, GotExpected, Receipt};
+use reth_primitives::{gas_spent_by_transactions, GotExpected, Receipt};
 
 /// Validate a block with regard to execution results:
 ///
 /// - Compares the receipts root in the block header to the block body
 /// - Compares the gas used in the block header to the actual gas usage after execution
-pub fn validate_block_post_execution<ChainSpec: EthereumHardforks>(
-    block: &BlockWithSenders,
-    chain_spec: &ChainSpec,
+pub fn validate_post_execution<H: BlockHeader>(
+    header: &H,
+    chain_spec: impl EthereumHardforks,
     receipts: &[Receipt],
     requests: &Requests,
 ) -> Result<(), ConsensusError> {
     // Check if gas used matches the value set in header.
     let cumulative_gas_used =
         receipts.last().map(|receipt| receipt.cumulative_gas_used).unwrap_or(0);
-    if block.gas_used != cumulative_gas_used {
+    if header.gas_used() != cumulative_gas_used {
         return Err(ConsensusError::BlockGasUsed {
-            gas: GotExpected { got: cumulative_gas_used, expected: block.gas_used },
+            gas: GotExpected { got: cumulative_gas_used, expected: header.gas_used() },
             gas_spent_by_tx: gas_spent_by_transactions(receipts),
         })
     }
@@ -28,18 +29,16 @@ pub fn validate_block_post_execution<ChainSpec: EthereumHardforks>(
     // operation as hashing that is required for state root got calculated in every
     // transaction This was replaced with is_success flag.
     // See more about EIP here: https://eips.ethereum.org/EIPS/eip-658
-    if chain_spec.is_byzantium_active_at_block(block.header.number) {
-        if let Err(error) =
-            verify_receipts(block.header.receipts_root, block.header.logs_bloom, receipts)
-        {
+    if chain_spec.is_byzantium_active_at_block(header.number()) {
+        if let Err(error) = verify_receipts(header.receipts_root(), header.logs_bloom(), receipts) {
             tracing::debug!(%error, ?receipts, "receipts verification failed");
             return Err(error)
         }
     }
 
     // Validate that the header requests hash matches the calculated requests hash
-    if chain_spec.is_prague_active_at_timestamp(block.timestamp) {
-        let Some(header_requests_hash) = block.header.requests_hash else {
+    if chain_spec.is_prague_active_at_timestamp(header.timestamp()) {
+        let Some(header_requests_hash) = header.requests_hash() else {
             return Err(ConsensusError::RequestsHashMissing)
         };
         let requests_hash = requests.requests_hash();

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -10,7 +10,7 @@ use alloy_eips::eip7685::Requests;
 use core::fmt::Display;
 use reth_chainspec::{ChainSpec, EthereumHardfork, EthereumHardforks, MAINNET};
 use reth_consensus::ConsensusError;
-use reth_ethereum_consensus::validate_block_post_execution;
+use reth_ethereum_consensus::validate_post_execution;
 use reth_evm::{
     execute::{
         BasicBlockExecutorProvider, BlockExecutionError, BlockExecutionStrategy,
@@ -282,7 +282,7 @@ where
         receipts: &[Receipt],
         requests: &Requests,
     ) -> Result<(), ConsensusError> {
-        validate_block_post_execution(block, &self.chain_spec.clone(), receipts, requests)
+        validate_post_execution(&block.header, &self.chain_spec, receipts, requests)
     }
 }
 

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -21,14 +21,14 @@ use reth_consensus_common::validation::{
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
-use reth_primitives::{BlockBody, BlockWithSenders, GotExpected, SealedBlock, SealedHeader};
+use reth_primitives::{BlockBody, GotExpected, SealedBlock, SealedHeader};
 use std::{sync::Arc, time::SystemTime};
 
 mod proof;
 pub use proof::calculate_receipt_root_no_memo_optimism;
 
 mod validation;
-pub use validation::validate_block_post_execution;
+pub use validation::validate_post_execution;
 
 /// Optimism consensus implementation.
 ///
@@ -81,12 +81,13 @@ impl Consensus for OpBeaconConsensus {
         Ok(())
     }
 
-    fn validate_block_post_execution(
+    fn validate_post_execution(
         &self,
-        block: &BlockWithSenders,
+        header: &Header,
+        _body: &BlockBody,
         input: PostExecutionInput<'_>,
     ) -> Result<(), ConsensusError> {
-        validate_block_post_execution(block, &self.chain_spec, input.receipts)
+        validate_post_execution(header, &self.chain_spec, input.receipts)
     }
 }
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -18,7 +18,7 @@ use reth_evm::{
     ConfigureEvm, TxEnvOverrides,
 };
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_consensus::validate_block_post_execution;
+use reth_optimism_consensus::validate_post_execution;
 use reth_optimism_forks::OpHardfork;
 use reth_optimism_primitives::OpPrimitives;
 use reth_primitives::{BlockWithSenders, Receipt, TxType};
@@ -284,7 +284,7 @@ where
         receipts: &[Receipt],
         _requests: &Requests,
     ) -> Result<(), ConsensusError> {
-        validate_block_post_execution(block, &self.chain_spec.clone(), receipts)
+        validate_post_execution(&block.header, &self.chain_spec.clone(), receipts)
     }
 }
 

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -178,8 +178,8 @@ where
         }
 
         self.consensus.validate_block_post_execution(
-            &block,
-            PostExecutionInput::new(&output.receipts, &output.requests),
+            &block.block,
+            PostExecutionInput::new(&block.senders, &output.receipts, &output.requests),
         )?;
 
         self.ensure_payment(&block, &output, &message)?;


### PR DESCRIPTION
Right now this takes `BlockWithSenders` which uses the default `Block` type:
https://github.com/paradigmxyz/reth/blob/36eaf565d9b7f40b05b10df4b1de0d0a9bfe955f/crates/consensus/consensus/src/lib.rs#L77-L81

However, we need to be able to pass arbitrary blocks with configured header and body into this method.

To avoid changing Consensus generics which will result in additional generics for networking components, this PR proposes different approach:
- `senders` vector is moved to `PostExecutionInput`
- `validate_post_execution` fn is added to `Consensus` which takes header, body and `PostExecutionInput` and performs same checks as `validate_block_post_execution`
- `validate_block_post_execution` is changed to be generic over `Block<Header = H, Body = B>` and invokes `validate_post_execution` by default, allowing to be callable on trait objects