### PR TITLE
chore(sdk): fix docs to match generic tx type

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -540,7 +540,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
         self.inner.in_memory_state.head_state().into_iter().flat_map(|head| head.iter())
     }
 
-    /// Returns a `TransactionSigned` for the given `TxHash` if found.
+    /// Returns [`SignedTransaction`] type for the given `TxHash` if found.
     pub fn transaction_by_hash(&self, hash: TxHash) -> Option<N::SignedTx>
     where
         N::SignedTx: Encodable2718,
@@ -560,8 +560,8 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
         None
     }
 
-    /// Returns a tuple with `TransactionSigned` and `TransactionMeta` for the
-    /// given `TxHash` if found.
+    /// Returns a tuple with [`SignedTransaction`] type and [`TransactionMeta`] for the
+    /// given [`TxHash`] if found.
     pub fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/12454

Fixes docs to match generic signed transaction type