### PR TITLE
perf: enable map-foldhash alloy-primitives feature globally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,7 +433,9 @@ revm-primitives = { version = "14.0.0", default-features = false }
 # eth
 alloy-chains = { version = "0.1.32", default-features = false }
 alloy-dyn-abi = "0.8.15"
-alloy-primitives = { version = "0.8.15", default-features = false }
+alloy-primitives = { version = "0.8.15", default-features = false, features = [
+    "map-foldhash",
+] }
 alloy-rlp = { version = "0.3.10", default-features = false }
 alloy-sol-types = "0.8.15"
 alloy-trie = { version = "0.7", default-features = false }
@@ -562,7 +564,6 @@ reqwest = { version = "0.12", default-features = false }
 tracing-futures = "0.2"
 tower = "0.4"
 tower-http = "0.6"
-
 
 # p2p
 discv5 = "0.8.0"

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -11,7 +11,6 @@ description = "Sparse MPT implementation"
 [lints]
 workspace = true
 
-
 [dependencies]
 # reth
 reth-primitives-traits.workspace = true


### PR DESCRIPTION
This is the default hasher in hashbrown. It is seeded randomly, and a lot faster than ahash and the standard's default siphash.

Improves sparse trie benchmarks by 10-12%. Likely benefits EVM by some small percentage as well.

```
calculate root from leaves/hash builder/1000                                                                           
                        time:   [458.34 µs 458.72 µs 459.18 µs]
                        change: [+1.2963% +1.6696% +1.9964%] (p = 0.00 < 0.05)
                        Performance has regressed.
calculate root from leaves/sparse trie/1000                                                                            
                        time:   [752.41 µs 753.01 µs 753.77 µs]
                        change: [-12.536% -12.005% -11.650%] (p = 0.00 < 0.05)
                        Performance has improved.
calculate root from leaves/hash builder/5000                                                                            
                        time:   [2.2433 ms 2.2463 ms 2.2486 ms]
                        change: [-2.4751% -2.1575% -1.8610%] (p = 0.00 < 0.05)
                        Performance has improved.
calculate root from leaves/sparse trie/5000                                                                            
                        time:   [4.7486 ms 4.8002 ms 4.8398 ms]
                        change: [-12.172% -11.112% -10.268%] (p = 0.00 < 0.05)
                        Performance has improved.
```