### PR TITLE
feat: introduce `StaticFileSegment::BlockMeta`

### DIFF
--- a/book/cli/reth/db/clear/static-file.md
+++ b/book/cli/reth/db/clear/static-file.md
@@ -14,6 +14,7 @@ Arguments:
           - headers:      Static File segment responsible for the `CanonicalHeaders`, `Headers`, `HeaderTerminalDifficulties` tables
           - transactions: Static File segment responsible for the `Transactions` table
           - receipts:     Static File segment responsible for the `Receipts` table
+          - block-meta:   Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`, `BlockWithdrawals` tables
 
 Options:
       --instance <INSTANCE>

--- a/book/cli/reth/db/get/static-file.md
+++ b/book/cli/reth/db/get/static-file.md
@@ -14,6 +14,7 @@ Arguments:
           - headers:      Static File segment responsible for the `CanonicalHeaders`, `Headers`, `HeaderTerminalDifficulties` tables
           - transactions: Static File segment responsible for the `Transactions` table
           - receipts:     Static File segment responsible for the `Receipts` table
+          - block-meta:   Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`, `BlockWithdrawals` tables
 
   <KEY>
           The key to get content for

--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -72,6 +72,7 @@ impl Command {
                     StaticFileSegment::Receipts => {
                         (table_key::<tables::Receipts>(&key)?, <ReceiptMask<ReceiptTy<N>>>::MASK)
                     }
+                    StaticFileSegment::BlockMeta => todo!(), // TODO(joshie),
                 };
 
                 let content = tool.provider_factory.static_file_provider().find_static_file(
@@ -112,6 +113,9 @@ impl Command {
                                         content[0].as_slice(),
                                     )?;
                                     println!("{}", serde_json::to_string_pretty(&receipt)?);
+                                }
+                                StaticFileSegment::BlockMeta => {
+                                    todo!() // TODO(joshie)
                                 }
                             }
                         }

--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -72,7 +72,7 @@ impl Command {
                     StaticFileSegment::Receipts => {
                         (table_key::<tables::Receipts>(&key)?, <ReceiptMask<ReceiptTy<N>>>::MASK)
                     }
-                    StaticFileSegment::BlockMeta => todo!(), // TODO(joshie),
+                    StaticFileSegment::BlockMeta => todo!(),
                 };
 
                 let content = tool.provider_factory.static_file_provider().find_static_file(
@@ -115,7 +115,7 @@ impl Command {
                                     println!("{}", serde_json::to_string_pretty(&receipt)?);
                                 }
                                 StaticFileSegment::BlockMeta => {
-                                    todo!() // TODO(joshie)
+                                    todo!()
                                 }
                             }
                         }

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -337,7 +337,7 @@ mod tests {
             StaticFileTargets {
                 headers: Some(0..=1),
                 receipts: Some(0..=1),
-                transactions: Some(0..=1)
+                transactions: Some(0..=1),
                 block_meta: Some(0..=1)
             }
         );
@@ -360,7 +360,8 @@ mod tests {
             StaticFileTargets {
                 headers: Some(2..=3),
                 receipts: Some(2..=3),
-                transactions: Some(2..=3)
+                transactions: Some(2..=3),
+                block_meta: Some(2..=3)
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
@@ -382,7 +383,7 @@ mod tests {
             StaticFileTargets {
                 headers: Some(4..=4),
                 receipts: Some(4..=4),
-                transactions: Some(4..=4)
+                transactions: Some(4..=4),
                 block_meta: Some(4..=4)
             }
         );
@@ -420,6 +421,7 @@ mod tests {
                         headers: Some(1),
                         receipts: Some(1),
                         transactions: Some(1),
+                        block_meta: Some(1),
                     })
                     .expect("get static file targets");
                 assert_matches!(locked_producer.run(targets.clone()), Ok(_));

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -228,10 +228,7 @@ where
                 )
             }),
             block_meta: finalized_block_numbers.block_meta.and_then(|finalized_block_number| {
-                self.get_static_file_target(
-                    highest_static_files.block_meta,
-                    finalized_block_number,
-                )
+                self.get_static_file_target(highest_static_files.block_meta, finalized_block_number)
             }),
         };
 
