### PR TITLE
fix(trie): retain updates only for sparse branch nodes in the prefix set

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -623,6 +623,7 @@ impl<P> RevealedSparseTrie<P> {
                         ));
                         continue
                     }
+                    let retain_updates = self.updates.is_some() && prefix_set_contains(&path);
 
                     buffers.branch_child_buf.clear();
                     // Walk children in a reverse order from `f` to `0`, so we pop the `0` first
@@ -650,7 +651,7 @@ impl<P> RevealedSparseTrie<P> {
                                 buffers.rlp_node_stack.pop().unwrap();
 
                             // Update the masks only if we need to retain trie updates
-                            if self.updates.is_some() {
+                            if retain_updates {
                                 // Set the trie mask
                                 let tree_mask_value = if node_type.store_in_db_trie() {
                                     // A branch or an extension node explicitly set the
@@ -716,7 +717,7 @@ impl<P> RevealedSparseTrie<P> {
                     // Save a branch node update only if it's not a root node, and we need to
                     // persist updates.
                     let store_in_db_trie_value = if let Some(updates) =
-                        self.updates.as_mut().filter(|_| !path.is_empty())
+                        self.updates.as_mut().filter(|_| retain_updates && !path.is_empty())
                     {
                         let mut tree_mask_values = tree_mask_values.into_iter().rev();
                         let mut hash_mask_values = hash_mask_values.into_iter().rev();


### PR DESCRIPTION
If an extension node had a blinded child that we revealed and it turned out to be a branch node, this node will get included in the trie updates on a call to `rlp_node` even though its path wasn't in the prefix set https://github.com/paradigmxyz/reth/blob/da5ffc24c229f8b0b459213b536ad8e7396c7348/crates/trie/sparse/src/trie.rs#L839-L850

This PR checks that the branch node is in the prefix set before calculating the trie updates.