### PR TITLE
chore: move calculate tx root to blockbody trait

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -7,9 +7,8 @@ use alloy_eips::{
 };
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::ConsensusError;
-use reth_primitives::{
-    BlockBody, BlockBodyTxExt, EthereumHardfork, GotExpected, SealedBlock, SealedHeader,
-};
+use reth_primitives::{BlockBody, EthereumHardfork, GotExpected, SealedBlock, SealedHeader};
+use reth_primitives_traits::BlockBody as _;
 use revm_primitives::calc_excess_blob_gas;
 
 /// Gas used needs to be less than gas limit. Gas used is going to be checked after execution.

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloc::{fmt, vec::Vec};
 use alloy_consensus::Transaction;
 use alloy_eips::{eip2718::Encodable2718, eip4844::DATA_GAS_PER_BLOB, eip4895::Withdrawals};
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, B256};
 
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
 pub trait FullBlockBody: BlockBody<Transaction: FullSignedTx> {}
@@ -43,6 +43,11 @@ pub trait BlockBody:
 
     /// Consume the block body and return a [`Vec`] of transactions.
     fn into_transactions(self) -> Vec<Self::Transaction>;
+
+    /// Calculate the transaction root for the block body.
+    fn calculate_tx_root(&self) -> B256 {
+        alloy_consensus::proofs::calculate_transaction_root(self.transactions())
+    }
 
     /// Returns block withdrawals if any.
     fn withdrawals(&self) -> Option<&Withdrawals>;

--- a/crates/primitives/src/traits.rs
+++ b/crates/primitives/src/traits.rs
@@ -3,7 +3,6 @@ use crate::{
     BlockWithSenders, SealedBlock,
 };
 use alloc::vec::Vec;
-use alloy_eips::eip2718::Encodable2718;
 use reth_primitives_traits::{Block, BlockBody, SealedHeader, SignedTransaction};
 use revm_primitives::{Address, B256};
 
@@ -91,14 +90,6 @@ impl<T: Block> BlockExt for T {}
 
 /// Extension trait for [`BlockBody`] adding helper methods operating with transactions.
 pub trait BlockBodyTxExt: BlockBody {
-    /// Calculate the transaction root for the block body.
-    fn calculate_tx_root(&self) -> B256
-    where
-        Self::Transaction: Encodable2718,
-    {
-        crate::proofs::calculate_transaction_root(self.transactions())
-    }
-
     /// Recover signer addresses for all transactions in the block body.
     fn recover_signers(&self) -> Option<Vec<Address>>
     where


### PR DESCRIPTION
we moved the calc root function to alloy, so we can now make this a default impl on BlockBody directly