### PR TITLE
feat: make bodies downloader generic over header

### DIFF
--- a/crates/net/downloaders/src/bodies/noop.rs
+++ b/crates/net/downloaders/src/bodies/noop.rs
@@ -9,18 +9,24 @@ use std::{fmt::Debug, ops::RangeInclusive};
 /// A [`BodyDownloader`] implementation that does nothing.
 #[derive(Debug, Default)]
 #[non_exhaustive]
-pub struct NoopBodiesDownloader<B>(std::marker::PhantomData<B>);
+pub struct NoopBodiesDownloader<H, B> {
+    _header: std::marker::PhantomData<H>,
+    _body: std::marker::PhantomData<B>,
+}
 
-impl<B: Debug + Send + Sync + Unpin + 'static> BodyDownloader for NoopBodiesDownloader<B> {
+impl<H: Debug + Send + Sync + Unpin + 'static, B: Debug + Send + Sync + Unpin + 'static>
+    BodyDownloader for NoopBodiesDownloader<H, B>
+{
     type Body = B;
+    type Header = H;
 
     fn set_download_range(&mut self, _: RangeInclusive<BlockNumber>) -> DownloadResult<()> {
         Ok(())
     }
 }
 
-impl<B> Stream for NoopBodiesDownloader<B> {
-    type Item = Result<Vec<BlockResponse<alloy_consensus::Header, B>>, DownloadError>;
+impl<H, B> Stream for NoopBodiesDownloader<H, B> {
+    type Item = Result<Vec<BlockResponse<H, B>>, DownloadError>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/crates/net/downloaders/src/bodies/queue.rs
+++ b/crates/net/downloaders/src/bodies/queue.rs
@@ -1,5 +1,6 @@
 use super::request::BodiesRequestFuture;
 use crate::metrics::BodyDownloaderMetrics;
+use alloy_consensus::BlockHeader;
 use alloy_primitives::BlockNumber;
 use futures::{stream::FuturesUnordered, Stream};
 use futures_util::StreamExt;
@@ -19,18 +20,19 @@ use std::{
 /// The wrapper around [`FuturesUnordered`] that keeps information
 /// about the blocks currently being requested.
 #[derive(Debug)]
-pub(crate) struct BodiesRequestQueue<B: BodiesClient> {
+pub(crate) struct BodiesRequestQueue<H, B: BodiesClient> {
     /// Inner body request queue.
-    inner: FuturesUnordered<BodiesRequestFuture<B>>,
+    inner: FuturesUnordered<BodiesRequestFuture<H, B>>,
     /// The downloader metrics.
     metrics: BodyDownloaderMetrics,
     /// Last requested block number.
     pub(crate) last_requested_block_number: Option<BlockNumber>,
 }
 
-impl<B> BodiesRequestQueue<B>
+impl<H, B> BodiesRequestQueue<H, B>
 where
     B: BodiesClient + 'static,
+    H: BlockHeader,
 {
     /// Create new instance of request queue.
     pub(crate) fn new(metrics: BodyDownloaderMetrics) -> Self {
@@ -58,15 +60,15 @@ where
     pub(crate) fn push_new_request(
         &mut self,
         client: Arc<B>,
-        consensus: Arc<dyn Consensus<alloy_consensus::Header, B::Body>>,
-        request: Vec<SealedHeader>,
+        consensus: Arc<dyn Consensus<H, B::Body>>,
+        request: Vec<SealedHeader<H>>,
     ) {
         // Set last max requested block number
         self.last_requested_block_number = request
             .last()
             .map(|last| match self.last_requested_block_number {
-                Some(num) => last.number.max(num),
-                None => last.number,
+                Some(num) => last.number().max(num),
+                None => last.number(),
             })
             .or(self.last_requested_block_number);
         // Create request and push into the queue.
@@ -76,11 +78,12 @@ where
     }
 }
 
-impl<B> Stream for BodiesRequestQueue<B>
+impl<H, B> Stream for BodiesRequestQueue<H, B>
 where
+    H: BlockHeader + Send + Sync + Unpin + 'static,
     B: BodiesClient<Body: InMemorySize> + 'static,
 {
-    type Item = DownloadResult<Vec<BlockResponse<alloy_consensus::Header, B::Body>>>;
+    type Item = DownloadResult<Vec<BlockResponse<H, B::Body>>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.get_mut().inner.poll_next_unpin(cx)

--- a/crates/net/p2p/src/bodies/downloader.rs
+++ b/crates/net/p2p/src/bodies/downloader.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use std::{fmt::Debug, ops::RangeInclusive};
 
 /// Body downloader return type.
-pub type BodyDownloaderResult<B> = DownloadResult<Vec<BlockResponse<alloy_consensus::Header, B>>>;
+pub type BodyDownloaderResult<H, B> = DownloadResult<Vec<BlockResponse<H, B>>>;
 
 /// A downloader capable of fetching and yielding block bodies from block headers.
 ///
@@ -13,8 +13,11 @@ pub type BodyDownloaderResult<B> = DownloadResult<Vec<BlockResponse<alloy_consen
 /// while a [`BodiesClient`][crate::bodies::client::BodiesClient] represents a client capable of
 /// fulfilling these requests.
 pub trait BodyDownloader:
-    Send + Sync + Stream<Item = BodyDownloaderResult<Self::Body>> + Unpin
+    Send + Sync + Stream<Item = BodyDownloaderResult<Self::Header, Self::Body>> + Unpin
 {
+    /// The type of header that can be returned in a blck
+    type Header: Debug + Send + Sync + Unpin + 'static;
+
     /// The type of the body that is being downloaded.
     type Body: Debug + Send + Sync + Unpin + 'static;
 

--- a/crates/net/p2p/src/bodies/response.rs
+++ b/crates/net/p2p/src/bodies/response.rs
@@ -1,10 +1,11 @@
+use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockNumber, U256};
 use reth_primitives::{BlockBody, SealedBlock, SealedHeader};
-use reth_primitives_traits::{BlockHeader, InMemorySize};
+use reth_primitives_traits::InMemorySize;
 
 /// The block response
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum BlockResponse<H = alloy_consensus::Header, B = BlockBody> {
+pub enum BlockResponse<H, B = BlockBody> {
     /// Full block response (with transactions or ommers)
     Full(SealedBlock<H, B>),
     /// The empty block response

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -87,7 +87,7 @@ pub fn build_pipeline<N, H, B, Executor>(
 where
     N: ProviderNodeTypes,
     H: HeaderDownloader<Header = HeaderTy<N>> + 'static,
-    B: BodyDownloader<Body = BodyTy<N>> + 'static,
+    B: BodyDownloader<Header = HeaderTy<N>, Body = BodyTy<N>> + 'static,
     Executor: BlockExecutorProvider<Primitives = N::Primitives>,
     N::Primitives: NodePrimitives<BlockHeader = reth_primitives::Header>,
 {

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -258,7 +258,7 @@ pub(crate) fn missing_static_data_error<Provider>(
     segment: StaticFileSegment,
 ) -> Result<StageError, ProviderError>
 where
-    Provider: BlockReader<Header = reth_primitives::Header> + StaticFileProviderFactory,
+    Provider: BlockReader + StaticFileProviderFactory,
 {
     let mut last_block =
         static_file_provider.get_highest_static_file_block(segment).unwrap_or_default();


### PR DESCRIPTION
This removes the remaining default types from the bodies downloader and bodies stage. Re-uses the `Provider::Header` convention that is currently used in the bodies downloader.