### PR TITLE
feat: impl compression traits for op primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7051,6 +7051,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-codecs",
  "reth-db-models",
+ "reth-optimism-primitives",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-prune-types",

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_consensus::Header;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
-use reth_db::transaction::{DbTx, DbTxMut};
+use reth_db::{table::{Compress, Decompress}, transaction::{DbTx, DbTxMut}};
 use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{AddOnsContext, EngineValidator, FullNodeComponents, NodeAddOns, TxTy};

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -9,7 +9,10 @@ use crate::{
 use alloy_consensus::Header;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
-use reth_db::{table::{Compress, Decompress}, transaction::{DbTx, DbTxMut}};
+use reth_db::{
+    table::{Compress, Decompress},
+    transaction::{DbTx, DbTxMut},
+};
 use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{AddOnsContext, EngineValidator, FullNodeComponents, NodeAddOns, TxTy};

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -9,10 +9,7 @@ use crate::{
 use alloy_consensus::Header;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
-use reth_db::{
-    table::{Compress, Decompress},
-    transaction::{DbTx, DbTxMut},
-};
+use reth_db::transaction::{DbTx, DbTxMut};
 use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{AddOnsContext, EngineValidator, FullNodeComponents, NodeAddOns, TxTy};

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -50,7 +50,7 @@ arbitrary.workspace = true
 proptest.workspace = true
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 std = [
 	"reth-primitives-traits/std",
 	"reth-primitives/std",

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -23,7 +23,7 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
-revm-primitives.workspace = true
+revm-primitives = { workspace = true, optional = true }
 secp256k1 = { workspace = true, optional = true }
 
 # op
@@ -61,7 +61,7 @@ std = [
 	"serde?/std",
 	"bytes?/std",
 	"derive_more/std",
-	"revm-primitives/std",
+	"revm-primitives?/std",
 	"secp256k1?/std",
 	"alloy-rlp/std",
 	"reth-zstd-compressors?/std",
@@ -91,7 +91,7 @@ serde = [
     "reth-codecs?/serde",
     "op-alloy-consensus/serde",
     "rand?/serde",
-    "revm-primitives/serde",
+    "revm-primitives?/serde",
     "secp256k1?/serde",
 ]
 serde-bincode-compat = [
@@ -111,10 +111,11 @@ arbitrary = [
     "alloy-consensus/arbitrary",
     "alloy-eips/arbitrary",
     "alloy-primitives/arbitrary",
-    "revm-primitives/arbitrary",
+    "revm-primitives?/arbitrary",
     "rand",
 ]
 optimism = [
+    "dep:revm-primitives",
 	"revm-primitives/optimism",
 	"reth-primitives/optimism"
 ]

--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -6,8 +6,6 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-// The `optimism` feature must be enabled to use this crate.
-#![cfg(feature = "optimism")]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -25,10 +25,11 @@ use once_cell::sync::OnceCell as OnceLock;
 use op_alloy_consensus::{OpPooledTransaction, OpTypedTransaction, TxDeposit};
 #[cfg(any(test, feature = "reth-codec"))]
 use proptest as _;
-use reth_primitives::transaction::{
-    recover_signer, recover_signer_unchecked, TransactionConversionError,
+use reth_primitives_traits::{
+    crypto::secp256k1::{recover_signer, recover_signer_unchecked},
+    transaction::error::TransactionConversionError,
+    InMemorySize, SignedTransaction,
 };
-use reth_primitives_traits::{InMemorySize, SignedTransaction};
 #[cfg(feature = "std")]
 use std::sync::OnceLock;
 

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # reth
 reth-codecs.workspace = true
 reth-db-models.workspace = true
+reth-optimism-primitives = { workspace = true, optional = true }
 reth-primitives = { workspace = true, features = ["reth-codec"] }
 reth-primitives-traits = { workspace = true, features = ["serde", "reth-codec"] }
 reth-prune-types.workspace = true
@@ -83,3 +84,4 @@ arbitrary = [
     "alloy-consensus/arbitrary",
 ]
 optimism = ["reth-primitives/optimism", "reth-codecs/op"]
+op = ["dep:reth-optimism-primitives", "reth-codecs/op"]

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -70,18 +70,23 @@ test-utils = [
     "reth-stages-types/test-utils",
 ]
 arbitrary = [
-    "reth-primitives/arbitrary",
-    "reth-db-models/arbitrary",
-    "dep:arbitrary",
-    "dep:proptest",
-    "reth-primitives-traits/arbitrary",
-    "reth-trie-common/arbitrary",
-    "alloy-primitives/arbitrary",
-    "parity-scale-codec/arbitrary",
-    "reth-codecs/arbitrary",
-    "reth-prune-types/arbitrary",
-    "reth-stages-types/arbitrary",
-    "alloy-consensus/arbitrary",
+	"reth-primitives/arbitrary",
+	"reth-db-models/arbitrary",
+	"dep:arbitrary",
+	"dep:proptest",
+	"reth-primitives-traits/arbitrary",
+	"reth-trie-common/arbitrary",
+	"alloy-primitives/arbitrary",
+	"parity-scale-codec/arbitrary",
+	"reth-codecs/arbitrary",
+	"reth-prune-types/arbitrary",
+	"reth-stages-types/arbitrary",
+	"alloy-consensus/arbitrary",
+	"reth-optimism-primitives?/arbitrary"
 ]
-optimism = ["reth-primitives/optimism", "reth-codecs/op"]
+optimism = [
+	"reth-primitives/optimism",
+	"reth-codecs/op",
+	"reth-optimism-primitives?/optimism"
+]
 op = ["dep:reth-optimism-primitives", "reth-codecs/op"]

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -235,6 +235,14 @@ impl_compression_for_compact!(
     GenesisAccount
 );
 
+#[cfg(feature = "op")]
+mod op {
+    use super::*;
+    use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
+
+    impl_compression_for_compact!(OpTransactionSigned, OpReceipt);
+}
+
 macro_rules! impl_compression_fixed_compact {
     ($($name:tt),+) => {
         $(


### PR DESCRIPTION
Adds `impl_compression_for_compact` invocation for op types.

Additionally changes op-primitives crate to only bound the `FillTxEnv` impl behind `optimism` feature, that way we don't have to enable revm optimism feature to use the crate