### PR TITLE
perf(`AllTransactions`-iter): do not clone all transactions by default

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -295,7 +295,7 @@ where
 
     /// Returns _all_ transactions in the pool.
     pub fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        self.get_pool_data().all().transactions_iter().filter(|tx| tx.propagate).collect()
+        self.get_pool_data().all().transactions_iter().filter(|tx| tx.propagate).cloned().collect()
     }
 
     /// Returns only the first `max` transactions in the pool.
@@ -303,7 +303,13 @@ where
         &self,
         max: usize,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        self.get_pool_data().all().transactions_iter().filter(|tx| tx.propagate).take(max).collect()
+        self.get_pool_data()
+            .all()
+            .transactions_iter()
+            .filter(|tx| tx.propagate)
+            .take(max)
+            .cloned()
+            .collect()
     }
 
     /// Converts the internally tracked transaction to the pooled format.
@@ -857,7 +863,12 @@ where
         &self,
         origin: TransactionOrigin,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        self.get_pool_data().all().transactions_iter().filter(|tx| tx.origin == origin).collect()
+        self.get_pool_data()
+            .all()
+            .transactions_iter()
+            .filter(|tx| tx.origin == origin)
+            .cloned()
+            .collect()
     }
 
     /// Returns all pending transactions filted by [`TransactionOrigin`]

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1095,11 +1095,11 @@ impl<T: PoolTransaction> AllTransactions<T> {
         self.by_hash.keys().copied()
     }
 
-    /// Returns an iterator over all _unique_ hashes in the pool
+    /// Returns an iterator over all transactions in the pool
     pub(crate) fn transactions_iter(
         &self,
-    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T>>> + '_ {
-        self.by_hash.values().cloned()
+    ) -> impl Iterator<Item = &Arc<ValidPoolTransaction<T>>> + '_ {
+        self.by_hash.values()
     }
 
     /// Returns if the transaction for the given hash is already included in this pool


### PR DESCRIPTION
We're spamming the mempool so hard it can take over 1s for `TxPool::on_canonical_state_change` to complete. This needs much improvement for chains with 200ms-1s block time.

Earlier profiling shows that ~10% is spent on cloning all transactions (via `AllTransactions::transactions_iter`) to count the transaction type in `update_transaction_type_metrics`.
![image](https://github.com/user-attachments/assets/ae86de93-8a89-4b81-a534-c568fb8ab8da)

And another 4% is spent on dropping the cloned `Arc`s.
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/cb197de6-0236-4bda-9dbe-95a199198a71">

We only need a reference for `tx.transaction.tx_type()`, so this PR makes `transactions_iter` return references by default and only clone on demand like in `pooled_transactions`.