### PR TITLE
feat: use primitive transaction as `PoolTransaction::Consensus`

### DIFF
--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -18,7 +18,10 @@ use reth_evm::{
     ConfigureEvm,
 };
 use reth_payload_validator::ExecutionPayloadValidator;
-use reth_primitives::{proofs, Block, BlockBody, BlockExt, Receipt, Receipts};
+use reth_primitives::{
+    proofs, transaction::SignedTransactionIntoRecoveredExt, Block, BlockBody, BlockExt, Receipt,
+    Receipts,
+};
 use reth_provider::{BlockReader, ExecutionOutcome, ProviderError, StateProviderFactory};
 use reth_revm::{
     database::StateProviderDatabase,

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -13,7 +13,7 @@ use reth_evm::execute::BasicBlockExecutorProvider;
 use reth_evm_ethereum::execute::EthExecutionStrategyFactory;
 use reth_network::{NetworkHandle, PeersInfo};
 use reth_node_api::{
-    AddOnsContext, ConfigureEvm, EngineValidator, FullNodeComponents, NodeTypesWithDB,
+    AddOnsContext, ConfigureEvm, EngineValidator, FullNodeComponents, NodeTypesWithDB, TxTy,
 };
 use reth_node_builder::{
     components::{
@@ -30,7 +30,7 @@ use reth_provider::{CanonStateSubscriptions, EthStorage};
 use reth_rpc::EthApi;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
-    blobstore::DiskFileBlobStore, EthTransactionPool, TransactionPool,
+    blobstore::DiskFileBlobStore, EthTransactionPool, PoolTransaction, TransactionPool,
     TransactionValidationTaskExecutor,
 };
 use reth_trie_db::MerklePatriciaTrie;
@@ -243,7 +243,9 @@ impl EthereumPayloadBuilder {
         Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
         Node: FullNodeTypes<Types = Types>,
         Evm: ConfigureEvm<Header = Header>,
-        Pool: TransactionPool + Unpin + 'static,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+            + Unpin
+            + 'static,
         Types::Engine: PayloadTypes<
             BuiltPayload = EthBuiltPayload,
             PayloadAttributes = EthPayloadAttributes,
@@ -280,7 +282,9 @@ impl<Types, Node, Pool> PayloadServiceBuilder<Node, Pool> for EthereumPayloadBui
 where
     Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
     Node: FullNodeTypes<Types = Types>,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
     Types::Engine: PayloadTypes<
         BuiltPayload = EthBuiltPayload,
         PayloadAttributes = EthPayloadAttributes,
@@ -305,7 +309,9 @@ pub struct EthereumNetworkBuilder {
 impl<Node, Pool> NetworkBuilder<Node, Pool> for EthereumNetworkBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = EthPrimitives>>,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
 {
     async fn build_network(
         self,

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -30,7 +30,8 @@ use reth_execution_types::Chain;
 use reth_exex::{ExExContext, ExExEvent, ExExNotification, ExExNotifications, Wal};
 use reth_network::{config::SecretKey, NetworkConfigBuilder, NetworkManager};
 use reth_node_api::{
-    FullNodeTypes, FullNodeTypesAdapter, NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine,
+    FullNodeTypes, FullNodeTypesAdapter, NodePrimitives, NodeTypes, NodeTypesWithDBAdapter,
+    NodeTypesWithEngine,
 };
 use reth_node_builder::{
     components::{
@@ -45,7 +46,7 @@ use reth_node_ethereum::{
     EthEngineTypes, EthEvmConfig,
 };
 use reth_payload_builder::noop::NoopPayloadBuilderService;
-use reth_primitives::{BlockExt, EthPrimitives, Head, SealedBlockWithSenders};
+use reth_primitives::{BlockExt, EthPrimitives, Head, SealedBlockWithSenders, TransactionSigned};
 use reth_provider::{
     providers::{BlockchainProvider, StaticFileProvider},
     BlockReader, EthStorage, ProviderFactory,
@@ -64,7 +65,7 @@ pub struct TestPoolBuilder;
 
 impl<Node> PoolBuilder<Node> for TestPoolBuilder
 where
-    Node: FullNodeTypes,
+    Node: FullNodeTypes<Types: NodeTypes<Primitives: NodePrimitives<SignedTx = TransactionSigned>>>,
 {
     type Pool = TestPool;
 

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -17,6 +17,7 @@ use reth_network_api::{
     NetworkEvent, NetworkEventListenerProvider, NetworkInfo, Peers,
 };
 use reth_network_peers::PeerId;
+use reth_primitives::TransactionSigned;
 use reth_provider::{test_utils::NoopProvider, ChainSpecProvider};
 use reth_storage_api::{BlockReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory};
 use reth_tasks::TokioTaskExecutor;
@@ -24,7 +25,7 @@ use reth_tokio_util::EventStream;
 use reth_transaction_pool::{
     blobstore::InMemoryBlobStore,
     test_utils::{TestPool, TestPoolBuilder},
-    EthTransactionPool, TransactionPool, TransactionValidationTaskExecutor,
+    EthTransactionPool, PoolTransaction, TransactionPool, TransactionValidationTaskExecutor,
 };
 use secp256k1::SecretKey;
 use std::{
@@ -202,7 +203,9 @@ where
         + Clone
         + Unpin
         + 'static,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + Unpin
+        + 'static,
 {
     /// Spawns the testnet to a separate task
     pub fn spawn(self) -> TestnetHandle<C, Pool> {
@@ -267,7 +270,9 @@ where
         > + HeaderProvider
         + Unpin
         + 'static,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + Unpin
+        + 'static,
 {
     type Output = ();
 
@@ -468,7 +473,9 @@ where
         > + HeaderProvider
         + Unpin
         + 'static,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + Unpin
+        + 'static,
 {
     type Output = ();
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -702,9 +702,8 @@ where
         BroadcastedTransaction: SignedTransaction,
         PooledTransaction: SignedTransaction,
     >,
-    <<Pool as TransactionPool>::Transaction as PoolTransaction>::Consensus:
-        Into<N::BroadcastedTransaction>,
-    <<Pool as TransactionPool>::Transaction as PoolTransaction>::Pooled: Into<N::PooledTransaction>,
+    Pool::Transaction:
+        PoolTransaction<Consensus = N::BroadcastedTransaction, Pooled: Into<N::PooledTransaction>>,
 {
     /// Invoked when transactions in the local mempool are considered __pending__.
     ///
@@ -1011,9 +1010,8 @@ where
 impl<Pool> TransactionsManager<Pool>
 where
     Pool: TransactionPool + 'static,
-    <<Pool as TransactionPool>::Transaction as PoolTransaction>::Consensus: Into<TransactionSigned>,
-    <<Pool as TransactionPool>::Transaction as PoolTransaction>::Pooled:
-        Into<PooledTransactionsElement>,
+    Pool::Transaction:
+        PoolTransaction<Consensus = TransactionSigned, Pooled: Into<PooledTransactionsElement>>,
 {
     /// Handles dedicated transaction events related to the `eth` protocol.
     fn on_network_tx_event(&mut self, event: NetworkTransactionEvent) {
@@ -1313,9 +1311,8 @@ where
 impl<Pool> Future for TransactionsManager<Pool>
 where
     Pool: TransactionPool + Unpin + 'static,
-    <<Pool as TransactionPool>::Transaction as PoolTransaction>::Consensus: Into<TransactionSigned>,
-    <<Pool as TransactionPool>::Transaction as PoolTransaction>::Pooled:
-        Into<PooledTransactionsElement>,
+    Pool::Transaction:
+        PoolTransaction<Consensus = TransactionSigned, Pooled: Into<PooledTransactionsElement>>,
 {
     type Output = ();
 
@@ -1503,11 +1500,11 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
     /// Create a new instance from a pooled transaction
     fn new<P>(tx: Arc<ValidPoolTransaction<P>>) -> Self
     where
-        P: PoolTransaction<Consensus: Into<T>>,
+        P: PoolTransaction<Consensus = T>,
     {
         let size = tx.encoded_length();
-        let transaction = tx.transaction.clone_into_consensus().into();
-        let transaction = Arc::new(transaction);
+        let transaction = tx.transaction.clone_into_consensus();
+        let transaction = Arc::new(transaction.into_signed());
         Self { size, transaction }
     }
 

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -8,11 +8,11 @@ use reth_consensus::FullConsensus;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
-use reth_node_types::{NodeTypes, NodeTypesWithDB, NodeTypesWithEngine};
+use reth_node_types::{NodeTypes, NodeTypesWithDB, NodeTypesWithEngine, TxTy};
 use reth_payload_builder_primitives::PayloadBuilder;
 use reth_provider::FullProvider;
 use reth_tasks::TaskExecutor;
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{future::Future, marker::PhantomData};
 
 /// A helper trait that is downstream of the [`NodeTypesWithEngine`] trait and adds stateful
@@ -47,7 +47,7 @@ where
 /// Encapsulates all types and components of the node.
 pub trait FullNodeComponents: FullNodeTypes + Clone + 'static {
     /// The transaction pool of the node.
-    type Pool: TransactionPool + Unpin;
+    type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
     type Evm: ConfigureEvm<Header = Header>;

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -37,7 +37,7 @@ use reth_provider::{
     BlockReader, ChainSpecProvider, FullProvider,
 };
 use reth_tasks::TaskExecutor;
-use reth_transaction_pool::{PoolConfig, TransactionPool};
+use reth_transaction_pool::{PoolConfig, PoolTransaction, TransactionPool};
 use revm_primitives::EnvKzgSettings;
 use secp256k1::SecretKey;
 use std::sync::Arc;
@@ -650,7 +650,10 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     /// connected to that network.
     pub fn start_network<Pool>(&self, builder: NetworkBuilder<(), ()>, pool: Pool) -> NetworkHandle
     where
-        Pool: TransactionPool + Unpin + 'static,
+        Pool: TransactionPool<
+                Transaction: PoolTransaction<Consensus = reth_primitives::TransactionSigned>,
+            > + Unpin
+            + 'static,
         Node::Provider: BlockReader<
             Block = reth_primitives::Block,
             Receipt = reth_primitives::Receipt,
@@ -673,7 +676,10 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         tx_config: TransactionsManagerConfig,
     ) -> NetworkHandle
     where
-        Pool: TransactionPool + Unpin + 'static,
+        Pool: TransactionPool<
+                Transaction: PoolTransaction<Consensus = reth_primitives::TransactionSigned>,
+            > + Unpin
+            + 'static,
         Node::Provider: BlockReader<
             Block = reth_primitives::Block,
             Receipt = reth_primitives::Receipt,

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -10,9 +10,9 @@ use crate::{
 use alloy_consensus::Header;
 use reth_consensus::FullConsensus;
 use reth_evm::execute::BlockExecutorProvider;
-use reth_node_api::{NodeTypes, NodeTypesWithEngine};
+use reth_node_api::{NodeTypes, NodeTypesWithEngine, TxTy};
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{future::Future, marker::PhantomData};
 
 /// A generic, general purpose and customizable [`NodeComponentsBuilder`] implementation.
@@ -375,7 +375,9 @@ where
     Node: FullNodeTypes,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<Components<Node, Pool, EVM, Executor, Cons>>> + Send,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
     EVM: ConfigureEvm<Header = Header>,
     Executor: BlockExecutorProvider<Primitives = <Node::Types as NodeTypes>::Primitives>,
     Cons: FullConsensus<<Node::Types as NodeTypes>::Primitives> + Clone + Unpin + 'static,

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -27,9 +27,9 @@ use reth_consensus::FullConsensus;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network::NetworkHandle;
 use reth_network_api::FullNetwork;
-use reth_node_api::{NodeTypes, NodeTypesWithEngine};
+use reth_node_api::{NodeTypes, NodeTypesWithEngine, TxTy};
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 /// An abstraction over the components of a node, consisting of:
 ///  - evm and executor
@@ -38,7 +38,7 @@ use reth_transaction_pool::TransactionPool;
 ///  - payload builder.
 pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'static {
     /// The transaction pool of the node.
-    type Pool: TransactionPool + Unpin;
+    type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<T::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
     type Evm: ConfigureEvm<Header = Header>;
@@ -97,7 +97,9 @@ impl<Node, Pool, EVM, Executor, Cons> NodeComponents<Node>
     for Components<Node, Pool, EVM, Executor, Cons>
 where
     Node: FullNodeTypes,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
     EVM: ConfigureEvm<Header = Header>,
     Executor: BlockExecutorProvider<Primitives = <Node::Types as NodeTypes>::Primitives>,
     Cons: FullConsensus<<Node::Types as NodeTypes>::Primitives> + Clone + Unpin + 'static,

--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -1,7 +1,8 @@
 //! Pool component for the node builder.
 
 use alloy_primitives::Address;
-use reth_transaction_pool::{PoolConfig, SubPoolLimit, TransactionPool};
+use reth_node_api::TxTy;
+use reth_transaction_pool::{PoolConfig, PoolTransaction, SubPoolLimit, TransactionPool};
 use std::{collections::HashSet, future::Future};
 
 use crate::{BuilderContext, FullNodeTypes};
@@ -9,7 +10,9 @@ use crate::{BuilderContext, FullNodeTypes};
 /// A type that knows how to build the transaction pool.
 pub trait PoolBuilder<Node: FullNodeTypes>: Send {
     /// The transaction pool to build.
-    type Pool: TransactionPool + Unpin + 'static;
+    type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static;
 
     /// Creates the transaction pool.
     fn build_pool(
@@ -21,7 +24,9 @@ pub trait PoolBuilder<Node: FullNodeTypes>: Send {
 impl<Node, F, Fut, Pool> PoolBuilder<Node> for F
 where
     Node: FullNodeTypes,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<Pool>> + Send,
 {

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -33,6 +33,7 @@ use reth_rpc_builder::{
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::{debug, info};
+use reth_transaction_pool::TransactionPool;
 
 use crate::EthApiBuilderCtx;
 
@@ -405,6 +406,7 @@ where
     N: FullNodeComponents<
         Types: ProviderNodeTypes<Primitives = EthPrimitives>,
         PayloadBuilder: PayloadBuilder<PayloadType = <N::Types as NodeTypesWithEngine>::Engine>,
+        Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     >,
     EthApi: EthApiTypes + FullEthApiServer + AddDevSigners + Unpin + 'static,
     EV: EngineValidatorBuilder<N>,
@@ -527,6 +529,7 @@ where
     N: FullNodeComponents<
         Types: ProviderNodeTypes<Primitives = EthPrimitives>,
         PayloadBuilder: PayloadBuilder<PayloadType = <N::Types as NodeTypesWithEngine>::Engine>,
+        Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     >,
     EthApi: EthApiTypes + FullEthApiServer + AddDevSigners + Unpin + 'static,
     EV: EngineValidatorBuilder<N>,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -13,7 +13,7 @@ use reth_db::transaction::{DbTx, DbTxMut};
 use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, PeersInfo};
 use reth_node_api::{
-    AddOnsContext, EngineValidator, FullNodeComponents, NodeAddOns, PayloadBuilder,
+    AddOnsContext, EngineValidator, FullNodeComponents, NodeAddOns, PayloadBuilder, TxTy,
 };
 use reth_node_builder::{
     components::{
@@ -42,7 +42,7 @@ use reth_provider::{
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
-    blobstore::DiskFileBlobStore, CoinbaseTipOrdering, TransactionPool,
+    blobstore::DiskFileBlobStore, CoinbaseTipOrdering, PoolTransaction, TransactionPool,
     TransactionValidationTaskExecutor,
 };
 use reth_trie_db::MerklePatriciaTrie;
@@ -465,7 +465,9 @@ where
                 Primitives = OpPrimitives,
             >,
         >,
-        Pool: TransactionPool + Unpin + 'static,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+            + Unpin
+            + 'static,
         Evm: ConfigureEvm<Header = Header>,
     {
         let payload_builder = reth_optimism_payload_builder::OpPayloadBuilder::new(evm_config)
@@ -505,7 +507,9 @@ where
             Primitives = OpPrimitives,
         >,
     >,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
     Txs: OpPayloadTransactions,
 {
     async fn spawn_payload_service(
@@ -577,7 +581,9 @@ impl OpNetworkBuilder {
 impl<Node, Pool> NetworkBuilder<Node, Pool> for OpNetworkBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives>>,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
 {
     async fn build_network(
         self,

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -70,7 +70,7 @@ impl<Client, Tx> OpTransactionValidator<Client, Tx> {
 impl<Client, Tx> OpTransactionValidator<Client, Tx>
 where
     Client: StateProviderFactory + BlockReaderIdExt<Block = reth_primitives::Block>,
-    Tx: EthPoolTransaction,
+    Tx: EthPoolTransaction<Consensus = TransactionSigned>,
 {
     /// Create a new [`OpTransactionValidator`].
     pub fn new(inner: EthTransactionValidator<Client, Tx>) -> Self {
@@ -142,7 +142,7 @@ where
             let l1_block_info = self.block_info.l1_block_info.read().clone();
 
             let mut encoded = Vec::with_capacity(valid_tx.transaction().encoded_length());
-            let tx: TransactionSigned = valid_tx.transaction().clone_into_consensus().into();
+            let tx = valid_tx.transaction().clone_into_consensus();
             tx.encode_2718(&mut encoded);
 
             let cost_addition = match l1_block_info.l1_tx_data_fee(
@@ -196,7 +196,7 @@ where
 impl<Client, Tx> TransactionValidator for OpTransactionValidator<Client, Tx>
 where
     Client: StateProviderFactory + BlockReaderIdExt<Block = reth_primitives::Block>,
-    Tx: EthPoolTransaction,
+    Tx: EthPoolTransaction<Consensus = TransactionSigned>,
 {
     type Transaction = Tx;
 

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -30,7 +30,7 @@ use reth_payload_util::{PayloadTransactions, PayloadTransactionsChain, PayloadTr
 use reth_primitives::{RecoveredTx, SealedBlock, Transaction, TransactionSigned};
 use reth_provider::providers::BlockchainProvider2;
 use reth_tasks::TaskManager;
-use reth_transaction_pool::pool::BestPayloadTransactions;
+use reth_transaction_pool::{pool::BestPayloadTransactions, PoolTransaction};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -44,9 +44,11 @@ impl OpPayloadTransactions for CustomTxPriority {
         &self,
         pool: Pool,
         attr: reth_transaction_pool::BestTransactionsAttributes,
-    ) -> impl PayloadTransactions
+    ) -> impl PayloadTransactions<Transaction = TransactionSigned>
     where
-        Pool: reth_transaction_pool::TransactionPool,
+        Pool: reth_transaction_pool::TransactionPool<
+            Transaction: PoolTransaction<Consensus = TransactionSigned>,
+        >,
     {
         // Block composition:
         // 1. Best transactions from the pool (up to 250k gas)

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -19,12 +19,13 @@ use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_payload_util::PayloadTransactions;
 use reth_primitives::{
-    proofs, Block, BlockBody, BlockExt, Receipt, SealedHeader, TransactionSigned, TxType,
+    proofs, transaction::SignedTransactionIntoRecoveredExt, Block, BlockBody, BlockExt, Receipt,
+    SealedHeader, TransactionSigned, TxType,
 };
 use reth_provider::{ProviderError, StateProofProvider, StateProviderFactory, StateRootProvider};
 use reth_revm::database::StateProviderDatabase;
 use reth_transaction_pool::{
-    noop::NoopTransactionPool, BestTransactionsAttributes, TransactionPool,
+    noop::NoopTransactionPool, BestTransactionsAttributes, PoolTransaction, TransactionPool,
 };
 use reth_trie::HashedPostState;
 use revm::{
@@ -112,7 +113,7 @@ where
     ) -> Result<BuildOutcome<OpBuiltPayload>, PayloadBuilderError>
     where
         Client: StateProviderFactory + ChainSpecProvider<ChainSpec = OpChainSpec>,
-        Pool: TransactionPool,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     {
         let (initialized_cfg, initialized_block_env) = self
             .cfg_and_block_env(&args.config.attributes, &args.config.parent_header)
@@ -213,7 +214,7 @@ where
 impl<Pool, Client, EvmConfig, Txs> PayloadBuilder<Pool, Client> for OpPayloadBuilder<EvmConfig, Txs>
 where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = OpChainSpec>,
-    Pool: TransactionPool,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     EvmConfig: ConfigureEvm<Header = Header>,
     Txs: OpPayloadTransactions,
 {
@@ -281,7 +282,7 @@ pub struct OpBuilder<Pool, Txs> {
 
 impl<Pool, Txs> OpBuilder<Pool, Txs>
 where
-    Pool: TransactionPool,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     Txs: OpPayloadTransactions,
 {
     /// Executes the payload and returns the outcome.
@@ -479,19 +480,23 @@ where
 pub trait OpPayloadTransactions: Clone + Send + Sync + Unpin + 'static {
     /// Returns an iterator that yields the transaction in the order they should get included in the
     /// new payload.
-    fn best_transactions<Pool: TransactionPool>(
+    fn best_transactions<
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    >(
         &self,
         pool: Pool,
         attr: BestTransactionsAttributes,
-    ) -> impl PayloadTransactions;
+    ) -> impl PayloadTransactions<Transaction = TransactionSigned>;
 }
 
 impl OpPayloadTransactions for () {
-    fn best_transactions<Pool: TransactionPool>(
+    fn best_transactions<
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    >(
         &self,
         pool: Pool,
         attr: BestTransactionsAttributes,
-    ) -> impl PayloadTransactions {
+    ) -> impl PayloadTransactions<Transaction = TransactionSigned> {
         BestPayloadTransactions::new(pool.best_transactions_with_attributes(attr))
     }
 }
@@ -830,11 +835,10 @@ where
         &self,
         info: &mut ExecutionInfo,
         db: &mut State<DB>,
-        mut best_txs: impl PayloadTransactions,
+        mut best_txs: impl PayloadTransactions<Transaction = TransactionSigned>,
     ) -> Result<Option<()>, PayloadBuilderError>
     where
         DB: Database<Error = ProviderError>,
-        Pool: TransactionPool,
     {
         let block_gas_limit = self.block_gas_limit();
         let base_fee = self.base_fee();

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -9,7 +9,7 @@ use reth_evm::ConfigureEvm;
 use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;
 use reth_primitives::{Receipt, SealedBlockWithSenders};
 use reth_provider::{
-    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ExecutionOutcome,
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ExecutionOutcome, ProviderTx,
     ReceiptProvider, StateProviderFactory,
 };
 use reth_rpc_eth_api::{
@@ -17,7 +17,7 @@ use reth_rpc_eth_api::{
     FromEthApiError, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock};
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm::primitives::BlockEnv;
 
 impl<N> LoadPendingBlock for OpEthApi<N>
@@ -25,13 +25,14 @@ where
     Self: SpawnBlocking,
     N: RpcNodeCore<
         Provider: BlockReaderIdExt<
+            Transaction = reth_primitives::TransactionSigned,
             Block = reth_primitives::Block,
             Receipt = reth_primitives::Receipt,
             Header = reth_primitives::Header,
         > + EvmEnvProvider
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
-        Pool: TransactionPool,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<N::Provider>>>,
         Evm: ConfigureEvm<Header = Header>,
     >,
 {

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -7,12 +7,15 @@ use reth_primitives::RecoveredTx;
 /// Can include transactions from the pool and other sources (alternative pools,
 /// sequencer-originated transactions, etc.).
 pub trait PayloadTransactions {
+    /// The transaction type this iterator yields.
+    type Transaction;
+
     /// Returns the next transaction to include in the block.
     fn next(
         &mut self,
         // In the future, `ctx` can include access to state for block building purposes.
         ctx: (),
-    ) -> Option<RecoveredTx>;
+    ) -> Option<RecoveredTx<Self::Transaction>>;
 
     /// Exclude descendants of the transaction with given sender and nonce from the iterator,
     /// because this transaction won't be included in the block.

--- a/crates/payload/util/src/transaction.rs
+++ b/crates/payload/util/src/transaction.rs
@@ -26,8 +26,10 @@ impl<T> PayloadTransactionsFixed<T> {
     }
 }
 
-impl PayloadTransactions for PayloadTransactionsFixed<RecoveredTx> {
-    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx> {
+impl<T: Clone> PayloadTransactions for PayloadTransactionsFixed<RecoveredTx<T>> {
+    type Transaction = T;
+
+    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx<T>> {
         (self.index < self.transactions.len()).then(|| {
             let tx = self.transactions[self.index].clone();
             self.index += 1;
@@ -87,20 +89,22 @@ impl<B: PayloadTransactions, A: PayloadTransactions> PayloadTransactionsChain<B,
     }
 }
 
-impl<B, A> PayloadTransactions for PayloadTransactionsChain<B, A>
+impl<A, B> PayloadTransactions for PayloadTransactionsChain<A, B>
 where
-    B: PayloadTransactions,
-    A: PayloadTransactions,
+    A: PayloadTransactions<Transaction: Transaction>,
+    B: PayloadTransactions<Transaction = A::Transaction>,
 {
-    fn next(&mut self, ctx: ()) -> Option<RecoveredTx> {
+    type Transaction = A::Transaction;
+
+    fn next(&mut self, ctx: ()) -> Option<RecoveredTx<Self::Transaction>> {
         while let Some(tx) = self.before.next(ctx) {
             if let Some(before_max_gas) = self.before_max_gas {
-                if self.before_gas + tx.transaction.gas_limit() <= before_max_gas {
-                    self.before_gas += tx.transaction.gas_limit();
+                if self.before_gas + tx.as_signed().gas_limit() <= before_max_gas {
+                    self.before_gas += tx.as_signed().gas_limit();
                     return Some(tx);
                 }
-                self.before.mark_invalid(tx.signer(), tx.transaction.nonce());
-                self.after.mark_invalid(tx.signer(), tx.transaction.nonce());
+                self.before.mark_invalid(tx.signer(), tx.as_signed().nonce());
+                self.after.mark_invalid(tx.signer(), tx.as_signed().nonce());
             } else {
                 return Some(tx);
             }
@@ -108,11 +112,11 @@ where
 
         while let Some(tx) = self.after.next(ctx) {
             if let Some(after_max_gas) = self.after_max_gas {
-                if self.after_gas + tx.transaction.gas_limit() <= after_max_gas {
-                    self.after_gas += tx.transaction.gas_limit();
+                if self.after_gas + tx.as_signed().gas_limit() <= after_max_gas {
+                    self.after_gas += tx.as_signed().gas_limit();
                     return Some(tx);
                 }
-                self.after.mark_invalid(tx.signer(), tx.transaction.nonce());
+                self.after.mark_invalid(tx.signer(), tx.as_signed().nonce());
             } else {
                 return Some(tx);
             }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1131,23 +1131,6 @@ impl TransactionSigned {
         Some(RecoveredTx { signed_transaction: self, signer })
     }
 
-    /// Tries to recover signer and return [`RecoveredTx`] by cloning the type.
-    pub fn try_ecrecovered(&self) -> Option<RecoveredTx> {
-        let signer = self.recover_signer()?;
-        Some(RecoveredTx { signed_transaction: self.clone(), signer })
-    }
-
-    /// Tries to recover signer and return [`RecoveredTx`].
-    ///
-    /// Returns `Err(Self)` if the transaction's signature is invalid, see also
-    /// [`Self::recover_signer`].
-    pub fn try_into_ecrecovered(self) -> Result<RecoveredTx, Self> {
-        match self.recover_signer() {
-            None => Err(self),
-            Some(signer) => Ok(RecoveredTx { signed_transaction: self, signer }),
-        }
-    }
-
     /// Tries to recover signer and return [`RecoveredTx`]. _without ensuring that
     /// the signature has a low `s` value_ (EIP-2).
     ///
@@ -1708,6 +1691,23 @@ impl<T: Encodable2718> Encodable2718 for RecoveredTx<T> {
 
 /// Extension trait for [`SignedTransaction`] to convert it into [`RecoveredTx`].
 pub trait SignedTransactionIntoRecoveredExt: SignedTransaction {
+    /// Tries to recover signer and return [`RecoveredTx`] by cloning the type.
+    fn try_ecrecovered(&self) -> Option<RecoveredTx<Self>> {
+        let signer = self.recover_signer()?;
+        Some(RecoveredTx { signed_transaction: self.clone(), signer })
+    }
+
+    /// Tries to recover signer and return [`RecoveredTx`].
+    ///
+    /// Returns `Err(Self)` if the transaction's signature is invalid, see also
+    /// [`Self::recover_signer`].
+    fn try_into_ecrecovered(self) -> Result<RecoveredTx<Self>, Self> {
+        match self.recover_signer() {
+            None => Err(self),
+            Some(signer) => Ok(RecoveredTx { signed_transaction: self, signer }),
+        }
+    }
+
     /// Consumes the type, recover signer and return [`RecoveredTx`] _without
     /// ensuring that the signature has a low `s` value_ (EIP-2).
     ///

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1700,7 +1700,7 @@ pub trait SignedTransactionIntoRecoveredExt: SignedTransaction {
     /// Tries to recover signer and return [`RecoveredTx`].
     ///
     /// Returns `Err(Self)` if the transaction's signature is invalid, see also
-    /// [`Self::recover_signer`].
+    /// [`SignedTransaction::recover_signer`].
     fn try_into_ecrecovered(self) -> Result<RecoveredTx<Self>, Self> {
         match self.recover_signer() {
             None => Err(self),

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -26,7 +26,7 @@
 //!     RethRpcModule, RpcModuleBuilder, RpcServerConfig, ServerBuilder, TransportRpcModuleConfig,
 //! };
 //! use reth_tasks::TokioTaskExecutor;
-//! use reth_transaction_pool::TransactionPool;
+//! use reth_transaction_pool::{PoolTransaction, TransactionPool};
 //!
 //! pub async fn launch<Provider, Pool, Network, Events, EvmConfig, BlockExecutor, Consensus>(
 //!     provider: Provider,
@@ -44,7 +44,9 @@
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
 //!         + ChangeSetReader,
-//!     Pool: TransactionPool + Unpin + 'static,
+//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+//!         + Unpin
+//!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events:
 //!         CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives> + Clone + 'static,
@@ -95,7 +97,7 @@
 //! };
 //! use reth_rpc_layer::JwtSecret;
 //! use reth_tasks::TokioTaskExecutor;
-//! use reth_transaction_pool::TransactionPool;
+//! use reth_transaction_pool::{PoolTransaction, TransactionPool};
 //! use tokio::try_join;
 //!
 //! pub async fn launch<
@@ -125,7 +127,9 @@
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
 //!         + ChangeSetReader,
-//!     Pool: TransactionPool + Unpin + 'static,
+//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+//!         + Unpin
+//!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events:
 //!         CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives> + Clone + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -277,7 +277,7 @@ where
             Header = reth_primitives::Header,
         > + AccountReader
         + ChangeSetReader,
-    Pool: TransactionPool + 'static,
+    Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction> + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions<Primitives = EthPrimitives> + Clone + 'static,
@@ -674,6 +674,7 @@ where
             Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
             Header = <EthApi::Provider as HeaderProvider>::Header,
         >,
+        Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     {
         let Self {
             provider,
@@ -793,6 +794,7 @@ where
             Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
             Header = <EthApi::Provider as HeaderProvider>::Header,
         >,
+        Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     {
         let mut modules = TransportRpcModules::default();
 
@@ -1328,7 +1330,7 @@ where
             Header = <EthApi::Provider as HeaderProvider>::Header,
         > + AccountReader
         + ChangeSetReader,
-    Pool: TransactionPool + 'static,
+    Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction> + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions<Primitives = EthPrimitives> + Clone + 'static,

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -240,7 +240,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                     RpcNodeCore::pool(self).get_transaction_by_sender_and_nonce(sender, nonce)
                 {
                     let transaction = tx.transaction.clone_into_consensus();
-                    return Ok(Some(from_recovered(transaction.into(), self.tx_resp_builder())?));
+                    return Ok(Some(from_recovered(transaction, self.tx_resp_builder())?));
                 }
             }
 
@@ -385,7 +385,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
 
             let pool_transaction =
                 <<Self as RpcNodeCore>::Pool as TransactionPool>::Transaction::try_from_consensus(
-                    transaction.into(),
+                    transaction,
                 )
                 .map_err(|_| EthApiError::TransactionConversionError)?;
 

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -8,8 +8,9 @@ use std::{
 use alloy_network::Network;
 use alloy_rpc_types_eth::Block;
 use reth_primitives::TransactionSigned;
-use reth_provider::{ReceiptProvider, TransactionsProvider};
+use reth_provider::{ProviderTx, ReceiptProvider, TransactionsProvider};
 use reth_rpc_types_compat::TransactionCompat;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 use crate::{AsEthApiError, FromEthApiError, FromEvmError, RpcNodeCore};
 
@@ -50,6 +51,9 @@ where
     Self: RpcNodeCore<
             Provider: TransactionsProvider<Transaction = TransactionSigned>
                           + ReceiptProvider<Receipt = reth_primitives::Receipt>,
+            Pool: TransactionPool<
+                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
+            >,
         > + EthApiTypes<
             TransactionCompat: TransactionCompat<
                 <Self::Provider as TransactionsProvider>::Transaction,
@@ -64,6 +68,9 @@ impl<T> FullEthApiTypes for T where
     T: RpcNodeCore<
             Provider: TransactionsProvider<Transaction = TransactionSigned>
                           + ReceiptProvider<Receipt = reth_primitives::Receipt>,
+            Pool: TransactionPool<
+                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
+            >,
         > + EthApiTypes<
             TransactionCompat: TransactionCompat<
                 <Self::Provider as TransactionsProvider>::Transaction,

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -3,13 +3,15 @@
 use alloy_consensus::Header;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
+use reth_provider::{
+    BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderTx, StateProviderFactory,
+};
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
     RpcNodeCore,
 };
 use reth_rpc_eth_types::PendingBlock;
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 use crate::EthApi;
 
@@ -19,13 +21,16 @@ where
     Self: SpawnBlocking
         + RpcNodeCore<
             Provider: BlockReaderIdExt<
+                Transaction = reth_primitives::TransactionSigned,
                 Block = reth_primitives::Block,
                 Receipt = reth_primitives::Receipt,
                 Header = reth_primitives::Header,
             > + EvmEnvProvider
                           + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                           + StateProviderFactory,
-            Pool: TransactionPool,
+            Pool: TransactionPool<
+                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
+            >,
             Evm: ConfigureEvm<Header = Header>,
         >,
 {

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -226,7 +226,7 @@ impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
 #[derive(Debug)]
 pub struct BestPayloadTransactions<T, I>
 where
-    T: PoolTransaction<Consensus: Into<RecoveredTx>>,
+    T: PoolTransaction,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
     invalid: HashSet<Address>,
@@ -235,7 +235,7 @@ where
 
 impl<T, I> BestPayloadTransactions<T, I>
 where
-    T: PoolTransaction<Consensus: Into<RecoveredTx>>,
+    T: PoolTransaction,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
     /// Create a new `BestPayloadTransactions` with the given iterator.
@@ -246,16 +246,18 @@ where
 
 impl<T, I> PayloadTransactions for BestPayloadTransactions<T, I>
 where
-    T: PoolTransaction<Consensus: Into<RecoveredTx>>,
+    T: PoolTransaction,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
-    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx> {
+    type Transaction = T::Consensus;
+
+    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx<Self::Transaction>> {
         loop {
             let tx = self.best.next()?;
             if self.invalid.contains(&tx.sender()) {
                 continue
             }
-            return Some(tx.to_recovered_transaction())
+            return Some(tx.to_consensus())
         }
     }
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -592,15 +592,17 @@ impl MockTransaction {
 impl PoolTransaction for MockTransaction {
     type TryFromConsensusError = TryFromRecoveredTransactionError;
 
-    type Consensus = RecoveredTx;
+    type Consensus = TransactionSigned;
 
     type Pooled = PooledTransactionsElementEcRecovered;
 
-    fn try_from_consensus(tx: Self::Consensus) -> Result<Self, Self::TryFromConsensusError> {
+    fn try_from_consensus(
+        tx: RecoveredTx<Self::Consensus>,
+    ) -> Result<Self, Self::TryFromConsensusError> {
         tx.try_into()
     }
 
-    fn into_consensus(self) -> Self::Consensus {
+    fn into_consensus(self) -> RecoveredTx<Self::Consensus> {
         self.into()
     }
 
@@ -609,7 +611,7 @@ impl PoolTransaction for MockTransaction {
     }
 
     fn try_consensus_into_pooled(
-        tx: Self::Consensus,
+        tx: RecoveredTx<Self::Consensus>,
     ) -> Result<Self::Pooled, Self::TryFromConsensusError> {
         Self::Pooled::try_from(tx).map_err(|_| TryFromRecoveredTransactionError::BlobSidecarMissing)
     }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -378,7 +378,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     /// Converts to this type into the consensus transaction of the pooled transaction.
     ///
     /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
-    pub fn to_consensus(&self) -> T::Consensus {
+    pub fn to_consensus(&self) -> RecoveredTx<T::Consensus> {
         self.transaction.clone_into_consensus()
     }
 
@@ -432,15 +432,6 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         }
 
         false
-    }
-}
-
-impl<T: PoolTransaction<Consensus: Into<RecoveredTx>>> ValidPoolTransaction<T> {
-    /// Converts to this type into a [`RecoveredTx`].
-    ///
-    /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
-    pub fn to_recovered_transaction(&self) -> RecoveredTx {
-        self.to_consensus().into()
     }
 }
 

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -38,14 +38,14 @@ use reth::{
     },
     network::NetworkHandle,
     payload::ExecutionPayloadValidator,
-    primitives::{Block, EthPrimitives, SealedBlockFor},
+    primitives::{Block, EthPrimitives, SealedBlockFor, TransactionSigned},
     providers::{CanonStateSubscriptions, EthStorage, StateProviderFactory},
     rpc::{
         eth::EthApi,
         types::engine::{ExecutionPayload, ExecutionPayloadSidecar, PayloadError},
     },
     tasks::TaskManager,
-    transaction_pool::TransactionPool,
+    transaction_pool::{PoolTransaction, TransactionPool},
 };
 use reth_basic_payload_builder::{
     BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig, BuildArguments, BuildOutcome,
@@ -340,7 +340,9 @@ where
             Primitives = EthPrimitives,
         >,
     >,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + Unpin
+        + 'static,
 {
     async fn spawn_payload_service(
         self,
@@ -380,7 +382,7 @@ pub struct CustomPayloadBuilder;
 impl<Pool, Client> PayloadBuilder<Pool, Client> for CustomPayloadBuilder
 where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
-    Pool: TransactionPool,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
     type Attributes = CustomPayloadBuilderAttributes;
     type BuiltPayload = EthBuiltPayload;

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -20,7 +20,7 @@ use reth::{
     },
     rpc::types::engine::PayloadAttributes,
     tasks::TaskManager,
-    transaction_pool::TransactionPool,
+    transaction_pool::{PoolTransaction, TransactionPool},
 };
 use reth_chainspec::{Chain, ChainSpec};
 use reth_evm_ethereum::EthEvmConfig;
@@ -183,7 +183,9 @@ impl<Types, Node, Pool> PayloadServiceBuilder<Node, Pool> for MyPayloadBuilder
 where
     Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
     Node: FullNodeTypes<Types = Types>,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + Unpin
+        + 'static,
     Types::Engine: PayloadTypes<
         BuiltPayload = EthBuiltPayload,
         PayloadAttributes = PayloadAttributes,

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -54,8 +54,7 @@ fn main() {
                     if let Some(recipient) = tx.to() {
                         if args.is_match(&recipient) {
                             // convert the pool transaction
-                            let call_request =
-                                transaction_to_call_request(tx.to_recovered_transaction());
+                            let call_request = transaction_to_call_request(tx.to_consensus());
 
                             let result = eth_api
                                 .spawn_with_call_at(

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -17,14 +17,14 @@ use reth::{
     cli::{config::PayloadBuilderConfig, Cli},
     payload::PayloadBuilderHandle,
     providers::CanonStateSubscriptions,
-    transaction_pool::TransactionPool,
+    transaction_pool::{PoolTransaction, TransactionPool},
 };
 use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
 use reth_chainspec::ChainSpec;
 use reth_node_api::NodeTypesWithEngine;
 use reth_node_ethereum::{node::EthereumAddOns, EthEngineTypes, EthEvmConfig, EthereumNode};
 use reth_payload_builder::PayloadBuilderService;
-use reth_primitives::EthPrimitives;
+use reth_primitives::{EthPrimitives, TransactionSigned};
 
 pub mod generator;
 pub mod job;
@@ -42,7 +42,9 @@ where
             Primitives = EthPrimitives,
         >,
     >,
-    Pool: TransactionPool + Unpin + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + Unpin
+        + 'static,
 {
     async fn spawn_payload_service(
         self,

--- a/examples/txpool-tracing/src/main.rs
+++ b/examples/txpool-tracing/src/main.rs
@@ -44,8 +44,7 @@ fn main() {
                     if let Some(recipient) = tx.to() {
                         if args.is_match(&recipient) {
                             // trace the transaction with `trace_call`
-                            let callrequest =
-                                transaction_to_call_request(tx.to_recovered_transaction());
+                            let callrequest = transaction_to_call_request(tx.to_consensus());
                             let tracerequest = TraceCallRequest::new(callrequest)
                                 .with_trace_type(TraceType::Trace);
                             if let Ok(trace_result) = traceapi.trace_call(tracerequest).await {


### PR DESCRIPTION
This PR updates the way tx pool handles `Consensus` transaction AT. Before it was being set to a recovered transaction making it tricky to define bounds. This PR changes it so we now specifiy just a primitive transaction type for `PoolTransaction::Consensus`. Methods which were earlier accepting/returning `Self::Consensus` now operate on `RecoveredTx<Self::Consensus>`

This allowed to relax bounds on `EthPoolTransaction` which now does not require anything from `Consensus` AT

Similar updates can be applied to `Pooled` transaction as well