### PR TITLE
chore: impl evm env provider for noop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7678,6 +7678,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-revm",
+ "reth-storage-api",
  "reth-storage-errors",
  "revm",
  "revm-primitives",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -24,6 +24,8 @@ reth-prune-types.workspace = true
 reth-revm.workspace = true
 reth-storage-errors.workspace = true
 
+reth-storage-api = { workspace = true, optional = true }
+
 revm.workspace = true
 revm-primitives.workspace = true
 
@@ -66,6 +68,7 @@ test-utils = [
     "reth-primitives/test-utils",
     "reth-primitives-traits/test-utils",
     "reth-revm/test-utils",
+	"dep:reth-storage-api",
     "revm/test-utils",
     "reth-prune-types/test-utils"
 ]

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -526,58 +526,6 @@ impl<C: Send + Sync + 'static, N: NodePrimitives> StateProviderFactory for NoopP
     }
 }
 
-// impl EvmEnvProvider for NoopProvider {
-//     fn fill_env_at<EvmConfig>(
-//         &self,
-//         _cfg: &mut CfgEnvWithHandlerCfg,
-//         _block_env: &mut BlockEnv,
-//         _at: BlockHashOrNumber,
-//         _evm_config: EvmConfig,
-//     ) -> ProviderResult<()>
-//     where
-//         EvmConfig: ConfigureEvmEnv<Header = Header>,
-//     {
-//         Ok(())
-//     }
-//
-//     fn fill_env_with_header<EvmConfig>(
-//         &self,
-//         _cfg: &mut CfgEnvWithHandlerCfg,
-//         _block_env: &mut BlockEnv,
-//         _header: &Header,
-//         _evm_config: EvmConfig,
-//     ) -> ProviderResult<()>
-//     where
-//         EvmConfig: ConfigureEvmEnv<Header = Header>,
-//     {
-//         Ok(())
-//     }
-//
-//     fn fill_cfg_env_at<EvmConfig>(
-//         &self,
-//         _cfg: &mut CfgEnvWithHandlerCfg,
-//         _at: BlockHashOrNumber,
-//         _evm_config: EvmConfig,
-//     ) -> ProviderResult<()>
-//     where
-//         EvmConfig: ConfigureEvmEnv<Header = Header>,
-//     {
-//         Ok(())
-//     }
-//
-//     fn fill_cfg_env_with_header<EvmConfig>(
-//         &self,
-//         _cfg: &mut CfgEnvWithHandlerCfg,
-//         _header: &Header,
-//         _evm_config: EvmConfig,
-//     ) -> ProviderResult<()>
-//     where
-//         EvmConfig: ConfigureEvmEnv<Header = Header>,
-//     {
-//         Ok(())
-//     }
-// }
-
 impl<C: Send + Sync, N: NodePrimitives> StageCheckpointReader for NoopProvider<C, N> {
     fn get_stage_checkpoint(&self, _id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         Ok(None)


### PR DESCRIPTION
this is a bit ugly, but the easiest way to add EvmEnvProvider support for the new NoopProvider

this will unblock a ton of cleanup in reth-provider