### PR TITLE
chore: bound most NetworkBuilder methods by NetworkPrimitives generic

### DIFF
--- a/crates/net/eth-wire/tests/pooled_transactions.rs
+++ b/crates/net/eth-wire/tests/pooled_transactions.rs
@@ -3,7 +3,7 @@
 use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::hex;
 use alloy_rlp::{Decodable, Encodable};
-use reth_eth_wire::{EthVersion, PooledTransactions, ProtocolMessage};
+use reth_eth_wire::{EthNetworkPrimitives, EthVersion, PooledTransactions, ProtocolMessage};
 use reth_primitives::PooledTransactionsElement;
 use std::{fs, path::PathBuf};
 use test_fuzz::test_fuzz;
@@ -51,7 +51,7 @@ fn decode_request_pair_pooled_blob_transactions() {
         .join("testdata/request_pair_pooled_blob_transactions");
     let data = fs::read_to_string(network_data_path).expect("Unable to read file");
     let hex_data = hex::decode(data.trim()).unwrap();
-    let _txs: ProtocolMessage =
+    let _txs: ProtocolMessage<EthNetworkPrimitives> =
         ProtocolMessage::decode_message(EthVersion::Eth68, &mut &hex_data[..]).unwrap();
 }
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -94,7 +94,7 @@ impl<N: NetworkPrimitives> NetworkConfig<(), N> {
     }
 
     /// Convenience method for creating the corresponding builder type with a random secret key.
-    pub fn builder_with_rng_secret_key() -> NetworkConfigBuilder {
+    pub fn builder_with_rng_secret_key() -> NetworkConfigBuilder<N> {
         NetworkConfigBuilder::with_rng_secret_key()
     }
 }


### PR DESCRIPTION
This bounds `NetworkBuilder` methods by its `NetworkPrimitives` generic, except for `transactions`, which requires `NetworkEventListenerProvider` generics. Also adds a concrete `EthNetworkPrimitives` to the `pooled_transactions` test.