### PR TITLE
chore: remove `MaybeArbitrary` trait

### DIFF
--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -1,8 +1,7 @@
 //! Block body abstraction.
 
 use crate::{
-    BlockHeader, FullSignedTx, InMemorySize, MaybeArbitrary, MaybeSerde, MaybeSerdeBincodeCompat,
-    SignedTransaction,
+    BlockHeader, FullSignedTx, InMemorySize, MaybeSerde, MaybeSerdeBincodeCompat, SignedTransaction,
 };
 use alloc::{fmt, vec::Vec};
 use alloy_consensus::Transaction;
@@ -28,7 +27,6 @@ pub trait BlockBody:
     + alloy_rlp::Decodable
     + InMemorySize
     + MaybeSerde
-    + MaybeArbitrary
     + MaybeSerdeBincodeCompat
     + 'static
 {

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -4,7 +4,7 @@ use core::{fmt, hash::Hash};
 
 use alloy_primitives::Sealable;
 
-use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde, MaybeSerdeBincodeCompat};
+use crate::{InMemorySize, MaybeCompact, MaybeSerde, MaybeSerdeBincodeCompat};
 
 /// Helper trait that unifies all behaviour required by block header to support full node
 /// operations.
@@ -29,7 +29,6 @@ pub trait BlockHeader:
     + Sealable
     + InMemorySize
     + MaybeSerde
-    + MaybeArbitrary
     + MaybeSerdeBincodeCompat
     + AsRef<Self>
     + 'static

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -6,10 +6,7 @@ pub mod header;
 use alloc::fmt;
 use alloy_rlp::{Decodable, Encodable};
 
-use crate::{
-    BlockBody, BlockHeader, FullBlockBody, FullBlockHeader, InMemorySize, MaybeArbitrary,
-    MaybeSerde,
-};
+use crate::{BlockBody, BlockHeader, FullBlockBody, FullBlockHeader, InMemorySize, MaybeSerde};
 
 /// Helper trait that unifies all behaviour required by block to support full node operations.
 pub trait FullBlock:
@@ -42,7 +39,6 @@ pub trait Block:
     + Eq
     + InMemorySize
     + MaybeSerde
-    + MaybeArbitrary
     + Encodable
     + Decodable
 {

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -74,18 +74,6 @@ pub use size::InMemorySize;
 pub mod node;
 pub use node::{BodyTy, FullNodePrimitives, HeaderTy, NodePrimitives, ReceiptTy};
 
-/// Helper trait that requires arbitrary implementation if the feature is enabled.
-#[cfg(any(feature = "test-utils", feature = "arbitrary"))]
-pub trait MaybeArbitrary: for<'a> arbitrary::Arbitrary<'a> {}
-/// Helper trait that requires arbitrary implementation if the feature is enabled.
-#[cfg(not(any(feature = "test-utils", feature = "arbitrary")))]
-pub trait MaybeArbitrary {}
-
-#[cfg(any(feature = "test-utils", feature = "arbitrary"))]
-impl<T> MaybeArbitrary for T where T: for<'a> arbitrary::Arbitrary<'a> {}
-#[cfg(not(any(feature = "test-utils", feature = "arbitrary")))]
-impl<T> MaybeArbitrary for T {}
-
 /// Helper trait that requires de-/serialize implementation since `serde` feature is enabled.
 #[cfg(feature = "serde")]
 pub trait MaybeSerde: serde::Serialize + for<'de> serde::Deserialize<'de> {}

--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -1,6 +1,6 @@
 //! Receipt abstraction
 
-use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
+use crate::{InMemorySize, MaybeCompact, MaybeSerde};
 use alloc::vec::Vec;
 use alloy_consensus::{
     Eip2718EncodableReceipt, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt, Typed2718,
@@ -28,7 +28,6 @@ pub trait Receipt:
     + Typed2718
     + MaybeSerde
     + InMemorySize
-    + MaybeArbitrary
 {
 }
 

--- a/crates/primitives-traits/src/transaction/mod.rs
+++ b/crates/primitives-traits/src/transaction/mod.rs
@@ -5,7 +5,7 @@ pub mod signed;
 
 pub mod error;
 
-use crate::{InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
+use crate::{InMemorySize, MaybeCompact, MaybeSerde};
 use core::{fmt, hash::Hash};
 
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
@@ -26,7 +26,6 @@ pub trait Transaction:
     + alloy_consensus::Transaction
     + InMemorySize
     + MaybeSerde
-    + MaybeArbitrary
 {
 }
 
@@ -42,6 +41,5 @@ impl<T> Transaction for T where
         + alloy_consensus::Transaction
         + InMemorySize
         + MaybeSerde
-        + MaybeArbitrary
 {
 }

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -1,6 +1,6 @@
 //! API of a signed transaction.
 
-use crate::{FillTxEnv, InMemorySize, MaybeArbitrary, MaybeCompact, MaybeSerde};
+use crate::{FillTxEnv, InMemorySize, MaybeCompact, MaybeSerde};
 use alloc::{fmt, vec::Vec};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{keccak256, Address, PrimitiveSignature, TxHash, B256};
@@ -28,7 +28,6 @@ pub trait SignedTransaction:
     + Decodable2718
     + alloy_consensus::Transaction
     + MaybeSerde
-    + MaybeArbitrary
     + InMemorySize
 {
     /// Returns reference to transaction hash.


### PR DESCRIPTION
It looks like we don't rely on it anywhere and it has been causing some weird feature errors for a while now.

It might be reasonable to reconsider approach with cfg gated supertraits. e.g we could introduce `ArbitraryNodePrimitives` which will be used by the types depending on arbitrary bound