### PR TITLE
feat: make RPC cache generic over primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8346,6 +8346,7 @@ dependencies = [
  "reth-optimism-forks",
  "reth-optimism-primitives",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-prune-types",
  "reth-revm",
  "revm",

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -16,6 +16,7 @@ reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-revm.workspace = true
 reth-execution-errors.workspace = true
 reth-execution-types.workspace = true

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -64,6 +64,7 @@ std = [
 	"alloy-genesis/std",
 	"alloy-primitives/std",
 	"revm-primitives/std",
+    "reth-primitives-traits/std",
 	"revm/std",
 	"reth-optimism-primitives/std",
 	"reth-ethereum-forks/std",

--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -8,7 +8,7 @@ use reth_chainspec::ChainSpec;
 use reth_execution_errors::BlockExecutionError;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardfork;
-use reth_primitives::BlockBody;
+use reth_primitives_traits::BlockBody;
 use revm::{
     primitives::{Bytecode, HashMap, SpecId},
     DatabaseCommit, L1BlockInfo,
@@ -32,9 +32,9 @@ const L1_BLOCK_ECOTONE_SELECTOR: [u8; 4] = hex!("440a5e20");
 /// transaction in the L2 block.
 ///
 /// Returns an error if the L1 info transaction is not found, if the block is empty.
-pub fn extract_l1_info(body: &BlockBody) -> Result<L1BlockInfo, OpBlockExecutionError> {
+pub fn extract_l1_info<B: BlockBody>(body: &B) -> Result<L1BlockInfo, OpBlockExecutionError> {
     let l1_info_tx_data = body
-        .transactions
+        .transactions()
         .first()
         .ok_or_else(|| OpBlockExecutionError::L1BlockInfoError {
             message: "could not find l1 block info tx in the L2 block".to_string(),

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -9,10 +9,10 @@ use reth_primitives::TransactionMeta;
 use reth_provider::HeaderProvider;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
-    RpcNodeCore, RpcReceipt,
+    RpcReceipt,
 };
 
-use crate::{OpEthApi, OpEthApiError, OpReceiptBuilder};
+use crate::{eth::OpNodeCore, OpEthApi, OpEthApiError, OpReceiptBuilder};
 
 impl<N> EthBlocks for OpEthApi<N>
 where
@@ -20,7 +20,7 @@ where
         Error = OpEthApiError,
         NetworkTypes: Network<ReceiptResponse = OpTransactionReceipt>,
     >,
-    N: RpcNodeCore<Provider: ChainSpecProvider<ChainSpec = OpChainSpec> + HeaderProvider>,
+    N: OpNodeCore<Provider: ChainSpecProvider<ChainSpec = OpChainSpec> + HeaderProvider>,
 {
     async fn block_receipts(
         &self,
@@ -77,6 +77,6 @@ where
 impl<N> LoadBlock for OpEthApi<N>
 where
     Self: LoadPendingBlock + SpawnBlocking,
-    N: RpcNodeCore,
+    N: OpNodeCore,
 {
 }

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,3 +1,4 @@
+use super::OpNodeCore;
 use crate::{OpEthApi, OpEthApiError};
 use alloy_consensus::Header;
 use alloy_primitives::{Bytes, TxKind, U256};
@@ -5,7 +6,7 @@ use alloy_rpc_types_eth::transaction::TransactionRequest;
 use reth_evm::ConfigureEvm;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
-    FromEthApiError, IntoEthApiError, RpcNodeCore,
+    FromEthApiError, IntoEthApiError,
 };
 use reth_rpc_eth_types::{revm_utils::CallFees, RpcInvalidTransactionError};
 use revm::primitives::{BlockEnv, OptimismFields, TxEnv};
@@ -13,7 +14,7 @@ use revm::primitives::{BlockEnv, OptimismFields, TxEnv};
 impl<N> EthCall for OpEthApi<N>
 where
     Self: EstimateCall + LoadPendingBlock,
-    N: RpcNodeCore,
+    N: OpNodeCore,
 {
 }
 
@@ -21,7 +22,7 @@ impl<N> EstimateCall for OpEthApi<N>
 where
     Self: Call,
     Self::Error: From<OpEthApiError>,
-    N: RpcNodeCore,
+    N: OpNodeCore,
 {
 }
 
@@ -29,7 +30,7 @@ impl<N> Call for OpEthApi<N>
 where
     Self: LoadState<Evm: ConfigureEvm<Header = Header>> + SpawnBlocking,
     Self::Error: From<OpEthApiError>,
-    N: RpcNodeCore,
+    N: OpNodeCore,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -10,17 +10,17 @@ use reth_primitives::{RecoveredTx, TransactionSigned};
 use reth_provider::{BlockReaderIdExt, ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
-    FromEthApiError, FullEthApiTypes, RpcNodeCore, TransactionCompat,
+    FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt, TransactionCompat,
 };
 use reth_rpc_eth_types::utils::recover_raw_transaction;
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 
-use crate::{OpEthApi, OpEthApiError, SequencerClient};
+use crate::{eth::OpNodeCore, OpEthApi, OpEthApiError, SequencerClient};
 
 impl<N> EthTransactions for OpEthApi<N>
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt>,
-    N: RpcNodeCore,
+    N: OpNodeCore,
 {
     fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>> {
         self.inner.eth_api.signers()
@@ -56,15 +56,15 @@ where
 
 impl<N> LoadTransaction for OpEthApi<N>
 where
-    Self: SpawnBlocking + FullEthApiTypes,
-    N: RpcNodeCore<Provider: TransactionsProvider, Pool: TransactionPool>,
+    Self: SpawnBlocking + FullEthApiTypes + RpcNodeCoreExt,
+    N: OpNodeCore<Provider: TransactionsProvider, Pool: TransactionPool>,
     Self::Pool: TransactionPool,
 {
 }
 
 impl<N> OpEthApi<N>
 where
-    N: RpcNodeCore,
+    N: OpNodeCore,
 {
     /// Returns the [`SequencerClient`] if one is set.
     pub fn raw_tx_forwarder(&self) -> Option<SequencerClient> {

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -15,11 +15,11 @@ pub type DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, Eth
 
 /// Handlers for core, filter and pubsub `eth` namespace APIs.
 #[derive(Debug, Clone)]
-pub struct EthHandlers<Provider, Pool, Network, Events, EthApi: EthApiTypes> {
+pub struct EthHandlers<Provider: BlockReader, Pool, Network, Events, EthApi: EthApiTypes> {
     /// Main `eth_` request handler
     pub api: EthApi,
     /// The async caching layer used by the eth handlers
-    pub cache: EthStateCache,
+    pub cache: EthStateCache<Provider::Block, Provider::Receipt>,
     /// Polling based filter handler available on all transports
     pub filter: EthFilter<Provider, Pool, EthApi>,
     /// Handler for subscriptions only available for transports that support it (ws, ipc)

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -925,7 +925,7 @@ impl RpcModuleConfigBuilder {
 /// A Helper type the holds instances of the configured modules.
 #[derive(Debug, Clone)]
 pub struct RpcRegistryInner<
-    Provider,
+    Provider: BlockReader,
     Pool,
     Network,
     Tasks,
@@ -1029,6 +1029,7 @@ where
 impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
     RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
 where
+    Provider: BlockReader,
     EthApi: EthApiTypes,
 {
     /// Returns a reference to the installed [`EthApi`](reth_rpc::eth::EthApi).
@@ -1045,7 +1046,7 @@ where
     ///
     /// This will spawn exactly one [`EthStateCache`] service if this is the first time the cache is
     /// requested.
-    pub const fn eth_cache(&self) -> &EthStateCache {
+    pub const fn eth_cache(&self) -> &EthStateCache<Provider::Block, Provider::Receipt> {
         &self.eth.cache
     }
 
@@ -1089,7 +1090,7 @@ impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
 where
     Network: NetworkInfo + Clone + 'static,
     EthApi: EthApiTypes,
-    Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
+    Provider: BlockReader + ChainSpecProvider<ChainSpec: EthereumHardforks>,
     BlockExecutor: BlockExecutorProvider,
 {
     /// Instantiates `AdminApi`

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -1,6 +1,7 @@
 //! Helper trait for interfacing with [`FullNodeComponents`].
 
 use reth_node_api::FullNodeComponents;
+use reth_provider::{BlockReader, ProviderBlock, ProviderReceipt};
 use reth_rpc_eth_types::EthStateCache;
 
 /// Helper trait to relax trait bounds on [`FullNodeComponents`].
@@ -76,7 +77,9 @@ where
 
 /// Additional components, asides the core node components, needed to run `eth_` namespace API
 /// server.
-pub trait RpcNodeCoreExt: RpcNodeCore {
+pub trait RpcNodeCoreExt: RpcNodeCore<Provider: BlockReader> {
     /// Returns handle to RPC cache service.
-    fn cache(&self) -> &EthStateCache;
+    fn cache(
+        &self,
+    ) -> &EthStateCache<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>;
 }

--- a/crates/rpc/rpc-eth-types/src/builder/ctx.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/ctx.rs
@@ -3,7 +3,7 @@
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::ChainSpecProvider;
 use reth_primitives::NodePrimitives;
-use reth_storage_api::BlockReaderIdExt;
+use reth_storage_api::{BlockReader, BlockReaderIdExt};
 use reth_tasks::TaskSpawner;
 
 use crate::{
@@ -13,7 +13,10 @@ use crate::{
 
 /// Context for building the `eth` namespace API.
 #[derive(Debug, Clone)]
-pub struct EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks, Events> {
+pub struct EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks, Events>
+where
+    Provider: BlockReader,
+{
     /// Database handle.
     pub provider: Provider,
     /// Mempool handle.
@@ -29,7 +32,7 @@ pub struct EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks, Events> {
     /// Events handle.
     pub events: Events,
     /// RPC cache handle.
-    pub cache: EthStateCache,
+    pub cache: EthStateCache<Provider::Block, Provider::Receipt>,
 }
 
 impl<Provider, Pool, EvmConfig, Network, Tasks, Events>
@@ -38,27 +41,24 @@ where
     Provider: BlockReaderIdExt + Clone,
 {
     /// Returns a new [`FeeHistoryCache`] for the context.
-    pub fn new_fee_history_cache(&self) -> FeeHistoryCache
+    pub fn new_fee_history_cache<N>(&self) -> FeeHistoryCache
     where
-        Provider: ChainSpecProvider + 'static,
+        N: NodePrimitives,
         Tasks: TaskSpawner,
-        Events: CanonStateSubscriptions<
-            Primitives: NodePrimitives<
-                Block = reth_primitives::Block,
-                Receipt = reth_primitives::Receipt,
-            >,
-        >,
+        Events: CanonStateSubscriptions<Primitives = N>,
+        Provider:
+            BlockReaderIdExt<Block = N::Block, Receipt = N::Receipt> + ChainSpecProvider + 'static,
     {
-        let fee_history_cache =
-            FeeHistoryCache::new(self.cache.clone(), self.config.fee_history_cache);
+        let fee_history_cache = FeeHistoryCache::new(self.config.fee_history_cache);
 
         let new_canonical_blocks = self.events.canonical_state_stream();
         let fhc = fee_history_cache.clone();
         let provider = self.provider.clone();
+        let cache = self.cache.clone();
         self.executor.spawn_critical(
             "cache canonical blocks for fee history task",
             Box::pin(async move {
-                fee_history_cache_new_blocks_task(fhc, new_canonical_blocks, provider).await;
+                fee_history_cache_new_blocks_task(fhc, new_canonical_blocks, provider, cache).await;
             }),
         );
 

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -1,14 +1,14 @@
 //! Async caching support for eth RPC
 
 use super::{EthStateCacheConfig, MultiConsumerLruCache};
-use alloy_consensus::Header;
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::B256;
 use futures::{future::Either, Stream, StreamExt};
 use reth_chain_state::CanonStateNotification;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_execution_types::Chain;
-use reth_primitives::{Receipt, SealedBlockWithSenders, TransactionSigned};
+use reth_primitives::{NodePrimitives, SealedBlockWithSenders};
+use reth_primitives_traits::{Block, BlockBody};
 use reth_storage_api::{BlockReader, StateProviderFactory, TransactionVariant};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use schnellru::{ByLength, Limiter};
@@ -30,41 +30,49 @@ pub mod metrics;
 pub mod multi_consumer;
 
 /// The type that can send the response to a requested [`SealedBlockWithSenders`]
-type BlockTransactionsResponseSender =
-    oneshot::Sender<ProviderResult<Option<Vec<TransactionSigned>>>>;
+type BlockTransactionsResponseSender<T> = oneshot::Sender<ProviderResult<Option<Vec<T>>>>;
 
 /// The type that can send the response to a requested [`SealedBlockWithSenders`]
-type BlockWithSendersResponseSender =
-    oneshot::Sender<ProviderResult<Option<Arc<SealedBlockWithSenders>>>>;
+type BlockWithSendersResponseSender<B> =
+    oneshot::Sender<ProviderResult<Option<Arc<SealedBlockWithSenders<B>>>>>;
 
 /// The type that can send the response to the requested receipts of a block.
-type ReceiptsResponseSender = oneshot::Sender<ProviderResult<Option<Arc<Vec<Receipt>>>>>;
+type ReceiptsResponseSender<R> = oneshot::Sender<ProviderResult<Option<Arc<Vec<R>>>>>;
 
 /// The type that can send the response to a requested header
-type HeaderResponseSender = oneshot::Sender<ProviderResult<Header>>;
+type HeaderResponseSender<H> = oneshot::Sender<ProviderResult<H>>;
 
-type BlockLruCache<L> = MultiConsumerLruCache<
+type BlockLruCache<B, L> = MultiConsumerLruCache<
     B256,
-    Arc<SealedBlockWithSenders>,
+    Arc<SealedBlockWithSenders<B>>,
     L,
-    Either<BlockWithSendersResponseSender, BlockTransactionsResponseSender>,
+    Either<
+        BlockWithSendersResponseSender<B>,
+        BlockTransactionsResponseSender<<<B as Block>::Body as BlockBody>::Transaction>,
+    >,
 >;
 
-type ReceiptsLruCache<L> =
-    MultiConsumerLruCache<B256, Arc<Vec<Receipt>>, L, ReceiptsResponseSender>;
+type ReceiptsLruCache<R, L> =
+    MultiConsumerLruCache<B256, Arc<Vec<R>>, L, ReceiptsResponseSender<R>>;
 
-type HeaderLruCache<L> = MultiConsumerLruCache<B256, Header, L, HeaderResponseSender>;
+type HeaderLruCache<H, L> = MultiConsumerLruCache<B256, H, L, HeaderResponseSender<H>>;
 
 /// Provides async access to cached eth data
 ///
 /// This is the frontend for the async caching service which manages cached data on a different
 /// task.
-#[derive(Debug, Clone)]
-pub struct EthStateCache {
-    to_service: UnboundedSender<CacheAction>,
+#[derive(Debug)]
+pub struct EthStateCache<B: Block, R> {
+    to_service: UnboundedSender<CacheAction<B, R>>,
 }
 
-impl EthStateCache {
+impl<B: Block, R> Clone for EthStateCache<B, R> {
+    fn clone(&self) -> Self {
+        Self { to_service: self.to_service.clone() }
+    }
+}
+
+impl<B: Block, R: Send + Sync> EthStateCache<B, R> {
     /// Creates and returns both [`EthStateCache`] frontend and the memory bound service.
     fn create<Provider, Tasks>(
         provider: Provider,
@@ -73,7 +81,10 @@ impl EthStateCache {
         max_receipts: u32,
         max_headers: u32,
         max_concurrent_db_operations: usize,
-    ) -> (Self, EthStateCacheService<Provider, Tasks>) {
+    ) -> (Self, EthStateCacheService<Provider, Tasks>)
+    where
+        Provider: BlockReader<Block = B, Receipt = R>,
+    {
         let (to_service, rx) = unbounded_channel();
         let service = EthStateCacheService {
             provider,
@@ -95,14 +106,8 @@ impl EthStateCache {
     /// See also [`Self::spawn_with`]
     pub fn spawn<Provider>(provider: Provider, config: EthStateCacheConfig) -> Self
     where
-        Provider: StateProviderFactory
-            + BlockReader<
-                Block = reth_primitives::Block,
-                Receipt = reth_primitives::Receipt,
-                Header = reth_primitives::Header,
-            > + Clone
-            + Unpin
-            + 'static,
+        Provider:
+            StateProviderFactory + BlockReader<Block = B, Receipt = R> + Clone + Unpin + 'static,
     {
         Self::spawn_with(provider, config, TokioTaskExecutor::default())
     }
@@ -117,14 +122,8 @@ impl EthStateCache {
         executor: Tasks,
     ) -> Self
     where
-        Provider: StateProviderFactory
-            + BlockReader<
-                Block = reth_primitives::Block,
-                Receipt = reth_primitives::Receipt,
-                Header = reth_primitives::Header,
-            > + Clone
-            + Unpin
-            + 'static,
+        Provider:
+            StateProviderFactory + BlockReader<Block = B, Receipt = R> + Clone + Unpin + 'static,
         Tasks: TaskSpawner + Clone + 'static,
     {
         let EthStateCacheConfig {
@@ -151,7 +150,7 @@ impl EthStateCache {
     pub async fn get_sealed_block_with_senders(
         &self,
         block_hash: B256,
-    ) -> ProviderResult<Option<Arc<SealedBlockWithSenders>>> {
+    ) -> ProviderResult<Option<Arc<SealedBlockWithSenders<B>>>> {
         let (response_tx, rx) = oneshot::channel();
         let _ = self.to_service.send(CacheAction::GetBlockWithSenders { block_hash, response_tx });
         rx.await.map_err(|_| ProviderError::CacheServiceUnavailable)?
@@ -160,10 +159,7 @@ impl EthStateCache {
     /// Requests the [Receipt] for the block hash
     ///
     /// Returns `None` if the block was not found.
-    pub async fn get_receipts(
-        &self,
-        block_hash: B256,
-    ) -> ProviderResult<Option<Arc<Vec<Receipt>>>> {
+    pub async fn get_receipts(&self, block_hash: B256) -> ProviderResult<Option<Arc<Vec<R>>>> {
         let (response_tx, rx) = oneshot::channel();
         let _ = self.to_service.send(CacheAction::GetReceipts { block_hash, response_tx });
         rx.await.map_err(|_| ProviderError::CacheServiceUnavailable)?
@@ -173,7 +169,7 @@ impl EthStateCache {
     pub async fn get_block_and_receipts(
         &self,
         block_hash: B256,
-    ) -> ProviderResult<Option<(Arc<SealedBlockWithSenders>, Arc<Vec<Receipt>>)>> {
+    ) -> ProviderResult<Option<(Arc<SealedBlockWithSenders<B>>, Arc<Vec<R>>)>> {
         let block = self.get_sealed_block_with_senders(block_hash);
         let receipts = self.get_receipts(block_hash);
 
@@ -185,7 +181,7 @@ impl EthStateCache {
     /// Requests the header for the given hash.
     ///
     /// Returns an error if the header is not found.
-    pub async fn get_header(&self, block_hash: B256) -> ProviderResult<Header> {
+    pub async fn get_header(&self, block_hash: B256) -> ProviderResult<B::Header> {
         let (response_tx, rx) = oneshot::channel();
         let _ = self.to_service.send(CacheAction::GetHeader { block_hash, response_tx });
         rx.await.map_err(|_| ProviderError::CacheServiceUnavailable)?
@@ -216,25 +212,26 @@ pub(crate) struct EthStateCacheService<
     LimitReceipts = ByLength,
     LimitHeaders = ByLength,
 > where
-    LimitBlocks: Limiter<B256, Arc<SealedBlockWithSenders>>,
-    LimitReceipts: Limiter<B256, Arc<Vec<Receipt>>>,
-    LimitHeaders: Limiter<B256, Header>,
+    Provider: BlockReader,
+    LimitBlocks: Limiter<B256, Arc<SealedBlockWithSenders<Provider::Block>>>,
+    LimitReceipts: Limiter<B256, Arc<Vec<Provider::Receipt>>>,
+    LimitHeaders: Limiter<B256, Provider::Header>,
 {
     /// The type used to lookup data from disk
     provider: Provider,
     /// The LRU cache for full blocks grouped by their hash.
-    full_block_cache: BlockLruCache<LimitBlocks>,
+    full_block_cache: BlockLruCache<Provider::Block, LimitBlocks>,
     /// The LRU cache for full blocks grouped by their hash.
-    receipts_cache: ReceiptsLruCache<LimitReceipts>,
+    receipts_cache: ReceiptsLruCache<Provider::Receipt, LimitReceipts>,
     /// The LRU cache for headers.
     ///
     /// Headers are cached because they are required to populate the environment for execution
     /// (evm).
-    headers_cache: HeaderLruCache<LimitHeaders>,
+    headers_cache: HeaderLruCache<Provider::Header, LimitHeaders>,
     /// Sender half of the action channel.
-    action_tx: UnboundedSender<CacheAction>,
+    action_tx: UnboundedSender<CacheAction<Provider::Block, Provider::Receipt>>,
     /// Receiver half of the action channel.
-    action_rx: UnboundedReceiverStream<CacheAction>,
+    action_rx: UnboundedReceiverStream<CacheAction<Provider::Block, Provider::Receipt>>,
     /// The type that's used to spawn tasks that do the actual work
     action_task_spawner: Tasks,
     /// Rate limiter
@@ -249,7 +246,7 @@ where
     fn on_new_block(
         &mut self,
         block_hash: B256,
-        res: ProviderResult<Option<Arc<SealedBlockWithSenders>>>,
+        res: ProviderResult<Option<Arc<SealedBlockWithSenders<Provider::Block>>>>,
     ) {
         if let Some(queued) = self.full_block_cache.remove(&block_hash) {
             // send the response to queued senders
@@ -260,7 +257,7 @@ where
                     }
                     Either::Right(transaction_tx) => {
                         let _ = transaction_tx.send(res.clone().map(|maybe_block| {
-                            maybe_block.map(|block| block.block.body.transactions.clone())
+                            maybe_block.map(|block| block.block.body.transactions().to_vec())
                         }));
                     }
                 }
@@ -276,7 +273,7 @@ where
     fn on_new_receipts(
         &mut self,
         block_hash: B256,
-        res: ProviderResult<Option<Arc<Vec<Receipt>>>>,
+        res: ProviderResult<Option<Arc<Vec<Provider::Receipt>>>>,
     ) {
         if let Some(queued) = self.receipts_cache.remove(&block_hash) {
             // send the response to queued senders
@@ -294,7 +291,7 @@ where
     fn on_reorg_block(
         &mut self,
         block_hash: B256,
-        res: ProviderResult<Option<SealedBlockWithSenders>>,
+        res: ProviderResult<Option<SealedBlockWithSenders<Provider::Block>>>,
     ) {
         let res = res.map(|b| b.map(Arc::new));
         if let Some(queued) = self.full_block_cache.remove(&block_hash) {
@@ -306,7 +303,7 @@ where
                     }
                     Either::Right(transaction_tx) => {
                         let _ = transaction_tx.send(res.clone().map(|maybe_block| {
-                            maybe_block.map(|block| block.block.body.transactions.clone())
+                            maybe_block.map(|block| block.block.body.transactions().to_vec())
                         }));
                     }
                 }
@@ -317,7 +314,7 @@ where
     fn on_reorg_receipts(
         &mut self,
         block_hash: B256,
-        res: ProviderResult<Option<Arc<Vec<Receipt>>>>,
+        res: ProviderResult<Option<Arc<Vec<Provider::Receipt>>>>,
     ) {
         if let Some(queued) = self.receipts_cache.remove(&block_hash) {
             // send the response to queued senders
@@ -336,14 +333,7 @@ where
 
 impl<Provider, Tasks> Future for EthStateCacheService<Provider, Tasks>
 where
-    Provider: StateProviderFactory
-        + BlockReader<
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
-            Header = reth_primitives::Header,
-        > + Clone
-        + Unpin
-        + 'static,
+    Provider: StateProviderFactory + BlockReader + Clone + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
 {
     type Output = ();
@@ -504,52 +494,55 @@ where
 }
 
 /// All message variants sent through the channel
-enum CacheAction {
+enum CacheAction<B: Block, R> {
     GetBlockWithSenders {
         block_hash: B256,
-        response_tx: BlockWithSendersResponseSender,
+        response_tx: BlockWithSendersResponseSender<B>,
     },
     GetHeader {
         block_hash: B256,
-        response_tx: HeaderResponseSender,
+        response_tx: HeaderResponseSender<B::Header>,
     },
     GetReceipts {
         block_hash: B256,
-        response_tx: ReceiptsResponseSender,
+        response_tx: ReceiptsResponseSender<R>,
     },
     BlockWithSendersResult {
         block_hash: B256,
-        res: ProviderResult<Option<Arc<SealedBlockWithSenders>>>,
+        res: ProviderResult<Option<Arc<SealedBlockWithSenders<B>>>>,
     },
     ReceiptsResult {
         block_hash: B256,
-        res: ProviderResult<Option<Arc<Vec<Receipt>>>>,
+        res: ProviderResult<Option<Arc<Vec<R>>>>,
     },
     HeaderResult {
         block_hash: B256,
-        res: Box<ProviderResult<Header>>,
+        res: Box<ProviderResult<B::Header>>,
     },
     CacheNewCanonicalChain {
-        chain_change: ChainChange,
+        chain_change: ChainChange<B, R>,
     },
     RemoveReorgedChain {
-        chain_change: ChainChange,
+        chain_change: ChainChange<B, R>,
     },
 }
 
-struct BlockReceipts {
+struct BlockReceipts<R> {
     block_hash: B256,
-    receipts: Vec<Option<Receipt>>,
+    receipts: Vec<Option<R>>,
 }
 
 /// A change of the canonical chain
-struct ChainChange {
-    blocks: Vec<SealedBlockWithSenders>,
-    receipts: Vec<BlockReceipts>,
+struct ChainChange<B: Block, R> {
+    blocks: Vec<SealedBlockWithSenders<B>>,
+    receipts: Vec<BlockReceipts<R>>,
 }
 
-impl ChainChange {
-    fn new(chain: Arc<Chain>) -> Self {
+impl<B: Block, R: Clone> ChainChange<B, R> {
+    fn new<N>(chain: Arc<Chain<N>>) -> Self
+    where
+        N: NodePrimitives<Block = B, Receipt = R>,
+    {
         let (blocks, receipts): (Vec<_>, Vec<_>) = chain
             .blocks_and_receipts()
             .map(|(block, receipts)| {
@@ -566,9 +559,11 @@ impl ChainChange {
 /// immediately before they need to be fetched from disk.
 ///
 /// Reorged blocks are removed from the cache.
-pub async fn cache_new_blocks_task<St>(eth_state_cache: EthStateCache, mut events: St)
-where
-    St: Stream<Item = CanonStateNotification> + Unpin + 'static,
+pub async fn cache_new_blocks_task<St, N: NodePrimitives>(
+    eth_state_cache: EthStateCache<N::Block, N::Receipt>,
+    mut events: St,
+) where
+    St: Stream<Item = CanonStateNotification<N>> + Unpin + 'static,
 {
     while let Some(event) = events.next().await {
         if let Some(reverted) = event.reverted() {

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -156,7 +156,7 @@ impl<B: Block, R: Send + Sync> EthStateCache<B, R> {
         rx.await.map_err(|_| ProviderError::CacheServiceUnavailable)?
     }
 
-    /// Requests the [Receipt] for the block hash
+    /// Requests the receipts for the block hash
     ///
     /// Returns `None` if the block was not found.
     pub async fn get_receipts(&self, block_hash: B256) -> ProviderResult<Option<Arc<Vec<R>>>> {

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{atomic::Ordering::SeqCst, Arc},
 };
 
+use alloy_consensus::{BlockHeader, Transaction, TxReceipt};
 use alloy_eips::eip1559::calc_next_block_base_fee;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::TxGasAndReward;
@@ -16,8 +17,8 @@ use futures::{
 use metrics::atomics::AtomicU64;
 use reth_chain_state::CanonStateNotification;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
-use reth_primitives::{NodePrimitives, Receipt, SealedBlock, TransactionSigned};
-use reth_primitives_traits::{Block, BlockBody};
+use reth_primitives::{NodePrimitives, SealedBlock};
+use reth_primitives_traits::BlockBody;
 use reth_rpc_server_types::constants::gas_oracle::MAX_HEADER_HISTORY;
 use reth_storage_api::BlockReaderIdExt;
 use revm_primitives::{calc_blob_gasprice, calc_excess_blob_gas};
@@ -36,13 +37,12 @@ pub struct FeeHistoryCache {
 
 impl FeeHistoryCache {
     /// Creates new `FeeHistoryCache` instance, initialize it with the more recent data, set bounds
-    pub fn new(eth_cache: EthStateCache, config: FeeHistoryCacheConfig) -> Self {
+    pub fn new(config: FeeHistoryCacheConfig) -> Self {
         let inner = FeeHistoryCacheInner {
             lower_bound: Default::default(),
             upper_bound: Default::default(),
             config,
             entries: Default::default(),
-            eth_cache,
         };
         Self { inner: Arc::new(inner) }
     }
@@ -73,9 +73,12 @@ impl FeeHistoryCache {
     }
 
     /// Insert block data into the cache.
-    async fn insert_blocks<'a, I>(&self, blocks: I)
+    async fn insert_blocks<'a, I, H, B, R>(&self, blocks: I)
     where
-        I: IntoIterator<Item = (&'a SealedBlock, Arc<Vec<Receipt>>)>,
+        H: BlockHeader + 'a,
+        B: BlockBody,
+        R: TxReceipt,
+        I: IntoIterator<Item = (&'a SealedBlock<H, B>, Arc<Vec<R>>)>,
     {
         let mut entries = self.inner.entries.write().await;
 
@@ -87,11 +90,11 @@ impl FeeHistoryCache {
                 &percentiles,
                 fee_history_entry.gas_used,
                 fee_history_entry.base_fee_per_gas,
-                &block.body.transactions,
+                block.body.transactions(),
                 &receipts,
             )
             .unwrap_or_default();
-            entries.insert(block.number, fee_history_entry);
+            entries.insert(block.number(), fee_history_entry);
         }
 
         // enforce bounds by popping the oldest entries
@@ -200,7 +203,6 @@ struct FeeHistoryCacheInner {
     config: FeeHistoryCacheConfig,
     /// Stores the entries of the cache
     entries: tokio::sync::RwLock<BTreeMap<u64, FeeHistoryEntry>>,
-    eth_cache: EthStateCache,
 }
 
 /// Awaits for new chain events and directly inserts them into the cache so they're available
@@ -209,10 +211,12 @@ pub async fn fee_history_cache_new_blocks_task<St, Provider, N>(
     fee_history_cache: FeeHistoryCache,
     mut events: St,
     provider: Provider,
+    cache: EthStateCache<N::Block, N::Receipt>,
 ) where
     St: Stream<Item = CanonStateNotification<N>> + Unpin + 'static,
-    Provider: BlockReaderIdExt + ChainSpecProvider + 'static,
-    N: NodePrimitives<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>,
+    Provider:
+        BlockReaderIdExt<Block = N::Block, Receipt = N::Receipt> + ChainSpecProvider + 'static,
+    N: NodePrimitives,
 {
     // We're listening for new blocks emitted when the node is in live sync.
     // If the node transitions to stage sync, we need to fetch the missing blocks
@@ -225,12 +229,7 @@ pub async fn fee_history_cache_new_blocks_task<St, Provider, N>(
                 trace!(target: "rpc::fee", ?block_number, "Fetching missing block for fee history cache");
                 if let Ok(Some(hash)) = provider.block_hash(block_number) {
                     // fetch missing block
-                    fetch_missing_block = fee_history_cache
-                        .inner
-                        .eth_cache
-                        .get_block_and_receipts(hash)
-                        .boxed()
-                        .fuse();
+                    fetch_missing_block = cache.get_block_and_receipts(hash).boxed().fuse();
                 }
             }
         }
@@ -270,13 +269,17 @@ pub async fn fee_history_cache_new_blocks_task<St, Provider, N>(
 /// the corresponding rewards for the transactions at each percentile.
 ///
 /// The results are returned as a vector of U256 values.
-pub fn calculate_reward_percentiles_for_block(
+pub fn calculate_reward_percentiles_for_block<T, R>(
     percentiles: &[f64],
     gas_used: u64,
     base_fee_per_gas: u64,
-    transactions: &[TransactionSigned],
-    receipts: &[Receipt],
-) -> Result<Vec<u128>, EthApiError> {
+    transactions: &[T],
+    receipts: &[R],
+) -> Result<Vec<u128>, EthApiError>
+where
+    T: Transaction,
+    R: TxReceipt,
+{
     let mut transactions = transactions
         .iter()
         .zip(receipts)
@@ -287,12 +290,12 @@ pub fn calculate_reward_percentiles_for_block(
             // While we will sum up the gas again later, it is worth
             // noting that the order of the transactions will be different,
             // so the sum will also be different for each receipt.
-            let gas_used = receipt.cumulative_gas_used - *previous_gas;
-            *previous_gas = receipt.cumulative_gas_used;
+            let gas_used = receipt.cumulative_gas_used() - *previous_gas;
+            *previous_gas = receipt.cumulative_gas_used();
 
             Some(TxGasAndReward {
-                gas_used,
-                reward: tx.effective_tip_per_gas(Some(base_fee_per_gas)).unwrap_or_default(),
+                gas_used: gas_used as u64,
+                reward: tx.effective_tip_per_gas(base_fee_per_gas).unwrap_or_default(),
             })
         })
         .collect::<Vec<_>>();
@@ -361,20 +364,20 @@ impl FeeHistoryEntry {
     /// Creates a new entry from a sealed block.
     ///
     /// Note: This does not calculate the rewards for the block.
-    pub fn new(block: &SealedBlock) -> Self {
+    pub fn new<H: BlockHeader, B: BlockBody>(block: &SealedBlock<H, B>) -> Self {
         Self {
-            base_fee_per_gas: block.base_fee_per_gas.unwrap_or_default(),
-            gas_used_ratio: block.gas_used as f64 / block.gas_limit as f64,
-            base_fee_per_blob_gas: block.blob_fee(),
-            blob_gas_used_ratio: block.body().blob_gas_used() as f64 /
+            base_fee_per_gas: block.base_fee_per_gas().unwrap_or_default(),
+            gas_used_ratio: block.gas_used() as f64 / block.gas_limit() as f64,
+            base_fee_per_blob_gas: block.excess_blob_gas().map(calc_blob_gasprice),
+            blob_gas_used_ratio: block.body.blob_gas_used() as f64 /
                 alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK as f64,
-            excess_blob_gas: block.excess_blob_gas,
-            blob_gas_used: block.blob_gas_used,
-            gas_used: block.gas_used,
+            excess_blob_gas: block.excess_blob_gas(),
+            blob_gas_used: block.blob_gas_used(),
+            gas_used: block.gas_used(),
             header_hash: block.hash(),
-            gas_limit: block.gas_limit,
+            gas_limit: block.gas_limit(),
             rewards: Vec::new(),
-            timestamp: block.timestamp,
+            timestamp: block.timestamp(),
         }
     }
 

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -9,8 +9,8 @@ use alloy_rpc_types_eth::{
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
 use reth_chainspec::ChainInfo;
-use reth_primitives::{Receipt, SealedBlockWithSenders};
-use reth_provider::{BlockIdReader, BlockReader, ProviderError};
+use reth_primitives::SealedBlockWithSenders;
+use reth_provider::{BlockIdReader, BlockReader, ProviderBlock, ProviderError, ProviderReceipt};
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, FullEthApiTypes, RpcTransaction, TransactionCompat,
 };
@@ -40,7 +40,7 @@ use tracing::{error, trace};
 const MAX_HEADERS_RANGE: u64 = 1_000; // with ~530bytes per header this is ~500kb
 
 /// `Eth` filter RPC implementation.
-pub struct EthFilter<Provider, Pool, Eth: EthApiTypes> {
+pub struct EthFilter<Provider: BlockReader, Pool, Eth: EthApiTypes> {
     /// All nested fields bundled together
     inner: Arc<EthFilterInner<Provider, Pool, RpcTransaction<Eth::NetworkTypes>>>,
     /// Assembles response data w.r.t. network.
@@ -50,6 +50,7 @@ pub struct EthFilter<Provider, Pool, Eth: EthApiTypes> {
 impl<Provider, Pool, Eth> Clone for EthFilter<Provider, Pool, Eth>
 where
     Eth: EthApiTypes,
+    Provider: BlockReader,
 {
     fn clone(&self) -> Self {
         Self { inner: self.inner.clone(), tx_resp_builder: self.tx_resp_builder.clone() }
@@ -58,7 +59,7 @@ where
 
 impl<Provider, Pool, Eth> EthFilter<Provider, Pool, Eth>
 where
-    Provider: Send + Sync + 'static,
+    Provider: BlockReader + Send + Sync + 'static,
     Pool: Send + Sync + 'static,
     Eth: EthApiTypes + 'static,
 {
@@ -73,7 +74,7 @@ where
     pub fn new(
         provider: Provider,
         pool: Pool,
-        eth_cache: EthStateCache,
+        eth_cache: EthStateCache<Provider::Block, Provider::Receipt>,
         config: EthFilterConfig,
         task_spawner: Box<dyn TaskSpawner>,
         tx_resp_builder: Eth::TransactionCompat,
@@ -334,6 +335,7 @@ where
 impl<Provider, Pool, Eth> std::fmt::Debug for EthFilter<Provider, Pool, Eth>
 where
     Eth: EthApiTypes,
+    Provider: BlockReader,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EthFilter").finish_non_exhaustive()
@@ -342,7 +344,7 @@ where
 
 /// Container type `EthFilter`
 #[derive(Debug)]
-struct EthFilterInner<Provider, Pool, Tx> {
+struct EthFilterInner<Provider: BlockReader, Pool, Tx> {
     /// The transaction pool.
     pool: Pool,
     /// The provider that can interact with the chain.
@@ -356,7 +358,7 @@ struct EthFilterInner<Provider, Pool, Tx> {
     /// Maximum number of logs that can be returned in a response
     max_logs_per_response: usize,
     /// The async cache frontend for eth related data
-    eth_cache: EthStateCache,
+    eth_cache: EthStateCache<Provider::Block, Provider::Receipt>,
     /// maximum number of headers to read at once for range filter
     max_headers_range: u64,
     /// The type that can spawn tasks.
@@ -536,8 +538,13 @@ where
         &self,
         block_num_hash: &BlockNumHash,
         best_number: u64,
-    ) -> Result<Option<(Arc<Vec<Receipt>>, Option<Arc<SealedBlockWithSenders>>)>, EthFilterError>
-    {
+    ) -> Result<
+        Option<(
+            Arc<Vec<ProviderReceipt<Provider>>>,
+            Option<Arc<SealedBlockWithSenders<ProviderBlock<Provider>>>>,
+        )>,
+        EthFilterError,
+    > {
         // The last 4 blocks are most likely cached, so we can just fetch them
         let cached_range = best_number.saturating_sub(4)..=best_number;
         let receipts_block = if cached_range.contains(&block_num_hash.number) {

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -2,10 +2,10 @@
 
 use alloy_rpc_types_eth::{BlockId, TransactionReceipt};
 use reth_primitives::TransactionMeta;
-use reth_provider::{BlockReaderIdExt, HeaderProvider};
+use reth_provider::{BlockReader, HeaderProvider};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
-    RpcReceipt,
+    RpcNodeCoreExt, RpcReceipt,
 };
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 
@@ -18,6 +18,7 @@ where
         NetworkTypes: alloy_network::Network<ReceiptResponse = TransactionReceipt>,
         Provider: HeaderProvider,
     >,
+    Provider: BlockReader,
 {
     async fn block_receipts(
         &self,
@@ -62,7 +63,7 @@ where
 
 impl<Provider, Pool, Network, EvmConfig> LoadBlock for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: LoadPendingBlock + SpawnBlocking,
-    Provider: BlockReaderIdExt,
+    Self: LoadPendingBlock + SpawnBlocking + RpcNodeCoreExt,
+    Provider: BlockReader,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -3,12 +3,15 @@
 use crate::EthApi;
 use alloy_consensus::Header;
 use reth_evm::ConfigureEvm;
+use reth_provider::BlockReader;
 use reth_rpc_eth_api::helpers::{
     estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking,
 };
 
-impl<Provider, Pool, Network, EvmConfig> EthCall for EthApi<Provider, Pool, Network, EvmConfig> where
-    Self: EstimateCall + LoadPendingBlock
+impl<Provider, Pool, Network, EvmConfig> EthCall for EthApi<Provider, Pool, Network, EvmConfig>
+where
+    Self: EstimateCall + LoadPendingBlock,
+    Provider: BlockReader,
 {
 }
 
@@ -16,6 +19,7 @@ impl<Provider, Pool, Network, EvmConfig> Call for EthApi<Provider, Pool, Network
 where
     Self: LoadState<Evm: ConfigureEvm<Header = Header>> + SpawnBlocking,
     EvmConfig: ConfigureEvm<Header = Header>,
+    Provider: BlockReader,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -28,7 +32,9 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig> EstimateCall for EthApi<Provider, Pool, Network, EvmConfig> where
-    Self: Call
+impl<Provider, Pool, Network, EvmConfig> EstimateCall for EthApi<Provider, Pool, Network, EvmConfig>
+where
+    Self: Call,
+    Provider: BlockReader,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,14 +1,18 @@
 //! Contains RPC handler implementations for fee history.
 
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
+use reth_provider::{
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory,
+};
 use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
 use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthFees for EthApi<Provider, Pool, Network, EvmConfig> where
-    Self: LoadFee
+impl<Provider, Pool, Network, EvmConfig> EthFees for EthApi<Provider, Pool, Network, EvmConfig>
+where
+    Self: LoadFee,
+    Provider: BlockReader,
 {
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -4,7 +4,8 @@ use alloy_consensus::Header;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_provider::{
-    BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderTx, StateProviderFactory,
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderTx,
+    StateProviderFactory,
 };
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
@@ -33,6 +34,7 @@ where
             >,
             Evm: ConfigureEvm<Header = Header, Transaction = ProviderTx<Self::Provider>>,
         >,
+    Provider: BlockReader,
 {
     #[inline]
     fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock>> {

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,7 +1,7 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
 use reth_primitives::{Receipt, TransactionMeta, TransactionSigned};
-use reth_provider::{ReceiptProvider, TransactionsProvider};
+use reth_provider::{BlockReader, ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 
@@ -13,6 +13,7 @@ where
         Provider: TransactionsProvider<Transaction = TransactionSigned>
                       + ReceiptProvider<Receipt = reth_primitives::Receipt>,
     >,
+    Provider: BlockReader,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -11,11 +11,14 @@ use alloy_rpc_types_eth::TransactionRequest;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use reth_primitives::TransactionSigned;
+use reth_provider::BlockReader;
 use reth_rpc_eth_api::helpers::{signer::Result, AddDevSigners, EthSigner};
 use reth_rpc_eth_types::SignError;
 
 impl<Provider, Pool, Network, EvmConfig> AddDevSigners
     for EthApi<Provider, Pool, Network, EvmConfig>
+where
+    Provider: BlockReader,
 {
     fn with_dev_accounts(&self) {
         *self.inner.signers().write() = DevSigner::random_signers(20)

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::U256;
 use reth_chainspec::EthereumHardforks;
 use reth_network_api::NetworkInfo;
-use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
+use reth_provider::{BlockNumReader, BlockReader, ChainSpecProvider, StageCheckpointReader};
 use reth_rpc_eth_api::{helpers::EthApiSpec, RpcNodeCore};
 
 use crate::EthApi;
@@ -14,6 +14,7 @@ where
                       + StageCheckpointReader,
         Network: NetworkInfo,
     >,
+    Provider: BlockReader,
 {
     fn starting_block(&self) -> U256 {
         self.inner.starting_block()

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -7,7 +7,9 @@ use reth_rpc_eth_api::helpers::{LoadState, Trace};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Network, EvmConfig> where
-    Self: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Header>>
+impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Network, EvmConfig>
+where
+    Self: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Header>>,
+    Provider: BlockReader,
 {
 }

--- a/crates/storage/storage-api/src/block.rs
+++ b/crates/storage/storage-api/src/block.rs
@@ -40,6 +40,9 @@ impl BlockSource {
     }
 }
 
+/// A helper type alias to access [`BlockReader::Block`].
+pub type ProviderBlock<P> = <P as BlockReader>::Block;
+
 /// Api trait for fetching `Block` related data.
 ///
 /// If not requested otherwise, implementers of this trait should prioritize fetching blocks from

--- a/crates/storage/storage-api/src/receipts.rs
+++ b/crates/storage/storage-api/src/receipts.rs
@@ -1,14 +1,18 @@
 use crate::BlockIdReader;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{TxHash, TxNumber};
+use reth_primitives_traits::Receipt;
 use reth_storage_errors::provider::ProviderResult;
 use std::ops::RangeBounds;
+
+/// A helper type alias to access [`ReceiptProvider::Receipt`].
+pub type ProviderReceipt<P> = <P as ReceiptProvider>::Receipt;
 
 /// Client trait for fetching receipt data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ReceiptProvider: Send + Sync {
     /// The receipt type.
-    type Receipt: Send + Sync;
+    type Receipt: Receipt;
 
     /// Get receipt by transaction number
     ///

--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -1,4 +1,4 @@
-use crate::{BlockNumReader, BlockReader, ReceiptProvider};
+use crate::{BlockNumReader, BlockReader};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockNumber, TxHash, TxNumber};
 use reth_primitives::TransactionMeta;
@@ -83,9 +83,6 @@ pub trait TransactionsProvider: BlockNumReader + Send + Sync {
 
 /// A helper type alias to access [`TransactionsProvider::Transaction`].
 pub type ProviderTx<P> = <P as TransactionsProvider>::Transaction;
-
-/// A helper type alias to access [`ReceiptProvider::Receipt`].
-pub type ProviderReceipt<P> = <P as ReceiptProvider>::Receipt;
 
 ///  Client trait for fetching additional transactions related data.
 #[auto_impl::auto_impl(&, Arc)]


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/13047

Changes `EthStateCache` to operate on block and receipt generics instead of concrete types.

This is done by enforcing `Provider: BlockReader` bound on struct definitions and using `Provider::Block` and `Provider::Receipt` ATs.

This required adding some redundant bounds to all impls of `EthApi` and `OpEthApi`.