### PR TITLE
typo fixed Update suite.rs

### DIFF
--- a/testing/ef-tests/src/suite.rs
+++ b/testing/ef-tests/src/suite.rs
@@ -21,7 +21,7 @@ pub trait Suite {
     /// - `BlockchainTests/TransitionTests`
     fn suite_name(&self) -> String;
 
-    /// Load an run each contained test case.
+    /// Load and run each contained test case.
     ///
     /// # Note
     ///


### PR DESCRIPTION
The typo is in the comment for the `run` method:

```rust
/// Load an run each contained test case.
```

Corrected to:

```rust
/// Load and run each contained test case.
```

Replaced `an` with `and` fixes the grammatical error.