### PR TITLE
perf(engine): include selfdestructs in StateRootTask bench input

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -68,7 +68,7 @@ fn create_bench_state_updates(params: &BenchParams) -> Vec<EvmState> {
                         code_hash: KECCAK_EMPTY,
                         code: Some(Default::default()),
                     },
-                    storage: (0..params.storage_slots_per_account)
+                    storage: (0..rng.gen_range(0..=params.storage_slots_per_account))
                         .map(|_| {
                             (
                                 U256::from(rng.gen::<u64>()),

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -133,7 +133,7 @@ fn setup_provider(
         let mut account_updates: Vec<(Address, Option<RethAccount>)> = Vec::new();
         let mut storage_updates: Vec<(Address, Vec<StorageEntry>)> = Vec::new();
 
-        for (address, account) in update.iter() {
+        for (address, account) in update {
             if account.status != AccountStatus::SelfDestructed {
                 account_updates.push((*address, convert_revm_to_reth_account(account)));
 
@@ -166,7 +166,7 @@ fn setup_provider(
         // second pass: Handle self-destructs
         let mut selfdestruct_updates = Vec::new();
 
-        for (address, account) in update.iter() {
+        for (address, account) in update {
             if account.status == AccountStatus::SelfDestructed {
                 // check if account exists in the current state before self-destructing
                 if let Ok(Some(_)) = provider_rw.basic_account(*address) {

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -143,6 +143,8 @@ fn setup_provider(
 }
 
 fn bench_state_root(c: &mut Criterion) {
+    reth_tracing::init_test_tracing();
+
     let mut group = c.benchmark_group("state_root");
 
     let scenarios = vec![

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -51,12 +51,7 @@ fn create_bench_state_updates(params: &BenchParams) -> Vec<EvmState> {
 
             let account = if is_selfdestruct {
                 RevmAccount {
-                    info: AccountInfo {
-                        balance: U256::ZERO,
-                        nonce: 0,
-                        code_hash: KECCAK_EMPTY,
-                        code: Some(Default::default()),
-                    },
+                    info: AccountInfo::default(),
                     storage: HashMap::default(),
                     status: AccountStatus::SelfDestructed,
                 }


### PR DESCRIPTION
follow up of this comment https://github.com/paradigmxyz/reth/pull/13212#discussion_r1876371739, introduces self-destructed accounts in the state before performing the benchmarks