### PR TITLE
chore: use leaner NoopProvider in network

### DIFF
--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -30,7 +30,6 @@ reth-ecies.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
 reth-storage-api.workspace = true
-reth-provider = { workspace = true, optional = true }
 reth-tokio-util.workspace = true
 reth-consensus.workspace = true
 reth-network-peers = { workspace = true, features = ["net"] }
@@ -90,7 +89,7 @@ reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 
 # alloy deps for testing against nodes
 alloy-node-bindings.workspace = true
-alloy-provider= { workspace = true, features = ["admin-api"] }
+alloy-provider = { workspace = true, features = ["admin-api"] }
 alloy-consensus.workspace = true
 
 # misc
@@ -112,7 +111,6 @@ serde = [
 	"reth-network-types/serde",
 	"reth-dns-discovery/serde",
 	"reth-eth-wire/serde",
-	"reth-provider?/serde",
 	"reth-eth-wire-types/serde",
 	"alloy-consensus/serde",
 	"alloy-eips/serde",
@@ -123,11 +121,10 @@ serde = [
 	"smallvec/serde",
 	"url/serde",
 	"reth-primitives-traits/serde",
-	"reth-ethereum-forks/serde"
+	"reth-ethereum-forks/serde",
+	"reth-provider/serde"
 ]
 test-utils = [
-	"dep:reth-provider",
-	"reth-provider?/test-utils",
 	"dep:tempfile",
 	"reth-transaction-pool/test-utils",
 	"reth-network-types/test-utils",
@@ -137,7 +134,8 @@ test-utils = [
 	"reth-network/test-utils",
 	"reth-network-p2p/test-utils",
 	"reth-primitives/test-utils",
-    "reth-primitives-traits/test-utils",
+	"reth-primitives-traits/test-utils",
+	"reth-provider/test-utils"
 ]
 
 [[bench]]

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -642,7 +642,7 @@ mod tests {
     use reth_chainspec::{Chain, MAINNET};
     use reth_dns_discovery::tree::LinkEntry;
     use reth_primitives::ForkHash;
-    use reth_provider::test_utils::NoopProvider;
+    use reth_storage_api::noop::NoopProvider;
     use std::sync::Arc;
 
     fn builder() -> NetworkConfigBuilder {

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -42,7 +42,7 @@
 //! ### Configure and launch a standalone network
 //!
 //! The [`NetworkConfig`] is used to configure the network.
-//! It requires an instance of [`BlockReader`](reth_provider::BlockReader).
+//! It requires an instance of [`BlockReader`](reth_storage_api::BlockReader).
 //!
 //! ```
 //! # async fn launch() {

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -50,7 +50,7 @@
 //!     config::rng_secret_key, EthNetworkPrimitives, NetworkConfig, NetworkManager,
 //! };
 //! use reth_network_peers::mainnet_nodes;
-//! use reth_provider::test_utils::NoopProvider;
+//! use reth_storage_api::noop::NoopProvider;
 //!
 //! // This block provider implementation is used for testing purposes.
 //! let client = NoopProvider::default();
@@ -79,7 +79,7 @@
 //!     config::rng_secret_key, EthNetworkPrimitives, NetworkConfig, NetworkManager,
 //! };
 //! use reth_network_peers::mainnet_nodes;
-//! use reth_provider::test_utils::NoopProvider;
+//! use reth_storage_api::noop::NoopProvider;
 //! use reth_transaction_pool::TransactionPool;
 //! async fn launch<Pool: TransactionPool>(pool: Pool) {
 //!     // This block provider implementation is used for testing purposes.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -296,7 +296,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
     ///     config::rng_secret_key, EthNetworkPrimitives, NetworkConfig, NetworkManager,
     /// };
     /// use reth_network_peers::mainnet_nodes;
-    /// use reth_provider::test_utils::NoopProvider;
+    /// use reth_storage_api::noop::NoopProvider;
     /// use reth_transaction_pool::TransactionPool;
     /// async fn launch<Pool: TransactionPool>(pool: Pool) {
     ///     // This block provider implementation is used for testing purposes.

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -556,22 +556,6 @@ pub(crate) enum StateAction<N: NetworkPrimitives> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        future::poll_fn,
-        sync::{atomic::AtomicU64, Arc},
-    };
-
-    use alloy_consensus::Header;
-    use alloy_primitives::B256;
-    use reth_eth_wire::{BlockBodies, Capabilities, Capability, EthNetworkPrimitives, EthVersion};
-    use reth_network_api::PeerRequestSender;
-    use reth_network_p2p::{bodies::client::BodiesClient, error::RequestError};
-    use reth_network_peers::PeerId;
-    use reth_primitives::BlockBody;
-    use reth_provider::test_utils::NoopProvider;
-    use tokio::sync::mpsc;
-    use tokio_stream::{wrappers::ReceiverStream, StreamExt};
-
     use crate::{
         discovery::Discovery,
         fetch::StateFetcher,
@@ -579,6 +563,20 @@ mod tests {
         state::{BlockNumReader, NetworkState},
         PeerRequest,
     };
+    use alloy_consensus::Header;
+    use alloy_primitives::B256;
+    use reth_eth_wire::{BlockBodies, Capabilities, Capability, EthNetworkPrimitives, EthVersion};
+    use reth_network_api::PeerRequestSender;
+    use reth_network_p2p::{bodies::client::BodiesClient, error::RequestError};
+    use reth_network_peers::PeerId;
+    use reth_primitives::BlockBody;
+    use reth_storage_api::noop::NoopProvider;
+    use std::{
+        future::poll_fn,
+        sync::{atomic::AtomicU64, Arc},
+    };
+    use tokio::sync::mpsc;
+    use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 
     /// Returns a testing instance of the [`NetworkState`].
     fn state() -> NetworkState<EthNetworkPrimitives> {

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use futures::{FutureExt, StreamExt};
 use pin_project::pin_project;
-use reth_chainspec::{Hardforks, MAINNET};
+use reth_chainspec::{ChainSpecProvider, Hardforks, MAINNET};
 use reth_eth_wire::{
     protocol::Protocol, DisconnectReason, EthNetworkPrimitives, HelloMessageWithProtocols,
 };
@@ -21,8 +21,9 @@ use reth_network_api::{
 };
 use reth_network_peers::PeerId;
 use reth_primitives::{PooledTransactionsElement, TransactionSigned};
-use reth_provider::{test_utils::NoopProvider, ChainSpecProvider};
-use reth_storage_api::{BlockReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory};
+use reth_storage_api::{
+    noop::NoopProvider, BlockReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory,
+};
 use reth_tasks::TokioTaskExecutor;
 use reth_tokio_util::EventStream;
 use reth_transaction_pool::{

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1905,7 +1905,7 @@ mod tests {
         error::{RequestError, RequestResult},
         sync::{NetworkSyncUpdater, SyncState},
     };
-    use reth_provider::test_utils::NoopProvider;
+    use reth_storage_api::noop::NoopProvider;
     use reth_transaction_pool::test_utils::{
         testing_pool, MockTransaction, MockTransactionFactory, TestPool,
     };

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -1,7 +1,5 @@
 //! Connection tests
 
-use std::{net::SocketAddr, time::Duration};
-
 use alloy_node_bindings::Geth;
 use alloy_primitives::map::HashSet;
 use alloy_provider::{ext::AdminApi, ProviderBuilder};
@@ -24,9 +22,10 @@ use reth_network_p2p::{
     sync::{NetworkSyncUpdater, SyncState},
 };
 use reth_network_peers::{mainnet_nodes, NodeRecord, TrustedPeer};
-use reth_provider::test_utils::NoopProvider;
+use reth_storage_api::noop::NoopProvider;
 use reth_transaction_pool::test_utils::testing_pool;
 use secp256k1::SecretKey;
+use std::{net::SocketAddr, time::Duration};
 use tokio::task;
 use url::Host;
 
@@ -99,7 +98,7 @@ async fn test_already_connected() {
     let p1 = PeerConfig::default();
 
     // initialize two peers with the same identifier
-    let p2 = PeerConfig::with_secret_key(client, secret_key);
+    let p2 = PeerConfig::with_secret_key(client.clone(), secret_key);
     let p3 = PeerConfig::with_secret_key(client, secret_key);
 
     net.extend_peer_with_config(vec![p1, p2, p3]).await.unwrap();
@@ -143,7 +142,7 @@ async fn test_get_peer() {
     let client = NoopProvider::default();
 
     let p1 = PeerConfig::default();
-    let p2 = PeerConfig::with_secret_key(client, secret_key);
+    let p2 = PeerConfig::with_secret_key(client.clone(), secret_key);
     let p3 = PeerConfig::with_secret_key(client, secret_key_1);
     net.extend_peer_with_config(vec![p1, p2, p3]).await.unwrap();
 
@@ -176,7 +175,7 @@ async fn test_get_peer_by_id() {
     let secret_key_1 = SecretKey::new(&mut rand::thread_rng());
     let client = NoopProvider::default();
     let p1 = PeerConfig::default();
-    let p2 = PeerConfig::with_secret_key(client, secret_key);
+    let p2 = PeerConfig::with_secret_key(client.clone(), secret_key);
     let p3 = PeerConfig::with_secret_key(client, secret_key_1);
 
     net.extend_peer_with_config(vec![p1, p2, p3]).await.unwrap();
@@ -234,7 +233,7 @@ async fn test_connect_with_builder() {
     let client = NoopProvider::default();
     let config = NetworkConfigBuilder::<EthNetworkPrimitives>::new(secret_key)
         .discovery(discv4)
-        .build(client);
+        .build(client.clone());
     let (handle, network, _, requests) = NetworkManager::new(config)
         .await
         .unwrap()
@@ -272,7 +271,7 @@ async fn test_connect_to_trusted_peer() {
     let client = NoopProvider::default();
     let config = NetworkConfigBuilder::<EthNetworkPrimitives>::new(secret_key)
         .discovery(discv4)
-        .build(client);
+        .build(client.clone());
     let transactions_manager_config = config.transactions_manager_config.clone();
     let (handle, network, transactions, requests) = NetworkManager::new(config)
         .await

--- a/crates/net/network/tests/it/session.rs
+++ b/crates/net/network/tests/it/session.rs
@@ -10,7 +10,7 @@ use reth_network_api::{
     events::{PeerEvent, SessionInfo},
     NetworkInfo, Peers,
 };
-use reth_provider::test_utils::NoopProvider;
+use reth_storage_api::noop::NoopProvider;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_session_established_with_highest_version() {

--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -11,7 +11,7 @@ use reth_network::{
     Discovery, NetworkConfigBuilder, NetworkManager,
 };
 use reth_network_api::{NetworkInfo, PeersInfo};
-use reth_provider::test_utils::NoopProvider;
+use reth_storage_api::noop::NoopProvider;
 use secp256k1::SecretKey;
 use tokio::net::TcpListener;
 

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -4,12 +4,12 @@ use crate::{
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
     BlockSource, ChangeSetReader, HashedPostStateProvider, HeaderProvider, NodePrimitivesProvider,
     PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader,
-    StateProofProvider, StateProvider, StateRootProvider, StorageRootProvider, TransactionVariant,
-    TransactionsProvider, WithdrawalsProvider,
+    StateProofProvider, StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider,
+    StorageRootProvider, TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
 use alloy_eips::{
     eip4895::{Withdrawal, Withdrawals},
-    BlockHashOrNumber, BlockId,
+    BlockHashOrNumber, BlockId, BlockNumberOrTag,
 };
 use alloy_primitives::{
     map::{HashMap, HashSet},
@@ -23,7 +23,7 @@ use reth_primitives::{
 use reth_primitives_traits::{Account, Bytecode, NodePrimitives, SealedHeader};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
-use reth_storage_errors::provider::ProviderResult;
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof, TrieInput,
 };
@@ -473,6 +473,58 @@ impl<C: Send + Sync, N: NodePrimitives> StateProvider for NoopProvider<C, N> {
 
     fn bytecode_by_hash(&self, _code_hash: B256) -> ProviderResult<Option<Bytecode>> {
         Ok(None)
+    }
+}
+
+impl<C: Send + Sync + 'static, N: NodePrimitives> StateProviderFactory for NoopProvider<C, N> {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn state_by_block_number_or_tag(
+        &self,
+        number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
+        match number_or_tag {
+            BlockNumberOrTag::Latest => self.latest(),
+            BlockNumberOrTag::Finalized => {
+                // we can only get the finalized state by hash, not by num
+                let hash =
+                    self.finalized_block_hash()?.ok_or(ProviderError::FinalizedBlockNotFound)?;
+
+                // only look at historical state
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Safe => {
+                // we can only get the safe state by hash, not by num
+                let hash = self.safe_block_hash()?.ok_or(ProviderError::SafeBlockNotFound)?;
+
+                self.history_by_block_hash(hash)
+            }
+            BlockNumberOrTag::Earliest => self.history_by_block_number(0),
+            BlockNumberOrTag::Pending => self.pending(),
+            BlockNumberOrTag::Number(num) => self.history_by_block_number(num),
+        }
+    }
+
+    fn history_by_block_number(&self, _block: BlockNumber) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
+        Ok(Some(Box::new(self.clone())))
     }
 }
 


### PR DESCRIPTION
we need to move away from the reth-provider::NoopProvider because this one is very expensive to import

this makes progress towards that goal by using the cheap to import storage-api::NoopProvider instead