### PR TITLE
chore: releax on canonical state change

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -150,18 +150,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use crate::{identifier::TransactionId, pool::PoolInner};
-use alloy_eips::eip4844::{BlobAndProofV1, BlobTransactionSidecar};
-use alloy_primitives::{Address, TxHash, B256, U256};
-use aquamarine as _;
-use reth_eth_wire_types::HandleMempoolData;
-use reth_execution_types::ChangedAccount;
-use reth_primitives::RecoveredTx;
-use reth_storage_api::StateProviderFactory;
-use std::{collections::HashSet, sync::Arc};
-use tokio::sync::mpsc::Receiver;
-use tracing::{instrument, trace};
-
 pub use crate::{
     blobstore::{BlobStore, BlobStoreError},
     config::{
@@ -182,6 +170,18 @@ pub use crate::{
         TransactionValidator, ValidPoolTransaction,
     },
 };
+use crate::{identifier::TransactionId, pool::PoolInner};
+use alloy_eips::eip4844::{BlobAndProofV1, BlobTransactionSidecar};
+use alloy_primitives::{Address, TxHash, B256, U256};
+use aquamarine as _;
+use reth_eth_wire_types::HandleMempoolData;
+use reth_execution_types::ChangedAccount;
+use reth_primitives::RecoveredTx;
+use reth_primitives_traits::{BlockBody, BlockHeader};
+use reth_storage_api::StateProviderFactory;
+use std::{collections::HashSet, sync::Arc};
+use tokio::sync::mpsc::Receiver;
+use tracing::{instrument, trace};
 
 pub mod error;
 pub mod maintain;
@@ -614,7 +614,11 @@ where
         self.pool.set_block_info(info)
     }
 
-    fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_>) {
+    fn on_canonical_state_change<H, B>(&self, update: CanonicalStateUpdate<'_, H, B>)
+    where
+        H: BlockHeader,
+        B: BlockBody,
+    {
         self.pool.on_canonical_state_change(update);
     }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -109,6 +109,7 @@ pub use events::{FullTransactionEvent, TransactionEvent};
 pub use listener::{AllTransactionsEvents, TransactionEvents};
 pub use parked::{BasefeeOrd, ParkedOrd, ParkedPool, QueuedOrd};
 pub use pending::PendingPool;
+use reth_primitives_traits::{BlockBody, BlockHeader};
 
 mod best;
 mod blob;
@@ -378,7 +379,11 @@ where
     }
 
     /// Updates the entire pool after a new block was executed.
-    pub fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_>) {
+    pub fn on_canonical_state_change<H, B>(&self, update: CanonicalStateUpdate<'_, H, B>)
+    where
+        H: BlockHeader,
+        B: BlockBody,
+    {
         trace!(target: "txpool", ?update, "updating pool on canonical state change");
 
         let block_info = update.block_info();

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_consensus::{
     constants::{EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID},
-    Transaction as _, Typed2718,
+    BlockHeader, Transaction as _, Typed2718,
 };
 use alloy_eips::{
     eip2718::Encodable2718,
@@ -24,7 +24,7 @@ use reth_primitives::{
     PooledTransaction, PooledTransactionsElementEcRecovered, RecoveredTx, SealedBlock, Transaction,
     TransactionSigned,
 };
-use reth_primitives_traits::SignedTransaction;
+use reth_primitives_traits::{BlockBody, SignedTransaction};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -517,7 +517,10 @@ pub trait TransactionPoolExt: TransactionPool {
     /// sidecar must not be removed from the blob store. Only after a blob transaction is
     /// finalized, its sidecar is removed from the blob store. This ensures that in case of a reorg,
     /// the sidecar is still available.
-    fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_>);
+    fn on_canonical_state_change<H, B>(&self, update: CanonicalStateUpdate<'_, H, B>)
+    where
+        H: reth_primitives_traits::BlockHeader,
+        B: BlockBody;
 
     /// Updates the accounts in the pool
     fn update_accounts(&self, accounts: Vec<ChangedAccount>);
@@ -717,9 +720,9 @@ pub enum PoolUpdateKind {
 ///
 /// This is used to update the pool state accordingly.
 #[derive(Clone, Debug)]
-pub struct CanonicalStateUpdate<'a> {
+pub struct CanonicalStateUpdate<'a, H, B> {
     /// Hash of the tip block.
-    pub new_tip: &'a SealedBlock,
+    pub new_tip: &'a SealedBlock<H, B>,
     /// EIP-1559 Base fee of the _next_ (pending) block
     ///
     /// The base fee of a block depends on the utilization of the last block and its base fee.
@@ -736,10 +739,13 @@ pub struct CanonicalStateUpdate<'a> {
     pub update_kind: PoolUpdateKind,
 }
 
-impl CanonicalStateUpdate<'_> {
+impl<H, B> CanonicalStateUpdate<'_, H, B>
+where
+    H: BlockHeader,
+{
     /// Returns the number of the tip block.
     pub fn number(&self) -> u64 {
-        self.new_tip.number
+        self.new_tip.number()
     }
 
     /// Returns the hash of the tip block.
@@ -749,13 +755,13 @@ impl CanonicalStateUpdate<'_> {
 
     /// Timestamp of the latest chain update
     pub fn timestamp(&self) -> u64 {
-        self.new_tip.timestamp
+        self.new_tip.timestamp()
     }
 
     /// Returns the block info for the tip block.
     pub fn block_info(&self) -> BlockInfo {
         BlockInfo {
-            block_gas_limit: self.new_tip.gas_limit,
+            block_gas_limit: self.new_tip.gas_limit(),
             last_seen_block_hash: self.hash(),
             last_seen_block_number: self.number(),
             pending_basefee: self.pending_block_base_fee,
@@ -764,7 +770,10 @@ impl CanonicalStateUpdate<'_> {
     }
 }
 
-impl fmt::Display for CanonicalStateUpdate<'_> {
+impl<H, B> fmt::Display for CanonicalStateUpdate<'_, H, B>
+where
+    H: BlockHeader,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CanonicalStateUpdate")
             .field("hash", &self.hash())


### PR DESCRIPTION
closes #13223

#13352 followup, this isn't super nice, but sufficient

as outlined, the better solution for the block update would be to solve this separately from the validator api