### PR TITLE
chore: disable more default features

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -5,9 +5,9 @@ set +e  # Disable immediate exit on error
 crates_to_check=(
     reth-codecs-derive
     reth-ethereum-forks
+    reth-primitives-traits
     # reth-evm
     # reth-primitives
-    # reth-primitives-traits
     # reth-optimism-forks
     # reth-optimism-chainspec
 )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -485,12 +485,12 @@ backon = { version = "1.2", default-features = false, features = [
 bincode = "1.3"
 bitflags = "2.4"
 boyer-moore-magiclen = "0.2.16"
-bytes = "1.5"
+bytes = { version = "1.5", default-features = false }
 cfg-if = "1.0"
 clap = "4"
 const_format = { version = "0.2.32", features = ["rust_1_64"] }
 dashmap = "6.0"
-derive_more = { version = "1", features = ["full"] }
+derive_more = { version = "1",  default-features = false,  features = ["full"] }
 dyn-clone = "1.0.17"
 eyre = "0.6"
 fdlimit = "0.3.0"

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -49,7 +49,8 @@ std = [
 	"alloy-consensus/std",
 	"once_cell/std",
 	"alloy-rlp/std",
-	"reth-ethereum-forks/std"
+	"reth-ethereum-forks/std",
+	"derive_more/std"
 ]
 arbitrary = [
 	"alloy-chains/arbitrary",

--- a/crates/consensus/consensus/Cargo.toml
+++ b/crates/consensus/consensus/Cargo.toml
@@ -32,7 +32,8 @@ std = [
 	"alloy-primitives/std",
 	"alloy-eips/std",
 	"alloy-consensus/std",
-	"reth-primitives-traits/std"
+	"reth-primitives-traits/std",
+	"derive_more/std"
 ]
 test-utils = [
 	"reth-primitives/test-utils",

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -31,5 +31,6 @@ std = [
 	"alloy-eips/std",
 	"alloy-primitives/std",
 	"revm-primitives/std",
-	"alloy-rlp/std"
+	"alloy-rlp/std",
+	"derive_more/std"
 ]

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -57,5 +57,6 @@ std = [
 	"alloy-eips/std",
 	"alloy-primitives/std",
 	"reth-primitives-traits/std",
-    "alloy-consensus/std",
+	"alloy-consensus/std",
+	"derive_more/std"
 ]

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -46,15 +46,16 @@ op-alloy-rpc-types.workspace = true
 [features]
 default = ["std"]
 std = [
-    "alloy-chains/std",
-    "alloy-genesis/std",
-    "alloy-primitives/std",
-    "alloy-eips/std",
-    "op-alloy-rpc-types/std",
-    "reth-chainspec/std",
-    "reth-ethereum-forks/std",
-    "reth-primitives-traits/std",
-    "reth-optimism-forks/std",
-    "alloy-consensus/std",
-    "once_cell/std",
+	"alloy-chains/std",
+	"alloy-genesis/std",
+	"alloy-primitives/std",
+	"alloy-eips/std",
+	"op-alloy-rpc-types/std",
+	"reth-chainspec/std",
+	"reth-ethereum-forks/std",
+	"reth-primitives-traits/std",
+	"reth-optimism-forks/std",
+	"alloy-consensus/std",
+	"once_cell/std",
+	"derive_more/std"
 ]

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -64,7 +64,8 @@ std = [
 	"alloy-primitives/std",
 	"revm-primitives/std",
 	"revm/std",
-	"reth-ethereum-forks/std"
+	"reth-ethereum-forks/std",
+	"derive_more/std"
 ]
 optimism = [
 	"reth-primitives/optimism",

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -50,6 +50,8 @@ std = [
 	"alloy-eips/std",
 	"alloy-primitives/std",
 	"serde/std",
+	"bytes/std",
+	"derive_more/std"
 ]
 reth-codec = [
     "dep:reth-codecs",

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -65,7 +65,9 @@ std = [
 	"revm-primitives/std",
 	"serde?/std",
 	"serde_with?/std",
-	"alloy-rlp/std"
+	"alloy-rlp/std",
+	"bytes/std",
+	"derive_more/std"
 ]
 test-utils = [
 	"arbitrary",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -106,7 +106,9 @@ std = [
 	"alloy-trie/std",
 	"serde_with?/std",
 	"alloy-rlp/std",
-	"reth-ethereum-forks/std"
+	"reth-ethereum-forks/std",
+	"bytes/std",
+	"derive_more/std"
 ]
 reth-codec = [
 	"dep:reth-codecs",

--- a/crates/storage/errors/Cargo.toml
+++ b/crates/storage/errors/Cargo.toml
@@ -29,5 +29,6 @@ std = [
 	"reth-primitives/std",
 	"alloy-eips/std",
 	"alloy-primitives/std",
-	"alloy-rlp/std"
+	"alloy-rlp/std",
+	"derive_more/std"
 ]


### PR DESCRIPTION
towards https://github.com/paradigmxyz/reth/issues/13021

makes reth-primitives-traits compat for risc by disabling more workspace wide features