### PR TITLE
chore: use `BlockWithParent` for `StageError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9237,6 +9237,7 @@ dependencies = [
 name = "reth-stages-api"
 version = "1.1.2"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "aquamarine",
  "assert_matches",

--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -18,7 +18,7 @@ const INVALID_HEADER_HIT_EVICTION_THRESHOLD: u8 = 128;
 #[derive(Debug)]
 pub struct InvalidHeaderCache {
     /// This maps a header hash to a reference to its invalid ancestor.
-    headers: LruMap<B256, HeaderEntry<BlockWithParent>>,
+    headers: LruMap<B256, HeaderEntry>,
     /// Metrics for the cache.
     metrics: InvalidHeaderCacheMetrics,
 }
@@ -80,11 +80,11 @@ impl InvalidHeaderCache {
     }
 }
 
-struct HeaderEntry<H> {
+struct HeaderEntry {
     /// Keeps track how many times this header has been hit.
     hit_count: u8,
     /// The actual header entry
-    header: Arc<H>,
+    header: Arc<BlockWithParent>,
 }
 
 /// Metrics for the invalid headers cache.

--- a/crates/consensus/beacon/src/engine/invalid_headers.rs
+++ b/crates/consensus/beacon/src/engine/invalid_headers.rs
@@ -82,7 +82,7 @@ impl<H: Debug> InvalidHeaderCache<H> {
 struct HeaderEntry<H> {
     /// Keeps track how many times this header has been hit.
     hit_count: u8,
-    /// The actually header entry
+    /// The actual header entry
     header: Arc<H>,
 }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -760,14 +760,14 @@ where
         // iterate over ancestors in the invalid cache
         // until we encounter the first valid ancestor
         let mut current_hash = parent_hash;
-        let mut current_header = self.invalid_headers.get(&current_hash);
-        while let Some(header) = current_header {
-            current_hash = header.parent_hash;
-            current_header = self.invalid_headers.get(&current_hash);
+        let mut current_block = self.invalid_headers.get(&current_hash);
+        while let Some(block_with_parent) = current_block {
+            current_hash = block_with_parent.parent;
+            current_block = self.invalid_headers.get(&current_hash);
 
             // If current_header is None, then the current_hash does not have an invalid
             // ancestor in the cache, check its presence in blockchain tree
-            if current_header.is_none() &&
+            if current_block.is_none() &&
                 self.blockchain.find_block_by_hash(current_hash, BlockSource::Any)?.is_some()
             {
                 return Ok(Some(current_hash))
@@ -806,13 +806,13 @@ where
         head: B256,
     ) -> ProviderResult<Option<PayloadStatus>> {
         // check if the check hash was previously marked as invalid
-        let Some(header) = self.invalid_headers.get(&check) else { return Ok(None) };
+        let Some(block_with_parent) = self.invalid_headers.get(&check) else { return Ok(None) };
 
         // populate the latest valid hash field
-        let status = self.prepare_invalid_response(header.parent_hash)?;
+        let status = self.prepare_invalid_response(block_with_parent.parent)?;
 
         // insert the head block into the invalid header cache
-        self.invalid_headers.insert_with_invalid_ancestor(head, header);
+        self.invalid_headers.insert_with_invalid_ancestor(head, block_with_parent);
 
         Ok(Some(status))
     }
@@ -821,10 +821,10 @@ where
     /// to a forkchoice update.
     fn check_invalid_ancestor(&mut self, head: B256) -> ProviderResult<Option<PayloadStatus>> {
         // check if the head was previously marked as invalid
-        let Some(header) = self.invalid_headers.get(&head) else { return Ok(None) };
+        let Some(block_with_parent) = self.invalid_headers.get(&head) else { return Ok(None) };
 
         // populate the latest valid hash field
-        Ok(Some(self.prepare_invalid_response(header.parent_hash)?))
+        Ok(Some(self.prepare_invalid_response(block_with_parent.parent)?))
     }
 
     /// Record latency metrics for one call to make a block canonical
@@ -1454,7 +1454,7 @@ where
     fn on_pipeline_outcome(&mut self, ctrl: ControlFlow) -> RethResult<()> {
         // Pipeline unwound, memorize the invalid block and wait for CL for next sync target.
         if let ControlFlow::Unwind { bad_block, .. } = ctrl {
-            warn!(target: "consensus::engine", invalid_hash=?bad_block.hash(), invalid_number=?bad_block.number, "Bad block detected in unwind");
+            warn!(target: "consensus::engine", invalid_num_hash=?bad_block.block, "Bad block detected in unwind");
             // update the `invalid_headers` cache with the new invalid header
             self.invalid_headers.insert(*bad_block);
             return Ok(())
@@ -1673,7 +1673,7 @@ where
                             self.latest_valid_hash_for_invalid_payload(block.parent_hash)?
                         };
                         // keep track of the invalid header
-                        self.invalid_headers.insert(block.header);
+                        self.invalid_headers.insert(block.header.block_with_parent());
                         PayloadStatus::new(
                             PayloadStatusEnum::Invalid { validation_error: error.to_string() },
                             latest_valid_hash,
@@ -1782,7 +1782,7 @@ where
                             let (block, err) = err.split();
                             warn!(target: "consensus::engine", invalid_number=?block.number, invalid_hash=?block.hash(), %err, "Marking block as invalid");
 
-                            self.invalid_headers.insert(block.header);
+                            self.invalid_headers.insert(block.header.block_with_parent());
                         }
                     }
                 }
@@ -2035,7 +2035,7 @@ mod tests {
             .await;
         assert_matches!(
             res.await,
-            Ok(Err(BeaconConsensusEngineError::Pipeline(n))) if matches!(*n.as_ref(),PipelineError::Stage( .. ))
+            Ok(Err(BeaconConsensusEngineError::Pipeline(n))) if matches!(*n.as_ref(), PipelineError::Stage(StageError::ChannelClosed))
         );
     }
 
@@ -2089,7 +2089,7 @@ mod tests {
                 Ok(result) => {
                     assert_matches!(
                         result,
-                        Err(BeaconConsensusEngineError::Pipeline(n)) if matches!(*n.as_ref(), PipelineError::Stage( .. ))
+                        Err(BeaconConsensusEngineError::Pipeline(n)) if matches!(*n.as_ref(), PipelineError::Stage(StageError::ChannelClosed))
                     );
                     break
                 }
@@ -2141,7 +2141,7 @@ mod tests {
 
         assert_matches!(
             rx.await,
-            Ok(Err(BeaconConsensusEngineError::Pipeline(n)))  if matches!(*n.as_ref(),PipelineError::Stage( .. ))
+            Ok(Err(BeaconConsensusEngineError::Pipeline(n)))  if matches!(*n.as_ref(), PipelineError::Stage(StageError::ChannelClosed))
         );
     }
 

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -761,8 +761,8 @@ where
         // until we encounter the first valid ancestor
         let mut current_hash = parent_hash;
         let mut current_block = self.invalid_headers.get(&current_hash);
-        while let Some(block_with_parent) = current_block {
-            current_hash = block_with_parent.parent;
+        while let Some(block) = current_block {
+            current_hash = block.parent;
             current_block = self.invalid_headers.get(&current_hash);
 
             // If current_header is None, then the current_hash does not have an invalid
@@ -806,13 +806,13 @@ where
         head: B256,
     ) -> ProviderResult<Option<PayloadStatus>> {
         // check if the check hash was previously marked as invalid
-        let Some(block_with_parent) = self.invalid_headers.get(&check) else { return Ok(None) };
+        let Some(block) = self.invalid_headers.get(&check) else { return Ok(None) };
 
         // populate the latest valid hash field
-        let status = self.prepare_invalid_response(block_with_parent.parent)?;
+        let status = self.prepare_invalid_response(block.parent)?;
 
         // insert the head block into the invalid header cache
-        self.invalid_headers.insert_with_invalid_ancestor(head, block_with_parent);
+        self.invalid_headers.insert_with_invalid_ancestor(head, block);
 
         Ok(Some(status))
     }
@@ -821,10 +821,10 @@ where
     /// to a forkchoice update.
     fn check_invalid_ancestor(&mut self, head: B256) -> ProviderResult<Option<PayloadStatus>> {
         // check if the head was previously marked as invalid
-        let Some(block_with_parent) = self.invalid_headers.get(&head) else { return Ok(None) };
+        let Some(block) = self.invalid_headers.get(&head) else { return Ok(None) };
 
         // populate the latest valid hash field
-        Ok(Some(self.prepare_invalid_response(block_with_parent.parent)?))
+        Ok(Some(self.prepare_invalid_response(block.parent)?))
     }
 
     /// Record latency metrics for one call to make a block canonical

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2035,7 +2035,7 @@ mod tests {
             .await;
         assert_matches!(
             res.await,
-            Ok(Err(BeaconConsensusEngineError::Pipeline(n))) if matches!(*n.as_ref(),PipelineError::Stage(StageError::ChannelClosed))
+            Ok(Err(BeaconConsensusEngineError::Pipeline(n))) if matches!(*n.as_ref(),PipelineError::Stage( .. ))
         );
     }
 
@@ -2089,7 +2089,7 @@ mod tests {
                 Ok(result) => {
                     assert_matches!(
                         result,
-                        Err(BeaconConsensusEngineError::Pipeline(n)) if matches!(*n.as_ref(), PipelineError::Stage(StageError::ChannelClosed))
+                        Err(BeaconConsensusEngineError::Pipeline(n)) if matches!(*n.as_ref(), PipelineError::Stage( .. ))
                     );
                     break
                 }
@@ -2141,7 +2141,7 @@ mod tests {
 
         assert_matches!(
             rx.await,
-            Ok(Err(BeaconConsensusEngineError::Pipeline(n)))  if matches!(*n.as_ref(),PipelineError::Stage(StageError::ChannelClosed))
+            Ok(Err(BeaconConsensusEngineError::Pipeline(n)))  if matches!(*n.as_ref(),PipelineError::Stage( .. ))
         );
     }
 

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -1,7 +1,7 @@
 use crate::InMemorySize;
 pub use alloy_consensus::Header;
 use alloy_consensus::Sealed;
-use alloy_eips::BlockNumHash;
+use alloy_eips::{eip1898::BlockWithParent, BlockNumHash};
 use alloy_primitives::{keccak256, BlockHash, Sealable};
 use alloy_rlp::{Decodable, Encodable};
 use bytes::BufMut;
@@ -64,6 +64,11 @@ impl<H: alloy_consensus::BlockHeader> SealedHeader<H> {
     /// Return the number hash tuple.
     pub fn num_hash(&self) -> BlockNumHash {
         BlockNumHash::new(self.number(), self.hash)
+    }
+
+    /// Return a [`BlockWithParent`] for this header.
+    pub fn block_with_parent(&self) -> BlockWithParent {
+        BlockWithParent { parent: self.parent_hash(), block: self.num_hash() }
     }
 }
 

--- a/crates/stages/api/Cargo.toml
+++ b/crates/stages/api/Cargo.toml
@@ -23,7 +23,9 @@ reth-errors.workspace = true
 reth-stages-types.workspace = true
 reth-static-file-types.workspace = true
 
+# alloy
 alloy-primitives.workspace = true
+alloy-eips.workspace = true
 
 # metrics
 reth-metrics.workspace = true

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -3,7 +3,6 @@ use alloy_eips::eip1898::BlockWithParent;
 use reth_consensus::ConsensusError;
 use reth_errors::{BlockExecutionError, DatabaseError, RethError};
 use reth_network_p2p::error::DownloadError;
-use reth_primitives_traits::SealedHeader;
 use reth_provider::ProviderError;
 use reth_prune::{PruneSegment, PruneSegmentError, PrunerError};
 use reth_static_file_types::StaticFileSegment;
@@ -56,9 +55,9 @@ pub enum StageError {
     )]
     DetachedHead {
         /// The local head we attempted to attach to.
-        local_head: BlockWithParent,
+        local_head: Box<BlockWithParent>,
         /// The header we attempted to attach.
-        header: BlockWithParent,
+        header: Box<BlockWithParent>,
         /// The error that occurred when attempting to attach the header.
         #[source]
         error: Box<ConsensusError>,

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -1,4 +1,5 @@
 use crate::PipelineEvent;
+use alloy_eips::eip1898::BlockWithParent;
 use reth_consensus::ConsensusError;
 use reth_errors::{BlockExecutionError, DatabaseError, RethError};
 use reth_network_p2p::error::DownloadError;
@@ -34,10 +35,10 @@ impl BlockErrorKind {
 #[derive(Error, Debug)]
 pub enum StageError {
     /// The stage encountered an error related to a block.
-    #[error("stage encountered an error in block #{number}: {error}", number = block.number)]
+    #[error("stage encountered an error in block #{number}: {error}", number = block.block.number)]
     Block {
         /// The block that caused the error.
-        block: Box<SealedHeader>,
+        block: Box<BlockWithParent>,
         /// The specific error type, either consensus or execution error.
         #[source]
         error: BlockErrorKind,
@@ -48,16 +49,16 @@ pub enum StageError {
         "stage encountered inconsistent chain: \
          downloaded header #{header_number} ({header_hash}) is detached from \
          local head #{head_number} ({head_hash}): {error}",
-        header_number = header.number,
-        header_hash = header.hash(),
-        head_number = local_head.number,
-        head_hash = local_head.hash(),
+        header_number = header.block.number,
+        header_hash = header.block.hash,
+        head_number = local_head.block.number,
+        head_hash = local_head.block.hash,
     )]
     DetachedHead {
         /// The local head we attempted to attach to.
-        local_head: Box<SealedHeader>,
+        local_head: BlockWithParent,
         /// The header we attempted to attach.
-        header: Box<SealedHeader>,
+        header: BlockWithParent,
         /// The error that occurred when attempting to attach the header.
         #[source]
         error: Box<ConsensusError>,
@@ -92,10 +93,10 @@ pub enum StageError {
     #[error("invalid download response: {0}")]
     Download(#[from] DownloadError),
     /// Database is ahead of static file data.
-    #[error("missing static file data for block number: {number}", number = block.number)]
+    #[error("missing static file data for block number: {number}", number = block.block.number)]
     MissingStaticFileData {
         /// Starting block with  missing data.
-        block: Box<SealedHeader>,
+        block: Box<BlockWithParent>,
         /// Static File segment
         segment: StaticFileSegment,
     },

--- a/crates/stages/api/src/pipeline/ctrl.rs
+++ b/crates/stages/api/src/pipeline/ctrl.rs
@@ -1,5 +1,5 @@
+use alloy_eips::eip1898::BlockWithParent;
 use alloy_primitives::BlockNumber;
-use reth_primitives_traits::SealedHeader;
 
 /// Determines the control flow during pipeline execution.
 ///
@@ -11,7 +11,7 @@ pub enum ControlFlow {
         /// The block to unwind to.
         target: BlockNumber,
         /// The block that caused the unwind.
-        bad_block: Box<SealedHeader>,
+        bad_block: Box<BlockWithParent>,
     },
     /// The pipeline made progress.
     Continue {

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -1,5 +1,6 @@
 use crate::stages::MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD;
 use alloy_consensus::{BlockHeader, Header};
+use alloy_eips::{eip1898::BlockWithParent, NumHash};
 use alloy_primitives::BlockNumber;
 use num_traits::Zero;
 use reth_config::config::ExecutionConfig;
@@ -11,7 +12,7 @@ use reth_evm::{
 };
 use reth_execution_types::Chain;
 use reth_exex::{ExExManagerHandle, ExExNotification, ExExNotificationSource};
-use reth_primitives::{SealedHeader, StaticFileSegment};
+use reth_primitives::StaticFileSegment;
 use reth_primitives_traits::{format_gas_throughput, Block, BlockBody, NodePrimitives};
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileWriter},
@@ -359,9 +360,15 @@ where
             let execute_start = Instant::now();
 
             self.metrics.metered_one((&block, td).into(), |input| {
-                executor.execute_and_verify_one(input).map_err(|error| StageError::Block {
-                    block: Box::new(SealedHeader::seal(block.header().clone())),
-                    error: BlockErrorKind::Execution(error),
+                executor.execute_and_verify_one(input).map_err(|error| {
+                    let header = block.header();
+                    StageError::Block {
+                        block: Box::new(BlockWithParent::new(
+                            header.parent_hash(),
+                            NumHash::new(header.number(), header.hash_slow()),
+                        )),
+                        error: BlockErrorKind::Execution(error),
+                    }
                 })
             })?;
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -357,7 +357,7 @@ fn validate_state_root(
             error: BlockErrorKind::Validation(ConsensusError::BodyStateRootDiff(
                 GotExpected { got, expected: expected.state_root }.into(),
             )),
-            block: Box::new(expected),
+            block: Box::new(expected.block_with_parent()),
         })
     }
 }

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -192,7 +192,7 @@ where
                                 })?;
 
                             Err(StageError::Block {
-                                block: Box::new(sealed_header),
+                                block: Box::new(sealed_header.block_with_parent()),
                                 error: BlockErrorKind::Validation(
                                     ConsensusError::TransactionSignerRecoveryError,
                                 ),

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -279,5 +279,8 @@ where
 
     let missing_block = Box::new(provider.sealed_header(last_block + 1)?.unwrap_or_default());
 
-    Ok(StageError::MissingStaticFileData { block: missing_block, segment })
+    Ok(StageError::MissingStaticFileData {
+        block: Box::new(missing_block.block_with_parent()),
+        segment,
+    })
 }

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -1,7 +1,11 @@
 //! Generators for different data structures like block headers, block bodies and ranges of those.
 
 use alloy_consensus::{Header, Transaction as _, TxLegacy};
-use alloy_eips::eip4895::{Withdrawal, Withdrawals};
+use alloy_eips::{
+    eip1898::BlockWithParent,
+    eip4895::{Withdrawal, Withdrawals},
+    NumHash,
+};
 use alloy_primitives::{Address, BlockNumber, Bytes, TxKind, B256, U256};
 pub use rand::Rng;
 use rand::{
@@ -93,6 +97,15 @@ pub fn random_header_range<R: Rng>(
         ));
     }
     headers
+}
+
+/// Generate a random [`BlockWithParent`].
+pub fn random_block_with_parent<R: Rng>(
+    rng: &mut R,
+    number: u64,
+    parent: Option<B256>,
+) -> BlockWithParent {
+    BlockWithParent { parent: parent.unwrap_or_default(), block: NumHash::new(number, rng.gen()) }
 }
 
 /// Generate a random [`SealedHeader`].


### PR DESCRIPTION
This fixes https://github.com/paradigmxyz/reth/issues/13197, changing to `BlockWithParent` for all of the fields that are currently `SealedHeader` in `StageError`