### PR TITLE
chore: flip tx conversion impl

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1267,7 +1267,8 @@ impl PoolTransaction for EthPooledTransaction {
         tx: RecoveredTx<Self::Consensus>,
     ) -> Result<RecoveredTx<Self::Pooled>, Self::TryFromConsensusError> {
         let (tx, signer) = tx.to_components();
-        let pooled = PooledTransactionsElement::try_from_broadcast(tx)
+        let pooled = tx
+            .try_into_pooled()
             .map_err(|_| TryFromRecoveredTransactionError::BlobSidecarMissing)?;
         Ok(RecoveredTx::from_signed_transaction(pooled, signer))
     }


### PR DESCRIPTION
as prep for 

https://github.com/alloy-rs/alloy/pull/1767

will make it easier to phase out `PooledTransactionElement`