### PR TITLE
chore: improve `CompactZstd` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8873,7 +8873,6 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "assert_matches",
- "bytes",
  "derive_more",
  "modular-bitfield",
  "proptest",

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -13,8 +13,6 @@ use reth_primitives_traits::receipt::ReceiptExt;
 use serde::{Deserialize, Serialize};
 
 use crate::TxType;
-#[cfg(feature = "reth-codec")]
-use reth_zstd_compressors::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR};
 
 /// Retrieves gas spent by transactions as a vector of tuples (transaction index, gas used).
 pub use reth_primitives_traits::receipt::gas_spent_by_transactions;
@@ -25,6 +23,10 @@ pub use reth_primitives_traits::receipt::gas_spent_by_transactions;
 )]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::CompactZstd))]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests)]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_zstd(
+    compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
+    decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
+))]
 #[rlp(trailing)]
 pub struct Receipt {
     /// Receipt type.

--- a/crates/prune/types/Cargo.toml
+++ b/crates/prune/types/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 reth-codecs.workspace = true
 
 alloy-primitives.workspace = true
-bytes.workspace = true
 derive_more.workspace = true
 modular-bitfield.workspace = true
 serde.workspace = true

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Generics};
+use syn::{Data, DeriveInput, Generics};
 
 mod generator;
 use generator::*;
@@ -42,10 +42,10 @@ pub enum FieldTypes {
 }
 
 /// Derives the `Compact` trait and its from/to implementations.
-pub fn derive(input: TokenStream, zstd: Option<ZstdConfig>) -> TokenStream {
+pub fn derive(input: DeriveInput, zstd: Option<ZstdConfig>) -> TokenStream {
     let mut output = quote! {};
 
-    let DeriveInput { ident, data, generics, attrs, .. } = parse_macro_input!(input);
+    let DeriveInput { ident, data, generics, attrs, .. } = input;
 
     let has_lifetime = has_lifetime(&generics);
 

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -15,6 +15,8 @@ use flags::*;
 mod structs;
 use structs::*;
 
+use crate::ZstdConfig;
+
 // Helper Alias type
 type IsCompact = bool;
 // Helper Alias type
@@ -40,7 +42,7 @@ pub enum FieldTypes {
 }
 
 /// Derives the `Compact` trait and its from/to implementations.
-pub fn derive(input: TokenStream, is_zstd: bool) -> TokenStream {
+pub fn derive(input: TokenStream, zstd: Option<ZstdConfig>) -> TokenStream {
     let mut output = quote! {};
 
     let DeriveInput { ident, data, generics, attrs, .. } = parse_macro_input!(input);
@@ -48,8 +50,8 @@ pub fn derive(input: TokenStream, is_zstd: bool) -> TokenStream {
     let has_lifetime = has_lifetime(&generics);
 
     let fields = get_fields(&data);
-    output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, is_zstd));
-    output.extend(generate_from_to(&ident, &attrs, has_lifetime, &fields, is_zstd));
+    output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, zstd.is_some()));
+    output.extend(generate_from_to(&ident, &attrs, has_lifetime, &fields, zstd));
     output.into()
 }
 
