### PR TITLE
chore: use consistent naming for tx fns

### DIFF
--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -144,7 +144,7 @@ impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
                 return Err(PayloadError::PostCancunWithoutCancunFields)
             }
         } else {
-            if sealed_block.has_blob_transactions() {
+            if sealed_block.has_eip4844_transactions() {
                 // cancun not active but blob transactions present
                 return Err(PayloadError::PreCancunBlockWithBlobTransactions)
             }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -265,8 +265,8 @@ impl<H, B> SealedBlock<H, B> {
 impl SealedBlock {
     /// Returns whether or not the block contains any blob transactions.
     #[inline]
-    pub fn has_blob_transactions(&self) -> bool {
-        self.body.has_blob_transactions()
+    pub fn has_eip4844_transactions(&self) -> bool {
+        self.body.has_eip4844_transactions()
     }
 
     /// Returns whether or not the block contains any eip-7702 transactions.
@@ -583,7 +583,7 @@ impl BlockBody {
     /// Returns an iterator over all blob versioned hashes from the block body.
     #[inline]
     pub fn blob_versioned_hashes_iter(&self) -> impl Iterator<Item = &B256> + '_ {
-        self.blob_transactions_iter()
+        self.eip4844_transactions_iter()
             .filter_map(|tx| tx.as_eip4844().map(|blob_tx| &blob_tx.blob_versioned_hashes))
             .flatten()
     }
@@ -611,7 +611,7 @@ impl<T> BlockBody<T> {
 impl<T: Transaction> BlockBody<T> {
     /// Returns whether or not the block body contains any blob transactions.
     #[inline]
-    pub fn has_blob_transactions(&self) -> bool {
+    pub fn has_eip4844_transactions(&self) -> bool {
         self.transactions.iter().any(|tx| tx.is_eip4844())
     }
 
@@ -623,14 +623,8 @@ impl<T: Transaction> BlockBody<T> {
 
     /// Returns an iterator over all blob transactions of the block
     #[inline]
-    pub fn blob_transactions_iter(&self) -> impl Iterator<Item = &T> + '_ {
+    pub fn eip4844_transactions_iter(&self) -> impl Iterator<Item = &T> + '_ {
         self.transactions.iter().filter(|tx| tx.is_eip4844())
-    }
-
-    /// Returns only the blob transactions, if any, from the block body.
-    #[inline]
-    pub fn blob_transactions(&self) -> Vec<&T> {
-        self.blob_transactions_iter().collect()
     }
 }
 


### PR DESCRIPTION
some prep for offloading those to the trait or relaxing the impls