@@ -329,7 +326,7 @@ mod tests {
                 headers: Some(1),
                 receipts: Some(1),
                 transactions: Some(1),
-                block_meta: Some(1),
+                block_meta: None,
             })
             .expect("get static file targets");
         assert_eq!(
@@ -338,13 +335,18 @@ mod tests {
                 headers: Some(0..=1),
                 receipts: Some(0..=1),
                 transactions: Some(0..=1),
-                block_meta: Some(0..=1)
+                block_meta: None
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles { headers: Some(1), receipts: Some(1), transactions: Some(1), block_meta: Some(1) }
+            HighestStaticFiles {
+                headers: Some(1),
+                receipts: Some(1),
+                transactions: Some(1),
+                block_meta: None
+            }
         );
 
         let targets = static_file_producer
@@ -352,7 +354,7 @@ mod tests {
                 headers: Some(3),
                 receipts: Some(3),
                 transactions: Some(3),
-                block_meta: Some(3),
+                block_meta: None,
             })
             .expect("get static file targets");
         assert_eq!(
@@ -361,13 +363,18 @@ mod tests {
                 headers: Some(2..=3),
                 receipts: Some(2..=3),
                 transactions: Some(2..=3),
-                block_meta: Some(2..=3)
+                block_meta: None
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3), block_meta: Some(3) }
+            HighestStaticFiles {
+                headers: Some(3),
+                receipts: Some(3),
+                transactions: Some(3),
+                block_meta: None
+            }
         );
 
         let targets = static_file_producer
@@ -375,7 +382,7 @@ mod tests {
                 headers: Some(4),
                 receipts: Some(4),
                 transactions: Some(4),
-                block_meta: Some(4),
+                block_meta: None,
             })
             .expect("get static file targets");
         assert_eq!(
@@ -384,7 +391,7 @@ mod tests {
                 headers: Some(4..=4),
                 receipts: Some(4..=4),
                 transactions: Some(4..=4),
-                block_meta: Some(4..=4)
+                block_meta: None
             }
         );
         assert_matches!(
@@ -393,7 +400,12 @@ mod tests {
         );
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3), block_meta: Some(3) }
+            HighestStaticFiles {
+                headers: Some(3),
+                receipts: Some(3),
+                transactions: Some(3),
+                block_meta: None
+            }
         );
     }
 

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -227,6 +227,12 @@ where
                     finalized_block_number,
                 )
             }),
+            block_meta: finalized_block_numbers.block_meta.and_then(|finalized_block_number| {
+                self.get_static_file_target(
+                    highest_static_files.block_meta,
+                    finalized_block_number,
+                )
+            }),
         };
 
         trace!(
@@ -323,6 +329,7 @@ mod tests {
                 headers: Some(1),
                 receipts: Some(1),
                 transactions: Some(1),
+                block_meta: Some(1),
             })
             .expect("get static file targets");
         assert_eq!(
@@ -331,12 +338,13 @@ mod tests {
                 headers: Some(0..=1),
                 receipts: Some(0..=1),
                 transactions: Some(0..=1)
+                block_meta: Some(0..=1)
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles { headers: Some(1), receipts: Some(1), transactions: Some(1) }
+            HighestStaticFiles { headers: Some(1), receipts: Some(1), transactions: Some(1), block_meta: Some(1) }
         );
 
         let targets = static_file_producer
@@ -344,6 +352,7 @@ mod tests {
                 headers: Some(3),
                 receipts: Some(3),
                 transactions: Some(3),
+                block_meta: Some(3),
             })
             .expect("get static file targets");
         assert_eq!(
@@ -357,7 +366,7 @@ mod tests {
         assert_matches!(static_file_producer.run(targets), Ok(_));
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3) }
+            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3), block_meta: Some(3) }
         );
 
         let targets = static_file_producer
@@ -365,6 +374,7 @@ mod tests {
                 headers: Some(4),
                 receipts: Some(4),
                 transactions: Some(4),
+                block_meta: Some(4),
             })
             .expect("get static file targets");
         assert_eq!(
@@ -373,6 +383,7 @@ mod tests {
                 headers: Some(4..=4),
                 receipts: Some(4..=4),
                 transactions: Some(4..=4)
+                block_meta: Some(4..=4)
             }
         );
         assert_matches!(
@@ -381,7 +392,7 @@ mod tests {
         );
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3) }
+            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3), block_meta: Some(3) }
         );
     }
 

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -187,6 +187,7 @@ where
             headers: stages_checkpoints[0],
             receipts: stages_checkpoints[1],
             transactions: stages_checkpoints[2],
+            block_meta: stages_checkpoints[2],
         };
         let targets = self.get_static_file_targets(highest_static_files)?;
         self.run(targets)?;

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -433,7 +433,7 @@ mod tests {
                         headers: Some(1),
                         receipts: Some(1),
                         transactions: Some(1),
-                        block_meta: Some(1),
+                        block_meta: None,
                     })
                     .expect("get static file targets");
                 assert_matches!(locked_producer.run(targets.clone()), Ok(_));

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -33,6 +33,9 @@ pub struct HighestStaticFiles {
     /// Highest static file block of transactions, inclusive.
     /// If [`None`], no static file is available.
     pub transactions: Option<BlockNumber>,
+    /// Highest static file block of transactions, inclusive.
+    /// If [`None`], no static file is available.
+    pub block_meta: Option<BlockNumber>,
 }
 
 impl HighestStaticFiles {
@@ -42,6 +45,7 @@ impl HighestStaticFiles {
             StaticFileSegment::Headers => self.headers,
             StaticFileSegment::Transactions => self.transactions,
             StaticFileSegment::Receipts => self.receipts,
+            StaticFileSegment::BlockMeta => self.block_meta,
         }
     }
 
