### PR TITLE
Fix grammatical issue in the description Update main.rs

### DIFF
--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -6,7 +6,7 @@
 //! cargo run -p bsc-p2p
 //! ```
 //!
-//! This launch the regular reth node overriding the engine api payload builder with our custom.
+//! This launches the regular reth node overriding the engine api payload builder with our custom.
 //!
 //! Credits to: <https://blog.merkle.io/blog/fastest-transaction-network-eth-polygon-bsc>
 


### PR DESCRIPTION
I noticed a grammatical error in the description. The sentence:

*"This launch the regular reth node"*

was corrected to:

*"This launches the regular reth node."*

