### PR TITLE
chore: small `Requests` clean up

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::Transaction as _;
-use alloy_eips::eip7685::Requests;
+use alloy_eips::{eip6110, eip7685::Requests};
 use core::fmt::Display;
 use reth_chainspec::{ChainSpec, EthereumHardfork, EthereumHardforks, MAINNET};
 use reth_consensus::ConsensusError;
@@ -246,7 +246,7 @@ where
             let mut requests = Requests::default();
 
             if !deposit_requests.is_empty() {
-                requests.push_request(core::iter::once(0).chain(deposit_requests).collect());
+                requests.push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
             }
 
             requests.extend(self.system_caller.apply_post_execution_changes(&mut evm)?);

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -134,19 +134,13 @@ where
         // Collect all EIP-7685 requests
         let withdrawal_requests = self.apply_withdrawal_requests_contract_call(evm)?;
         if !withdrawal_requests.is_empty() {
-            requests.push_request(
-                core::iter::once(WITHDRAWAL_REQUEST_TYPE).chain(withdrawal_requests).collect(),
-            );
+            requests.push_request_with_type(WITHDRAWAL_REQUEST_TYPE, withdrawal_requests);
         }
 
         // Collect all EIP-7251 requests
         let consolidation_requests = self.apply_consolidation_requests_contract_call(evm)?;
         if !consolidation_requests.is_empty() {
-            requests.push_request(
-                core::iter::once(CONSOLIDATION_REQUEST_TYPE)
-                    .chain(consolidation_requests)
-                    .collect(),
-            );
+            requests.push_request_with_type(CONSOLIDATION_REQUEST_TYPE, consolidation_requests);
         }
 
         Ok(requests)


### PR DESCRIPTION
Uses constant for deposit request type and `Requests::push_request_with_type`

Also changed payload builder to reuse `SystemCaller::apply_post_execution_changes`