### PR TITLE
feat(op): Rely on upstream impl's for `OpTxType` wrapper

### DIFF
--- a/crates/optimism/primitives/src/transaction/tx_type.rs
+++ b/crates/optimism/primitives/src/transaction/tx_type.rs
@@ -93,7 +93,7 @@ impl Default for OpTxType {
 
 impl PartialEq<u8> for OpTxType {
     fn eq(&self, other: &u8) -> bool {
-        self.0.eq(other) // Use inner type's implementation
+        self.0.eq(other)
     }
 }
 


### PR DESCRIPTION
We created a wrapper on `alloy:OpTxType` in https://github.com/paradigmxyz/reth/pull/12443.

At that time, the upstream code missed some trait impl's, and we had to introduce some manual implementations due to orphan rule: https://github.com/paradigmxyz/reth/pull/12443#discussion_r1836621032

Now that upstream code is matured, we can rely on them instead of writing our own custom logic for the inner type.

Fixes #13031 

