### PR TITLE
fix(engine): wait for all state updates before returning state root task result

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -736,10 +736,13 @@ mod tests {
         let task = StateRootTask::new(config, tx.clone(), rx);
         let handle = task.spawn();
 
+        let state_hook_sender = StateHookSender(tx.clone());
         for update in state_updates {
-            tx.send(StateRootMessage::StateUpdate(update)).expect("failed to send state");
+            state_hook_sender
+                .send(StateRootMessage::StateUpdate(update))
+                .expect("failed to send state");
         }
-        drop(tx);
+        drop(state_hook_sender);
 
         let (root_from_task, _) = handle.wait_for_result().expect("task failed");
         let root_from_base = state_root(accumulated_state);

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -736,7 +736,7 @@ mod tests {
         let task = StateRootTask::new(config, tx.clone(), rx);
         let handle = task.spawn();
 
-        let state_hook_sender = StateHookSender(tx.clone());
+        let state_hook_sender = StateHookSender(tx);
         for update in state_updates {
             state_hook_sender
                 .send(StateRootMessage::StateUpdate(update))

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -18,6 +18,7 @@ use reth_trie_sparse::{
 use revm_primitives::{keccak256, EvmState, B256};
 use std::{
     collections::BTreeMap,
+    ops::Deref,
     sync::{
         mpsc::{self, Receiver, Sender},
         Arc,
@@ -156,14 +157,20 @@ impl ProofSequencer {
 
 /// A wrapper for the sender that signals completion when dropped
 #[allow(dead_code)]
-pub(crate) struct StateHookSender {
-    pub(crate) tx: Sender<StateRootMessage>,
+pub(crate) struct StateHookSender(Sender<StateRootMessage>);
+
+impl Deref for StateHookSender {
+    type Target = Sender<StateRootMessage>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl Drop for StateHookSender {
     fn drop(&mut self) {
         // Send completion signal when the sender is dropped
-        let _ = self.tx.send(StateRootMessage::FinishedStateUpdates);
+        let _ = self.0.send(StateRootMessage::FinishedStateUpdates);
     }
 }
 


### PR DESCRIPTION
Depending on timing, the current condition for returning the state root from task can allow to return too early, when not all state updates have been processed https://github.com/paradigmxyz/reth/blob/main/crates/engine/tree/src/tree/root.rs#L437

These changes allow the state root task to detect when the sender in the state hook is dropped, so that no new state updates are expected. It should be used from the `EngineApiTreeHandler` like:
```rust
let state_hook_sender = root::StateHookSender { tx: state_root_tx.clone() };
let state_hook = move |state: &EvmState| {
    let _ = state_hook_sender.send(StateRootMessage::StateUpdate(state.clone()));
};       
```