### PR TITLE
chore: add docs for removing from state in system calls

### DIFF
--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -65,6 +65,11 @@ where
         }
     };
 
+    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
+    // and includes them in the result.
+    //
+    // There should be no state changes to these addresses anyways as a result of this system call,
+    // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
 

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -75,6 +75,11 @@ where
         }
     };
 
+    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
+    // and includes them in the result.
+    //
+    // There should be no state changes to these addresses anyways as a result of this system call,
+    // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
 

--- a/crates/evm/src/system_calls/eip7002.rs
+++ b/crates/evm/src/system_calls/eip7002.rs
@@ -51,7 +51,11 @@ where
         }
     };
 
-    // cleanup the state
+    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
+    // and includes them in the result.
+    //
+    // There should be no state changes to these addresses anyways as a result of this system call,
+    // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip7002::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
 

--- a/crates/evm/src/system_calls/eip7251.rs
+++ b/crates/evm/src/system_calls/eip7251.rs
@@ -53,7 +53,11 @@ where
         }
     };
 
-    // cleanup the state
+    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
+    // and includes them in the result.
+    //
+    // There should be no state changes to these addresses anyways as a result of this system call,
+    // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip7002::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
 


### PR DESCRIPTION
Adds docs for why we remove from the state in system calls, to all system call implementations.

cc @rakita 