### PR TITLE
fix: typos in documentation files

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -83,7 +83,7 @@ pub struct Command<C: ChainSpecParser> {
 }
 
 impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
-    /// Fetches the best block block from the database.
+    /// Fetches the best block from the database.
     ///
     /// If the database is empty, returns the genesis block.
     fn lookup_best_block<N: ProviderNodeTypes<ChainSpec = C::ChainSpec>>(

--- a/testing/ef-tests/src/suite.rs
+++ b/testing/ef-tests/src/suite.rs
@@ -21,7 +21,7 @@ pub trait Suite {
     /// - `BlockchainTests/TransitionTests`
     fn suite_name(&self) -> String;
 
-    /// Load an run each contained test case.
+    /// Load and run each contained test case.
     ///
     /// # Note
     ///


### PR DESCRIPTION
Corrected `best block block from` to `best block from`
Corrected `Load an run` to `Load and run`