### PR TITLE
Fix incorrect favicon URL Update lib.rs

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
-    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/97369466?s=256"
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]


### PR DESCRIPTION
While reviewing the crate's documentation configuration, I noticed an issue with the `html_favicon_url` attribute. The URL currently uses `avatars0.githubusercontent.com`, which is incorrect. GitHub uses `avatars.githubusercontent.com` (without the `0`) as the proper domain for avatar URLs.  

I’ve updated the attribute to use the correct domain:  

**Before:**  
```rust
html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256"
```

**After:**  
```rust
html_favicon_url = "https://avatars.githubusercontent.com/u/97369466?s=256"
```  
