### PR TITLE
chore: fix `cargo check -p reth-stages --tests`

### DIFF
--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -70,6 +70,7 @@ reth-network-p2p = { workspace = true, features = ["test-utils"] }
 reth-downloaders.workspace = true
 reth-revm.workspace = true
 reth-static-file.workspace = true
+reth-stages-api = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
 reth-trie = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }


### PR DESCRIPTION
Previously this would error because `test-utils` was not enabled by default when compiling tests