### PR TITLE
feat: remove default receipts for network components

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -223,7 +223,11 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Represents a `GetReceipts` request-response pair.
     GetReceipts(RequestPair<GetReceipts>),
     /// Represents a Receipts request-response pair.
-    Receipts(RequestPair<Receipts>),
+    #[cfg_attr(
+        feature = "serde",
+        serde(bound = "N::Receipt: serde::Serialize + serde::de::DeserializeOwned")
+    )]
+    Receipts(RequestPair<Receipts<N::Receipt>>),
 }
 
 impl<N: NetworkPrimitives> EthMessage<N> {

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -1,5 +1,6 @@
 //! Abstraction over primitive types in network messages.
 
+use alloy_consensus::{RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt};
 use alloy_rlp::{Decodable, Encodable};
 use reth_primitives_traits::{Block, BlockBody, BlockHeader, SignedTransaction};
 use std::fmt::Debug;
@@ -30,15 +31,12 @@ pub trait NetworkPrimitives:
     type PooledTransaction: SignedTransaction + TryFrom<Self::BroadcastedTransaction> + 'static;
 
     /// The transaction type which peers return in `GetReceipts` messages.
-    type Receipt: Encodable
+    type Receipt: TxReceipt
+        + RlpEncodableReceipt
+        + RlpDecodableReceipt
+        + Encodable
         + Decodable
-        + Send
-        + Sync
         + Unpin
-        + Clone
-        + Debug
-        + PartialEq
-        + Eq
         + 'static;
 }
 

--- a/crates/net/network-api/src/events.rs
+++ b/crates/net/network-api/src/events.rs
@@ -225,7 +225,7 @@ pub enum PeerRequest<N: NetworkPrimitives = EthNetworkPrimitives> {
         /// The request for receipts.
         request: GetReceipts,
         /// The channel to send the response for receipts.
-        response: oneshot::Sender<RequestResult<Receipts>>,
+        response: oneshot::Sender<RequestResult<Receipts<N::Receipt>>>,
     },
 }
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -148,7 +148,7 @@ where
 impl<C, N> NetworkConfig<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader<Block = N::Block, Receipt = reth_primitives::Receipt, Header = N::BlockHeader>
+    C: BlockReader<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
         + HeaderProvider
         + Clone
         + Unpin

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -4,7 +4,7 @@ use crate::{
     budget::DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS, metered_poll_nested_stream_with_budget,
     metrics::EthRequestHandlerMetrics,
 };
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{BlockHeader, ReceiptWithBloom, TxReceipt};
 use alloy_eips::BlockHashOrNumber;
 use alloy_rlp::Encodable;
 use futures::StreamExt;
@@ -81,7 +81,7 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
 impl<C, N> EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader + HeaderProvider + ReceiptProvider<Receipt = reth_primitives::Receipt>,
+    C: BlockReader + HeaderProvider + ReceiptProvider<Receipt: Encodable + TxReceipt>,
 {
     /// Returns the list of requested headers
     fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<C::Header> {
@@ -188,7 +188,7 @@ where
         &self,
         _peer_id: PeerId,
         request: GetReceipts,
-        response: oneshot::Sender<RequestResult<Receipts>>,
+        response: oneshot::Sender<RequestResult<Receipts<C::Receipt>>>,
     ) {
         self.metrics.eth_receipts_requests_received_total.increment(1);
 
@@ -202,7 +202,11 @@ where
             {
                 let receipt = receipts_by_block
                     .into_iter()
-                    .map(|receipt| receipt.with_bloom())
+                    .map(|receipt| {
+                        // TODO: use `into_with_bloom` on new alloy release
+                        let bloom = receipt.bloom();
+                        ReceiptWithBloom::new(receipt, bloom)
+                    })
                     .collect::<Vec<_>>();
 
                 total_bytes += receipt.length();
@@ -226,7 +230,7 @@ where
 impl<C, N> Future for EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader<Block = N::Block, Receipt = reth_primitives::Receipt>
+    C: BlockReader<Block = N::Block, Receipt = N::Receipt>
         + HeaderProvider<Header = N::BlockHeader>
         + Unpin,
 {
@@ -317,6 +321,6 @@ pub enum IncomingEthRequest<N: NetworkPrimitives = EthNetworkPrimitives> {
         /// The specific receipts requested.
         request: GetReceipts,
         /// The channel sender for the response containing receipts.
-        response: oneshot::Sender<RequestResult<Receipts>>,
+        response: oneshot::Sender<RequestResult<Receipts<N::Receipt>>>,
     },
 }

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -200,14 +200,8 @@ where
             if let Some(receipts_by_block) =
                 self.client.receipts_by_block(BlockHashOrNumber::Hash(hash)).unwrap_or_default()
             {
-                let receipt = receipts_by_block
-                    .into_iter()
-                    .map(|receipt| {
-                        // TODO: use `into_with_bloom` on new alloy release
-                        let bloom = receipt.bloom();
-                        ReceiptWithBloom::new(receipt, bloom)
-                    })
-                    .collect::<Vec<_>>();
+                let receipt =
+                    receipts_by_block.into_iter().map(ReceiptWithBloom::from).collect::<Vec<_>>();
 
                 total_bytes += receipt.length();
                 receipts.push(receipt);

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -99,7 +99,7 @@ pub enum PeerResponse<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Represents a response to a request for receipts.
     Receipts {
         /// The receiver channel for the response to a receipts request.
-        response: oneshot::Receiver<RequestResult<Receipts>>,
+        response: oneshot::Receiver<RequestResult<Receipts<N::Receipt>>>,
     },
 }
 
@@ -150,7 +150,7 @@ pub enum PeerResponseResult<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Represents a result containing node data or an error.
     NodeData(RequestResult<Vec<Bytes>>),
     /// Represents a result containing receipts or an error.
-    Receipts(RequestResult<Vec<Vec<ReceiptWithBloom<reth_primitives::Receipt>>>>),
+    Receipts(RequestResult<Vec<Vec<ReceiptWithBloom<N::Receipt>>>>),
 }
 
 // === impl PeerResponseResult ===

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -662,11 +662,8 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
                 >,
             > + Unpin
             + 'static,
-        Node::Provider: BlockReader<
-            Receipt = reth_primitives::Receipt,
-            Block = N::Block,
-            Header = N::BlockHeader,
-        >,
+        Node::Provider:
+            BlockReader<Receipt = N::Receipt, Block = N::Block, Header = N::BlockHeader>,
     {
         self.start_network_with(builder, pool, Default::default())
     }
@@ -692,11 +689,8 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
                 >,
             > + Unpin
             + 'static,
-        Node::Provider: BlockReader<
-            Receipt = reth_primitives::Receipt,
-            Block = N::Block,
-            Header = N::BlockHeader,
-        >,
+        Node::Provider:
+            BlockReader<Receipt = N::Receipt, Block = N::Block, Header = N::BlockHeader>,
     {
         let (handle, network, txpool, eth) = builder
             .transactions(pool, tx_config)


### PR DESCRIPTION
Removes some default `Receipt` types, replacing with the associated type from `NetworkPrimitives`.