### PR TITLE
fix: reth-trie no_std case hashmap

### DIFF
--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{BlockNumber, B256};
+use alloy_primitives::{BlockNumber, B256, map::{HashMap, HashSet}};
 use derive_more::Deref;
 use reth_db::tables;
 use reth_db_api::{
@@ -13,7 +13,6 @@ use reth_trie::{
     KeyHasher, Nibbles,
 };
 use std::{
-    collections::{HashMap, HashSet},
     marker::PhantomData,
     ops::RangeInclusive,
 };

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -1,7 +1,5 @@
-use std::collections::hash_map;
-
 use crate::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
-use alloy_primitives::{keccak256, Address, BlockNumber, B256};
+use alloy_primitives::{keccak256, Address, BlockNumber, B256, map::hash_map};
 use reth_db::{cursor::DbCursorRO, models::BlockNumberAddress, tables, DatabaseError};
 use reth_db_api::transaction::DbTx;
 use reth_execution_errors::StorageRootError;


### PR DESCRIPTION
When std is disabled, the hash map type will be used from alloy-primitives.