### PR TITLE
chore: relax cli bounds

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -29,7 +29,8 @@ use reth_fs_util as fs;
 use reth_node_api::{BlockTy, EngineApiMessageVersion, PayloadBuilderAttributes};
 use reth_node_ethereum::{EthEvmConfig, EthExecutorProvider};
 use reth_primitives::{
-    BlockExt, SealedBlockFor, SealedBlockWithSenders, SealedHeader, Transaction, TransactionSigned,
+    BlockExt, EthPrimitives, SealedBlockFor, SealedBlockWithSenders, SealedHeader, Transaction,
+    TransactionSigned,
 };
 use reth_provider::{
     providers::{BlockchainProvider, ProviderNodeTypes},
@@ -121,7 +122,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
     }
 
     /// Execute `debug in-memory-merkle` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives>>(
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -25,6 +25,7 @@ use reth_network_p2p::{headers::client::HeadersClient, EthBlockClient};
 use reth_node_api::NodeTypesWithDBAdapter;
 use reth_node_ethereum::EthExecutorProvider;
 use reth_node_events::node::NodeEvent;
+use reth_primitives::EthPrimitives;
 use reth_provider::{
     providers::ProviderNodeTypes, ChainSpecProvider, ProviderFactory, StageCheckpointReader,
 };
@@ -59,7 +60,7 @@ pub struct Command<C: ChainSpecParser> {
 }
 
 impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
