### PR TITLE
feat: add Op DA config

### DIFF
--- a/crates/optimism/payload/src/config.rs
+++ b/crates/optimism/payload/src/config.rs
@@ -1,0 +1,87 @@
+//! Additional configuration for the OP builder
+
+use std::sync::{atomic::AtomicU64, Arc};
+
+/// Contains the Data Availability configuration for the OP builder.
+#[derive(Debug, Clone, Default)]
+pub struct OpDAConfig {
+    inner: Arc<OpDAConfigInner>,
+}
+
+impl OpDAConfig {
+    /// Creates a new Data Availability configuration with the given maximum sizes.
+    pub fn new(max_da_tx_size: u64, max_da_block_size: u64) -> Self {
+        let this = Self::default();
+        this.set_max_da_size(max_da_tx_size, max_da_block_size);
+        this
+    }
+
+    /// Returns the max allowed data availability size per transactions, if any.
+    pub fn max_da_tx_size(&self) -> Option<u64> {
+        let val = self.inner.max_da_tx_size.load(std::sync::atomic::Ordering::Relaxed);
+        if val == 0 {
+            None
+        } else {
+            Some(val)
+        }
+    }
+
+    /// Returns the max allowed data availability size per block, if any.
+    pub fn max_da_block_size(&self) -> Option<u64> {
+        let val = self.inner.max_da_block_size.load(std::sync::atomic::Ordering::Relaxed);
+        if val == 0 {
+            None
+        } else {
+            Some(val)
+        }
+    }
+
+    /// Sets the maximum data availability size currently allowed for inclusion. 0 means no maximum.
+    pub fn set_max_da_size(&self, max_da_tx_size: u64, max_da_block_size: u64) {
+        self.set_max_tx_size(max_da_tx_size);
+        self.set_max_block_size(max_da_block_size);
+    }
+
+    /// Sets the maximum data availability size per transaction currently allowed for inclusion. 0
+    /// means no maximum.
+    pub fn set_max_tx_size(&self, max_da_tx_size: u64) {
+        self.inner.max_da_tx_size.store(max_da_tx_size, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Sets the maximum data availability size per block currently allowed for inclusion. 0 means
+    /// no maximum.
+    pub fn set_max_block_size(&self, max_da_block_size: u64) {
+        self.inner.max_da_block_size.store(max_da_block_size, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug, Default)]
+struct OpDAConfigInner {
+    /// Don't include any transactions with data availability size larger than this in any built
+    /// block
+    ///
+    /// 0 means no limit.
+    max_da_tx_size: AtomicU64,
+    /// Maximum total data availability size for a block
+    ///
+    /// 0 means no limit.
+    max_da_block_size: AtomicU64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_da() {
+        let da = OpDAConfig::default();
+        assert_eq!(da.max_da_tx_size(), None);
+        assert_eq!(da.max_da_block_size(), None);
+        da.set_max_da_size(100, 200);
+        assert_eq!(da.max_da_tx_size(), Some(100));
+        assert_eq!(da.max_da_block_size(), Some(200));
+        da.set_max_da_size(0, 0);
+        assert_eq!(da.max_da_tx_size(), None);
+        assert_eq!(da.max_da_block_size(), None);
+    }
+}

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -16,3 +16,5 @@ pub use builder::OpPayloadBuilder;
 pub mod error;
 pub mod payload;
 pub use payload::{OpBuiltPayload, OpPayloadAttributes, OpPayloadBuilderAttributes};
+
+pub mod config;


### PR DESCRIPTION
we need to make this configurable for the OpBuilder

needs will be exposed via HTTP #13092 hence this is an atomic

ref https://github.com/ethereum-optimism/op-geth/blob/0a46245ccc5c801e7b18c258aceb5327d8ad69ad/miner/miner.go#L169-L183
https://github.com/ethereum-optimism/op-geth/blob/0a46245ccc5c801e7b18c258aceb5327d8ad69ad/miner/miner.go#L67-L69

> MaxDATxSize      *big.Int `toml:",omitempty"` // if non-nil, don't include any txs with data availability size larger than this in any built block
	MaxDABlockSize   *big.Int `toml:",omitempty"` // if non-nil, then don't build a block requiring more than this amount of total data availability


needs integration in builder once we know how to compute the DA values per tx
