### PR TITLE
Fix Unnecessary unwrap() Usage in Genesis Parsing

### DIFF
--- a/examples/custom-dev-node/src/main.rs
+++ b/examples/custom-dev-node/src/main.rs
@@ -93,6 +93,6 @@ fn custom_chain() -> Arc<ChainSpec> {
     }
 }
 "#;
-    let genesis: Genesis = serde_json::from_str(custom_genesis).unwrap();
+    let genesis: Genesis = serde_json::from_str(custom_genesis)?;
     Arc::new(genesis.into())
 }


### PR DESCRIPTION
In the previous implementation, `unwrap()` was used to handle the deserialization of the `custom_genesis` JSON string:

```rust
let genesis: Genesis = serde_json::from_str(custom_genesis).unwrap();
```

This is problematic because `unwrap()` will panic if the deserialization fails, which could lead to unexpected crashes, especially when the input data is malformed or invalid. Using `unwrap()` in such cases is risky, as it doesn't provide any error handling or graceful recovery from failures.

To improve the robustness of the code, I've replaced `unwrap()` with proper error handling using the `?` operator:

```rust
let genesis: Genesis = serde_json::from_str(custom_genesis)?;
```

This change ensures that if the deserialization fails, the error is propagated up the call stack, allowing it to be handled appropriately elsewhere in the code, rather than crashing the application. This is a much safer approach, particularly for production code where unexpected errors need to be gracefully managed rather than causing panics.