### PR TITLE
chore(ci): fix hive patch

### DIFF
--- a/.github/assets/hive/no_sim_build.diff
+++ b/.github/assets/hive/no_sim_build.diff
@@ -1,24 +1,23 @@
 diff --git a/internal/libdocker/builder.go b/internal/libdocker/builder.go
-index 4731c9d..d717f52 100644
+index e4bf99b6..2023f7e2 100644
 --- a/internal/libdocker/builder.go
 +++ b/internal/libdocker/builder.go
-@@ -7,9 +7,7 @@ import (
- 	"fmt"
+@@ -8,7 +8,6 @@ import (
  	"io"
  	"io/fs"
+ 	"log/slog"
 -	"os"
  	"path/filepath"
--	"strings"
- 
- 	"github.com/ethereum/hive/internal/libhive"
- 	docker "github.com/fsouza/go-dockerclient"
-@@ -53,24 +51,8 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
+ 	"slices"
+ 	"strings"
+@@ -49,25 +48,8 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
  
  // BuildSimulatorImage builds a docker image of a simulator.
- func (b *Builder) BuildSimulatorImage(ctx context.Context, name string) (string, error) {
+ func (b *Builder) BuildSimulatorImage(ctx context.Context, name string, buildArgs map[string]string) (string, error) {
 -	dir := b.config.Inventory.SimulatorDirectory(name)
 -	buildContextPath := dir
 -	buildDockerfile := "Dockerfile"
+-
 -	// build context dir of simulator can be overridden with "hive_context.txt" file containing the desired build path
 -	if contextPathBytes, err := os.ReadFile(filepath.Join(filepath.FromSlash(dir), "hive_context.txt")); err == nil {
 -		buildContextPath = filepath.Join(dir, strings.TrimSpace(string(contextPathBytes)))
@@ -32,14 +31,14 @@ index 4731c9d..d717f52 100644
 -		}
 -	}
  	tag := fmt.Sprintf("hive/simulators/%s:latest", name)
--	err := b.buildImage(ctx, buildContextPath, buildDockerfile, tag, nil)
+-	err := b.buildImage(ctx, buildContextPath, buildDockerfile, tag, buildArgs)
 -	return tag, err
 +	return tag, nil
  }
  
  // BuildImage creates a container by archiving the given file system,
 diff --git a/internal/libdocker/proxy.go b/internal/libdocker/proxy.go
-index a53e5af..0bb2ea9 100644
+index d3a14ae6..8779671e 100644
 --- a/internal/libdocker/proxy.go
 +++ b/internal/libdocker/proxy.go
 @@ -16,7 +16,7 @@ const hiveproxyTag = "hive/hiveproxy"


### PR DESCRIPTION
Adapt `no_sim_build.diff` patch after the changes in https://github.com/ethereum/hive/pull/1182, was causing errors like https://github.com/paradigmxyz/reth/actions/runs/12150438140/job/33883195985
```
error: patch failed: internal/libdocker/builder.go:7
Error: error: internal/libdocker/builder.go: patch does not apply
Error: Process completed with exit code 1.
```