### PR TITLE
feat: EthApi traits abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9171,6 +9171,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "jsonrpsee-types",
  "reth-primitives",
+ "reth-primitives-traits",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9052,6 +9052,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
  "alloy-serde",

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -97,7 +97,9 @@ where
     where
         Engine::ExecutionPayloadEnvelopeV3: From<Engine::BuiltPayload> + PayloadEnvelopeExt,
         Engine::ExecutionPayloadEnvelopeV4: From<Engine::BuiltPayload> + PayloadEnvelopeExt,
-        AddOns::EthApi: EthApiSpec + EthTransactions + TraceExt,
+        AddOns::EthApi: EthApiSpec<Provider: BlockReader<Block = reth_primitives::Block>>
+            + EthTransactions
+            + TraceExt,
     {
         let mut chain = Vec::with_capacity(length as usize);
         for i in 0..length {

--- a/crates/e2e-test-utils/src/rpc.rs
+++ b/crates/e2e-test-utils/src/rpc.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{Bytes, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_node_api::{FullNodeComponents, NodePrimitives};
 use reth_node_builder::{rpc::RpcRegistry, NodeTypes};
+use reth_provider::BlockReader;
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_eth_api::{
     helpers::{EthApiSpec, EthTransactions, TraceExt},
@@ -26,7 +27,9 @@ where
             >,
         >,
     >,
-    EthApi: EthApiSpec + EthTransactions + TraceExt,
+    EthApi: EthApiSpec<Provider: BlockReader<Block = reth_primitives::Block>>
+        + EthTransactions
+        + TraceExt,
 {
     /// Injects a raw transaction into the node tx pool via RPC server
     pub async fn inject_tx(&self, raw_tx: Bytes) -> Result<B256, EthApi::Error> {

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -927,6 +927,7 @@ where
                         alloy_rpc_types::Transaction,
                         alloy_rpc_types::Block,
                         alloy_rpc_types::Receipt,
+                        alloy_rpc_types::Header,
                     >::chain_id(&client)
                     .await
                 })?

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -19,7 +19,7 @@ use reth_node_core::{
 };
 use reth_payload_builder::PayloadStore;
 use reth_primitives::EthPrimitives;
-use reth_provider::providers::ProviderNodeTypes;
+use reth_provider::{providers::ProviderNodeTypes, BlockReader};
 use reth_rpc::{
     eth::{EthApiTypes, FullEthApiServer},
     EthApi,
@@ -408,7 +408,16 @@ where
         PayloadBuilder: PayloadBuilder<PayloadType = <N::Types as NodeTypesWithEngine>::Engine>,
         Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     >,
-    EthApi: EthApiTypes + FullEthApiServer + AddDevSigners + Unpin + 'static,
+    EthApi: EthApiTypes
+        + FullEthApiServer<
+            Provider: BlockReader<
+                Block = reth_primitives::Block,
+                Receipt = reth_primitives::Receipt,
+                Header = reth_primitives::Header,
+            >,
+        > + AddDevSigners
+        + Unpin
+        + 'static,
     EV: EngineValidatorBuilder<N>,
 {
     /// Launches the RPC servers with the given context and an additional hook for extending
@@ -531,7 +540,16 @@ where
         PayloadBuilder: PayloadBuilder<PayloadType = <N::Types as NodeTypesWithEngine>::Engine>,
         Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     >,
-    EthApi: EthApiTypes + FullEthApiServer + AddDevSigners + Unpin + 'static,
+    EthApi: EthApiTypes
+        + FullEthApiServer<
+            Provider: BlockReader<
+                Block = reth_primitives::Block,
+                Receipt = reth_primitives::Receipt,
+                Header = reth_primitives::Header,
+            >,
+        > + AddDevSigners
+        + Unpin
+        + 'static,
     EV: EngineValidatorBuilder<N>,
 {
     type Handle = RpcHandle<N, EthApi>;

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,9 +1,9 @@
 use super::OpNodeCore;
 use crate::{OpEthApi, OpEthApiError};
-use alloy_consensus::Header;
 use alloy_primitives::{Bytes, TxKind, U256};
 use alloy_rpc_types_eth::transaction::TransactionRequest;
 use reth_evm::ConfigureEvm;
+use reth_provider::ProviderHeader;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEthApiError, IntoEthApiError,
@@ -28,7 +28,7 @@ where
 
 impl<N> Call for OpEthApi<N>
 where
-    Self: LoadState<Evm: ConfigureEvm<Header = Header>> + SpawnBlocking,
+    Self: LoadState<Evm: ConfigureEvm<Header = ProviderHeader<Self::Provider>>> + SpawnBlocking,
     Self::Error: From<OpEthApiError>,
     N: OpNodeCore,
 {

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -1,28 +1,36 @@
 //! Loads OP pending block for a RPC response.
 
 use crate::OpEthApi;
-use alloy_consensus::Header;
-use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{BlockNumber, B256};
+use alloy_consensus::{
+    constants::EMPTY_WITHDRAWALS, proofs::calculate_transaction_root, Header, EMPTY_OMMER_ROOT_HASH,
+};
+use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE, BlockNumberOrTag};
+use alloy_primitives::{B256, U256};
+use op_alloy_network::Network;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;
-use reth_primitives::{Receipt, SealedBlockWithSenders, TransactionSigned};
+use reth_primitives::{logs_bloom, BlockBody, Receipt, SealedBlockWithSenders, TransactionSigned};
 use reth_provider::{
-    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ExecutionOutcome, ProviderTx,
-    ReceiptProvider, StateProviderFactory,
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderBlock,
+    ProviderHeader, ProviderReceipt, ProviderTx, ReceiptProvider, StateProviderFactory,
 };
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
-    FromEthApiError, RpcNodeCore,
+    EthApiTypes, FromEthApiError, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
-use revm::primitives::BlockEnv;
+use revm::primitives::{BlockEnv, CfgEnvWithHandlerCfg, ExecutionResult, SpecId};
 
 impl<N> LoadPendingBlock for OpEthApi<N>
 where
-    Self: SpawnBlocking,
+    Self: SpawnBlocking
+        + EthApiTypes<
+            NetworkTypes: Network<
+                HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+            >,
+        >,
     N: RpcNodeCore<
         Provider: BlockReaderIdExt<
             Transaction = reth_primitives::TransactionSigned,
@@ -37,7 +45,11 @@ where
     >,
 {
     #[inline]
-    fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock>> {
+    fn pending_block(
+        &self,
+    ) -> &tokio::sync::Mutex<
+        Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>,
+    > {
         self.inner.eth_api.pending_block()
     }
 
@@ -68,20 +80,76 @@ where
         Ok(Some((block, receipts)))
     }
 
-    fn receipts_root(
+    fn assemble_block(
         &self,
-        block_env: &BlockEnv,
-        execution_outcome: &ExecutionOutcome,
-        block_number: BlockNumber,
-    ) -> B256 {
-        execution_outcome
-            .generic_receipts_root_slow(block_number, |receipts| {
-                calculate_receipt_root_no_memo_optimism(
-                    receipts,
-                    self.provider().chain_spec().as_ref(),
-                    block_env.timestamp.to::<u64>(),
-                )
-            })
-            .expect("Block is present")
+        cfg: CfgEnvWithHandlerCfg,
+        block_env: BlockEnv,
+        parent_hash: B256,
+        state_root: B256,
+        transactions: Vec<ProviderTx<Self::Provider>>,
+        receipts: &[ProviderReceipt<Self::Provider>],
+    ) -> reth_provider::ProviderBlock<Self::Provider> {
+        let chain_spec = self.provider().chain_spec();
+
+        let transactions_root = calculate_transaction_root(&transactions);
+        let receipts_root = calculate_receipt_root_no_memo_optimism(
+            &receipts.iter().collect::<Vec<_>>(),
+            &chain_spec,
+            block_env.timestamp.to::<u64>(),
+        );
+
+        let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| &r.logs));
+
+        let header = Header {
+            parent_hash,
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: block_env.coinbase,
+            state_root,
+            transactions_root,
+            receipts_root,
+            withdrawals_root: (cfg.handler_cfg.spec_id >= SpecId::SHANGHAI)
+                .then_some(EMPTY_WITHDRAWALS),
+            logs_bloom,
+            timestamp: block_env.timestamp.to::<u64>(),
+            mix_hash: block_env.prevrandao.unwrap_or_default(),
+            nonce: BEACON_NONCE.into(),
+            base_fee_per_gas: Some(block_env.basefee.to::<u64>()),
+            number: block_env.number.to::<u64>(),
+            gas_limit: block_env.gas_limit.to::<u64>(),
+            difficulty: U256::ZERO,
+            gas_used: receipts.last().map(|r| r.cumulative_gas_used).unwrap_or_default(),
+            blob_gas_used: (cfg.handler_cfg.spec_id >= SpecId::CANCUN).then(|| {
+                transactions.iter().map(|tx| tx.blob_gas_used().unwrap_or_default()).sum::<u64>()
+            }),
+            excess_blob_gas: block_env.get_blob_excess_gas().map(Into::into),
+            extra_data: Default::default(),
+            parent_beacon_block_root: (cfg.handler_cfg.spec_id >= SpecId::CANCUN)
+                .then_some(B256::ZERO),
+            requests_hash: (cfg.handler_cfg.spec_id >= SpecId::PRAGUE)
+                .then_some(EMPTY_REQUESTS_HASH),
+            target_blobs_per_block: None,
+        };
+
+        // seal the block
+        reth_primitives::Block {
+            header,
+            body: BlockBody { transactions, ommers: vec![], withdrawals: None },
+        }
+    }
+
+    fn assemble_receipt(
+        &self,
+        tx: &reth_primitives::RecoveredTx<ProviderTx<Self::Provider>>,
+        result: ExecutionResult,
+        cumulative_gas_used: u64,
+    ) -> reth_provider::ProviderReceipt<Self::Provider> {
+        #[allow(clippy::needless_update)]
+        Receipt {
+            tx_type: tx.tx_type(),
+            success: result.is_success(),
+            cumulative_gas_used,
+            logs: result.into_logs().into_iter().map(Into::into).collect(),
+            ..Default::default()
+        }
     }
 }

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -7,7 +7,9 @@ use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types::Transaction;
 use reth_node_api::FullNodeComponents;
 use reth_primitives::{RecoveredTx, TransactionSigned};
-use reth_provider::{BlockReaderIdExt, ReceiptProvider, TransactionsProvider};
+use reth_provider::{
+    BlockReader, BlockReaderIdExt, ProviderTx, ReceiptProvider, TransactionsProvider,
+};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
     FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt, TransactionCompat,
@@ -20,9 +22,9 @@ use crate::{eth::OpNodeCore, OpEthApi, OpEthApiError, SequencerClient};
 impl<N> EthTransactions for OpEthApi<N>
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt>,
-    N: OpNodeCore,
+    N: OpNodeCore<Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>>,
 {
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>> {
+    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>> {
         self.inner.eth_api.signers()
     }
 

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -4,7 +4,7 @@ pub mod body;
 pub mod header;
 
 use alloc::fmt;
-use alloy_rlp::Encodable;
+use alloy_rlp::{Decodable, Encodable};
 
 use crate::{
     BlockBody, BlockHeader, FullBlockBody, FullBlockHeader, InMemorySize, MaybeArbitrary,
@@ -41,6 +41,7 @@ pub trait Block:
     + MaybeSerde
     + MaybeArbitrary
     + Encodable
+    + Decodable
 {
     /// Header part of the block.
     type Header: BlockHeader;

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -4,6 +4,7 @@ pub mod body;
 pub mod header;
 
 use alloc::fmt;
+use alloy_rlp::Encodable;
 
 use crate::{
     BlockBody, BlockHeader, FullBlockBody, FullBlockHeader, InMemorySize, MaybeArbitrary,
@@ -39,6 +40,7 @@ pub trait Block:
     + InMemorySize
     + MaybeSerde
     + MaybeArbitrary
+    + Encodable
 {
     /// Header part of the block.
     type Header: BlockHeader;

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -447,31 +447,6 @@ where
     }
 }
 
-impl<H, B> reth_primitives_traits::Block for SealedBlock<H, B>
-where
-    H: reth_primitives_traits::BlockHeader,
-    B: reth_primitives_traits::BlockBody<OmmerHeader = H>,
-{
-    type Header = H;
-    type Body = B;
-
-    fn new(header: Self::Header, body: Self::Body) -> Self {
-        Self { header: SealedHeader::seal(header), body }
-    }
-
-    fn header(&self) -> &Self::Header {
-        self.header.header()
-    }
-
-    fn body(&self) -> &Self::Body {
-        &self.body
-    }
-
-    fn split(self) -> (Self::Header, Self::Body) {
-        (self.header.unseal(), self.body)
-    }
-}
-
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a, H, B> arbitrary::Arbitrary<'a> for SealedBlock<H, B>
 where

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -997,7 +997,6 @@ mod tests {
     const fn _traits() {
         const fn assert_block<T: reth_primitives_traits::Block>() {}
         assert_block::<Block>();
-        assert_block::<SealedBlock>();
     }
 
     /// Check parsing according to EIP-1898.

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1506,6 +1506,11 @@ impl<T> RecoveredTx<T> {
     pub const fn from_signed_transaction(signed_transaction: T, signer: Address) -> Self {
         Self { signed_transaction, signer }
     }
+
+    /// Applies the given closure to the inner transactions.
+    pub fn map_transaction<Tx>(self, f: impl FnOnce(T) -> Tx) -> RecoveredTx<Tx> {
+        RecoveredTx::from_signed_transaction(f(self.signed_transaction), self.signer)
+    }
 }
 
 impl<T: Encodable> Encodable for RecoveredTx<T> {

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -654,6 +654,18 @@ impl TryFrom<TransactionSigned> for PooledTransactionsElement {
     }
 }
 
+impl From<PooledTransactionsElement> for TransactionSigned {
+    fn from(element: PooledTransactionsElement) -> Self {
+        match element {
+            PooledTransactionsElement::Legacy(tx) => tx.into(),
+            PooledTransactionsElement::Eip2930(tx) => tx.into(),
+            PooledTransactionsElement::Eip1559(tx) => tx.into(),
+            PooledTransactionsElement::Eip7702(tx) => tx.into(),
+            PooledTransactionsElement::BlobTransaction(blob_tx) => blob_tx.into_parts().0,
+        }
+    }
+}
+
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for PooledTransactionsElement {
     /// Generates an arbitrary `PooledTransactionsElement`.

--- a/crates/rpc/rpc-api/src/otterscan.rs
+++ b/crates/rpc/rpc-api/src/otterscan.rs
@@ -1,7 +1,6 @@
 use alloy_eips::BlockId;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, TxHash, B256};
-use alloy_rpc_types_eth::Header;
 use alloy_rpc_types_trace::otterscan::{
     BlockDetails, ContractCreator, InternalOperation, OtsBlockTransactions, TraceEntry,
     TransactionsWithReceipts,

--- a/crates/rpc/rpc-api/src/otterscan.rs
+++ b/crates/rpc/rpc-api/src/otterscan.rs
@@ -11,7 +11,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 /// Otterscan rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "ots"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "ots"))]
-pub trait Otterscan<T: RpcObject> {
+pub trait Otterscan<T: RpcObject, H: RpcObject> {
     /// Get the block header by block number, required by otterscan.
     /// Otterscan currently requires this endpoint, used as:
     ///
@@ -20,7 +20,7 @@ pub trait Otterscan<T: RpcObject> {
     ///
     /// Ref: <https://github.com/otterscan/otterscan/blob/071d8c55202badf01804f6f8d53ef9311d4a9e47/src/useProvider.ts#L71>
     #[method(name = "getHeaderByNumber", aliases = ["erigon_getHeaderByNumber"])]
-    async fn get_header_by_number(&self, block_number: u64) -> RpcResult<Option<Header>>;
+    async fn get_header_by_number(&self, block_number: u64) -> RpcResult<Option<H>>;
 
     /// Check if a certain address contains a deployed code.
     #[method(name = "hasCode")]
@@ -48,11 +48,11 @@ pub trait Otterscan<T: RpcObject> {
     /// Tailor-made and expanded version of eth_getBlockByNumber for block details page in
     /// Otterscan.
     #[method(name = "getBlockDetails")]
-    async fn get_block_details(&self, block_number: u64) -> RpcResult<BlockDetails>;
+    async fn get_block_details(&self, block_number: u64) -> RpcResult<BlockDetails<H>>;
 
     /// Tailor-made and expanded version of eth_getBlockByHash for block details page in Otterscan.
     #[method(name = "getBlockDetailsByHash")]
-    async fn get_block_details_by_hash(&self, block_hash: B256) -> RpcResult<BlockDetails>;
+    async fn get_block_details_by_hash(&self, block_hash: B256) -> RpcResult<BlockDetails<H>>;
 
     /// Get paginated transactions for a certain block. Also remove some verbose fields like logs.
     #[method(name = "getBlockTransactions")]
@@ -61,7 +61,7 @@ pub trait Otterscan<T: RpcObject> {
         block_number: u64,
         page_number: usize,
         page_size: usize,
-    ) -> RpcResult<OtsBlockTransactions<T>>;
+    ) -> RpcResult<OtsBlockTransactions<T, H>>;
 
     /// Gets paginated inbound/outbound transaction calls for a certain address.
     #[method(name = "searchTransactionsBefore")]

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -206,7 +206,9 @@ use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives::{EthPrimitives, NodePrimitives};
 use reth_provider::{
-    AccountReader, BlockReader, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader, EvmEnvProvider, FullRpcProvider, HeaderProvider, ProviderBlock, ProviderHeader, ProviderReceipt, ReceiptProvider, StateProviderFactory
+    AccountReader, BlockReader, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
+    EvmEnvProvider, FullRpcProvider, HeaderProvider, ProviderBlock, ProviderHeader,
+    ProviderReceipt, ReceiptProvider, StateProviderFactory,
 };
 use reth_rpc::{
     AdminApi, DebugApi, EngineEthApi, EthBundle, MinerApi, NetApi, OtterscanApi, RPCApi, RethApi,
@@ -214,7 +216,8 @@ use reth_rpc::{
 };
 use reth_rpc_api::servers::*;
 use reth_rpc_eth_api::{
-    helpers::{Call, EthApiSpec, EthTransactions, LoadPendingBlock, TraceExt}, EthApiServer, EthApiTypes, FullEthApiServer, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction
+    helpers::{Call, EthApiSpec, EthTransactions, LoadPendingBlock, TraceExt},
+    EthApiServer, EthApiTypes, FullEthApiServer, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
 };
 use reth_rpc_eth_types::{EthConfig, EthStateCache, EthSubscriptionIdProvider};
 use reth_rpc_layer::{AuthLayer, Claims, CompressionLayer, JwtAuthValidator, JwtSecret};
@@ -284,7 +287,13 @@ where
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions<Primitives = EthPrimitives> + Clone + 'static,
     EvmConfig: ConfigureEvm<Header = alloy_consensus::Header>,
-    EthApi: FullEthApiServer,
+    EthApi: FullEthApiServer<
+        Provider: BlockReader<
+            Block = reth_primitives::Block,
+            Receipt = reth_primitives::Receipt,
+            Header = reth_primitives::Header,
+        >,
+    >,
     BlockExecutor: BlockExecutorProvider<
         Primitives: NodePrimitives<
             Block = reth_primitives::Block,
@@ -670,7 +679,13 @@ where
     where
         EngineT: EngineTypes,
         EngineApi: EngineApiServer<EngineT>,
-        EthApi: FullEthApiServer,
+        EthApi: FullEthApiServer<
+            Provider: BlockReader<
+                Block = reth_primitives::Block,
+                Receipt = reth_primitives::Receipt,
+                Header = reth_primitives::Header,
+            >,
+        >,
         Provider: BlockReader<
             Block = <EthApi::Provider as BlockReader>::Block,
             Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
@@ -790,7 +805,13 @@ where
         eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, EthApi>,
     ) -> TransportRpcModules<()>
     where
-        EthApi: FullEthApiServer,
+        EthApi: FullEthApiServer<
+            Provider: BlockReader<
+                Block = reth_primitives::Block,
+                Receipt = reth_primitives::Receipt,
+                Header = reth_primitives::Header,
+            >,
+        >,
         Provider: BlockReader<
             Block = <EthApi::Provider as BlockReader>::Block,
             Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
@@ -1169,10 +1190,16 @@ where
     /// If called outside of the tokio runtime. See also [`Self::eth_api`]
     pub fn register_debug(&mut self) -> &mut Self
     where
-        EthApi: EthApiSpec + EthTransactions + TraceExt,
+        EthApi: EthApiSpec
+            + EthTransactions<
+                Provider: BlockReader<
+                    Block = reth_primitives::Block,
+                    Receipt = reth_primitives::Receipt,
+                >,
+            > + TraceExt,
         Provider: BlockReader<
             Block = <EthApi::Provider as BlockReader>::Block,
-            Receipt = <EthApi::Provier as ReceiptProvider>::Receipt,
+            Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
         >,
     {
         let debug_api = self.debug_api();
@@ -1338,7 +1365,13 @@ where
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     Events: CanonStateSubscriptions<Primitives = EthPrimitives> + Clone + 'static,
-    EthApi: FullEthApiServer,
+    EthApi: FullEthApiServer<
+        Provider: BlockReader<
+            Block = reth_primitives::Block,
+            Receipt = reth_primitives::Receipt,
+            Header = reth_primitives::Header,
+        >,
+    >,
     BlockExecutor: BlockExecutorProvider<
         Primitives: NodePrimitives<
             Block = reth_primitives::Block,

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -5,7 +5,7 @@ use crate::utils::{launch_http, launch_http_ws, launch_ws};
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{hex_literal::hex, Address, Bytes, TxHash, B256, B64, U256, U64};
 use alloy_rpc_types_eth::{
-    transaction::TransactionRequest, Block, FeeHistory, Filter, Index, Log,
+    transaction::TransactionRequest, Block, FeeHistory, Filter, Header, Index, Log,
     PendingTransactionFilterKind, SyncStatus, Transaction, TransactionReceipt,
 };
 use alloy_rpc_types_trace::filter::TraceFilter;
@@ -174,16 +174,24 @@ where
     .unwrap();
 
     // Implemented
-    EthApiClient::<Transaction, Block, Receipt>::protocol_version(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::chain_id(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::accounts(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::get_account(client, address, block_number.into())
+    EthApiClient::<Transaction, Block, Receipt, Header>::protocol_version(client).await.unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::chain_id(client).await.unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::accounts(client).await.unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::get_account(
+        client,
+        address,
+        block_number.into(),
+    )
+    .await
+    .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::block_number(client).await.unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::get_code(client, address, None)
         .await
         .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::block_number(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::get_code(client, address, None).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::send_raw_transaction(client, tx).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::fee_history(
+    EthApiClient::<Transaction, Block, Receipt, Header>::send_raw_transaction(client, tx)
+        .await
+        .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::fee_history(
         client,
         U64::from(0),
         block_number,
@@ -191,11 +199,13 @@ where
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::balance(client, address, None).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::transaction_count(client, address, None)
+    EthApiClient::<Transaction, Block, Receipt, Header>::balance(client, address, None)
         .await
         .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::storage_at(
+    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_count(client, address, None)
+        .await
+        .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::storage_at(
         client,
         address,
         U256::default().into(),
@@ -203,64 +213,79 @@ where
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::block_by_hash(client, hash, false).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::block_by_number(client, block_number, false)
+    EthApiClient::<Transaction, Block, Receipt, Header>::block_by_hash(client, hash, false)
         .await
         .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::block_transaction_count_by_number(
+    EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
+        client,
+        block_number,
+        false,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::block_transaction_count_by_number(
         client,
         block_number,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::block_transaction_count_by_hash(client, hash)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::block_uncles_count_by_hash(client, hash)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::block_uncles_count_by_number(client, block_number)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::uncle_by_block_hash_and_index(client, hash, index)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::uncle_by_block_number_and_index(
-        client,
-        block_number,
-        index,
+    EthApiClient::<Transaction, Block, Receipt, Header>::block_transaction_count_by_hash(
+        client, hash,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::sign(client, address, bytes.clone())
-        .await
-        .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::sign_typed_data(client, address, typed_data)
-        .await
-        .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::transaction_by_hash(client, tx_hash)
+    EthApiClient::<Transaction, Block, Receipt, Header>::block_uncles_count_by_hash(client, hash)
         .await
         .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::transaction_by_block_hash_and_index(
+    EthApiClient::<Transaction, Block, Receipt, Header>::block_uncles_count_by_number(
+        client,
+        block_number,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::uncle_by_block_hash_and_index(
         client, hash, index,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::transaction_by_block_number_and_index(
+    EthApiClient::<Transaction, Block, Receipt, Header>::uncle_by_block_number_and_index(
         client,
         block_number,
         index,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::create_access_list(
+    EthApiClient::<Transaction, Block, Receipt, Header>::sign(client, address, bytes.clone())
+        .await
+        .unwrap_err();
+    EthApiClient::<Transaction, Block, Receipt, Header>::sign_typed_data(
+        client, address, typed_data,
+    )
+    .await
+    .unwrap_err();
+    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_by_hash(client, tx_hash)
+        .await
+        .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_by_block_hash_and_index(
+        client, hash, index,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_by_block_number_and_index(
+        client,
+        block_number,
+        index,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::create_access_list(
         client,
         call_request.clone(),
         Some(block_number.into()),
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::estimate_gas(
+    EthApiClient::<Transaction, Block, Receipt, Header>::estimate_gas(
         client,
         call_request.clone(),
         Some(block_number.into()),
@@ -268,7 +293,7 @@ where
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::call(
+    EthApiClient::<Transaction, Block, Receipt, Header>::call(
         client,
         call_request.clone(),
         Some(block_number.into()),
@@ -277,44 +302,47 @@ where
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::syncing(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::send_transaction(
+    EthApiClient::<Transaction, Block, Receipt, Header>::syncing(client).await.unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::send_transaction(
         client,
         transaction_request.clone(),
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::sign_transaction(client, transaction_request)
-        .await
-        .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::hashrate(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::submit_hashrate(
+    EthApiClient::<Transaction, Block, Receipt, Header>::sign_transaction(
+        client,
+        transaction_request,
+    )
+    .await
+    .unwrap_err();
+    EthApiClient::<Transaction, Block, Receipt, Header>::hashrate(client).await.unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::submit_hashrate(
         client,
         U256::default(),
         B256::default(),
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::gas_price(client).await.unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::max_priority_fee_per_gas(client)
+    EthApiClient::<Transaction, Block, Receipt, Header>::gas_price(client).await.unwrap_err();
+    EthApiClient::<Transaction, Block, Receipt, Header>::max_priority_fee_per_gas(client)
         .await
         .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt>::get_proof(client, address, vec![], None)
+    EthApiClient::<Transaction, Block, Receipt, Header>::get_proof(client, address, vec![], None)
         .await
         .unwrap();
 
     // Unimplemented
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt>::author(client).await.err().unwrap()
+        EthApiClient::<Transaction, Block, Receipt, Header>::author(client).await.err().unwrap()
     ));
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt>::is_mining(client).await.err().unwrap()
+        EthApiClient::<Transaction, Block, Receipt, Header>::is_mining(client).await.err().unwrap()
     ));
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt>::get_work(client).await.err().unwrap()
+        EthApiClient::<Transaction, Block, Receipt, Header>::get_work(client).await.err().unwrap()
     ));
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt>::submit_work(
+        EthApiClient::<Transaction, Block, Receipt, Header>::submit_work(
             client,
             B64::default(),
             B256::default(),
@@ -402,28 +430,32 @@ where
     let nonce = 1;
     let block_hash = B256::default();
 
-    OtterscanClient::<Transaction>::get_header_by_number(client, block_number).await.unwrap();
-
-    OtterscanClient::<Transaction>::has_code(client, address, None).await.unwrap();
-    OtterscanClient::<Transaction>::has_code(client, address, Some(block_number.into()))
+    OtterscanClient::<Transaction, Header>::get_header_by_number(client, block_number)
         .await
         .unwrap();
 
-    OtterscanClient::<Transaction>::get_api_level(client).await.unwrap();
+    OtterscanClient::<Transaction, Header>::has_code(client, address, None).await.unwrap();
+    OtterscanClient::<Transaction, Header>::has_code(client, address, Some(block_number.into()))
+        .await
+        .unwrap();
 
-    OtterscanClient::<Transaction>::get_internal_operations(client, tx_hash).await.unwrap();
+    OtterscanClient::<Transaction, Header>::get_api_level(client).await.unwrap();
 
-    OtterscanClient::<Transaction>::get_transaction_error(client, tx_hash).await.unwrap();
+    OtterscanClient::<Transaction, Header>::get_internal_operations(client, tx_hash).await.unwrap();
 
-    OtterscanClient::<Transaction>::trace_transaction(client, tx_hash).await.unwrap();
+    OtterscanClient::<Transaction, Header>::get_transaction_error(client, tx_hash).await.unwrap();
 
-    OtterscanClient::<Transaction>::get_block_details(client, block_number).await.unwrap_err();
+    OtterscanClient::<Transaction, Header>::trace_transaction(client, tx_hash).await.unwrap();
 
-    OtterscanClient::<Transaction>::get_block_details_by_hash(client, block_hash)
+    OtterscanClient::<Transaction, Header>::get_block_details(client, block_number)
         .await
         .unwrap_err();
 
-    OtterscanClient::<Transaction>::get_block_transactions(
+    OtterscanClient::<Transaction, Header>::get_block_details_by_hash(client, block_hash)
+        .await
+        .unwrap_err();
+
+    OtterscanClient::<Transaction, Header>::get_block_transactions(
         client,
         block_number,
         page_number,
@@ -434,7 +466,7 @@ where
     .unwrap();
 
     assert!(is_unimplemented(
-        OtterscanClient::<Transaction>::search_transactions_before(
+        OtterscanClient::<Transaction, Header>::search_transactions_before(
             client,
             address,
             block_number,
@@ -445,7 +477,7 @@ where
         .unwrap()
     ));
     assert!(is_unimplemented(
-        OtterscanClient::<Transaction>::search_transactions_after(
+        OtterscanClient::<Transaction, Header>::search_transactions_after(
             client,
             address,
             block_number,
@@ -455,13 +487,13 @@ where
         .err()
         .unwrap()
     ));
-    assert!(OtterscanClient::<Transaction>::get_transaction_by_sender_and_nonce(
+    assert!(OtterscanClient::<Transaction, Header>::get_transaction_by_sender_and_nonce(
         client, sender, nonce
     )
     .await
     .err()
     .is_none());
-    assert!(OtterscanClient::<Transaction>::get_contract_creator(client, address)
+    assert!(OtterscanClient::<Transaction, Header>::get_contract_creator(client, address)
         .await
         .unwrap()
         .is_none());

--- a/crates/rpc/rpc-builder/tests/it/middleware.rs
+++ b/crates/rpc/rpc-builder/tests/it/middleware.rs
@@ -1,5 +1,5 @@
 use crate::utils::{test_address, test_rpc_builder};
-use alloy_rpc_types_eth::{Block, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction};
 use jsonrpsee::{
     server::{middleware::rpc::RpcServiceT, RpcServiceBuilder},
     types::Request,
@@ -75,7 +75,7 @@ async fn test_rpc_middleware() {
         .unwrap();
 
     let client = handle.http_client().unwrap();
-    EthApiClient::<Transaction, Block, Receipt>::protocol_version(&client).await.unwrap();
+    EthApiClient::<Transaction, Block, Receipt, Header>::protocol_version(&client).await.unwrap();
     let count = mylayer.count.load(Ordering::Relaxed);
     assert_eq!(count, 1);
 }

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -34,6 +34,7 @@ reth-node-api.workspace = true
 reth-trie-common = { workspace = true, features = ["eip1186"] }
 
 # ethereum
+alloy-rlp.workspace = true
 alloy-serde.workspace = true
 alloy-eips.workspace = true
 alloy-dyn-abi = { workspace = true, features = ["eip712"] }

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -15,10 +15,11 @@ use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use tracing::trace;
+use reth_provider::ProviderHeader;
 
 use crate::{
     helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
-    RpcBlock, RpcReceipt, RpcTransaction,
+    RpcBlock, RpcReceipt, RpcTransaction, RpcHeader
 };
 
 /// Helper trait, unifies functionality that must be supported to implement all RPC methods for
@@ -28,6 +29,7 @@ pub trait FullEthApiServer:
         RpcTransaction<Self::NetworkTypes>,
         RpcBlock<Self::NetworkTypes>,
         RpcReceipt<Self::NetworkTypes>,
+        RpcHeader<Self::NetworkTypes>,
     > + FullEthApi
     + Clone
 {
@@ -38,6 +40,7 @@ impl<T> FullEthApiServer for T where
             RpcTransaction<T::NetworkTypes>,
             RpcBlock<T::NetworkTypes>,
             RpcReceipt<T::NetworkTypes>,
+            RpcHeader<T::NetworkTypes>,
         > + FullEthApi
         + Clone
 {
@@ -46,7 +49,7 @@ impl<T> FullEthApiServer for T where
 /// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
-pub trait EthApi<T: RpcObject, B: RpcObject, R: RpcObject> {
+pub trait EthApi<T: RpcObject, B: RpcObject, R: RpcObject, H: RpcObject> {
     /// Returns the protocol version encoded as a string.
     #[method(name = "protocolVersion")]
     async fn protocol_version(&self) -> RpcResult<U64>;
@@ -200,11 +203,11 @@ pub trait EthApi<T: RpcObject, B: RpcObject, R: RpcObject> {
 
     /// Returns the block's header at given number.
     #[method(name = "getHeaderByNumber")]
-    async fn header_by_number(&self, hash: BlockNumberOrTag) -> RpcResult<Option<Header>>;
+    async fn header_by_number(&self, hash: BlockNumberOrTag) -> RpcResult<Option<H>>;
 
     /// Returns the block's header at given hash.
     #[method(name = "getHeaderByHash")]
-    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<Header>>;
+    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<H>>;
 
     /// `eth_simulateV1` executes an arbitrary number of transactions on top of the requested state.
     /// The transactions are packed into individual blocks. Overrides can be provided.
@@ -366,6 +369,7 @@ impl<T>
         RpcTransaction<T::NetworkTypes>,
         RpcBlock<T::NetworkTypes>,
         RpcReceipt<T::NetworkTypes>,
+        RpcHeader<T::NetworkTypes>,
     > for T
 where
     T: FullEthApi,
@@ -607,13 +611,13 @@ where
     }
 
     /// Handler for: `eth_getHeaderByNumber`
-    async fn header_by_number(&self, block_number: BlockNumberOrTag) -> RpcResult<Option<Header>> {
+    async fn header_by_number(&self, block_number: BlockNumberOrTag) -> RpcResult<Option<Header<ProviderHeader<T::Provider>>>> {
         trace!(target: "rpc::eth", ?block_number, "Serving eth_getHeaderByNumber");
         Ok(EthBlocks::rpc_block_header(self, block_number.into()).await?)
     }
 
     /// Handler for: `eth_getHeaderByHash`
-    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<Header>> {
+    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<Header<ProviderHeader<T::Provider>>>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getHeaderByHash");
         Ok(EthBlocks::rpc_block_header(self, hash.into()).await?)
     }

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -8,12 +8,12 @@ use alloy_rpc_types_eth::{
     simulate::{SimulatePayload, SimulatedBlock},
     state::{EvmOverrides, StateOverride},
     transaction::TransactionRequest,
-    BlockOverrides, Bundle, EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Header,
-    Index, StateContext, SyncStatus, Work,
+    BlockOverrides, Bundle, EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Index,
+    StateContext, SyncStatus, Work,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_provider::{BlockReader, ProviderHeader};
+use reth_provider::BlockReader;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use tracing::trace;
 
@@ -619,16 +619,13 @@ where
     async fn header_by_number(
         &self,
         block_number: BlockNumberOrTag,
-    ) -> RpcResult<Option<Header<ProviderHeader<T::Provider>>>> {
+    ) -> RpcResult<Option<RpcHeader<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?block_number, "Serving eth_getHeaderByNumber");
         Ok(EthBlocks::rpc_block_header(self, block_number.into()).await?)
     }
 
     /// Handler for: `eth_getHeaderByHash`
-    async fn header_by_hash(
-        &self,
-        hash: B256,
-    ) -> RpcResult<Option<Header<ProviderHeader<T::Provider>>>> {
+    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<RpcHeader<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getHeaderByHash");
         Ok(EthBlocks::rpc_block_header(self, hash.into()).await?)
     }

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -38,6 +38,7 @@ pub type BlockAndReceiptsResult<Eth> = Result<
 /// `eth_` namespace.
 pub trait EthBlocks: LoadBlock {
     /// Returns the block header for the given block id.
+    #[expect(clippy::type_complexity)]
     fn rpc_block_header(
         &self,
         block_id: BlockId,
@@ -176,6 +177,7 @@ pub trait EthBlocks: LoadBlock {
     /// Returns uncle headers of given block.
     ///
     /// Returns an empty vec if there are none.
+    #[expect(clippy::type_complexity)]
     fn ommers(
         &self,
         block_id: BlockId,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -20,7 +20,9 @@ use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_node_api::BlockBody;
 use reth_primitives_traits::SignedTransaction;
-use reth_provider::{BlockIdReader, ChainSpecProvider, HeaderProvider, ProviderHeader};
+use reth_provider::{
+    BlockIdReader, BlockReader, ChainSpecProvider, HeaderProvider, ProviderHeader,
+};
 use reth_revm::{
     database::StateProviderDatabase,
     db::CacheDB,
@@ -70,7 +72,12 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock {
         block: Option<BlockId>,
     ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send
     where
-        Self: LoadBlock + FullEthApiTypes,
+        Self: LoadBlock<
+                Provider: BlockReader<
+                    Header = alloy_consensus::Header,
+                    Transaction = reth_primitives::TransactionSigned,
+                >,
+            > + FullEthApiTypes,
     {
         async move {
             if payload.block_state_calls.len() > self.max_simulate_blocks() as usize {

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -6,7 +6,7 @@ use crate::{
     helpers::estimate::EstimateCall, FromEthApiError, FromEvmError, FullEthApiTypes,
     IntoEthApiError, RpcBlock, RpcNodeCore,
 };
-use alloy_consensus::{BlockHeader, Header};
+use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1559::calc_next_block_base_fee, eip2930::AccessListResult};
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use alloy_rpc_types_eth::{

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -2,11 +2,12 @@
 
 use super::{Call, LoadPendingBlock};
 use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
+use alloy_consensus::Header;
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::{state::StateOverride, transaction::TransactionRequest, BlockId};
 use futures::Future;
 use reth_chainspec::{EthChainSpec, MIN_TRANSACTION_GAS};
-use reth_provider::{ChainSpecProvider, StateProvider};
+use reth_provider::{ChainSpecProvider, HeaderProvider, StateProvider};
 use reth_revm::{
     database::StateProviderDatabase,
     db::CacheDB,

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -2,12 +2,11 @@
 
 use super::{Call, LoadPendingBlock};
 use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
-use alloy_consensus::Header;
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::{state::StateOverride, transaction::TransactionRequest, BlockId};
 use futures::Future;
 use reth_chainspec::{EthChainSpec, MIN_TRANSACTION_GAS};
-use reth_provider::{ChainSpecProvider, HeaderProvider, StateProvider};
+use reth_provider::{ChainSpecProvider, StateProvider};
 use reth_revm::{
     database::StateProviderDatabase,
     db::CacheDB,

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -5,6 +5,7 @@ use alloy_primitives::U256;
 use alloy_rpc_types_eth::{BlockNumberOrTag, FeeHistory};
 use futures::Future;
 use reth_chainspec::EthChainSpec;
+use reth_primitives_traits::BlockBody;
 use reth_provider::{BlockIdReader, ChainSpecProvider, HeaderProvider};
 use reth_rpc_eth_types::{
     fee_history::calculate_reward_percentiles_for_block, EthApiError, FeeHistoryCache,
@@ -183,7 +184,7 @@ pub trait EthFees: LoadFee {
                                 percentiles,
                                 header.gas_used(),
                                 header.base_fee_per_gas().unwrap_or_default(),
-                                &block.body.transactions,
+                                &block.body.transactions(),
                                 &receipts,
                             )
                             .unwrap_or_default(),

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -184,7 +184,7 @@ pub trait EthFees: LoadFee {
                                 percentiles,
                                 header.gas_used(),
                                 header.base_fee_per_gas().unwrap_or_default(),
-                                &block.body.transactions(),
+                                block.body.transactions(),
                                 &receipts,
                             )
                             .unwrap_or_default(),

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -196,7 +196,7 @@ pub trait LoadPendingBlock:
         }
     }
 
-    /// Assembles a [`Receipt`] for a transaction, based on its [`ExecutionResult`].
+    /// Assembles a receipt for a transaction, based on its [`ExecutionResult`].
     fn assemble_receipt(
         &self,
         tx: &RecoveredTx<ProviderTx<Self::Provider>>,

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -3,10 +3,11 @@
 
 use super::SpawnBlocking;
 use crate::{EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore};
-use alloy_consensus::{BlockHeader, Header, EMPTY_OMMER_ROOT_HASH};
+use alloy_consensus::{BlockHeader, Header, Transaction, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{
     eip4844::MAX_DATA_GAS_PER_BLOCK, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE,
 };
+use alloy_network::{primitives::HeaderResponse, Network};
 use alloy_primitives::{BlockNumber, B256, U256};
 use alloy_rpc_types_eth::{BlockNumberOrTag, Withdrawals};
 use futures::Future;
@@ -21,9 +22,10 @@ use reth_primitives::{
     proofs::calculate_transaction_root, Block, BlockBody, BlockExt, InvalidTransactionError,
     Receipt, RecoveredTx, SealedBlockWithSenders,
 };
+use reth_primitives_traits::receipt::ReceiptExt;
 use reth_provider::{
-    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderError,
-    ProviderReceipt, ProviderTx, ReceiptProvider, StateProviderFactory,
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderBlock, ProviderError,
+    ProviderHeader, ProviderReceipt, ProviderTx, ReceiptProvider, StateProviderFactory,
 };
 use reth_revm::{
     database::StateProviderDatabase,
@@ -46,29 +48,38 @@ use tracing::debug;
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` blocks RPC methods.
 pub trait LoadPendingBlock:
-    EthApiTypes
-    + RpcNodeCore<
-        Provider: BlockReaderIdExt<
-            Transaction = reth_primitives::TransactionSigned,
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
-            Header = reth_primitives::Header,
-        > + EvmEnvProvider
+    EthApiTypes<
+        NetworkTypes: Network<
+            HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+        >,
+    > + RpcNodeCore<
+        Provider: BlockReaderIdExt<Receipt: ReceiptExt>
+                      + EvmEnvProvider<ProviderHeader<Self::Provider>>
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
-        Evm: ConfigureEvm<Header = Header, Transaction = ProviderTx<Self::Provider>>,
+        Evm: ConfigureEvm<
+            Header = ProviderHeader<Self::Provider>,
+            Transaction = ProviderTx<Self::Provider>,
+        >,
     >
 {
     /// Returns a handle to the pending block.
     ///
     /// Data access in default (L1) trait method implementations.
-    fn pending_block(&self) -> &Mutex<Option<PendingBlock>>;
+    fn pending_block(
+        &self,
+    ) -> &Mutex<Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>>;
 
     /// Configures the [`CfgEnvWithHandlerCfg`] and [`BlockEnv`] for the pending block
     ///
     /// If no pending block is available, this will derive it from the `latest` block
-    fn pending_block_env_and_cfg(&self) -> Result<PendingBlockEnv, Self::Error> {
+    fn pending_block_env_and_cfg(
+        &self,
+    ) -> Result<
+        PendingBlockEnv<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>,
+        Self::Error,
+    > {
         if let Some(block) =
             self.provider().pending_block_with_senders().map_err(Self::Error::from_eth_err)?
         {
@@ -154,8 +165,8 @@ pub trait LoadPendingBlock:
             // check if the block is still good
             if let Some(pending_block) = lock.as_ref() {
                 // this is guaranteed to be the `latest` header
-                if pending.block_env.number.to::<u64>() == pending_block.block.number &&
-                    parent_hash == pending_block.block.parent_hash &&
+                if pending.block_env.number.to::<u64>() == pending_block.block.number() &&
+                    parent_hash == pending_block.block.parent_hash() &&
                     now <= pending_block.expires_at
                 {
                     return Ok(Some((pending_block.block.clone(), pending_block.receipts.clone())));
@@ -191,31 +202,19 @@ pub trait LoadPendingBlock:
     /// Assembles a [`Receipt`] for a transaction, based on its [`ExecutionResult`].
     fn assemble_receipt(
         &self,
-        tx: &RecoveredTx,
+        tx: &RecoveredTx<ProviderTx<Self::Provider>>,
         result: ExecutionResult,
         cumulative_gas_used: u64,
-    ) -> Receipt {
-        #[allow(clippy::needless_update)]
-        Receipt {
-            tx_type: tx.tx_type(),
-            success: result.is_success(),
-            cumulative_gas_used,
-            logs: result.into_logs().into_iter().map(Into::into).collect(),
-            ..Default::default()
-        }
-    }
+    ) -> ProviderReceipt<Self::Provider>;
 
-    /// Calculates receipts root in block building.
-    ///
-    /// Panics if block is not in the [`ExecutionOutcome`]'s block range.
-    fn receipts_root(
+    /// Assembles a pending block.
+    fn assemble_block(
         &self,
-        _block_env: &BlockEnv,
-        execution_outcome: &ExecutionOutcome,
-        block_number: BlockNumber,
-    ) -> B256 {
-        execution_outcome.receipts_root_slow(block_number).expect("Block is present")
-    }
+        parent_hash: B256,
+        state_root: B256,
+        transactions: Vec<ProviderTx<Self::Provider>>,
+        receipts: &[ProviderReceipt<Self::Provider>],
+    ) -> ProviderBlock<Self::Provider>;
 
     /// Builds a pending block using the configured provider and pool.
     ///
@@ -228,7 +227,13 @@ pub trait LoadPendingBlock:
         cfg: CfgEnvWithHandlerCfg,
         block_env: BlockEnv,
         parent_hash: B256,
-    ) -> Result<(SealedBlockWithSenders, Vec<Receipt>), Self::Error>
+    ) -> Result<
+        (
+            SealedBlockWithSenders<ProviderBlock<Self::Provider>>,
+            Vec<ProviderReceipt<Self::Provider>>,
+        ),
+        Self::Error,
+    >
     where
         EthApiError: From<ProviderError>,
     {
@@ -253,14 +258,10 @@ pub trait LoadPendingBlock:
                 block_env.get_blob_gasprice().map(|gasprice| gasprice as u64),
             ));
 
-        let withdrawals: Option<Withdrawals> = None;
-        let withdrawals_root = None;
-
         let chain_spec = self.provider().chain_spec();
 
         let mut system_caller = SystemCaller::new(self.evm_config().clone(), chain_spec.clone());
 
-        let parent_beacon_block_root = None;
         system_caller
             .pre_block_blockhashes_contract_call(&mut db, &cfg, &block_env, parent_hash)
             .map_err(|err| EthApiError::Internal(err.into()))?;
@@ -301,8 +302,7 @@ pub trait LoadPendingBlock:
 
             // There's only limited amount of blob space available per block, so we need to check if
             // the EIP-4844 can still fit in the block
-            if let Some(blob_tx) = tx.transaction.as_eip4844() {
-                let tx_blob_gas = blob_tx.blob_gas();
+            if let Some(tx_blob_gas) = tx.blob_gas_used() {
                 if sum_blob_gas_used + tx_blob_gas > MAX_DATA_GAS_PER_BLOCK {
                     // we can't fit this _blob_ transaction into the block, so we mark it as
                     // invalid, which removes its dependent transactions from
@@ -360,8 +360,7 @@ pub trait LoadPendingBlock:
             db.commit(state);
 
             // add to the total blob gas used if the transaction successfully executed
-            if let Some(blob_tx) = tx.transaction.as_eip4844() {
-                let tx_blob_gas = blob_tx.blob_gas();
+            if let Some(tx_blob_gas) = tx.blob_gas_used() {
                 sum_blob_gas_used += tx_blob_gas;
 
                 // if we've reached the max data gas per block, we can skip blob txs entirely
@@ -388,7 +387,7 @@ pub trait LoadPendingBlock:
         let balance_increments = post_block_withdrawals_balance_increments(
             chain_spec.as_ref(),
             block_env.timestamp.try_into().unwrap_or(u64::MAX),
-            &withdrawals.clone().unwrap_or_default(),
+            &[],
         );
 
         // increment account balances for withdrawals
@@ -397,15 +396,14 @@ pub trait LoadPendingBlock:
         // merge all transitions into bundle state.
         db.merge_transitions(BundleRetention::PlainState);
 
-        let execution_outcome = ExecutionOutcome::new(
-            db.take_bundle(),
-            vec![receipts.clone()].into(),
-            block_number,
-            Vec::new(),
-        );
+        let execution_outcome: ExecutionOutcome<ProviderReceipt<Self::Provider>> =
+            ExecutionOutcome::new(
+                db.take_bundle(),
+                vec![receipts.clone()].into(),
+                block_number,
+                Vec::new(),
+            );
         let hashed_state = db.database.hashed_post_state(execution_outcome.state());
-
-        let receipts_root = self.receipts_root(&block_env, &execution_outcome, block_number);
 
         let logs_bloom =
             execution_outcome.block_logs_bloom(block_number).expect("Block is present");
@@ -424,39 +422,10 @@ pub trait LoadPendingBlock:
             .is_prague_active_at_timestamp(block_env.timestamp.to::<u64>())
             .then_some(EMPTY_REQUESTS_HASH);
 
-        let header = Header {
-            parent_hash,
-            ommers_hash: EMPTY_OMMER_ROOT_HASH,
-            beneficiary: block_env.coinbase,
-            state_root,
-            transactions_root,
-            receipts_root,
-            withdrawals_root,
-            logs_bloom,
-            timestamp: block_env.timestamp.to::<u64>(),
-            mix_hash: block_env.prevrandao.unwrap_or_default(),
-            nonce: BEACON_NONCE.into(),
-            base_fee_per_gas: Some(base_fee),
-            number: block_number,
-            gas_limit: block_gas_limit,
-            difficulty: U256::ZERO,
-            gas_used: cumulative_gas_used,
-            blob_gas_used: blob_gas_used.map(Into::into),
-            excess_blob_gas: block_env.get_blob_excess_gas().map(Into::into),
-            extra_data: Default::default(),
-            parent_beacon_block_root,
-            requests_hash,
-            target_blobs_per_block: None,
-        };
-
         // Convert Vec<Option<Receipt>> to Vec<Receipt>
-        let receipts: Vec<Receipt> = receipts.into_iter().flatten().collect();
+        let receipts: Vec<_> = receipts.into_iter().flatten().collect();
+        let block = self.assemble_block(parent_hash, state_root, executed_txs, &receipts);
 
-        // seal the block
-        let block = Block {
-            header,
-            body: BlockBody { transactions: executed_txs, ommers: vec![], withdrawals },
-        };
         Ok((SealedBlockWithSenders { block: block.seal_slow(), senders }, receipts))
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -207,8 +207,10 @@ pub trait LoadPendingBlock:
     /// Assembles a pending block.
     fn assemble_block(
         &self,
-        parent_hash: B256,
-        state_root: B256,
+        cfg: CfgEnvWithHandlerCfg,
+        block_env: BlockEnv,
+        parent_hash: revm_primitives::B256,
+        state_root: revm_primitives::B256,
         transactions: Vec<ProviderTx<Self::Provider>>,
         receipts: &[ProviderReceipt<Self::Provider>],
     ) -> ProviderBlock<Self::Provider>;
@@ -408,7 +410,8 @@ pub trait LoadPendingBlock:
 
         // Convert Vec<Option<Receipt>> to Vec<Receipt>
         let receipts: Vec<_> = receipts.into_iter().flatten().collect();
-        let block = self.assemble_block(parent_hash, state_root, executed_txs, &receipts);
+        let block =
+            self.assemble_block(cfg, block_env, parent_hash, state_root, executed_txs, &receipts);
 
         Ok((SealedBlockWithSenders { block: block.seal_slow(), senders }, receipts))
     }

--- a/crates/rpc/rpc-eth-api/src/helpers/signer.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/signer.rs
@@ -13,7 +13,7 @@ pub type Result<T> = result::Result<T, SignError>;
 
 /// An Ethereum Signer used via RPC.
 #[async_trait::async_trait]
-pub trait EthSigner: Send + Sync + DynClone {
+pub trait EthSigner<T>: Send + Sync + DynClone {
     /// Returns the available accounts for this signer.
     fn accounts(&self) -> Vec<Address>;
 
@@ -26,17 +26,13 @@ pub trait EthSigner: Send + Sync + DynClone {
     async fn sign(&self, address: Address, message: &[u8]) -> Result<Signature>;
 
     /// signs a transaction request using the given account in request
-    async fn sign_transaction(
-        &self,
-        request: TransactionRequest,
-        address: &Address,
-    ) -> Result<TransactionSigned>;
+    async fn sign_transaction(&self, request: TransactionRequest, address: &Address) -> Result<T>;
 
     /// Encodes and signs the typed data according EIP-712. Payload must implement Eip712 trait.
     fn sign_typed_data(&self, address: Address, payload: &TypedData) -> Result<Signature>;
 }
 
-dyn_clone::clone_trait_object!(EthSigner);
+dyn_clone::clone_trait_object!(<T> EthSigner<T>);
 
 /// Adds 20 random dev signers for access via the API. Used in dev mode.
 #[auto_impl::auto_impl(&)]

--- a/crates/rpc/rpc-eth-api/src/helpers/signer.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/signer.rs
@@ -4,7 +4,6 @@ use alloy_dyn_abi::TypedData;
 use alloy_primitives::{Address, PrimitiveSignature as Signature};
 use alloy_rpc_types_eth::TransactionRequest;
 use dyn_clone::DynClone;
-use reth_primitives::TransactionSigned;
 use reth_rpc_eth_types::SignError;
 use std::result;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -6,9 +6,7 @@ use futures::Future;
 use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_errors::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
-use reth_provider::{
-    BlockNumReader, ChainSpecProvider, ProviderTx, StageCheckpointReader, TransactionsProvider,
-};
+use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
 
 use crate::{helpers::EthSigner, RpcNodeCore};
 

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -6,7 +6,9 @@ use futures::Future;
 use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_errors::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
-use reth_provider::{BlockNumReader, ChainSpecProvider, StageCheckpointReader};
+use reth_provider::{
+    BlockNumReader, ChainSpecProvider, ProviderTx, StageCheckpointReader, TransactionsProvider,
+};
 
 use crate::{helpers::EthSigner, RpcNodeCore};
 
@@ -22,11 +24,14 @@ pub trait EthApiSpec:
     Network: NetworkInfo,
 >
 {
+    /// The transaction type signers are using.
+    type Transaction;
+
     /// Returns the block node is started on.
     fn starting_block(&self) -> U256;
 
     /// Returns a handle to the signers owned by provider.
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>>;
+    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<Self::Transaction>>>>;
 
     /// Returns the current ethereum protocol version.
     fn protocol_version(&self) -> impl Future<Output = RethResult<U64>> + Send {

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -2,7 +2,7 @@
 //! RPC methods.
 use super::{EthApiSpec, LoadPendingBlock, SpawnBlocking};
 use crate::{EthApiTypes, FromEthApiError, RpcNodeCore, RpcNodeCoreExt};
-use alloy_consensus::{constants::KECCAK_EMPTY, BlockHeader, Header};
+use alloy_consensus::{constants::KECCAK_EMPTY, BlockHeader};
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_eth::{Account, EIP1186AccountProofResponse};

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -2,7 +2,7 @@
 //! RPC methods.
 use super::{EthApiSpec, LoadPendingBlock, SpawnBlocking};
 use crate::{EthApiTypes, FromEthApiError, RpcNodeCore, RpcNodeCoreExt};
-use alloy_consensus::{constants::KECCAK_EMPTY, Header};
+use alloy_consensus::{constants::KECCAK_EMPTY, BlockHeader, Header};
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_eth::{Account, EIP1186AccountProofResponse};
@@ -11,7 +11,6 @@ use futures::Future;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
 use reth_evm::ConfigureEvmEnv;
-use alloy_consensus::BlockHeader;
 use reth_provider::{
     BlockIdReader, BlockNumReader, ChainSpecProvider, EvmEnvProvider as _, ProviderHeader,
     StateProvider, StateProviderBox, StateProviderFactory,

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -8,9 +8,12 @@ use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
 use futures::Future;
 use reth_chainspec::ChainSpecProvider;
+use alloy_consensus::BlockHeader;
 use reth_evm::{system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv};
-use reth_primitives::SealedBlockWithSenders;
-use reth_provider::BlockReader;
+use reth_primitives::{SealedBlockWithSenders, TransactionSigned};
+use reth_primitives_traits::SignedTransaction;
+use reth_primitives_traits::BlockBody;
+use reth_provider::{BlockReader, HeaderProvider, ProviderBlock, ProviderHeader, ProviderTx};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDb, StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},
@@ -25,7 +28,15 @@ use revm_primitives::{
 use super::{Call, LoadBlock, LoadPendingBlock, LoadState, LoadTransaction};
 
 /// Executes CPU heavy tasks.
-pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Header>> {
+pub trait Trace:
+    LoadState<
+    Provider: BlockReader,
+    Evm: ConfigureEvm<
+        Header = ProviderHeader<Self::Provider>,
+        Transaction = ProviderTx<Self::Provider>,
+    >,
+>
+{
     /// Executes the [`EnvWithHandlerCfg`] against the given [Database] without committing state
     /// changes.
     fn inspect<DB, I>(
@@ -190,7 +201,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
 
             // we need to get the state of the parent block because we're essentially replaying the
             // block the transaction is included in
-            let parent_block = block.parent_hash;
+            let parent_block = block.parent_hash();
 
             let this = self.clone();
             self.spawn_with_state_at_block(parent_block.into(), move |state| {
@@ -205,7 +216,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
                     cfg.clone(),
                     block_env.clone(),
                     block_txs,
-                    tx.hash(),
+                    *tx.tx_hash(),
                 )?;
 
                 let env = EnvWithHandlerCfg::new_with_cfg_env(
@@ -231,7 +242,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
     fn trace_block_until<F, R>(
         &self,
         block_id: BlockId,
-        block: Option<Arc<SealedBlockWithSenders<<Self::Provider as BlockReader>::Block>>>,
+        block: Option<Arc<SealedBlockWithSenders<ProviderBlock<Self::Provider>>>>,
         highest_index: Option<u64>,
         config: TracingInspectorConfig,
         f: F,
@@ -271,7 +282,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
     fn trace_block_until_with_inspector<Setup, Insp, F, R>(
         &self,
         block_id: BlockId,
-        block: Option<Arc<SealedBlockWithSenders>>,
+        block: Option<Arc<SealedBlockWithSenders<ProviderBlock<Self::Provider>>>>,
         highest_index: Option<u64>,
         mut inspector_setup: Setup,
         f: F,
@@ -304,7 +315,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
 
             let Some(block) = block else { return Ok(None) };
 
-            if block.body.transactions.is_empty() {
+            if block.body.transactions().is_empty() {
                 // nothing to trace
                 return Ok(Some(Vec::new()))
             }
@@ -313,7 +324,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
             self.spawn_tracing(move |this| {
                 // we need to get the state of the parent block because we're replaying this block
                 // on top of its parent block's state
-                let state_at = block.parent_hash;
+                let state_at = block.parent_hash();
                 let block_hash = block.hash();
 
                 let block_number = block_env.number.saturating_to::<u64>();
@@ -329,7 +340,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
                 // prepare transactions, we do everything upfront to reduce time spent with open
                 // state
                 let max_transactions =
-                    highest_index.map_or(block.body.transactions.len(), |highest| {
+                    highest_index.map_or(block.body.transactions().len(), |highest| {
                         // we need + 1 because the index is 0-based
                         highest as usize + 1
                     });
@@ -341,7 +352,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
                     .enumerate()
                     .map(|(idx, (signer, tx))| {
                         let tx_info = TransactionInfo {
-                            hash: Some(tx.hash()),
+                            hash: Some(*tx.tx_hash()),
                             index: Some(idx as u64),
                             block_hash: Some(block_hash),
                             block_number: Some(block_number),
@@ -389,7 +400,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
     fn trace_block_with<F, R>(
         &self,
         block_id: BlockId,
-        block: Option<Arc<SealedBlockWithSenders>>,
+        block: Option<Arc<SealedBlockWithSenders<ProviderBlock<Self::Provider>>>>,
         config: TracingInspectorConfig,
         f: F,
     ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
@@ -428,7 +439,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
     fn trace_block_inspector<Setup, Insp, F, R>(
         &self,
         block_id: BlockId,
-        block: Option<Arc<SealedBlockWithSenders>>,
+        block: Option<Arc<SealedBlockWithSenders<ProviderBlock<Self::Provider>>>>,
         insp_setup: Setup,
         f: F,
     ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
@@ -459,7 +470,7 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
     /// already applied.
     fn apply_pre_execution_changes<DB: Send + Database<Error: Display> + DatabaseCommit>(
         &self,
-        block: &SealedBlockWithSenders,
+        block: &SealedBlockWithSenders<ProviderBlock<Self::Provider>>,
         db: &mut DB,
         cfg: &CfgEnvWithHandlerCfg,
         block_env: &BlockEnv,
@@ -472,12 +483,12 @@ pub trait Trace: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Hea
                 db,
                 cfg,
                 block_env,
-                block.header.parent_beacon_block_root,
+                block.header.parent_beacon_block_root(),
             )
             .map_err(|_| EthApiError::EvmCustom("failed to apply 4788 system call".to_string()))?;
 
         system_caller
-            .pre_block_blockhashes_contract_call(db, cfg, block_env, block.header.parent_hash)
+            .pre_block_blockhashes_contract_call(db, cfg, block_env, block.header.parent_hash())
             .map_err(|_| {
                 EthApiError::EvmCustom("failed to apply blockhashes system call".to_string())
             })?;

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -3,15 +3,15 @@
 use std::{fmt::Display, sync::Arc};
 
 use crate::{FromEvmError, RpcNodeCore};
-use alloy_consensus::{BlockHeader, Header};
+use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
 use futures::Future;
 use reth_chainspec::ChainSpecProvider;
 use reth_evm::{system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv};
-use reth_primitives::{SealedBlockWithSenders, TransactionSigned};
+use reth_primitives::SealedBlockWithSenders;
 use reth_primitives_traits::{BlockBody, SignedTransaction};
-use reth_provider::{BlockReader, HeaderProvider, ProviderBlock, ProviderHeader, ProviderTx};
+use reth_provider::{BlockReader, ProviderBlock, ProviderHeader, ProviderTx};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDb, StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -3,16 +3,14 @@
 use std::{fmt::Display, sync::Arc};
 
 use crate::{FromEvmError, RpcNodeCore};
-use alloy_consensus::Header;
+use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
 use futures::Future;
 use reth_chainspec::ChainSpecProvider;
-use alloy_consensus::BlockHeader;
 use reth_evm::{system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{SealedBlockWithSenders, TransactionSigned};
-use reth_primitives_traits::SignedTransaction;
-use reth_primitives_traits::BlockBody;
+use reth_primitives_traits::{BlockBody, SignedTransaction};
 use reth_provider::{BlockReader, HeaderProvider, ProviderBlock, ProviderHeader, ProviderTx};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_types::{

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -11,7 +11,6 @@ use futures::Future;
 use reth_node_api::BlockBody;
 use reth_primitives::{
     transaction::SignedTransactionIntoRecoveredExt, SealedBlockWithSenders, TransactionMeta,
-    TransactionSigned,
 };
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::{
@@ -61,6 +60,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     /// Returns a handle for signing data.
     ///
     /// Singer access in default (L1) trait method implementations.
+    #[expect(clippy::type_complexity)]
     fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>>;
 
     /// Returns the transaction by hash.
@@ -468,6 +468,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     }
 
     /// Returns the signer for the given account, if found in configured signers.
+    #[expect(clippy::type_complexity)]
     fn find_signer(
         &self,
         account: &Address,

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -13,6 +13,7 @@ use reth_primitives::{
     transaction::SignedTransactionIntoRecoveredExt, SealedBlockWithSenders, TransactionMeta,
     TransactionSigned,
 };
+use reth_primitives_traits::SignedTransaction;
 use reth_provider::{
     BlockNumReader, BlockReaderIdExt, ProviderBlock, ProviderReceipt, ProviderTx, ReceiptProvider,
     TransactionsProvider,
@@ -213,7 +214,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 let base_fee_per_gas = block.base_fee_per_gas();
                 if let Some((signer, tx)) = block.transactions_with_sender().nth(index) {
                     let tx_info = TransactionInfo {
-                        hash: Some(tx.hash()),
+                        hash: Some(*tx.tx_hash()),
                         block_hash: Some(block_hash),
                         block_number: Some(block_number),
                         base_fee: base_fee_per_gas.map(u128::from),
@@ -294,7 +295,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                         .find(|(_, (signer, tx))| **signer == sender && (*tx).nonce() == nonce)
                         .map(|(index, (signer, tx))| {
                             let tx_info = TransactionInfo {
-                                hash: Some(tx.hash()),
+                                hash: Some(*tx.tx_hash()),
                                 block_hash: Some(block_hash),
                                 block_number: Some(block_number),
                                 base_fee: base_fee_per_gas.map(u128::from),

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -61,7 +61,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     /// Returns a handle for signing data.
     ///
     /// Singer access in default (L1) trait method implementations.
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>>;
+    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>>;
 
     /// Returns the transaction by hash.
     ///
@@ -415,7 +415,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         &self,
         from: &Address,
         txn: TransactionRequest,
-    ) -> impl Future<Output = Result<TransactionSigned, Self::Error>> + Send {
+    ) -> impl Future<Output = Result<ProviderTx<Self::Provider>, Self::Error>> + Send {
         async move {
             self.find_signer(from)?
                 .sign_transaction(txn, from)
@@ -471,7 +471,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn find_signer(
         &self,
         account: &Address,
-    ) -> Result<Box<(dyn EthSigner + 'static)>, Self::Error> {
+    ) -> Result<Box<(dyn EthSigner<ProviderTx<Self::Provider>> + 'static)>, Self::Error> {
         self.signers()
             .read()
             .iter()

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -29,7 +29,7 @@ pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
 pub use reth_rpc_types_compat::TransactionCompat;
-pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcReceipt, RpcTransaction, RpcHeader};
+pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 
 #[cfg(feature = "client")]
 pub use bundle::{EthBundleApiClient, EthCallBundleApiClient};

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -29,7 +29,7 @@ pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
 pub use reth_rpc_types_compat::TransactionCompat;
-pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcReceipt, RpcTransaction};
+pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcReceipt, RpcTransaction, RpcHeader};
 
 #[cfg(feature = "client")]
 pub use bundle::{EthBundleApiClient, EthCallBundleApiClient};

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -24,7 +24,7 @@ pub trait EthApiTypes: Send + Sync + Clone {
         + Send
         + Sync;
     /// Blockchain primitive types, specific to network, e.g. block and transaction.
-    type NetworkTypes: Network<HeaderResponse = alloy_rpc_types_eth::Header>;
+    type NetworkTypes: Network;
     /// Conversion methods for transaction RPC type.
     type TransactionCompat: Send + Sync + Clone + fmt::Debug;
 
@@ -40,6 +40,9 @@ pub type RpcBlock<T> = Block<RpcTransaction<T>, <T as Network>::HeaderResponse>;
 
 /// Adapter for network specific receipt type.
 pub type RpcReceipt<T> = <T as Network>::ReceiptResponse;
+
+/// Adapter for network specific header type.
+pub type RpcHeader<T> = <T as Network>::HeaderResponse;
 
 /// Adapter for network specific error type.
 pub type RpcError<T> = <T as EthApiTypes>::Error;

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -14,13 +14,13 @@ use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg};
 
 /// Configured [`BlockEnv`] and [`CfgEnvWithHandlerCfg`] for a pending block.
 #[derive(Debug, Clone, Constructor)]
-pub struct PendingBlockEnv {
+pub struct PendingBlockEnv<B: Block = reth_primitives::Block, R = Receipt> {
     /// Configured [`CfgEnvWithHandlerCfg`] for the pending block.
     pub cfg: CfgEnvWithHandlerCfg,
     /// Configured [`BlockEnv`] for the pending block.
     pub block_env: BlockEnv,
     /// Origin block for the config
-    pub origin: PendingBlockEnvOrigin,
+    pub origin: PendingBlockEnvOrigin<B, R>,
 }
 
 /// The origin for a configured [`PendingBlockEnv`]
@@ -77,11 +77,11 @@ impl<B: Block, R> PendingBlockEnvOrigin<B, R> {
 
 /// Locally built pending block for `pending` tag.
 #[derive(Debug, Constructor)]
-pub struct PendingBlock {
+pub struct PendingBlock<B: Block, R> {
     /// Timestamp when the pending block is considered outdated.
     pub expires_at: Instant,
     /// The locally built pending block.
-    pub block: SealedBlockWithSenders,
+    pub block: SealedBlockWithSenders<B>,
     /// The receipts for the pending block
-    pub receipts: Vec<Receipt>,
+    pub receipts: Vec<R>,
 }

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -8,7 +8,7 @@ use std::{
 
 use alloy_eips::BlockId;
 use alloy_primitives::{TxHash, B256};
-use alloy_rpc_types_eth::{transaction::TransactionRequest, Block, Transaction};
+use alloy_rpc_types_eth::{transaction::TransactionRequest, Block, Header, Transaction};
 use alloy_rpc_types_trace::{
     common::TraceResult,
     geth::{GethDebugTracerType, GethDebugTracingOptions, GethTrace},
@@ -77,7 +77,7 @@ pub trait DebugApiExt {
 
 impl<T> DebugApiExt for T
 where
-    T: EthApiClient<Transaction, Block, Receipt> + DebugApiClient + Sync,
+    T: EthApiClient<Transaction, Block, Receipt, Header> + DebugApiClient + Sync,
 {
     type Provider = T;
 

--- a/crates/rpc/rpc-testing-util/tests/it/trace.rs
+++ b/crates/rpc/rpc-testing-util/tests/it/trace.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the trace API.
 
 use alloy_primitives::map::HashSet;
-use alloy_rpc_types_eth::{Block, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Transaction};
 use alloy_rpc_types_trace::{
     filter::TraceFilter, parity::TraceType, tracerequest::TraceCallRequest,
 };
@@ -113,7 +113,7 @@ async fn debug_trace_block_entire_chain() {
 
     let client = HttpClientBuilder::default().build(url).unwrap();
     let current_block: u64 =
-        <HttpClient as EthApiClient<Transaction, Block, Receipt>>::block_number(&client)
+        <HttpClient as EthApiClient<Transaction, Block, Receipt, Header>>::block_number(&client)
             .await
             .unwrap()
             .try_into()

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 
 # ethereum
 alloy-eips.workspace = true

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -1,13 +1,17 @@
 //! Compatibility functions for rpc `Block` type.
 
-use alloy_consensus::Sealed;
+use alloy_consensus::{BlockHeader, Sealable, Sealed};
 use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::{B256, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{
     Block, BlockTransactions, BlockTransactionsKind, Header, TransactionInfo,
 };
-use reth_primitives::{Block as PrimitiveBlock, BlockWithSenders, TransactionSigned};
+use reth_primitives::{
+    transaction::SignedTransactionIntoRecoveredExt, Block as PrimitiveBlock, BlockWithSenders,
+    TransactionSigned,
+};
+use reth_primitives_traits::{Block as BlockTrait, BlockBody, SignedTransaction};
 
 use crate::{transaction::from_recovered_with_block_context, TransactionCompat};
 
@@ -15,19 +19,23 @@ use crate::{transaction::from_recovered_with_block_context, TransactionCompat};
 /// [`BlockTransactionsKind`]
 ///
 /// If a `block_hash` is provided, then this is used, otherwise the block hash is computed.
-pub fn from_block<T: TransactionCompat>(
-    block: BlockWithSenders,
+pub fn from_block<T, B>(
+    block: BlockWithSenders<B>,
     total_difficulty: U256,
     kind: BlockTransactionsKind,
     block_hash: Option<B256>,
     tx_resp_builder: &T,
-) -> Result<Block<T::Transaction>, T::Error> {
+) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
+where
+    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
+    B: BlockTrait,
+{
     match kind {
         BlockTransactionsKind::Hashes => {
-            Ok(from_block_with_tx_hashes::<T::Transaction>(block, total_difficulty, block_hash))
+            Ok(from_block_with_tx_hashes::<T::Transaction, B>(block, total_difficulty, block_hash))
         }
         BlockTransactionsKind::Full => {
-            from_block_full::<T>(block, total_difficulty, block_hash, tx_resp_builder)
+            from_block_full::<T, B>(block, total_difficulty, block_hash, tx_resp_builder)
         }
     }
 }
@@ -37,13 +45,16 @@ pub fn from_block<T: TransactionCompat>(
 ///
 /// This will populate the `transactions` field with only the hashes of the transactions in the
 /// block: [`BlockTransactions::Hashes`]
-pub fn from_block_with_tx_hashes<T>(
-    block: BlockWithSenders,
+pub fn from_block_with_tx_hashes<T, B>(
+    block: BlockWithSenders<B>,
     total_difficulty: U256,
     block_hash: Option<B256>,
-) -> Block<T> {
-    let block_hash = block_hash.unwrap_or_else(|| block.header.hash_slow());
-    let transactions = block.body.transactions.iter().map(|tx| tx.hash()).collect();
+) -> Block<T, Header<B::Header>>
+where
+    B: BlockTrait,
+{
+    let block_hash = block_hash.unwrap_or_else(|| block.header().hash_slow());
+    let transactions = block.body().transactions().iter().map(|tx| *tx.tx_hash()).collect();
 
     from_block_with_transactions(
         block.length(),
@@ -59,25 +70,29 @@ pub fn from_block_with_tx_hashes<T>(
 ///
 /// This will populate the `transactions` field with the _full_
 /// [`TransactionCompat::Transaction`] objects: [`BlockTransactions::Full`]
-pub fn from_block_full<T: TransactionCompat>(
-    mut block: BlockWithSenders,
+pub fn from_block_full<T, B>(
+    mut block: BlockWithSenders<B>,
     total_difficulty: U256,
     block_hash: Option<B256>,
     tx_resp_builder: &T,
-) -> Result<Block<T::Transaction>, T::Error> {
-    let block_hash = block_hash.unwrap_or_else(|| block.block.header.hash_slow());
-    let block_number = block.block.number;
-    let base_fee_per_gas = block.block.base_fee_per_gas;
+) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
+where
+    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
+    B: BlockTrait,
+{
+    let block_hash = block_hash.unwrap_or_else(|| block.block.header().hash_slow());
+    let block_number = block.block.header().number();
+    let base_fee_per_gas = block.block.header().base_fee_per_gas();
 
     // NOTE: we can safely remove the body here because not needed to finalize the `Block` in
     // `from_block_with_transactions`, however we need to compute the length before
     let block_length = block.block.length();
-    let transactions = std::mem::take(&mut block.block.body.transactions);
+    let transactions = block.block.body().transactions().to_vec();
     let transactions_with_senders = transactions.into_iter().zip(block.senders);
     let transactions = transactions_with_senders
         .enumerate()
         .map(|(idx, (tx, sender))| {
-            let tx_hash = tx.hash();
+            let tx_hash = *tx.tx_hash();
             let signed_tx_ec_recovered = tx.with_signer(sender);
             let tx_info = TransactionInfo {
                 hash: Some(tx_hash),
@@ -87,7 +102,7 @@ pub fn from_block_full<T: TransactionCompat>(
                 index: Some(idx as u64),
             };
 
-            from_recovered_with_block_context::<TransactionSigned, T>(
+            from_recovered_with_block_context::<_, T>(
                 signed_tx_ec_recovered,
                 tx_info,
                 tx_resp_builder,
@@ -105,23 +120,28 @@ pub fn from_block_full<T: TransactionCompat>(
 }
 
 #[inline]
-fn from_block_with_transactions<T>(
+fn from_block_with_transactions<T, B: BlockTrait>(
     block_length: usize,
     block_hash: B256,
-    block: PrimitiveBlock,
+    block: B,
     total_difficulty: U256,
     transactions: BlockTransactions<T>,
-) -> Block<T> {
+) -> Block<T, Header<B::Header>> {
     let withdrawals = block
-        .header
-        .withdrawals_root
+        .header()
+        .withdrawals_root()
         .is_some()
-        .then(|| block.body.withdrawals.map(Withdrawals::into_inner).map(Into::into))
+        .then(|| block.body().withdrawals().cloned().map(Withdrawals::into_inner).map(Into::into))
         .flatten();
 
-    let uncles = block.body.ommers.into_iter().map(|h| h.hash_slow()).collect();
+    let uncles = block
+        .body()
+        .ommers()
+        .map(|o| o.into_iter().map(|h| h.hash_slow()).collect())
+        .unwrap_or_default();
+    let (header, _) = block.split();
     let header = Header::from_consensus(
-        Sealed::new_unchecked(block.header, block_hash),
+        Sealed::new_unchecked(header, block_hash),
         Some(total_difficulty),
         Some(U256::from(block_length)),
     );

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -3,14 +3,10 @@
 use alloy_consensus::{BlockHeader, Sealable, Sealed};
 use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::{B256, U256};
-use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{
     Block, BlockTransactions, BlockTransactionsKind, Header, TransactionInfo,
 };
-use reth_primitives::{
-    transaction::SignedTransactionIntoRecoveredExt, Block as PrimitiveBlock, BlockWithSenders,
-    TransactionSigned,
-};
+use reth_primitives::{transaction::SignedTransactionIntoRecoveredExt, BlockWithSenders};
 use reth_primitives_traits::{Block as BlockTrait, BlockBody, SignedTransaction};
 
 use crate::{transaction::from_recovered_with_block_context, TransactionCompat};
@@ -19,6 +15,7 @@ use crate::{transaction::from_recovered_with_block_context, TransactionCompat};
 /// [`BlockTransactionsKind`]
 ///
 /// If a `block_hash` is provided, then this is used, otherwise the block hash is computed.
+#[expect(clippy::type_complexity)]
 pub fn from_block<T, B>(
     block: BlockWithSenders<B>,
     total_difficulty: U256,
@@ -70,8 +67,9 @@ where
 ///
 /// This will populate the `transactions` field with the _full_
 /// [`TransactionCompat::Transaction`] objects: [`BlockTransactions::Full`]
+#[expect(clippy::type_complexity)]
 pub fn from_block_full<T, B>(
-    mut block: BlockWithSenders<B>,
+    block: BlockWithSenders<B>,
     total_difficulty: U256,
     block_hash: Option<B256>,
     tx_resp_builder: &T,
@@ -137,7 +135,7 @@ fn from_block_with_transactions<T, B: BlockTrait>(
     let uncles = block
         .body()
         .ommers()
-        .map(|o| o.into_iter().map(|h| h.hash_slow()).collect())
+        .map(|o| o.iter().map(|h| h.hash_slow()).collect())
         .unwrap_or_default();
     let (header, _) = block.split();
     let header = Header::from_consensus(

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -19,7 +19,7 @@ use reth_evm::{
     execute::{BlockExecutorProvider, Executor},
     ConfigureEvmEnv,
 };
-use reth_primitives::{Block, BlockExt, NodePrimitives, SealedBlockWithSenders};
+use reth_primitives::{BlockExt, NodePrimitives, SealedBlockWithSenders};
 use reth_primitives_traits::{Block as _, BlockBody, SignedTransaction};
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider, ProviderBlock,
@@ -522,7 +522,7 @@ where
         let mut replay_block_txs = true;
 
         // if a transaction index is provided, we need to replay the transactions until the index
-        let num_txs = transaction_index.index().unwrap_or(block.body.transactions().len());
+        let num_txs = transaction_index.index().unwrap_or_else(|| block.body.transactions().len());
         // but if all transactions are to be replayed, we can use the state at the block itself
         // this works with the exception of the PENDING block, because its state might not exist if
         // built locally

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,3 +1,4 @@
+use alloy_consensus::BlockHeader;
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
@@ -19,10 +20,10 @@ use reth_evm::{
     ConfigureEvmEnv,
 };
 use reth_primitives::{Block, BlockExt, NodePrimitives, SealedBlockWithSenders};
-use reth_primitives_traits::SignedTransaction;
+use reth_primitives_traits::{Block as _, BlockBody, SignedTransaction};
 use reth_provider::{
-    BlockReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider, StateProofProvider,
-    StateProviderFactory, TransactionVariant,
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider, ProviderBlock,
+    StateProofProvider, StateProviderFactory, TransactionVariant,
 };
 use reth_revm::{database::StateProviderDatabase, witness::ExecutionWitnessRecord};
 use reth_rpc_api::DebugApiServer;
@@ -81,9 +82,8 @@ where
         + StateProviderFactory
         + 'static,
     Eth: EthApiTypes + TraceExt + 'static,
-    BlockExecutor: BlockExecutorProvider<
-        Primitives: NodePrimitives<Block = <<Eth as RpcNodeCore>::Provider as BlockReader>::Block>,
-    >,
+    BlockExecutor:
+        BlockExecutorProvider<Primitives: NodePrimitives<Block = ProviderBlock<Eth::Provider>>>,
 {
     /// Acquires a permit to execute a tracing call.
     async fn acquire_trace_permit(&self) -> Result<OwnedSemaphorePermit, AcquireError> {
@@ -93,7 +93,7 @@ where
     /// Trace the entire block asynchronously
     async fn trace_block(
         &self,
-        block: Arc<SealedBlockWithSenders>,
+        block: Arc<SealedBlockWithSenders<ProviderBlock<Eth::Provider>>>,
         cfg: CfgEnvWithHandlerCfg,
         block_env: BlockEnv,
         opts: GethDebugTracingOptions,
@@ -101,8 +101,8 @@ where
         // replay all transactions of the block
         let this = self.clone();
         self.eth_api()
-            .spawn_with_state_at_block(block.parent_hash.into(), move |state| {
-                let mut results = Vec::with_capacity(block.body.transactions.len());
+            .spawn_with_state_at_block(block.parent_hash().into(), move |state| {
+                let mut results = Vec::with_capacity(block.body.transactions().len());
                 let mut db = CacheDB::new(StateProviderDatabase::new(state));
 
                 this.eth_api().apply_pre_execution_changes(&block, &mut db, &cfg, &block_env)?;
@@ -110,7 +110,7 @@ where
                 let mut transactions = block.transactions_with_sender().enumerate().peekable();
                 let mut inspector = None;
                 while let Some((index, (signer, tx))) = transactions.next() {
-                    let tx_hash = tx.hash();
+                    let tx_hash = *tx.tx_hash();
 
                     let env = EnvWithHandlerCfg {
                         env: Env::boxed(
@@ -157,18 +157,22 @@ where
         rlp_block: Bytes,
         opts: GethDebugTracingOptions,
     ) -> Result<Vec<TraceResult>, Eth::Error> {
-        let block = Block::decode(&mut rlp_block.as_ref())
+        let block: ProviderBlock<Eth::Provider> = Decodable::decode(&mut rlp_block.as_ref())
             .map_err(BlockError::RlpDecodeRawBlock)
             .map_err(Eth::Error::from_eth_err)?;
 
-        let (cfg, block_env) = self.eth_api().evm_env_for_raw_block(&block.header).await?;
+        let (cfg, block_env) = self.eth_api().evm_env_for_raw_block(block.header()).await?;
 
         // Depending on EIP-2 we need to recover the transactions differently
-        let senders = if self.inner.provider.chain_spec().is_homestead_active_at_block(block.number)
+        let senders = if self
+            .inner
+            .provider
+            .chain_spec()
+            .is_homestead_active_at_block(block.header().number())
         {
             block
-                .body
-                .transactions
+                .body()
+                .transactions()
                 .iter()
                 .map(|tx| {
                     tx.recover_signer()
@@ -178,8 +182,8 @@ where
                 .collect::<Result<Vec<_>, Eth::Error>>()?
         } else {
             block
-                .body
-                .transactions
+                .body()
+                .transactions()
                 .iter()
                 .map(|tx| {
                     tx.recover_signer_unchecked()
@@ -237,7 +241,7 @@ where
 
         // we need to get the state of the parent block because we're essentially replaying the
         // block the transaction is included in
-        let state_at: BlockId = block.parent_hash.into();
+        let state_at: BlockId = block.parent_hash().into();
         let block_hash = block.hash();
 
         let this = self.clone();
@@ -258,7 +262,7 @@ where
                     cfg.clone(),
                     block_env.clone(),
                     block_txs,
-                    tx.hash(),
+                    *tx.tx_hash(),
                 )?;
 
                 let env = EnvWithHandlerCfg {
@@ -277,7 +281,7 @@ where
                     Some(TransactionContext {
                         block_hash: Some(block_hash),
                         tx_index: Some(index),
-                        tx_hash: Some(tx.hash()),
+                        tx_hash: Some(*tx.tx_hash()),
                     }),
                     &mut None,
                 )
@@ -514,15 +518,15 @@ where
 
         // we're essentially replaying the transactions in the block here, hence we need the state
         // that points to the beginning of the block, which is the state at the parent block
-        let mut at = block.parent_hash;
+        let mut at = block.parent_hash();
         let mut replay_block_txs = true;
 
         // if a transaction index is provided, we need to replay the transactions until the index
-        let num_txs = transaction_index.index().unwrap_or(block.body.transactions.len());
+        let num_txs = transaction_index.index().unwrap_or(block.body.transactions().len());
         // but if all transactions are to be replayed, we can use the state at the block itself
         // this works with the exception of the PENDING block, because its state might not exist if
         // built locally
-        if !target_block.is_pending() && num_txs == block.body.transactions.len() {
+        if !target_block.is_pending() && num_txs == block.body.transactions().len() {
             at = block.hash();
             replay_block_txs = false;
         }
@@ -622,7 +626,7 @@ where
             .ok_or(EthApiError::HeaderNotFound(block_id.into()))?;
 
         self.eth_api()
-            .spawn_with_state_at_block(block.parent_hash.into(), move |state_provider| {
+            .spawn_with_state_at_block(block.parent_hash().into(), move |state_provider| {
                 let db = StateProviderDatabase::new(&state_provider);
                 let block_executor = this.inner.block_executor.executor(db);
 
@@ -630,7 +634,7 @@ where
 
                 let _ = block_executor
                     .execute_with_state_closure(
-                        (&(*block).clone().unseal(), block.difficulty).into(),
+                        (&(*block).clone().unseal(), block.difficulty()).into(),
                         |statedb: &State<_>| {
                             witness_record.record_executed_state(statedb);
                         },

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -9,7 +9,7 @@ use jsonrpsee::core::RpcResult as Result;
 use reth_rpc_api::{EngineEthApiServer, EthApiServer, EthFilterApiServer};
 /// Re-export for convenience
 pub use reth_rpc_engine_api::EngineApi;
-use reth_rpc_eth_api::{FullEthApiTypes, RpcBlock, RpcReceipt, RpcTransaction};
+use reth_rpc_eth_api::{FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 use tracing_futures::Instrument;
 
 macro_rules! engine_span {
@@ -41,6 +41,7 @@ where
             RpcTransaction<Eth::NetworkTypes>,
             RpcBlock<Eth::NetworkTypes>,
             RpcReceipt<Eth::NetworkTypes>,
+            RpcHeader<Eth::NetworkTypes>,
         > + FullEthApiTypes,
     EthFilter: EthFilterApiServer<RpcTransaction<Eth::NetworkTypes>>,
 {

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -7,7 +7,8 @@ use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_primitives::{PooledTransactionsElement, Transaction};
-use reth_provider::{ChainSpecProvider, HeaderProvider};
+use reth_primitives_traits::SignedTransaction;
+use reth_provider::{ChainSpecProvider, HeaderProvider, ProviderTx};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_api::{
     helpers::{Call, EthTransactions, LoadPendingBlock},
@@ -15,6 +16,7 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError, RpcInvalidTransactionError};
 use reth_tasks::pool::BlockingTaskGuard;
+use reth_transaction_pool::{PoolConsensusTx, PoolPooledTx, PoolTransaction, TransactionPool};
 use revm::{
     db::{CacheDB, DatabaseCommit, DatabaseRef},
     primitives::{ResultAndState, TxEnv},
@@ -42,7 +44,16 @@ impl<Eth> EthBundle<Eth> {
 
 impl<Eth> EthBundle<Eth>
 where
-    Eth: EthTransactions + LoadPendingBlock + Call + 'static,
+    Eth: EthTransactions<
+            Pool: TransactionPool<
+                Transaction: PoolTransaction<
+                    Consensus: From<PooledTransactionsElement>,
+                    Pooled = PooledTransactionsElement,
+                >,
+            >,
+        > + LoadPendingBlock
+        + Call
+        + 'static,
 {
     /// Simulates a bundle of transactions at the top of a given block number with the state of
     /// another (or the same) block. This can be used to simulate future blocks with the current
@@ -79,7 +90,7 @@ where
 
         let transactions = txs
             .into_iter()
-            .map(recover_raw_transaction::<PooledTransactionsElement>)
+            .map(recover_raw_transaction::<PoolPooledTx<Eth::Pool>>)
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .map(|tx| tx.to_components())
@@ -192,12 +203,11 @@ where
                         })?;
                     }
 
-                    let tx = tx.into_transaction();
+                    let tx: PoolConsensusTx<Eth::Pool> = tx.into();
 
-                    hasher.update(tx.hash());
-                    let gas_price = Transaction::effective_tip_per_gas(tx.deref(), basefee)
-                        .ok_or_else(|| RpcInvalidTransactionError::FeeCapTooLow)
-                        .map_err(Eth::Error::from_eth_err)?;
+                    hasher.update(*tx.tx_hash());
+                    let gas_price = tx
+                        .effective_gas_price(basefee);
                     eth_api.evm_config().fill_tx_env(evm.tx_mut(), &tx, signer);
                     let ResultAndState { result, state } =
                         evm.transact().map_err(Eth::Error::from_evm_err)?;
@@ -235,7 +245,7 @@ where
                         gas_price: U256::from(gas_price),
                         gas_used,
                         to_address: tx.to(),
-                        tx_hash: tx.hash(),
+                        tx_hash: *tx.tx_hash(),
                         value,
                         revert,
                     };

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -6,9 +6,9 @@ use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTra
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
-use reth_primitives::{PooledTransactionsElement, Transaction};
+use reth_primitives::PooledTransactionsElement;
 use reth_primitives_traits::SignedTransaction;
-use reth_provider::{ChainSpecProvider, HeaderProvider, ProviderTx};
+use reth_provider::{ChainSpecProvider, HeaderProvider};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_api::{
     helpers::{Call, EthTransactions, LoadPendingBlock},
@@ -22,7 +22,7 @@ use revm::{
     primitives::{ResultAndState, TxEnv},
 };
 use revm_primitives::{EnvKzgSettings, EnvWithHandlerCfg, SpecId, MAX_BLOB_GAS_PER_BLOCK};
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 /// `Eth` bundle implementation.
 pub struct EthBundle<Eth> {
@@ -206,8 +206,7 @@ where
                     let tx: PoolConsensusTx<Eth::Pool> = tx.into();
 
                     hasher.update(*tx.tx_hash());
-                    let gas_price = tx
-                        .effective_gas_price(basefee);
+                    let gas_price = tx.effective_gas_price(basefee);
                     eth_api.evm_config().fill_tx_env(evm.tx_mut(), &tx, signer);
                     let ResultAndState { result, state } =
                         evm.transact().map_err(Eth::Error::from_evm_err)?;

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -1,6 +1,6 @@
 //! `Eth` bundle implementation and helpers.
 
-use alloy_consensus::Transaction as _;
+use alloy_consensus::{BlockHeader, Transaction as _};
 use alloy_primitives::{Keccak256, U256};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use jsonrpsee::core::RpcResult;

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -260,7 +260,7 @@ pub struct EthApiInner<Provider: BlockReader, Pool, Network, EvmConfig> {
     /// The type that can spawn tasks which would otherwise block.
     task_spawner: Box<dyn TaskSpawner>,
     /// Cached pending block if any
-    pending_block: Mutex<Option<PendingBlock>>,
+    pending_block: Mutex<Option<PendingBlock<Provider::Block, Provider::Receipt>>>,
     /// A pool dedicated to CPU heavy blocking tasks.
     blocking_task_pool: BlockingTaskPool,
     /// Cache for block fees history

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -583,7 +583,7 @@ mod tests {
     /// Invalid block range
     #[tokio::test]
     async fn test_fee_history_empty() {
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &build_test_eth_api(NoopProvider::default()),
             U64::from(1),
             BlockNumberOrTag::Latest,
@@ -605,7 +605,7 @@ mod tests {
         let (eth_api, _, _) =
             prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
 
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
             U64::from(newest_block + 1),
             newest_block.into(),
@@ -628,7 +628,7 @@ mod tests {
         let (eth_api, _, _) =
             prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
 
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
             U64::from(1),
             (newest_block + 1000).into(),
@@ -651,7 +651,7 @@ mod tests {
         let (eth_api, _, _) =
             prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
 
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
             &eth_api,
             U64::from(0),
             newest_block.into(),

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -244,7 +244,7 @@ pub struct EthApiInner<Provider: BlockReader, Pool, Network, EvmConfig> {
     /// An interface to interact with the network
     network: Network,
     /// All configured Signers
-    signers: parking_lot::RwLock<Vec<Box<dyn EthSigner>>>,
+    signers: parking_lot::RwLock<Vec<Box<dyn EthSigner<Provider::Transaction>>>>,
     /// The async cache frontend for eth related data
     eth_cache: EthStateCache<Provider::Block, Provider::Receipt>,
     /// The async gas oracle frontend for gas price suggestions
@@ -343,7 +343,9 @@ where
 
     /// Returns a handle to the pending block.
     #[inline]
-    pub const fn pending_block(&self) -> &Mutex<Option<PendingBlock>> {
+    pub const fn pending_block(
+        &self,
+    ) -> &Mutex<Option<PendingBlock<Provider::Block, Provider::Receipt>>> {
         &self.pending_block
     }
 
@@ -397,7 +399,9 @@ where
 
     /// Returns a handle to the signers.
     #[inline]
-    pub const fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>> {
+    pub const fn signers(
+        &self,
+    ) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<Provider::Transaction>>>> {
         &self.signers
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -4,7 +4,7 @@ use alloy_consensus::BlockHeader;
 use alloy_rpc_types_eth::{BlockId, TransactionReceipt};
 use reth_primitives::TransactionMeta;
 use reth_primitives_traits::{BlockBody, SignedTransaction};
-use reth_provider::{BlockReader, HeaderProvider};
+use reth_provider::BlockReader;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
     RpcNodeCoreExt, RpcReceipt,
@@ -42,7 +42,7 @@ where
             return block
                 .body
                 .transactions()
-                .into_iter()
+                .iter()
                 .zip(receipts.iter())
                 .enumerate()
                 .map(|(idx, (tx, receipt))| {
@@ -55,7 +55,7 @@ where
                         excess_blob_gas,
                         timestamp,
                     };
-                    EthReceiptBuilder::new(&tx, meta, receipt, &receipts)
+                    EthReceiptBuilder::new(tx, meta, receipt, &receipts)
                         .map(|builder| builder.build())
                 })
                 .collect::<Result<Vec<_>, Self::Error>>()

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -1,7 +1,9 @@
 //! Contains RPC handler implementations specific to blocks.
 
+use alloy_consensus::BlockHeader;
 use alloy_rpc_types_eth::{BlockId, TransactionReceipt};
 use reth_primitives::TransactionMeta;
+use reth_primitives_traits::BlockBody;
 use reth_provider::{BlockReader, HeaderProvider};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
@@ -16,7 +18,7 @@ where
     Self: LoadBlock<
         Error = EthApiError,
         NetworkTypes: alloy_network::Network<ReceiptResponse = TransactionReceipt>,
-        Provider: HeaderProvider,
+        Provider: BlockReader<Receipt = reth_primitives::Receipt>,
     >,
     Provider: BlockReader,
 {
@@ -28,15 +30,15 @@ where
         Self: LoadReceipt,
     {
         if let Some((block, receipts)) = self.load_block_and_receipts(block_id).await? {
-            let block_number = block.number;
-            let base_fee = block.base_fee_per_gas;
+            let block_number = block.number();
+            let base_fee = block.base_fee_per_gas();
             let block_hash = block.hash();
-            let excess_blob_gas = block.excess_blob_gas;
-            let timestamp = block.timestamp;
+            let excess_blob_gas = block.excess_blob_gas();
+            let timestamp = block.timestamp();
 
             return block
                 .body
-                .transactions
+                .transactions()
                 .into_iter()
                 .zip(receipts.iter())
                 .enumerate()

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_rpc_types_eth::{BlockId, TransactionReceipt};
 use reth_primitives::TransactionMeta;
-use reth_primitives_traits::BlockBody;
+use reth_primitives_traits::{BlockBody, SignedTransaction};
 use reth_provider::{BlockReader, HeaderProvider};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
@@ -18,7 +18,10 @@ where
     Self: LoadBlock<
         Error = EthApiError,
         NetworkTypes: alloy_network::Network<ReceiptResponse = TransactionReceipt>,
-        Provider: BlockReader<Receipt = reth_primitives::Receipt>,
+        Provider: BlockReader<
+            Transaction = reth_primitives::TransactionSigned,
+            Receipt = reth_primitives::Receipt,
+        >,
     >,
     Provider: BlockReader,
 {
@@ -44,7 +47,7 @@ where
                 .enumerate()
                 .map(|(idx, (tx, receipt))| {
                     let meta = TransactionMeta {
-                        tx_hash: tx.hash(),
+                        tx_hash: *tx.tx_hash(),
                         index: idx as u64,
                         block_hash,
                         block_number,

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -3,7 +3,7 @@
 use crate::EthApi;
 use alloy_consensus::Header;
 use reth_evm::ConfigureEvm;
-use reth_provider::BlockReader;
+use reth_provider::{BlockReader, ProviderHeader};
 use reth_rpc_eth_api::helpers::{
     estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking,
 };
@@ -17,7 +17,7 @@ where
 
 impl<Provider, Pool, Network, EvmConfig> Call for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: LoadState<Evm: ConfigureEvm<Header = Header>> + SpawnBlocking,
+    Self: LoadState<Evm: ConfigureEvm<Header = ProviderHeader<Self::Provider>>> + SpawnBlocking,
     EvmConfig: ConfigureEvm<Header = Header>,
     Provider: BlockReader,
 {

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -1,7 +1,6 @@
 //! Support for building a pending block with transactions from local view of mempool.
 
 use alloy_consensus::Header;
-use alloy_network::primitives::HeaderResponse;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_provider::{
@@ -49,19 +48,19 @@ where
 
     fn assemble_block(
         &self,
-        parent_hash: revm_primitives::B256,
-        state_root: revm_primitives::B256,
-        transactions: Vec<ProviderTx<Self::Provider>>,
-        receipts: &[reth_provider::ProviderReceipt<Self::Provider>],
+        _parent_hash: revm_primitives::B256,
+        _state_root: revm_primitives::B256,
+        _transactions: Vec<ProviderTx<Self::Provider>>,
+        _receipts: &[reth_provider::ProviderReceipt<Self::Provider>],
     ) -> reth_provider::ProviderBlock<Self::Provider> {
         todo!()
     }
 
     fn assemble_receipt(
         &self,
-        tx: &reth_primitives::RecoveredTx<ProviderTx<Self::Provider>>,
-        result: revm_primitives::ExecutionResult,
-        cumulative_gas_used: u64,
+        _tx: &reth_primitives::RecoveredTx<ProviderTx<Self::Provider>>,
+        _result: revm_primitives::ExecutionResult,
+        _cumulative_gas_used: u64,
     ) -> reth_provider::ProviderReceipt<Self::Provider> {
         todo!()
     }

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -1,8 +1,15 @@
 //! Support for building a pending block with transactions from local view of mempool.
 
-use alloy_consensus::Header;
+use alloy_consensus::{constants::EMPTY_WITHDRAWALS, Header, EMPTY_OMMER_ROOT_HASH};
+use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
+use alloy_primitives::U256;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
+use reth_primitives::{
+    logs_bloom,
+    proofs::{calculate_receipt_root_no_memo, calculate_transaction_root},
+    BlockBody, Receipt,
+};
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderBlock,
     ProviderReceipt, ProviderTx, StateProviderFactory,
@@ -13,6 +20,7 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::PendingBlock;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, SpecId, B256};
 
 use crate::EthApi;
 
@@ -48,20 +56,68 @@ where
 
     fn assemble_block(
         &self,
-        _parent_hash: revm_primitives::B256,
-        _state_root: revm_primitives::B256,
-        _transactions: Vec<ProviderTx<Self::Provider>>,
-        _receipts: &[reth_provider::ProviderReceipt<Self::Provider>],
+        cfg: CfgEnvWithHandlerCfg,
+        block_env: BlockEnv,
+        parent_hash: revm_primitives::B256,
+        state_root: revm_primitives::B256,
+        transactions: Vec<ProviderTx<Self::Provider>>,
+        receipts: &[ProviderReceipt<Self::Provider>],
     ) -> reth_provider::ProviderBlock<Self::Provider> {
-        todo!()
+        let transactions_root = calculate_transaction_root(&transactions);
+        let receipts_root = calculate_receipt_root_no_memo(&receipts.iter().collect::<Vec<_>>());
+
+        let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| &r.logs));
+
+        let header = Header {
+            parent_hash,
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: block_env.coinbase,
+            state_root,
+            transactions_root,
+            receipts_root,
+            withdrawals_root: (cfg.handler_cfg.spec_id >= SpecId::SHANGHAI)
+                .then_some(EMPTY_WITHDRAWALS),
+            logs_bloom,
+            timestamp: block_env.timestamp.to::<u64>(),
+            mix_hash: block_env.prevrandao.unwrap_or_default(),
+            nonce: BEACON_NONCE.into(),
+            base_fee_per_gas: Some(block_env.basefee.to::<u64>()),
+            number: block_env.number.to::<u64>(),
+            gas_limit: block_env.gas_limit.to::<u64>(),
+            difficulty: U256::ZERO,
+            gas_used: receipts.last().map(|r| r.cumulative_gas_used).unwrap_or_default(),
+            blob_gas_used: (cfg.handler_cfg.spec_id >= SpecId::CANCUN).then(|| {
+                transactions.iter().map(|tx| tx.blob_gas_used().unwrap_or_default()).sum::<u64>()
+            }),
+            excess_blob_gas: block_env.get_blob_excess_gas().map(Into::into),
+            extra_data: Default::default(),
+            parent_beacon_block_root: (cfg.handler_cfg.spec_id >= SpecId::CANCUN)
+                .then_some(B256::ZERO),
+            requests_hash: (cfg.handler_cfg.spec_id >= SpecId::PRAGUE)
+                .then_some(EMPTY_REQUESTS_HASH),
+            target_blobs_per_block: None,
+        };
+
+        // seal the block
+        reth_primitives::Block {
+            header,
+            body: BlockBody { transactions, ommers: vec![], withdrawals: None },
+        }
     }
 
     fn assemble_receipt(
         &self,
-        _tx: &reth_primitives::RecoveredTx<ProviderTx<Self::Provider>>,
-        _result: revm_primitives::ExecutionResult,
-        _cumulative_gas_used: u64,
+        tx: &reth_primitives::RecoveredTx<ProviderTx<Self::Provider>>,
+        result: revm_primitives::ExecutionResult,
+        cumulative_gas_used: u64,
     ) -> reth_provider::ProviderReceipt<Self::Provider> {
-        todo!()
+        #[allow(clippy::needless_update)]
+        Receipt {
+            tx_type: tx.tx_type(),
+            success: result.is_success(),
+            cumulative_gas_used,
+            logs: result.into_logs().into_iter().map(Into::into).collect(),
+            ..Default::default()
+        }
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -40,4 +40,23 @@ where
     fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock>> {
         self.inner.pending_block()
     }
+
+    fn assemble_block(
+        &self,
+        parent_hash: revm_primitives::B256,
+        state_root: revm_primitives::B256,
+        transactions: Vec<ProviderTx<Self::Provider>>,
+        receipts: &[reth_provider::ProviderReceipt<Self::Provider>],
+    ) -> reth_provider::ProviderBlock<Self::Provider> {
+        todo!()
+    }
+
+    fn assemble_receipt(
+        &self,
+        tx: &reth_primitives::RecoveredTx<ProviderTx<Self::Provider>>,
+        result: revm_primitives::ExecutionResult,
+        cumulative_gas_used: u64,
+    ) -> reth_provider::ProviderReceipt<Self::Provider> {
+        todo!()
+    }
 }

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::U256;
 use reth_chainspec::EthereumHardforks;
 use reth_network_api::NetworkInfo;
-use reth_primitives::TransactionSigned;
 use reth_provider::{
     BlockNumReader, BlockReader, ChainSpecProvider, ProviderTx, StageCheckpointReader,
 };

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,7 +1,10 @@
 use alloy_primitives::U256;
 use reth_chainspec::EthereumHardforks;
 use reth_network_api::NetworkInfo;
-use reth_provider::{BlockNumReader, BlockReader, ChainSpecProvider, StageCheckpointReader};
+use reth_primitives::TransactionSigned;
+use reth_provider::{
+    BlockNumReader, BlockReader, ChainSpecProvider, ProviderTx, StageCheckpointReader,
+};
 use reth_rpc_eth_api::{helpers::EthApiSpec, RpcNodeCore};
 
 use crate::EthApi;
@@ -16,11 +19,16 @@ where
     >,
     Provider: BlockReader,
 {
+    type Transaction = ProviderTx<Provider>;
+
     fn starting_block(&self) -> U256 {
         self.inner.starting_block()
     }
 
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn reth_rpc_eth_api::helpers::EthSigner>>> {
+    fn signers(
+        &self,
+    ) -> &parking_lot::RwLock<Vec<Box<dyn reth_rpc_eth_api::helpers::EthSigner<Self::Transaction>>>>
+    {
         self.inner.signers()
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -2,14 +2,20 @@
 
 use alloy_consensus::Header;
 use reth_evm::ConfigureEvm;
-use reth_provider::BlockReader;
+use reth_provider::{BlockReader, ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::helpers::{LoadState, Trace};
 
 use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: LoadState<Provider: BlockReader, Evm: ConfigureEvm<Header = Header>>,
+    Self: LoadState<
+        Provider: BlockReader,
+        Evm: ConfigureEvm<
+            Header = ProviderHeader<Self::Provider>,
+            Transaction = ProviderTx<Self::Provider>,
+        >,
+    >,
     Provider: BlockReader,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -1,6 +1,5 @@
 //! Contains RPC handler implementations specific to tracing.
 
-use alloy_consensus::Header;
 use reth_evm::ConfigureEvm;
 use reth_provider::{BlockReader, ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::helpers::{LoadState, Trace};

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -1,6 +1,6 @@
 //! Contains RPC handler implementations specific to transactions
 
-use reth_provider::{BlockReader, BlockReaderIdExt, TransactionsProvider};
+use reth_provider::{BlockReader, BlockReaderIdExt, ProviderTx, TransactionsProvider};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
     FullEthApiTypes, RpcNodeCoreExt,
@@ -16,7 +16,7 @@ where
     Provider: BlockReader,
 {
     #[inline]
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner>>> {
+    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>> {
         self.inner.signers()
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -13,7 +13,7 @@ impl<Provider, Pool, Network, EvmConfig> EthTransactions
     for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt>,
-    Provider: BlockReader,
+    Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
 {
     #[inline]
     fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>> {

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -11,7 +11,6 @@ use alloy_rpc_types_mev::{
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
-use reth_primitives::{PooledTransactionsElement, TransactionSigned};
 use reth_provider::{ChainSpecProvider, HeaderProvider, ProviderTx};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::MevSimApiServer;

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::Transaction;
+use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_network::{ReceiptResponse, TransactionResponse};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
@@ -12,10 +12,11 @@ use alloy_rpc_types_trace::{
 };
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
+use reth_provider::ProviderHeader;
 use reth_rpc_api::{EthApiServer, OtterscanServer};
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
-    FullEthApiTypes, RpcBlock, RpcReceipt, RpcTransaction, TransactionCompat,
+    FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction, TransactionCompat,
 };
 use reth_rpc_eth_types::{utils::binary_search, EthApiError};
 use reth_rpc_server_types::result::internal_rpc_err;
@@ -49,7 +50,7 @@ where
         &self,
         block: RpcBlock<Eth::NetworkTypes>,
         receipts: Vec<RpcReceipt<Eth::NetworkTypes>>,
-    ) -> RpcResult<BlockDetails> {
+    ) -> RpcResult<BlockDetails<RpcHeader<Eth::NetworkTypes>>> {
         // blob fee is burnt, so we don't need to calculate it
         let total_fees = receipts
             .iter()
@@ -61,18 +62,23 @@ where
 }
 
 #[async_trait]
-impl<Eth> OtterscanServer<RpcTransaction<Eth::NetworkTypes>> for OtterscanApi<Eth>
+impl<Eth> OtterscanServer<RpcTransaction<Eth::NetworkTypes>, RpcHeader<Eth::NetworkTypes>>
+    for OtterscanApi<Eth>
 where
     Eth: EthApiServer<
             RpcTransaction<Eth::NetworkTypes>,
             RpcBlock<Eth::NetworkTypes>,
             RpcReceipt<Eth::NetworkTypes>,
+            RpcHeader<Eth::NetworkTypes>,
         > + EthTransactions
         + TraceExt
         + 'static,
 {
     /// Handler for `{ots,erigon}_getHeaderByNumber`
-    async fn get_header_by_number(&self, block_number: u64) -> RpcResult<Option<Header>> {
+    async fn get_header_by_number(
+        &self,
+        block_number: u64,
+    ) -> RpcResult<Option<RpcHeader<Eth::NetworkTypes>>> {
         self.eth.header_by_number(BlockNumberOrTag::Number(block_number)).await
     }
 
@@ -165,7 +171,10 @@ where
     }
 
     /// Handler for `ots_getBlockDetails`
-    async fn get_block_details(&self, block_number: u64) -> RpcResult<BlockDetails<Header>> {
+    async fn get_block_details(
+        &self,
+        block_number: u64,
+    ) -> RpcResult<BlockDetails<RpcHeader<Eth::NetworkTypes>>> {
         let block_id = block_number.into();
         let block = self.eth.block_by_number(block_id, true);
         let block_id = block_id.into();
@@ -178,7 +187,10 @@ where
     }
 
     /// Handler for `getBlockDetailsByHash`
-    async fn get_block_details_by_hash(&self, block_hash: B256) -> RpcResult<BlockDetails<Header>> {
+    async fn get_block_details_by_hash(
+        &self,
+        block_hash: B256,
+    ) -> RpcResult<BlockDetails<RpcHeader<Eth::NetworkTypes>>> {
         let block = self.eth.block_by_hash(block_hash, true);
         let block_id = block_hash.into();
         let receipts = self.eth.block_receipts(block_id);
@@ -195,7 +207,9 @@ where
         block_number: u64,
         page_number: usize,
         page_size: usize,
-    ) -> RpcResult<OtsBlockTransactions<RpcTransaction<Eth::NetworkTypes>, Header>> {
+    ) -> RpcResult<
+        OtsBlockTransactions<RpcTransaction<Eth::NetworkTypes>, RpcHeader<Eth::NetworkTypes>>,
+    > {
         let block_id = block_number.into();
         // retrieve full block and its receipts
         let block = self.eth.block_by_number(block_id, true);
@@ -236,7 +250,7 @@ where
         }
 
         // Crop receipts and transform them into OtsTransactionReceipt
-        let timestamp = Some(block.header.timestamp);
+        let timestamp = Some(block.header.timestamp());
         let receipts = receipts
             .drain(page_start..page_end)
             .zip(transactions.iter().map(Transaction::ty))

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -2,7 +2,7 @@ use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_network::{ReceiptResponse, TransactionResponse};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
-use alloy_rpc_types_eth::{BlockTransactions, Header, TransactionReceipt};
+use alloy_rpc_types_eth::{BlockTransactions, TransactionReceipt};
 use alloy_rpc_types_trace::{
     otterscan::{
         BlockDetails, ContractCreator, InternalOperation, OperationType, OtsBlockTransactions,
@@ -12,7 +12,6 @@ use alloy_rpc_types_trace::{
 };
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
-use reth_provider::ProviderHeader;
 use reth_rpc_api::{EthApiServer, OtterscanServer};
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -19,7 +19,6 @@ use reth_consensus_common::calc::{
     base_block_reward, base_block_reward_pre_merge, block_reward, ommer_reward,
 };
 use reth_evm::ConfigureEvmEnv;
-use reth_primitives::{Header, PooledTransactionsElement, RecoveredTx};
 use reth_primitives_traits::{BlockBody, BlockHeader};
 use reth_provider::{BlockReader, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
@@ -27,7 +26,7 @@ use reth_rpc_api::TraceApiServer;
 use reth_rpc_eth_api::{helpers::TraceExt, FromEthApiError};
 use reth_rpc_eth_types::{error::EthApiError, utils::recover_raw_transaction};
 use reth_tasks::pool::BlockingTaskGuard;
-use reth_transaction_pool::{PoolConsensusTx, PoolPooledTx, PoolTransaction, TransactionPool};
+use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionPool};
 use revm::{
     db::{CacheDB, DatabaseCommit},
     primitives::EnvWithHandlerCfg,
@@ -316,7 +315,7 @@ where
         // add reward traces for all blocks
         for block in &blocks {
             if let Some(base_block_reward) =
-                self.calculate_base_block_reward(*&block.header.header())?
+                self.calculate_base_block_reward(block.header.header())?
             {
                 all_traces.extend(
                     self.extract_reward_traces(

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1036,7 +1036,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
         self.get_in_memory_or_storage_by_block(
             id,
             |provider| provider.transactions_by_block(id),
-            |block_state| Ok(Some(block_state.block_ref().block().body().transactions().to_vec())),
+            |block_state| Ok(Some(block_state.block_ref().block().body.transactions().to_vec())),
         )
     }
 
@@ -1047,7 +1047,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
         self.get_in_memory_or_storage_by_block_range_while(
             range,
             |db_provider, range, _| db_provider.transactions_by_block_range(range),
-            |block_state, _| Some(block_state.block_ref().block().body().transactions().to_vec()),
+            |block_state, _| Some(block_state.block_ref().block().body.transactions().to_vec()),
             |_| true,
         )
     }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -24,7 +24,7 @@ use reth_primitives::{
     Account, BlockWithSenders, SealedBlockFor, SealedBlockWithSenders, SealedHeader, StorageEntry,
     TransactionMeta,
 };
-use reth_primitives_traits::{Block, BlockBody};
+use reth_primitives_traits::BlockBody;
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{

--- a/crates/storage/storage-api/src/header.rs
+++ b/crates/storage/storage-api/src/header.rs
@@ -5,6 +5,9 @@ use reth_primitives_traits::BlockHeader;
 use reth_storage_errors::provider::ProviderResult;
 use std::ops::RangeBounds;
 
+/// A helper type alias to access [`HeaderProvider::Header`].
+pub type ProviderHeader<P> = <P as HeaderProvider>::Header;
+
 /// Client trait for fetching `Header` related data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait HeaderProvider: Send + Sync {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -967,10 +967,10 @@ pub trait PoolTransaction:
     type TryFromConsensusError: fmt::Display;
 
     /// Associated type representing the raw consensus variant of the transaction.
-    type Consensus;
+    type Consensus: From<Self::Pooled>;
 
     /// Associated type representing the recovered pooled variant of the transaction.
-    type Pooled: SignedTransaction + Into<Self::Consensus>;
+    type Pooled: SignedTransaction;
 
     /// Define a method to convert from the `Consensus` type to `Self`
     fn try_from_consensus(
@@ -1005,6 +1005,11 @@ pub trait PoolTransaction:
     fn try_consensus_into_pooled(
         tx: RecoveredTx<Self::Consensus>,
     ) -> Result<RecoveredTx<Self::Pooled>, Self::TryFromConsensusError>;
+
+    /// Converts the `Pooled` type into the `Consensus` type.
+    fn pooled_into_consensus(tx: Self::Pooled) -> Self::Consensus {
+        tx.into()
+    }
 
     /// Hash of the transaction.
     fn hash(&self) -> &TxHash;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -43,6 +43,9 @@ pub type PeerId = alloy_primitives::B512;
 /// Helper type alias to access [`PoolTransaction::Consensus`] for a given [`TransactionPool`].
 pub type PoolConsensusTx<P> = <<P as TransactionPool>::Transaction as PoolTransaction>::Consensus;
 
+/// Helper type alias to access [`PoolTransaction::Pooled`] for a given [`TransactionPool`].
+pub type PoolPooledTx<P> = <<P as TransactionPool>::Transaction as PoolTransaction>::Pooled;
+
 /// General purpose abstraction of a transaction-pool.
 ///
 /// This is intended to be used by API-consumers such as RPC that need inject new incoming,
@@ -967,7 +970,7 @@ pub trait PoolTransaction:
     type Consensus;
 
     /// Associated type representing the recovered pooled variant of the transaction.
-    type Pooled: SignedTransaction;
+    type Pooled: SignedTransaction + Into<Self::Consensus>;
 
     /// Define a method to convert from the `Consensus` type to `Self`
     fn try_from_consensus(


### PR DESCRIPTION
This completes most of the abstraction for `eth` namespace traits.

Changes include:
- `Header` generic is added to `EthApiServer`
- `LoadPendingBlock` is refactored so that header and block construction are handled by a separate `assemble_block` method and can be defined separately for OP and eth. Eventually this should be refactored to use payload builder instead

This should unblock abstraction of other namespaces implementations. The latest not abstracted endpoint for `eth` namespace is `eth_simulateV1` which also requires building blocks, I'll work on it in a separate PR