### PR TITLE
chore: rm receiptsext trait

### DIFF
--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -415,7 +415,7 @@ where
 
             // Compute or add new fields
             transactions_root: proofs::calculate_transaction_root(&transactions),
-            receipts_root: outcome.receipts_root_slow(reorg_target.header.number).unwrap(),
+            receipts_root: outcome.ethereum_receipts_root(reorg_target.header.number).unwrap(),
             logs_bloom: outcome.block_logs_bloom(reorg_target.header.number).unwrap(),
             gas_used: cumulative_gas_used,
             blob_gas_used: blob_gas_used.map(Into::into),

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -408,7 +408,7 @@ where
         vec![requests.clone().unwrap_or_default()],
     );
     let receipts_root =
-        execution_outcome.receipts_root_slow(block_number).expect("Number is in range");
+        execution_outcome.ethereum_receipts_root(block_number).expect("Number is in range");
     let logs_bloom = execution_outcome.block_logs_bloom(block_number).expect("Number is in range");
 
     // calculate the state root

--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -1,19 +1,16 @@
 //! Receipt abstraction
 
+use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
 use alloc::vec::Vec;
-use core::fmt;
-
 use alloy_consensus::{
     Eip2718EncodableReceipt, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt, Typed2718,
 };
-use alloy_primitives::B256;
-
-use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
+use core::fmt;
 
 /// Helper trait that unifies all behaviour required by receipt to support full node operations.
 pub trait FullReceipt: Receipt + MaybeCompact {}
 
-impl<T> FullReceipt for T where T: ReceiptExt + MaybeCompact {}
+impl<T> FullReceipt for T where T: Receipt + MaybeCompact {}
 
 /// Abstraction of a receipt.
 #[auto_impl::auto_impl(&, Arc)]
@@ -33,12 +30,6 @@ pub trait Receipt:
     + InMemorySize
     + MaybeArbitrary
 {
-}
-
-/// Extension if [`Receipt`] used in block execution.
-pub trait ReceiptExt: Receipt {
-    /// Calculates the receipts root of the given receipts.
-    fn receipts_root(receipts: &[&Self]) -> B256;
 }
 
 /// Retrieves gas spent by transactions as a vector of tuples (transaction index, gas used).

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -9,7 +9,6 @@ use alloy_primitives::{Bloom, Log, B256};
 use alloy_rlp::{Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
 use bytes::BufMut;
 use derive_more::{DerefMut, From, IntoIterator};
-use reth_primitives_traits::receipt::ReceiptExt;
 use serde::{Deserialize, Serialize};
 
 use crate::TxType;
@@ -266,15 +265,6 @@ impl Typed2718 for Receipt {
 }
 
 impl reth_primitives_traits::Receipt for Receipt {}
-
-impl ReceiptExt for Receipt {
-    fn receipts_root(_receipts: &[&Self]) -> B256 {
-        #[cfg(feature = "optimism")]
-        panic!("This should not be called in optimism mode. Use `optimism_receipts_root_slow` instead.");
-        #[cfg(not(feature = "optimism"))]
-        crate::proofs::calculate_receipt_root_no_memo(_receipts)
-    }
-}
 
 impl InMemorySize for Receipt {
     /// Calculates a heuristic for the in-memory size of the [Receipt].

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -16,7 +16,7 @@ use reth_evm::{
     ConfigureEvm, ConfigureEvmEnv, NextBlockEnvAttributes,
 };
 use reth_primitives::{BlockExt, InvalidTransactionError, SealedBlockWithSenders};
-use reth_primitives_traits::receipt::ReceiptExt;
+use reth_primitives_traits::Receipt;
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, ProviderBlock, ProviderError,
     ProviderHeader, ProviderReceipt, ProviderTx, ReceiptProvider, StateProviderFactory,
@@ -47,7 +47,7 @@ pub trait LoadPendingBlock:
             HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
         >,
     > + RpcNodeCore<
-        Provider: BlockReaderIdExt<Receipt: ReceiptExt>
+        Provider: BlockReaderIdExt<Receipt: Receipt>
                       + EvmEnvProvider<ProviderHeader<Self::Provider>>
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,


### PR DESCRIPTION
this trait was pretty much useless because it didn't allow the OP specific receipt root.

renamed the function that relied on this for clarity.

we can also remove this fn from `ExecutionOutcome` which only has an additional helper (can remove separately after relaxing `calculate_receipt_root_no_memo` )

where this is still problematic is in the reorg tester code, only for those usecases we'd need an abstraction that can do both OP and eth, but since this is only really used for eth testing this should be okay, it would have paniced before this pr.