### PR TITLE
perf(validate-tx-pool): fast non-allocating `is_create`

### DIFF
--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -719,6 +719,16 @@ impl PoolTransaction for MockTransaction {
         }
     }
 
+    /// Returns true if the transaction is a contract creation.
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Legacy { to, .. } | Self::Eip1559 { to, .. } | Self::Eip2930 { to, .. } => {
+                to.is_create()
+            }
+            Self::Eip4844 { .. } => false,
+        }
+    }
+
     /// Returns the input data associated with the transaction.
     fn input(&self) -> &[u8] {
         self.get_input()

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -815,7 +815,7 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
     let gas_after_merge = validate_initial_tx_gas(
         spec_id,
         transaction.input(),
-        transaction.kind().is_create(),
+        transaction.is_create(),
         transaction.access_list().map(|list| list.0.as_slice()).unwrap_or(&[]),
         transaction.authorization_count() as u64,
     );


### PR DESCRIPTION
Towards #12838. 