### PR TITLE
feat: make BlockResponse generic over header

### DIFF
--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -21,7 +21,7 @@ impl BodyDownloader for NoopBodiesDownloader {
 }
 
 impl Stream for NoopBodiesDownloader {
-    type Item = Result<Vec<BlockResponse<BlockBody>>, DownloadError>;
+    type Item = Result<Vec<BlockResponse<alloy_consensus::Header, BlockBody>>, DownloadError>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -80,7 +80,7 @@ impl<B> Stream for BodiesRequestQueue<B>
 where
     B: BodiesClient<Body: InMemorySize> + 'static,
 {
-    type Item = DownloadResult<Vec<BlockResponse<B::Body>>>;
+    type Item = DownloadResult<Vec<BlockResponse<alloy_consensus::Header, B::Body>>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.get_mut().inner.poll_next_unpin(cx)

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -48,7 +48,7 @@ pub(crate) struct BodiesRequestFuture<B: BodiesClient> {
     // Headers to download. The collection is shrunk as responses are buffered.
     pending_headers: VecDeque<SealedHeader>,
     /// Internal buffer for all blocks
-    buffer: Vec<BlockResponse<B::Body>>,
+    buffer: Vec<BlockResponse<alloy_consensus::Header, B::Body>>,
     fut: Option<B::Output>,
     /// Tracks how many bodies we requested in the last request.
     last_request_len: Option<usize>,
@@ -217,7 +217,7 @@ impl<B> Future for BodiesRequestFuture<B>
 where
     B: BodiesClient<Body: InMemorySize> + 'static,
 {
-    type Output = DownloadResult<Vec<BlockResponse<B::Body>>>;
+    type Output = DownloadResult<Vec<BlockResponse<alloy_consensus::Header, B::Body>>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();

--- a/crates/net/p2p/src/bodies/downloader.rs
+++ b/crates/net/p2p/src/bodies/downloader.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use std::{fmt::Debug, ops::RangeInclusive};
 
 /// Body downloader return type.
-pub type BodyDownloaderResult<B> = DownloadResult<Vec<BlockResponse<B>>>;
+pub type BodyDownloaderResult<B> = DownloadResult<Vec<BlockResponse<alloy_consensus::Header, B>>>;
 
 /// A downloader capable of fetching and yielding block bodies from block headers.
 ///

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -67,7 +67,7 @@ impl<H: alloy_consensus::BlockHeader> SealedHeader<H> {
     }
 }
 
-impl InMemorySize for SealedHeader {
+impl<H: InMemorySize> InMemorySize for SealedHeader<H> {
     /// Calculates a heuristic for the in-memory size of the [`SealedHeader`].
     #[inline]
     fn size(&self) -> usize {

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -56,7 +56,7 @@ pub struct BodyStage<D: BodyDownloader> {
     /// The body downloader.
     downloader: D,
     /// Block response buffer.
-    buffer: Option<Vec<BlockResponse<D::Body>>>,
+    buffer: Option<Vec<BlockResponse<alloy_consensus::Header, D::Body>>>,
 }
 
 impl<D: BodyDownloader> BodyStage<D> {


### PR DESCRIPTION
This used a concrete `alloy_consensus::Header` type which will not be sufficient when we start to use a configurable header type