### PR TITLE
cachore: disable alloy-chains default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,7 +429,7 @@ revm-primitives = { version = "14.0.0", features = [
 ], default-features = false }
 
 # eth
-alloy-chains = "0.1.32"
+alloy-chains = { version = "0.1.32", default-features = false }
 alloy-dyn-abi = "0.8.11"
 alloy-primitives = { version = "0.8.11", default-features = false }
 alloy-rlp = "0.3.4"

--- a/crates/optimism/hardforks/Cargo.toml
+++ b/crates/optimism/hardforks/Cargo.toml
@@ -30,7 +30,8 @@ default = ["std"]
 std = [
 	"alloy-primitives/std",
 	"once_cell/std",
-	"serde?/std"
+	"serde?/std",
+	"alloy-chains/std"
 ]
 serde = [
 	"dep:serde",


### PR DESCRIPTION
one step towards more riscv32imac-unknown-none-elf support

needs more incremental progress 

cc @zobront 

ref https://github.com/paradigmxyz/reth/issues/13041