### PR TITLE
chore: mark chainspec as riscv compatible

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -10,6 +10,7 @@ crates_to_check=(
     reth-optimism-forks
     reth-network-peers
     reth-trie-common
+    reth-chainspec
     # reth-evm
     # reth-primitives
     # reth-optimism-chainspec


### PR DESCRIPTION
towards #13041 