### PR TITLE
feat: Use `PrimitiveSignature` instead of `Signature`

### DIFF
--- a/crates/net/network/src/transactions/validation.rs
+++ b/crates/net/network/src/transactions/validation.rs
@@ -3,7 +3,7 @@
 //! announcements. Validation and filtering of announcements is network dependent.
 
 use crate::metrics::{AnnouncedTxTypesMetrics, TxTypesCounter};
-use alloy_primitives::{Signature, TxHash};
+use alloy_primitives::{PrimitiveSignature as Signature, TxHash};
 use derive_more::{Deref, DerefMut};
 use reth_eth_wire::{
     DedupPayload, Eth68TxMetadata, HandleMempoolData, PartiallyValidData, ValidAnnouncementData,


### PR DESCRIPTION
`PrimitiveSignature` was introduced in https://github.com/alloy-rs/core/pull/776 and `Signature` will be deprecated. We should use `PrimitiveSignature` instead.
(maybe this is the last part where the old `Signature` is still being used in reth)

from: https://github.com/alloy-rs/core/issues/788