### PR TITLE
chore: remove revm default std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,7 +426,7 @@ reth-trie-sparse = { path = "crates/trie/sparse" }
 reth-zstd-compressors = { path = "crates/storage/zstd-compressors", default-features = false }
 
 # revm
-revm = { version = "18.0.0", features = ["std"], default-features = false }
+revm = { version = "18.0.0", default-features = false }
 revm-inspectors = "0.13.0"
 revm-primitives = { version = "14.0.0", default-features = false }
 revm-interpreter = { version = "14.0.0", default-features = false }


### PR DESCRIPTION
this is already propagated everywhere:

https://github.com/paradigmxyz/reth/blob/9e5c02094f5f4de71db65c3c5e6397371f8b691b/crates/evm/Cargo.toml#L61-L61

hence unchanged cargo.lock