### PR TITLE
fix(engine): return error on StateRootTask multiproof and root calculation failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,6 +7406,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-engine-primitives",
  "reth-evm",
+ "reth-execution-errors",
  "reth-exex-types",
  "reth-metrics",
  "reth-network-p2p",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -21,6 +21,7 @@ reth-consensus.workspace = true
 reth-engine-primitives.workspace = true
 reth-errors.workspace = true
 reth-evm.workspace = true
+reth-execution-errors.workspace = true
 reth-network-p2p.workspace = true
 reth-payload-builder-primitives.workspace = true
 reth-payload-builder.workspace = true


### PR DESCRIPTION
The errors on multiproof and state root calculations are only logged, not returned. On errors the task just gets stuck.