### PR TITLE
Allow replacement txs with exactly price bump

### DIFF
--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -405,8 +405,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         let price_bump = price_bumps.price_bump(self.tx_type());
 
         // Check if the max fee per gas is underpriced.
-        if maybe_replacement.max_fee_per_gas() < self.max_fee_per_gas() * (100 + price_bump) / 100
-        {
+        if maybe_replacement.max_fee_per_gas() < self.max_fee_per_gas() * (100 + price_bump) / 100 {
             return true
         }
 

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -405,7 +405,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         let price_bump = price_bumps.price_bump(self.tx_type());
 
         // Check if the max fee per gas is underpriced.
-        if maybe_replacement.max_fee_per_gas() <= self.max_fee_per_gas() * (100 + price_bump) / 100
+        if maybe_replacement.max_fee_per_gas() < self.max_fee_per_gas() * (100 + price_bump) / 100
         {
             return true
         }
@@ -418,7 +418,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         // Check max priority fee per gas (relevant for EIP-1559 transactions only)
         if existing_max_priority_fee_per_gas != 0 &&
             replacement_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas <=
+            replacement_max_priority_fee_per_gas <
                 existing_max_priority_fee_per_gas * (100 + price_bump) / 100
         {
             return true
@@ -429,7 +429,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
             // This enforces that blob txs can only be replaced by blob txs
             let replacement_max_blob_fee_per_gas =
                 maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or_default();
-            if replacement_max_blob_fee_per_gas <=
+            if replacement_max_blob_fee_per_gas <
                 existing_max_blob_fee_per_gas * (100 + price_bump) / 100
             {
                 return true


### PR DESCRIPTION
Currently, if replacement transaction is bumped exactly by the `price_bump%`, transaction is rejected due to being underpriced. This behavior doesn't match with the Geth implementation, and also doesn't work with speed-up feature of well-known wallet applications such as Metamask since they increase the fee exactly 10% (default price bump rate).

Here is the exact line in Geth: https://github.com/ethereum/go-ethereum/blob/67a3b087951a3f3a8e341ae32b6ec18f3553e5cc/core/txpool/legacypool/list.go#L323 

closes #13160 