### PR TITLE
fix: only terminate the stream if range is empty

### DIFF
--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -190,7 +190,7 @@ where
             }
 
             if this.range.peek().is_none() {
-                // only terminate the stream if there are blocks to process
+                // only terminate the stream if there are no more blocks to process
                 return Poll::Ready(None);
             }
         }

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -13,7 +13,6 @@ use reth_prune_types::PruneModes;
 use reth_stages_api::ExecutionStageThresholds;
 use reth_tracing::tracing::debug;
 use std::{
-    iter::Peekable,
     ops::RangeInclusive,
     pin::Pin,
     task::{ready, Context, Poll},
@@ -53,7 +52,7 @@ pub struct StreamBackfillJob<E, P, T> {
     executor: E,
     provider: P,
     prune_modes: PruneModes,
-    range: Peekable<RangeInclusive<BlockNumber>>,
+    range: RangeInclusive<BlockNumber>,
     tasks: BackfillTasks<T>,
     parallelism: usize,
     batch_size: usize,
@@ -189,7 +188,7 @@ where
                 return Poll::Ready(res);
             }
 
-            if this.range.peek().is_none() {
+            if this.range.is_empty() {
                 // only terminate the stream if there are no more blocks to process
                 return Poll::Ready(None);
             }
@@ -203,7 +202,7 @@ impl<E, P> From<SingleBlockBackfillJob<E, P>> for StreamBackfillJob<E, P, Single
             executor: job.executor,
             provider: job.provider,
             prune_modes: PruneModes::default(),
-            range: job.range.peekable(),
+            range: job.range,
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,
             batch_size: 1,
@@ -222,7 +221,7 @@ where
             executor: job.executor,
             provider: job.provider,
             prune_modes: job.prune_modes,
-            range: job.range.peekable(),
+            range: job.range,
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,
             batch_size,

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -1,10 +1,5 @@
+use super::job::BackfillJobResult;
 use crate::{BackfillJob, SingleBlockBackfillJob};
-use std::{
-    ops::RangeInclusive,
-    pin::Pin,
-    task::{ready, Context, Poll},
-};
-
 use alloy_primitives::BlockNumber;
 use futures::{
     stream::{FuturesOrdered, Stream},
@@ -17,9 +12,13 @@ use reth_provider::{BlockReader, Chain, HeaderProvider, StateProviderFactory};
 use reth_prune_types::PruneModes;
 use reth_stages_api::ExecutionStageThresholds;
 use reth_tracing::tracing::debug;
+use std::{
+    iter::Peekable,
+    ops::RangeInclusive,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
 use tokio::task::JoinHandle;
-
-use super::job::BackfillJobResult;
 
 /// The default parallelism for active tasks in [`StreamBackfillJob`].
 pub(crate) const DEFAULT_PARALLELISM: usize = 4;
@@ -54,7 +53,7 @@ pub struct StreamBackfillJob<E, P, T> {
     executor: E,
     provider: P,
     prune_modes: PruneModes,
-    range: RangeInclusive<BlockNumber>,
+    range: Peekable<RangeInclusive<BlockNumber>>,
     tasks: BackfillTasks<T>,
     parallelism: usize,
     batch_size: usize,
@@ -157,33 +156,44 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        // Spawn new tasks only if we are below the parallelism configured.
-        while this.tasks.len() < this.parallelism {
-            // Take the next `batch_size` blocks from the range and calculate the range bounds
-            let mut range = this.range.by_ref().take(this.batch_size);
-            let start = range.next();
-            let range_bounds = start.zip(range.last().or(start));
+        loop {
+            // Spawn new tasks only if we are below the parallelism configured.
+            while this.tasks.len() < this.parallelism {
+                // Take the next `batch_size` blocks from the range and calculate the range bounds
+                let mut range = this.range.by_ref().take(this.batch_size);
+                let start = range.next();
+                let range_bounds = start.zip(range.last().or(start));
 
-            // Create the range from the range bounds. If it is empty, we are done.
-            let Some(range) = range_bounds.map(|(first, last)| first..=last) else {
-                debug!(target: "exex::backfill", tasks = %this.tasks.len(), range = ?this.range, "No more block batches to backfill");
-                break;
-            };
+                // Create the range from the range bounds. If it is empty, we are done.
+                let Some(range) = range_bounds.map(|(first, last)| first..=last) else {
+                    debug!(target: "exex::backfill", tasks = %this.tasks.len(), range = ?this.range, "No more block batches to backfill");
+                    break;
+                };
 
-            // Spawn a new task for that range
-            debug!(target: "exex::backfill", tasks = %this.tasks.len(), ?range, "Spawning new block batch backfill task");
-            let job = Box::new(BackfillJob {
-                executor: this.executor.clone(),
-                provider: this.provider.clone(),
-                prune_modes: this.prune_modes.clone(),
-                thresholds: this.thresholds.clone(),
-                range,
-                stream_parallelism: this.parallelism,
-            }) as BackfillTaskIterator<_>;
-            this.push_back(job);
+                // Spawn a new task for that range
+                debug!(target: "exex::backfill", tasks = %this.tasks.len(), ?range, "Spawning new block batch backfill task");
+                let job = Box::new(BackfillJob {
+                    executor: this.executor.clone(),
+                    provider: this.provider.clone(),
+                    prune_modes: this.prune_modes.clone(),
+                    thresholds: this.thresholds.clone(),
+                    range,
+                    stream_parallelism: this.parallelism,
+                }) as BackfillTaskIterator<_>;
+                this.push_back(job);
+            }
+
+            let res = ready!(this.poll_next_task(cx));
+
+            if res.is_some() {
+                return Poll::Ready(res);
+            }
+
+            if this.range.peek().is_none() {
+                // only terminate the stream if there are blocks to process
+                return Poll::Ready(None);
+            }
         }
-
-        this.poll_next_task(cx)
     }
 }
 
@@ -193,7 +203,7 @@ impl<E, P> From<SingleBlockBackfillJob<E, P>> for StreamBackfillJob<E, P, Single
             executor: job.executor,
             provider: job.provider,
             prune_modes: PruneModes::default(),
-            range: job.range,
+            range: job.range.peekable(),
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,
             batch_size: 1,
@@ -212,7 +222,7 @@ where
             executor: job.executor,
             provider: job.provider,
             prune_modes: job.prune_modes,
-            range: job.range,
+            range: job.range.peekable(),
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,
             batch_size,
@@ -310,10 +320,9 @@ mod tests {
             blocks_and_execution_outcome(provider_factory, chain_spec, key_pair)?;
 
         // Backfill the same range
-        let factory =
-            BackfillJobFactory::new(executor.clone(), blockchain_db.clone()).with_thresholds(
-                ExecutionStageThresholds { max_blocks: Some(2), ..Default::default() },
-            );
+        let factory = BackfillJobFactory::new(executor.clone(), blockchain_db.clone())
+            .with_thresholds(ExecutionStageThresholds { max_blocks: Some(2), ..Default::default() })
+            .with_stream_parallelism(1);
         let mut backfill_stream = factory.backfill(1..=2).into_stream();
         let mut chain = backfill_stream.next().await.unwrap().unwrap();
         chain.execution_outcome_mut().state_mut().reverts.sort();


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/13279

@shekhirin this fixes a logic bug that would terminate the entire stream after the first task because we'd end up

here https://github.com/paradigmxyz/reth/blob/7610cb4cf3f227323b8f4f3d8e71f77b7405c0dc/crates/exex/exex/src/backfill/stream.rs#L113-L113 

but the range can still have blocks

perhaps there's a nicer way to solve this