### PR TITLE
Check holocene activation based on the parent's timestamp

### DIFF
--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -186,14 +186,20 @@ pub struct OpChainSpec {
 
 impl OpChainSpec {
     /// Read from parent to determine the base fee for the next block
+    ///
+    /// See also [Base fee computation](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#base-fee-computation)
     pub fn next_block_base_fee(
         &self,
         parent: &Header,
         timestamp: u64,
     ) -> Result<U256, DecodeError> {
-        let is_holocene_activated = self
-            .inner
-            .is_fork_active_at_timestamp(reth_optimism_forks::OpHardfork::Holocene, parent.timestamp);
+        // > if Holocene is active in parent_header.timestamp, then the parameters from
+        // > parent_header.extraData are used.
+        let is_holocene_activated = self.inner.is_fork_active_at_timestamp(
+            reth_optimism_forks::OpHardfork::Holocene,
+            parent.timestamp,
+        );
+
         // If we are in the Holocene, we need to use the base fee params
         // from the parent block's extra data.
         // Else, use the base fee params (default values) from chainspec

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -193,7 +193,7 @@ impl OpChainSpec {
     ) -> Result<U256, DecodeError> {
         let is_holocene_activated = self
             .inner
-            .is_fork_active_at_timestamp(reth_optimism_forks::OpHardfork::Holocene, timestamp);
+            .is_fork_active_at_timestamp(reth_optimism_forks::OpHardfork::Holocene, parent.timestamp);
         // If we are in the Holocene, we need to use the base fee params
         // from the parent block's extra data.
         // Else, use the base fee params (default values) from chainspec


### PR DESCRIPTION
It seems like, when op-reth is decoding the extraData for holocene gas fee, it is currently using the current block's timestamp to check if the holocene was activated. However, according to the [spec](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#base-fee-computation), the check should be done on the parent block's timestamp since only holocene-activated parent would have proper extraData. 

This PR modifies the behavior to check for the parent block's timestamp. 

Please correct me if my understanding of reth codebase is incorrect! :) 
