### PR TITLE
chore: disable default std serde_json feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -522,7 +522,7 @@ rayon = "1.7"
 rustc-hash = { version = "2.0", default-features = false }
 schnellru = "0.2"
 serde = { version = "1.0", default-features = false }
-serde_json = "1.0.94"
+serde_json = { version = "1.0.94", default-features = false, features = ["alloc"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 sha2 = { version = "0.10", default-features = false }
 shellexpand = "3.0.0"

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -52,7 +52,8 @@ std = [
 	"reth-ethereum-forks/std",
 	"derive_more/std",
 	"reth-network-peers/std",
-	"reth-trie-common/std"
+	"reth-trie-common/std",
+	"serde_json/std"
 ]
 arbitrary = [
 	"alloy-chains/arbitrary",

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -51,5 +51,6 @@ std = [
 	"alloy-primitives/std",
 	"revm-primitives/std",
 	"secp256k1/std",
-	"reth-ethereum-forks/std"
+	"reth-ethereum-forks/std",
+	"serde_json/std"
 ]

--- a/crates/fs-util/Cargo.toml
+++ b/crates/fs-util/Cargo.toml
@@ -14,6 +14,6 @@ workspace = true
 [dependencies]
 
 # misc
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["std"] }
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/net/network-types/Cargo.toml
+++ b/crates/net/network-types/Cargo.toml
@@ -20,7 +20,7 @@ reth-ethereum-forks.workspace = true
 # misc
 serde = { workspace = true, optional = true }
 humantime-serde = { workspace = true, optional = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 
 # misc
 tracing.workspace = true

--- a/crates/net/peers/Cargo.toml
+++ b/crates/net/peers/Cargo.toml
@@ -44,6 +44,7 @@ std = [
 	"serde_with/std",
 	"thiserror/std",
 	"url/std",
+	"serde_json/std"
 ]
 secp256k1 = ["dep:secp256k1", "enr/secp256k1"]
 net = ["std", "dep:tokio", "tokio?/net"]

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -61,5 +61,6 @@ std = [
 	"once_cell/std",
 	"derive_more/std",
 	"reth-network-peers/std",
-	"thiserror/std"
+	"thiserror/std",
+	"serde_json/std"
 ]

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -88,7 +88,8 @@ std = [
 	"k256/std",
 	"secp256k1?/std",
 	"thiserror/std",
-	"alloy-trie/std"
+	"alloy-trie/std",
+	"serde_json/std"
 ]
 secp256k1 = ["dep:secp256k1"]
 test-utils = [

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -115,7 +115,8 @@ std = [
 	"derive_more/std",
 	"reth-zstd-compressors?/std",
 	"secp256k1?/std",
-	"reth-trie-common/std"
+	"reth-trie-common/std",
+	"serde_json/std"
 ]
 reth-codec = [
 	"dep:reth-codecs",

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -59,7 +59,8 @@ std = [
 	"alloy-eips?/std",
 	"alloy-genesis?/std",
 	"alloy-trie?/std",
-	"serde/std"
+	"serde/std",
+	"serde_json/std"
 ]
 alloy = [
     "dep:alloy-consensus",

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -72,7 +72,8 @@ std = [
 	"nybbles/std",
 	"reth-primitives-traits/std",
 	"serde?/std",
-	"serde_with?/std"
+	"serde_with?/std",
+	"serde_json/std"
 ]
 eip1186 = [
     "alloy-rpc-types-eth/serde",


### PR DESCRIPTION
towards https://github.com/paradigmxyz/reth/issues/13041

```
#[cfg(not(any(feature = "std", feature = "alloc")))]
compile_error! {
    "serde_json requires that either `std` (default) or `alloc` feature is enabled"
}
```

serde-json supports no-std but requires at least alloc