### PR TITLE
chore: rm redundant return

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -266,7 +266,6 @@ where
         if maybe_more_incoming_requests {
             // make sure we're woken up again
             cx.waker().wake_by_ref();
-            return Poll::Pending
         }
 
         Poll::Pending


### PR DESCRIPTION
this is not needed