### PR TITLE
fix: return bool for set_max_da_size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4df88a2f8020801e0fefce79471d3946d39ca3311802dbbd0ecfdeee5e972e3"
+checksum = "d2aff127863f8279921397be8af0ac3f05a8757d5c4c972b491c278518fa07c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5413,9 +5413,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848b3567a9a469ab0c9c712fca0fd6bbce13a9a0b723c94cb81214f53507cf07"
+checksum = "534e21b77059390e2b93e04c7f912865623c6a8eb7c4aef48c469bf6920926ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5430,39 +5430,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-consensus"
-version = "0.8.3"
-source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "serde",
- "thiserror 2.0.7",
-]
-
-[[package]]
 name = "op-alloy-genesis"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd04d0e24b3538e2bc9c024da1c08e0a97822c63b341c4491a6b29e86740641"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "serde_repr",
- "thiserror 2.0.7",
-]
-
-[[package]]
-name = "op-alloy-genesis"
-version = "0.8.3"
-source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
+checksum = "3ae4912c15ce3971338fa03be316850364a2c1354c21e96b19c535ed70316ed0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5475,24 +5446,24 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de7f38f96e4d8bc13bd6b05f27d9876c17e897898705734020a59291a06d781"
+checksum = "91c1dac374e46105703d47ef78d25dc9389444168d4252ef7433f3e364376b6d"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
 ]
 
 [[package]]
 name = "op-alloy-protocol"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0d72853e704a067ad6229dd3a753d1662fa02c4ea85783e25a887d7aadd150"
