### PR TITLE
chore: relax PayloadBuilderService bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8686,6 +8686,7 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives",
+ "reth-primitives-traits",
  "revm",
  "tokio",
  "tokio-stream",

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -19,7 +19,7 @@ use reth_evm::state_change::post_block_withdrawals_balance_increments;
 use reth_payload_builder::{KeepPayloadJobAlive, PayloadId, PayloadJob, PayloadJobGenerator};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadKind};
-use reth_primitives::{proofs, SealedHeader};
+use reth_primitives::{proofs, NodePrimitives, SealedHeader};
 use reth_provider::{BlockReaderIdExt, CanonStateNotification, StateProviderFactory};
 use reth_revm::cached::CachedReads;
 use reth_tasks::TaskSpawner;
@@ -191,7 +191,7 @@ where
         Ok(job)
     }
 
-    fn on_new_state(&mut self, new_state: CanonStateNotification) {
+    fn on_new_state<N: NodePrimitives>(&mut self, new_state: CanonStateNotification<N>) {
         let mut cached = CachedReads::default();
 
         // extract the state from the notification and put it into the cache

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives = { workspace = true, optional = true }
+reth-primitives-traits.workspace = true
 reth-chain-state.workspace = true
 reth-payload-builder-primitives.workspace = true
 reth-payload-primitives.workspace = true

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -45,8 +45,9 @@ alloy-consensus.workspace = true
 
 [features]
 test-utils = [
-    "alloy-primitives",
-    "reth-chain-state/test-utils",
-    "reth-primitives/test-utils",
-    "revm/test-utils",
+	"alloy-primitives",
+	"reth-chain-state/test-utils",
+	"reth-primitives/test-utils",
+	"revm/test-utils",
+	"reth-primitives-traits/test-utils"
 ]

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -14,6 +14,7 @@ use reth_payload_builder_primitives::{
     Events, PayloadBuilder, PayloadBuilderError, PayloadEvents, PayloadStoreExt,
 };
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadKind, PayloadTypes};
+use reth_primitives_traits::NodePrimitives;
 use std::{
     fmt,
     future::Future,
@@ -352,12 +353,13 @@ where
     }
 }
 
-impl<Gen, St, T> Future for PayloadBuilderService<Gen, St, T>
+impl<Gen, St, T, N> Future for PayloadBuilderService<Gen, St, T>
 where
     T: PayloadTypes,
+    N: NodePrimitives,
     Gen: PayloadJobGenerator + Unpin + 'static,
     <Gen as PayloadJobGenerator>::Job: Unpin + 'static,
-    St: Stream<Item = CanonStateNotification> + Send + Unpin + 'static,
+    St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
     Gen::Job: PayloadJob<PayloadAttributes = T::PayloadBuilderAttributes>,
     <Gen::Job as PayloadJob>::BuiltPayload: Into<T::BuiltPayload>,
 {

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -3,6 +3,7 @@
 use reth_chain_state::CanonStateNotification;
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadKind};
+use reth_primitives_traits::NodePrimitives;
 use std::future::Future;
 
 /// A type that can build a payload.
@@ -105,7 +106,7 @@ pub trait PayloadJobGenerator: Send + Sync {
     ///
     /// This is intended for any logic that needs to be run when the chain state changes or used to
     /// use the in memory state for the head block.
-    fn on_new_state(&mut self, new_state: CanonStateNotification) {
+    fn on_new_state<N: NodePrimitives>(&mut self, new_state: CanonStateNotification<N>) {
         let _ = new_state;
     }
 }


### PR DESCRIPTION
Adds primitives generic to `PayloadJobGenerator::on_new_state`. Ideally it would only work for a fixed primitives impl but it's not neccesarry now as we're only processing state