### PR TITLE
feat(trie): return hash mask from blinded provider

### DIFF
--- a/crates/trie/sparse/src/blinded.rs
+++ b/crates/trie/sparse/src/blinded.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Bytes, B256};
 use reth_execution_errors::SparseTrieError;
-use reth_trie_common::Nibbles;
+use reth_trie_common::{Nibbles, TrieMask};
 
 /// Factory for instantiating blinded node providers.
 pub trait BlindedProviderFactory {
@@ -24,7 +24,20 @@ pub trait BlindedProvider {
     type Error: Into<SparseTrieError>;
 
     /// Retrieve blinded node by path.
-    fn blinded_node(&mut self, path: Nibbles) -> Result<Option<Bytes>, Self::Error>;
+    fn blinded_node(&mut self, path: Nibbles) -> Result<Option<BlindedNode>, Self::Error>;
+}
+
+/// Blinded node retrieved by [`BlindedProvider`].
+#[derive(Debug, Clone)]
+pub struct BlindedNode {
+    /// RLP encoded node.
+    pub node: Bytes,
+    /// Hash mask for the node. See `hash_mask` field of the
+    /// [`reth_trie_common::BranchNodeCompact`] struct.
+    ///
+    /// If the node is not a branch node, or the hash mask retention is not enabled,
+    /// this field will be `None`.
+    pub hash_mask: Option<TrieMask>,
 }
 
 /// Default blinded node provider factory that creates [`DefaultBlindedProvider`].
@@ -51,7 +64,7 @@ pub struct DefaultBlindedProvider;
 impl BlindedProvider for DefaultBlindedProvider {
     type Error = SparseTrieError;
 
-    fn blinded_node(&mut self, _path: Nibbles) -> Result<Option<Bytes>, Self::Error> {
+    fn blinded_node(&mut self, _path: Nibbles) -> Result<Option<BlindedNode>, Self::Error> {
         Ok(None)
     }
 }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1,4 +1,4 @@
-use crate::blinded::{BlindedProvider, DefaultBlindedProvider};
+use crate::blinded::{BlindedNode, BlindedProvider, DefaultBlindedProvider};
 use alloy_primitives::{
     hex, keccak256,
     map::{HashMap, HashSet},
@@ -973,11 +973,12 @@ where
 
                         if self.nodes.get(&child_path).unwrap().is_hash() {
                             trace!(target: "trie::sparse", ?child_path, "Retrieving remaining blinded branch child");
-                            if let Some(node) = self.provider.blinded_node(child_path.clone())? {
+                            if let Some(BlindedNode { node, hash_mask }) =
+                                self.provider.blinded_node(child_path.clone())?
+                            {
                                 let decoded = TrieNode::decode(&mut &node[..])?;
                                 trace!(target: "trie::sparse", ?child_path, ?decoded, "Revealing remaining blinded branch child");
-                                // TODO: fetch hash mask
-                                self.reveal_node(child_path.clone(), decoded, None)?;
+                                self.reveal_node(child_path.clone(), decoded, hash_mask)?;
                             }
                         }
 

--- a/crates/trie/trie/src/proof/blinded.rs
+++ b/crates/trie/trie/src/proof/blinded.rs
@@ -20,7 +20,7 @@ pub struct ProofBlindedProviderFactory<T, H> {
     hashed_cursor_factory: H,
     /// A set of prefix sets that have changes.
     prefix_sets: Arc<TriePrefixSetsMut>,
-    /// Flag indicating whether to include branch node hash masks in the proof.
+    /// Flag indicating whether to include branch node hash masks in the response.
     with_branch_node_hash_masks: bool,
 }
 
@@ -30,14 +30,19 @@ impl<T, H> ProofBlindedProviderFactory<T, H> {
         trie_cursor_factory: T,
         hashed_cursor_factory: H,
         prefix_sets: Arc<TriePrefixSetsMut>,
-        with_branch_node_hash_masks: bool,
     ) -> Self {
         Self {
             trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets,
-            with_branch_node_hash_masks,
+            with_branch_node_hash_masks: false,
         }
+    }
+
+    /// Set the flag indicating whether to include branch node hash masks in the response.
+    pub const fn with_branch_node_hash_masks(mut self, with_branch_node_hash_masks: bool) -> Self {
+        self.with_branch_node_hash_masks = with_branch_node_hash_masks;
+        self
     }
 }
 
@@ -78,7 +83,7 @@ pub struct ProofBlindedAccountProvider<T, H> {
     hashed_cursor_factory: H,
     /// A set of prefix sets that have changes.
     prefix_sets: Arc<TriePrefixSetsMut>,
-    /// Flag indicating whether to include branch node hash masks in the proof.
+    /// Flag indicating whether to include branch node hash masks in the response.
     with_branch_node_hash_masks: bool,
 }
 
@@ -88,14 +93,19 @@ impl<T, H> ProofBlindedAccountProvider<T, H> {
         trie_cursor_factory: T,
         hashed_cursor_factory: H,
         prefix_sets: Arc<TriePrefixSetsMut>,
-        with_branch_node_hash_masks: bool,
     ) -> Self {
         Self {
             trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets,
-            with_branch_node_hash_masks,
+            with_branch_node_hash_masks: false,
         }
+    }
+
+    /// Set the flag indicating whether to include branch node hash masks in the response.
+    pub const fn with_branch_node_hash_masks(mut self, with_branch_node_hash_masks: bool) -> Self {
+        self.with_branch_node_hash_masks = with_branch_node_hash_masks;
+        self
     }
 }
 
@@ -131,7 +141,7 @@ pub struct ProofBlindedStorageProvider<T, H> {
     hashed_cursor_factory: H,
     /// A set of prefix sets that have changes.
     prefix_sets: Arc<TriePrefixSetsMut>,
-    /// Flag indicating whether to include branch node hash masks in the proof.
+    /// Flag indicating whether to include branch node hash masks in the response.
     with_branch_node_hash_masks: bool,
     /// Target account.
     account: B256,
@@ -143,16 +153,21 @@ impl<T, H> ProofBlindedStorageProvider<T, H> {
         trie_cursor_factory: T,
         hashed_cursor_factory: H,
         prefix_sets: Arc<TriePrefixSetsMut>,
-        with_branch_node_hash_masks: bool,
         account: B256,
     ) -> Self {
         Self {
             trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets,
-            with_branch_node_hash_masks,
+            with_branch_node_hash_masks: false,
             account,
         }
+    }
+
+    /// Set the flag indicating whether to include branch node hash masks in the response.
+    pub const fn with_branch_node_hash_masks(mut self, with_branch_node_hash_masks: bool) -> Self {
+        self.with_branch_node_hash_masks = with_branch_node_hash_masks;
+        self
     }
 }
 

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -114,7 +114,6 @@ where
             self.trie_cursor_factory,
             self.hashed_cursor_factory,
             Arc::new(self.prefix_sets),
-            false,
         );
         let mut sparse_trie =
             SparseStateTrie::new(WitnessBlindedProviderFactory::new(proof_provider_factory, tx));

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -16,7 +16,7 @@ use reth_execution_errors::{
 };
 use reth_trie_common::Nibbles;
 use reth_trie_sparse::{
-    blinded::{BlindedProvider, BlindedProviderFactory},
+    blinded::{BlindedNode, BlindedProvider, BlindedProviderFactory},
     SparseStateTrie,
 };
 use std::sync::{mpsc, Arc};
@@ -114,6 +114,7 @@ where
             self.trie_cursor_factory,
             self.hashed_cursor_factory,
             Arc::new(self.prefix_sets),
+            false,
         );
         let mut sparse_trie =
             SparseStateTrie::new(WitnessBlindedProviderFactory::new(proof_provider_factory, tx));
@@ -248,9 +249,9 @@ where
 {
     type Error = P::Error;
 
-    fn blinded_node(&mut self, path: Nibbles) -> Result<Option<Bytes>, Self::Error> {
+    fn blinded_node(&mut self, path: Nibbles) -> Result<Option<BlindedNode>, Self::Error> {
         let maybe_node = self.provider.blinded_node(path)?;
-        if let Some(node) = &maybe_node {
+        if let Some(BlindedNode { node, .. }) = &maybe_node {
             self.tx.send(node.clone()).map_err(|error| SparseTrieError::Other(Box::new(error)))?;
         }
         Ok(maybe_node)


### PR DESCRIPTION
Fixes the following TODO https://github.com/paradigmxyz/reth/blob/aae8fe695340f26f5cdf08c613e2b682cc4d5705/crates/trie/sparse/src/trie.rs#L978-L979