### PR TITLE
chore(trie): make `MultiProofTargets` a type alias

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -13,29 +13,11 @@ use alloy_trie::{
     proof::{verify_proof, ProofNodes, ProofVerificationError},
     TrieMask, EMPTY_ROOT_HASH,
 };
-use derive_more::derive::{Deref, DerefMut, From, Into, IntoIterator};
 use itertools::Itertools;
 use reth_primitives_traits::Account;
 
 /// Proof targets map.
-#[derive(Debug, Default, Clone, Deref, DerefMut, From, Into, IntoIterator)]
-pub struct MultiProofTargets(B256HashMap<B256HashSet>);
-
-impl MultiProofTargets {
-    /// Extends the proof targets map with another one.
-    pub fn extend(&mut self, other: Self) {
-        for (address, slots) in other.0 {
-            self.0.entry(address).or_default().extend(slots);
-        }
-    }
-
-    /// Extends the proof targets map with another one by reference.
-    pub fn extend_ref(&mut self, other: &Self) {
-        for (address, slots) in &other.0 {
-            self.0.entry(*address).or_default().extend(slots);
-        }
-    }
-}
+pub type MultiProofTargets = B256HashMap<B256HashSet>;
 
 /// The state multiproof of target accounts and multiproofs of their storage tries.
 /// Multiproof is effectively a state subtrie that only contains the nodes

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -39,9 +39,7 @@ fn includes_empty_node_preimage() {
 
     let state_root = StateRoot::from_tx(provider.tx_ref()).root().unwrap();
     let multiproof = Proof::from_tx(provider.tx_ref())
-        .multiproof(
-            HashMap::from_iter([(hashed_address, HashSet::from_iter([hashed_slot]))]).into(),
-        )
+        .multiproof(HashMap::from_iter([(hashed_address, HashSet::from_iter([hashed_slot]))]))
         .unwrap();
 
     let witness = TrieWitness::from_tx(provider.tx_ref())
@@ -79,9 +77,7 @@ fn includes_nodes_for_destroyed_storage_nodes() {
 
     let state_root = StateRoot::from_tx(provider.tx_ref()).root().unwrap();
     let multiproof = Proof::from_tx(provider.tx_ref())
-        .multiproof(
-            HashMap::from_iter([(hashed_address, HashSet::from_iter([hashed_slot]))]).into(),
-        )
+        .multiproof(HashMap::from_iter([(hashed_address, HashSet::from_iter([hashed_slot]))]))
         .unwrap();
 
     let witness =
@@ -126,13 +122,10 @@ fn correctly_decodes_branch_node_values() {
 
     let state_root = StateRoot::from_tx(provider.tx_ref()).root().unwrap();
     let multiproof = Proof::from_tx(provider.tx_ref())
-        .multiproof(
-            HashMap::from_iter([(
-                hashed_address,
-                HashSet::from_iter([hashed_slot1, hashed_slot2]),
-            )])
-            .into(),
-        )
+        .multiproof(HashMap::from_iter([(
+            hashed_address,
+            HashSet::from_iter([hashed_slot1, hashed_slot2]),
+        )]))
         .unwrap();
 
     let witness = TrieWitness::from_tx(provider.tx_ref())

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -560,8 +560,7 @@ mod tests {
                 HashMap::from_iter([
                     (address_1, HashSet::from_iter([slot_1, slot_2])),
                     (address_2, HashSet::from_iter([slot_1, slot_2])),
-                ])
-                .into(),
+                ]),
                 MultiProof {
                     account_subtree: proof_nodes,
                     branch_node_hash_masks: HashMap::from_iter([(

--- a/crates/trie/trie/src/proof/blinded.rs
+++ b/crates/trie/trie/src/proof/blinded.rs
@@ -91,7 +91,7 @@ where
         let proof =
             Proof::new(self.trie_cursor_factory.clone(), self.hashed_cursor_factory.clone())
                 .with_prefix_sets_mut(self.prefix_sets.as_ref().clone())
-                .multiproof(targets.into())
+                .multiproof(targets)
                 .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
 
         Ok(proof.account_subtree.into_inner().remove(path))

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -94,10 +94,10 @@ where
         slots: &[B256],
     ) -> Result<AccountProof, StateProofError> {
         Ok(self
-            .multiproof(
-                HashMap::from_iter([(keccak256(address), slots.iter().map(keccak256).collect())])
-                    .into(),
-            )?
+            .multiproof(HashMap::from_iter([(
+                keccak256(address),
+                slots.iter().map(keccak256).collect(),
+            )]))?
             .account_proof(address, slots)?)
     }
 


### PR DESCRIPTION
Better ergonomics for external usage