### PR TITLE
feat: use generic CapabilityMessage everywhere

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -398,7 +398,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
         &mut self,
         peer_id: PeerId,
         _capabilities: Arc<Capabilities>,
-        _message: CapabilityMessage,
+        _message: CapabilityMessage<N>,
     ) {
         trace!(target: "net", ?peer_id, "received unexpected message");
         self.swarm

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -264,7 +264,7 @@ pub enum ActiveSessionMessage<N: NetworkPrimitives> {
         /// Announced capabilities of the remote peer.
         capabilities: Arc<Capabilities>,
         /// Message received from the peer.
-        message: CapabilityMessage,
+        message: CapabilityMessage<N>,
     },
     /// Received a bad message from the peer.
     BadMessage {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -710,7 +710,7 @@ pub enum SessionEvent<N: NetworkPrimitives> {
         /// Announced capabilities of the remote peer.
         capabilities: Arc<Capabilities>,
         /// Message received from the peer.
-        message: CapabilityMessage,
+        message: CapabilityMessage<N>,
     },
     /// Received a bad message from the peer.
     BadMessage {

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -350,7 +350,7 @@ pub(crate) enum SwarmEvent<N: NetworkPrimitives = EthNetworkPrimitives> {
         /// Announced capabilities of the remote peer.
         capabilities: Arc<Capabilities>,
         /// Message received from the peer.
-        message: CapabilityMessage,
+        message: CapabilityMessage<N>,
     },
     /// Received a bad message from the peer.
     BadMessage {


### PR DESCRIPTION
The generic here can be propagated for all usages of `CapabilityMessage`