### PR TITLE
perf: avoid cloning bytecode when converting revm's `&AccountInfo` to reth's `Account`

### DIFF
--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -147,7 +147,7 @@ impl<T> ExecutionOutcome<T> {
 
     /// Get account if account is known.
     pub fn account(&self, address: &Address) -> Option<Option<Account>> {
-        self.bundle.account(address).map(|a| a.info.clone().map(Into::into))
+        self.bundle.account(address).map(|a| a.info.as_ref().map(Into::into))
     }
 
     /// Get storage if value is known.

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -178,11 +178,20 @@ impl From<&GenesisAccount> for Account {
 
 impl From<AccountInfo> for Account {
     fn from(revm_acc: AccountInfo) -> Self {
-        let code_hash = revm_acc.code_hash;
         Self {
             balance: revm_acc.balance,
             nonce: revm_acc.nonce,
-            bytecode_hash: (code_hash != KECCAK_EMPTY).then_some(code_hash),
+            bytecode_hash: (!revm_acc.is_empty_code_hash()).then_some(revm_acc.code_hash),
+        }
+    }
+}
+
+impl From<&AccountInfo> for Account {
+    fn from(revm_acc: &AccountInfo) -> Self {
+        Self {
+            balance: revm_acc.balance,
+            nonce: revm_acc.nonce,
+            bytecode_hash: (!revm_acc.is_empty_code_hash()).then_some(revm_acc.code_hash),
         }
     }
 }

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -45,7 +45,7 @@ impl ExecutionWitnessRecord {
             let hashed_address = keccak256(address);
             self.hashed_state
                 .accounts
-                .insert(hashed_address, account.account.as_ref().map(|a| a.info.clone().into()));
+                .insert(hashed_address, account.account.as_ref().map(|a| (&a.info).into()));
 
             let storage = self
                 .hashed_state

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -171,7 +171,7 @@ fn bundle_state_root(execution_outcome: &ExecutionOutcome) -> B256 {
                 (
                     address,
                     (
-                        Into::<Account>::into(info.clone()),
+                        Into::<Account>::into(info),
                         storage_root_unhashed(
                             account
                                 .storage

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -357,7 +357,7 @@ mod tests {
 
         let reth_account_a = account_a.into();
         let reth_account_b = account_b.into();
-        let reth_account_b_changed = account_b_changed.clone().into();
+        let reth_account_b_changed = (&account_b_changed).into();
 
         // Check plain state
         assert_eq!(

--- a/crates/trie/trie/benches/hash_post_state.rs
+++ b/crates/trie/trie/benches/hash_post_state.rs
@@ -29,7 +29,7 @@ fn from_bundle_state_seq(state: &HashMap<Address, BundleAccount>) -> HashedPostS
 
     for (address, account) in state {
         let hashed_address = keccak256(address);
-        this.accounts.insert(hashed_address, account.info.clone().map(Into::into));
+        this.accounts.insert(hashed_address, account.info.as_ref().map(Into::into));
 
         let hashed_storage = HashedStorage::from_iter(
             account.status.was_destroyed(),

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -34,7 +34,7 @@ impl HashedPostState {
             .into_par_iter()
             .map(|(address, account)| {
                 let hashed_address = KH::hash_key(address);
-                let hashed_account = account.info.clone().map(Into::into);
+                let hashed_account = account.info.as_ref().map(Into::into);
                 let hashed_storage = HashedStorage::from_plain_storage(
                     account.status,
                     account.storage.iter().map(|(slot, value)| (slot, &value.present_value)),
@@ -61,7 +61,7 @@ impl HashedPostState {
             .into_par_iter()
             .map(|(address, account)| {
                 let hashed_address = KH::hash_key(address);
-                let hashed_account = account.account.as_ref().map(|a| a.info.clone().into());
+                let hashed_account = account.account.as_ref().map(|a| (&a.info).into());
                 let hashed_storage = HashedStorage::from_plain_storage(
                     account.status,
                     account.account.as_ref().map(|a| a.storage.iter()).into_iter().flatten(),


### PR DESCRIPTION
Towards #12838.

Currently, conversions from `&AccountInfo` to `Account` would pre-clone `AccountInfo::code` just to drop it in the conversion. This PR provides a `From` instance that only copies `balance`, `nonce`, and `code_hash` without the extra `code` (de)allocation.