### PR TITLE
perf: prevent changed senders clone

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -462,10 +462,12 @@ impl<T: TransactionOrdering> TxPool<T> {
         &mut self,
         changed_senders: HashMap<SenderId, SenderInfo>,
     ) -> UpdateOutcome<T::Transaction> {
-        // track changed accounts
-        self.sender_info.extend(changed_senders.clone());
         // Apply the state changes to the total set of transactions which triggers sub-pool updates.
-        let updates = self.all_transactions.update(changed_senders);
+        let updates = self.all_transactions.update(&changed_senders);
+
+        // track changed accounts
+        self.sender_info.extend(changed_senders);
+
         // Process the sub-pool updates
         let update = self.process_updates(updates);
         // update the metrics after the update
@@ -1180,7 +1182,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
     /// that got transaction included in the block.
     pub(crate) fn update(
         &mut self,
-        changed_accounts: HashMap<SenderId, SenderInfo>,
+        changed_accounts: &HashMap<SenderId, SenderInfo>,
     ) -> Vec<PoolUpdate> {
         // pre-allocate a few updates
         let mut updates = Vec::with_capacity(64);


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/pull/13187 #13193

cc @hai-rise

prevents a clone by changing the order, this is okay because `all_transactions` is entirely separate from `sender_info`