### PR TITLE
chore: add `test_segment_config_backwards`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9393,6 +9393,7 @@ dependencies = [
  "alloy-primitives",
  "clap",
  "derive_more",
+ "reth-nippy-jar",
  "serde",
  "strum",
 ]

--- a/crates/static-file/types/Cargo.toml
+++ b/crates/static-file/types/Cargo.toml
@@ -19,5 +19,8 @@ derive_more.workspace = true
 serde = { workspace = true, features = ["derive"] }
 strum = { workspace = true, features = ["derive"] }
 
+[dev-dependencies]
+reth-nippy-jar.workspace = true
+
 [features]
 clap = ["dep:clap"]

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     error::Error as StdError,
     fs::File,
+    io::Read,
     ops::Range,
     path::{Path, PathBuf},
 };
@@ -201,9 +202,14 @@ impl<H: NippyJarHeader> NippyJar<H> {
         let config_file = File::open(&config_path)
             .map_err(|err| reth_fs_util::FsPathError::open(err, config_path))?;
 
-        let mut obj: Self = bincode::deserialize_from(&config_file)?;
+        let mut obj = Self::load_from_reader(config_file)?;
         obj.path = path.to_path_buf();
         Ok(obj)
+    }
+
+    /// Deserializes an instance of [`Self`] from a [`Read`] type.
+    pub fn load_from_reader<R: Read>(reader: R) -> Result<Self, NippyJarError> {
+        Ok(bincode::deserialize_from(reader)?)
     }
 
     /// Returns the path for the data file


### PR DESCRIPTION
If the order of the variants is changed, it will result in a different deserialization result.

Adds the test to ensure we don't change it without any failures.

https://github.com/paradigmxyz/reth/blob/138004bf3b7372d3e1293cbfd8334c03ea4d57fe/crates/static-file/types/src/segment.rs#L26-L37