### PR TITLE
refactor: simplify and relax some RPC bounds

### DIFF
--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -3,7 +3,9 @@
 use alloc::vec::Vec;
 use core::fmt;
 
-use alloy_consensus::{TxReceipt, Typed2718};
+use alloy_consensus::{
+    Eip2718EncodableReceipt, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt, Typed2718,
+};
 use alloy_primitives::B256;
 
 use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
@@ -23,8 +25,9 @@ pub trait Receipt:
     + Default
     + fmt::Debug
     + TxReceipt<Log = alloy_primitives::Log>
-    + alloy_rlp::Encodable
-    + alloy_rlp::Decodable
+    + RlpEncodableReceipt
+    + RlpDecodableReceipt
+    + Eip2718EncodableReceipt
     + Typed2718
     + MaybeSerde
     + InMemorySize

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1215,7 +1215,6 @@ where
     pub fn register_trace(&mut self) -> &mut Self
     where
         EthApi: TraceExt,
-        Provider: BlockReader<Block = <EthApi::Provider as BlockReader>::Block>,
     {
         let trace_api = self.trace_api();
         self.modules.insert(RethRpcModule::Trace, trace_api.into_rpc().into());
@@ -1276,12 +1275,11 @@ where
     /// # Panics
     ///
     /// If called outside of the tokio runtime. See also [`Self::eth_api`]
-    pub fn trace_api(&self) -> TraceApi<Provider, EthApi>
+    pub fn trace_api(&self) -> TraceApi<EthApi>
     where
         EthApi: TraceExt,
     {
         TraceApi::new(
-            self.provider.clone(),
             self.eth_api().clone(),
             self.blocking_pool_guard.clone(),
         )
@@ -1305,14 +1303,13 @@ where
     /// # Panics
     ///
     /// If called outside of the tokio runtime. See also [`Self::eth_api`]
-    pub fn debug_api(&self) -> DebugApi<Provider, EthApi, BlockExecutor>
+    pub fn debug_api(&self) -> DebugApi<EthApi, BlockExecutor>
     where
         EthApi: EthApiSpec + EthTransactions + TraceExt,
         BlockExecutor:
             BlockExecutorProvider<Primitives: NodePrimitives<Block = reth_primitives::Block>>,
     {
         DebugApi::new(
-            self.provider.clone(),
             self.eth_api().clone(),
             self.blocking_pool_guard.clone(),
             self.block_executor.clone(),
@@ -1468,7 +1465,6 @@ where
                                 .into()
                         }
                         RethRpcModule::Debug => DebugApi::new(
-                            self.provider.clone(),
                             eth_api.clone(),
                             self.blocking_pool_guard.clone(),
                             self.block_executor.clone(),
@@ -1496,7 +1492,6 @@ where
                             NetApi::new(self.network.clone(), eth_api.clone()).into_rpc().into()
                         }
                         RethRpcModule::Trace => TraceApi::new(
-                            self.provider.clone(),
                             eth_api.clone(),
                             self.blocking_pool_guard.clone(),
                         )

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -204,7 +204,7 @@ use reth_consensus::FullConsensus;
 use reth_engine_primitives::EngineTypes;
 use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
-use reth_primitives::{EthPrimitives, NodePrimitives};
+use reth_primitives::NodePrimitives;
 use reth_provider::{
     AccountReader, BlockReader, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, FullRpcProvider, HeaderProvider, ProviderBlock, ProviderHeader,
@@ -815,7 +815,6 @@ where
         Provider: BlockReader<
             Block = <EthApi::Provider as BlockReader>::Block,
             Receipt = <EthApi::Provider as ReceiptProvider>::Receipt,
-            Header = <EthApi::Provider as HeaderProvider>::Header,
         >,
         Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     {
@@ -963,7 +962,7 @@ pub struct RpcRegistryInner<
     /// Holds the configuration for the RPC modules
     config: RpcModuleConfig,
     /// Holds a all `eth_` namespace handlers
-    eth: EthHandlers<Provider, Pool, Network, Events, EthApi>,
+    eth: EthHandlers<Provider, Events, EthApi>,
     /// to put trace calls behind semaphore
     blocking_pool_guard: BlockingTaskGuard,
     /// Contains the [Methods] of a module
@@ -1056,7 +1055,7 @@ where
     }
 
     /// Returns a reference to the installed [`EthHandlers`].
-    pub const fn eth_handlers(&self) -> &EthHandlers<Provider, Pool, Network, Events, EthApi> {
+    pub const fn eth_handlers(&self) -> &EthHandlers<Provider, Events, EthApi> {
         &self.eth
     }
 
@@ -1484,7 +1483,7 @@ where
                         }
                         RethRpcModule::Web3 => Web3Api::new(self.network.clone()).into_rpc().into(),
                         RethRpcModule::Txpool => TxPoolApi::new(
-                            self.pool.clone(),
+                            self.eth.api.pool().clone(),
                             self.eth.api.tx_resp_builder().clone(),
                         )
                         .into_rpc()

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -88,7 +88,6 @@ where
     Pool: TransactionPool + 'static,
     Events: CanonStateSubscriptions<
             Primitives: NodePrimitives<
-                SignedTx: Encodable2718,
                 BlockHeader = reth_primitives::Header,
                 Receipt = reth_primitives::Receipt,
             >,

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -17,8 +17,10 @@ use jsonrpsee::{
 };
 use reth_network_api::NetworkInfo;
 use reth_primitives::NodePrimitives;
-use reth_provider::{BlockReader, CanonStateSubscriptions, EvmEnvProvider};
-use reth_rpc_eth_api::{pubsub::EthPubSubApiServer, TransactionCompat};
+use reth_provider::{BlockNumReader, CanonStateSubscriptions};
+use reth_rpc_eth_api::{
+    pubsub::EthPubSubApiServer, EthApiTypes, RpcNodeCore, RpcTransaction, TransactionCompat,
+};
 use reth_rpc_eth_types::logs_utils;
 use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err};
 use reth_rpc_types_compat::transaction::from_recovered;
@@ -35,57 +37,37 @@ use tracing::error;
 ///
 /// This handles `eth_subscribe` RPC calls.
 #[derive(Clone)]
-pub struct EthPubSub<Provider, Pool, Events, Network, Eth> {
+pub struct EthPubSub<Eth, Events> {
     /// All nested fields bundled together.
-    inner: Arc<EthPubSubInner<Provider, Pool, Events, Network>>,
+    inner: Arc<EthPubSubInner<Eth, Events>>,
     /// The type that's used to spawn subscription tasks.
     subscription_task_spawner: Box<dyn TaskSpawner>,
-    tx_resp_builder: Eth,
 }
 
 // === impl EthPubSub ===
 
-impl<Provider, Pool, Events, Network, Eth> EthPubSub<Provider, Pool, Events, Network, Eth> {
+impl<Eth, Events> EthPubSub<Eth, Events> {
     /// Creates a new, shareable instance.
     ///
     /// Subscription tasks are spawned via [`tokio::task::spawn`]
-    pub fn new(
-        provider: Provider,
-        pool: Pool,
-        chain_events: Events,
-        network: Network,
-        tx_resp_builder: Eth,
-    ) -> Self {
-        Self::with_spawner(
-            provider,
-            pool,
-            chain_events,
-            network,
-            Box::<TokioTaskExecutor>::default(),
-            tx_resp_builder,
-        )
+    pub fn new(eth_api: Eth, chain_events: Events) -> Self {
+        Self::with_spawner(eth_api, chain_events, Box::<TokioTaskExecutor>::default())
     }
 
     /// Creates a new, shareable instance.
     pub fn with_spawner(
-        provider: Provider,
-        pool: Pool,
+        eth_api: Eth,
         chain_events: Events,
-        network: Network,
         subscription_task_spawner: Box<dyn TaskSpawner>,
-        tx_resp_builder: Eth,
     ) -> Self {
-        let inner = EthPubSubInner { provider, pool, chain_events, network };
-        Self { inner: Arc::new(inner), subscription_task_spawner, tx_resp_builder }
+        let inner = EthPubSubInner { eth_api, chain_events };
+        Self { inner: Arc::new(inner), subscription_task_spawner }
     }
 }
 
 #[async_trait::async_trait]
-impl<Provider, Pool, Events, Network, Eth> EthPubSubApiServer<Eth::Transaction>
-    for EthPubSub<Provider, Pool, Events, Network, Eth>
+impl<Eth, Events> EthPubSubApiServer<RpcTransaction<Eth::NetworkTypes>> for EthPubSub<Eth, Events>
 where
-    Provider: BlockReader + EvmEnvProvider + Clone + 'static,
-    Pool: TransactionPool + 'static,
     Events: CanonStateSubscriptions<
             Primitives: NodePrimitives<
                 BlockHeader = reth_primitives::Header,
@@ -93,8 +75,9 @@ where
             >,
         > + Clone
         + 'static,
-    Network: NetworkInfo + Clone + 'static,
-    Eth: TransactionCompat<PoolConsensusTx<Pool>> + 'static,
+    Eth: RpcNodeCore<Provider: BlockNumReader, Pool: TransactionPool, Network: NetworkInfo>
+        + EthApiTypes<TransactionCompat: TransactionCompat<PoolConsensusTx<Eth::Pool>>>
+        + 'static,
 {
     /// Handler for `eth_subscribe`
     async fn subscribe(
@@ -105,9 +88,8 @@ where
     ) -> jsonrpsee::core::SubscriptionResult {
         let sink = pending.accept().await?;
         let pubsub = self.inner.clone();
-        let resp_builder = self.tx_resp_builder.clone();
         self.subscription_task_spawner.spawn(Box::pin(async move {
-            let _ = handle_accepted(pubsub, sink, kind, params, resp_builder).await;
+            let _ = handle_accepted(pubsub, sink, kind, params).await;
         }));
 
         Ok(())
@@ -115,16 +97,13 @@ where
 }
 
 /// The actual handler for an accepted [`EthPubSub::subscribe`] call.
-async fn handle_accepted<Provider, Pool, Events, Network, Eth>(
-    pubsub: Arc<EthPubSubInner<Provider, Pool, Events, Network>>,
+async fn handle_accepted<Eth, Events>(
+    pubsub: Arc<EthPubSubInner<Eth, Events>>,
     accepted_sink: SubscriptionSink,
     kind: SubscriptionKind,
     params: Option<Params>,
-    tx_resp_builder: Eth,
 ) -> Result<(), ErrorObject<'static>>
 where
-    Provider: BlockReader + EvmEnvProvider + Clone + 'static,
-    Pool: TransactionPool + 'static,
     Events: CanonStateSubscriptions<
             Primitives: NodePrimitives<
                 SignedTx: Encodable2718,
@@ -133,8 +112,8 @@ where
             >,
         > + Clone
         + 'static,
-    Network: NetworkInfo + Clone + 'static,
-    Eth: TransactionCompat<PoolConsensusTx<Pool>>,
+    Eth: RpcNodeCore<Provider: BlockNumReader, Pool: TransactionPool, Network: NetworkInfo>
+        + EthApiTypes<TransactionCompat: TransactionCompat<PoolConsensusTx<Eth::Pool>>>,
 {
     match kind {
         SubscriptionKind::NewHeads => {
@@ -165,7 +144,7 @@ where
                         let stream = pubsub.full_pending_transaction_stream().filter_map(|tx| {
                             let tx_value = match from_recovered(
                                 tx.transaction.to_consensus(),
-                                &tx_resp_builder,
+                                pubsub.eth_api.tx_resp_builder(),
                             ) {
                                 Ok(tx) => {
                                     Some(EthSubscriptionResult::FullTransaction(Box::new(tx)))
@@ -203,7 +182,7 @@ where
             let mut canon_state =
                 BroadcastStream::new(pubsub.chain_events.subscribe_to_canonical_state());
             // get current sync status
-            let mut initial_sync_status = pubsub.network.is_syncing();
+            let mut initial_sync_status = pubsub.eth_api.network().is_syncing();
             let current_sub_res = pubsub.sync_status(initial_sync_status);
 
             // send the current status immediately
@@ -214,7 +193,7 @@ where
             }
 
             while canon_state.next().await.is_some() {
-                let current_syncing = pubsub.network.is_syncing();
+                let current_syncing = pubsub.eth_api.network().is_syncing();
                 // Only send a new response if the sync status has changed
                 if current_syncing != initial_sync_status {
                     // Update the sync status on each new block
@@ -284,9 +263,7 @@ where
     }
 }
 
-impl<Provider, Pool, Events, Network, Eth> std::fmt::Debug
-    for EthPubSub<Provider, Pool, Events, Network, Eth>
-{
+impl<Eth, Events> std::fmt::Debug for EthPubSub<Eth, Events> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EthPubSub").finish_non_exhaustive()
     }
@@ -294,28 +271,28 @@ impl<Provider, Pool, Events, Network, Eth> std::fmt::Debug
 
 /// Container type `EthPubSub`
 #[derive(Clone)]
-struct EthPubSubInner<Provider, Pool, Events, Network> {
-    /// The transaction pool.
-    pool: Pool,
-    /// The provider that can interact with the chain.
-    provider: Provider,
+struct EthPubSubInner<EthApi, Events> {
+    /// The `eth` API.
+    eth_api: EthApi,
     /// A type that allows to create new event subscriptions.
     chain_events: Events,
-    /// The network.
-    network: Network,
 }
 
 // == impl EthPubSubInner ===
 
-impl<Provider, Pool, Events, Network> EthPubSubInner<Provider, Pool, Events, Network>
+impl<Eth, Events> EthPubSubInner<Eth, Events>
 where
-    Provider: BlockReader + 'static,
+    Eth: RpcNodeCore<Provider: BlockNumReader>,
 {
     /// Returns the current sync status for the `syncing` subscription
     fn sync_status(&self, is_syncing: bool) -> EthSubscriptionResult {
         if is_syncing {
-            let current_block =
-                self.provider.chain_info().map(|info| info.best_number).unwrap_or_default();
+            let current_block = self
+                .eth_api
+                .provider()
+                .chain_info()
+                .map(|info| info.best_number)
+                .unwrap_or_default();
             EthSubscriptionResult::SyncState(PubSubSyncStatus::Detailed(SyncStatusMetadata {
                 syncing: true,
                 starting_block: 0,
@@ -328,35 +305,31 @@ where
     }
 }
 
-impl<Provider, Pool, Events, Network> EthPubSubInner<Provider, Pool, Events, Network>
+impl<Eth, Events> EthPubSubInner<Eth, Events>
 where
-    Pool: TransactionPool + 'static,
+    Eth: RpcNodeCore<Pool: TransactionPool>,
 {
     /// Returns a stream that yields all transaction hashes emitted by the txpool.
     fn pending_transaction_hashes_stream(&self) -> impl Stream<Item = TxHash> {
-        ReceiverStream::new(self.pool.pending_transactions_listener())
+        ReceiverStream::new(self.eth_api.pool().pending_transactions_listener())
     }
 
     /// Returns a stream that yields all transactions emitted by the txpool.
     fn full_pending_transaction_stream(
         &self,
-    ) -> impl Stream<Item = NewTransactionEvent<<Pool as TransactionPool>::Transaction>> {
-        self.pool.new_pending_pool_transactions_listener()
+    ) -> impl Stream<Item = NewTransactionEvent<<Eth::Pool as TransactionPool>::Transaction>> {
+        self.eth_api.pool().new_pending_pool_transactions_listener()
     }
 }
 
-impl<Provider, Pool, Events, Network> EthPubSubInner<Provider, Pool, Events, Network>
+impl<Eth, Events> EthPubSubInner<Eth, Events>
 where
-    Provider: BlockReader + EvmEnvProvider + 'static,
     Events: CanonStateSubscriptions<
-            Primitives: NodePrimitives<
-                SignedTx: Encodable2718,
-                BlockHeader = reth_primitives::Header,
-                Receipt = reth_primitives::Receipt,
-            >,
-        > + 'static,
-    Network: NetworkInfo + 'static,
-    Pool: 'static,
+        Primitives: NodePrimitives<
+            BlockHeader = reth_primitives::Header,
+            Receipt = reth_primitives::Receipt,
+        >,
+    >,
 {
     /// Returns a stream that yields all new RPC blocks.
     fn new_headers_stream(&self) -> impl Stream<Item = Header> {

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -13,9 +13,7 @@ use alloy_rpc_types_trace::{
     tracerequest::TraceCallRequest,
 };
 use async_trait::async_trait;
-use reth_provider::HeaderProvider;
 use jsonrpsee::core::RpcResult;
-use reth_provider::BlockNumReader;
 use reth_chainspec::EthereumHardforks;
 use reth_consensus_common::calc::{
     base_block_reward, base_block_reward_pre_merge, block_reward, ommer_reward,

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -20,7 +20,7 @@ use reth_consensus_common::calc::{
 };
 use reth_evm::ConfigureEvmEnv;
 use reth_primitives_traits::{BlockBody, BlockHeader};
-use reth_provider::{BlockReader, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
+use reth_provider::{BlockNumReader, BlockReader, ChainSpecProvider, HeaderProvider};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::TraceApiServer;
 use reth_rpc_eth_api::{helpers::TraceExt, FromEthApiError, RpcNodeCore};

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -1,4 +1,6 @@
-use alloy_consensus::{BlobTransactionValidationError, EnvKzgSettings, Transaction, TxReceipt};
+use alloy_consensus::{
+    BlobTransactionValidationError, BlockHeader, EnvKzgSettings, Transaction, TxReceipt,
+};
 use alloy_eips::{eip4844::kzg_to_versioned_hash, eip7685::RequestsOrHash};
 use alloy_rpc_types_beacon::relay::{
     BidTrace, BuilderBlockValidationRequest, BuilderBlockValidationRequestV2,
@@ -16,10 +18,10 @@ use reth_errors::{BlockExecutionError, ConsensusError, ProviderError};
 use reth_ethereum_consensus::GAS_LIMIT_BOUND_DIVISOR;
 use reth_evm::execute::{BlockExecutorProvider, Executor};
 use reth_payload_validator::ExecutionPayloadValidator;
-use reth_primitives::{Block, GotExpected, NodePrimitives, SealedBlockWithSenders, SealedHeader};
+use reth_primitives::{GotExpected, NodePrimitives, SealedBlockWithSenders, SealedHeader};
+use reth_primitives_traits::{Block as _, BlockBody};
 use reth_provider::{
-    BlockExecutionInput, BlockExecutionOutput, BlockReaderIdExt, HeaderProvider,
-    StateProviderFactory, WithdrawalsProvider,
+    BlockExecutionInput, BlockExecutionOutput, BlockReaderIdExt, StateProviderFactory,
 };
 use reth_revm::{cached::CachedReads, database::StateProviderDatabase};
 use reth_rpc_api::BlockSubmissionValidationApiServer;
@@ -32,7 +34,7 @@ use tokio::sync::{oneshot, RwLock};
 
 /// The type that implements the `validation` rpc namespace trait
 #[derive(Clone, Debug, derive_more::Deref)]
-pub struct ValidationApi<Provider: ChainSpecProvider, E> {
+pub struct ValidationApi<Provider: ChainSpecProvider, E: BlockExecutorProvider> {
     #[deref]
     inner: Arc<ValidationApiInner<Provider, E>>,
 }
@@ -40,11 +42,12 @@ pub struct ValidationApi<Provider: ChainSpecProvider, E> {
 impl<Provider, E> ValidationApi<Provider, E>
 where
     Provider: ChainSpecProvider,
+    E: BlockExecutorProvider,
 {
     /// Create a new instance of the [`ValidationApi`]
     pub fn new(
         provider: Provider,
-        consensus: Arc<dyn FullConsensus>,
+        consensus: Arc<dyn FullConsensus<E::Primitives>>,
         executor_provider: E,
         config: ValidationApiConfig,
         task_spawner: Box<dyn TaskSpawner>,
@@ -91,20 +94,18 @@ where
     Provider: BlockReaderIdExt<Header = reth_primitives::Header>
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
-        + HeaderProvider
-        + WithdrawalsProvider
         + 'static,
     E: BlockExecutorProvider<
         Primitives: NodePrimitives<
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
+            BlockHeader = Provider::Header,
+            BlockBody = reth_primitives::BlockBody,
         >,
     >,
 {
     /// Validates the given block and a [`BidTrace`] against it.
     pub async fn validate_message_against_block(
         &self,
-        block: SealedBlockWithSenders,
+        block: SealedBlockWithSenders<<E::Primitives as NodePrimitives>::Block>,
         message: BidTrace,
         registered_gas_limit: u64,
     ) -> Result<(), ValidationApiError> {
@@ -186,9 +187,9 @@ where
         let state_root =
             state_provider.state_root(state_provider.hashed_post_state(&output.state))?;
 
-        if state_root != block.state_root {
+        if state_root != block.header().state_root() {
             return Err(ConsensusError::BodyStateRootDiff(
-                GotExpected { got: state_root, expected: block.state_root }.into(),
+                GotExpected { got: state_root, expected: block.header().state_root() }.into(),
             )
             .into())
         }
@@ -261,7 +262,7 @@ where
     /// to checking the latest block transaction.
     fn ensure_payment(
         &self,
-        block: &Block,
+        block: &<E::Primitives as NodePrimitives>::Block,
         output: &BlockExecutionOutput<<E::Primitives as NodePrimitives>::Receipt>,
         message: &BidTrace,
     ) -> Result<(), ValidationApiError> {
@@ -278,7 +279,7 @@ where
             (U256::ZERO, U256::ZERO)
         };
 
-        if let Some(withdrawals) = &block.body.withdrawals {
+        if let Some(withdrawals) = block.body().withdrawals() {
             for withdrawal in withdrawals {
                 if withdrawal.address == message.proposer_fee_recipient {
                     balance_before += withdrawal.amount_wei();
@@ -293,7 +294,7 @@ where
         let (receipt, tx) = output
             .receipts
             .last()
-            .zip(block.body.transactions.last())
+            .zip(block.body().transactions().last())
             .ok_or(ValidationApiError::ProposerPayment)?;
 
         if !receipt.status() {
@@ -312,7 +313,7 @@ where
             return Err(ValidationApiError::ProposerPayment)
         }
 
-        if let Some(block_base_fee) = block.base_fee_per_gas {
+        if let Some(block_base_fee) = block.header().base_fee_per_gas() {
             if tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0 {
                 return Err(ValidationApiError::ProposerPayment)
             }
@@ -411,14 +412,12 @@ where
     Provider: BlockReaderIdExt<Header = reth_primitives::Header>
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
-        + HeaderProvider
-        + WithdrawalsProvider
         + Clone
         + 'static,
     E: BlockExecutorProvider<
         Primitives: NodePrimitives<
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
+            BlockHeader = Provider::Header,
+            BlockBody = reth_primitives::BlockBody,
         >,
     >,
 {
@@ -474,11 +473,11 @@ where
 }
 
 #[derive(Debug)]
-pub struct ValidationApiInner<Provider: ChainSpecProvider, E> {
+pub struct ValidationApiInner<Provider: ChainSpecProvider, E: BlockExecutorProvider> {
     /// The provider that can interact with the chain.
     provider: Provider,
     /// Consensus implementation.
-    consensus: Arc<dyn FullConsensus>,
+    consensus: Arc<dyn FullConsensus<E::Primitives>>,
     /// Execution payload validator.
     payload_validator: ExecutionPayloadValidator<Provider::ChainSpec>,
     /// Block executor factory.

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -18,7 +18,7 @@ use reth_evm::execute::{BlockExecutorProvider, Executor};
 use reth_payload_validator::ExecutionPayloadValidator;
 use reth_primitives::{Block, GotExpected, NodePrimitives, SealedBlockWithSenders, SealedHeader};
 use reth_provider::{
-    AccountReader, BlockExecutionInput, BlockExecutionOutput, BlockReaderIdExt, HeaderProvider,
+    BlockExecutionInput, BlockExecutionOutput, BlockReaderIdExt, HeaderProvider,
     StateProviderFactory, WithdrawalsProvider,
 };
 use reth_revm::{cached::CachedReads, database::StateProviderDatabase};
@@ -92,7 +92,6 @@ where
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + HeaderProvider
-        + AccountReader
         + WithdrawalsProvider
         + 'static,
     E: BlockExecutorProvider<
@@ -413,7 +412,6 @@ where
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + HeaderProvider
-        + AccountReader
         + WithdrawalsProvider
         + Clone
         + 'static,


### PR DESCRIPTION
This PR updates `DebugApi`, `TraceApi`, `EthPubSub` and `EthFilters` so that they obtain provider and network handle from `EthApi` which is required to hold both through `RpcNodeCore`. This allowed to simplify some of the bounds

Additionally this relaxes bounds for `DebugApi` to not depend on concrete primitives and for `ValidationApi` to not depend on concrete receipt type, further abstraction of `ValidationApi` is blocked by abstraction of `ExecutionPayloadValidator` over block and payload