### PR TITLE
chore: propagate network primitives generic to EthStream usages

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -839,7 +839,7 @@ mod tests {
             f: F,
         ) -> Pin<Box<dyn Future<Output = ()> + Send>>
         where
-            F: FnOnce(EthStream<P2PStream<ECIESStream<TcpStream>>>) -> O + Send + 'static,
+            F: FnOnce(EthStream<P2PStream<ECIESStream<TcpStream>>, N>) -> O + Send + 'static,
             O: Future<Output = ()> + Send + Sync,
         {
             let status = self.status;

--- a/examples/manual-p2p/src/main.rs
+++ b/examples/manual-p2p/src/main.rs
@@ -16,7 +16,7 @@ use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
     EthMessage, EthStream, HelloMessage, P2PStream, Status, UnauthedEthStream, UnauthedP2PStream,
 };
-use reth_network::config::rng_secret_key;
+use reth_network::{config::rng_secret_key, EthNetworkPrimitives};
 use reth_network_peers::{mainnet_nodes, pk2id, NodeRecord};
 use reth_primitives::{EthereumHardfork, Head};
 use secp256k1::{SecretKey, SECP256K1};
@@ -24,7 +24,7 @@ use std::sync::LazyLock;
 use tokio::net::TcpStream;
 
 type AuthedP2PStream = P2PStream<ECIESStream<TcpStream>>;
-type AuthedEthStream = EthStream<P2PStream<ECIESStream<TcpStream>>>;
+type AuthedEthStream = EthStream<P2PStream<ECIESStream<TcpStream>>, EthNetworkPrimitives>;
 
 pub static MAINNET_BOOT_NODES: LazyLock<Vec<NodeRecord>> = LazyLock::new(mainnet_nodes);
 


### PR DESCRIPTION
Updates a usage of `EthStream` that was using the default type, also updates the manual p2p example to specify a primitives type