### PR TITLE
feat: install op miner endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5401,6 +5401,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-alloy-rpc-jsonrpsee"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98debc5266443e64e03195cd1a3b6cdbe8d8679e9d8c4b76a3670d24b2e267a"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "jsonrpsee",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
 name = "op-alloy-rpc-types"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8493,6 +8506,7 @@ dependencies = [
  "jsonrpsee-types",
  "op-alloy-consensus",
  "op-alloy-network",
+ "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,6 +472,7 @@ alloy-transport-ws = { version = "0.7.2", default-features = false }
 # op
 op-alloy-rpc-types = "0.7.3"
 op-alloy-rpc-types-engine = "0.7.3"
+op-alloy-rpc-jsonrpsee = "0.7.3"
 op-alloy-network = "0.7.3"
 op-alloy-consensus = "0.7.3"
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -419,7 +419,7 @@ where
         ext: F,
     ) -> eyre::Result<RpcHandle<N, EthApi>>
     where
-        F: FnOnce(&mut TransportRpcModules) -> eyre::Result<()>,
+        F: FnOnce(&mut TransportRpcModules, &mut AuthRpcModule) -> eyre::Result<()>,
     {
         let Self { eth_api_builder, engine_validator_builder, hooks, _pd: _ } = self;
 
@@ -477,7 +477,7 @@ where
 
         let RpcHooks { on_rpc_started, extend_rpc_modules } = hooks;
 
-        ext(ctx.modules)?;
+        ext(ctx.modules, ctx.auth_module)?;
         extend_rpc_modules.extend_rpc_modules(ctx)?;
 
         let server_config = config.rpc.rpc_server_config();
@@ -537,7 +537,7 @@ where
     type Handle = RpcHandle<N, EthApi>;
 
     async fn launch_add_ons(self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
-        self.launch_add_ons_with(ctx, |_| Ok(())).await
+        self.launch_add_ons_with(ctx, |_, _| Ok(())).await
     }
 }
 

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -45,6 +45,7 @@ alloy-consensus.workspace = true
 op-alloy-network.workspace = true
 op-alloy-rpc-types.workspace = true
 op-alloy-rpc-types-engine.workspace = true
+op-alloy-rpc-jsonrpsee.workspace = true
 op-alloy-consensus.workspace = true
 revm.workspace = true
 

--- a/crates/optimism/rpc/src/lib.rs
+++ b/crates/optimism/rpc/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod error;
 pub mod eth;
+pub mod miner;
 pub mod sequencer;
 pub mod witness;
 

--- a/crates/optimism/rpc/src/miner.rs
+++ b/crates/optimism/rpc/src/miner.rs
@@ -4,6 +4,7 @@ use alloy_primitives::U64;
 use jsonrpsee_core::{async_trait, RpcResult};
 pub use op_alloy_rpc_jsonrpsee::traits::MinerApiExtServer;
 use reth_optimism_payload_builder::config::OpDAConfig;
+use tracing::debug;
 
 /// Miner API extension for OP, exposes settings for the data availability configuration via the
 /// `miner_` API.
@@ -22,7 +23,9 @@ impl OpMinerExtApi {
 
 #[async_trait]
 impl MinerApiExtServer for OpMinerExtApi {
+    /// Handler for `miner_setMaxDASize` RPC method.
     async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<()> {
+        debug!(target: "rpc", "Setting max DA size: tx={}, block={}", max_tx_size, max_block_size);
         self.da_config.set_max_da_size(max_tx_size.to(), max_block_size.to());
         Ok(())
     }

--- a/crates/optimism/rpc/src/miner.rs
+++ b/crates/optimism/rpc/src/miner.rs
@@ -1,0 +1,29 @@
+//! Miner API extension for OP.
+
+use alloy_primitives::U64;
+use jsonrpsee_core::{async_trait, RpcResult};
+pub use op_alloy_rpc_jsonrpsee::traits::MinerApiExtServer;
+use reth_optimism_payload_builder::config::OpDAConfig;
+
+/// Miner API extension for OP, exposes settings for the data availability configuration via the
+/// `miner_` API.
+#[derive(Debug, Clone)]
+pub struct OpMinerExtApi {
+    da_config: OpDAConfig,
+}
+
+impl OpMinerExtApi {
+    /// Instantiate the miner API extension with the given, sharable data availability
+    /// configuration.
+    pub const fn new(da_config: OpDAConfig) -> Self {
+        Self { da_config }
+    }
+}
+
+#[async_trait]
+impl MinerApiExtServer for OpMinerExtApi {
+    async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<()> {
+        self.da_config.set_max_da_size(max_tx_size.to(), max_block_size.to());
+        Ok(())
+    }
+}


### PR DESCRIPTION
closes #13092

installs the miner extension for op-reth

still needs impl to actually enforce it but this should at least no longer crash the newest batcher