### PR TITLE
feat: make ommers table generic over header

### DIFF
--- a/crates/cli/commands/src/test_vectors/tables.rs
+++ b/crates/cli/commands/src/test_vectors/tables.rs
@@ -72,7 +72,7 @@ pub fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
         (HeaderNumbers, PER_TABLE, TABLE),
         (Headers<Header>, PER_TABLE, TABLE),
         (BlockBodyIndices, PER_TABLE, TABLE),
-        (BlockOmmers, 100, TABLE),
+        (BlockOmmers<Header>, 100, TABLE),
         (TransactionHashNumbers, PER_TABLE, TABLE),
         (Transactions<TransactionSignedNoHash>, 100, TABLE),
         (PlainStorageState, PER_TABLE, DUPSORT),

--- a/crates/optimism/storage/src/lib.rs
+++ b/crates/optimism/storage/src/lib.rs
@@ -13,7 +13,7 @@
 mod tests {
     use reth_codecs::{test_utils::UnusedBits, validate_bitflag_backwards_compat};
     use reth_db_api::models::{
-        CompactClientVersion, CompactU256, CompactU64, StoredBlockBodyIndices, StoredBlockOmmers,
+        CompactClientVersion, CompactU256, CompactU64, StoredBlockBodyIndices,
         StoredBlockWithdrawals,
     };
     use reth_primitives::{Account, Receipt};
@@ -43,7 +43,6 @@ mod tests {
         assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
-        assert_eq!(StoredBlockOmmers::bitflag_encoded_bytes(), 0);
         assert_eq!(StoredBlockWithdrawals::bitflag_encoded_bytes(), 0);
         assert_eq!(StorageHashingCheckpoint::bitflag_encoded_bytes(), 1);
 
@@ -67,7 +66,6 @@ mod tests {
         validate_bitflag_backwards_compat!(StageCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(StageUnitCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockBodyIndices, UnusedBits::Zero);
-        validate_bitflag_backwards_compat!(StoredBlockOmmers, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockWithdrawals, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StorageHashingCheckpoint, UnusedBits::NotZero);
     }

--- a/crates/storage/db-api/src/models/blocks.rs
+++ b/crates/storage/db-api/src/models/blocks.rs
@@ -8,12 +8,30 @@ use serde::{Deserialize, Serialize};
 /// The storage representation of a block's ommers.
 ///
 /// It is stored as the headers of the block's uncles.
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, Compact)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[add_arbitrary_tests(compact)]
-pub struct StoredBlockOmmers {
+pub struct StoredBlockOmmers<H = Header> {
     /// The block headers of this block's uncles.
-    pub ommers: Vec<Header>,
+    pub ommers: Vec<H>,
+}
+
+impl<H: Compact> Compact for StoredBlockOmmers<H> {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let mut buffer = bytes::BytesMut::new();
+        self.ommers.to_compact(&mut buffer);
+        let total_length = buffer.len();
+        buf.put(buffer);
+        total_length
+    }
+
+    fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let (ommers, new_buf) = Vec::from_compact(buf, buf.len());
+        (Self { ommers }, new_buf)
+    }
 }
 
 /// Hash of the block header.
@@ -30,5 +48,19 @@ mod tests {
         ommer.ommers.push(Header::default());
         ommer.ommers.push(Header::default());
         assert_eq!(ommer.clone(), StoredBlockOmmers::decompress(&ommer.compress()).unwrap());
+    }
+
+    #[test]
+    fn fuzz_stored_block_ommers() {
+        fuzz_test_stored_block_ommers(StoredBlockOmmers::default())
+    }
+
+    #[test_fuzz::test_fuzz]
+    fn fuzz_test_stored_block_ommers(obj: StoredBlockOmmers) {
+        use reth_codecs::Compact;
+        let mut buf = vec![];
+        let len = obj.to_compact(&mut buf);
+        let (same_obj, _) = StoredBlockOmmers::from_compact(buf.as_ref(), len);
+        assert_eq!(obj, same_obj);
     }
 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -189,9 +189,9 @@ impl Decode for ClientVersion {
 
 /// Implements compression for Compact type.
 macro_rules! impl_compression_for_compact {
-    ($($name:tt),+) => {
+    ($($name:ident$(<$($generic:ident),*>)?),+) => {
         $(
-            impl Compress for $name {
+            impl$(<$($generic: core::fmt::Debug + Send + Sync + Compact),*>)? Compress for $name$(<$($generic),*>)? {
                 type Compressed = Vec<u8>;
 
                 fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
@@ -199,8 +199,8 @@ macro_rules! impl_compression_for_compact {
                 }
             }
 
-            impl Decompress for $name {
-                fn decompress(value: &[u8]) -> Result<$name, $crate::DatabaseError> {
+            impl$(<$($generic: core::fmt::Debug + Send + Sync + Compact),*>)? Decompress for $name$(<$($generic),*>)? {
+                fn decompress(value: &[u8]) -> Result<$name$(<$($generic),*>)?, $crate::DatabaseError> {
                     let (obj, _) = Compact::from_compact(value, value.len());
                     Ok(obj)
                 }
@@ -222,7 +222,7 @@ impl_compression_for_compact!(
     StoredNibblesSubKey,
     StorageTrieEntry,
     StoredBlockBodyIndices,
-    StoredBlockOmmers,
+    StoredBlockOmmers<H>,
     StoredBlockWithdrawals,
     Bytecode,
     AccountBeforeTx,

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -339,7 +339,6 @@ mod tests {
         assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
-        assert_eq!(StoredBlockOmmers::bitflag_encoded_bytes(), 0);
         assert_eq!(StoredBlockWithdrawals::bitflag_encoded_bytes(), 0);
         assert_eq!(StorageHashingCheckpoint::bitflag_encoded_bytes(), 1);
 
@@ -360,7 +359,6 @@ mod tests {
         validate_bitflag_backwards_compat!(StageCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(StageUnitCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockBodyIndices, UnusedBits::Zero);
-        validate_bitflag_backwards_compat!(StoredBlockOmmers, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockWithdrawals, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StorageHashingCheckpoint, UnusedBits::NotZero);
     }

--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -139,6 +139,7 @@ macro_rules! tables {
             impl$(<$($generic),*>)? reth_db_api::table::Table for $name$(<$($generic),*>)?
             where
                 $value: reth_db_api::table::Value + 'static
+                $($(,$generic: Send + Sync)*)?
             {
                 const NAME: &'static str = table_names::$name;
                 const DUPSORT: bool = tables!(@bool $($subkey)?);
@@ -314,9 +315,9 @@ tables! {
     }
 
     /// Stores the uncles/ommers of the block.
-    table BlockOmmers {
+    table BlockOmmers<H = Header> {
         type Key = BlockNumber;
-        type Value = StoredBlockOmmers;
+        type Value = StoredBlockOmmers<H>;
     }
 
     /// Stores the block withdrawals.


### PR DESCRIPTION
Makes `StoredBlockOmmers` and `BlockOmmers` table generic over header.

The expansion of Compact before the PR for reference:
```rust
impl StoredBlockOmmers {
    #[doc = "Used bytes by [`StoredBlockOmmersFlags`]"]
    pub const fn bitflag_encoded_bytes() -> usize {
        0
    }
    #[doc = "Unused bits for new fields by [`StoredBlockOmmersFlags`]"]
    pub const fn bitflag_unused_bits() -> usize {
        0
    }
}
#[doc = r" Placeholder struct for when there is no need for a fieldset. Doesn't actually write or read any data."]
#[derive(Debug, Default)]
pub struct StoredBlockOmmersFlags {}

impl StoredBlockOmmersFlags {
    #[doc = r" Placeholder: does not read any value."]
    pub fn from(mut buf: &[u8]) -> (Self, &[u8]) {
        (StoredBlockOmmersFlags::default(), buf)
    }
    #[doc = r" Placeholder: returns an empty array."]
    pub fn into_bytes(self) -> [u8; 0] {
        []
    }
}
#[cfg(test)]
#[allow(dead_code)]
#[test_fuzz::test_fuzz]
fn fuzz_test_stored_block_ommers(obj: StoredBlockOmmers) {
    use reth_codecs::Compact;
    let mut buf = vec![];
    let len = obj.clone().to_compact(&mut buf);
    let (same_obj, buf) = StoredBlockOmmers::from_compact(buf.as_ref(), len);
    assert_eq!(obj, same_obj);
}
#[test]
#[allow(missing_docs)]
pub fn fuzz_stored_block_ommers() {
    fuzz_test_stored_block_ommers(StoredBlockOmmers::default())
}
impl reth_codecs::Compact for StoredBlockOmmers {
    fn to_compact<B>(&self, buf: &mut B) -> usize
    where
        B: bytes::BufMut + AsMut<[u8]>,
    {
        let mut flags = StoredBlockOmmersFlags::default();
        let mut total_length = 0;
        let mut buffer = bytes::BytesMut::new();
        let ommers_len = self.ommers.to_compact(&mut buffer);
        let flags = flags.into_bytes();
        total_length += flags.len() + buffer.len();
        buf.put_slice(&flags);
        buf.put(buffer);
        total_length
    }
    fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
        let (flags, mut buf) = StoredBlockOmmersFlags::from(buf);
        let (ommers, new_buf) = Vec::from_compact(buf, buf.len());
        buf = new_buf;
        let obj = StoredBlockOmmers { ommers };
        (obj, buf)
    }
}
```