### PR TITLE
Fixed typos and improved clarity in documentation

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -77,12 +77,12 @@ pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + f
 }
 
 impl Cli {
-    /// Parsers only the default CLI arguments
+    /// Parses only the default CLI arguments
     pub fn parse_args() -> Self {
         Self::parse()
     }
 
-    /// Parsers only the default CLI arguments from the given iterator
+    /// Parses only the default CLI arguments from the given iterator
     pub fn try_parse_args_from<I, T>(itr: I) -> Result<Self, clap::error::Error>
     where
         I: IntoIterator<Item = T>,

--- a/book/jsonrpc/intro.md
+++ b/book/jsonrpc/intro.md
@@ -58,7 +58,7 @@ To enable JSON-RPC namespaces on the HTTP server, pass each namespace separated 
 reth node --http --http.api eth,net,trace
 ```
 
-You can pass the `all` option, which is a convenient wrapper for the all the JSON-RPC namespaces `admin,debug,eth,net,trace,txpool,web3,rpc` on the HTTP server:
+You can pass the `all` option, which is a convenient wrapper for all the JSON-RPC namespaces `admin,debug,eth,net,trace,txpool,web3,rpc` on the HTTP server:
 
 ```bash
 reth node --http --http.api all

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -11,7 +11,7 @@ use std::collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap, HashSet
 
 /// Internal indices of the blocks and chains.
 ///
-/// This is main connection between blocks, chains and canonical chain.
+/// This is the main connection between blocks, chains and canonical chain.
 ///
 /// It contains a list of canonical block hashes, forks to child blocks, and a mapping of block hash
 /// to chain ID.

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -69,7 +69,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         let db_path = data_dir.db();
         let static_files_path = data_dir.static_files();
 
-        // ensure the provided datadir exist
+        // ensure the provided datadir exists
         eyre::ensure!(
             data_dir.data_dir().is_dir(),
             "Datadir does not exist: {:?}",

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -76,7 +76,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
             data_dir.data_dir()
         );
 
-        // ensure the provided database exist
+        // ensure the provided database exists
         eyre::ensure!(db_path.is_dir(), "Database does not exist: {:?}", db_path);
 
         match self.command {


### PR DESCRIPTION
Changes made:

Parsers - Parses 

for the all - for all the

This is main - This is the main

exist - exists