### PR TITLE
chore: make `NodeEvent` generic over `NodePrimitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8316,6 +8316,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "derive_more",
  "futures",
  "humantime",
  "pin-project",

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -24,6 +24,7 @@ use reth_network_api::NetworkInfo;
 use reth_network_p2p::{headers::client::HeadersClient, EthBlockClient};
 use reth_node_api::NodeTypesWithDBAdapter;
 use reth_node_ethereum::EthExecutorProvider;
+use reth_node_events::node::NodeEvent;
 use reth_provider::{
     providers::ProviderNodeTypes, ChainSpecProvider, ProviderFactory, StageCheckpointReader,
 };
@@ -211,7 +212,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             reth_node_events::node::handle_events(
                 Some(Box::new(network)),
                 latest_block_number,
-                pipeline.events().map(Into::into),
+                pipeline.events().map(Into::<NodeEvent<N::Primitives>>::into),
             ),
         );
 

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -165,7 +165,7 @@ pub fn build_import_pipeline<N, C, E>(
     static_file_producer: StaticFileProducer<ProviderFactory<N>>,
     disable_exec: bool,
     executor: E,
-) -> eyre::Result<(Pipeline<N>, impl Stream<Item = NodeEvent>)>
+) -> eyre::Result<(Pipeline<N>, impl Stream<Item = NodeEvent<N::Primitives>>)>
 where
     N: ProviderNodeTypes + CliNodeTypes,
     C: Consensus + 'static,

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -34,7 +34,7 @@ use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
 };
-use reth_node_events::{cl::ConsensusLayerHealthEvents, node};
+use reth_node_events::{cl::ConsensusLayerHealthEvents, node, node::NodeEvent};
 use reth_provider::providers::{BlockchainProvider, NodeTypesForTree};
 use reth_rpc::eth::RpcNodeCore;
 use reth_tasks::TaskExecutor;
@@ -292,7 +292,7 @@ where
         info!(target: "reth::cli", "Consensus engine initialized");
 
         let events = stream_select!(
-            pipeline_events.map(Into::into),
+            pipeline_events.map(Into::<NodeEvent<Types::Primitives>>::into),
             if ctx.node_config().debug.tip.is_none() && !ctx.is_dev() {
                 Either::Left(
                     ConsensusLayerHealthEvents::new(Box::new(ctx.blockchain_db().clone()))

--- a/crates/node/events/Cargo.toml
+++ b/crates/node/events/Cargo.toml
@@ -38,3 +38,4 @@ tracing.workspace = true
 # misc
 pin-project.workspace = true
 humantime.workspace = true
+derive_more.workspace = true


### PR DESCRIPTION
Based on #13533 

We need to propagate `NodePrimitives` to `BeaconConsensusEngineEvent`