### PR TITLE
chore: set event logs from `StaticFileProducer` and `Pruner` to `debug` 

### DIFF
--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -298,14 +298,14 @@ impl NodeState {
     fn handle_pruner_event(&self, event: PrunerEvent) {
         match event {
             PrunerEvent::Started { tip_block_number } => {
-                info!(tip_block_number, "Pruner started");
+                debug!(tip_block_number, "Pruner started");
             }
             PrunerEvent::Finished { tip_block_number, elapsed, stats } => {
                 let stats = format!(
                     "[{}]",
                     stats.iter().map(|item| item.to_string()).collect::<Vec<_>>().join(", ")
                 );
-                info!(tip_block_number, ?elapsed, %stats, "Pruner finished");
+                debug!(tip_block_number, ?elapsed, pruned_segments = %stats, "Pruner finished");
             }
         }
     }
@@ -313,10 +313,10 @@ impl NodeState {
     fn handle_static_file_producer_event(&self, event: StaticFileProducerEvent) {
         match event {
             StaticFileProducerEvent::Started { targets } => {
-                info!(?targets, "Static File Producer started");
+                debug!(?targets, "Static File Producer started");
             }
             StaticFileProducerEvent::Finished { targets, elapsed } => {
-                info!(?targets, ?elapsed, "Static File Producer finished");
+                debug!(?targets, ?elapsed, "Static File Producer finished");
             }
         }
     }


### PR DESCRIPTION
related to https://github.com/paradigmxyz/reth/issues/7732#event-1545098545

Pruner **does run in archival node** because right now, we write to both database and static files when saving blocks during live sync (issue: https://github.com/paradigmxyz/reth/issues/11918). Until that is handled, we need to have the pruner running as to clean-up the duplicated data.

What we can do is downgrades the event logs from `StaticFileProducer` and `Pruner` to `debug` , as not to potentially confuse users when running archival nodes.
