### PR TITLE
chore: add container question to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -60,6 +60,18 @@ body:
         - Mac (Apple Silicon)
         - Windows (x86)
         - Windows (ARM)
+  - type: dropdown
+    id: container_type
+    attributes:
+      label: Container Type
+      description: Were you running it in a container?
+      multiple: true
+      options:
+        - None
+        - Docker
+        - Kubernetes
+        - LXC/LXD
+        - Other
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
As a dropdown so it can be as frictionless as possible.

Running it on docker is quite common and comes with a bunch of potential issues (eg. https://github.com/paradigmxyz/reth/pull/13133) . Better to know straight away