### PR TITLE
chore: cut down on tx_type usage

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1717,7 +1717,7 @@ impl PooledTransactionsHashesBuilder {
             Self::Eth68(msg) => {
                 msg.hashes.push(*tx.tx_hash());
                 msg.sizes.push(tx.size);
-                msg.types.push(tx.transaction.tx_type().into());
+                msg.types.push(tx.transaction.ty());
             }
         }
     }

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -54,7 +54,7 @@ impl OpTransactionSigned {
     /// Calculates hash of given transaction and signature and returns new instance.
     pub fn new(transaction: OpTypedTransaction, signature: Signature) -> Self {
         let signed_tx = Self::new_unhashed(transaction, signature);
-        if !matches!(signed_tx.tx_type(), OpTxType::Deposit) {
+        if signed_tx.ty() != OpTxType::Deposit {
             signed_tx.hash.get_or_init(|| signed_tx.recalculate_hash());
         }
 
@@ -246,9 +246,10 @@ impl alloy_rlp::Decodable for OpTransactionSigned {
 
 impl Encodable2718 for OpTransactionSigned {
     fn type_flag(&self) -> Option<u8> {
-        match self.tx_type() {
-            op_alloy_consensus::OpTxType::Legacy => None,
-            tx_type => Some(tx_type as u8),
+        if Typed2718::is_legacy(self) {
+            None
+        } else {
+            Some(self.ty())
         }
     }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1921,13 +1921,12 @@ mod tests {
     // Test vector from https://sepolia.etherscan.io/tx/0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
     // Blobscan: https://sepolia.blobscan.com/tx/0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
     fn test_decode_recover_sepolia_4844_tx() {
-        use crate::TxType;
         use alloy_primitives::{address, b256};
 
         // https://sepolia.etherscan.io/getRawTx?tx=0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
         let raw_tx = alloy_primitives::hex::decode("0x03f9011d83aa36a7820fa28477359400852e90edd0008252089411e9ca82a3a762b4b5bd264d4173a242e7a770648080c08504a817c800f8a5a0012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921aa00152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4a0013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7a001148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1a0011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e654901a0c8de4cced43169f9aa3d36506363b2d2c44f6c49fc1fd91ea114c86f3757077ea01e11fdd0d1934eda0492606ee0bb80a7bf8f35cc5f86ec60fe5031ba48bfd544").unwrap();
         let decoded = TransactionSigned::decode_2718(&mut raw_tx.as_slice()).unwrap();
-        assert_eq!(decoded.tx_type(), TxType::Eip4844);
+        assert!(decoded.is_eip4844());
 
         let from = decoded.recover_signer();
         assert_eq!(from, Some(address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2")));

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -49,7 +49,7 @@ impl BlobStoreCanonTracker {
                 .body
                 .transactions()
                 .iter()
-                .filter(|tx| tx.tx_type().is_eip4844())
+                .filter(|tx| tx.is_eip4844())
                 .map(|tx| tx.trie_hash());
             (*num, iter)
         });

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_consensus::{
     constants::{EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID},
-    Transaction as _,
+    Transaction as _, Typed2718,
 };
 use alloy_eips::{
     eip2718::Encodable2718,
@@ -1368,7 +1368,7 @@ impl PoolTransaction for EthPooledTransaction {
 
     /// Returns the transaction type
     fn tx_type(&self) -> u8 {
-        self.transaction.tx_type().into()
+        self.transaction.ty()
     }
 
     /// Returns the length of the rlp encoded object
@@ -1444,7 +1444,7 @@ impl TryFrom<RecoveredTx> for EthPooledTransaction {
 
     fn try_from(tx: RecoveredTx) -> Result<Self, Self::Error> {
         // ensure we can handle the transaction type and its format
-        match tx.tx_type() as u8 {
+        match tx.ty() {
             0..=EIP1559_TX_TYPE_ID | EIP7702_TX_TYPE_ID => {
                 // supported
             }


### PR DESCRIPTION
incremental prep for #13286

it looks like we don't need `TxType` trait and can remove that entirely next