### PR TITLE
fix: bounds for BundleApi

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -18,7 +18,7 @@ use reth_node_core::{
     version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA},
 };
 use reth_payload_builder::PayloadStore;
-use reth_primitives::EthPrimitives;
+use reth_primitives::{EthPrimitives, PooledTransactionsElement};
 use reth_provider::providers::ProviderNodeTypes;
 use reth_rpc::{
     eth::{EthApiTypes, FullEthApiServer},
@@ -33,6 +33,7 @@ use reth_rpc_builder::{
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::{debug, info};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::sync::Arc;
 
 use crate::EthApiBuilderCtx;
@@ -403,7 +404,9 @@ where
 
 impl<N, EthApi, EV> RpcAddOns<N, EthApi, EV>
 where
-    N: FullNodeComponents,
+    N: FullNodeComponents<
+        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
+    >,
     EthApi: EthApiTypes
         + FullEthApiServer<Provider = N::Provider, Pool = N::Pool, Network = N::Network>
         + AddDevSigners
@@ -531,7 +534,10 @@ where
 
 impl<N, EthApi, EV> NodeAddOns<N> for RpcAddOns<N, EthApi, EV>
 where
-    N: FullNodeComponents<Types: ProviderNodeTypes<Primitives = EthPrimitives>>,
+    N: FullNodeComponents<
+        Types: ProviderNodeTypes<Primitives = EthPrimitives>,
+        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
+    >,
     EthApi: EthApiTypes
         + FullEthApiServer<Provider = N::Provider, Pool = N::Pool, Network = N::Network>
         + AddDevSigners

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -244,6 +244,7 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
+        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
     >,
     OpEngineValidator: EngineValidator<<N::Types as NodeTypesWithEngine>::Engine>,
 {
@@ -294,6 +295,7 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
+        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
     >,
     OpEngineValidator: EngineValidator<<N::Types as NodeTypesWithEngine>::Engine>,
 {

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -19,7 +19,7 @@
 //! use reth_engine_primitives::PayloadValidator;
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_primitives::{Header, TransactionSigned, PooledTransactionsElement};
+//! use reth_primitives::{Header, PooledTransactionsElement, TransactionSigned};
 //! use reth_provider::{AccountReader, CanonStateSubscriptions, ChangeSetReader, FullRpcProvider};
 //! use reth_rpc::EthApi;
 //! use reth_rpc_builder::{
@@ -55,8 +55,12 @@
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
 //!         + ChangeSetReader,
-//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned, Pooled = PooledTransactionsElement>>
-//!         + Unpin
+//!     Pool: TransactionPool<
+//!             Transaction: PoolTransaction<
+//!                 Consensus = TransactionSigned,
+//!                 Pooled = PooledTransactionsElement,
+//!             >,
+//!         > + Unpin
 //!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events:
@@ -98,7 +102,7 @@
 //! use reth_engine_primitives::{EngineTypes, PayloadValidator};
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_primitives::{Header, TransactionSigned, PooledTransactionsElement};
+//! use reth_primitives::{Header, PooledTransactionsElement, TransactionSigned};
 //! use reth_provider::{AccountReader, CanonStateSubscriptions, ChangeSetReader, FullRpcProvider};
 //! use reth_rpc::EthApi;
 //! use reth_rpc_api::EngineApiServer;
@@ -141,8 +145,12 @@
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
 //!         + ChangeSetReader,
-//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned, Pooled = PooledTransactionsElement>>
-//!         + Unpin
+//!     Pool: TransactionPool<
+//!             Transaction: PoolTransaction<
+//!                 Consensus = TransactionSigned,
+//!                 Pooled = PooledTransactionsElement,
+//!             >,
+//!         > + Unpin
 //!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     Events:

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -19,7 +19,7 @@
 //! use reth_engine_primitives::PayloadValidator;
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_primitives::{Header, TransactionSigned};
+//! use reth_primitives::{Header, TransactionSigned, PooledTransactionsElement};
 //! use reth_provider::{AccountReader, CanonStateSubscriptions, ChangeSetReader, FullRpcProvider};
 //! use reth_rpc::EthApi;
 //! use reth_rpc_builder::{
@@ -55,7 +55,7 @@
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
 //!         + ChangeSetReader,
-//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned, Pooled = PooledTransactionsElement>>
 //!         + Unpin
 //!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
@@ -98,7 +98,7 @@
 //! use reth_engine_primitives::{EngineTypes, PayloadValidator};
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_network_api::{NetworkInfo, Peers};
-//! use reth_primitives::{Header, TransactionSigned};
+//! use reth_primitives::{Header, TransactionSigned, PooledTransactionsElement};
 //! use reth_provider::{AccountReader, CanonStateSubscriptions, ChangeSetReader, FullRpcProvider};
 //! use reth_rpc::EthApi;
 //! use reth_rpc_api::EngineApiServer;
@@ -141,7 +141,7 @@
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
 //!         + ChangeSetReader,
-//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+//!     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned, Pooled = PooledTransactionsElement>>
 //!         + Unpin
 //!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -222,7 +222,7 @@ use reth_consensus::FullConsensus;
 use reth_engine_primitives::{EngineTypes, PayloadValidator};
 use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
-use reth_primitives::NodePrimitives;
+use reth_primitives::{NodePrimitives, PooledTransactionsElement};
 use reth_provider::{
     AccountReader, BlockReader, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, FullRpcProvider, ProviderBlock, ProviderHeader, ProviderReceipt,
@@ -240,7 +240,7 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{EthConfig, EthStateCache, EthSubscriptionIdProvider};
 use reth_rpc_layer::{AuthLayer, Claims, CompressionLayer, JwtAuthValidator, JwtSecret};
 use reth_tasks::{pool::BlockingTaskGuard, TaskSpawner, TokioTaskExecutor};
-use reth_transaction_pool::{noop::NoopTransactionPool, TransactionPool};
+use reth_transaction_pool::{noop::NoopTransactionPool, PoolTransaction, TransactionPool};
 use serde::{Deserialize, Serialize};
 use tower::Layer;
 use tower_http::cors::CorsLayer;
@@ -315,6 +315,7 @@ where
             Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         >,
+        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
     >,
     BlockExecutor: BlockExecutorProvider,
 {
@@ -706,6 +707,7 @@ where
                 Receipt = <Events::Primitives as NodePrimitives>::Receipt,
                 Header = <Events::Primitives as NodePrimitives>::BlockHeader,
             >,
+            Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
         >,
     {
         let Self {
@@ -831,6 +833,7 @@ where
                 Block = <Events::Primitives as NodePrimitives>::Block,
                 Header = <Events::Primitives as NodePrimitives>::BlockHeader,
             >,
+            Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
         >,
         Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     {
@@ -1371,6 +1374,7 @@ where
             Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         >,
+        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
     >,
     BlockExecutor: BlockExecutorProvider,
     Consensus: reth_consensus::FullConsensus<BlockExecutor::Primitives> + Clone + 'static,

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -285,10 +285,14 @@ where
 #[async_trait::async_trait]
 impl<Eth> EthCallBundleApiServer for EthBundle<Eth>
 where
-    Eth: EthTransactions + LoadPendingBlock + Call + 'static,
+    Eth: EthTransactions<
+            Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransactionsElement>>,
+        > + LoadPendingBlock
+        + Call
+        + 'static,
 {
     async fn call_bundle(&self, request: EthCallBundle) -> RpcResult<EthCallBundleResponse> {
-        Self::call_bundle(self, request).await.map_err(Into::into)
+        self.call_bundle(request).await.map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
Bounds for `EthCallBundleApiServer` are less strict then bounds for the impl for `EthBundle`, resulting in it recursing on every request