### PR TITLE
chore(trie): exclude blinded providers from `Debug` impl

### DIFF
--- a/crates/trie/sparse/src/blinded.rs
+++ b/crates/trie/sparse/src/blinded.rs
@@ -28,7 +28,7 @@ pub trait BlindedProvider {
 }
 
 /// Default blinded node provider factory that creates [`DefaultBlindedProvider`].
-#[derive(PartialEq, Eq, Clone, Default)]
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
 pub struct DefaultBlindedProviderFactory;
 
 impl BlindedProviderFactory for DefaultBlindedProviderFactory {
@@ -45,7 +45,7 @@ impl BlindedProviderFactory for DefaultBlindedProviderFactory {
 }
 
 /// Default blinded node provider that always returns `Ok(None)`.
-#[derive(PartialEq, Eq, Clone, Default)]
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
 pub struct DefaultBlindedProvider;
 
 impl BlindedProvider for DefaultBlindedProvider {

--- a/crates/trie/sparse/src/blinded.rs
+++ b/crates/trie/sparse/src/blinded.rs
@@ -28,7 +28,7 @@ pub trait BlindedProvider {
 }
 
 /// Default blinded node provider factory that creates [`DefaultBlindedProvider`].
-#[derive(PartialEq, Eq, Clone, Default, Debug)]
+#[derive(PartialEq, Eq, Clone, Default)]
 pub struct DefaultBlindedProviderFactory;
 
 impl BlindedProviderFactory for DefaultBlindedProviderFactory {
@@ -45,7 +45,7 @@ impl BlindedProviderFactory for DefaultBlindedProviderFactory {
 }
 
 /// Default blinded node provider that always returns `Ok(None)`.
-#[derive(PartialEq, Eq, Clone, Default, Debug)]
+#[derive(PartialEq, Eq, Clone, Default)]
 pub struct DefaultBlindedProvider;
 
 impl BlindedProvider for DefaultBlindedProvider {

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -3,6 +3,7 @@ use crate::{
     RevealedSparseTrie, SparseStateTrieError, SparseStateTrieResult, SparseTrie, SparseTrieError,
 };
 use alloy_primitives::{
+    hex,
     map::{HashMap, HashSet},
     Bytes, B256,
 };
@@ -13,10 +14,9 @@ use reth_trie_common::{
     updates::{StorageTrieUpdates, TrieUpdates},
     MultiProof, Nibbles, TrieAccount, TrieNode, EMPTY_ROOT_HASH, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use std::iter::Peekable;
+use std::{fmt, iter::Peekable};
 
 /// Sparse state trie representing lazy-loaded Ethereum state trie.
-#[derive(Debug)]
 pub struct SparseStateTrie<F: BlindedProviderFactory = DefaultBlindedProviderFactory> {
     /// Blinded node provider factory.
     provider_factory: F,
@@ -42,6 +42,18 @@ impl Default for SparseStateTrie {
             retain_updates: false,
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
         }
+    }
+}
+
+impl fmt::Debug for SparseStateTrie {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SparseStateTrie")
+            .field("state", &self.state)
+            .field("storages", &self.storages)
+            .field("revealed", &self.revealed)
+            .field("retain_updates", &self.retain_updates)
+            .field("account_rlp_buf", &hex::encode(&self.account_rlp_buf))
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -19,12 +19,21 @@ use std::{borrow::Cow, fmt};
 
 /// Inner representation of the sparse trie.
 /// Sparse trie is blind by default until nodes are revealed.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq)]
 pub enum SparseTrie<P = DefaultBlindedProvider> {
     /// None of the trie nodes are known.
     Blind,
     /// The trie nodes have been revealed.
     Revealed(Box<RevealedSparseTrie<P>>),
+}
+
+impl<P> fmt::Debug for SparseTrie<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Blind => write!(f, "Blind"),
+            Self::Revealed(revealed) => write!(f, "Revealed({revealed:?})"),
+        }
+    }
 }
 
 impl<P> Default for SparseTrie<P> {
@@ -164,7 +173,7 @@ impl<P> fmt::Debug for RevealedSparseTrie<P> {
             .field("prefix_set", &self.prefix_set)
             .field("updates", &self.updates)
             .field("rlp_buf", &hex::encode(&self.rlp_buf))
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
## Description

Exclude blinded providers from `Debug` implementations.