### PR TITLE
feat(engine): add error logging in `state_hook`

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -283,7 +283,9 @@ where
         let state_hook = StateHookSender::new(self.tx.clone());
 
         move |state: &EvmState| {
-            let _ = state_hook.send(StateRootMessage::StateUpdate(state.clone()));
+            if let Err(error) = state_hook.send(StateRootMessage::StateUpdate(state.clone())) {
+                error!(target: "engine::root", ?error, "Failed to send state updater");
+            }
         }
     }
 

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -284,7 +284,7 @@ where
 
         move |state: &EvmState| {
             if let Err(error) = state_hook.send(StateRootMessage::StateUpdate(state.clone())) {
-                error!(target: "engine::root", ?error, "Failed to send state updater");
+                error!(target: "engine::root", ?error, "Failed to send state update");
             }
         }
     }


### PR DESCRIPTION
This PR adds error logging in the `state_hook` function.