### PR TITLE
perf(`history_by_block_hash`): reuse provider instead of creating two

### DIFF
--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -203,7 +203,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             .block_number(block_hash)?
             .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
 
-        let state_provider = self.provider()?.try_into_history_at_block(block_number)?;
+        let state_provider = provider.try_into_history_at_block(block_number)?;
         trace!(target: "providers::db", ?block_number, %block_hash, "Returning historical state provider for block hash");
         Ok(state_provider)
     }


### PR DESCRIPTION
Towards #12838.

Currently, `history_by_block_hash` creates a second `provider` instead of reusing a created one, which unnecessarily clones a bunch and creates an extra DB transaction. This is the biggest allocation per `bytehound` and a suspect that causes OOM when we spam submit 20-30M transactions.

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/c0c7fa58-cfda-43c5-844c-a48de80756b6" />
