### PR TITLE
feat(rpc): relax `VaidationApi` and `EngineApi`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8947,7 +8947,6 @@ dependencies = [
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
- "reth-payload-validator",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8939,6 +8939,7 @@ dependencies = [
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
+ "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-consensus",
  "reth-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9020,7 +9020,6 @@ dependencies = [
 name = "reth-rpc-builder"
 version = "1.1.2"
 dependencies = [
- "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -18,7 +18,7 @@ pub use alloy_rpc_types_engine::{
 };
 pub use payload::{EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_chainspec::ChainSpec;
-use reth_engine_primitives::{EngineTypes, EngineValidator};
+use reth_engine_primitives::{EngineTypes, EngineValidator, PayloadValidator};
 use reth_payload_primitives::{
     validate_version_specific_fields, EngineApiMessageVersion, EngineObjectValidationError,
     PayloadOrAttributes, PayloadTypes,
@@ -82,12 +82,22 @@ impl EthereumEngineValidator {
     }
 }
 
+impl PayloadValidator for EthereumEngineValidator {
+    type Block = Block;
+
+    fn ensure_well_formed_payload(
+        &self,
+        payload: ExecutionPayload,
+        sidecar: ExecutionPayloadSidecar,
+    ) -> Result<SealedBlock, PayloadError> {
+        self.inner.ensure_well_formed_payload(payload, sidecar)
+    }
+}
+
 impl<Types> EngineValidator<Types> for EthereumEngineValidator
 where
     Types: EngineTypes<PayloadAttributes = EthPayloadAttributes>,
 {
-    type Block = Block;
-
     fn validate_version_specific_fields(
         &self,
         version: EngineApiMessageVersion,
@@ -102,13 +112,5 @@ where
         attributes: &EthPayloadAttributes,
     ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(self.chain_spec(), version, attributes.into())
-    }
-
-    fn ensure_well_formed_payload(
-        &self,
-        payload: ExecutionPayload,
-        sidecar: ExecutionPayloadSidecar,
-    ) -> Result<SealedBlock, PayloadError> {
-        self.inner.ensure_well_formed_payload(payload, sidecar)
     }
 }

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -6,14 +6,13 @@ use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGenera
 use reth_beacon_consensus::EthBeaconConsensus;
 use reth_chainspec::ChainSpec;
 use reth_ethereum_engine_primitives::{
-    EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes, EthereumEngineValidator,
+    EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
 };
 use reth_evm::execute::BasicBlockExecutorProvider;
 use reth_evm_ethereum::execute::EthExecutionStrategyFactory;
 use reth_network::{NetworkHandle, PeersInfo};
 use reth_node_api::{
-    AddOnsContext, ConfigureEvm, EngineValidator, FullNodeComponents, HeaderTy, NodeTypesWithDB,
-    TxTy,
+    AddOnsContext, ConfigureEvm, FullNodeComponents, HeaderTy, NodeTypesWithDB, TxTy,
 };
 use reth_node_builder::{
     components::{
@@ -36,6 +35,8 @@ use reth_transaction_pool::{
 use reth_trie_db::MerklePatriciaTrie;
 
 use crate::{EthEngineTypes, EthEvmConfig};
+
+pub use reth_ethereum_engine_primitives::EthereumEngineValidator;
 
 /// Type configuration for a regular Ethereum node.
 #[derive(Debug, Default, Clone, Copy)]
@@ -353,9 +354,12 @@ pub struct EthereumEngineValidatorBuilder;
 
 impl<Node, Types> EngineValidatorBuilder<Node> for EthereumEngineValidatorBuilder
 where
-    Types: NodeTypesWithEngine<ChainSpec = ChainSpec>,
+    Types: NodeTypesWithEngine<
+        ChainSpec = ChainSpec,
+        Engine = EthEngineTypes,
+        Primitives = EthPrimitives,
+    >,
     Node: FullNodeComponents<Types = Types>,
-    EthereumEngineValidator: EngineValidator<Types::Engine>,
 {
     type Validator = EthereumEngineValidator;
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -10,8 +10,8 @@ use std::{
 use alloy_rpc_types::engine::ClientVersionV1;
 use futures::TryFutureExt;
 use reth_node_api::{
-    AddOnsContext, BlockTy, EngineValidator, FullNodeComponents, NodeAddOns, NodePrimitives,
-    NodeTypes, NodeTypesWithEngine,
+    AddOnsContext, BlockTy, EngineValidator, FullNodeComponents, NodeAddOns, NodeTypes,
+    NodeTypesWithEngine,
 };
 use reth_node_core::{
     node_config::NodeConfig,
@@ -403,15 +403,7 @@ where
 
 impl<N, EthApi, EV> RpcAddOns<N, EthApi, EV>
 where
-    N: FullNodeComponents<
-        Types: ProviderNodeTypes<
-            Primitives: NodePrimitives<
-                Block = reth_primitives::Block,
-                BlockHeader = reth_primitives::Header,
-                BlockBody = reth_primitives::BlockBody,
-            >,
-        >,
-    >,
+    N: FullNodeComponents,
     EthApi: EthApiTypes
         + FullEthApiServer<Provider = N::Provider, Pool = N::Pool, Network = N::Network>
         + AddDevSigners

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -10,8 +10,8 @@ use std::{
 use alloy_rpc_types::engine::ClientVersionV1;
 use futures::TryFutureExt;
 use reth_node_api::{
-    AddOnsContext, EngineValidator, FullNodeComponents, NodeAddOns, NodePrimitives, NodeTypes,
-    NodeTypesWithEngine,
+    AddOnsContext, BlockTy, EngineValidator, FullNodeComponents, NodeAddOns, NodePrimitives,
+    NodeTypes, NodeTypesWithEngine,
 };
 use reth_node_core::{
     node_config::NodeConfig,
@@ -33,6 +33,7 @@ use reth_rpc_builder::{
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::{debug, info};
+use std::sync::Arc;
 
 use crate::EthApiBuilderCtx;
 
@@ -449,7 +450,7 @@ where
             Box::new(node.task_executor().clone()),
             client,
             EngineCapabilities::default(),
-            engine_validator,
+            engine_validator.clone(),
         );
         info!(target: "reth::cli", "Engine API handler initialized");
 
@@ -466,7 +467,12 @@ where
             .with_evm_config(node.evm_config().clone())
             .with_block_executor(node.block_executor().clone())
             .with_consensus(node.consensus().clone())
-            .build_with_auth_server(module_config, engine_api, eth_api_builder);
+            .build_with_auth_server(
+                module_config,
+                engine_api,
+                eth_api_builder,
+                Arc::new(engine_validator),
+            );
 
         // in dev mode we generate 20 random dev-signer accounts
         if config.dev.dev {
@@ -588,7 +594,8 @@ impl<N: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> EthApi
 /// Helper trait that provides the validator for the engine API
 pub trait EngineValidatorAddOn<Node: FullNodeComponents>: Send {
     /// The Validator type to use for the engine API.
-    type Validator: EngineValidator<<Node::Types as NodeTypesWithEngine>::Engine>;
+    type Validator: EngineValidator<<Node::Types as NodeTypesWithEngine>::Engine, Block = BlockTy<Node::Types>>
+        + Clone;
 
     /// Creates the engine validator for an engine API based node.
     fn engine_validator(
@@ -613,7 +620,8 @@ where
 /// A type that knows how to build the engine validator.
 pub trait EngineValidatorBuilder<Node: FullNodeComponents>: Send + Sync + Clone {
     /// The consensus implementation to build.
-    type Validator: EngineValidator<<Node::Types as NodeTypesWithEngine>::Engine>;
+    type Validator: EngineValidator<<Node::Types as NodeTypesWithEngine>::Engine, Block = BlockTy<Node::Types>>
+        + Clone;
 
     /// Creates the engine validator.
     fn build(
@@ -625,8 +633,10 @@ pub trait EngineValidatorBuilder<Node: FullNodeComponents>: Send + Sync + Clone 
 impl<Node, F, Fut, Validator> EngineValidatorBuilder<Node> for F
 where
     Node: FullNodeComponents,
-    Validator:
-        EngineValidator<<Node::Types as NodeTypesWithEngine>::Engine> + Clone + Unpin + 'static,
+    Validator: EngineValidator<<Node::Types as NodeTypesWithEngine>::Engine, Block = BlockTy<Node::Types>>
+        + Clone
+        + Unpin
+        + 'static,
     F: FnOnce(&AddOnsContext<'_, Node>) -> Fut + Send + Sync + Clone,
     Fut: Future<Output = eyre::Result<Validator>> + Send,
 {

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -12,7 +12,7 @@ use reth_node_api::{
         EngineObjectValidationError, MessageValidationKind, PayloadOrAttributes, PayloadTypes,
         VersionSpecificValidationError,
     },
-    validate_version_specific_fields, EngineTypes, EngineValidator,
+    validate_version_specific_fields, EngineTypes, EngineValidator, PayloadValidator,
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::{OpHardfork, OpHardforks};
@@ -77,12 +77,22 @@ impl OpEngineValidator {
     }
 }
 
+impl PayloadValidator for OpEngineValidator {
+    type Block = Block;
+
+    fn ensure_well_formed_payload(
+        &self,
+        payload: ExecutionPayload,
+        sidecar: ExecutionPayloadSidecar,
+    ) -> Result<SealedBlockFor<Self::Block>, PayloadError> {
+        self.inner.ensure_well_formed_payload(payload, sidecar)
+    }
+}
+
 impl<Types> EngineValidator<Types> for OpEngineValidator
 where
     Types: EngineTypes<PayloadAttributes = OpPayloadAttributes>,
 {
-    type Block = Block;
-
     fn validate_version_specific_fields(
         &self,
         version: EngineApiMessageVersion,
@@ -135,14 +145,6 @@ where
         }
 
         Ok(())
-    }
-
-    fn ensure_well_formed_payload(
-        &self,
-        payload: ExecutionPayload,
-        sidecar: ExecutionPayloadSidecar,
-    ) -> Result<SealedBlockFor<Self::Block>, PayloadError> {
-        self.inner.ensure_well_formed_payload(payload, sidecar)
     }
 }
 

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -238,7 +238,12 @@ impl<N: FullNodeComponents<Types: NodeTypes<Primitives = OpPrimitives>>> OpAddOn
 impl<N> NodeAddOns<N> for OpAddOns<N>
 where
     N: FullNodeComponents<
-        Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives, Storage = OpStorage>,
+        Types: NodeTypesWithEngine<
+            ChainSpec = OpChainSpec,
+            Primitives = OpPrimitives,
+            Storage = OpStorage,
+            Engine = OpEngineTypes,
+        >,
     >,
     OpEngineValidator: EngineValidator<<N::Types as NodeTypesWithEngine>::Engine>,
 {
@@ -283,7 +288,12 @@ where
 impl<N> RethRpcAddOns<N> for OpAddOns<N>
 where
     N: FullNodeComponents<
-        Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives, Storage = OpStorage>,
+        Types: NodeTypesWithEngine<
+            ChainSpec = OpChainSpec,
+            Primitives = OpPrimitives,
+            Storage = OpStorage,
+            Engine = OpEngineTypes,
+        >,
     >,
     OpEngineValidator: EngineValidator<<N::Types as NodeTypesWithEngine>::Engine>,
 {
@@ -296,8 +306,13 @@ where
 
 impl<N> EngineValidatorAddOn<N> for OpAddOns<N>
 where
-    N: FullNodeComponents<Types: NodeTypes<ChainSpec = OpChainSpec>>,
-    OpEngineValidator: EngineValidator<<N::Types as NodeTypesWithEngine>::Engine>,
+    N: FullNodeComponents<
+        Types: NodeTypesWithEngine<
+            ChainSpec = OpChainSpec,
+            Primitives = OpPrimitives,
+            Engine = OpEngineTypes,
+        >,
+    >,
 {
     type Validator = OpEngineValidator;
 
@@ -674,9 +689,12 @@ pub struct OpEngineValidatorBuilder;
 
 impl<Node, Types> EngineValidatorBuilder<Node> for OpEngineValidatorBuilder
 where
-    Types: NodeTypesWithEngine<ChainSpec = OpChainSpec>,
+    Types: NodeTypesWithEngine<
+        ChainSpec = OpChainSpec,
+        Primitives = OpPrimitives,
+        Engine = OpEngineTypes,
+    >,
     Node: FullNodeComponents<Types = Types>,
-    OpEngineValidator: EngineValidator<Types::Engine>,
 {
     type Validator = OpEngineValidator;
 

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -31,8 +31,6 @@ reth-transaction-pool.workspace = true
 reth-evm.workspace = true
 reth-engine-primitives.workspace = true
 
-alloy-consensus.workspace = true
-
 # rpc/net
 jsonrpsee = { workspace = true, features = ["server"] }
 tower-http = { workspace = true, features = ["full"] }

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -1,4 +1,3 @@
-use alloy_consensus::Header;
 use reth_evm::ConfigureEvm;
 use reth_primitives::NodePrimitives;
 use reth_provider::{BlockReader, CanonStateSubscriptions, EvmEnvProvider, StateProviderFactory};
@@ -62,7 +61,7 @@ where
         >,
     ) -> Self
     where
-        EvmConfig: ConfigureEvm<Header = Header>,
+        EvmConfig: ConfigureEvm<Header = Provider::Header>,
         Tasks: TaskSpawner + Clone + 'static,
     {
         let cache = EthStateCache::spawn_with(provider.clone(), config.cache, executor.clone());

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -187,7 +187,6 @@ use std::{
 };
 
 use crate::{auth::AuthRpcModule, error::WsHttpSamePortError, metrics::RpcRequestMetrics};
-use alloy_consensus::Header;
 use error::{ConflictingModules, RpcError, ServerKind};
 use eth::DynEthApiBuilder;
 use http::{header::AUTHORIZATION, HeaderMap};
@@ -298,12 +297,7 @@ where
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         >,
     >,
-    BlockExecutor: BlockExecutorProvider<
-        Primitives: NodePrimitives<
-            BlockHeader = reth_primitives::Header,
-            BlockBody = reth_primitives::BlockBody,
-        >,
-    >,
+    BlockExecutor: BlockExecutorProvider,
 {
     let module_config = module_config.into();
     server_config
@@ -652,6 +646,7 @@ where
     Provider: FullRpcProvider<
             Block = <Events::Primitives as NodePrimitives>::Block,
             Receipt = <Events::Primitives as NodePrimitives>::Receipt,
+            Header = <Events::Primitives as NodePrimitives>::BlockHeader,
         > + AccountReader
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
@@ -662,12 +657,7 @@ where
         Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         Transaction = <BlockExecutor::Primitives as NodePrimitives>::SignedTx,
     >,
-    BlockExecutor: BlockExecutorProvider<
-        Primitives: NodePrimitives<
-            BlockHeader = reth_primitives::Header,
-            BlockBody = reth_primitives::BlockBody,
-        >,
-    >,
+    BlockExecutor: BlockExecutorProvider,
     Consensus: reth_consensus::FullConsensus<BlockExecutor::Primitives> + Clone + 'static,
 {
     /// Configures all [`RpcModule`]s specific to the given [`TransportRpcModuleConfig`] which can
@@ -1019,7 +1009,7 @@ where
         payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
     ) -> Self
     where
-        EvmConfig: ConfigureEvm<Header = Header>,
+        EvmConfig: ConfigureEvm<Header = Provider::Header>,
     {
         let blocking_pool_guard = BlockingTaskGuard::new(config.eth.max_tracing_requests);
 
@@ -1360,12 +1350,7 @@ where
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         >,
     >,
-    BlockExecutor: BlockExecutorProvider<
-        Primitives: NodePrimitives<
-            BlockHeader = reth_primitives::Header,
-            BlockBody = reth_primitives::BlockBody,
-        >,
-    >,
+    BlockExecutor: BlockExecutorProvider,
     Consensus: reth_consensus::FullConsensus<BlockExecutor::Primitives> + Clone + 'static,
 {
     /// Configures the auth module that includes the

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -761,6 +761,7 @@ where
     /// use reth_rpc_builder::RpcModuleBuilder;
     /// use reth_tasks::TokioTaskExecutor;
     /// use reth_transaction_pool::noop::NoopTransactionPool;
+    /// use std::sync::Arc;
     ///
     /// fn init<Evm, Validator>(evm: Evm, validator: Validator)
     /// where

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1317,7 +1317,7 @@ where
     }
 
     /// Instantiates `ValidationApi`
-    pub fn validation_api(&self) -> ValidationApi<Provider, BlockExecutor>
+    pub fn validation_api(&self) -> ValidationApi<Provider, BlockExecutor, EthEngineTypes, EthereumEngineValidator>
     where
         Consensus: reth_consensus::FullConsensus<BlockExecutor::Primitives> + Clone + 'static,
     {
@@ -1327,6 +1327,7 @@ where
             self.block_executor.clone(),
             self.config.flashbots.clone(),
             Box::new(self.executor.clone()),
+            EthereumEngineValidator::new(self.chain_spec.clone()),
         )
     }
 }
@@ -1500,6 +1501,7 @@ where
                             self.block_executor.clone(),
                             self.config.flashbots.clone(),
                             Box::new(self.executor.clone()),
+                            EthereumEngineValidator::new(self.chain_spec.clone()),
                         )
                         .into_rpc()
                         .into(),

--- a/crates/rpc/rpc-builder/tests/it/middleware.rs
+++ b/crates/rpc/rpc-builder/tests/it/middleware.rs
@@ -5,6 +5,8 @@ use jsonrpsee::{
     types::Request,
     MethodResponse,
 };
+use reth_chainspec::MAINNET;
+use reth_ethereum_engine_primitives::EthereumEngineValidator;
 use reth_rpc::EthApi;
 use reth_rpc_builder::{RpcServerConfig, TransportRpcModuleConfig};
 use reth_rpc_eth_api::EthApiClient;
@@ -63,6 +65,7 @@ async fn test_rpc_middleware() {
     let modules = builder.build(
         TransportRpcModuleConfig::set_http(RpcModuleSelection::All),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
 
     let mylayer = MyMiddlewareLayer::default();

--- a/crates/rpc/rpc-builder/tests/it/startup.rs
+++ b/crates/rpc/rpc-builder/tests/it/startup.rs
@@ -1,7 +1,9 @@
 //! Startup tests
 
-use std::io;
+use std::{io, sync::Arc};
 
+use reth_chainspec::MAINNET;
+use reth_ethereum_engine_primitives::EthereumEngineValidator;
 use reth_rpc::EthApi;
 use reth_rpc_builder::{
     error::{RpcError, ServerKind, WsHttpSamePortError},
@@ -30,6 +32,7 @@ async fn test_http_addr_in_use() {
     let server = builder.build(
         TransportRpcModuleConfig::set_http(vec![RethRpcModule::Admin]),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
     let result =
         RpcServerConfig::http(Default::default()).with_http_address(addr).start(&server).await;
@@ -45,6 +48,7 @@ async fn test_ws_addr_in_use() {
     let server = builder.build(
         TransportRpcModuleConfig::set_ws(vec![RethRpcModule::Admin]),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
     let result = RpcServerConfig::ws(Default::default()).with_ws_address(addr).start(&server).await;
     let err = result.unwrap_err();
@@ -66,6 +70,7 @@ async fn test_launch_same_port_different_modules() {
         TransportRpcModuleConfig::set_ws(vec![RethRpcModule::Admin])
             .with_http(vec![RethRpcModule::Eth]),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
     let addr = test_address();
     let res = RpcServerConfig::ws(Default::default())
@@ -88,6 +93,7 @@ async fn test_launch_same_port_same_cors() {
         TransportRpcModuleConfig::set_ws(vec![RethRpcModule::Eth])
             .with_http(vec![RethRpcModule::Eth]),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
     let addr = test_address();
     let res = RpcServerConfig::ws(Default::default())
@@ -108,6 +114,7 @@ async fn test_launch_same_port_different_cors() {
         TransportRpcModuleConfig::set_ws(vec![RethRpcModule::Eth])
             .with_http(vec![RethRpcModule::Eth]),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
     let addr = test_address();
     let res = RpcServerConfig::ws(Default::default())

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -1,4 +1,7 @@
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
+};
 
 use alloy_rpc_types_engine::{ClientCode, ClientVersionV1};
 use reth_beacon_consensus::BeaconConsensusEngineHandle;
@@ -61,8 +64,11 @@ pub async fn launch_auth(secret: JwtSecret) -> AuthServerHandle {
 /// Launches a new server with http only with the given modules
 pub async fn launch_http(modules: impl Into<RpcModuleSelection>) -> RpcServerHandle {
     let builder = test_rpc_builder();
-    let server =
-        builder.build(TransportRpcModuleConfig::set_http(modules), Box::new(EthApi::with_spawner));
+    let server = builder.build(
+        TransportRpcModuleConfig::set_http(modules),
+        Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
+    );
     RpcServerConfig::http(Default::default())
         .with_http_address(test_address())
         .start(&server)
@@ -73,8 +79,11 @@ pub async fn launch_http(modules: impl Into<RpcModuleSelection>) -> RpcServerHan
 /// Launches a new server with ws only with the given modules
 pub async fn launch_ws(modules: impl Into<RpcModuleSelection>) -> RpcServerHandle {
     let builder = test_rpc_builder();
-    let server =
-        builder.build(TransportRpcModuleConfig::set_ws(modules), Box::new(EthApi::with_spawner));
+    let server = builder.build(
+        TransportRpcModuleConfig::set_ws(modules),
+        Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
+    );
     RpcServerConfig::ws(Default::default())
         .with_ws_address(test_address())
         .start(&server)
@@ -89,6 +98,7 @@ pub async fn launch_http_ws(modules: impl Into<RpcModuleSelection>) -> RpcServer
     let server = builder.build(
         TransportRpcModuleConfig::set_ws(modules.clone()).with_http(modules),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
     RpcServerConfig::ws(Default::default())
         .with_ws_address(test_address())
@@ -107,6 +117,7 @@ pub async fn launch_http_ws_same_port(modules: impl Into<RpcModuleSelection>) ->
     let server = builder.build(
         TransportRpcModuleConfig::set_ws(modules.clone()).with_http(modules),
         Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(MAINNET.clone())),
     );
     let addr = test_address();
     RpcServerConfig::ws(Default::default())

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -25,7 +25,7 @@ use reth_payload_primitives::{
     validate_payload_timestamp, EngineApiMessageVersion, PayloadBuilderAttributes,
     PayloadOrAttributes,
 };
-use reth_primitives::{Block, EthereumHardfork};
+use reth_primitives::EthereumHardfork;
 use reth_rpc_api::EngineApiServer;
 use reth_rpc_types_compat::engine::payload::{
     convert_payload_input_v2_to_payload, convert_to_payload_body_v1,
@@ -80,11 +80,7 @@ struct EngineApiInner<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec
 impl<Provider, EngineT, Pool, Validator, ChainSpec>
     EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
 where
-    Provider: HeaderProvider
-        + BlockReader<Block = reth_primitives::Block>
-        + StateProviderFactory
-        + EvmEnvProvider
-        + 'static,
+    Provider: HeaderProvider + BlockReader + StateProviderFactory + EvmEnvProvider + 'static,
     EngineT: EngineTypes,
     Pool: TransactionPool + 'static,
     Validator: EngineValidator<EngineT>,
@@ -573,7 +569,7 @@ where
         f: F,
     ) -> EngineApiResult<Vec<Option<R>>>
     where
-        F: Fn(Block) -> R + Send + 'static,
+        F: Fn(Provider::Block) -> R + Send + 'static,
         R: Send + 'static,
     {
         let len = hashes.len() as u64;
@@ -748,11 +744,7 @@ where
 impl<Provider, EngineT, Pool, Validator, ChainSpec> EngineApiServer<EngineT>
     for EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
 where
-    Provider: HeaderProvider
-        + BlockReader<Block = reth_primitives::Block>
-        + StateProviderFactory
-        + EvmEnvProvider
-        + 'static,
+    Provider: HeaderProvider + BlockReader + StateProviderFactory + EvmEnvProvider + 'static,
     EngineT: EngineTypes,
     Pool: TransactionPool + 'static,
     Validator: EngineValidator<EngineT>,
@@ -1045,7 +1037,7 @@ mod tests {
     use reth_engine_primitives::BeaconEngineMessage;
     use reth_ethereum_engine_primitives::{EthEngineTypes, EthereumEngineValidator};
     use reth_payload_builder::test_utils::spawn_test_payload_service;
-    use reth_primitives::SealedBlock;
+    use reth_primitives::{Block, SealedBlock};
     use reth_provider::test_utils::MockEthProvider;
     use reth_rpc_types_compat::engine::payload::execution_payload_from_sealed_block;
     use reth_tasks::TokioTaskExecutor;
@@ -1171,7 +1163,7 @@ mod tests {
             let expected = blocks
                 .iter()
                 .cloned()
-                .map(|b| Some(convert_to_payload_body_v1(b.unseal())))
+                .map(|b| Some(convert_to_payload_body_v1(b.unseal::<Block>())))
                 .collect::<Vec<_>>();
 
             let res = api.get_payload_bodies_by_range_v1(start, count).await.unwrap();
@@ -1213,7 +1205,7 @@ mod tests {
                     if first_missing_range.contains(&b.number) {
                         None
                     } else {
-                        Some(convert_to_payload_body_v1(b.unseal()))
+                        Some(convert_to_payload_body_v1(b.unseal::<Block>()))
                     }
                 })
                 .collect::<Vec<_>>();
@@ -1232,7 +1224,7 @@ mod tests {
                     {
                         None
                     } else {
-                        Some(convert_to_payload_body_v1(b.unseal()))
+                        Some(convert_to_payload_body_v1(b.unseal::<Block>()))
                     }
                 })
                 .collect::<Vec<_>>();

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -38,7 +38,7 @@ fn payload_body_roundtrip() {
         0..=99,
         BlockRangeParams { tx_count: 0..2, ..Default::default() },
     ) {
-        let unsealed = block.clone().unseal();
+        let unsealed = block.clone().unseal::<Block>();
         let payload_body: ExecutionPayloadBodyV1 = convert_to_payload_body_v1(unsealed);
 
         assert_eq!(

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -16,6 +16,7 @@ use reth_primitives::{
     proofs::{self},
     Block, BlockBody, BlockExt, SealedBlock, TransactionSigned,
 };
+use reth_primitives_traits::BlockBody as _;
 
 /// Converts [`ExecutionPayloadV1`] to [`Block`]
 pub fn try_payload_v1_to_block(payload: ExecutionPayloadV1) -> Result<Block, PayloadError> {
@@ -320,15 +321,13 @@ pub fn validate_block_hash(
 }
 
 /// Converts [`Block`] to [`ExecutionPayloadBodyV1`]
-pub fn convert_to_payload_body_v1(value: Block) -> ExecutionPayloadBodyV1 {
-    let transactions = value.body.transactions.into_iter().map(|tx| {
-        let mut out = Vec::new();
-        tx.encode_2718(&mut out);
-        out.into()
-    });
+pub fn convert_to_payload_body_v1(
+    value: impl reth_primitives_traits::Block,
+) -> ExecutionPayloadBodyV1 {
+    let transactions = value.body().transactions().iter().map(|tx| tx.encoded_2718().into());
     ExecutionPayloadBodyV1 {
         transactions: transactions.collect(),
-        withdrawals: value.body.withdrawals.map(Withdrawals::into_inner),
+        withdrawals: value.body().withdrawals().cloned().map(Withdrawals::into_inner),
     }
 }
 

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -36,7 +36,6 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-types.workspace = true
 reth-consensus.workspace = true
-reth-payload-validator.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -18,6 +18,7 @@ reth-primitives = { workspace = true, features = ["secp256k1"] }
 reth-primitives-traits.workspace = true
 reth-rpc-api.workspace = true
 reth-rpc-eth-api.workspace = true
+reth-engine-primitives.workspace = true
 reth-errors.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-provider.workspace = true

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -55,7 +55,7 @@ use reth_chainspec::{Chain, ChainSpec, ChainSpecProvider};
 use reth_node_api::{
     payload::{EngineApiMessageVersion, EngineObjectValidationError, PayloadOrAttributes},
     validate_version_specific_fields, AddOnsContext, EngineTypes, EngineValidator,
-    FullNodeComponents, PayloadAttributes, PayloadBuilderAttributes,
+    FullNodeComponents, PayloadAttributes, PayloadBuilderAttributes, PayloadValidator,
 };
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{
@@ -189,12 +189,22 @@ impl CustomEngineValidator {
     }
 }
 
+impl PayloadValidator for CustomEngineValidator {
+    type Block = Block;
+
+    fn ensure_well_formed_payload(
+        &self,
+        payload: ExecutionPayload,
+        sidecar: ExecutionPayloadSidecar,
+    ) -> Result<SealedBlockFor<Self::Block>, PayloadError> {
+        self.inner.ensure_well_formed_payload(payload, sidecar)
+    }
+}
+
 impl<T> EngineValidator<T> for CustomEngineValidator
 where
     T: EngineTypes<PayloadAttributes = CustomPayloadAttributes>,
 {
-    type Block = Block;
-
     fn validate_version_specific_fields(
         &self,
         version: EngineApiMessageVersion,
@@ -220,14 +230,6 @@ where
         Ok(())
     }
 
-    fn ensure_well_formed_payload(
-        &self,
-        payload: ExecutionPayload,
-        sidecar: ExecutionPayloadSidecar,
-    ) -> Result<SealedBlockFor<Self::Block>, PayloadError> {
-        self.inner.ensure_well_formed_payload(payload, sidecar)
-    }
-
     fn validate_payload_attributes_against_header(
         &self,
         _attr: &<T as PayloadTypes>::PayloadAttributes,
@@ -246,7 +248,11 @@ pub struct CustomEngineValidatorBuilder;
 impl<N> EngineValidatorBuilder<N> for CustomEngineValidatorBuilder
 where
     N: FullNodeComponents<
-        Types: NodeTypesWithEngine<Engine = CustomEngineTypes, ChainSpec = ChainSpec>,
+        Types: NodeTypesWithEngine<
+            Engine = CustomEngineTypes,
+            ChainSpec = ChainSpec,
+            Primitives = EthPrimitives,
+        >,
     >,
 {
     type Validator = CustomEngineValidator;

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -34,7 +34,9 @@ use reth::rpc::builder::{
 // Configuring the network parts, ideally also wouldn't need to think about this.
 use myrpc_ext::{MyRpcExt, MyRpcExtApiServer};
 use reth::{blockchain_tree::noop::NoopBlockchainTree, tasks::TokioTaskExecutor};
-use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider, EthereumNode};
+use reth_node_ethereum::{
+    node::EthereumEngineValidator, EthEvmConfig, EthExecutorProvider, EthereumNode,
+};
 use reth_provider::{test_utils::TestCanonStateSubscriptions, ChainSpecProvider};
 
 // Custom rpc extension
@@ -70,11 +72,15 @@ async fn main() -> eyre::Result<()> {
         .with_evm_config(EthEvmConfig::new(spec.clone()))
         .with_events(TestCanonStateSubscriptions::default())
         .with_block_executor(EthExecutorProvider::ethereum(provider.chain_spec()))
-        .with_consensus(EthBeaconConsensus::new(spec));
+        .with_consensus(EthBeaconConsensus::new(spec.clone()));
 
     // Pick which namespaces to expose.
     let config = TransportRpcModuleConfig::default().with_http([RethRpcModule::Eth]);
-    let mut server = rpc_builder.build(config, Box::new(EthApi::with_spawner));
+    let mut server = rpc_builder.build(
+        config,
+        Box::new(EthApi::with_spawner),
+        Arc::new(EthereumEngineValidator::new(spec)),
+    );
 
     // Add a custom rpc namespace
     let custom_rpc = MyRpcExt { provider };


### PR DESCRIPTION
Based on #13232 

Relaxes bounds for `ValidationApi` and `EngineApi`, migrating all of the RPC setup off the concrete primitives.

Changes:
- `Block` AT and `ensure_well_formed_payload` method are extracted from `EngineValidator` into a separate `PayloadValidator` which can be used to validate `ExecutionPayload`s without the need to know entire `EngineTypes`
- `Arc<dyn PayloadValidator>` is stored on rpc builder and rpc registry, and passed to `ValidationApi` to abastract the `ExecutionPayload` -> `Block` conversion. I didn't make it a generic because this would require adding an additional generic to `RpcRegistry` and all types that hold it including user-facing `RpcHandle` https://github.com/paradigmxyz/reth/blob/8f98b0fec3823c6298f4325785ba774c8e8888c0/crates/node/builder/src/rpc.rs#L192-L206
  A one way we could consider simplifying this is require users to implement engine validation traits directly on `Consensus`. This feels semantically right and should also allow make it easier to support nodes without engine