### PR TITLE
feat: relax eth_callBundle bounds

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -18,8 +18,7 @@ use reth_node_core::{
     version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA},
 };
 use reth_payload_builder::PayloadStore;
-use reth_primitives::{EthPrimitives, PooledTransaction};
-use reth_provider::providers::NodeTypesForProvider;
+use reth_primitives::EthPrimitives;
 use reth_rpc::{
     eth::{EthApiTypes, FullEthApiServer},
     EthApi,
@@ -33,7 +32,6 @@ use reth_rpc_builder::{
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::{debug, info};
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::sync::Arc;
 
 use crate::EthApiBuilderCtx;
@@ -404,9 +402,7 @@ where
 
 impl<N, EthApi, EV> RpcAddOns<N, EthApi, EV>
 where
-    N: FullNodeComponents<
-        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
-    >,
+    N: FullNodeComponents,
     EthApi: EthApiTypes
         + FullEthApiServer<Provider = N::Provider, Pool = N::Pool, Network = N::Network>
         + AddDevSigners
@@ -534,10 +530,7 @@ where
 
 impl<N, EthApi, EV> NodeAddOns<N> for RpcAddOns<N, EthApi, EV>
 where
-    N: FullNodeComponents<
-        Types: NodeTypesForProvider<Primitives = EthPrimitives>,
-        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
-    >,
+    N: FullNodeComponents,
     EthApi: EthApiTypes
         + FullEthApiServer<Provider = N::Provider, Pool = N::Pool, Network = N::Network>
         + AddDevSigners

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -252,7 +252,6 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
     >,
     OpEngineValidator: EngineValidator<<N::Types as NodeTypesWithEngine>::Engine>,
 {
@@ -303,7 +302,6 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
     >,
     OpEngineValidator: EngineValidator<<N::Types as NodeTypesWithEngine>::Engine>,
 {

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -230,7 +230,7 @@ use reth_consensus::FullConsensus;
 use reth_engine_primitives::{EngineTypes, PayloadValidator};
 use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
-use reth_primitives::{NodePrimitives, PooledTransaction};
+use reth_primitives::NodePrimitives;
 use reth_provider::{
     AccountReader, BlockReader, CanonStateSubscriptions, ChainSpecProvider, ChangeSetReader,
     EvmEnvProvider, FullRpcProvider, ProviderBlock, ProviderHeader, ProviderReceipt,
@@ -248,7 +248,7 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{EthConfig, EthStateCache, EthSubscriptionIdProvider};
 use reth_rpc_layer::{AuthLayer, Claims, CompressionLayer, JwtAuthValidator, JwtSecret};
 use reth_tasks::{pool::BlockingTaskGuard, TaskSpawner, TokioTaskExecutor};
-use reth_transaction_pool::{noop::NoopTransactionPool, PoolTransaction, TransactionPool};
+use reth_transaction_pool::{noop::NoopTransactionPool, TransactionPool};
 use serde::{Deserialize, Serialize};
 use tower::Layer;
 use tower_http::cors::CorsLayer;
@@ -323,7 +323,6 @@ where
             Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         >,
-        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
     >,
     BlockExecutor: BlockExecutorProvider,
 {
@@ -715,7 +714,6 @@ where
                 Receipt = <Events::Primitives as NodePrimitives>::Receipt,
                 Header = <Events::Primitives as NodePrimitives>::BlockHeader,
             >,
-            Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
         >,
     {
         let Self {
@@ -841,7 +839,6 @@ where
                 Block = <Events::Primitives as NodePrimitives>::Block,
                 Header = <Events::Primitives as NodePrimitives>::BlockHeader,
             >,
-            Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
         >,
         Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     {
@@ -1382,7 +1379,6 @@ where
             Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         >,
-        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = PooledTransaction>>,
     >,
     BlockExecutor: BlockExecutorProvider,
     Consensus: reth_consensus::FullConsensus<BlockExecutor::Primitives> + Clone + 'static,


### PR DESCRIPTION
Relaxes bounds for `EthCallBundle` API by using `EthPoolTransaction` methods to get and validate blobs for any pooled transactions.

This is not perfect but should be OK while we are embedding 4844 logic into pool abstraction