### PR TITLE
chore: ignore warnings from hickory

### DIFF
--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -18,11 +18,11 @@ pub(crate) type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 const RETH_LOG_FILE_NAME: &str = "reth.log";
 
 /// Default [directives](Directive) for [`EnvFilter`] which disables high-frequency debug logs from
-/// `hyper`, `trust-dns`, `jsonrpsee-server`, and `discv5`.
+/// `hyper`, `hickory-resolver`, `jsonrpsee-server`, and `discv5`.
 const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 5] = [
     "hyper::proto::h1=off",
-    "trust_dns_proto=off",
-    "trust_dns_resolver=off",
+    "hickory_resolver=off",
+    "hickory_proto=off",
     "discv5=off",
     "jsonrpsee-server=off",
 ];


### PR DESCRIPTION
we changed the dns lib from trust_dns to hickory which is a trust_dns fork. #13227

so we need to ignore the new targets