### PR TITLE
chore: remove unused trie-common alloy-serde dep

### DIFF
--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -57,7 +57,7 @@ serde_with.workspace = true
 
 [features]
 eip1186 = [
-    "dep:alloy-rpc-types-eth",
+    "alloy-rpc-types-eth/serde",
     "dep:alloy-serde",
 ]
 serde = [
@@ -88,7 +88,7 @@ test-utils = [
 arbitrary = [
 	"alloy-trie/arbitrary",
 	"dep:arbitrary",
-	"alloy-serde/arbitrary",
+    "alloy-serde?/arbitrary",
 	"reth-primitives-traits/arbitrary",
 	"alloy-consensus/arbitrary",
 	"alloy-primitives/arbitrary",


### PR DESCRIPTION
The `alloy-serde` dep is unused when just the `arbitrary` feature is present. The `serde` feature is enabled for `alloy-rpc-types-eth` alongside the dep when `eip1186` is enabled, because otherwise the proof type does not exist.

`cargo hack check --feature-powerset` also now works.