### PR TITLE
fix(trie): delete self destructed accounts from sparse trie

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -258,8 +258,7 @@ where
                 trace!(target: "engine::root", ?address, ?hashed_address, "Adding account to state update");
 
                 let destroyed = account.is_selfdestructed();
-                let info =
-                    if destroyed || account.is_empty() { None } else { Some(account.info.into()) };
+                let info = if destroyed { None } else { Some(account.info.into()) };
                 hashed_state_update.accounts.insert(hashed_address, info);
 
                 let mut changed_storage_iter = account

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -258,7 +258,8 @@ where
                 trace!(target: "engine::root", ?address, ?hashed_address, "Adding account to state update");
 
                 let destroyed = account.is_selfdestructed();
-                let info = if account.is_empty() { None } else { Some(account.info.into()) };
+                let info =
+                    if destroyed || account.is_empty() { None } else { Some(account.info.into()) };
                 hashed_state_update.accounts.insert(hashed_address, info);
 
                 let mut changed_storage_iter = account


### PR DESCRIPTION
We need to do the same as in tests https://github.com/paradigmxyz/reth/blob/8226fa0cacc42c5ca55f7638b3fed57a16cac008/crates/engine/tree/src/tree/root.rs#L699

Revm doesn't set the account to empty when it's self-destructed https://github.com/bluealloy/revm/blob/1fe91d520410fb78318c2702f06262ca09ac980b/crates/context/src/journaled_state.rs#L610-L626