### PR TITLE
Return a propoer error code for txpool is full error

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -676,6 +676,9 @@ impl From<RpcPoolError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: RpcPoolError) -> Self {
         match error {
             RpcPoolError::Invalid(err) => err.into(),
+            RpcPoolError::TxPoolOverflow => {
+                rpc_error_with_code(EthRpcErrorCode::TransactionRejected.code(), error.to_string())
+            }
             error => internal_rpc_err(error.to_string()),
         }
     }


### PR DESCRIPTION
Currently, when reth's transaction pool is full, it returns an RPC error without a specific error code. This leads to two issues:
1. Users receive ambiguous errors with code = None in the response
2. Monitoring systems (like proxyd) cannot properly categorize and alert on pool overflow conditions since the error lacks a standard error code

**Solution**
Map the `RpcPoolError::TxPoolOverflow` error to a proper JSON-RPC error code by modifying the error conversion implementation:
```
impl From<RpcPoolError> for jsonrpsee_types::error::ErrorObject<'static> {
    fn from(error: RpcPoolError) -> Self {
        match error {
            RpcPoolError::Invalid(err) => err.into(),
            RpcPoolError::TxPoolOverflow => rpc_error_with_code(
                EthRpcErrorCode::TransactionRejected.code(),
                error.to_string()
            ),
            error => internal_rpc_err(error.to_string()),
        }
    }
}
```
**This change**:
1. Maps pool overflow errors to the standard TransactionRejected error code (-32003)
2. Maintains the descriptive error message "txpool is full"
3. Keeps other error handling behavior unchanged

**Benefits**
1. Users receive clear error responses with proper error codes
2. Monitoring systems can properly track and alert on pool overflow conditions
3. Better alignment with Ethereum JSON-RPC error code standards