### PR TITLE
chore: move serde bincode compat bound to NodePrimitives

### DIFF
--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -539,6 +539,7 @@ pub(super) mod serde_bincode_compat {
     use reth_primitives::{
         serde_bincode_compat::SealedBlockWithSenders, EthPrimitives, NodePrimitives,
     };
+    use reth_primitives_traits::{serde_bincode_compat::SerdeBincodeCompat, Block};
     use reth_trie_common::serde_bincode_compat::updates::TrieUpdates;
     use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
@@ -576,7 +577,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<B> Serialize for SealedBlocksWithSenders<'_, B>
     where
-        B: reth_primitives_traits::Block,
+        B: Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -594,7 +595,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'de, B> Deserialize<'de> for SealedBlocksWithSenders<'_, B>
     where
-        B: reth_primitives_traits::Block,
+        B: Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -9,9 +9,9 @@ use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawals};
 use alloy_primitives::{Bytes, B256};
 
 /// Helper trait that unifies all behaviour required by transaction to support full node operations.
-pub trait FullBlockBody: BlockBody<Transaction: FullSignedTx> {}
+pub trait FullBlockBody: BlockBody<Transaction: FullSignedTx> + MaybeSerdeBincodeCompat {}
 
-impl<T> FullBlockBody for T where T: BlockBody<Transaction: FullSignedTx> {}
+impl<T> FullBlockBody for T where T: BlockBody<Transaction: FullSignedTx> + MaybeSerdeBincodeCompat {}
 
 /// Abstraction for block's body.
 pub trait BlockBody:
@@ -27,7 +27,6 @@ pub trait BlockBody:
     + alloy_rlp::Decodable
     + InMemorySize
     + MaybeSerde
-    + MaybeSerdeBincodeCompat
     + 'static
 {
     /// Ordered list of signed transactions as committed in block.

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Block, BlockBody, BlockHeader, FullBlock, FullBlockBody, FullBlockHeader, FullReceipt,
-    FullSignedTx, Receipt, SignedTransaction,
-};
+use crate::{Block, FullBlock, FullBlockBody, FullBlockHeader, FullReceipt, FullSignedTx, Receipt};
 use core::fmt;
 
 /// Configures all the primitive types of the node.
@@ -11,11 +8,11 @@ pub trait NodePrimitives:
     /// Block primitive.
     type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody>;
     /// Block header primitive.
-    type BlockHeader: BlockHeader;
+    type BlockHeader: FullBlockHeader;
     /// Block body primitive.
-    type BlockBody: BlockBody<Transaction = Self::SignedTx, OmmerHeader = Self::BlockHeader>;
+    type BlockBody: FullBlockBody<Transaction = Self::SignedTx, OmmerHeader = Self::BlockHeader>;
     /// Signed version of the transaction type.
-    type SignedTx: SignedTransaction + 'static;
+    type SignedTx: FullSignedTx;
     /// A receipt.
     type Receipt: Receipt;
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -655,7 +655,7 @@ impl<T: InMemorySize> InMemorySize for BlockBody<T> {
 
 impl<T> reth_primitives_traits::BlockBody for BlockBody<T>
 where
-    T: SignedTransaction + MaybeSerdeBincodeCompat,
+    T: SignedTransaction,
 {
     type Transaction = T;
     type OmmerHeader = Header;
@@ -715,7 +715,10 @@ pub(super) mod serde_bincode_compat {
     use alloy_consensus::serde_bincode_compat::Header;
     use alloy_eips::eip4895::Withdrawals;
     use alloy_primitives::Address;
-    use reth_primitives_traits::serde_bincode_compat::{SealedHeader, SerdeBincodeCompat};
+    use reth_primitives_traits::{
+        serde_bincode_compat::{SealedHeader, SerdeBincodeCompat},
+        Block,
+    };
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
@@ -868,7 +871,7 @@ pub(super) mod serde_bincode_compat {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct SealedBlockWithSenders<'a, B = super::Block>
     where
-        B: reth_primitives_traits::Block,
+        B: Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         block: SealedBlock<'a, B::Header, B::Body>,
         senders: Cow<'a, Vec<Address>>,
@@ -876,7 +879,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, B> From<&'a super::SealedBlockWithSenders<B>> for SealedBlockWithSenders<'a, B>
     where
-        B: reth_primitives_traits::Block,
+        B: Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         fn from(value: &'a super::SealedBlockWithSenders<B>) -> Self {
             Self { block: SealedBlock::from(&value.block), senders: Cow::Borrowed(&value.senders) }
@@ -885,7 +888,7 @@ pub(super) mod serde_bincode_compat {
 
     impl<'a, B> From<SealedBlockWithSenders<'a, B>> for super::SealedBlockWithSenders<B>
     where
-        B: reth_primitives_traits::Block,
+        B: Block<Header: SerdeBincodeCompat, Body: SerdeBincodeCompat>,
     {
         fn from(value: SealedBlockWithSenders<'a, B>) -> Self {
             Self { block: value.block.into(), senders: value.senders.into_owned() }


### PR DESCRIPTION
This moves `BlockBody: SerdeBincodeCompat` bound to `FullBlockBody` and enforces `Full*` bounds directly on `NodePrimitives`. This is needed to allow using `reth_primitives::BlockBody` by just bounding transaction with `T: SignedTransaction`

We can't make bincode compat a supertrait of `SignedTransaction` because we need it to be implemented in pooled transaction as well which is never being bincode serialized

This essentially makes `NodePrimitives` same as `FullNodePrimitives` which makes sense imo because there's not much benefit in implementing NodePrimitives for a set of types which can't be used for all of the components