### PR TITLE
ci: don't run codspeed in merge_group for now

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,7 +2,8 @@
 
 on:
   pull_request:
-  merge_group:
+  # TODO: Disabled temporarily for https://github.com/CodSpeedHQ/runner/issues/55
+  # merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
Not yet supported: https://github.com/CodSpeedHQ/runner/issues/55