### PR TITLE
refactor: avoid using NoopTransactionPool in OP payload builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8562,6 +8562,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
+ "derive_more",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "reth-basic-payload-builder",

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -47,6 +47,7 @@ alloy-rpc-types-debug.workspace = true
 alloy-consensus.workspace = true
 
 # misc
+derive_more.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 sha2.workspace = true

--- a/crates/payload/util/src/lib.rs
+++ b/crates/payload/util/src/lib.rs
@@ -11,5 +11,5 @@
 mod traits;
 mod transaction;
 
-pub use traits::PayloadTransactions;
+pub use traits::{NoopPayloadTransactions, PayloadTransactions};
 pub use transaction::{PayloadTransactionsChain, PayloadTransactionsFixed};

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -21,3 +21,17 @@ pub trait PayloadTransactions {
     /// because this transaction won't be included in the block.
     fn mark_invalid(&mut self, sender: Address, nonce: u64);
 }
+
+/// [`PayloadTransactions`] implementation that produces nothing.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopPayloadTransactions<T>(core::marker::PhantomData<T>);
+
+impl<T> PayloadTransactions for NoopPayloadTransactions<T> {
+    type Transaction = T;
+
+    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx<Self::Transaction>> {
+        None
+    }
+
+    fn mark_invalid(&mut self, _sender: Address, _nonce: u64) {}
+}


### PR DESCRIPTION
Right now OP payload builder depends on `NoopTransactionPool` tx type when building empty payloads or constructing witnesses. This is unconvinient because we don't know the `PoolTransaction` AT there

This PR changes logic to operate on a simple closure `BestTransactionsAttributes` -> iterator which may optionally capture and use the pool. That way for building a payload without external transactions we no longer need to mock the pool

Likely a nicer solution could be to force payload builders to hold a pool, this would also allow simplifying the `BuildArguments` struct although has other implications as this would leak pool generic to some rpc types which deal directly with payload builder