### PR TITLE
feat: make `PoolInner` functions `pub`

### DIFF
--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -77,7 +77,8 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
 /// be executed on the current state, but only yields transactions that are ready to be executed
 /// now. While it contains all gapless transactions of a sender, it _always_ only returns the
 /// transaction with the current on chain nonce.
-pub(crate) struct BestTransactions<T: TransactionOrdering> {
+#[derive(Debug)]
+pub struct BestTransactions<T: TransactionOrdering> {
     /// Contains a copy of _all_ transactions of the pending pool at the point in time this
     /// iterator was created.
     pub(crate) all: BTreeMap<TransactionId, PendingTransaction<T>>,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -166,7 +166,7 @@ where
     S: BlobStore,
 {
     /// Create a new transaction pool instance.
-    pub(crate) fn new(validator: V, ordering: T, blob_store: S, config: PoolConfig) -> Self {
+    pub fn new(validator: V, ordering: T, blob_store: S, config: PoolConfig) -> Self {
         Self {
             identifiers: Default::default(),
             validator,
@@ -182,31 +182,31 @@ where
     }
 
     /// Returns the configured blob store.
-    pub(crate) const fn blob_store(&self) -> &S {
+    pub const fn blob_store(&self) -> &S {
         &self.blob_store
     }
 
     /// Returns stats about the size of the pool.
-    pub(crate) fn size(&self) -> PoolSize {
+    pub fn size(&self) -> PoolSize {
         self.get_pool_data().size()
     }
 
     /// Returns the currently tracked block
-    pub(crate) fn block_info(&self) -> BlockInfo {
+    pub fn block_info(&self) -> BlockInfo {
         self.get_pool_data().block_info()
     }
     /// Sets the currently tracked block
-    pub(crate) fn set_block_info(&self, info: BlockInfo) {
+    pub fn set_block_info(&self, info: BlockInfo) {
         self.pool.write().set_block_info(info)
     }
 
     /// Returns the internal [`SenderId`] for this address
-    pub(crate) fn get_sender_id(&self, addr: Address) -> SenderId {
+    pub fn get_sender_id(&self, addr: Address) -> SenderId {
         self.identifiers.write().sender_id_or_create(addr)
     }
 
     /// Returns all senders in the pool
-    pub(crate) fn unique_senders(&self) -> HashSet<Address> {
+    pub fn unique_senders(&self) -> HashSet<Address> {
         self.get_pool_data().unique_senders()
     }
 
@@ -266,19 +266,14 @@ where
 
     /// If the pool contains the transaction, this adds a new listener that gets notified about
     /// transaction events.
-    pub(crate) fn add_transaction_event_listener(
-        &self,
-        tx_hash: TxHash,
-    ) -> Option<TransactionEvents> {
+    pub fn add_transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents> {
         self.get_pool_data()
             .contains(&tx_hash)
             .then(|| self.event_listener.write().subscribe(tx_hash))
     }
 
     /// Adds a listener for all transaction events.
-    pub(crate) fn add_all_transactions_event_listener(
-        &self,
-    ) -> AllTransactionsEvents<T::Transaction> {
+    pub fn add_all_transactions_event_listener(&self) -> AllTransactionsEvents<T::Transaction> {
         self.event_listener.write().subscribe_all()
     }
 
@@ -288,7 +283,7 @@ where
     }
 
     /// Returns hashes of _all_ transactions in the pool.
-    pub(crate) fn pooled_transactions_hashes(&self) -> Vec<TxHash> {
+    pub fn pooled_transactions_hashes(&self) -> Vec<TxHash> {
         self.get_pool_data()
             .all()
             .transactions_iter()
@@ -298,12 +293,12 @@ where
     }
 
     /// Returns _all_ transactions in the pool.
-    pub(crate) fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+    pub fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.get_pool_data().all().transactions_iter().filter(|tx| tx.propagate).collect()
     }
 
     /// Returns only the first `max` transactions in the pool.
-    pub(crate) fn pooled_transactions_max(
+    pub fn pooled_transactions_max(
         &self,
         max: usize,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -340,7 +335,7 @@ where
     }
 
     /// Returns pooled transactions for the given transaction hashes.
-    pub(crate) fn get_pooled_transaction_elements(
+    pub fn get_pooled_transaction_elements(
         &self,
         tx_hashes: Vec<TxHash>,
         limit: GetPooledTransactionLimit,
@@ -352,7 +347,7 @@ where
     }
 
     /// Returns pooled transactions for the given transaction hashes as the requested type.
-    pub(crate) fn get_pooled_transactions_as<P>(
+    pub fn get_pooled_transactions_as<P>(
         &self,
         tx_hashes: Vec<TxHash>,
         limit: GetPooledTransactionLimit,
@@ -382,7 +377,7 @@ where
     }
 
     /// Returns converted pooled transaction for the given transaction hash.
-    pub(crate) fn get_pooled_transaction_element(
+    pub fn get_pooled_transaction_element(
         &self,
         tx_hash: TxHash,
     ) -> Option<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>
@@ -393,7 +388,7 @@ where
     }
 
     /// Updates the entire pool after a new block was executed.
-    pub(crate) fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_>) {
+    pub fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_>) {
         trace!(target: "txpool", ?update, "updating pool on canonical state change");
 
         let block_info = update.block_info();
@@ -422,7 +417,7 @@ where
     /// Performs account updates on the pool.
     ///
     /// This will either promote or discard transactions based on the new account state.
-    pub(crate) fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
+    pub fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
         let changed_senders = self.changed_senders(accounts.into_iter());
         let UpdateOutcome { promoted, discarded } =
             self.pool.write().update_accounts(changed_senders);
@@ -522,7 +517,8 @@ where
         }
     }
 
-    pub(crate) fn add_transaction_and_subscribe(
+    /// Adds a transaction and returns the event stream.
+    pub fn add_transaction_and_subscribe(
         &self,
         origin: TransactionOrigin,
         tx: TransactionValidationOutcome<T::Transaction>,
@@ -676,13 +672,13 @@ where
     }
 
     /// Returns an iterator that yields transactions that are ready to be included in the block.
-    pub(crate) fn best_transactions(&self) -> BestTransactions<T> {
+    pub fn best_transactions(&self) -> BestTransactions<T> {
         self.get_pool_data().best_transactions()
     }
 
     /// Returns an iterator that yields transactions that are ready to be included in the block with
     /// the given base fee and optional blob fee attributes.
-    pub(crate) fn best_transactions_with_attributes(
+    pub fn best_transactions_with_attributes(
         &self,
         best_transactions_attributes: BestTransactionsAttributes,
     ) -> Box<dyn crate::traits::BestTransactions<Item = Arc<ValidPoolTransaction<T::Transaction>>>>
@@ -691,7 +687,7 @@ where
     }
 
     /// Returns only the first `max` transactions in the pending pool.
-    pub(crate) fn pending_transactions_max(
+    pub fn pending_transactions_max(
         &self,
         max: usize,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -699,17 +695,17 @@ where
     }
 
     /// Returns all transactions from the pending sub-pool
-    pub(crate) fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+    pub fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.get_pool_data().pending_transactions()
     }
 
     /// Returns all transactions from parked pools
-    pub(crate) fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+    pub fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.get_pool_data().queued_transactions()
     }
 
     /// Returns all transactions in the pool
-    pub(crate) fn all_transactions(&self) -> AllPoolTransactions<T::Transaction> {
+    pub fn all_transactions(&self) -> AllPoolTransactions<T::Transaction> {
         let pool = self.get_pool_data();
         AllPoolTransactions {
             pending: pool.pending_transactions(),
@@ -718,7 +714,7 @@ where
     }
 
     /// Removes and returns all matching transactions from the pool.
-    pub(crate) fn remove_transactions(
+    pub fn remove_transactions(
         &self,
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -736,7 +732,7 @@ where
 
     /// Removes and returns all matching transactions and their dependent transactions from the
     /// pool.
-    pub(crate) fn remove_transactions_and_descendants(
+    pub fn remove_transactions_and_descendants(
         &self,
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -752,7 +748,8 @@ where
         removed
     }
 
-    pub(crate) fn remove_transactions_by_sender(
+    /// Removes and returns all transactions by the specified sender from the pool.
+    pub fn remove_transactions_by_sender(
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -767,7 +764,7 @@ where
     }
 
     /// Removes and returns all transactions that are present in the pool.
-    pub(crate) fn retain_unknown<A>(&self, announcement: &mut A)
+    pub fn retain_unknown<A>(&self, announcement: &mut A)
     where
         A: HandleMempoolData,
     {
@@ -779,15 +776,12 @@ where
     }
 
     /// Returns the transaction by hash.
-    pub(crate) fn get(
-        &self,
-        tx_hash: &TxHash,
-    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+    pub fn get(&self, tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
         self.get_pool_data().get(tx_hash)
     }
 
     /// Returns all transactions of the address
-    pub(crate) fn get_transactions_by_sender(
+    pub fn get_transactions_by_sender(
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -796,7 +790,7 @@ where
     }
 
     /// Returns all queued transactions of the address by sender
-    pub(crate) fn get_queued_transactions_by_sender(
+    pub fn get_queued_transactions_by_sender(
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -805,7 +799,7 @@ where
     }
 
     /// Returns all pending transactions filtered by predicate
-    pub(crate) fn pending_transactions_with_predicate(
+    pub fn pending_transactions_with_predicate(
         &self,
         predicate: impl FnMut(&ValidPoolTransaction<T::Transaction>) -> bool,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -813,7 +807,7 @@ where
     }
 
     /// Returns all pending transactions of the address by sender
-    pub(crate) fn get_pending_transactions_by_sender(
+    pub fn get_pending_transactions_by_sender(
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -822,7 +816,7 @@ where
     }
 
     /// Returns the highest transaction of the address
-    pub(crate) fn get_highest_transaction_by_sender(
+    pub fn get_highest_transaction_by_sender(
         &self,
         sender: Address,
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -831,7 +825,7 @@ where
     }
 
     /// Returns the transaction with the highest nonce that is executable given the on chain nonce.
-    pub(crate) fn get_highest_consecutive_transaction_by_sender(
+    pub fn get_highest_consecutive_transaction_by_sender(
         &self,
         sender: Address,
         on_chain_nonce: u64,
@@ -842,8 +836,16 @@ where
         )
     }
 
+    /// Returns the transaction given a [`TransactionId`]
+    pub fn get_transaction_by_transaction_id(
+        &self,
+        transaction_id: &TransactionId,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.get_pool_data().all().get(transaction_id).map(|tx| tx.transaction.clone())
+    }
+
     /// Returns all transactions that where submitted with the given [`TransactionOrigin`]
-    pub(crate) fn get_transactions_by_origin(
+    pub fn get_transactions_by_origin(
         &self,
         origin: TransactionOrigin,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -851,7 +853,7 @@ where
     }
 
     /// Returns all pending transactions filted by [`TransactionOrigin`]
-    pub(crate) fn get_pending_transactions_by_origin(
+    pub fn get_pending_transactions_by_origin(
         &self,
         origin: TransactionOrigin,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
@@ -861,10 +863,7 @@ where
     /// Returns all the transactions belonging to the hashes.
     ///
     /// If no transaction exists, it is skipped.
-    pub(crate) fn get_all(
-        &self,
-        txs: Vec<TxHash>,
-    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+    pub fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
             return Vec::new()
         }
@@ -872,7 +871,7 @@ where
     }
 
     /// Notify about propagated transactions.
-    pub(crate) fn on_propagated(&self, txs: PropagatedTransactions) {
+    pub fn on_propagated(&self, txs: PropagatedTransactions) {
         if txs.0.is_empty() {
             return
         }
@@ -921,17 +920,17 @@ where
     }
 
     /// Delete a blob from the blob store
-    pub(crate) fn delete_blob(&self, blob: TxHash) {
+    pub fn delete_blob(&self, blob: TxHash) {
         let _ = self.blob_store.delete(blob);
     }
 
     /// Delete all blobs from the blob store
-    pub(crate) fn delete_blobs(&self, txs: Vec<TxHash>) {
+    pub fn delete_blobs(&self, txs: Vec<TxHash>) {
         let _ = self.blob_store.delete_all(txs);
     }
 
     /// Cleans up the blob store
-    pub(crate) fn cleanup_blobs(&self) {
+    pub fn cleanup_blobs(&self) {
         let stat = self.blob_store.cleanup();
         self.blob_store_metrics.blobstore_failed_deletes.increment(stat.delete_failed as u64);
         self.update_blob_store_metrics();

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -278,7 +278,7 @@ where
     }
 
     /// Returns a read lock to the pool's data.
-    pub(crate) fn get_pool_data(&self) -> RwLockReadGuard<'_, TxPool<T>> {
+    pub fn get_pool_data(&self) -> RwLockReadGuard<'_, TxPool<T>> {
         self.pool.read()
     }
 
@@ -881,17 +881,17 @@ where
     }
 
     /// Number of transactions in the entire pool
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.get_pool_data().len()
     }
 
     /// Whether the pool is empty
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.get_pool_data().is_empty()
     }
 
     /// Returns whether or not the pool is over its configured size and transaction count limits.
-    pub(crate) fn is_exceeded(&self) -> bool {
+    pub fn is_exceeded(&self) -> bool {
         self.pool.read().is_exceeded()
     }
 
@@ -899,7 +899,7 @@ where
     ///
     /// If some of the transactions are blob transactions, they are also removed from the blob
     /// store.
-    pub(crate) fn discard_worst(&self) -> HashSet<TxHash> {
+    pub fn discard_worst(&self) -> HashSet<TxHash> {
         let discarded = self.pool.write().discard_worst();
 
         // delete any blobs associated with discarded blob transactions


### PR DESCRIPTION
Resolves https://github.com/paradigmxyz/reth/issues/13108

- The first commit contains the minimal changes required to allow using `PoolInner` directly.
- The second commit contains reasonable changes.

----

Note: Most changes are trivial, except the addition of `get_transaction_by_transaction_id`.