### PR TITLE
feat: make `ReceiptFileClient` generic over receipt

### DIFF
--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -464,9 +464,9 @@ impl ChunkedFileReader {
     }
 
     /// Read next chunk from file. Returns [`FileClient`] containing decoded chunk.
-    pub async fn next_receipts_chunk<T, D>(&mut self) -> Result<Option<T>, T::Error>
+    pub async fn next_receipts_chunk<T>(&mut self) -> Result<Option<T>, T::Error>
     where
-        T: FromReceiptReader<D>,
+        T: FromReceiptReader,
     {
         let Some(next_chunk_byte_len) = self.read_next_chunk().await? else { return Ok(None) };
 

--- a/crates/net/downloaders/src/receipt_file_client.rs
+++ b/crates/net/downloaders/src/receipt_file_client.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io, marker::PhantomData};
+use std::{fmt, io};
 
 use futures::Future;
 use reth_primitives::{Receipt, Receipts};
@@ -9,27 +9,35 @@ use tracing::{trace, warn};
 
 use crate::{DecodedFileChunk, FileClientError};
 
+/// Helper trait implemented for [`Decoder`] that decodes the receipt type.
+pub trait ReceiptDecoder: Decoder<Item = Option<ReceiptWithBlockNumber<Self::Receipt>>> {
+    /// The receipt type being decoded.
+    type Receipt;
+}
+
+impl<T, R> ReceiptDecoder for T
+where
+    T: Decoder<Item = Option<ReceiptWithBlockNumber<R>>>,
+{
+    type Receipt = R;
+}
+
 /// File client for reading RLP encoded receipts from file. Receipts in file must be in sequential
 /// order w.r.t. block number.
 #[derive(Debug)]
-pub struct ReceiptFileClient<D> {
+pub struct ReceiptFileClient<D: ReceiptDecoder> {
     /// The buffered receipts, read from file, as nested lists. One list per block number.
-    pub receipts: Receipts,
+    pub receipts: Receipts<D::Receipt>,
     /// First (lowest) block number read from file.
     pub first_block: u64,
     /// Total number of receipts. Count of elements in [`Receipts`] flattened.
     pub total_receipts: usize,
-    /// marker
-    _marker: PhantomData<D>,
 }
 
 /// Constructs a file client from a reader and decoder.
-pub trait FromReceiptReader<D> {
+pub trait FromReceiptReader {
     /// Error returned by file client type.
     type Error: From<io::Error>;
-
-    /// Returns a decoder instance
-    fn decoder() -> D;
 
     /// Returns a file client
     fn from_receipt_reader<B>(
@@ -42,17 +50,11 @@ pub trait FromReceiptReader<D> {
         B: AsyncReadExt + Unpin;
 }
 
-impl<D> FromReceiptReader<D> for ReceiptFileClient<D>
+impl<D> FromReceiptReader for ReceiptFileClient<D>
 where
-    D: Decoder<Item = Option<ReceiptWithBlockNumber>, Error = FileClientError>
-        + fmt::Debug
-        + Default,
+    D: ReceiptDecoder<Error = FileClientError> + fmt::Debug + Default,
 {
     type Error = D::Error;
-
-    fn decoder() -> D {
-        D::default()
-    }
 
     /// Initialize the [`ReceiptFileClient`] from bytes that have been read from file. Caution! If
     /// first block has no transactions, it's assumed to be the genesis block.
@@ -67,12 +69,12 @@ where
         let mut receipts = Receipts::default();
 
         // use with_capacity to make sure the internal buffer contains the entire chunk
-        let mut stream = FramedRead::with_capacity(reader, Self::decoder(), num_bytes as usize);
+        let mut stream = FramedRead::with_capacity(reader, D::default(), num_bytes as usize);
 
         trace!(target: "downloaders::file",
             target_num_bytes=num_bytes,
             capacity=stream.read_buffer().capacity(),
-            codec=?Self::decoder(),
+            codec=?D::default(),
             "init decode stream"
         );
 
@@ -193,7 +195,6 @@ where
                     receipts,
                     first_block: first_block.unwrap_or_default(),
                     total_receipts,
-                    _marker: Default::default(),
                 },
                 remaining_bytes,
                 highest_block: Some(block_number),
@@ -204,9 +205,9 @@ where
 
 /// [`Receipt`] with block number.
 #[derive(Debug, PartialEq, Eq)]
-pub struct ReceiptWithBlockNumber {
+pub struct ReceiptWithBlockNumber<R = Receipt> {
     /// Receipt.
-    pub receipt: Receipt,
+    pub receipt: R,
     /// Block number.
     pub number: u64,
 }

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -161,7 +161,7 @@ where
         .expect("transaction static files must exist before importing receipts");
 
     while let Some(file_client) =
-        reader.next_receipts_chunk::<ReceiptFileClient<_>, HackReceiptFileCodec>().await?
+        reader.next_receipts_chunk::<ReceiptFileClient<HackReceiptFileCodec>>().await?
     {
         if highest_block_receipts == highest_block_transactions {
             warn!(target: "reth::cli",  highest_block_receipts, highest_block_transactions, "Ignoring all other blocks in the file since we have reached the desired height");


### PR DESCRIPTION
Adds helper `ReceiptDecoder` which allows to use its `Receipt` AT directly on ReceiptFileClient and to get rid of phantomdata.

Additionally makes `HackReceiptFileCodec` generic over receipt being decoded and provides impl for `OpReceipt`