### PR TITLE
feat: bound NetworkPrimitives types by proper traits

### DIFF
--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -1,7 +1,7 @@
 //! Abstraction over primitive types in network messages.
 
 use alloy_rlp::{Decodable, Encodable};
-use reth_primitives_traits::{Block, BlockHeader, SignedTransaction};
+use reth_primitives_traits::{Block, BlockBody, BlockHeader, SignedTransaction};
 use std::fmt::Debug;
 
 /// Abstraction over primitive types which might appear in network messages. See
@@ -10,56 +10,21 @@ pub trait NetworkPrimitives:
     Send + Sync + Unpin + Clone + Debug + PartialEq + Eq + 'static
 {
     /// The block header type.
-    type BlockHeader: BlockHeader
-        + Encodable
-        + Decodable
-        + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Debug
-        + PartialEq
-        + Eq
-        + 'static;
+    type BlockHeader: BlockHeader + 'static;
 
     /// The block body type.
-    type BlockBody: Encodable
-        + Decodable
-        + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Debug
-        + PartialEq
-        + Eq
-        + 'static;
+    type BlockBody: BlockBody + 'static;
 
     /// Full block type.
     type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody>
         + Encodable
         + Decodable
-        + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Debug
-        + PartialEq
-        + Eq
         + 'static;
 
     /// The transaction type which peers announce in `Transactions` messages. It is different from
     /// `PooledTransactions` to account for Ethereum case where EIP-4844 transactions are not being
     /// announced and can only be explicitly requested from peers.
-    type BroadcastedTransaction: Encodable
-        + Decodable
-        + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Debug
-        + PartialEq
-        + Eq
-        + 'static;
+    type BroadcastedTransaction: SignedTransaction + 'static;
 
     /// The transaction type which peers return in `PooledTransactions` messages.
     type PooledTransaction: SignedTransaction + TryFrom<Self::BroadcastedTransaction> + 'static;


### PR DESCRIPTION
Removes some redundant trait bounds captured by existing bounds, also uses `BlockBody` for the body, and `SignedTransaction` for the broadcasted transaction