### PR TITLE
chore: pass primiitves generic to `EngineApiTreeHandler` fields

### DIFF
--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -31,6 +31,7 @@ reth-consensus.workspace = true
 reth-node-types.workspace = true
 
 # ethereum
+alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
 

--- a/crates/engine/local/src/service.rs
+++ b/crates/engine/local/src/service.rs
@@ -52,7 +52,7 @@ where
     /// Processes requests.
     ///
     /// This type is responsible for processing incoming requests.
-    handler: EngineApiRequestHandler<EngineApiRequest<N::Engine>>,
+    handler: EngineApiRequestHandler<EngineApiRequest<N::Engine, N::Primitives>>,
     /// Receiver for incoming requests (from the engine API endpoint) that need to be processed.
     incoming_requests: EngineMessageStream<N::Engine>,
 }

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -17,7 +17,7 @@ pub use reth_engine_tree::{
 };
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network_p2p::EthBlockClient;
-use reth_node_types::{BlockTy, NodeTypesWithEngine};
+use reth_node_types::{BlockTy, NodeTypes, NodeTypesWithEngine};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_primitives::EthPrimitives;
 use reth_provider::{providers::BlockchainProvider2, ProviderFactory};
@@ -37,7 +37,9 @@ pub type EngineMessageStream<T> = Pin<Box<dyn Stream<Item = BeaconEngineMessage<
 /// Alias for chain orchestrator.
 type EngineServiceType<N, Client> = ChainOrchestrator<
     EngineHandler<
-        EngineApiRequestHandler<EngineApiRequest<<N as NodeTypesWithEngine>::Engine>>,
+        EngineApiRequestHandler<
+            EngineApiRequest<<N as NodeTypesWithEngine>::Engine, <N as NodeTypes>::Primitives>,
+        >,
         EngineMessageStream<<N as NodeTypesWithEngine>::Engine>,
         BasicBlockDownloader<Client>,
     >,

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -238,14 +238,14 @@ impl EngineApiKind {
 
 /// The request variants that the engine API handler can receive.
 #[derive(Debug)]
-pub enum EngineApiRequest<T: EngineTypes> {
+pub enum EngineApiRequest<T: EngineTypes, N: NodePrimitives> {
     /// A request received from the consensus engine.
     Beacon(BeaconEngineMessage<T>),
     /// Request to insert an already executed block, e.g. via payload building.
-    InsertExecutedBlock(ExecutedBlock),
+    InsertExecutedBlock(ExecutedBlock<N>),
 }
 
-impl<T: EngineTypes> Display for EngineApiRequest<T> {
+impl<T: EngineTypes, N: NodePrimitives> Display for EngineApiRequest<T, N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Beacon(msg) => msg.fmt(f),
@@ -256,14 +256,16 @@ impl<T: EngineTypes> Display for EngineApiRequest<T> {
     }
 }
 
-impl<T: EngineTypes> From<BeaconEngineMessage<T>> for EngineApiRequest<T> {
+impl<T: EngineTypes, N: NodePrimitives> From<BeaconEngineMessage<T>> for EngineApiRequest<T, N> {
     fn from(msg: BeaconEngineMessage<T>) -> Self {
         Self::Beacon(msg)
     }
 }
 
-impl<T: EngineTypes> From<EngineApiRequest<T>> for FromEngine<EngineApiRequest<T>> {
-    fn from(req: EngineApiRequest<T>) -> Self {
+impl<T: EngineTypes, N: NodePrimitives> From<EngineApiRequest<T, N>>
+    for FromEngine<EngineApiRequest<T, N>>
+{
+    fn from(req: EngineApiRequest<T, N>) -> Self {
         Self::Request(req)
     }
 }


### PR DESCRIPTION
Passes primitives down to parts of `EngineApiTreeHandler`. Didn't change any bounds yet