### PR TITLE
chore(ci): update hive rpc-compat expected failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -13,12 +13,6 @@ rpc-compat:
   - eth_getTransactionReceipt/get-access-list (reth)
   - eth_getTransactionReceipt/get-blob-tx (reth)
   - eth_getTransactionReceipt/get-dynamic-fee (reth)
-  - eth_getBlockByHash/get-block-by-hash (reth)
-  - eth_getBlockByNumber/get-block-n (reth)
-  - eth_getBlockByNumber/get-finalized (reth)
-  - eth_getBlockByNumber/get-genesis (reth)
-  - eth_getBlockByNumber/get-latest (reth)
-  - eth_getBlockByNumber/get-safe (reth)
 
 # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:


### PR DESCRIPTION
After #13303 some rpc-compat tests previously failing bc of rpc responses including `totalDifficulty` are passing, eg. https://github.com/paradigmxyz/reth/actions/runs/12372646231/job/34532049787

```
Unexpected Passes: ['eth_getBlockByHash/get-block-by-hash (reth)', 'eth_getBlockByNumber/get-block-n (reth)', 'eth_getBlockByNumber/get-finalized (reth)', 'eth_getBlockByNumber/get-genesis (reth)', 'eth_getBlockByNumber/get-latest (reth)', 'eth_getBlockByNumber/get-safe (reth)']
```