### PR TITLE
chore: use op feature for engine local

### DIFF
--- a/crates/engine/local/Cargo.toml
+++ b/crates/engine/local/Cargo.toml
@@ -48,8 +48,6 @@ op-alloy-rpc-types-engine = { workspace = true, optional = true }
 workspace = true
 
 [features]
-optimism = [
-    "op-alloy-rpc-types-engine",
-    "reth-beacon-consensus/optimism",
-    "reth-provider/optimism",
+op = [
+    "dep:op-alloy-rpc-types-engine"
 ]

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -45,7 +45,7 @@ where
     }
 }
 
-#[cfg(feature = "optimism")]
+#[cfg(feature = "op")]
 impl<ChainSpec> PayloadAttributesBuilder<op_alloy_rpc_types_engine::OpPayloadAttributes>
     for LocalPayloadAttributesBuilder<ChainSpec>
 where

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -93,7 +93,7 @@ optimism = [
 	"reth-beacon-consensus/optimism",
 	"revm/optimism",
 	"reth-optimism-rpc/optimism",
-	"reth-engine-local/optimism",
+	"reth-engine-local/op",
 	"reth-optimism-consensus/optimism",
 	"reth-db/optimism",
 	"reth-optimism-node/optimism",


### PR DESCRIPTION
closes #13440

this is non problematic. we use `op` for these cases, otherwise zepter does complain