### PR TITLE
Propagating OpDAConfig to OpPayloadBuilder

### DIFF
--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -32,10 +32,12 @@ fn main() {
                     let engine_tree_config = TreeConfig::default()
                         .with_persistence_threshold(rollup_args.persistence_threshold)
                         .with_memory_block_buffer_target(rollup_args.memory_block_buffer_target);
+
+                    let op_node = OpNode::new(rollup_args.clone());
                     let handle = builder
                         .with_types_and_provider::<OpNode, BlockchainProvider2<_>>()
-                        .with_components(OpNode::components(rollup_args.clone()))
-                        .with_add_ons(OpNode::new(rollup_args).add_ons())
+                        .with_components(op_node.components())
+                        .with_add_ons(op_node.add_ons())
                         .launch_with_fn(|builder| {
                             let launcher = EngineNodeLauncher::new(
                                 builder.task_executor().clone(),

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -506,7 +506,8 @@ pub struct OpPayloadBuilder<Txs = ()> {
 }
 
 impl OpPayloadBuilder {
-    /// Create a new instance with the given `compute_pending_block` flag and data availability config.
+    /// Create a new instance with the given `compute_pending_block` flag and data availability
+    /// config.
     pub fn new(compute_pending_block: bool) -> Self {
         Self { compute_pending_block, best_transactions: (), da_config: OpDAConfig::default() }
     }

--- a/crates/optimism/node/tests/it/builder.rs
+++ b/crates/optimism/node/tests/it/builder.rs
@@ -12,11 +12,12 @@ fn test_basic_setup() {
     let config = NodeConfig::new(BASE_MAINNET.clone());
     let db = create_test_rw_db();
     let args = RollupArgs::default();
+    let op_node = OpNode::new(args);
     let _builder = NodeBuilder::new(config)
         .with_database(db)
         .with_types::<OpNode>()
-        .with_components(OpNode::components(args.clone()))
-        .with_add_ons(OpNode::new(args).add_ons())
+        .with_components(op_node.components())
+        .with_add_ons(op_node.add_ons())
         .on_component_initialized(move |ctx| {
             let _provider = ctx.provider();
             Ok(())

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -24,7 +24,7 @@ use reth_optimism_node::{
     utils::optimism_payload_attributes,
     OpEngineTypes, OpNode,
 };
-use reth_optimism_payload_builder::{builder::OpPayloadTransactions, config::OpDAConfig};
+use reth_optimism_payload_builder::builder::OpPayloadTransactions;
 use reth_optimism_primitives::OpPrimitives;
 use reth_payload_util::{PayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
 use reth_primitives::{RecoveredTx, SealedBlock, Transaction, TransactionSigned};
@@ -108,7 +108,7 @@ where
         .node_types::<Node>()
         .pool(OpPoolBuilder::default())
         .payload(
-            OpPayloadBuilder::new(compute_pending_block, OpDAConfig::default())
+            OpPayloadBuilder::new(compute_pending_block)
                 .with_transactions(CustomTxPriority { chain_id }),
         )
         .network(OpNetworkBuilder { disable_txpool_gossip, disable_discovery_v4: !discovery_v4 })

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -24,7 +24,7 @@ use reth_optimism_node::{
     utils::optimism_payload_attributes,
     OpEngineTypes, OpNode,
 };
-use reth_optimism_payload_builder::builder::OpPayloadTransactions;
+use reth_optimism_payload_builder::{builder::OpPayloadTransactions, config::OpDAConfig};
 use reth_optimism_primitives::OpPrimitives;
 use reth_payload_util::{PayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
 use reth_primitives::{RecoveredTx, SealedBlock, Transaction, TransactionSigned};
@@ -108,7 +108,7 @@ where
         .node_types::<Node>()
         .pool(OpPoolBuilder::default())
         .payload(
-            OpPayloadBuilder::new(compute_pending_block)
+            OpPayloadBuilder::new(compute_pending_block, OpDAConfig::default())
                 .with_transactions(CustomTxPriority { chain_id }),
         )
         .network(OpNetworkBuilder { disable_txpool_gossip, disable_discovery_v4: !discovery_v4 })


### PR DESCRIPTION
Closes #13314.

Not sure if 100% solves it since `OpDAConfig::default()` is passed into `ComponentsBuilder` instead of `self.da_config` from OpNode. But since i saw in bin/src/main.rs that the OpNodes were separate, I didn't want to adjust anything unnecessarily!

Lmk if any adjustments are needed.