### PR TITLE
fix: debug client etherscan

### DIFF
--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -33,7 +33,7 @@ impl EtherscanBlockProvider {
     /// are supported.
     pub async fn load_block(&self, block_number_or_tag: BlockNumberOrTag) -> eyre::Result<Block> {
         let tag = match block_number_or_tag {
-            BlockNumberOrTag::Number(num) => format!("{num:x}"),
+            BlockNumberOrTag::Number(num) => format!("{num:#02x}"),
             tag => tag.to_string(),
         };
         let block: EtherscanBlockResponse = self

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -33,7 +33,7 @@ impl EtherscanBlockProvider {
     /// are supported.
     pub async fn load_block(&self, block_number_or_tag: BlockNumberOrTag) -> eyre::Result<Block> {
         let tag = match block_number_or_tag {
-            BlockNumberOrTag::Number(num) => format!("{num}"),
+            BlockNumberOrTag::Number(num) => format!("{num:x}"),
             tag => tag.to_string(),
         };
         let block: EtherscanBlockResponse = self

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -33,7 +33,7 @@ impl EtherscanBlockProvider {
     /// are supported.
     pub async fn load_block(&self, block_number_or_tag: BlockNumberOrTag) -> eyre::Result<Block> {
         let tag = match block_number_or_tag {
-            BlockNumberOrTag::Number(x) => format!("{x:x}"),
+            BlockNumberOrTag::Number(num) => format!("{num}"),
             tag => tag.to_string(),
         };
         let block: EtherscanBlockResponse = self

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -32,13 +32,17 @@ impl EtherscanBlockProvider {
     /// `BlockNumberOrTag::Earliest`, `BlockNumberOrTag::Pending`, `BlockNumberOrTag::Number(u64)`
     /// are supported.
     pub async fn load_block(&self, block_number_or_tag: BlockNumberOrTag) -> eyre::Result<Block> {
+        let tag = match block_number_or_tag {
+            BlockNumberOrTag::Number(x) => format!("{x:x}"),
+            tag => tag.to_string(),
+        };
         let block: EtherscanBlockResponse = self
             .http_client
             .get(&self.base_url)
             .query(&[
                 ("module", "proxy"),
                 ("action", "eth_getBlockByNumber"),
-                ("tag", &block_number_or_tag.to_string()),
+                ("tag", &tag),
                 ("boolean", "true"),
                 ("apikey", &self.api_key),
             ])


### PR DESCRIPTION
Fixes the tag for the debug client, as the [`Display` implementation](https://github.com/alloy-rs/alloy/blob/b6e2795b43f78a8c4039aabf0e7d157d5a52febf/crates/eips/src/eip1898.rs#L219) for `BlockNumberOrTag` will add `number` at the beginning of the string for the `Number` variant.