### PR TITLE
refactor: use is_none_or instead of map_or

### DIFF
--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -335,7 +335,7 @@ pub fn shared_capability_offsets(
             // highest wins, others are ignored
             if shared_capabilities
                 .get(&peer_capability.name)
-                .map_or(true, |v| peer_capability.version > v.version)
+                .is_none_or(|v| peer_capability.version > v.version)
             {
                 shared_capabilities.insert(
                     peer_capability.name.clone(),

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -49,7 +49,7 @@ impl Account {
     pub fn is_empty(&self) -> bool {
         self.nonce == 0 &&
             self.balance.is_zero() &&
-            self.bytecode_hash.map_or(true, |hash| hash == KECCAK_EMPTY)
+            self.bytecode_hash.is_none_or(|hash| hash == KECCAK_EMPTY)
     }
 
     /// Returns an account bytecode's hash.

--- a/crates/revm/src/batch.rs
+++ b/crates/revm/src/batch.rs
@@ -112,7 +112,7 @@ impl<T> BlockBatchRecord<T> {
 
     /// Returns the [`BundleRetention`] for the given block based on the configured prune modes.
     pub fn bundle_retention(&self, block_number: BlockNumber) -> BundleRetention {
-        if self.tip.map_or(true, |tip| {
+        if self.tip.is_none_or(|tip| {
             !self
                 .prune_modes
                 .account_history

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -92,7 +92,7 @@ impl StaticFileTargets {
         ]
         .iter()
         .all(|(target_block_range, highest_static_fileted_block)| {
-            target_block_range.map_or(true, |target_block_range| {
+            target_block_range.is_none_or(|target_block_range| {
                 *target_block_range.start() ==
                     highest_static_fileted_block.map_or(0, |highest_static_fileted_block| {
                         highest_static_fileted_block + 1

--- a/crates/tracing/src/formatter.rs
+++ b/crates/tracing/src/formatter.rs
@@ -54,7 +54,7 @@ impl LogFormat {
             .unwrap_or_else(|_|
                 // If `RUST_LOG_TARGET` is not set, show target in logs only if the max enabled
                 // level is higher than INFO (DEBUG, TRACE)
-                filter.max_level_hint().map_or(true, |max_level| max_level > tracing::Level::INFO));
+                filter.max_level_hint().is_none_or(|max_level| max_level > tracing::Level::INFO));
 
         match self {
             Self::Json => {

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -461,7 +461,7 @@ impl FinalizedBlockTracker {
         let finalized = finalized_block?;
         self.last_finalized_block
             .replace(finalized)
-            .map_or(true, |last| last < finalized)
+            .is_none_or(|last| last < finalized)
             .then_some(finalized)
     }
 }

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -57,7 +57,7 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
             if best.transaction.max_fee_per_gas() >= self.base_fee as u128 &&
                 best.transaction
                     .max_fee_per_blob_gas()
-                    .map_or(true, |fee| fee >= self.base_fee_per_blob_gas as u128)
+                    .is_none_or(|fee| fee >= self.base_fee_per_blob_gas as u128)
             {
                 return Some(best);
             }

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -76,7 +76,7 @@ impl CursorSubNode {
     pub fn state_flag(&self) -> bool {
         self.node
             .as_ref()
-            .map_or(true, |node| self.nibble < 0 || node.state_mask.is_bit_set(self.nibble as u8))
+            .is_none_or(|node| self.nibble < 0 || node.state_mask.is_bit_set(self.nibble as u8))
     }
 
     /// Returns `true` if the tree flag is set for the current nibble.
@@ -84,7 +84,7 @@ impl CursorSubNode {
     pub fn tree_flag(&self) -> bool {
         self.node
             .as_ref()
-            .map_or(true, |node| self.nibble < 0 || node.tree_mask.is_bit_set(self.nibble as u8))
+            .is_none_or(|node| self.nibble < 0 || node.tree_mask.is_bit_set(self.nibble as u8))
     }
 
     /// Returns `true` if the current nibble has a root hash.


### PR DESCRIPTION
currently some time have a error like, this PR will fix it
```
error: this `map_or` can be simplified
  --> crates/primitives-traits/src/account.rs:52:13
   |
52 |             self.bytecode_hash.map_or(true, |hash| hash == KECCAK_EMPTY)
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use is_none_or instead: `self.bytecode_hash.is_none_or(|hash| hash == KECCAK_EMPTY)`
```
Example -> https://github.com/paradigmxyz/reth/actions/runs/12095789021/job/33729355229