### PR TITLE
chore: rename codecs optimism feature to op

### DIFF
--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -83,7 +83,7 @@ assert_matches.workspace = true
 [features]
 optimism = [
     "reth-blockchain-tree/optimism",
-    "reth-codecs/optimism",
+    "reth-codecs/op",
     "reth-chainspec",
     "reth-db-api/optimism",
     "reth-db/optimism",

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # reth
 reth-primitives.workspace = true
 reth-primitives-traits = { workspace = true, features = ["op"] }
-reth-codecs = { workspace = true, optional = true, features = ["optimism"] }
+reth-codecs = { workspace = true, optional = true, features = ["op"] }
 
 # ethereum
 alloy-primitives.workspace = true
@@ -36,7 +36,7 @@ derive_more.workspace = true
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
-reth-codecs = { workspace = true, features = ["test-utils", "optimism"] }
+reth-codecs = { workspace = true, features = ["test-utils", "op"] }
 rstest.workspace = true
 arbitrary.workspace = true
 
@@ -55,7 +55,7 @@ reth-codec = [
     "dep:reth-codecs",
     "reth-primitives/reth-codec",
     "reth-primitives-traits/reth-codec",
-    "reth-codecs?/optimism",
+    "reth-codecs?/op",
     "reth-primitives/reth-codec"
 ]
 serde = [

--- a/crates/optimism/storage/Cargo.toml
+++ b/crates/optimism/storage/Cargo.toml
@@ -22,6 +22,6 @@ reth-stages-types.workspace = true
 [features]
 optimism = [
 	"reth-primitives/optimism",
-	"reth-codecs/optimism",
+	"reth-codecs/op",
 	"reth-db-api/optimism"
 ]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -144,7 +144,7 @@ c-kzg = [
 ]
 optimism = [
 	"dep:op-alloy-consensus",
-	"reth-codecs?/optimism",
+	"reth-codecs?/op",
 	"revm-primitives/optimism",
 ]
 alloy-compat = [

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -67,7 +67,7 @@ alloy = [
     "dep:modular-bitfield",
     "dep:alloy-trie",
 ]
-optimism = ["alloy", "dep:op-alloy-consensus"]
+op = ["alloy", "dep:op-alloy-consensus"]
 test-utils = [
 	"std",
     "alloy",

--- a/crates/storage/codecs/src/alloy/transaction/mod.rs
+++ b/crates/storage/codecs/src/alloy/transaction/mod.rs
@@ -9,9 +9,9 @@ cond_mod!(
 );
 
 
-#[cfg(all(feature = "test-utils", feature = "optimism"))]
+#[cfg(all(feature = "test-utils", feature = "op"))]
 pub mod optimism;
-#[cfg(all(not(feature = "test-utils"), feature = "optimism"))]
+#[cfg(all(not(feature = "test-utils"), feature = "op"))]
 mod optimism;
 
 #[cfg(test)]
@@ -41,7 +41,7 @@ mod tests {
         assert_eq!(TxEip7702::bitflag_encoded_bytes(), 4);
     }
 
-    #[cfg(feature = "optimism")]
+    #[cfg(feature = "op")]
     #[test]
     fn test_ensure_backwards_compatibility_optimism() {
         assert_eq!(crate::alloy::transaction::optimism::TxDeposit::bitflag_encoded_bytes(), 2);
@@ -89,11 +89,11 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "optimism")]
+    #[cfg(feature = "op")]
     #[test]
     fn test_decode_deposit() {
         test_decode::<op_alloy_consensus::TxDeposit>(&hex!(
             "8108ac8f15983d59b6ae4911a00ff7bfcd2e53d2950926f8c82c12afad02861c46fcb293e776204052725e1c08ff2e9ff602ca916357601fa972a14094891fe3598b718758f22c46f163c18bcaa6296ce87e5267ef3fd932112842fbbf79011548cdf067d93ce6098dfc0aaf5a94531e439f30d6dfd0c6"
-        )); 
+        ));
     }
 }

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -82,4 +82,4 @@ arbitrary = [
     "reth-stages-types/arbitrary",
     "alloy-consensus/arbitrary",
 ]
-optimism = ["reth-primitives/optimism", "reth-codecs/optimism"]
+optimism = ["reth-primitives/optimism", "reth-codecs/op"]

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -92,7 +92,7 @@ optimism = [
     "reth-primitives/optimism",
     "reth-execution-types/optimism",
     "reth-optimism-primitives",
-    "reth-codecs/optimism",
+    "reth-codecs/op",
     "reth-db/optimism",
     "reth-db-api/optimism",
     "revm/optimism",


### PR DESCRIPTION
Renaming this feature to `op` since it just enables / disables op-alloy dependencies and implementations