@@ -236,7 +238,7 @@ mod tests {
         let DeriveInput { ident, data, attrs, .. } = parse2(f_struct).unwrap();
         let fields = get_fields(&data);
         output.extend(generate_flag_struct(&ident, &attrs, false, &fields, false));
-        output.extend(generate_from_to(&ident, &attrs, false, &fields, false));
+        output.extend(generate_from_to(&ident, &attrs, false, &fields, None));
 
         // Expected output in a TokenStream format. Commas matter!
         let should_output = quote! {

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -300,10 +300,10 @@ mod tests {
                 fuzz_test_test_struct(TestStruct::default())
             }
             impl reth_codecs::Compact for TestStruct {
-                fn to_compact<B>(&self, buf: &mut B) -> usize where B: bytes::BufMut + AsMut<[u8]> {
+                fn to_compact<B>(&self, buf: &mut B) -> usize where B: reth_codecs::__private::bytes::BufMut + AsMut<[u8]> {
                     let mut flags = TestStructFlags::default();
                     let mut total_length = 0;
-                    let mut buffer = bytes::BytesMut::new();
+                    let mut buffer = reth_codecs::__private::bytes::BytesMut::new();
                     let f_u64_len = self.f_u64.to_compact(&mut buffer);
                     flags.set_f_u64_len(f_u64_len as u8);
                     let f_u256_len = self.f_u256.to_compact(&mut buffer);

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -57,21 +57,18 @@ pub(crate) struct ZstdConfig {
 ///   efficient decoding.
 #[proc_macro_derive(Compact, attributes(maybe_zero, reth_codecs))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    compact::derive(input, None)
+    compact::derive(parse_macro_input!(input as DeriveInput), None)
 }
 
 /// Adds `zstd` compression to derived [`Compact`].
 #[proc_macro_derive(CompactZstd, attributes(maybe_zero, reth_codecs, reth_zstd))]
 pub fn derive_zstd(input: TokenStream) -> TokenStream {
-    let derive_input = {
-        let input = input.clone();
-        parse_macro_input!(input as DeriveInput)
-    };
+    let input = parse_macro_input!(input as DeriveInput);
 
     let mut compressor = None;
     let mut decompressor = None;
 
-    for attr in derive_input.attrs {
+    for attr in &input.attrs {
         if attr.path().is_ident("reth_zstd") {
             if let Err(err) = attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("compressor") {

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -20,6 +20,12 @@ use syn::{
 mod arbitrary;
 mod compact;
 
+#[derive(Clone)]
+pub(crate) struct ZstdConfig {
+    compressor: syn::Path,
+    decompressor: syn::Path,
+}
+
 /// Derives the `Compact` trait for custom structs, optimizing serialization with a possible
 /// bitflag struct.
 ///
@@ -51,15 +57,49 @@ mod compact;
 ///   efficient decoding.
 #[proc_macro_derive(Compact, attributes(maybe_zero, reth_codecs))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    let is_zstd = false;
-    compact::derive(input, is_zstd)
+    compact::derive(input, None)
 }
 
 /// Adds `zstd` compression to derived [`Compact`].
-#[proc_macro_derive(CompactZstd, attributes(maybe_zero, reth_codecs))]
+#[proc_macro_derive(CompactZstd, attributes(maybe_zero, reth_codecs, reth_zstd))]
 pub fn derive_zstd(input: TokenStream) -> TokenStream {
-    let is_zstd = true;
-    compact::derive(input, is_zstd)
+    let derive_input = {
+        let input = input.clone();
+        parse_macro_input!(input as DeriveInput)
+    };
+
+    let mut compressor = None;
+    let mut decompressor = None;
+
+    for attr in derive_input.attrs {
+        if attr.path().is_ident("reth_zstd") {
+            if let Err(err) = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("compressor") {
+                    let value = meta.value()?;
+                    let path: syn::Path = value.parse()?;
+                    compressor = Some(path);
+                } else if meta.path.is_ident("decompressor") {
+                    let value = meta.value()?;
+                    let path: syn::Path = value.parse()?;
+                    decompressor = Some(path);
+                } else {
+                    return Err(meta.error("unsupported attribute"))
+                }
+                Ok(())
+            }) {
+                return err.to_compile_error().into()
+            }
+        }
+    }
+
+    let (Some(compressor), Some(decompressor)) = (compressor, decompressor) else {
+        return quote! {
+            compile_error!("missing compressor or decompressor attribute");
+        }
+        .into()
+    };
+
+    compact::derive(input, Some(ZstdConfig { compressor, decompressor }))
 }
 
 /// Generates tests for given type.

--- a/crates/storage/codecs/src/private.rs
+++ b/crates/storage/codecs/src/private.rs
@@ -1,3 +1,3 @@
 pub use modular_bitfield;
 
-pub use bytes::Buf;
+pub use bytes::{self, Buf};


### PR DESCRIPTION
Replaces some references to `bytes` crate with `reth_codecs::__private::bytes`

Changes `CompactZstd` macro to receive compressor and decompressor from user's input in `reth_zstd` attribute instead of expecting them to be available as `{struct_name}_COMPRESSOR`