### PR TITLE
Fix typos in documentation

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -33,7 +33,7 @@ help:
   text: |
     Reth uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
 
-    It looks like one more more checks failed; please check the console output.
+    It looks like one more checks failed; please check the console output.
 
     You can try to automatically address them by installing zepter (`cargo install zepter --locked`) and simply running `zepter` in the workspace root.
   links:

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,7 +30,7 @@ See examples in a [dedicated repository](https://github.com/paradigmxyz/reth-exe
 
 | Example                 | Description                                                                 |
 | ----------------------- | --------------------------------------------------------------------------- |
-| [DB over RPC](./rpc-db) | Illustrates how to run a standalone RPC server over a Rethdatabase instance |
+| [DB over RPC](./rpc-db) | Illustrates how to run a standalone RPC server over a Reth database instance |
 
 ## Database
 


### PR DESCRIPTION

## Changes Made

### 1. In `examples/README.md`:
Changed `Rethdatabase` to `Reth database`

**Before:**
Illustrates how to run a standalone RPC server over a Rethdatabase instance

**After:**
Illustrates how to run a standalone RPC server over a Reth database instance

### 2. In `.config/zepter.yaml`:
Removed redundant word "more"

**Before:**
It looks like one more more checks failed; please check the console output.

**After:**
It looks like one more checks failed; please check the console output.

## Reason for Changes

1. The term "Reth database" should be written as two separate words for better readability and consistency with other documentation.

2. Fixed a duplicate word ("more more") that was likely a typo in the error message.

These changes improve documentation clarity and fix grammatical errors without affecting any functionality.