### PR TITLE
fix: use correct merge activation block for sepolia

### DIFF
--- a/crates/ethereum-forks/src/hardfork/ethereum.rs
+++ b/crates/ethereum-forks/src/hardfork/ethereum.rs
@@ -96,7 +96,7 @@ impl EthereumHardfork {
     /// Retrieves the activation block for the specified hardfork on the Sepolia testnet.
     pub const fn sepolia_activation_block(&self) -> Option<u64> {
         match self {
-            Self::Paris => Some(1735371),
+            Self::Paris => Some(1450409),
             Self::Shanghai => Some(2990908),
             Self::Cancun => Some(5187023),
             Self::Frontier |


### PR DESCRIPTION
should be this one 

https://github.com/paradigmxyz/reth/blob/1284152550328df0dca0adcfd72755b7273d2c2b/crates/chainspec/src/spec.rs#L66-L67