### PR TITLE
chore: rm blob_versioned_hashes

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -79,7 +79,7 @@ impl Command {
             let block_number = block.header.number;
 
             let versioned_hashes: Vec<B256> =
-                block.body.blob_versioned_hashes().into_iter().copied().collect();
+                block.body.blob_versioned_hashes_iter().copied().collect();
             let parent_beacon_block_root = block.parent_beacon_block_root;
             let payload = block_to_payload(block);
 

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -63,7 +63,7 @@ impl Command {
             let gas_used = block.gas_used;
 
             let versioned_hashes: Vec<B256> =
-                block.body.blob_versioned_hashes().into_iter().copied().collect();
+                block.body.blob_versioned_hashes_iter().copied().collect();
             let parent_beacon_block_root = block.parent_beacon_block_root;
             let payload = block_to_payload(block);
 

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -211,13 +211,12 @@ where
 
         let block = payload.block();
 
-        let cancun_fields = self
-            .provider
-            .chain_spec()
-            .is_cancun_active_at_timestamp(block.timestamp)
-            .then(|| CancunPayloadFields {
-                parent_beacon_block_root: block.parent_beacon_block_root.unwrap(),
-                versioned_hashes: block.body.blob_versioned_hashes().into_iter().copied().collect(),
+        let cancun_fields =
+            self.provider.chain_spec().is_cancun_active_at_timestamp(block.timestamp).then(|| {
+                CancunPayloadFields {
+                    parent_beacon_block_root: block.parent_beacon_block_root.unwrap(),
+                    versioned_hashes: block.body.blob_versioned_hashes_iter().copied().collect(),
+                }
             });
 
         let (tx, rx) = oneshot::channel();

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -586,12 +586,6 @@ impl BlockBody {
             .filter_map(|tx| tx.as_eip4844().map(|blob_tx| &blob_tx.blob_versioned_hashes))
             .flatten()
     }
-
-    /// Returns all blob versioned hashes from the block body.
-    #[inline]
-    pub fn blob_versioned_hashes(&self) -> Vec<&B256> {
-        self.blob_versioned_hashes_iter().collect()
-    }
 }
 
 impl<T> BlockBody<T> {


### PR DESCRIPTION
prep for replacing reth's blockbody with alloy#s

this function shouldn't be used