### PR TITLE
chore: introduce receipts generic

### DIFF
--- a/crates/net/eth-wire-types/src/receipts.rs
+++ b/crates/net/eth-wire-types/src/receipts.rs
@@ -1,5 +1,6 @@
 //! Implements the `GetReceipts` and `Receipts` message types.
 
+use alloy_consensus::{RlpDecodableReceipt, RlpEncodableReceipt};
 use alloy_primitives::B256;
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 use reth_codecs_derive::add_arbitrary_tests;
@@ -17,7 +18,7 @@ pub struct GetReceipts(
 
 /// The response to [`GetReceipts`], containing receipt lists that correspond to each block
 /// requested.
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[add_arbitrary_tests(rlp)]
@@ -25,6 +26,24 @@ pub struct Receipts<T = Receipt>(
     /// Each receipt hash should correspond to a block hash in the request.
     pub Vec<Vec<ReceiptWithBloom<T>>>,
 );
+
+impl<T: RlpEncodableReceipt> alloy_rlp::Encodable for Receipts<T> {
+    #[inline]
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.0.encode(out)
+    }
+    #[inline]
+    fn length(&self) -> usize {
+        self.0.length()
+    }
+}
+
+impl<T: RlpDecodableReceipt> alloy_rlp::Decodable for Receipts<T> {
+    #[inline]
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        alloy_rlp::Decodable::decode(buf).map(Self)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/net/eth-wire-types/src/receipts.rs
+++ b/crates/net/eth-wire-types/src/receipts.rs
@@ -21,9 +21,9 @@ pub struct GetReceipts(
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[add_arbitrary_tests(rlp)]
-pub struct Receipts(
+pub struct Receipts<T = Receipt>(
     /// Each receipt hash should correspond to a block hash in the request.
-    pub Vec<Vec<ReceiptWithBloom<Receipt>>>,
+    pub Vec<Vec<ReceiptWithBloom<T>>>,
 );
 
 #[cfg(test)]


### PR DESCRIPTION
on networkprimitives we likely need to enforce

https://github.com/paradigmxyz/reth/blob/cfd3553f1096dcbb56d6fe7b1534b31fa1cd69e0/crates/net/eth-wire-types/src/primitives.rs#L33-L33

`EncodeableReceipt` instead so that we have `Encodable2718` for `ReceiptWithBloom<T>`