### PR TITLE
refactor: rename `TransactionSignedEcRecovered` to `RecoveredTx`

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1390,7 +1390,7 @@ mod tests {
     use reth_node_types::FullNodePrimitives;
     use reth_primitives::{
         proofs::{calculate_receipt_root, calculate_transaction_root},
-        Account, BlockBody, Transaction, TransactionSigned, TransactionSignedEcRecovered,
+        Account, BlockBody, RecoveredTx, Transaction, TransactionSigned,
     };
     use reth_provider::{
         providers::ProviderNodeTypes,
@@ -1574,7 +1574,7 @@ mod tests {
         }
 
         let single_tx_cost = U256::from(INITIAL_BASE_FEE * MIN_TRANSACTION_GAS);
-        let mock_tx = |nonce: u64| -> TransactionSignedEcRecovered {
+        let mock_tx = |nonce: u64| -> RecoveredTx {
             TransactionSigned::new_unhashed(
                 Transaction::Eip1559(TxEip1559 {
                     chain_id: chain_spec.chain.id(),
@@ -1591,7 +1591,7 @@ mod tests {
 
         let mock_block = |number: u64,
                           parent: Option<B256>,
-                          body: Vec<TransactionSignedEcRecovered>,
+                          body: Vec<RecoveredTx>,
                           num_of_signer_txs: u64|
          -> SealedBlockWithSenders {
             let signed_body =

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -14,9 +14,8 @@ use reth_chainspec::{ChainSpec, EthereumHardfork, MIN_TRANSACTION_GAS};
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_primitives::{
     proofs::{calculate_receipt_root, calculate_transaction_root, calculate_withdrawals_root},
-    BlockBody, EthPrimitives, NodePrimitives, Receipt, Receipts, SealedBlock,
+    BlockBody, EthPrimitives, NodePrimitives, Receipt, Receipts, RecoveredTx, SealedBlock,
     SealedBlockWithSenders, SealedHeader, Transaction, TransactionSigned,
-    TransactionSignedEcRecovered,
 };
 use reth_storage_api::NodePrimitivesProvider;
 use reth_trie::{root::state_root_unhashed, updates::TrieUpdates, HashedPostState};
@@ -91,7 +90,7 @@ impl TestBlockBuilder {
     ) -> SealedBlockWithSenders {
         let mut rng = thread_rng();
 
-        let mock_tx = |nonce: u64| -> TransactionSignedEcRecovered {
+        let mock_tx = |nonce: u64| -> RecoveredTx {
             let tx = Transaction::Eip1559(TxEip1559 {
                 chain_id: self.chain_spec.chain.id(),
                 nonce,
@@ -109,7 +108,7 @@ impl TestBlockBuilder {
 
         let num_txs = rng.gen_range(0..5);
         let signer_balance_decrease = Self::single_tx_cost() * U256::from(num_txs);
-        let transactions: Vec<TransactionSignedEcRecovered> = (0..num_txs)
+        let transactions: Vec<RecoveredTx> = (0..num_txs)
             .map(|_| {
                 let tx = mock_tx(self.signer_build_account_info.nonce);
                 self.signer_build_account_info.nonce += 1;

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -436,7 +436,7 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
         self.blocks.values().flat_map(|block| block.transactions_with_sender())
     }
 
-    /// Returns an iterator over all [`Recovered`] in the blocks
+    /// Returns an iterator over all [`RecoveredTx`] in the blocks
     ///
     /// Note: This clones the transactions since it is assumed this is part of a shared [Chain].
     #[inline]

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -8,8 +8,8 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash};
 use core::{fmt, ops::RangeInclusive};
 use reth_execution_errors::{BlockExecutionError, InternalBlockExecutionError};
 use reth_primitives::{
-    transaction::SignedTransactionIntoRecoveredExt, SealedBlockFor, SealedBlockWithSenders,
-    SealedHeader, TransactionSignedEcRecovered,
+    transaction::SignedTransactionIntoRecoveredExt, RecoveredTx, SealedBlockFor,
+    SealedBlockWithSenders, SealedHeader,
 };
 use reth_primitives_traits::{Block, BlockBody, NodePrimitives, SignedTransaction};
 use reth_trie::updates::TrieUpdates;
@@ -436,14 +436,13 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
         self.blocks.values().flat_map(|block| block.transactions_with_sender())
     }
 
-    /// Returns an iterator over all [`TransactionSignedEcRecovered`] in the blocks
+    /// Returns an iterator over all [`Recovered`] in the blocks
     ///
     /// Note: This clones the transactions since it is assumed this is part of a shared [Chain].
     #[inline]
     pub fn transactions_ecrecovered(
         &self,
-    ) -> impl Iterator<Item = TransactionSignedEcRecovered<<B::Body as BlockBody>::Transaction>> + '_
-    {
+    ) -> impl Iterator<Item = RecoveredTx<<B::Body as BlockBody>::Transaction>> + '_ {
         self.transactions_with_sender().map(|(signer, tx)| tx.clone().with_signer(*signer))
     }
 

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -237,7 +237,7 @@ mod tests {
     use alloy_primitives::{PrimitiveSignature as Signature, TxKind, U256};
     use op_alloy_consensus::TxDeposit;
     use reth_chainspec::MAINNET;
-    use reth_primitives::{Transaction, TransactionSigned, TransactionSignedEcRecovered};
+    use reth_primitives::{RecoveredTx, Transaction, TransactionSigned};
     use reth_provider::test_utils::MockEthProvider;
     use reth_transaction_pool::{
         blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
@@ -266,8 +266,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(deposit_tx, signature);
-        let signed_recovered =
-            TransactionSignedEcRecovered::from_signed_transaction(signed_tx, signer);
+        let signed_recovered = RecoveredTx::from_signed_transaction(signed_tx, signer);
         let len = signed_recovered.encode_2718_len();
         let pooled_tx = EthPooledTransaction::new(signed_recovered, len);
         let outcome = validator.validate_one(origin, pooled_tx);

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -27,7 +27,7 @@ use reth_optimism_node::{
 use reth_optimism_payload_builder::builder::OpPayloadTransactions;
 use reth_optimism_primitives::OpPrimitives;
 use reth_payload_util::{PayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
-use reth_primitives::{SealedBlock, Transaction, TransactionSigned, TransactionSignedEcRecovered};
+use reth_primitives::{RecoveredTx, SealedBlock, Transaction, TransactionSigned};
 use reth_provider::providers::BlockchainProvider2;
 use reth_tasks::TaskManager;
 use reth_transaction_pool::pool::BestPayloadTransactions;
@@ -64,7 +64,7 @@ impl OpPayloadTransactions for CustomTxPriority {
             ..Default::default()
         };
         let signature = sender.sign_transaction_sync(&mut end_of_block_tx).unwrap();
-        let end_of_block_tx = TransactionSignedEcRecovered::from_signed_transaction(
+        let end_of_block_tx = RecoveredTx::from_signed_transaction(
             TransactionSigned::new_unhashed(Transaction::Eip1559(end_of_block_tx), signature),
             sender.address(),
         );

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -749,7 +749,7 @@ where
                 ))
             }
 
-            // Convert the transaction to a [TransactionSignedEcRecovered]. This is
+            // Convert the transaction to a [Recovered]. This is
             // purely for the purposes of utilizing the `evm_config.tx_env`` function.
             // Deposit transactions do not have signatures, so if the tx is a deposit, this
             // will just pull in its `from` address.

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -749,7 +749,7 @@ where
                 ))
             }
 
-            // Convert the transaction to a [Recovered]. This is
+            // Convert the transaction to a [RecoveredTx]. This is
             // purely for the purposes of utilizing the `evm_config.tx_env`` function.
             // Deposit transactions do not have signatures, so if the tx is a deposit, this
             // will just pull in its `from` address.

--- a/crates/optimism/payload/src/error.rs
+++ b/crates/optimism/payload/src/error.rs
@@ -4,8 +4,8 @@
 #[derive(Debug, thiserror::Error)]
 pub enum OpPayloadBuilderError {
     /// Thrown when a transaction fails to convert to a
-    /// [`reth_primitives::Recovered`].
-    #[error("failed to convert deposit transaction to Recovered")]
+    /// [`reth_primitives::RecoveredTx`].
+    #[error("failed to convert deposit transaction to RecoveredTx")]
     TransactionEcRecoverFailed,
     /// Thrown when the L1 block info could not be parsed from the calldata of the
     /// first transaction supplied in the payload attributes.

--- a/crates/optimism/payload/src/error.rs
+++ b/crates/optimism/payload/src/error.rs
@@ -4,8 +4,8 @@
 #[derive(Debug, thiserror::Error)]
 pub enum OpPayloadBuilderError {
     /// Thrown when a transaction fails to convert to a
-    /// [`reth_primitives::TransactionSignedEcRecovered`].
-    #[error("failed to convert deposit transaction to TransactionSignedEcRecovered")]
+    /// [`reth_primitives::Recovered`].
+    #[error("failed to convert deposit transaction to Recovered")]
     TransactionEcRecoverFailed,
     /// Thrown when the L1 block info could not be parsed from the calldata of the
     /// first transaction supplied in the payload attributes.

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -6,7 +6,7 @@ use alloy_rpc_types_eth::TransactionInfo;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types::Transaction;
 use reth_node_api::FullNodeComponents;
-use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
+use reth_primitives::{RecoveredTx, TransactionSigned};
 use reth_provider::{BlockReaderIdExt, ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
@@ -81,7 +81,7 @@ where
 
     fn fill(
         &self,
-        tx: TransactionSignedEcRecovered,
+        tx: RecoveredTx,
         tx_info: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use reth_primitives::TransactionSignedEcRecovered;
+use reth_primitives::RecoveredTx;
 
 /// Iterator that returns transactions for the block building process in the order they should be
 /// included in the block.
@@ -12,7 +12,7 @@ pub trait PayloadTransactions {
         &mut self,
         // In the future, `ctx` can include access to state for block building purposes.
         ctx: (),
-    ) -> Option<TransactionSignedEcRecovered>;
+    ) -> Option<RecoveredTx>;
 
     /// Exclude descendants of the transaction with given sender and nonce from the iterator,
     /// because this transaction won't be included in the block.

--- a/crates/payload/util/src/transaction.rs
+++ b/crates/payload/util/src/transaction.rs
@@ -1,7 +1,7 @@
 use crate::PayloadTransactions;
 use alloy_consensus::Transaction;
 use alloy_primitives::Address;
-use reth_primitives::TransactionSignedEcRecovered;
+use reth_primitives::RecoveredTx;
 
 /// An implementation of [`crate::traits::PayloadTransactions`] that yields
 /// a pre-defined set of transactions.
@@ -26,8 +26,8 @@ impl<T> PayloadTransactionsFixed<T> {
     }
 }
 
-impl PayloadTransactions for PayloadTransactionsFixed<TransactionSignedEcRecovered> {
-    fn next(&mut self, _ctx: ()) -> Option<TransactionSignedEcRecovered> {
+impl PayloadTransactions for PayloadTransactionsFixed<RecoveredTx> {
+    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx> {
         (self.index < self.transactions.len()).then(|| {
             let tx = self.transactions[self.index].clone();
             self.index += 1;
@@ -92,7 +92,7 @@ where
     B: PayloadTransactions,
     A: PayloadTransactions,
 {
-    fn next(&mut self, ctx: ()) -> Option<TransactionSignedEcRecovered> {
+    fn next(&mut self, ctx: ()) -> Option<RecoveredTx> {
         while let Some(tx) = self.before.next(ctx) {
             if let Some(before_max_gas) = self.before_max_gas {
                 if self.before_gas + tx.transaction.gas_limit() <= before_max_gas {

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,6 +1,6 @@
 use crate::{
     traits::BlockExt, transaction::SignedTransactionIntoRecoveredExt, BlockBodyTxExt, GotExpected,
-    SealedHeader, TransactionSigned, TransactionSignedEcRecovered,
+    RecoveredTx, SealedHeader, TransactionSigned,
 };
 use alloc::vec::Vec;
 use alloy_consensus::Header;
@@ -206,11 +206,7 @@ impl<B: reth_primitives_traits::Block> BlockWithSenders<B> {
     #[inline]
     pub fn into_transactions_ecrecovered(
         self,
-    ) -> impl Iterator<
-        Item = TransactionSignedEcRecovered<
-            <B::Body as reth_primitives_traits::BlockBody>::Transaction,
-        >,
-    >
+    ) -> impl Iterator<Item = RecoveredTx<<B::Body as reth_primitives_traits::BlockBody>::Transaction>>
     where
         <B::Body as reth_primitives_traits::BlockBody>::Transaction: SignedTransaction,
     {
@@ -560,11 +556,7 @@ impl<B: reth_primitives_traits::Block> SealedBlockWithSenders<B> {
     #[inline]
     pub fn into_transactions_ecrecovered(
         self,
-    ) -> impl Iterator<
-        Item = TransactionSignedEcRecovered<
-            <B::Body as reth_primitives_traits::BlockBody>::Transaction,
-        >,
-    >
+    ) -> impl Iterator<Item = RecoveredTx<<B::Body as reth_primitives_traits::BlockBody>::Transaction>>
     where
         <B::Body as reth_primitives_traits::BlockBody>::Transaction: SignedTransaction,
     {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -52,8 +52,8 @@ pub use static_file::StaticFileSegment;
 pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
     BlobTransaction, InvalidTransactionError, PooledTransactionsElement,
-    PooledTransactionsElementEcRecovered, Transaction, TransactionMeta, TransactionSigned,
-    TransactionSignedEcRecovered, TransactionSignedNoHash, TxType,
+    PooledTransactionsElementEcRecovered, RecoveredTx, Transaction, TransactionMeta,
+    TransactionSigned, TransactionSignedNoHash, TxType,
 };
 
 // Re-exports

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -53,7 +53,7 @@ pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
     BlobTransaction, InvalidTransactionError, PooledTransactionsElement,
     PooledTransactionsElementEcRecovered, RecoveredTx, Transaction, TransactionMeta,
-    TransactionSigned, TransactionSignedNoHash, TxType,
+    TransactionSigned, TransactionSignedEcRecovered, TransactionSignedNoHash, TxType,
 };
 
 // Re-exports

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -76,7 +76,7 @@ pub enum TransactionConversionError {
 }
 
 /// Represents error variants than can happen when trying to convert a
-/// [`TransactionSignedEcRecovered`](crate::TransactionSignedEcRecovered) transaction.
+/// [`Recovered`](crate::Recovered) transaction.
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Display)]
 pub enum TryFromRecoveredTransactionError {
     /// Thrown if the transaction type is unsupported.

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -76,7 +76,7 @@ pub enum TransactionConversionError {
 }
 
 /// Represents error variants than can happen when trying to convert a
-/// [`Recovered`](crate::Recovered) transaction.
+/// [`RecoveredTx`](crate::RecoveredTx) transaction.
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Display)]
 pub enum TryFromRecoveredTransactionError {
     /// Thrown if the transaction type is unsupported.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1107,56 +1107,56 @@ impl TransactionSigned {
         }
     }
 
-    /// Returns the [`TransactionSignedEcRecovered`] transaction with the given sender.
+    /// Returns the [`Recovered`] transaction with the given sender.
     #[inline]
-    pub const fn with_signer(self, signer: Address) -> TransactionSignedEcRecovered {
-        TransactionSignedEcRecovered::from_signed_transaction(self, signer)
+    pub const fn with_signer(self, signer: Address) -> RecoveredTx {
+        RecoveredTx::from_signed_transaction(self, signer)
     }
 
-    /// Consumes the type, recover signer and return [`TransactionSignedEcRecovered`]
+    /// Consumes the type, recover signer and return [`Recovered`]
     ///
     /// Returns `None` if the transaction's signature is invalid, see also [`Self::recover_signer`].
-    pub fn into_ecrecovered(self) -> Option<TransactionSignedEcRecovered> {
+    pub fn into_ecrecovered(self) -> Option<RecoveredTx> {
         let signer = self.recover_signer()?;
-        Some(TransactionSignedEcRecovered { signed_transaction: self, signer })
+        Some(RecoveredTx { signed_transaction: self, signer })
     }
 
-    /// Consumes the type, recover signer and return [`TransactionSignedEcRecovered`] _without
+    /// Consumes the type, recover signer and return [`Recovered`] _without
     /// ensuring that the signature has a low `s` value_ (EIP-2).
     ///
     /// Returns `None` if the transaction's signature is invalid, see also
     /// [`Self::recover_signer_unchecked`].
-    pub fn into_ecrecovered_unchecked(self) -> Option<TransactionSignedEcRecovered> {
+    pub fn into_ecrecovered_unchecked(self) -> Option<RecoveredTx> {
         let signer = self.recover_signer_unchecked()?;
-        Some(TransactionSignedEcRecovered { signed_transaction: self, signer })
+        Some(RecoveredTx { signed_transaction: self, signer })
     }
 
-    /// Tries to recover signer and return [`TransactionSignedEcRecovered`] by cloning the type.
-    pub fn try_ecrecovered(&self) -> Option<TransactionSignedEcRecovered> {
+    /// Tries to recover signer and return [`Recovered`] by cloning the type.
+    pub fn try_ecrecovered(&self) -> Option<RecoveredTx> {
         let signer = self.recover_signer()?;
-        Some(TransactionSignedEcRecovered { signed_transaction: self.clone(), signer })
+        Some(RecoveredTx { signed_transaction: self.clone(), signer })
     }
 
-    /// Tries to recover signer and return [`TransactionSignedEcRecovered`].
+    /// Tries to recover signer and return [`Recovered`].
     ///
     /// Returns `Err(Self)` if the transaction's signature is invalid, see also
     /// [`Self::recover_signer`].
-    pub fn try_into_ecrecovered(self) -> Result<TransactionSignedEcRecovered, Self> {
+    pub fn try_into_ecrecovered(self) -> Result<RecoveredTx, Self> {
         match self.recover_signer() {
             None => Err(self),
-            Some(signer) => Ok(TransactionSignedEcRecovered { signed_transaction: self, signer }),
+            Some(signer) => Ok(RecoveredTx { signed_transaction: self, signer }),
         }
     }
 
-    /// Tries to recover signer and return [`TransactionSignedEcRecovered`]. _without ensuring that
+    /// Tries to recover signer and return [`Recovered`]. _without ensuring that
     /// the signature has a low `s` value_ (EIP-2).
     ///
     /// Returns `Err(Self)` if the transaction's signature is invalid, see also
     /// [`Self::recover_signer_unchecked`].
-    pub fn try_into_ecrecovered_unchecked(self) -> Result<TransactionSignedEcRecovered, Self> {
+    pub fn try_into_ecrecovered_unchecked(self) -> Result<RecoveredTx, Self> {
         match self.recover_signer_unchecked() {
             None => Err(self),
-            Some(signer) => Ok(TransactionSignedEcRecovered { signed_transaction: self, signer }),
+            Some(signer) => Ok(RecoveredTx { signed_transaction: self, signer }),
         }
     }
 
@@ -1433,8 +1433,8 @@ impl alloy_consensus::Transaction for TransactionSigned {
     }
 }
 
-impl From<TransactionSignedEcRecovered> for TransactionSigned {
-    fn from(recovered: TransactionSignedEcRecovered) -> Self {
+impl From<RecoveredTx> for TransactionSigned {
+    fn from(recovered: RecoveredTx) -> Self {
         recovered.signed_transaction
     }
 }
@@ -1622,7 +1622,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
 
 /// Signed transaction with recovered signer.
 #[derive(Debug, Clone, PartialEq, Hash, Eq, AsRef, Deref)]
-pub struct TransactionSignedEcRecovered<T = TransactionSigned> {
+pub struct RecoveredTx<T = TransactionSigned> {
     /// Signer of the transaction
     signer: Address,
     /// Signed transaction
@@ -1631,9 +1631,9 @@ pub struct TransactionSignedEcRecovered<T = TransactionSigned> {
     signed_transaction: T,
 }
 
-// === impl TransactionSignedEcRecovered ===
+// === impl Recovered ===
 
-impl<T> TransactionSignedEcRecovered<T> {
+impl<T> RecoveredTx<T> {
     /// Signer of transaction recovered from signature
     pub const fn signer(&self) -> Address {
         self.signer
@@ -1654,7 +1654,7 @@ impl<T> TransactionSignedEcRecovered<T> {
         (self.signed_transaction, self.signer)
     }
 
-    /// Create [`TransactionSignedEcRecovered`] from [`TransactionSigned`] and [`Address`] of the
+    /// Create [`Recovered`] from [`TransactionSigned`] and [`Address`] of the
     /// signer.
     #[inline]
     pub const fn from_signed_transaction(signed_transaction: T, signer: Address) -> Self {
@@ -1662,7 +1662,7 @@ impl<T> TransactionSignedEcRecovered<T> {
     }
 }
 
-impl<T: Encodable> Encodable for TransactionSignedEcRecovered<T> {
+impl<T: Encodable> Encodable for RecoveredTx<T> {
     /// This encodes the transaction _with_ the signature, and an rlp header.
     ///
     /// Refer to docs for [`TransactionSigned::encode`] for details on the exact format.
@@ -1675,7 +1675,7 @@ impl<T: Encodable> Encodable for TransactionSignedEcRecovered<T> {
     }
 }
 
-impl<T: SignedTransaction> Decodable for TransactionSignedEcRecovered<T> {
+impl<T: SignedTransaction> Decodable for RecoveredTx<T> {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let signed_transaction = T::decode(buf)?;
         let signer = signed_transaction
@@ -1685,20 +1685,38 @@ impl<T: SignedTransaction> Decodable for TransactionSignedEcRecovered<T> {
     }
 }
 
-/// Extension trait for [`SignedTransaction`] to convert it into [`TransactionSignedEcRecovered`].
+impl<T: Encodable2718> Encodable2718 for RecoveredTx<T> {
+    fn type_flag(&self) -> Option<u8> {
+        self.signed_transaction.type_flag()
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        self.signed_transaction.encode_2718_len()
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.signed_transaction.encode_2718(out)
+    }
+
+    fn trie_hash(&self) -> B256 {
+        self.signed_transaction.trie_hash()
+    }
+}
+
+/// Extension trait for [`SignedTransaction`] to convert it into [`Recovered`].
 pub trait SignedTransactionIntoRecoveredExt: SignedTransaction {
-    /// Consumes the type, recover signer and return [`TransactionSignedEcRecovered`] _without
+    /// Consumes the type, recover signer and return [`Recovered`] _without
     /// ensuring that the signature has a low `s` value_ (EIP-2).
     ///
     /// Returns `None` if the transaction's signature is invalid.
-    fn into_ecrecovered_unchecked(self) -> Option<TransactionSignedEcRecovered<Self>> {
+    fn into_ecrecovered_unchecked(self) -> Option<RecoveredTx<Self>> {
         let signer = self.recover_signer_unchecked()?;
-        Some(TransactionSignedEcRecovered::from_signed_transaction(self, signer))
+        Some(RecoveredTx::from_signed_transaction(self, signer))
     }
 
-    /// Returns the [`TransactionSignedEcRecovered`] transaction with the given sender.
-    fn with_signer(self, signer: Address) -> TransactionSignedEcRecovered<Self> {
-        TransactionSignedEcRecovered::from_signed_transaction(self, signer)
+    /// Returns the [`Recovered`] transaction with the given sender.
+    fn with_signer(self, signer: Address) -> RecoveredTx<Self> {
+        RecoveredTx::from_signed_transaction(self, signer)
     }
 }
 
@@ -1944,7 +1962,7 @@ where
 mod tests {
     use crate::{
         transaction::{TxEip1559, TxKind, TxLegacy},
-        Transaction, TransactionSigned, TransactionSignedEcRecovered,
+        RecoveredTx, Transaction, TransactionSigned,
     };
     use alloy_consensus::Transaction as _;
     use alloy_eips::eip2718::{Decodable2718, Encodable2718};
@@ -2205,8 +2223,7 @@ mod tests {
         let tx = TransactionSigned::decode(&mut &input[..]).unwrap();
         let recovered = tx.into_ecrecovered().unwrap();
 
-        let decoded =
-            TransactionSignedEcRecovered::decode(&mut &alloy_rlp::encode(&recovered)[..]).unwrap();
+        let decoded = RecoveredTx::decode(&mut &alloy_rlp::encode(&recovered)[..]).unwrap();
         assert_eq!(recovered, decoded)
     }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1620,6 +1620,9 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
     }
 }
 
+/// Type alias kept for backward compatibility.
+pub type TransactionSignedEcRecovered<T = TransactionSigned> = RecoveredTx<T>;
+
 /// Signed transaction with recovered signer.
 #[derive(Debug, Clone, PartialEq, Hash, Eq, AsRef, Deref)]
 pub struct RecoveredTx<T = TransactionSigned> {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1107,13 +1107,13 @@ impl TransactionSigned {
         }
     }
 
-    /// Returns the [`Recovered`] transaction with the given sender.
+    /// Returns the [`RecoveredTx`] transaction with the given sender.
     #[inline]
     pub const fn with_signer(self, signer: Address) -> RecoveredTx {
         RecoveredTx::from_signed_transaction(self, signer)
     }
 
-    /// Consumes the type, recover signer and return [`Recovered`]
+    /// Consumes the type, recover signer and return [`RecoveredTx`]
     ///
     /// Returns `None` if the transaction's signature is invalid, see also [`Self::recover_signer`].
     pub fn into_ecrecovered(self) -> Option<RecoveredTx> {
@@ -1121,7 +1121,7 @@ impl TransactionSigned {
         Some(RecoveredTx { signed_transaction: self, signer })
     }
 
-    /// Consumes the type, recover signer and return [`Recovered`] _without
+    /// Consumes the type, recover signer and return [`RecoveredTx`] _without
     /// ensuring that the signature has a low `s` value_ (EIP-2).
     ///
     /// Returns `None` if the transaction's signature is invalid, see also
@@ -1131,13 +1131,13 @@ impl TransactionSigned {
         Some(RecoveredTx { signed_transaction: self, signer })
     }
 
-    /// Tries to recover signer and return [`Recovered`] by cloning the type.
+    /// Tries to recover signer and return [`RecoveredTx`] by cloning the type.
     pub fn try_ecrecovered(&self) -> Option<RecoveredTx> {
         let signer = self.recover_signer()?;
         Some(RecoveredTx { signed_transaction: self.clone(), signer })
     }
 
-    /// Tries to recover signer and return [`Recovered`].
+    /// Tries to recover signer and return [`RecoveredTx`].
     ///
     /// Returns `Err(Self)` if the transaction's signature is invalid, see also
     /// [`Self::recover_signer`].
@@ -1148,7 +1148,7 @@ impl TransactionSigned {
         }
     }
 
-    /// Tries to recover signer and return [`Recovered`]. _without ensuring that
+    /// Tries to recover signer and return [`RecoveredTx`]. _without ensuring that
     /// the signature has a low `s` value_ (EIP-2).
     ///
     /// Returns `Err(Self)` if the transaction's signature is invalid, see also
@@ -1631,7 +1631,7 @@ pub struct RecoveredTx<T = TransactionSigned> {
     signed_transaction: T,
 }
 
-// === impl Recovered ===
+// === impl RecoveredTx ===
 
 impl<T> RecoveredTx<T> {
     /// Signer of transaction recovered from signature
@@ -1654,7 +1654,7 @@ impl<T> RecoveredTx<T> {
         (self.signed_transaction, self.signer)
     }
 
-    /// Create [`Recovered`] from [`TransactionSigned`] and [`Address`] of the
+    /// Create [`RecoveredTx`] from [`TransactionSigned`] and [`Address`] of the
     /// signer.
     #[inline]
     pub const fn from_signed_transaction(signed_transaction: T, signer: Address) -> Self {
@@ -1703,9 +1703,9 @@ impl<T: Encodable2718> Encodable2718 for RecoveredTx<T> {
     }
 }
 
-/// Extension trait for [`SignedTransaction`] to convert it into [`Recovered`].
+/// Extension trait for [`SignedTransaction`] to convert it into [`RecoveredTx`].
 pub trait SignedTransactionIntoRecoveredExt: SignedTransaction {
-    /// Consumes the type, recover signer and return [`Recovered`] _without
+    /// Consumes the type, recover signer and return [`RecoveredTx`] _without
     /// ensuring that the signature has a low `s` value_ (EIP-2).
     ///
     /// Returns `None` if the transaction's signature is invalid.
@@ -1714,7 +1714,7 @@ pub trait SignedTransactionIntoRecoveredExt: SignedTransaction {
         Some(RecoveredTx::from_signed_transaction(self, signer))
     }
 
-    /// Returns the [`Recovered`] transaction with the given sender.
+    /// Returns the [`RecoveredTx`] transaction with the given sender.
     fn with_signer(self, signer: Address) -> RecoveredTx<Self> {
         RecoveredTx::from_signed_transaction(self, signer)
     }

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -74,7 +74,7 @@ impl PooledTransactionsElement {
         }
     }
 
-    /// Converts from an EIP-4844 [`Recovered`] to a
+    /// Converts from an EIP-4844 [`RecoveredTx`] to a
     /// [`PooledTransactionsElementEcRecovered`] with the given sidecar.
     ///
     /// Returns an `Err` containing the original `TransactionSigned` if the transaction is not
@@ -164,7 +164,7 @@ impl PooledTransactionsElement {
         }
     }
 
-    /// Create [`Recovered`] by converting this transaction into
+    /// Create [`RecoveredTx`] by converting this transaction into
     /// [`TransactionSigned`] and [`Address`] of the signer.
     pub fn into_ecrecovered_transaction(self, signer: Address) -> RecoveredTx {
         RecoveredTx::from_signed_transaction(self.into_transaction(), signer)
@@ -691,13 +691,13 @@ impl<'a> arbitrary::Arbitrary<'a> for PooledTransactionsElement {
 pub type PooledTransactionsElementEcRecovered<T = PooledTransactionsElement> = RecoveredTx<T>;
 
 impl PooledTransactionsElementEcRecovered {
-    /// Transform back to [`Recovered`]
+    /// Transform back to [`RecoveredTx`]
     pub fn into_ecrecovered_transaction(self) -> RecoveredTx {
         let (tx, signer) = self.to_components();
         tx.into_ecrecovered_transaction(signer)
     }
 
-    /// Converts from an EIP-4844 [`Recovered`] to a
+    /// Converts from an EIP-4844 [`RecoveredTx`] to a
     /// [`PooledTransactionsElementEcRecovered`] with the given sidecar.
     ///
     /// Returns the transaction is not an EIP-4844 transaction.

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -5,9 +5,7 @@ use super::{
     error::TransactionConversionError, recover_signer_unchecked, signature::recover_signer,
     TxEip7702,
 };
-use crate::{
-    BlobTransaction, Transaction, TransactionSigned, TransactionSignedEcRecovered, TxType,
-};
+use crate::{BlobTransaction, RecoveredTx, Transaction, TransactionSigned, TxType};
 use alloc::vec::Vec;
 use alloy_consensus::{
     constants::EIP4844_TX_TYPE_ID,
@@ -26,7 +24,6 @@ use alloy_primitives::{
 use alloy_rlp::{Decodable, Encodable, Error as RlpError, Header};
 use bytes::Buf;
 use core::hash::{Hash, Hasher};
-use derive_more::{AsRef, Deref};
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
 use revm_primitives::keccak256;
 use serde::{Deserialize, Serialize};
@@ -77,7 +74,7 @@ impl PooledTransactionsElement {
         }
     }
 
-    /// Converts from an EIP-4844 [`TransactionSignedEcRecovered`] to a
+    /// Converts from an EIP-4844 [`Recovered`] to a
     /// [`PooledTransactionsElementEcRecovered`] with the given sidecar.
     ///
     /// Returns an `Err` containing the original `TransactionSigned` if the transaction is not
@@ -151,7 +148,7 @@ impl PooledTransactionsElement {
     pub fn try_into_ecrecovered(self) -> Result<PooledTransactionsElementEcRecovered, Self> {
         match self.recover_signer() {
             None => Err(self),
-            Some(signer) => Ok(PooledTransactionsElementEcRecovered { transaction: self, signer }),
+            Some(signer) => Ok(RecoveredTx { signed_transaction: self, signer }),
         }
     }
 
@@ -167,10 +164,10 @@ impl PooledTransactionsElement {
         }
     }
 
-    /// Create [`TransactionSignedEcRecovered`] by converting this transaction into
+    /// Create [`Recovered`] by converting this transaction into
     /// [`TransactionSigned`] and [`Address`] of the signer.
-    pub fn into_ecrecovered_transaction(self, signer: Address) -> TransactionSignedEcRecovered {
-        TransactionSignedEcRecovered::from_signed_transaction(self.into_transaction(), signer)
+    pub fn into_ecrecovered_transaction(self, signer: Address) -> RecoveredTx {
+        RecoveredTx::from_signed_transaction(self.into_transaction(), signer)
     }
 
     /// Returns the inner [`TransactionSigned`].
@@ -645,7 +642,7 @@ impl InMemorySize for PooledTransactionsElement {
 
 impl From<PooledTransactionsElementEcRecovered> for PooledTransactionsElement {
     fn from(recovered: PooledTransactionsElementEcRecovered) -> Self {
-        recovered.into_transaction()
+        recovered.into_signed()
     }
 }
 
@@ -691,89 +688,42 @@ impl<'a> arbitrary::Arbitrary<'a> for PooledTransactionsElement {
 }
 
 /// A signed pooled transaction with recovered signer.
-#[derive(Debug, Clone, PartialEq, Eq, AsRef, Deref)]
-pub struct PooledTransactionsElementEcRecovered<T = PooledTransactionsElement> {
-    /// Signer of the transaction
-    signer: Address,
-    /// Signed transaction
-    #[deref]
-    #[as_ref]
-    transaction: T,
-}
+pub type PooledTransactionsElementEcRecovered<T = PooledTransactionsElement> = RecoveredTx<T>;
 
-impl<T> PooledTransactionsElementEcRecovered<T> {
-    /// Create an instance from the given transaction and the [`Address`] of the signer.
-    pub const fn from_signed_transaction(transaction: T, signer: Address) -> Self {
-        Self { transaction, signer }
-    }
-
-    /// Signer of transaction recovered from signature
-    pub const fn signer(&self) -> Address {
-        self.signer
-    }
-
-    /// Consume the type and return the transaction
-    pub fn into_transaction(self) -> T {
-        self.transaction
-    }
-
-    /// Dissolve Self to its component
-    pub fn into_components(self) -> (T, Address) {
-        (self.transaction, self.signer)
-    }
-}
 impl PooledTransactionsElementEcRecovered {
-    /// Transform back to [`TransactionSignedEcRecovered`]
-    pub fn into_ecrecovered_transaction(self) -> TransactionSignedEcRecovered {
-        let (tx, signer) = self.into_components();
+    /// Transform back to [`Recovered`]
+    pub fn into_ecrecovered_transaction(self) -> RecoveredTx {
+        let (tx, signer) = self.to_components();
         tx.into_ecrecovered_transaction(signer)
     }
 
-    /// Converts from an EIP-4844 [`TransactionSignedEcRecovered`] to a
+    /// Converts from an EIP-4844 [`Recovered`] to a
     /// [`PooledTransactionsElementEcRecovered`] with the given sidecar.
     ///
     /// Returns the transaction is not an EIP-4844 transaction.
     pub fn try_from_blob_transaction(
-        tx: TransactionSignedEcRecovered,
+        tx: RecoveredTx,
         sidecar: BlobTransactionSidecar,
-    ) -> Result<Self, TransactionSignedEcRecovered> {
-        let TransactionSignedEcRecovered { signer, signed_transaction } = tx;
+    ) -> Result<Self, RecoveredTx> {
+        let RecoveredTx { signer, signed_transaction } = tx;
         let transaction =
             PooledTransactionsElement::try_from_blob_transaction(signed_transaction, sidecar)
-                .map_err(|tx| TransactionSignedEcRecovered { signer, signed_transaction: tx })?;
-        Ok(Self { transaction, signer })
+                .map_err(|tx| RecoveredTx { signer, signed_transaction: tx })?;
+        Ok(Self::from_signed_transaction(transaction, signer))
     }
 }
 
-/// Converts a `TransactionSignedEcRecovered` into a `PooledTransactionsElementEcRecovered`.
-impl TryFrom<TransactionSignedEcRecovered> for PooledTransactionsElementEcRecovered {
+/// Converts a `Recovered` into a `PooledTransactionsElementEcRecovered`.
+impl TryFrom<RecoveredTx> for PooledTransactionsElementEcRecovered {
     type Error = TransactionConversionError;
 
-    fn try_from(tx: TransactionSignedEcRecovered) -> Result<Self, Self::Error> {
+    fn try_from(tx: RecoveredTx) -> Result<Self, Self::Error> {
         match PooledTransactionsElement::try_from(tx.signed_transaction) {
             Ok(pooled_transaction) => {
-                Ok(Self { transaction: pooled_transaction, signer: tx.signer })
+                Ok(Self::from_signed_transaction(pooled_transaction, tx.signer))
             }
             Err(_) => Err(TransactionConversionError::UnsupportedForP2P),
         }
-    }
-}
-
-impl<T: Encodable2718> Encodable2718 for PooledTransactionsElementEcRecovered<T> {
-    fn type_flag(&self) -> Option<u8> {
-        self.transaction.type_flag()
-    }
-
-    fn encode_2718_len(&self) -> usize {
-        self.transaction.encode_2718_len()
-    }
-
-    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
-        self.transaction.encode_2718(out)
-    }
-
-    fn trie_hash(&self) -> B256 {
-        self.transaction.trie_hash()
     }
 }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -18,7 +18,7 @@ use reth_evm::{
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{
     proofs::calculate_transaction_root, Block, BlockBody, BlockExt, InvalidTransactionError,
-    Receipt, SealedBlockWithSenders, SealedHeader, TransactionSignedEcRecovered,
+    Receipt, RecoveredTx, SealedBlockWithSenders, SealedHeader,
 };
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderError,
@@ -194,7 +194,7 @@ pub trait LoadPendingBlock:
     /// Assembles a [`Receipt`] for a transaction, based on its [`ExecutionResult`].
     fn assemble_receipt(
         &self,
-        tx: &TransactionSignedEcRecovered,
+        tx: &RecoveredTx,
         result: ExecutionResult,
         cumulative_gas_used: u64,
     ) -> Receipt {

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -4,7 +4,7 @@
 
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
-use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
+use reth_primitives::{RecoveredTx, TransactionSigned};
 use reth_primitives_traits::SignedTransaction;
 use reth_rpc_types_compat::{
     transaction::{from_recovered, from_recovered_with_block_context},
@@ -15,13 +15,13 @@ use reth_rpc_types_compat::{
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionSource<T = TransactionSigned> {
     /// Transaction exists in the pool (Pending)
-    Pool(TransactionSignedEcRecovered<T>),
+    Pool(RecoveredTx<T>),
     /// Transaction already included in a block
     ///
     /// This can be a historical block or a pending block (received from the CL)
     Block {
         /// Transaction fetched via provider
-        transaction: TransactionSignedEcRecovered<T>,
+        transaction: RecoveredTx<T>,
         /// Index of the transaction in the block
         index: u64,
         /// Hash of the block.
@@ -37,7 +37,7 @@ pub enum TransactionSource<T = TransactionSigned> {
 
 impl<T: SignedTransaction> TransactionSource<T> {
     /// Consumes the type and returns the wrapped transaction.
-    pub fn into_recovered(self) -> TransactionSignedEcRecovered<T> {
+    pub fn into_recovered(self) -> RecoveredTx<T> {
         self.into()
     }
 
@@ -63,7 +63,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     }
 
     /// Returns the transaction and block related info, if not pending
-    pub fn split(self) -> (TransactionSignedEcRecovered<T>, TransactionInfo) {
+    pub fn split(self) -> (RecoveredTx<T>, TransactionInfo) {
         match self {
             Self::Pool(tx) => {
                 let hash = tx.trie_hash();
@@ -86,7 +86,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     }
 }
 
-impl<T> From<TransactionSource<T>> for TransactionSignedEcRecovered<T> {
+impl<T> From<TransactionSource<T>> for RecoveredTx<T> {
     fn from(value: TransactionSource<T>) -> Self {
         match value {
             TransactionSource::Pool(tx) => tx,

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_eth::{
     request::{TransactionInput, TransactionRequest},
     TransactionInfo,
 };
-use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
+use reth_primitives::{RecoveredTx, TransactionSigned};
 use serde::{Deserialize, Serialize};
 
 /// Create a new rpc transaction result for a mined transaction, using the given block hash,
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// The block hash, number, and tx index fields should be from the original block where the
 /// transaction was mined.
 pub fn from_recovered_with_block_context<Tx, T: TransactionCompat<Tx>>(
-    tx: TransactionSignedEcRecovered<Tx>,
+    tx: RecoveredTx<Tx>,
     tx_info: TransactionInfo,
     resp_builder: &T,
 ) -> Result<T::Transaction, T::Error> {
@@ -27,7 +27,7 @@ pub fn from_recovered_with_block_context<Tx, T: TransactionCompat<Tx>>(
 /// Create a new rpc transaction result for a _pending_ signed transaction, setting block
 /// environment related fields to `None`.
 pub fn from_recovered<Tx, T: TransactionCompat<Tx>>(
-    tx: TransactionSignedEcRecovered<Tx>,
+    tx: RecoveredTx<Tx>,
     resp_builder: &T,
 ) -> Result<T::Transaction, T::Error> {
     resp_builder.fill(tx, TransactionInfo::default())
@@ -53,7 +53,7 @@ pub trait TransactionCompat<T = TransactionSigned>:
     /// environment related fields to `None`.
     fn fill(
         &self,
-        tx: TransactionSignedEcRecovered<T>,
+        tx: RecoveredTx<T>,
         tx_inf: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error>;
 
@@ -63,8 +63,8 @@ pub trait TransactionCompat<T = TransactionSigned>:
     fn otterscan_api_truncate_input(tx: &mut Self::Transaction);
 }
 
-/// Convert [`TransactionSignedEcRecovered`] to [`TransactionRequest`]
-pub fn transaction_to_call_request(tx: TransactionSignedEcRecovered) -> TransactionRequest {
+/// Convert [`Recovered`] to [`TransactionRequest`]
+pub fn transaction_to_call_request(tx: RecoveredTx) -> TransactionRequest {
     let from = tx.signer();
     let to = Some(tx.transaction.to().into());
     let gas = tx.transaction.gas_limit();

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -63,7 +63,7 @@ pub trait TransactionCompat<T = TransactionSigned>:
     fn otterscan_api_truncate_input(tx: &mut Self::Transaction);
 }
 
-/// Convert [`Recovered`] to [`TransactionRequest`]
+/// Convert [`RecoveredTx`] to [`TransactionRequest`]
 pub fn transaction_to_call_request(tx: RecoveredTx) -> TransactionRequest {
     let from = tx.signer();
     let to = Some(tx.transaction.to().into());

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -81,7 +81,7 @@ where
             .map(recover_raw_transaction)
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
-            .map(|tx| tx.into_components())
+            .map(|tx| tx.to_components())
             .collect::<Vec<_>>();
 
         // Validate that the bundle does not contain more than MAX_BLOB_NUMBER_PER_BLOCK blob

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_eth::{
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
 use reth_chainspec::ChainInfo;
-use reth_primitives::{Receipt, SealedBlockWithSenders, TransactionSignedEcRecovered};
+use reth_primitives::{Receipt, RecoveredTx, SealedBlockWithSenders};
 use reth_provider::{BlockIdReader, BlockReader, ProviderError};
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, FullEthApiTypes, RpcTransaction, TransactionCompat,
@@ -621,7 +621,7 @@ where
     /// Returns all new pending transactions received since the last poll.
     async fn drain(&self) -> FilterChanges<TxCompat::Transaction>
     where
-        T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>,
+        T: PoolTransaction<Consensus: Into<RecoveredTx>>,
     {
         let mut pending_txs = Vec::new();
         let mut prepared_stream = self.txs_stream.lock().await;
@@ -651,7 +651,7 @@ trait FullTransactionsFilter<T>: fmt::Debug + Send + Sync + Unpin + 'static {
 impl<T, TxCompat> FullTransactionsFilter<TxCompat::Transaction>
     for FullTransactionsReceiver<T, TxCompat>
 where
-    T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>> + 'static,
+    T: PoolTransaction<Consensus: Into<RecoveredTx>> + 'static,
     TxCompat: TransactionCompat + 'static,
 {
     async fn drain(&self) -> FilterChanges<TxCompat::Transaction> {

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::{Signed, Transaction as _, TxEip4844Variant, TxEnvelope};
 use alloy_network::{Ethereum, Network};
 use alloy_rpc_types_eth::{Transaction, TransactionInfo};
-use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
+use reth_primitives::{RecoveredTx, TransactionSigned};
 use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::TransactionCompat;
@@ -37,7 +37,7 @@ where
 
     fn fill(
         &self,
-        tx: TransactionSignedEcRecovered,
+        tx: RecoveredTx,
         tx_info: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -172,7 +172,7 @@ where
                     BundleItem::Tx { tx, can_revert } => {
                         let recovered_tx =
                             recover_raw_transaction(tx.clone()).map_err(EthApiError::from)?;
-                        let (tx, signer) = recovered_tx.into_components();
+                        let (tx, signer) = recovered_tx.to_components();
                         let tx = tx.into_transaction();
 
                         let refund_percent =

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_txpool::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_primitives::TransactionSignedEcRecovered;
+use reth_primitives::RecoveredTx;
 use reth_rpc_api::TxPoolApiServer;
 use reth_rpc_types_compat::{transaction::from_recovered, TransactionCompat};
 use reth_transaction_pool::{AllPoolTransactions, PoolTransaction, TransactionPool};
@@ -44,7 +44,7 @@ where
             resp_builder: &RpcTxB,
         ) -> Result<(), RpcTxB::Error>
         where
-            Tx: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>,
+            Tx: PoolTransaction<Consensus: Into<RecoveredTx>>,
             RpcTxB: TransactionCompat,
         {
             content.entry(tx.sender()).or_default().insert(
@@ -96,12 +96,12 @@ where
         trace!(target: "rpc::eth", "Serving txpool_inspect");
 
         #[inline]
-        fn insert<T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>>(
+        fn insert<T: PoolTransaction<Consensus: Into<RecoveredTx>>>(
             tx: &T,
             inspect: &mut BTreeMap<Address, BTreeMap<String, TxpoolInspectSummary>>,
         ) {
             let entry = inspect.entry(tx.sender()).or_default();
-            let tx: TransactionSignedEcRecovered = tx.clone_into_consensus().into();
+            let tx: RecoveredTx = tx.clone_into_consensus().into();
             entry.insert(
                 tx.nonce().to_string(),
                 TxpoolInspectSummary {

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -19,8 +19,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_execution_types::ChangedAccount;
 use reth_fs_util::FsPathError;
 use reth_primitives::{
-    PooledTransactionsElementEcRecovered, SealedHeader, TransactionSigned,
-    TransactionSignedEcRecovered,
+    PooledTransactionsElementEcRecovered, RecoveredTx, SealedHeader, TransactionSigned,
 };
 use reth_primitives_traits::SignedTransaction;
 use reth_storage_api::{errors::provider::ProviderError, BlockReaderIdExt, StateProviderFactory};
@@ -604,8 +603,7 @@ where
     let local_transactions = local_transactions
         .into_iter()
         .map(|tx| {
-            let recovered: TransactionSignedEcRecovered =
-                tx.transaction.clone_into_consensus().into();
+            let recovered: RecoveredTx = tx.transaction.clone_into_consensus().into();
             recovered.into_signed()
         })
         .collect::<Vec<_>>();

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy_primitives::Address;
 use core::fmt;
 use reth_payload_util::PayloadTransactions;
-use reth_primitives::{InvalidTransactionError, TransactionSignedEcRecovered};
+use reth_primitives::{InvalidTransactionError, RecoveredTx};
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
     sync::Arc,
@@ -226,7 +226,7 @@ impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
 #[derive(Debug)]
 pub struct BestPayloadTransactions<T, I>
 where
-    T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>,
+    T: PoolTransaction<Consensus: Into<RecoveredTx>>,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
     invalid: HashSet<Address>,
@@ -235,7 +235,7 @@ where
 
 impl<T, I> BestPayloadTransactions<T, I>
 where
-    T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>,
+    T: PoolTransaction<Consensus: Into<RecoveredTx>>,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
     /// Create a new `BestPayloadTransactions` with the given iterator.
@@ -246,10 +246,10 @@ where
 
 impl<T, I> PayloadTransactions for BestPayloadTransactions<T, I>
 where
-    T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>,
+    T: PoolTransaction<Consensus: Into<RecoveredTx>>,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
-    fn next(&mut self, _ctx: ()) -> Option<TransactionSignedEcRecovered> {
+    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx> {
         loop {
             let tx = self.best.next()?;
             if self.invalid.contains(&tx.sender()) {

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -26,7 +26,7 @@ use rand::{
 };
 use reth_primitives::{
     transaction::TryFromRecoveredTransactionError, PooledTransactionsElementEcRecovered,
-    Transaction, TransactionSigned, TransactionSignedEcRecovered, TxType,
+    RecoveredTx, Transaction, TransactionSigned, TxType,
 };
 use reth_primitives_traits::InMemorySize;
 use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
@@ -592,7 +592,7 @@ impl MockTransaction {
 impl PoolTransaction for MockTransaction {
     type TryFromConsensusError = TryFromRecoveredTransactionError;
 
-    type Consensus = TransactionSignedEcRecovered;
+    type Consensus = RecoveredTx;
 
     type Pooled = PooledTransactionsElementEcRecovered;
 
@@ -804,10 +804,10 @@ impl EthPoolTransaction for MockTransaction {
     }
 }
 
-impl TryFrom<TransactionSignedEcRecovered> for MockTransaction {
+impl TryFrom<RecoveredTx> for MockTransaction {
     type Error = TryFromRecoveredTransactionError;
 
-    fn try_from(tx: TransactionSignedEcRecovered) -> Result<Self, Self::Error> {
+    fn try_from(tx: RecoveredTx) -> Result<Self, Self::Error> {
         let sender = tx.signer();
         let transaction = tx.into_signed();
         let hash = transaction.hash();
@@ -926,7 +926,7 @@ impl From<PooledTransactionsElementEcRecovered> for MockTransaction {
     }
 }
 
-impl From<MockTransaction> for TransactionSignedEcRecovered {
+impl From<MockTransaction> for RecoveredTx {
     fn from(tx: MockTransaction) -> Self {
         let signed_tx =
             TransactionSigned::new(tx.clone().into(), Signature::test_signature(), *tx.hash());
@@ -1029,11 +1029,9 @@ impl proptest::arbitrary::Arbitrary for MockTransaction {
 
         arb::<(TransactionSigned, Address)>()
             .prop_map(|(signed_transaction, signer)| {
-                TransactionSignedEcRecovered::from_signed_transaction(signed_transaction, signer)
+                RecoveredTx::from_signed_transaction(signed_transaction, signer)
                     .try_into()
-                    .expect(
-                        "Failed to create an Arbitrary MockTransaction via TransactionSignedEcRecovered",
-                    )
+                    .expect("Failed to create an Arbitrary MockTransaction via Recovered")
             })
             .boxed()
     }

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1031,7 +1031,7 @@ impl proptest::arbitrary::Arbitrary for MockTransaction {
             .prop_map(|(signed_transaction, signer)| {
                 RecoveredTx::from_signed_transaction(signed_transaction, signer)
                     .try_into()
-                    .expect("Failed to create an Arbitrary MockTransaction via Recovered")
+                    .expect("Failed to create an Arbitrary MockTransaction via RecoveredTx")
             })
             .boxed()
     }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -20,8 +20,7 @@ use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
 use reth_primitives::{
     kzg::KzgSettings, transaction::TryFromRecoveredTransactionError, PooledTransactionsElement,
-    PooledTransactionsElementEcRecovered, SealedBlock, Transaction, TransactionSigned,
-    TransactionSignedEcRecovered,
+    PooledTransactionsElementEcRecovered, RecoveredTx, SealedBlock, Transaction, TransactionSigned,
 };
 use reth_primitives_traits::SignedTransaction;
 #[cfg(feature = "serde")]
@@ -577,12 +576,12 @@ pub struct AllPoolTransactions<T: PoolTransaction> {
 // === impl AllPoolTransactions ===
 
 impl<T: PoolTransaction> AllPoolTransactions<T> {
-    /// Returns an iterator over all pending [`TransactionSignedEcRecovered`] transactions.
+    /// Returns an iterator over all pending [`Recovered`] transactions.
     pub fn pending_recovered(&self) -> impl Iterator<Item = T::Consensus> + '_ {
         self.pending.iter().map(|tx| tx.transaction.clone().into())
     }
 
-    /// Returns an iterator over all queued [`TransactionSignedEcRecovered`] transactions.
+    /// Returns an iterator over all queued [`Recovered`] transactions.
     pub fn queued_recovered(&self) -> impl Iterator<Item = T::Consensus> + '_ {
         self.queued.iter().map(|tx| tx.transaction.clone().into())
     }
@@ -1132,9 +1131,7 @@ pub trait PoolTransaction: fmt::Debug + Send + Sync + Clone {
 /// Ethereum pool.
 pub trait EthPoolTransaction:
     PoolTransaction<
-    Consensus: From<TransactionSignedEcRecovered>
-                   + Into<TransactionSignedEcRecovered>
-                   + Into<TransactionSigned>,
+    Consensus: From<RecoveredTx> + Into<RecoveredTx> + Into<TransactionSigned>,
     Pooled: From<PooledTransactionsElementEcRecovered>
                 + Into<PooledTransactionsElementEcRecovered>
                 + Into<PooledTransactionsElement>,
@@ -1166,10 +1163,10 @@ pub trait EthPoolTransaction:
 
 /// The default [`PoolTransaction`] for the [Pool](crate::Pool) for Ethereum.
 ///
-/// This type is essentially a wrapper around [`TransactionSignedEcRecovered`] with additional
+/// This type is essentially a wrapper around [`Recovered`] with additional
 /// fields derived from the transaction that are frequently used by the pools for ordering.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EthPooledTransaction<T = TransactionSignedEcRecovered> {
+pub struct EthPooledTransaction<T = RecoveredTx> {
     /// `EcRecovered` transaction, the consensus format.
     pub(crate) transaction: T,
 
@@ -1192,7 +1189,7 @@ impl EthPooledTransaction {
     ///
     /// Caution: In case of blob transactions, this does marks the blob sidecar as
     /// [`EthBlobTransactionSidecar::Missing`]
-    pub fn new(transaction: TransactionSignedEcRecovered, encoded_length: usize) -> Self {
+    pub fn new(transaction: RecoveredTx, encoded_length: usize) -> Self {
         let mut blob_sidecar = EthBlobTransactionSidecar::None;
 
         let gas_cost = U256::from(transaction.transaction.max_fee_per_gas())
@@ -1215,7 +1212,7 @@ impl EthPooledTransaction {
     }
 
     /// Return the reference to the underlying transaction.
-    pub const fn transaction(&self) -> &TransactionSignedEcRecovered {
+    pub const fn transaction(&self) -> &RecoveredTx {
         &self.transaction
     }
 }
@@ -1224,12 +1221,12 @@ impl EthPooledTransaction {
 impl From<PooledTransactionsElementEcRecovered> for EthPooledTransaction {
     fn from(tx: PooledTransactionsElementEcRecovered) -> Self {
         let encoded_length = tx.encode_2718_len();
-        let (tx, signer) = tx.into_components();
+        let (tx, signer) = tx.to_components();
         match tx {
             PooledTransactionsElement::BlobTransaction(tx) => {
                 // include the blob sidecar
                 let (tx, blob) = tx.into_parts();
-                let tx = TransactionSignedEcRecovered::from_signed_transaction(tx, signer);
+                let tx = RecoveredTx::from_signed_transaction(tx, signer);
                 let mut pooled = Self::new(tx, encoded_length);
                 pooled.blob_sidecar = EthBlobTransactionSidecar::Present(blob);
                 pooled
@@ -1245,7 +1242,7 @@ impl From<PooledTransactionsElementEcRecovered> for EthPooledTransaction {
 impl PoolTransaction for EthPooledTransaction {
     type TryFromConsensusError = TryFromRecoveredTransactionError;
 
-    type Consensus = TransactionSignedEcRecovered;
+    type Consensus = RecoveredTx;
 
     type Pooled = PooledTransactionsElementEcRecovered;
 
@@ -1406,10 +1403,10 @@ impl EthPoolTransaction for EthPooledTransaction {
     }
 }
 
-impl TryFrom<TransactionSignedEcRecovered> for EthPooledTransaction {
+impl TryFrom<RecoveredTx> for EthPooledTransaction {
     type Error = TryFromRecoveredTransactionError;
 
-    fn try_from(tx: TransactionSignedEcRecovered) -> Result<Self, Self::Error> {
+    fn try_from(tx: RecoveredTx) -> Result<Self, Self::Error> {
         // ensure we can handle the transaction type and its format
         match tx.tx_type() as u8 {
             0..=EIP1559_TX_TYPE_ID | EIP7702_TX_TYPE_ID => {
@@ -1433,7 +1430,7 @@ impl TryFrom<TransactionSignedEcRecovered> for EthPooledTransaction {
     }
 }
 
-impl From<EthPooledTransaction> for TransactionSignedEcRecovered {
+impl From<EthPooledTransaction> for RecoveredTx {
     fn from(tx: EthPooledTransaction) -> Self {
         tx.transaction
     }
@@ -1645,8 +1642,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction =
-            TransactionSignedEcRecovered::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1667,8 +1663,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction =
-            TransactionSignedEcRecovered::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1689,8 +1684,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction =
-            TransactionSignedEcRecovered::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1713,8 +1707,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction =
-            TransactionSignedEcRecovered::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 300);
 
         // Check that the pooled transaction is created correctly
@@ -1737,8 +1730,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction =
-            TransactionSignedEcRecovered::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -576,12 +576,12 @@ pub struct AllPoolTransactions<T: PoolTransaction> {
 // === impl AllPoolTransactions ===
 
 impl<T: PoolTransaction> AllPoolTransactions<T> {
-    /// Returns an iterator over all pending [`Recovered`] transactions.
+    /// Returns an iterator over all pending [`RecoveredTx`] transactions.
     pub fn pending_recovered(&self) -> impl Iterator<Item = T::Consensus> + '_ {
         self.pending.iter().map(|tx| tx.transaction.clone().into())
     }
 
-    /// Returns an iterator over all queued [`Recovered`] transactions.
+    /// Returns an iterator over all queued [`RecoveredTx`] transactions.
     pub fn queued_recovered(&self) -> impl Iterator<Item = T::Consensus> + '_ {
         self.queued.iter().map(|tx| tx.transaction.clone().into())
     }
@@ -1163,7 +1163,7 @@ pub trait EthPoolTransaction:
 
 /// The default [`PoolTransaction`] for the [Pool](crate::Pool) for Ethereum.
 ///
-/// This type is essentially a wrapper around [`Recovered`] with additional
+/// This type is essentially a wrapper around [`RecoveredTx`] with additional
 /// fields derived from the transaction that are frequently used by the pools for ordering.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EthPooledTransaction<T = RecoveredTx> {

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_eips::eip4844::BlobTransactionSidecar;
 use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
-use reth_primitives::{SealedBlock, TransactionSignedEcRecovered};
+use reth_primitives::{RecoveredTx, SealedBlock};
 use std::{fmt, future::Future, time::Instant};
 
 mod constants;
@@ -435,11 +435,11 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     }
 }
 
-impl<T: PoolTransaction<Consensus: Into<TransactionSignedEcRecovered>>> ValidPoolTransaction<T> {
-    /// Converts to this type into a [`TransactionSignedEcRecovered`].
+impl<T: PoolTransaction<Consensus: Into<RecoveredTx>>> ValidPoolTransaction<T> {
+    /// Converts to this type into a [`Recovered`].
     ///
     /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
-    pub fn to_recovered_transaction(&self) -> TransactionSignedEcRecovered {
+    pub fn to_recovered_transaction(&self) -> RecoveredTx {
         self.to_consensus().into()
     }
 }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -436,7 +436,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
 }
 
 impl<T: PoolTransaction<Consensus: Into<RecoveredTx>>> ValidPoolTransaction<T> {
-    /// Converts to this type into a [`Recovered`].
+    /// Converts to this type into a [`RecoveredTx`].
     ///
     /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
     pub fn to_recovered_transaction(&self) -> RecoveredTx {


### PR DESCRIPTION
This will mostly be used with transaction generic so long type name isn't useful.

I've also made `PooledTransactionsElementEcRecovered` to just be a type alias for `RecoveredTx<PooledTransactionsElement>`:

https://github.com/paradigmxyz/reth/blob/4b6ee79c77bb217ffc5f1fba788849a86e7d73ae/crates/primitives/src/transaction/pooled.rs#L690-L691