### PR TITLE
feat: add miner rpc bindings

### DIFF
--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -21,6 +21,7 @@ mod engine;
 mod ganache;
 mod hardhat;
 mod mev;
+mod miner;
 mod net;
 mod otterscan;
 mod reth;
@@ -40,6 +41,7 @@ pub mod servers {
         debug::{DebugApiServer, DebugExecutionWitnessApiServer},
         engine::{EngineApiServer, EngineEthApiServer},
         mev::{MevFullApiServer, MevSimApiServer},
+        miner::MinerApiServer,
         net::NetApiServer,
         otterscan::OtterscanServer,
         reth::RethApiServer,
@@ -70,6 +72,7 @@ pub mod clients {
         ganache::GanacheApiClient,
         hardhat::HardhatApiClient,
         mev::{MevFullApiClient, MevSimApiClient},
+        miner::MinerApiClient,
         net::NetApiClient,
         otterscan::OtterscanClient,
         reth::RethApiClient,

--- a/crates/rpc/rpc-api/src/miner.rs
+++ b/crates/rpc/rpc-api/src/miner.rs
@@ -1,0 +1,21 @@
+use alloy_primitives::{Bytes, U128};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+/// Miner namespace rpc interface that can control miner/builder settings
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "miner"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "miner"))]
+pub trait MinerApi {
+    /// Sets the extra data string that is included when this miner mines a block.
+    ///
+    /// Returns an error if the extra data is too long.
+    #[method(name = "setExtra")]
+    fn set_extra(&self, record: Bytes) -> RpcResult<bool>;
+
+    /// Sets the minimum accepted gas price for the miner.
+    #[method(name = "setGasPrice")]
+    fn set_gas_price(&self, gas_price: U128) -> RpcResult<bool>;
+
+    /// Sets the gaslimit to target towards during mining.
+    #[method(name = "setGasLimit")]
+    fn set_gas_limit(&self, gas_price: U128) -> RpcResult<bool>;
+}


### PR DESCRIPTION
adds rpc bindings for the miner_ endpoint

geth reference:

https://github.com/ethereum/go-ethereum/blob/e0deac7f6f8dd3cb59529e25ccdd548dd003ed4d/eth/api_miner.go#L26-L26

this is prep for op miner API extension #13092