### PR TITLE
chore: make ensure_well_formed_payload generic over transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8733,6 +8733,7 @@ dependencies = [
  "alloy-rpc-types",
  "reth-chainspec",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-rpc-types-compat",
 ]
 

--- a/crates/payload/validator/Cargo.toml
+++ b/crates/payload/validator/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # reth
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-rpc-types-compat.workspace = true
 
 # alloy

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -10,9 +10,7 @@ use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 use derive_more::{Deref, DerefMut};
 #[cfg(any(test, feature = "arbitrary"))]
 pub use reth_primitives_traits::test_utils::{generate_valid_header, valid_header_strategy};
-use reth_primitives_traits::{
-    BlockBody as _, InMemorySize, MaybeSerdeBincodeCompat, SignedTransaction, Transaction,
-};
+use reth_primitives_traits::{BlockBody as _, InMemorySize, SignedTransaction, Transaction};
 use serde::{Deserialize, Serialize};
 
 /// Ethereum full block.
@@ -36,7 +34,7 @@ impl<T> Default for Block<T> {
 
 impl<T> reth_primitives_traits::Block for Block<T>
 where
-    T: SignedTransaction + Encodable + Decodable + MaybeSerdeBincodeCompat,
+    T: SignedTransaction,
 {
     type Header = Header;
     type Body = BlockBody<T>;


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/13323

Allows to reuse `EnginePayloadValidator` for op and eth as long as they share the same block types with only transaction being different