### PR TITLE
chore: rename HighestStaticFiles::min

### DIFF
--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -24,7 +24,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
         info!(target: "reth::cli", "Copying data from database to static files...");
         let static_file_producer =
             StaticFileProducer::new(provider_factory.clone(), prune_config.segments.clone());
-        let lowest_static_file_height = static_file_producer.lock().copy_to_static_files()?.min();
+        let lowest_static_file_height =
+            static_file_producer.lock().copy_to_static_files()?.min_block_num();
         info!(target: "reth::cli", ?lowest_static_file_height, "Copied data from database to static files");
 
         // Delete data which has been copied to static files.

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -58,7 +58,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         let highest_static_file_block = provider_factory
             .static_file_provider()
             .get_highest_static_files()
-            .max()
+            .max_block_num()
             .filter(|highest_static_file_block| *highest_static_file_block > target);
 
         // Execute a pipeline unwind if the start of the range overlaps the existing static

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -256,7 +256,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
     pub fn move_to_static_files(&self) -> RethResult<()> {
         // Copies data from database to static files
         let lowest_static_file_height =
-            self.static_file_producer.lock().copy_to_static_files()?.min();
+            self.static_file_producer.lock().copy_to_static_files()?.min_block_num();
 
         // Deletes data which has been copied to static files.
         if let Some(prune_tip) = lowest_static_file_height {

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -55,12 +55,12 @@ impl HighestStaticFiles {
     }
 
     /// Returns the minimum block of all segments.
-    pub fn min(&self) -> Option<u64> {
+    pub fn min_block_num(&self) -> Option<u64> {
         [self.headers, self.transactions, self.receipts].iter().filter_map(|&option| option).min()
     }
 
     /// Returns the maximum block of all segments.
-    pub fn max(&self) -> Option<u64> {
+    pub fn max_block_num(&self) -> Option<u64> {
         [self.headers, self.transactions, self.receipts].iter().filter_map(|&option| option).max()
     }
 }
@@ -154,11 +154,11 @@ mod tests {
             HighestStaticFiles { headers: Some(300), receipts: Some(100), transactions: None };
 
         // Minimum value among the available segments
-        assert_eq!(files.min(), Some(100));
+        assert_eq!(files.min_block_num(), Some(100));
 
         let empty_files = HighestStaticFiles::default();
         // No values, should return None
-        assert_eq!(empty_files.min(), None);
+        assert_eq!(empty_files.min_block_num(), None);
     }
 
     #[test]
@@ -167,11 +167,11 @@ mod tests {
             HighestStaticFiles { headers: Some(300), receipts: Some(100), transactions: Some(500) };
 
         // Maximum value among the available segments
-        assert_eq!(files.max(), Some(500));
+        assert_eq!(files.max_block_num(), Some(500));
 
         let empty_files = HighestStaticFiles::default();
         // No values, should return None
-        assert_eq!(empty_files.max(), None);
+        assert_eq!(empty_files.max_block_num(), None);
     }
 
     #[test]


### PR DESCRIPTION
My IDE was having trouble distinguishing this from the `min` method from `Ord` for some reason, so I just changed the name