### PR TITLE
feat(executor): send EvmState in state hook

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -48,7 +48,7 @@ use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
 use reth_trie::{updates::TrieUpdates, HashedPostState, TrieInput};
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
-use revm_primitives::ResultAndState;
+use revm_primitives::EvmState;
 use std::{
     cmp::Ordering,
     collections::{btree_map, hash_map, BTreeMap, VecDeque},
@@ -2212,7 +2212,7 @@ where
 
         // TODO: create StateRootTask with the receiving end of a channel and
         // pass the sending end of the channel to the state hook.
-        let noop_state_hook = |_result_and_state: &ResultAndState| {};
+        let noop_state_hook = |_state: &EvmState| {};
         let output = self.metrics.executor.execute_metered(
             executor,
             (&block, U256::MAX).into(),

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -193,7 +193,7 @@ where
                     error: Box::new(new_err),
                 }
             })?;
-            self.system_caller.on_state(&result_and_state);
+            self.system_caller.on_state(&result_and_state.state);
             let ResultAndState { result, state } = result_and_state;
             evm.db_mut().commit(state);
 

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -19,7 +19,7 @@ mod eip7251;
 
 /// A hook that is called after each state change.
 pub trait OnStateHook {
-    /// Invoked with the result and state after each system call.
+    /// Invoked with the state after each system call.
     fn on_state(&mut self, state: &EvmState);
 }
 

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -10,7 +10,7 @@ use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::BlockExecutionError;
 use reth_primitives::Block;
 use revm::{Database, DatabaseCommit, Evm};
-use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ResultAndState, B256};
+use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, EvmState, B256};
 
 mod eip2935;
 mod eip4788;
@@ -20,14 +20,14 @@ mod eip7251;
 /// A hook that is called after each state change.
 pub trait OnStateHook {
     /// Invoked with the result and state after each system call.
-    fn on_state(&mut self, state: &ResultAndState);
+    fn on_state(&mut self, state: &EvmState);
 }
 
 impl<F> OnStateHook for F
 where
-    F: FnMut(&ResultAndState),
+    F: FnMut(&EvmState),
 {
-    fn on_state(&mut self, state: &ResultAndState) {
+    fn on_state(&mut self, state: &EvmState) {
         self(state)
     }
 }
@@ -38,7 +38,7 @@ where
 pub struct NoopHook;
 
 impl OnStateHook for NoopHook {
-    fn on_state(&mut self, _state: &ResultAndState) {}
+    fn on_state(&mut self, _state: &EvmState) {}
 }
 
 /// An ephemeral helper type for executing system calls.
@@ -182,7 +182,7 @@ where
 
         if let Some(res) = result_and_state {
             if let Some(ref mut hook) = self.hook {
-                hook.on_state(&res);
+                hook.on_state(&res.state);
             }
             evm.context.evm.db.commit(res.state);
         }
@@ -237,7 +237,7 @@ where
 
         if let Some(res) = result_and_state {
             if let Some(ref mut hook) = self.hook {
-                hook.on_state(&res);
+                hook.on_state(&res.state);
             }
             evm.context.evm.db.commit(res.state);
         }
@@ -276,7 +276,7 @@ where
             eip7002::transact_withdrawal_requests_contract_call(&self.evm_config.clone(), evm)?;
 
         if let Some(ref mut hook) = self.hook {
-            hook.on_state(&result_and_state);
+            hook.on_state(&result_and_state.state);
         }
         evm.context.evm.db.commit(result_and_state.state);
 
@@ -314,7 +314,7 @@ where
             eip7251::transact_consolidation_requests_contract_call(&self.evm_config.clone(), evm)?;
 
         if let Some(ref mut hook) = self.hook {
-            hook.on_state(&result_and_state);
+            hook.on_state(&result_and_state.state);
         }
         evm.context.evm.db.commit(result_and_state.state);
 
@@ -322,7 +322,7 @@ where
     }
 
     /// Delegate to stored `OnStateHook`, noop if hook is `None`.
-    pub fn on_state(&mut self, state: &ResultAndState) {
+    pub fn on_state(&mut self, state: &EvmState) {
         if let Some(ref mut hook) = &mut self.hook {
             hook.on_state(state);
         }

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -221,7 +221,7 @@ where
                 ?transaction,
                 "Executed transaction"
             );
-            self.system_caller.on_state(&result_and_state);
+            self.system_caller.on_state(&result_and_state.state);
             let ResultAndState { result, state } = result_and_state;
             evm.db_mut().commit(state);
 


### PR DESCRIPTION
Towards #13024

We are only using the `EvmState` part of `ResultAndState`, `Result` is being discarded.