### PR TITLE
feat: make InvalidBlockHook generic over NodePrimitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7998,7 +7998,6 @@ dependencies = [
 name = "reth-node-api"
 version = "1.1.2"
 dependencies = [
- "alloy-consensus",
  "alloy-rpc-types-engine",
  "eyre",
  "reth-beacon-consensus",

--- a/crates/engine/local/src/service.rs
+++ b/crates/engine/local/src/service.rs
@@ -72,7 +72,7 @@ where
         payload_builder: PayloadBuilderHandle<N::Engine>,
         payload_validator: V,
         tree_config: TreeConfig,
-        invalid_block_hook: Box<dyn InvalidBlockHook>,
+        invalid_block_hook: Box<dyn InvalidBlockHook<N::Primitives>>,
         sync_metrics_tx: MetricEventsSender,
         to_engine: UnboundedSender<BeaconEngineMessage<N::Engine>>,
         from_engine: EngineMessageStream<N::Engine>,

--- a/crates/engine/primitives/src/invalid_block_hook.rs
+++ b/crates/engine/primitives/src/invalid_block_hook.rs
@@ -1,35 +1,36 @@
 use alloy_primitives::B256;
 use reth_execution_types::BlockExecutionOutput;
-use reth_primitives::{Receipt, SealedBlockWithSenders, SealedHeader};
+use reth_primitives::{NodePrimitives, SealedBlockWithSenders, SealedHeader};
 use reth_trie::updates::TrieUpdates;
 
 /// An invalid block hook.
-pub trait InvalidBlockHook: Send + Sync {
+pub trait InvalidBlockHook<N: NodePrimitives>: Send + Sync {
     /// Invoked when an invalid block is encountered.
     fn on_invalid_block(
         &self,
-        parent_header: &SealedHeader,
-        block: &SealedBlockWithSenders,
-        output: &BlockExecutionOutput<Receipt>,
+        parent_header: &SealedHeader<N::BlockHeader>,
+        block: &SealedBlockWithSenders<N::Block>,
+        output: &BlockExecutionOutput<N::Receipt>,
         trie_updates: Option<(&TrieUpdates, B256)>,
     );
 }
 
-impl<F> InvalidBlockHook for F
+impl<F, N> InvalidBlockHook<N> for F
 where
+    N: NodePrimitives,
     F: Fn(
-            &SealedHeader,
-            &SealedBlockWithSenders,
-            &BlockExecutionOutput<Receipt>,
+            &SealedHeader<N::BlockHeader>,
+            &SealedBlockWithSenders<N::Block>,
+            &BlockExecutionOutput<N::Receipt>,
             Option<(&TrieUpdates, B256)>,
         ) + Send
         + Sync,
 {
     fn on_invalid_block(
         &self,
-        parent_header: &SealedHeader,
-        block: &SealedBlockWithSenders,
-        output: &BlockExecutionOutput<Receipt>,
+        parent_header: &SealedHeader<N::BlockHeader>,
+        block: &SealedBlockWithSenders<N::Block>,
+        output: &BlockExecutionOutput<N::Receipt>,
         trie_updates: Option<(&TrieUpdates, B256)>,
     ) {
         self(parent_header, block, output, trie_updates)

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -78,7 +78,7 @@ where
         payload_builder: PayloadBuilderHandle<N::Engine>,
         payload_validator: V,
         tree_config: TreeConfig,
-        invalid_block_hook: Box<dyn InvalidBlockHook>,
+        invalid_block_hook: Box<dyn InvalidBlockHook<N::Primitives>>,
         sync_metrics_tx: MetricEventsSender,
     ) -> Self
     where

--- a/crates/engine/tree/src/tree/invalid_block_hook.rs
+++ b/crates/engine/tree/src/tree/invalid_block_hook.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::B256;
 use reth_engine_primitives::InvalidBlockHook;
-use reth_primitives::{Receipt, SealedBlockWithSenders, SealedHeader};
+use reth_primitives::{NodePrimitives, SealedBlockWithSenders, SealedHeader};
 use reth_provider::BlockExecutionOutput;
 use reth_trie::updates::TrieUpdates;
 
@@ -9,32 +9,32 @@ use reth_trie::updates::TrieUpdates;
 #[non_exhaustive]
 pub struct NoopInvalidBlockHook;
 
-impl InvalidBlockHook for NoopInvalidBlockHook {
+impl<N: NodePrimitives> InvalidBlockHook<N> for NoopInvalidBlockHook {
     fn on_invalid_block(
         &self,
-        _parent_header: &SealedHeader,
-        _block: &SealedBlockWithSenders,
-        _output: &BlockExecutionOutput<Receipt>,
+        _parent_header: &SealedHeader<N::BlockHeader>,
+        _block: &SealedBlockWithSenders<N::Block>,
+        _output: &BlockExecutionOutput<N::Receipt>,
         _trie_updates: Option<(&TrieUpdates, B256)>,
     ) {
     }
 }
 
 /// Multiple [`InvalidBlockHook`]s that are executed in order.
-pub struct InvalidBlockHooks(pub Vec<Box<dyn InvalidBlockHook>>);
+pub struct InvalidBlockHooks<N: NodePrimitives>(pub Vec<Box<dyn InvalidBlockHook<N>>>);
 
-impl std::fmt::Debug for InvalidBlockHooks {
+impl<N: NodePrimitives> std::fmt::Debug for InvalidBlockHooks<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InvalidBlockHooks").field("len", &self.0.len()).finish()
     }
 }
 
-impl InvalidBlockHook for InvalidBlockHooks {
+impl<N: NodePrimitives> InvalidBlockHook<N> for InvalidBlockHooks<N> {
     fn on_invalid_block(
         &self,
-        parent_header: &SealedHeader,
-        block: &SealedBlockWithSenders,
-        output: &BlockExecutionOutput<Receipt>,
+        parent_header: &SealedHeader<N::BlockHeader>,
+        block: &SealedBlockWithSenders<N::Block>,
+        output: &BlockExecutionOutput<N::Receipt>,
         trie_updates: Option<(&TrieUpdates, B256)>,
     ) {
         for hook in &self.0 {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -469,6 +469,7 @@ pub enum TreeAction {
 /// emitting events.
 pub struct EngineApiTreeHandler<N, P, E, T, V>
 where
+    N: NodePrimitives,
     T: EngineTypes,
 {
     provider: P,
@@ -507,7 +508,7 @@ where
     /// Metrics for the engine api.
     metrics: EngineApiMetrics,
     /// An invalid block hook.
-    invalid_block_hook: Box<dyn InvalidBlockHook>,
+    invalid_block_hook: Box<dyn InvalidBlockHook<N>>,
     /// The engine API variant of this handler
     engine_kind: EngineApiKind,
     /// Captures the types the engine operates on
@@ -516,6 +517,8 @@ where
 
 impl<N, P: Debug, E: Debug, T: EngineTypes + Debug, V: Debug> std::fmt::Debug
     for EngineApiTreeHandler<N, P, E, T, V>
+where
+    N: NodePrimitives,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EngineApiTreeHandler")
@@ -597,7 +600,7 @@ where
     }
 
     /// Sets the invalid block hook.
-    fn set_invalid_block_hook(&mut self, invalid_block_hook: Box<dyn InvalidBlockHook>) {
+    fn set_invalid_block_hook(&mut self, invalid_block_hook: Box<dyn InvalidBlockHook<N>>) {
         self.invalid_block_hook = invalid_block_hook;
     }
 
@@ -616,7 +619,7 @@ where
         payload_builder: PayloadBuilderHandle<T>,
         canonical_in_memory_state: CanonicalInMemoryState,
         config: TreeConfig,
-        invalid_block_hook: Box<dyn InvalidBlockHook>,
+        invalid_block_hook: Box<dyn InvalidBlockHook<N>>,
         kind: EngineApiKind,
     ) -> (Sender<FromEngine<EngineApiRequest<T>>>, UnboundedReceiver<EngineApiEvent>) {
         let best_block_number = provider.best_block_number().unwrap_or(0);

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -152,7 +152,7 @@ where
         let env = self.evm_env_for_block(&block.header, total_difficulty);
         let mut evm = self.evm_config.evm_with_env(&mut self.state, env);
 
-        self.system_caller.apply_pre_execution_changes(block, &mut evm)?;
+        self.system_caller.apply_pre_execution_changes(&block.block, &mut evm)?;
 
         Ok(())
     }
@@ -247,7 +247,7 @@ where
         drop(evm);
 
         let mut balance_increments =
-            post_block_balance_increments(&self.chain_spec, block, total_difficulty);
+            post_block_balance_increments(&self.chain_spec, &block.block, total_difficulty);
 
         // Irregular state change at Ethereum DAO hardfork
         if self.chain_spec.fork(EthereumHardfork::Dao).transitions_at_block(block.number) {

--- a/crates/evm/src/state_change.rs
+++ b/crates/evm/src/state_change.rs
@@ -1,43 +1,55 @@
 //! State changes that are not related to transactions.
 
+use alloy_consensus::BlockHeader;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{map::HashMap, Address, U256};
 use reth_chainspec::EthereumHardforks;
 use reth_consensus_common::calc;
-use reth_primitives::Block;
+use reth_primitives_traits::BlockBody;
 
 /// Collect all balance changes at the end of the block.
 ///
 /// Balance changes might include the block reward, uncle rewards, withdrawals, or irregular
 /// state changes (DAO fork).
 #[inline]
-pub fn post_block_balance_increments<ChainSpec: EthereumHardforks>(
+pub fn post_block_balance_increments<ChainSpec, Block>(
     chain_spec: &ChainSpec,
     block: &Block,
     total_difficulty: U256,
-) -> HashMap<Address, u128> {
+) -> HashMap<Address, u128>
+where
+    ChainSpec: EthereumHardforks,
+    Block: reth_primitives_traits::Block,
+{
     let mut balance_increments = HashMap::default();
 
     // Add block rewards if they are enabled.
-    if let Some(base_block_reward) =
-        calc::base_block_reward(chain_spec, block.number, block.difficulty, total_difficulty)
-    {
+    if let Some(base_block_reward) = calc::base_block_reward(
+        chain_spec,
+        block.header().number(),
+        block.header().difficulty(),
+        total_difficulty,
+    ) {
         // Ommer rewards
-        for ommer in &block.body.ommers {
-            *balance_increments.entry(ommer.beneficiary).or_default() +=
-                calc::ommer_reward(base_block_reward, block.number, ommer.number);
+        if let Some(ommers) = block.body().ommers() {
+            for ommer in ommers {
+                *balance_increments.entry(ommer.beneficiary()).or_default() +=
+                    calc::ommer_reward(base_block_reward, block.header().number(), ommer.number());
+            }
         }
 
         // Full block reward
-        *balance_increments.entry(block.beneficiary).or_default() +=
-            calc::block_reward(base_block_reward, block.body.ommers.len());
+        *balance_increments.entry(block.header().beneficiary()).or_default() += calc::block_reward(
+            base_block_reward,
+            block.body().ommers().map(|s| s.len()).unwrap_or(0),
+        );
     }
 
     // process withdrawals
     insert_post_block_withdrawals_balance_increments(
         chain_spec,
-        block.timestamp,
-        block.body.withdrawals.as_ref().map(|w| w.as_slice()),
+        block.header().timestamp(),
+        block.body().withdrawals().as_ref().map(|w| w.as_slice()),
         &mut balance_increments,
     );
 

--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -4,7 +4,6 @@ use alloc::{boxed::Box, string::ToString};
 use alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS;
 
 use crate::ConfigureEvm;
-use alloy_consensus::Header;
 use alloy_primitives::B256;
 use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
@@ -35,7 +34,7 @@ pub(crate) fn transact_blockhashes_contract_call<EvmConfig, EXT, DB>(
 where
     DB: Database,
     DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm<Header = Header>,
+    EvmConfig: ConfigureEvm,
 {
     if !chain_spec.is_prague_active_at_timestamp(block_timestamp) {
         return Ok(None)

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -2,7 +2,6 @@
 use alloc::{boxed::Box, string::ToString};
 
 use crate::ConfigureEvm;
-use alloy_consensus::Header;
 use alloy_eips::eip4788::BEACON_ROOTS_ADDRESS;
 use alloy_primitives::B256;
 use reth_chainspec::EthereumHardforks;
@@ -31,7 +30,7 @@ pub(crate) fn transact_beacon_root_contract_call<EvmConfig, EXT, DB, Spec>(
 where
     DB: Database,
     DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm<Header = Header>,
+    EvmConfig: ConfigureEvm,
     Spec: EthereumHardforks,
 {
     if !chain_spec.is_cancun_active_at_timestamp(block_timestamp) {

--- a/crates/evm/src/system_calls/eip7002.rs
+++ b/crates/evm/src/system_calls/eip7002.rs
@@ -1,7 +1,6 @@
 //! [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) system call implementation.
 use crate::ConfigureEvm;
 use alloc::{boxed::Box, format};
-use alloy_consensus::Header;
 use alloy_eips::eip7002::WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS;
 use alloy_primitives::Bytes;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
@@ -21,7 +20,7 @@ pub(crate) fn transact_withdrawal_requests_contract_call<EvmConfig, EXT, DB>(
 where
     DB: Database,
     DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm<Header = Header>,
+    EvmConfig: ConfigureEvm,
 {
     // get previous env
     let previous_env = Box::new(evm.context.env().clone());

--- a/crates/evm/src/system_calls/eip7251.rs
+++ b/crates/evm/src/system_calls/eip7251.rs
@@ -1,7 +1,6 @@
 //! [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) system call implementation.
 use crate::ConfigureEvm;
 use alloc::{boxed::Box, format};
-use alloy_consensus::Header;
 use alloy_eips::eip7251::CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS;
 use alloy_primitives::Bytes;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
@@ -22,7 +21,7 @@ pub(crate) fn transact_consolidation_requests_contract_call<EvmConfig, EXT, DB>(
 where
     DB: Database,
     DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm<Header = Header>,
+    EvmConfig: ConfigureEvm,
 {
     // get previous env
     let previous_env = Box::new(evm.context.env().clone());

--- a/crates/node/api/Cargo.toml
+++ b/crates/node/api/Cargo.toml
@@ -26,6 +26,5 @@ reth-node-types.workspace = true
 reth-node-core.workspace = true
 
 alloy-rpc-types-engine.workspace = true
-alloy-consensus.workspace = true
 
 eyre.workspace = true

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -1,14 +1,13 @@
 //! Traits for configuring a node.
 
 use crate::ConfigureEvm;
-use alloy_consensus::Header;
 use alloy_rpc_types_engine::JwtSecret;
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
 use reth_consensus::FullConsensus;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
-use reth_node_types::{NodeTypes, NodeTypesWithDB, NodeTypesWithEngine, TxTy};
+use reth_node_types::{HeaderTy, NodeTypes, NodeTypesWithDB, NodeTypesWithEngine, TxTy};
 use reth_payload_builder_primitives::PayloadBuilder;
 use reth_provider::FullProvider;
 use reth_tasks::TaskExecutor;
@@ -50,7 +49,7 @@ pub trait FullNodeComponents: FullNodeTypes + Clone + 'static {
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvm<Header = Header>;
+    type Evm: ConfigureEvm<Header = HeaderTy<Self::Types>>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <Self::Types as NodeTypes>::Primitives>;

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -7,10 +7,9 @@ use crate::{
     },
     BuilderContext, ConfigureEvm, FullNodeTypes,
 };
-use alloy_consensus::Header;
 use reth_consensus::FullConsensus;
 use reth_evm::execute::BlockExecutorProvider;
-use reth_node_api::{NodeTypes, NodeTypesWithEngine, TxTy};
+use reth_node_api::{HeaderTy, NodeTypes, NodeTypesWithEngine, TxTy};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{future::Future, marker::PhantomData};
@@ -378,7 +377,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: ConfigureEvm<Header = Header>,
+    EVM: ConfigureEvm<Header = HeaderTy<Node::Types>>,
     Executor: BlockExecutorProvider<Primitives = <Node::Types as NodeTypes>::Primitives>,
     Cons: FullConsensus<<Node::Types as NodeTypes>::Primitives> + Clone + Unpin + 'static,
 {

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -1,8 +1,7 @@
 //! EVM component for the node builder.
 use crate::{BuilderContext, FullNodeTypes};
-use alloy_consensus::Header;
 use reth_evm::execute::BlockExecutorProvider;
-use reth_node_api::ConfigureEvm;
+use reth_node_api::{ConfigureEvm, HeaderTy};
 use std::future::Future;
 
 /// A type that knows how to build the executor types.
@@ -10,7 +9,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
     /// The EVM config to use.
     ///
     /// This provides the node with the necessary configuration to configure an EVM.
-    type EVM: ConfigureEvm<Header = Header>;
+    type EVM: ConfigureEvm<Header = HeaderTy<Node::Types>>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<
@@ -27,7 +26,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
 impl<Node, F, Fut, EVM, Executor> ExecutorBuilder<Node> for F
 where
     Node: FullNodeTypes,
-    EVM: ConfigureEvm<Header = Header>,
+    EVM: ConfigureEvm<Header = HeaderTy<Node::Types>>,
     Executor:
         BlockExecutorProvider<Primitives = <Node::Types as reth_node_api::NodeTypes>::Primitives>,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -22,12 +22,11 @@ pub use payload::*;
 pub use pool::*;
 
 use crate::{ConfigureEvm, FullNodeTypes};
-use alloy_consensus::Header;
 use reth_consensus::FullConsensus;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network::NetworkHandle;
 use reth_network_api::FullNetwork;
-use reth_node_api::{NodeTypes, NodeTypesWithEngine, TxTy};
+use reth_node_api::{HeaderTy, NodeTypes, NodeTypesWithEngine, TxTy};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
@@ -41,7 +40,7 @@ pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'stati
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<T::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvm<Header = Header>;
+    type Evm: ConfigureEvm<Header = HeaderTy<T::Types>>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <T::Types as NodeTypes>::Primitives>;
@@ -100,7 +99,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: ConfigureEvm<Header = Header>,
+    EVM: ConfigureEvm<Header = HeaderTy<Node::Types>>,
     Executor: BlockExecutorProvider<Primitives = <Node::Types as NodeTypes>::Primitives>,
     Cons: FullConsensus<<Node::Types as NodeTypes>::Primitives> + Clone + Unpin + 'static,
 {
@@ -140,7 +139,7 @@ impl<Node, Pool, EVM, Executor, Cons> Clone for Components<Node, Pool, EVM, Exec
 where
     Node: FullNodeTypes,
     Pool: TransactionPool,
-    EVM: ConfigureEvm<Header = Header>,
+    EVM: ConfigureEvm<Header = HeaderTy<Node::Types>>,
     Executor: BlockExecutorProvider,
     Cons: Clone,
 {

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -258,7 +258,7 @@ where
         _receipts: &[Receipt],
     ) -> Result<Requests, Self::Error> {
         let balance_increments =
-            post_block_balance_increments(&self.chain_spec.clone(), block, total_difficulty);
+            post_block_balance_increments(&self.chain_spec.clone(), &block.block, total_difficulty);
         // increment balances
         self.state
             .increment_balances(balance_increments.clone())


### PR DESCRIPTION
Makes `InvalidBlockHook` generic over primitives and updates some bounds on `ConfigureEvm` to not lock the header type or set it to NodePrimitives type.