### PR TITLE
chore: add `StorageLocation` to `BlockBodyWriter` trait

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -36,7 +36,7 @@ use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_primitives::{BlockBody, PooledTransactionsElement, TransactionSigned};
 use reth_provider::{
     providers::ChainStorage, BlockBodyReader, BlockBodyWriter, CanonStateSubscriptions,
-    ChainSpecProvider, DBProvider, EthStorage, ProviderResult, ReadBodyInput,
+    ChainSpecProvider, DBProvider, EthStorage, ProviderResult, ReadBodyInput, StorageLocation,
 };
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
@@ -56,16 +56,18 @@ impl<Provider: DBProvider<Tx: DbTxMut>> BlockBodyWriter<Provider, BlockBody> for
         &self,
         provider: &Provider,
         bodies: Vec<(u64, Option<BlockBody>)>,
+        write_to: StorageLocation,
     ) -> ProviderResult<()> {
-        self.0.write_block_bodies(provider, bodies)
+        self.0.write_block_bodies(provider, bodies, write_to)
     }
 
     fn remove_block_bodies_above(
         &self,
         provider: &Provider,
         block: alloy_primitives::BlockNumber,
+        remove_from: StorageLocation,
     ) -> ProviderResult<()> {
-        self.0.remove_block_bodies_above(provider, block)
+        self.0.remove_block_bodies_above(provider, block, remove_from)
     }
 }
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -3,32 +3,9 @@ use reth_db_api::models::StoredBlockBodyIndices;
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_node_types::NodePrimitives;
 use reth_primitives::SealedBlockWithSenders;
-use reth_storage_api::NodePrimitivesProvider;
+use reth_storage_api::{NodePrimitivesProvider, StorageLocation};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{updates::TrieUpdates, HashedPostStateSorted};
-
-/// An enum that represents the storage location for a piece of data.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum StorageLocation {
-    /// Write only to static files.
-    StaticFiles,
-    /// Write only to the database.
-    Database,
-    /// Write to both the database and static files.
-    Both,
-}
-
-impl StorageLocation {
-    /// Returns true if the storage location includes static files.
-    pub const fn static_files(&self) -> bool {
-        matches!(self, Self::StaticFiles | Self::Both)
-    }
-
-    /// Returns true if the storage location includes the database.
-    pub const fn database(&self) -> bool {
-        matches!(self, Self::Database | Self::Both)
-    }
-}
 
 /// `BlockExecution` Writer
 pub trait BlockExecutionWriter:
@@ -120,7 +97,7 @@ pub trait BlockWriter: Send + Sync {
     fn append_block_bodies(
         &self,
         bodies: Vec<(BlockNumber, Option<<Self::Block as reth_primitives_traits::Block>::Body>)>,
-        write_transactions_to: StorageLocation,
+        write_to: StorageLocation,
     ) -> ProviderResult<()>;
 
     /// Removes all blocks above the given block number from the database.
@@ -129,14 +106,14 @@ pub trait BlockWriter: Send + Sync {
     fn remove_blocks_above(
         &self,
         block: BlockNumber,
-        remove_transactions_from: StorageLocation,
+        remove_from: StorageLocation,
     ) -> ProviderResult<()>;
 
     /// Removes all block bodies above the given block number from the database.
     fn remove_bodies_above(
         &self,
         block: BlockNumber,
-        remove_transactions_from: StorageLocation,
+        remove_from: StorageLocation,
     ) -> ProviderResult<()>;
 
     /// Appends a batch of sealed blocks to the blockchain, including sender information, and

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -1,4 +1,4 @@
-use crate::DBProvider;
+use crate::{DBProvider, StorageLocation};
 use alloy_primitives::BlockNumber;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_db::{
@@ -22,6 +22,7 @@ pub trait BlockBodyWriter<Provider, Body: BlockBody> {
         &self,
         provider: &Provider,
         bodies: Vec<(BlockNumber, Option<Body>)>,
+        write_to: StorageLocation,
     ) -> ProviderResult<()>;
 
     /// Removes all block bodies above the given block number from the database.
@@ -29,6 +30,7 @@ pub trait BlockBodyWriter<Provider, Body: BlockBody> {
         &self,
         provider: &Provider,
         block: BlockNumber,
+        remove_from: StorageLocation,
     ) -> ProviderResult<()>;
 }
 
@@ -87,6 +89,7 @@ where
         &self,
         provider: &Provider,
         bodies: Vec<(u64, Option<reth_primitives::BlockBody>)>,
+        _write_to: StorageLocation,
     ) -> ProviderResult<()> {
         let mut ommers_cursor = provider.tx_ref().cursor_write::<tables::BlockOmmers>()?;
         let mut withdrawals_cursor =
@@ -116,6 +119,7 @@ where
         &self,
         provider: &Provider,
         block: BlockNumber,
+        _remove_from: StorageLocation,
     ) -> ProviderResult<()> {
         provider.tx_ref().unwind_table_by_num::<tables::BlockWithdrawals>(block)?;
         provider.tx_ref().unwind_table_by_num::<tables::BlockOmmers>(block)?;

--- a/crates/storage/storage-api/src/storage.rs
+++ b/crates/storage/storage-api/src/storage.rs
@@ -41,3 +41,26 @@ pub trait StorageChangeSetReader: Send + Sync {
         block_number: BlockNumber,
     ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>>;
 }
+
+/// An enum that represents the storage location for a piece of data.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum StorageLocation {
+    /// Write only to static files.
+    StaticFiles,
+    /// Write only to the database.
+    Database,
+    /// Write to both the database and static files.
+    Both,
+}
+
+impl StorageLocation {
+    /// Returns true if the storage location includes static files.
+    pub const fn static_files(&self) -> bool {
+        matches!(self, Self::StaticFiles | Self::Both)
+    }
+
+    /// Returns true if the storage location includes the database.
+    pub const fn database(&self) -> bool {
+        matches!(self, Self::Database | Self::Both)
+    }
+}


### PR DESCRIPTION
* moves `StorageLocation` to `storage-api`
* adds `StorageLocation` arguments to `BlockBodyWriter` trait methods.

in preparation for https://github.com/paradigmxyz/reth/issues/13264