### PR TITLE
chore: expose execution error of debug_cmd/merkle.rs

### DIFF
--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -215,10 +215,11 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
             let clean_input = ExecInput { target: Some(sealed_block.number), checkpoint: None };
             loop {
-                let clean_result = merkle_stage.execute(&provider_rw, clean_input);
-                assert!(clean_result.is_ok(), "Clean state root calculation failed");
-                if clean_result.unwrap().done {
-                    break
+                let clean_result = merkle_stage
+                    .execute(&provider_rw, clean_input)
+                    .map_err(|e| eyre::eyre!("Clean state root calculation failed: {}", e))?;
+                if clean_result.done {
+                    break;
                 }
             }
 


### PR DESCRIPTION
The `assert!` conceals the underlying execution errors, and exposing these errors would help to identify the root cause of the execution.