@@ -51,17 +55,24 @@ impl HighestStaticFiles {
             StaticFileSegment::Headers => &mut self.headers,
             StaticFileSegment::Transactions => &mut self.transactions,
             StaticFileSegment::Receipts => &mut self.receipts,
+            StaticFileSegment::BlockMeta => &mut self.block_meta,
         }
     }
 
     /// Returns the minimum block of all segments.
     pub fn min_block_num(&self) -> Option<u64> {
-        [self.headers, self.transactions, self.receipts].iter().filter_map(|&option| option).min()
+        [self.headers, self.transactions, self.receipts, self.block_meta]
+            .iter()
+            .filter_map(|&option| option)
+            .min()
     }
 
     /// Returns the maximum block of all segments.
     pub fn max_block_num(&self) -> Option<u64> {
-        [self.headers, self.transactions, self.receipts].iter().filter_map(|&option| option).max()
+        [self.headers, self.transactions, self.receipts, self.block_meta]
+            .iter()
+            .filter_map(|&option| option)
+            .max()
     }
 }
 

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -92,7 +92,10 @@ pub struct StaticFileTargets {
 impl StaticFileTargets {
     /// Returns `true` if any of the targets are [Some].
     pub const fn any(&self) -> bool {
-        self.headers.is_some() || self.receipts.is_some() || self.transactions.is_some() || self.block_meta.is_some()
+        self.headers.is_some() ||
+            self.receipts.is_some() ||
+            self.transactions.is_some() ||
+            self.block_meta.is_some()
     }
 
     /// Returns `true` if all targets are either [`None`] or has beginning of the range equal to the

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -85,12 +85,14 @@ pub struct StaticFileTargets {
     pub receipts: Option<RangeInclusive<BlockNumber>>,
     /// Targeted range of transactions.
     pub transactions: Option<RangeInclusive<BlockNumber>>,
+    /// Targeted range of block meta.
+    pub block_meta: Option<RangeInclusive<BlockNumber>>,
 }
 
 impl StaticFileTargets {
     /// Returns `true` if any of the targets are [Some].
     pub const fn any(&self) -> bool {
-        self.headers.is_some() || self.receipts.is_some() || self.transactions.is_some()
+        self.headers.is_some() || self.receipts.is_some() || self.transactions.is_some() || self.block_meta.is_some()
     }
 
     /// Returns `true` if all targets are either [`None`] or has beginning of the range equal to the
@@ -100,6 +102,7 @@ impl StaticFileTargets {
             (self.headers.as_ref(), static_files.headers),
             (self.receipts.as_ref(), static_files.receipts),
             (self.transactions.as_ref(), static_files.transactions),
+            (self.block_meta.as_ref(), static_files.block_meta),
         ]
         .iter()
         .all(|(target_block_range, highest_static_fileted_block)| {
@@ -129,8 +132,12 @@ mod tests {
 
     #[test]
     fn test_highest_static_files_highest() {
-        let files =
-            HighestStaticFiles { headers: Some(100), receipts: Some(200), transactions: None };
+        let files = HighestStaticFiles {
+            headers: Some(100),
+            receipts: Some(200),
+            transactions: None,
+            block_meta: None,
+        };
 
         // Test for headers segment
         assert_eq!(files.highest(StaticFileSegment::Headers), Some(100));
@@ -157,12 +164,20 @@ mod tests {
         // Modify transactions value
         *files.as_mut(StaticFileSegment::Transactions) = Some(350);
         assert_eq!(files.transactions, Some(350));
+
+        // Modify block meta value
+        *files.as_mut(StaticFileSegment::BlockMeta) = Some(350);
+        assert_eq!(files.block_meta, Some(350));
     }
 
     #[test]
     fn test_highest_static_files_min() {
-        let files =
-            HighestStaticFiles { headers: Some(300), receipts: Some(100), transactions: None };
+        let files = HighestStaticFiles {
+            headers: Some(300),
+            receipts: Some(100),
+            transactions: None,
+            block_meta: None,
+        };
 
         // Minimum value among the available segments
         assert_eq!(files.min_block_num(), Some(100));
@@ -174,8 +189,12 @@ mod tests {
 
     #[test]
     fn test_highest_static_files_max() {
-        let files =
-            HighestStaticFiles { headers: Some(300), receipts: Some(100), transactions: Some(500) };
+        let files = HighestStaticFiles {
+            headers: Some(300),
+            receipts: Some(100),
+            transactions: Some(500),
+            block_meta: Some(500),
+        };
 
         // Maximum value among the available segments
         assert_eq!(files.max_block_num(), Some(500));

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -59,20 +59,19 @@ impl HighestStaticFiles {
         }
     }
 
+    /// Returns an iterator over all static file segments
+    fn iter(&self) -> impl Iterator<Item = Option<BlockNumber>> {
+        [self.headers, self.transactions, self.receipts, self.block_meta].into_iter()
+    }
+
     /// Returns the minimum block of all segments.
     pub fn min_block_num(&self) -> Option<u64> {
-        [self.headers, self.transactions, self.receipts, self.block_meta]
-            .iter()
-            .filter_map(|&option| option)
-            .min()
+        self.iter().flatten().min()
     }
 
     /// Returns the maximum block of all segments.
     pub fn max_block_num(&self) -> Option<u64> {
-        [self.headers, self.transactions, self.receipts, self.block_meta]
-            .iter()
-            .filter_map(|&option| option)
-            .max()
+        self.iter().flatten().max()
     }
 }
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -58,8 +58,7 @@ impl StaticFileSegment {
     /// Returns the number of columns for the segment
     pub const fn columns(&self) -> usize {
         match self {
-            Self::Headers => 3,
-            Self::BlockMeta => 3,
+            Self::Headers | Self::BlockMeta => 3,
             Self::Transactions | Self::Receipts => 1,
         }
     }
@@ -261,14 +260,12 @@ impl SegmentHeader {
                     range.end = range.end.saturating_sub(num);
                 }
             };
-        } else {
-            if let Some(range) = &mut self.tx_range {
-                if num > range.end - range.start {
-                    self.tx_range = None;
-                } else {
-                    range.end = range.end.saturating_sub(num);
-                }
-            };
+        } else if let Some(range) = &mut self.tx_range {
+            if num > range.end - range.start {
+                self.tx_range = None;
+            } else {
+                range.end = range.end.saturating_sub(num);
+            }
         }
     }
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -35,7 +35,8 @@ pub enum StaticFileSegment {
     /// Static File segment responsible for the `Receipts` table.
     Receipts,
     #[strum(serialize = "block_meta")]
-    /// Static File segment responsible for the `Receipts` table.
+    /// Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`,
+    /// `BlockWithdrawals` tables.
     BlockMeta,
 }
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -34,7 +34,7 @@ pub enum StaticFileSegment {
     #[strum(serialize = "receipts")]
     /// Static File segment responsible for the `Receipts` table.
     Receipts,
-    #[strum(serialize = "block_meta")]
+    #[strum(serialize = "bmeta")]
     /// Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`,
     /// `BlockWithdrawals` tables.
     BlockMeta,

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -3,7 +3,7 @@ use alloy_primitives::TxNumber;
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use std::{ops::RangeInclusive, str::FromStr};
-use strum::{AsRefStr, EnumIter, EnumString};
+use strum::{AsRefStr, EnumString};
 
 #[derive(
     Debug,
@@ -17,7 +17,6 @@ use strum::{AsRefStr, EnumIter, EnumString};
     Deserialize,
     Serialize,
     EnumString,
-    EnumIter,
     AsRefStr,
     Display,
 )]
@@ -34,7 +33,7 @@ pub enum StaticFileSegment {
     #[strum(serialize = "receipts")]
     /// Static File segment responsible for the `Receipts` table.
     Receipts,
-    #[strum(serialize = "bmeta")]
+    #[strum(serialize = "blockmeta")]
     /// Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`,
     /// `BlockWithdrawals` tables.
     BlockMeta,
@@ -49,6 +48,13 @@ impl StaticFileSegment {
             Self::Receipts => "receipts",
             Self::BlockMeta => "blockmeta",
         }
+    }
+
+    /// Returns an iterator over all segments.
+    pub fn iter() -> impl Iterator<Item = Self> {
+        // The order of segments is significant and must be maintained to ensure correctness. For
+        // example, Transactions require BlockBodyIndices from Blockmeta to be sound.
+        [Self::Headers, Self::BlockMeta, Self::Transactions, Self::Receipts].into_iter()
     }
 
     /// Returns the default configuration of the segment.
@@ -361,7 +367,6 @@ mod tests {
     use super::*;
     use alloy_primitives::hex;
     use reth_nippy_jar::NippyJar;
-    use strum::IntoEnumIterator;
 
     #[test]
     fn test_filename() {

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -50,7 +50,7 @@ add_static_file_mask! {
 }
 add_static_file_mask! {
     #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]
-    OmmerMask, <BlockOmmers as Table>::Value, 0b010
+    OmmerMask<H>, H, 0b010
 }
 add_static_file_mask! {
     #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -1,10 +1,10 @@
 use crate::{
     add_static_file_mask,
     static_file::mask::{ColumnSelectorOne, ColumnSelectorTwo},
-    BlockBodyIndices, BlockOmmers, BlockWithdrawals, HeaderTerminalDifficulties,
+    BlockBodyIndices, BlockWithdrawals, HeaderTerminalDifficulties,
 };
 use alloy_primitives::BlockHash;
-use reth_db_api::table::Table;
+use reth_db_api::{models::StoredBlockOmmers, table::Table};
 
 // HEADER MASKS
 add_static_file_mask! {
@@ -46,13 +46,13 @@ add_static_file_mask! {
 // BLOCK_META MASKS
 add_static_file_mask! {
     #[doc = "Mask for a `StoredBlockBodyIndices` from BlockMeta static file segment"]
-    BodyIndiceMask, <BlockBodyIndices as Table>::Value, 0b001
+    BodyIndicesMask, <BlockBodyIndices as Table>::Value, 0b001
+}
+add_static_file_mask! {
+    #[doc = "Mask for a `StoredBlockOmmers` from BlockMeta static file segment"]
+    OmmersMask<H>, StoredBlockOmmers<H>, 0b010
 }
 add_static_file_mask! {
     #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]
-    OmmerMask<H>, H, 0b010
-}
-add_static_file_mask! {
-    #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]
-    WithdrawalMask, <BlockWithdrawals as Table>::Value, 0b100
+    WithdrawalsMask, <BlockWithdrawals as Table>::Value, 0b100
 }

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -1,7 +1,7 @@
 use crate::{
     add_static_file_mask,
     static_file::mask::{ColumnSelectorOne, ColumnSelectorTwo},
-    HeaderTerminalDifficulties,
+    BlockBodyIndices, BlockOmmers, BlockWithdrawals, HeaderTerminalDifficulties,
 };
 use alloy_primitives::BlockHash;
 use reth_db_api::table::Table;
@@ -41,4 +41,18 @@ add_static_file_mask! {
 add_static_file_mask! {
     #[doc = "Mask for selecting a single transaction from Transactions static file segment"]
     TransactionMask<T>, T, 0b1
+}
+
+// BLOCK_META MASKS
+add_static_file_mask! {
+    #[doc = "Mask for a `StoredBlockBodyIndices` from BlockMeta static file segment"]
+    BodyIndiceMask, <BlockBodyIndices as Table>::Value, 0b001
+}
+add_static_file_mask! {
+    #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]
+    OmmerMask, <BlockOmmers as Table>::Value, 0b010
+}
+add_static_file_mask! {
+    #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]
+    WithdrawalMask, <BlockWithdrawals as Table>::Value, 0b100
 }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -7,11 +7,7 @@ use crate::{
     TransactionsProvider,
 };
 use alloy_consensus::transaction::TransactionMeta;
-use alloy_eips::{
-    eip2718::Encodable2718,
-    eip4895::{Withdrawal, Withdrawals},
-    BlockHashOrNumber,
-};
+use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawals, BlockHashOrNumber};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use reth_chainspec::ChainInfo;
 use reth_db::{
@@ -23,7 +19,7 @@ use reth_db::{
     table::{Decompress, Value},
 };
 use reth_node_types::{FullNodePrimitives, NodePrimitives};
-use reth_primitives::{transaction::recover_signers, SealedHeader};
+use reth_primitives::SealedHeader;
 use reth_primitives_traits::SignedTransaction;
 use reth_storage_api::{BlockBodyIndicesProvider, OmmersProvider, WithdrawalsProvider};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
@@ -369,11 +365,6 @@ impl<N: NodePrimitives> WithdrawalsProvider for StaticFileJarProvider<'_, N> {
             return Ok(self.cursor()?.get_one::<WithdrawalsMask>(num.into())?.map(|s| s.withdrawals))
         }
         // Only accepts block number queries
-        Err(ProviderError::UnsupportedProvider)
-    }
-
-    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
-        // Required data not present in static_files
         Err(ProviderError::UnsupportedProvider)
     }
 }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -17,8 +17,8 @@ use reth_chainspec::ChainInfo;
 use reth_db::{
     models::StoredBlockBodyIndices,
     static_file::{
-        BlockHashMask, BodyIndiceMask, HeaderMask, HeaderWithHashMask, OmmerMask, ReceiptMask,
-        StaticFileCursor, TDWithHashMask, TotalDifficultyMask, TransactionMask, WithdrawalMask,
+        BlockHashMask, BodyIndicesMask, HeaderMask, HeaderWithHashMask, OmmersMask, ReceiptMask,
+        StaticFileCursor, TDWithHashMask, TotalDifficultyMask, TransactionMask, WithdrawalsMask,
     },
     table::{Decompress, Value},
 };
@@ -366,9 +366,9 @@ impl<N: NodePrimitives> WithdrawalsProvider for StaticFileJarProvider<'_, N> {
         _: u64,
     ) -> ProviderResult<Option<Withdrawals>> {
         if let Some(num) = id.as_number() {
-            return Ok(self.cursor()?.get_one::<WithdrawalMask>(num.into())?.map(|s| s.withdrawals))
+            return Ok(self.cursor()?.get_one::<WithdrawalsMask>(num.into())?.map(|s| s.withdrawals))
         }
-        // Only accepts block number quries
+        // Only accepts block number queries
         Err(ProviderError::UnsupportedProvider)
     }
 
@@ -381,15 +381,18 @@ impl<N: NodePrimitives> WithdrawalsProvider for StaticFileJarProvider<'_, N> {
 impl<N: FullNodePrimitives<BlockHeader: Value>> OmmersProvider for StaticFileJarProvider<'_, N> {
     fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
         if let Some(num) = id.as_number() {
-            return Ok(self.cursor()?.get_one::<OmmerMask>(num.into())?.map(|s| s.ommers))
+            return Ok(self
+                .cursor()?
+                .get_one::<OmmersMask<Self::Header>>(num.into())?
+                .map(|s| s.ommers))
         }
-        // Only accepts block number quries
+        // Only accepts block number queries
         Err(ProviderError::UnsupportedProvider)
     }
 }
 
 impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileJarProvider<'_, N> {
     fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.cursor()?.get_one::<BodyIndiceMask>(num.into())
+        self.cursor()?.get_one::<BodyIndicesMask>(num.into())
     }
 }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -7,18 +7,25 @@ use crate::{
     TransactionsProvider,
 };
 use alloy_consensus::transaction::TransactionMeta;
-use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
+use alloy_eips::{
+    eip2718::Encodable2718,
+    eip4895::{Withdrawal, Withdrawals},
+    BlockHashOrNumber,
+};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use reth_chainspec::ChainInfo;
 use reth_db::{
+    models::StoredBlockBodyIndices,
     static_file::{
-        BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor,
-        TDWithHashMask, TotalDifficultyMask, TransactionMask,
+        BlockHashMask, BodyIndiceMask, HeaderMask, HeaderWithHashMask, OmmerMask, ReceiptMask,
+        StaticFileCursor, TDWithHashMask, TotalDifficultyMask, TransactionMask, WithdrawalMask,
     },
     table::{Decompress, Value},
 };
-use reth_node_types::NodePrimitives;
-use reth_primitives_traits::{SealedHeader, SignedTransaction};
+use reth_node_types::{FullNodePrimitives, NodePrimitives};
+use reth_primitives::{transaction::recover_signers, SealedHeader};
+use reth_primitives_traits::SignedTransaction;
+use reth_storage_api::{BlockBodyIndicesProvider, OmmersProvider, WithdrawalsProvider};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::{
     fmt::Debug,
@@ -349,5 +356,40 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction, Receipt: Decomp
             }
         }
         Ok(receipts)
+    }
+}
+
+impl<N: NodePrimitives> WithdrawalsProvider for StaticFileJarProvider<'_, N> {
+    fn withdrawals_by_block(
+        &self,
+        id: BlockHashOrNumber,
+        _: u64,
+    ) -> ProviderResult<Option<Withdrawals>> {
+        if let Some(num) = id.as_number() {
+            return Ok(self.cursor()?.get_one::<WithdrawalMask>(num.into())?.map(|s| s.withdrawals))
+        }
+        // Only accepts block number quries
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    fn latest_withdrawal(&self) -> ProviderResult<Option<Withdrawal>> {
+        // Required data not present in static_files
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl<N: FullNodePrimitives<BlockHeader: Value>> OmmersProvider for StaticFileJarProvider<'_, N> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
+        if let Some(num) = id.as_number() {
+            return Ok(self.cursor()?.get_one::<OmmerMask>(num.into())?.map(|s| s.ommers))
+        }
+        // Only accepts block number quries
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileJarProvider<'_, N> {
+    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        self.cursor()?.get_one::<BodyIndiceMask>(num.into())
     }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -48,7 +48,6 @@ use std::{
     path::{Path, PathBuf},
     sync::{mpsc, Arc},
 };
-use strum::IntoEnumIterator;
 use tracing::{info, trace, warn};
 
 /// Alias type for a map that can be queried for block ranges from a transaction
@@ -682,6 +681,11 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         };
 
         for segment in StaticFileSegment::iter() {
+            // Not integrated yet
+            if segment.is_block_meta() {
+                continue
+            }
+
             if has_receipt_pruning && segment.is_receipts() {
                 // Pruned nodes (including full node) do not store receipts as static files.
                 continue
@@ -780,7 +784,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     .ensure_invariants::<_, tables::BlockBodyIndices>(
                         provider,
                         segment,
-                        highest_tx,
+                        highest_block,
                         highest_block,
                     )?,
             } {
@@ -832,34 +836,39 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     where
         Provider: DBProvider + BlockReader + StageCheckpointReader,
     {
-        let highest_static_file_entry = highest_static_file_entry.unwrap_or_default();
-        let highest_static_file_block = highest_static_file_block.unwrap_or_default();
         let mut db_cursor = provider.tx_ref().cursor_read::<T>()?;
 
         if let Some((db_first_entry, _)) = db_cursor.first()? {
-            // If there is a gap between the entry found in static file and
-            // database, then we have most likely lost static file data and need to unwind so we can
-            // load it again
-            if !(db_first_entry <= highest_static_file_entry ||
-                highest_static_file_entry + 1 == db_first_entry)
+            if let (Some(highest_entry), Some(highest_block)) =
+                (highest_static_file_entry, highest_static_file_block)
             {
-                info!(
-                    target: "reth::providers::static_file",
-                    ?db_first_entry,
-                    ?highest_static_file_entry,
-                    unwind_target = highest_static_file_block,
-                    ?segment,
-                    "Setting unwind target."
-                );
-                return Ok(Some(highest_static_file_block))
+                // If there is a gap between the entry found in static file and
+                // database, then we have most likely lost static file data and need to unwind so we
+                // can load it again
+                if !(db_first_entry <= highest_entry || highest_entry + 1 == db_first_entry) {
+                    info!(
+                        target: "reth::providers::static_file",
+                        ?db_first_entry,
+                        ?highest_entry,
+                        unwind_target = highest_block,
+                        ?segment,
+                        "Setting unwind target."
+                    );
+                    return Ok(Some(highest_block))
+                }
             }
 
             if let Some((db_last_entry, _)) = db_cursor.last()? {
-                if db_last_entry > highest_static_file_entry {
+                if highest_static_file_entry
+                    .is_none_or(|highest_entry| db_last_entry > highest_entry)
+                {
                     return Ok(None)
                 }
             }
         }
+
+        let highest_static_file_entry = highest_static_file_entry.unwrap_or_default();
+        let highest_static_file_block = highest_static_file_block.unwrap_or_default();
 
         // If static file entry is ahead of the database entries, then ensure the checkpoint block
         // number matches.
@@ -900,6 +909,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 // TODO(joshie): is_block_meta
                 writer.prune_headers(highest_static_file_block - checkpoint_block_number)?;
             } else if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
+                // todo joshie: is querying block_body_indices a potential issue once bbi is moved
+                // to sf as well
                 let number = highest_static_file_entry - block.last_tx_num();
                 if segment.is_receipts() {
                     writer.prune_receipts(number, checkpoint_block_number)?;

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1666,25 +1666,56 @@ impl<N: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>>
 impl<N: NodePrimitives> WithdrawalsProvider for StaticFileProvider<N> {
     fn withdrawals_by_block(
         &self,
-        _id: BlockHashOrNumber,
-        _timestamp: u64,
+        id: BlockHashOrNumber,
+        _: u64,
     ) -> ProviderResult<Option<Withdrawals>> {
-        // Required data not present in static_files
+        if let Some(num) = id.as_number() {
+            return self
+                .get_segment_provider_from_block(StaticFileSegment::BlockMeta, num, None)
+                .and_then(|provider| provider.withdrawals_by_block(num))
+                .or_else(|err| {
+                    if let ProviderError::MissingStaticFileBlock(_, _) = err {
+                        Ok(None)
+                    } else {
+                        Err(err)
+                    }
+                })
+        }
+        // Only accepts block number quries
         Err(ProviderError::UnsupportedProvider)
     }
 }
 
 impl<N: FullNodePrimitives<BlockHeader: Value>> OmmersProvider for StaticFileProvider<N> {
-    fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
-        // Required data not present in static_files
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
+        if let Some(num) = id.as_number() {
+            return self
+                .get_segment_provider_from_block(StaticFileSegment::BlockMeta, num, None)
+                .and_then(|provider| provider.ommers(id))
+                .or_else(|err| {
+                    if let ProviderError::MissingStaticFileBlock(_, _) = err {
+                        Ok(None)
+                    } else {
+                        Err(err)
+                    }
+                })
+        }
+        // Only accepts block number quries
         Err(ProviderError::UnsupportedProvider)
     }
 }
 
-impl<N: Send + Sync> BlockBodyIndicesProvider for StaticFileProvider<N> {
-    fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        // Required data not present in static_files
-        Err(ProviderError::UnsupportedProvider)
+impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileProvider<N> {
+    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        self.get_segment_provider_from_block(StaticFileSegment::BlockMeta, num, None)
+            .and_then(|provider| provider.block_body_indices(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileBlock(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -862,9 +862,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let checkpoint_block_number = provider
             .get_stage_checkpoint(match segment {
                 StaticFileSegment::Headers => StageId::Headers,
-                StaticFileSegment::Transactions => StageId::Bodies,
+                StaticFileSegment::Transactions | StaticFileSegment::BlockMeta => StageId::Bodies,
                 StaticFileSegment::Receipts => StageId::Execution,
-                StaticFileSegment::BlockMeta => StageId::Bodies,
             })?
             .unwrap_or_default()
             .block_number;

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -33,6 +33,7 @@ pub(crate) struct StaticFileWriters<N> {
     headers: RwLock<Option<StaticFileProviderRW<N>>>,
     transactions: RwLock<Option<StaticFileProviderRW<N>>>,
     receipts: RwLock<Option<StaticFileProviderRW<N>>>,
+    block_meta: RwLock<Option<StaticFileProviderRW<N>>>,
 }
 
 impl<N> Default for StaticFileWriters<N> {
@@ -41,6 +42,7 @@ impl<N> Default for StaticFileWriters<N> {
             headers: Default::default(),
             transactions: Default::default(),
             receipts: Default::default(),
+            block_meta: Default::default(),
         }
     }
 }
@@ -55,7 +57,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             StaticFileSegment::Headers => self.headers.write(),
             StaticFileSegment::Transactions => self.transactions.write(),
             StaticFileSegment::Receipts => self.receipts.write(),
-            StaticFileSegment::BlockMeta => todo!(), // TODO(joshie),
+            StaticFileSegment::BlockMeta => self.block_meta.write(),
         };
 
         if write_guard.is_none() {

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -6,7 +6,7 @@ use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber, TxNumber, U256};
 use parking_lot::{lock_api::RwLockWriteGuard, RawRwLock, RwLock};
 use reth_codecs::Compact;
-use reth_db::models::StoredBlockBodyIndices;
+use reth_db::models::{StoredBlockBodyIndices, StoredBlockOmmers, StoredBlockWithdrawals};
 use reth_db_api::models::CompactU256;
 use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
 use reth_node_types::NodePrimitives;
@@ -234,7 +234,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 StaticFileSegment::Receipts => {
                     self.prune_receipt_data(to_delete, last_block_number.expect("should exist"))?
                 }
-                StaticFileSegment::BlockMeta => todo!(), // TODO(joshie),
+                StaticFileSegment::BlockMeta => todo!(),
             }
         }
 
@@ -557,9 +557,25 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         Ok(())
     }
 
+    /// Appends [`StoredBlockBodyIndices`], [`StoredBlockOmmers`] and [`StoredBlockWithdrawals`] to
+    /// static file.
+    ///
+    /// It **CALLS** `increment_block()` since it's a block based segment.
+    pub fn append_eth_block_meta(
+        &mut self,
+        body_indices: &StoredBlockBodyIndices,
+        ommers: &StoredBlockOmmers<N::BlockHeader>,
+        withdrawals: &StoredBlockWithdrawals,
+        expected_block_number: BlockNumber,
+    ) -> ProviderResult<()>
+    where
+        N::BlockHeader: Compact,
+    {
+        self.append_block_meta(body_indices, ommers, withdrawals, expected_block_number)
+    }
+
     /// Appends [`StoredBlockBodyIndices`] and any other two arbitrary types belonging to the block
-    /// body ([`reth_db::models::StoredBlockOmmers`] and
-    /// [`reth_db::models::StoredBlockWithdrawals`] on ethereum) to static file.
+    /// body to static file.
     ///
     /// It **CALLS** `increment_block()` since it's a block based segment.
     pub fn append_block_meta<F1, F2>(


### PR DESCRIPTION
Related to [History pre-merge sync#13186 ](https://github.com/paradigmxyz/reth/issues/13186) as this data would need to be provided as well.

Adds `StaticFileSegment::BlockMeta` which would contain:
* `BlockBodyIndices`
* `BlockOmmers`
* `BlockWithdrawals`

Only introduces the segment, alongside some of the future methods.

~~Side-effect: on booting up, it will create an empty block meta static file which won't be used.~~
Should have no side effects
