### PR TITLE
chore: introduce ethereum-primitives crate

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -5,6 +5,7 @@ set +e  # Disable immediate exit on error
 crates_to_check=(
     reth-codecs-derive
     reth-ethereum-forks
+    reth-ethereum-primitives
     reth-primitives-traits
     reth-optimism-forks
     # reth-evm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7569,6 +7569,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ethereum-primitives"
+version = "1.1.2"
+
+[[package]]
 name = "reth-etl"
 version = "1.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/ethereum/evm",
     "crates/ethereum/node",
     "crates/ethereum/payload/",
+    "crates/ethereum/primitives/",
     "crates/etl/",
     "crates/evm/",
     "crates/evm/execution-errors",
@@ -341,6 +342,7 @@ reth-ethereum-consensus = { path = "crates/ethereum/consensus" }
 reth-ethereum-engine-primitives = { path = "crates/ethereum/engine-primitives" }
 reth-ethereum-forks = { path = "crates/ethereum-forks", default-features = false }
 reth-ethereum-payload-builder = { path = "crates/ethereum/payload" }
+reth-ethereum-primitives = { path = "crates/ethereum/primitives", default-features = false  }
 reth-etl = { path = "crates/etl" }
 reth-evm = { path = "crates/evm" }
 reth-evm-ethereum = { path = "crates/ethereum/evm" }

--- a/crates/ethereum/primitives/Cargo.toml
+++ b/crates/ethereum/primitives/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "reth-ethereum-primitives"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Ethereum primitive types"
+
+[lints]
+workspace = true
+
+[dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/crates/ethereum/primitives/src/lib.rs
+++ b/crates/ethereum/primitives/src/lib.rs
@@ -1,0 +1,10 @@
+//! Standalone crate for ethereum-specific Reth primitive types.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
minimal prep for splitting OP and Eth types for good.

this will mirror optimism-primitives and include the ethereum specific types.

migration strategy will be, offloading non feature gated types from reth-primitives to the op/eth primitives