### PR TITLE
perf: remove redundant fallback cleanup

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -602,7 +602,6 @@ where
             &mut valid_announcement_data,
             |hash| bad_imports.contains(hash),
             &peer_id,
-            |peer_id| self.peers.contains_key(&peer_id),
             &client,
         );
 


### PR DESCRIPTION
similar as #13398

this scanned the fallback peers on every hash and cleaned up no longer connected peers.

this is entirely redundant because we only select active peers anyway

https://github.com/paradigmxyz/reth/blob/0e019f28594624a32eed4d6aaf5d011ec472e024/crates/net/network/src/transactions/fetcher.rs#L199-L205

so we don't need to do this