### PR TITLE
chore: use slice arg for tx decoding

### DIFF
--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -32,7 +32,7 @@ where
     ///
     /// Returns the hash of the transaction.
     async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256, Self::Error> {
-        let recovered = recover_raw_transaction(tx.clone())?;
+        let recovered = recover_raw_transaction(&tx)?;
         let pool_transaction = <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
 
         // On optimism, transactions are forwarded directly to the sequencer to be included in

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -343,7 +343,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         tx: Bytes,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
         async move {
-            let recovered = recover_raw_transaction(tx)?;
+            let recovered = recover_raw_transaction(&tx)?;
             let pool_transaction =
                 <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
 

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -90,7 +90,7 @@ where
 
         let transactions = txs
             .into_iter()
-            .map(recover_raw_transaction::<PoolPooledTx<Eth::Pool>>)
+            .map(|tx| recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(&tx))
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .map(|tx| tx.to_components())

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -171,9 +171,8 @@ where
             while idx < body.len() {
                 match &body[idx] {
                     BundleItem::Tx { tx, can_revert } => {
-                        let recovered_tx =
-                            recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(tx.clone())
-                                .map_err(EthApiError::from)?;
+                        let recovered_tx = recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(tx)
+                            .map_err(EthApiError::from)?;
                         let (tx, signer) = recovered_tx.to_components();
                         let tx: PoolConsensusTx<Eth::Pool> =
                             <Eth::Pool as TransactionPool>::Transaction::pooled_into_consensus(tx);

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -117,7 +117,7 @@ where
         trace_types: HashSet<TraceType>,
         block_id: Option<BlockId>,
     ) -> Result<TraceResults, Eth::Error> {
-        let tx = recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(tx)?
+        let tx = recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(&tx)?
             .map_transaction(<Eth::Pool as TransactionPool>::Transaction::pooled_into_consensus);
 
         let (cfg, block, at) = self.eth_api().evm_env_at(block_id.unwrap_or_default()).await?;


### PR DESCRIPTION
gets rid of a few Bytes::clone here and there