### PR TITLE
fix: drop and remove lockfile when test

### DIFF
--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -64,7 +64,7 @@ impl StorageLock {
 impl Drop for StorageLock {
     fn drop(&mut self) {
         // The lockfile is not created in disable-lock mode, so we don't need to delete it.
-        #[cfg(not(feature = "disable-lock"))]
+        #[cfg(any(test, not(feature = "disable-lock")))]
         if Arc::strong_count(&self.0) == 1 && self.0.file_path.exists() {
             // TODO: should only happen during tests that the file does not exist: tempdir is
             // getting dropped first. However, tempdir shouldn't be dropped


### PR DESCRIPTION
`make test` output the failure:

```
failures:

---- lockfile::tests::test_drop_lock stdout ----
thread 'lockfile::tests::test_drop_lock' panicked at crates/storage/db/src/lockfile.rs:214:9: assertion failed: !lock_file.exists()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```