+checksum = "2b9e5978b53b864204efd2a802b9bd93a4ab24df083bcfecfa73d6a140f23f2e"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -5504,31 +5475,8 @@ dependencies = [
  "brotli",
  "cfg-if",
  "miniz_oxide",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-genesis 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "thiserror 2.0.7",
- "tracing",
- "unsigned-varint",
-]
-
-[[package]]
-name = "op-alloy-protocol"
-version = "0.8.3"
-source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
-dependencies = [
- "alloc-no-stdlib",
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "async-trait",
- "brotli",
- "cfg-if",
- "miniz_oxide",
- "op-alloy-consensus 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
- "op-alloy-genesis 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "op-alloy-consensus",
+ "op-alloy-genesis",
  "serde",
  "thiserror 2.0.7",
  "tracing",
@@ -5537,21 +5485,22 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.8.3"
-source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075f6c16c5e60b03cca15e678ddeb472950b37587f297de5638706567a5e6e28"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "jsonrpsee",
- "op-alloy-rpc-types 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
- "op-alloy-rpc-types-engine 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a555dd1bd39cbcdd60b92f03a21871767a16e3a2ce2f82a26cff9aade56d35f"
+checksum = "708072e60066bc2fc39d81c6068b59f40a2bc28d70d0bea0c38b8d2017df0dca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5561,33 +5510,16 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "derive_more",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "op-alloy-rpc-types"
-version = "0.8.3"
-source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "derive_more",
- "op-alloy-consensus 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "op-alloy-consensus",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16779322cc84d57f68afaef4cdabc150a5f8b53f345982f1aea010fe4d790267"
+checksum = "abf8bccdb49c5e1c4bded85e395065adfeb10b776119bfbb7ae395fb4f377689"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5595,28 +5527,11 @@ dependencies = [
  "alloy-serde",
  "derive_more",
  "ethereum_ssz",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-genesis 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-protocol 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
+ "op-alloy-genesis",
+ "op-alloy-protocol",
  "serde",
  "snap",
- "thiserror 2.0.7",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.8.3"
-source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-serde",
- "derive_more",
- "op-alloy-consensus 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
- "op-alloy-genesis 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
- "op-alloy-protocol 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
- "serde",
  "thiserror 2.0.7",
 ]
 
@@ -6981,7 +6896,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
  "reth-codecs-derive",
@@ -7323,7 +7238,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "jsonrpsee",
- "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types-engine",
  "reth-chainspec",
  "reth-db",
  "reth-engine-local",
@@ -7393,7 +7308,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types-engine",
  "reth-beacon-consensus",
  "reth-chainspec",
  "reth-consensus",
@@ -8457,8 +8372,8 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "once_cell",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -8479,7 +8394,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures-util",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
  "proptest",
  "reth-chainspec",
  "reth-cli",
@@ -8546,7 +8461,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "derive_more",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -8592,8 +8507,8 @@ dependencies = [
  "clap",
  "eyre",
  "futures",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "parking_lot",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
@@ -8643,8 +8558,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
@@ -8681,7 +8596,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "modular-bitfield",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
@@ -8706,11 +8621,11 @@ dependencies = [
  "alloy-rpc-types-eth",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-jsonrpsee",
- "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
  "parking_lot",
  "reqwest",
  "reth-chainspec",
@@ -8793,7 +8708,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -8846,8 +8761,8 @@ dependencies = [
  "derive_more",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
  "pprof",
  "proptest",
  "proptest-arbitrary-interop",
@@ -8888,7 +8803,7 @@ dependencies = [
  "derive_more",
  "k256",
  "modular-bitfield",
- "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,10 +5430,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-alloy-consensus"
+version = "0.8.3"
+source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "thiserror 2.0.7",
+]
+
+[[package]]
 name = "op-alloy-genesis"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd04d0e24b3538e2bc9c024da1c08e0a97822c63b341c4491a6b29e86740641"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_repr",
+ "thiserror 2.0.7",
+]
+
+[[package]]
+name = "op-alloy-genesis"
+version = "0.8.3"
+source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5455,8 +5484,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5475,8 +5504,31 @@ dependencies = [
  "brotli",
  "cfg-if",
  "miniz_oxide",
- "op-alloy-consensus",
- "op-alloy-genesis",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-genesis 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror 2.0.7",
+ "tracing",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "op-alloy-protocol"
+version = "0.8.3"
+source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "async-trait",
+ "brotli",
+ "cfg-if",
+ "miniz_oxide",
+ "op-alloy-consensus 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "op-alloy-genesis 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
  "serde",
  "thiserror 2.0.7",
  "tracing",
@@ -5486,14 +5538,13 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
 version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d5234f9aad47742ad3719c54fbdf2940a3731b659373d75d0f53f11d4a28c"
+source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "jsonrpsee",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "op-alloy-rpc-types-engine 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
 ]
 
 [[package]]
@@ -5510,7 +5561,24 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.8.3"
+source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more",
+ "op-alloy-consensus 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
  "serde",
  "serde_json",
 ]
@@ -5527,11 +5595,28 @@ dependencies = [
  "alloy-serde",
  "derive_more",
  "ethereum_ssz",
- "op-alloy-consensus",
- "op-alloy-genesis",
- "op-alloy-protocol",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-genesis 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-protocol 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "snap",
+ "thiserror 2.0.7",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.8.3"
+source = "git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type#2877906e7228be6957c9ea960b21a4c7b6d84ab3"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "derive_more",
+ "op-alloy-consensus 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "op-alloy-genesis 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "op-alloy-protocol 0.8.3 (git+https://github.com/ffddw/op-alloy.git?branch=issues/fix-return-type)",
+ "serde",
  "thiserror 2.0.7",
 ]
 
@@ -6896,7 +6981,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
  "proptest-arbitrary-interop",
  "reth-codecs-derive",
@@ -7238,7 +7323,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "jsonrpsee",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reth-chainspec",
  "reth-db",
  "reth-engine-local",
@@ -7308,7 +7393,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reth-beacon-consensus",
  "reth-chainspec",
  "reth-consensus",
@@ -8372,8 +8457,8 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "once_cell",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -8394,7 +8479,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures-util",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
  "reth-chainspec",
  "reth-cli",
@@ -8461,7 +8546,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -8507,8 +8592,8 @@ dependencies = [
  "clap",
  "eyre",
  "futures",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
@@ -8558,8 +8643,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
@@ -8596,7 +8681,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
@@ -8621,11 +8706,11 @@ dependencies = [
  "alloy-rpc-types-eth",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "op-alloy-network",
  "op-alloy-rpc-jsonrpsee",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
  "reqwest",
  "reth-chainspec",
@@ -8708,7 +8793,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -8761,8 +8846,8 @@ dependencies = [
  "derive_more",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "op-alloy-rpc-types 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pprof",
  "proptest",
  "proptest-arbitrary-interop",
@@ -8803,7 +8888,7 @@ dependencies = [
  "derive_more",
  "k256",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -477,11 +477,11 @@ alloy-transport-ipc = { version = "0.8.1", default-features = false }
 alloy-transport-ws = { version = "0.8.1", default-features = false }
 
 # op
-op-alloy-rpc-types = "0.8.3"
-op-alloy-rpc-types-engine = "0.8.3"
-op-alloy-rpc-jsonrpsee = { git = "https://github.com/ffddw/op-alloy.git", branch = "issues/fix-return-type" } # TODO: to be replaced
-op-alloy-network = "0.8.3"
-op-alloy-consensus = "0.8.3"
+op-alloy-rpc-types = "0.8.4"
+op-alloy-rpc-types-engine = "0.8.4"
+op-alloy-rpc-jsonrpsee = "0.8.4"
+op-alloy-network = "0.8.4"
+op-alloy-consensus = "0.8.4"
 
 # misc
 aquamarine = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -479,7 +479,7 @@ alloy-transport-ws = { version = "0.8.1", default-features = false }
 # op
 op-alloy-rpc-types = "0.8.3"
 op-alloy-rpc-types-engine = "0.8.3"
-op-alloy-rpc-jsonrpsee = "0.8.3"
+op-alloy-rpc-jsonrpsee = { git = "https://github.com/ffddw/op-alloy.git", branch = "issues/fix-return-type" } # TODO: to be replaced
 op-alloy-network = "0.8.3"
 op-alloy-consensus = "0.8.3"
 

--- a/crates/optimism/rpc/src/miner.rs
+++ b/crates/optimism/rpc/src/miner.rs
@@ -24,9 +24,9 @@ impl OpMinerExtApi {
 #[async_trait]
 impl MinerApiExtServer for OpMinerExtApi {
     /// Handler for `miner_setMaxDASize` RPC method.
-    async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<()> {
+    async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<bool> {
         debug!(target: "rpc", "Setting max DA size: tx={}, block={}", max_tx_size, max_block_size);
         self.da_config.set_max_da_size(max_tx_size.to(), max_block_size.to());
-        Ok(())
+        Ok(true)
     }
 }


### PR DESCRIPTION
ref: https://github.com/alloy-rs/op-alloy/pull/346, #13422


## Motivation

While op-batcher tries to set SetMaxDASize by calling miner_setMaxDASize of op-reth, returns error
```
ERROR[12-17|18:17:23.568] Result of SetMaxDASize was false, retrying.
ERROR[12-17|18:17:25.566] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.567] Starting batch-submitter work at safe-head safe=576f49..32600c:0
INFO [12-17|18:17:25.568] Added L2 block to local state            block=b3d6c5..31bcad:1 tx_count=1 time=1,734,423,746
ERROR[12-17|18:17:25.569] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.569] Added L2 block to local state            block=94dd18..cca0b0:2 tx_count=1 time=1,734,423,748
ERROR[12-17|18:17:25.569] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.569] Added L2 block to local state            block=66c587..a527bf:3 tx_count=1 time=1,734,423,750
ERROR[12-17|18:17:25.570] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.570] Added L2 block to local state            block=9425c1..828a77:4 tx_count=1 time=1,734,423,752
ERROR[12-17|18:17:25.570] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.570] Added L2 block to local state            block=b6cae3..91f714:5 tx_count=1 time=1,734,423,754
ERROR[12-17|18:17:25.570] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.571] Added L2 block to local state            block=e298dd..63bee4:6 tx_count=1 time=1,734,423,756
ERROR[12-17|18:17:25.571] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.571] Added L2 block to local state            block=41e4eb..fbfead:7 tx_count=1 time=1,734,423,758
ERROR[12-17|18:17:25.571] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.571] Added L2 block to local state            block=a1edc1..9a645e:8 tx_count=1 time=1,734,423,760
ERROR[12-17|18:17:25.571] Result of SetMaxDASize was false, retrying.
INFO [12-17|18:17:25.572] Added L2 block to local state
```

[Original golang implementation](https://github.com/ethereum-optimism/op-geth/blob/optimism/eth/api_miner.go#L62) of op-geth returns bool type, op-batcher expects `true` for the result, or treat as error for others, including `null`.

expected
```json
{
  "jsonrpc": "2.0",
  "id": 0,
  "result": true
}
```

as-is
```json
{
  "jsonrpc": "2.0",
  "id": 0,
  "result": null
}
```

## Solution
Change `set_max_da_size` return type from `RpcResult<()>` to `RpcResult<bool>`
https://github.com/paradigmxyz/reth/blob/main/crates/optimism/rpc/src/miner.rs#L27

- [x] TODO: After PR merged on op-alloy side, dependency on Cargo.toml should be replaced.

closes #13422
