### PR TITLE
Fix typo in the command example in the comments Update main.rs

### DIFF
--- a/examples/beacon-api-sidecar-fetcher/src/main.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p beacon-api-beacon-sidecar-fetcher --node -- full
+//! cargo run -p beacon-api-beacon-sidecar-fetcher --node --full
 //! ```
 //!
 //! This launches a regular reth instance and subscribes to payload attributes event stream.


### PR DESCRIPTION
I noticed a typo in the comment section of the code. Specifically, in the command example:

```rust
//! cargo run -p beacon-api-beacon-sidecar-fetcher --node -- full
```

There is an extra space between `--node` and `full`, which could cause confusion or errors when running the command. The correct version should be:

```rust
//! cargo run -p beacon-api-beacon-sidecar-fetcher --node --full
```

I’ve fixed this typo to ensure the command is properly formatted and avoids any potential issues when users follow the example.