### PR TITLE
chore: unify unchecked naming

### DIFF
--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -122,7 +122,7 @@ where
             // TODO(alexey): report gas metrics using `block.header.gas_used`
 
             // Seal the block back and save it
-            blocks.push(block.seal(hash));
+            blocks.push(block.seal_unchecked(hash));
 
             // Check if we should commit now
             let bundle_size_hint = executor.size_hint().unwrap_or_default() as u64;

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -69,7 +69,7 @@ where
             .block_with_senders(block_id, Default::default())
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::HeaderNotFound(block_id.into()))?
-            .seal(latest.hash());
+            .seal_unchecked(latest.hash());
 
         let receipts = self
             .provider()

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -176,7 +176,7 @@ impl<B: reth_primitives_traits::Block> BlockWithSenders<B> {
     ///
     /// WARNING: This method does not perform validation whether the hash is correct.
     #[inline]
-    pub fn seal(self, hash: B256) -> SealedBlockWithSenders<B> {
+    pub fn seal_unchecked(self, hash: B256) -> SealedBlockWithSenders<B> {
         let Self { block, senders } = self;
         SealedBlockWithSenders::<B> { block: block.seal(hash), senders }
     }

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -428,7 +428,7 @@ where
         if !blocks.is_empty() {
             let blocks = blocks.into_iter().map(|block| {
                 let hash = block.header().hash_slow();
-                block.seal(hash)
+                block.seal_unchecked(hash)
             });
 
             let previous_input =

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2577,7 +2577,7 @@ mod tests {
                             .unseal::<reth_primitives::Block>()
                             .with_recovered_senders()
                             .unwrap()
-                            .seal(block.hash())
+                            .seal_unchecked(block.hash())
                     )
                 ),
                 (BlockHashOrNumber::Number(u64::MAX), TransactionVariant::WithHash)
@@ -2593,7 +2593,7 @@ mod tests {
                             .unseal::<reth_primitives::Block>()
                             .with_recovered_senders()
                             .unwrap()
-                            .seal(block.hash())
+                            .seal_unchecked(block.hash())
                     )
                 ),
                 (BlockHashOrNumber::Hash(B256::random()), TransactionVariant::WithHash)


### PR DESCRIPTION
across the codebase base these types of functions are called `_unchecked`.