### PR TITLE
fix: don't use reserved word None in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -67,7 +67,7 @@ body:
       description: Were you running it in a container?
       multiple: true
       options:
-        - None
+        - Not running in a container
         - Docker
         - Kubernetes
         - LXC/LXD


### PR DESCRIPTION
Right now we have this:

![Screenshot 2024-12-06 at 2 52 02 PM](https://github.com/user-attachments/assets/af58d173-df9c-4b81-a31e-b0efd4494825)

So apparently we can't use the word `None`