-    fn build_pipeline<N: ProviderNodeTypes<ChainSpec = C::ChainSpec> + CliNodeTypes, Client>(
+    fn build_pipeline<N, Client>(
         &self,
         config: &Config,
         client: Client,
@@ -69,6 +70,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         static_file_producer: StaticFileProducer<ProviderFactory<N>>,
     ) -> eyre::Result<Pipeline<N>>
     where
+        N: ProviderNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives> + CliNodeTypes,
         Client: EthBlockClient + 'static,
     {
         // building network downloaders using the fetch client
@@ -117,7 +119,9 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         Ok(pipeline)
     }
 
-    async fn build_network<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
+    async fn build_network<
+        N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives>,
+    >(
         &self,
         config: &Config,
         task_executor: TaskExecutor,
@@ -161,7 +165,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
     }
 
     /// Execute `execution-debug` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives>>(
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -21,7 +21,7 @@ use reth_network::{BlockDownloaderProvider, NetworkHandle};
 use reth_network_api::NetworkInfo;
 use reth_node_api::{BlockTy, NodePrimitives};
 use reth_node_ethereum::EthExecutorProvider;
-use reth_primitives::BlockExt;
+use reth_primitives::{BlockExt, EthPrimitives};
 use reth_provider::{
     providers::ProviderNodeTypes, AccountExtReader, ChainSpecProvider, DatabaseProviderFactory,
     HashedPostStateProvider, HashingWriter, LatestStateProviderRef, OriginalValuesKnown,
@@ -88,7 +88,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
     }
 
     /// Execute `debug in-memory-merkle` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives>>(
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -19,6 +19,7 @@ use reth_network_api::NetworkInfo;
 use reth_network_p2p::full_block::FullBlockClient;
 use reth_node_api::{BlockTy, NodePrimitives};
 use reth_node_ethereum::EthExecutorProvider;
+use reth_primitives::EthPrimitives;
 use reth_provider::{
     providers::ProviderNodeTypes, BlockNumReader, BlockWriter, ChainSpecProvider,
     DatabaseProviderFactory, HeaderProvider, LatestStateProviderRef, OriginalValuesKnown,
@@ -87,7 +88,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
     }
 
     /// Execute `merkle-debug` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives>>(
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {

--- a/bin/reth/src/commands/debug_cmd/mod.rs
+++ b/bin/reth/src/commands/debug_cmd/mod.rs
@@ -6,6 +6,7 @@ use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::CliNodeTypes;
 use reth_cli_runner::CliContext;
 use reth_node_ethereum::EthEngineTypes;
+use reth_primitives::EthPrimitives;
 
 mod build_block;
 mod execution;
@@ -37,7 +38,9 @@ pub enum Subcommands<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
     /// Execute `debug` command
-    pub async fn execute<N: CliNodeTypes<Engine = EthEngineTypes, ChainSpec = C::ChainSpec>>(
+    pub async fn execute<
+        N: CliNodeTypes<Engine = EthEngineTypes, Primitives = EthPrimitives, ChainSpec = C::ChainSpec>,
+    >(
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {

--- a/bin/reth/src/commands/debug_cmd/replay_engine.rs
+++ b/bin/reth/src/commands/debug_cmd/replay_engine.rs
@@ -22,6 +22,7 @@ use reth_network_api::NetworkInfo;
 use reth_node_api::{EngineApiMessageVersion, NodePrimitives, NodeTypesWithDBAdapter};
 use reth_node_ethereum::{EthEngineTypes, EthEvmConfig, EthExecutorProvider};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
+use reth_primitives::EthPrimitives;
 use reth_provider::{
     providers::{BlockchainProvider, ProviderNodeTypes},
     CanonStateSubscriptions, ChainSpecProvider, ProviderFactory,
@@ -87,7 +88,9 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
     }
 
     /// Execute `debug replay-engine` command
-    pub async fn execute<N: CliNodeTypes<Engine = EthEngineTypes, ChainSpec = C::ChainSpec>>(
+    pub async fn execute<
+        N: CliNodeTypes<Engine = EthEngineTypes, Primitives = EthPrimitives, ChainSpec = C::ChainSpec>,
+    >(
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -15,7 +15,6 @@ use reth_node_core::{
     args::{DatabaseArgs, DatadirArgs},
     dirs::{ChainPath, DataDirPath},
 };
-use reth_primitives::EthPrimitives;
 use reth_provider::{
     providers::{NodeTypesForProvider, StaticFileProvider},
     ProviderFactory, StaticFileProviderFactory,
@@ -198,11 +197,5 @@ impl AccessRights {
 
 /// Helper trait with a common set of requirements for the
 /// [`NodeTypes`](reth_node_builder::NodeTypes) in CLI.
-pub trait CliNodeTypes:
-    NodeTypesWithEngine + NodeTypesForProvider<Primitives = EthPrimitives>
-{
-}
-impl<N> CliNodeTypes for N where
-    N: NodeTypesWithEngine + NodeTypesForProvider<Primitives = EthPrimitives>
-{
-}
+pub trait CliNodeTypes: NodeTypesWithEngine + NodeTypesForProvider {}
+impl<N> CliNodeTypes for N where N: NodeTypesWithEngine + NodeTypesForProvider {}

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -20,6 +20,7 @@ use reth_network_p2p::{
     bodies::downloader::BodyDownloader,
     headers::downloader::{HeaderDownloader, SyncTarget},
 };
+use reth_node_api::{BlockTy, BodyTy, HeaderTy};
 use reth_node_core::version::SHORT_VERSION;
 use reth_node_events::node::NodeEvent;
 use reth_provider::{
@@ -86,7 +87,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportComm
         let mut total_decoded_blocks = 0;
         let mut total_decoded_txns = 0;
 
-        while let Some(file_client) = reader.next_chunk::<FileClient>().await? {
+        while let Some(file_client) = reader.next_chunk::<FileClient<_>>().await? {
             // create a new FileClient from chunk read from file
             info!(target: "reth::cli",
                 "Importing chain file chunk"
@@ -161,14 +162,14 @@ pub fn build_import_pipeline<N, C, E>(
     config: &Config,
     provider_factory: ProviderFactory<N>,
     consensus: &Arc<C>,
-    file_client: Arc<FileClient>,
+    file_client: Arc<FileClient<BlockTy<N>>>,
     static_file_producer: StaticFileProducer<ProviderFactory<N>>,
     disable_exec: bool,
     executor: E,
 ) -> eyre::Result<(Pipeline<N>, impl Stream<Item = NodeEvent<N::Primitives>>)>
 where
     N: ProviderNodeTypes + CliNodeTypes,
-    C: Consensus + 'static,
+    C: Consensus<HeaderTy<N>, BodyTy<N>> + 'static,
     E: BlockExecutorProvider<Primitives = N::Primitives>,
 {
     if !file_client.has_canonical_blocks() {

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -6,11 +6,11 @@ use clap::Parser;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_db_common::init::init_from_state_dump;
+use reth_node_api::NodePrimitives;
 use reth_primitives::SealedHeader;
 use reth_provider::{
     BlockNumReader, DatabaseProviderFactory, StaticFileProviderFactory, StaticFileWriter,
 };
-
 use std::{io::BufReader, path::PathBuf, str::FromStr};
 use tracing::info;
 
@@ -67,7 +67,13 @@ pub struct InitStateCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateCommand<C> {
     /// Execute the `init` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(self) -> eyre::Result<()> {
+    pub async fn execute<N>(self) -> eyre::Result<()>
+    where
+        N: CliNodeTypes<
+            ChainSpec = C::ChainSpec,
+            Primitives: NodePrimitives<BlockHeader = alloy_consensus::Header>,
+        >,
+    {
         info!(target: "reth::cli", "Reth init-state starting");
 
         let Environment { config, provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;

--- a/crates/cli/commands/src/recover/storage_tries.rs
+++ b/crates/cli/commands/src/recover/storage_tries.rs
@@ -1,4 +1,5 @@
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use alloy_consensus::BlockHeader;
 use clap::Parser;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -51,10 +52,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         }
 
         let state_root = StateRoot::from_tx(tx_mut).root()?;
-        if state_root != best_header.state_root {
+        if state_root != best_header.state_root() {
             eyre::bail!(
                 "Recovery failed. Incorrect state root. Expected: {:?}. Received: {:?}",
-                best_header.state_root,
+                best_header.state_root(),
                 state_root
             );
         }

--- a/crates/cli/commands/src/stage/dump/execution.rs
+++ b/crates/cli/commands/src/stage/dump/execution.rs
@@ -7,7 +7,6 @@ use reth_db_api::{
 };
 use reth_db_common::DbTool;
 use reth_evm::{execute::BlockExecutorProvider, noop::NoopBlockExecutorProvider};
-use reth_node_api::NodePrimitives;
 use reth_node_builder::NodeTypesWithDB;
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::{
@@ -26,14 +25,7 @@ pub(crate) async fn dump_execution_stage<N, E>(
     executor: E,
 ) -> eyre::Result<()>
 where
-    N: ProviderNodeTypes<
-        DB = Arc<DatabaseEnv>,
-        Primitives: NodePrimitives<
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
-            BlockHeader = reth_primitives::Header,
-        >,
-    >,
+    N: ProviderNodeTypes<DB = Arc<DatabaseEnv>>,
     E: BlockExecutorProvider<Primitives = N::Primitives>,
 {
     let (output_db, tip_block_number) = setup(from, to, &output_datadir.db(), db_tool)?;
@@ -139,9 +131,7 @@ fn import_tables_with_range<N: NodeTypesWithDB>(
 /// Dry-run an unwind to FROM block, so we can get the `PlainStorageState` and
 /// `PlainAccountState` safely. There might be some state dependency from an address
 /// which hasn't been changed in the given range.
-fn unwind_and_copy<
-    N: ProviderNodeTypes<Primitives: NodePrimitives<BlockHeader = reth_primitives::Header>>,
->(
+fn unwind_and_copy<N: ProviderNodeTypes>(
     db_tool: &DbTool<N>,
     from: u64,
     tip_block_number: u64,
@@ -179,13 +169,7 @@ fn dry_run<N, E>(
     executor: E,
 ) -> eyre::Result<()>
 where
-    N: ProviderNodeTypes<
-        Primitives: NodePrimitives<
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
-            BlockHeader = reth_primitives::Header,
-        >,
-    >,
+    N: ProviderNodeTypes,
     E: BlockExecutorProvider<Primitives = N::Primitives>,
 {
     info!(target: "reth::cli", "Executing stage. [dry-run]");

--- a/crates/cli/commands/src/stage/dump/merkle.rs
+++ b/crates/cli/commands/src/stage/dump/merkle.rs
@@ -9,7 +9,6 @@ use reth_db_api::{database::Database, table::TableImporter};
 use reth_db_common::DbTool;
 use reth_evm::noop::NoopBlockExecutorProvider;
 use reth_exex::ExExManagerHandle;
-use reth_node_api::NodePrimitives;
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::{
     providers::{ProviderNodeTypes, StaticFileProvider},
@@ -33,14 +32,7 @@ pub(crate) async fn dump_merkle_stage<N>(
     should_run: bool,
 ) -> Result<()>
 where
-    N: ProviderNodeTypes<
-        DB = Arc<DatabaseEnv>,
-        Primitives: NodePrimitives<
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
-            BlockHeader = reth_primitives::Header,
-        >,
-    >,
+    N: ProviderNodeTypes<DB = Arc<DatabaseEnv>>,
 {
     let (output_db, tip_block_number) = setup(from, to, &output_datadir.db(), db_tool)?;
 
@@ -78,15 +70,7 @@ where
 }
 
 /// Dry-run an unwind to FROM block and copy the necessary table data to the new database.
-fn unwind_and_copy<
-    N: ProviderNodeTypes<
-        Primitives: NodePrimitives<
-            Block = reth_primitives::Block,
-            Receipt = reth_primitives::Receipt,
-            BlockHeader = reth_primitives::Header,
-        >,
-    >,
->(
+fn unwind_and_copy<N: ProviderNodeTypes>(
     db_tool: &DbTool<N>,
     range: (u64, u64),
     tip_block_number: u64,
@@ -166,7 +150,7 @@ fn unwind_and_copy<
 /// Try to re-execute the stage straight away
 fn dry_run<N>(output_provider_factory: ProviderFactory<N>, to: u64, from: u64) -> eyre::Result<()>
 where
-    N: ProviderNodeTypes<Primitives: NodePrimitives<BlockHeader = reth_primitives::Header>>,
+    N: ProviderNodeTypes,
 {
     info!(target: "reth::cli", "Executing stage.");
     let provider = output_provider_factory.database_provider_rw()?;

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -4,6 +4,7 @@
 
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use alloy_eips::BlockHashOrNumber;
+use alloy_primitives::Sealable;
 use clap::Parser;
 use reth_beacon_consensus::EthBeaconConsensus;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -32,13 +32,7 @@ pub trait NetworkPrimitives:
     type PooledTransaction: SignedTransaction + TryFrom<Self::BroadcastedTransaction> + 'static;
 
     /// The transaction type which peers return in `GetReceipts` messages.
-    type Receipt: TxReceipt
-        + RlpEncodableReceipt
-        + RlpDecodableReceipt
-        + Encodable
-        + Decodable
-        + Unpin
-        + 'static;
+    type Receipt: TxReceipt + RlpEncodableReceipt + RlpDecodableReceipt + Unpin + 'static;
 }
 
 /// This is a helper trait for use in bounds, where some of the [`NetworkPrimitives`] associated

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -15,7 +15,7 @@ use reth_downloaders::file_client::{
 use reth_node_core::version::SHORT_VERSION;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpExecutorProvider;
-use reth_optimism_primitives::bedrock::is_dup_tx;
+use reth_optimism_primitives::{bedrock::is_dup_tx, OpPrimitives};
 use reth_provider::{ChainSpecProvider, StageCheckpointReader};
 use reth_prune::PruneModes;
 use reth_stages::StageId;
@@ -43,7 +43,9 @@ pub struct ImportOpCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ImportOpCommand<C> {
     /// Execute `import` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(self) -> eyre::Result<()> {
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+        self,
+    ) -> eyre::Result<()> {
         info!(target: "reth::cli", "reth {} starting", SHORT_VERSION);
 
         info!(target: "reth::cli",

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -14,7 +14,7 @@ use reth_downloaders::{
 use reth_execution_types::ExecutionOutcome;
 use reth_node_core::version::SHORT_VERSION;
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_primitives::bedrock::is_dup_tx;
+use reth_optimism_primitives::{bedrock::is_dup_tx, OpPrimitives};
 use reth_primitives::{NodePrimitives, Receipts};
 use reth_provider::{
     providers::ProviderNodeTypes, writer::UnifiedStorageWriter, DatabaseProviderFactory,
@@ -47,7 +47,9 @@ pub struct ImportReceiptsOpCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ImportReceiptsOpCommand<C> {
     /// Execute `import` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(self) -> eyre::Result<()> {
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+        self,
+    ) -> eyre::Result<()> {
         info!(target: "reth::cli", "reth {} starting", SHORT_VERSION);
 
         debug!(target: "reth::cli",

--- a/crates/optimism/cli/src/commands/init_state.rs
+++ b/crates/optimism/cli/src/commands/init_state.rs
@@ -5,7 +5,10 @@ use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment};
 use reth_db_common::init::init_from_state_dump;
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_primitives::bedrock::{BEDROCK_HEADER, BEDROCK_HEADER_HASH, BEDROCK_HEADER_TTD};
+use reth_optimism_primitives::{
+    bedrock::{BEDROCK_HEADER, BEDROCK_HEADER_HASH, BEDROCK_HEADER_TTD},
+    OpPrimitives,
+};
 use reth_primitives::SealedHeader;
 use reth_provider::{
     BlockNumReader, ChainSpecProvider, DatabaseProviderFactory, StaticFileProviderFactory,
@@ -35,7 +38,9 @@ pub struct InitStateCommandOp<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitStateCommandOp<C> {
     /// Execute the `init` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(self) -> eyre::Result<()> {
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+        self,
+    ) -> eyre::Result<()> {
         info!(target: "reth::cli", "Reth init-state starting");
 
         let Environment { config, provider_factory, .. } =

--- a/crates/optimism/cli/src/receipt_file_codec.rs
+++ b/crates/optimism/cli/src/receipt_file_codec.rs
@@ -25,8 +25,14 @@ use reth_downloaders::{file_client::FileClientError, receipt_file_client::Receip
 ///
 /// It's recommended to use [`with_capacity`](tokio_util::codec::FramedRead::with_capacity) to set
 /// the capacity of the framed reader to the size of the file.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct HackReceiptFileCodec<R = Receipt>(core::marker::PhantomData<R>);
+
+impl<R> Default for HackReceiptFileCodec<R> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 
 impl<R> Decoder for HackReceiptFileCodec<R>
 where


### PR DESCRIPTION
Relaxes bounds for common commands and `CliNodeTypes`. Bounds eth/op specific commands to eth/op primitives