### PR TITLE
perf: query accounts with `&Address` to avoid copying address

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -1019,7 +1019,7 @@ mod tests {
     }
 
     impl AccountReader for MockStateProvider {
-        fn basic_account(&self, _address: Address) -> ProviderResult<Option<Account>> {
+        fn basic_account(&self, _address: &Address) -> ProviderResult<Option<Account>> {
             Ok(None)
         }
     }

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -96,9 +96,9 @@ impl<N: NodePrimitives> BlockHashReader for MemoryOverlayStateProviderRef<'_, N>
 }
 
 impl<N: NodePrimitives> AccountReader for MemoryOverlayStateProviderRef<'_, N> {
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         for block in &self.in_memory {
-            if let Some(account) = block.execution_output.account(&address) {
+            if let Some(account) = block.execution_output.account(address) {
                 return Ok(account);
             }
         }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -396,7 +396,7 @@ mod tests {
     }
 
     impl AccountReader for Provider {
-        fn basic_account(&self, _address: Address) -> ProviderResult<Option<Account>> {
+        fn basic_account(&self, _address: &Address) -> ProviderResult<Option<Account>> {
             Ok(self.account)
         }
     }

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -119,7 +119,7 @@ fn setup_provider(
             // other updates
             let should_process = match account.status {
                 AccountStatus::SelfDestructed => {
-                    provider_rw.basic_account(*address).ok().flatten().is_some()
+                    provider_rw.basic_account(address).ok().flatten().is_some()
                 }
                 _ => true,
             };

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -16,7 +16,7 @@ pub trait EvmStateProvider: Send + Sync {
     /// Get basic account information.
     ///
     /// Returns [`None`] if the account doesn't exist.
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>>;
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>>;
 
     /// Get the hash of the block with the given number. Returns [`None`] if no block with this
     /// number exists.
@@ -38,7 +38,7 @@ pub trait EvmStateProvider: Send + Sync {
 
 // Blanket implementation of EvmStateProvider for any type that implements StateProvider.
 impl<T: reth_storage_api::StateProvider> EvmStateProvider for T {
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         <T as reth_storage_api::AccountReader>::basic_account(self, address)
     }
 
@@ -141,7 +141,7 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     /// Returns `Ok` with `Some(AccountInfo)` if the account exists,
     /// `None` if it doesn't, or an error if encountered.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        Ok(self.basic_account(address)?.map(Into::into))
+        Ok(self.basic_account(&address)?.map(Into::into))
     }
 
     /// Retrieves the bytecode associated with a given code hash.

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -47,8 +47,8 @@ impl StateProviderTest {
 }
 
 impl AccountReader for StateProviderTest {
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
-        Ok(self.accounts.get(&address).map(|(_, acc)| *acc))
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(self.accounts.get(address).map(|(_, acc)| *acc))
     }
 }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -87,7 +87,7 @@ pub trait EstimateCall: Call {
         // Optimize for simple transfer transactions, potentially reducing the gas estimate.
         if env.tx.data.is_empty() {
             if let TransactTo::Call(to) = env.tx.transact_to {
-                if let Ok(code) = db.db.account_code(to) {
+                if let Ok(code) = db.db.account_code(&to) {
                     let no_code_callee = code.map(|code| code.is_empty()).unwrap_or(true);
                     if no_code_callee {
                         // If the tx is a simple transfer (call to an account with no code) we can

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -53,7 +53,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         self.spawn_blocking_io(move |this| {
             Ok(this
                 .state_at_block_id_or_latest(block_id)?
-                .account_balance(address)
+                .account_balance(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default())
         })
@@ -131,7 +131,7 @@ pub trait EthState: LoadState + SpawnBlocking {
     ) -> impl Future<Output = Result<Option<Account>, Self::Error>> + Send {
         self.spawn_blocking_io(move |this| {
             let state = this.state_at_block_id(block_id)?;
-            let account = state.basic_account(address).map_err(Self::Error::from_eth_err)?;
+            let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
             let Some(account) = account else { return Ok(None) };
 
             // Check whether the distance to the block exceeds the maximum configured proof window.
@@ -252,7 +252,7 @@ pub trait LoadState:
             // first fetch the on chain nonce of the account
             let on_chain_account_nonce = this
                 .latest_state()?
-                .account_nonce(address)
+                .account_nonce(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default();
 
@@ -290,7 +290,7 @@ pub trait LoadState:
             // first fetch the on chain nonce of the account
             let on_chain_account_nonce = this
                 .state_at_block_id_or_latest(block_id)?
-                .account_nonce(address)
+                .account_nonce(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default();
 
@@ -333,7 +333,7 @@ pub trait LoadState:
         self.spawn_blocking_io(move |this| {
             Ok(this
                 .state_at_block_id_or_latest(block_id)?
-                .account_code(address)
+                .account_code(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default()
                 .original_bytes())

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -106,7 +106,7 @@ impl reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'_> {
 impl reth_storage_api::AccountReader for StateProviderTraitObjWrapper<'_> {
     fn basic_account(
         &self,
-        address: revm_primitives::Address,
+        address: &revm_primitives::Address,
     ) -> reth_errors::ProviderResult<Option<reth_primitives::Account>> {
         self.0.basic_account(address)
     }
@@ -163,21 +163,21 @@ impl StateProvider for StateProviderTraitObjWrapper<'_> {
 
     fn account_code(
         &self,
-        addr: revm_primitives::Address,
+        addr: &revm_primitives::Address,
     ) -> reth_errors::ProviderResult<Option<reth_primitives::Bytecode>> {
         self.0.account_code(addr)
     }
 
     fn account_balance(
         &self,
-        addr: revm_primitives::Address,
+        addr: &revm_primitives::Address,
     ) -> reth_errors::ProviderResult<Option<U256>> {
         self.0.account_balance(addr)
     }
 
     fn account_nonce(
         &self,
-        addr: revm_primitives::Address,
+        addr: &revm_primitives::Address,
     ) -> reth_errors::ProviderResult<Option<u64>> {
         self.0.account_nonce(addr)
     }

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -73,7 +73,7 @@ where
         let hash_map = accounts_before.iter().try_fold(
             HashMap::default(),
             |mut hash_map, account_before| -> RethResult<_> {
-                let current_balance = state.account_balance(account_before.address)?;
+                let current_balance = state.account_balance(&account_before.address)?;
                 let prev_balance = account_before.info.map(|info| info.balance);
                 if current_balance != prev_balance {
                     hash_map.insert(account_before.address, current_balance.unwrap_or_default());

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -939,17 +939,17 @@ mod tests {
 
             // assert accounts
             assert_eq!(
-                provider.basic_account(account1),
+                provider.basic_account(&account1),
                 Ok(Some(account1_info)),
                 "Post changed of a account"
             );
             assert_eq!(
-                provider.basic_account(account2),
+                provider.basic_account(&account2),
                 Ok(Some(account2_info)),
                 "Post changed of a account"
             );
             assert_eq!(
-                provider.basic_account(account3),
+                provider.basic_account(&account3),
                 Ok(Some(account3_info)),
                 "Post changed of a account"
             );
@@ -1075,19 +1075,19 @@ mod tests {
 
             // assert unwind stage
             assert_eq!(
-                provider.basic_account(acc1),
+                provider.basic_account(&acc1),
                 Ok(Some(acc1_info)),
                 "Pre changed of a account"
             );
             assert_eq!(
-                provider.basic_account(acc2),
+                provider.basic_account(&acc2),
                 Ok(Some(acc2_info)),
                 "Post changed of a account"
             );
 
             let miner_acc = address!("2adc25665018aa1fe0e6bc666dac8fc2697ff9ba");
             assert_eq!(
-                provider.basic_account(miner_acc),
+                provider.basic_account(&miner_acc),
                 Ok(None),
                 "Third account should be unwound"
             );
@@ -1173,7 +1173,7 @@ mod tests {
 
         // assert unwind stage
         let provider = test_db.factory.database_provider_rw().unwrap();
-        assert_eq!(provider.basic_account(destroyed_address), Ok(None), "Account was destroyed");
+        assert_eq!(provider.basic_account(&destroyed_address), Ok(None), "Account was destroyed");
 
         assert_eq!(
             provider.tx_ref().get::<tables::PlainStorageState>(destroyed_address),

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -748,7 +748,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for BlockchainProvider2<N> {
 
 impl<N: ProviderNodeTypes> AccountReader for BlockchainProvider2<N> {
     /// Get basic account information.
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         self.consistent_provider()?.basic_account(address)
     }
 }

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -68,9 +68,9 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> BlockHashReader
 }
 
 impl<SP: StateProvider, EDP: ExecutionDataProvider> AccountReader for BundleStateProvider<SP, EDP> {
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         if let Some(account) =
-            self.block_execution_data_provider.execution_outcome().account(&address)
+            self.block_execution_data_provider.execution_outcome().account(address)
         {
             Ok(account)
         } else {

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -234,7 +234,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             let AccountBeforeTx { info: old_info, address } = account_before;
             match state.entry(address) {
                 hash_map::Entry::Vacant(entry) => {
-                    let new_info = state_provider.basic_account(address)?;
+                    let new_info = state_provider.basic_account(&address)?;
                     entry.insert((old_info, new_info, HashMap::new()));
                 }
                 hash_map::Entry::Occupied(mut entry) => {
@@ -252,7 +252,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             // get account state or insert from plain state.
             let account_state = match state.entry(address) {
                 hash_map::Entry::Vacant(entry) => {
-                    let present_info = state_provider.basic_account(address)?;
+                    let present_info = state_provider.basic_account(&address)?;
                     entry.insert((present_info, present_info, HashMap::new()))
                 }
                 hash_map::Entry::Occupied(entry) => entry.into_mut(),
@@ -1441,7 +1441,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
 
 impl<N: ProviderNodeTypes> AccountReader for ConsistentProvider<N> {
     /// Get basic account information.
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         // use latest state provider
         let state_provider = self.latest_ref()?;
         state_provider.basic_account(address)

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -862,8 +862,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx, N: NodeTypes> AccountReader for DatabaseProvider<TX, N> {
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
-        Ok(self.tx.get::<tables::PlainAccountState>(address)?)
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(self.tx.get_by_encoded_key::<tables::PlainAccountState>(address)?)
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -949,7 +949,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for BlockchainProvider<N> {
 
 impl<N: ProviderNodeTypes> AccountReader for BlockchainProvider<N> {
     /// Get basic account information.
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         self.database.provider()?.basic_account(address)
     }
 }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -43,8 +43,8 @@ impl<'b, Provider: DBProvider> LatestStateProviderRef<'b, Provider> {
 
 impl<Provider: DBProvider> AccountReader for LatestStateProviderRef<'_, Provider> {
     /// Get basic account information.
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
-        self.tx().get::<tables::PlainAccountState>(address).map_err(Into::into)
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        self.tx().get_by_encoded_key::<tables::PlainAccountState>(address).map_err(Into::into)
     }
 }
 

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -31,7 +31,7 @@ macro_rules! delegate_provider_impls {
         $crate::providers::state::macros::delegate_impls_to_as_ref!(
             for $target =>
             AccountReader $(where [$($generics)*])? {
-                fn basic_account(&self, address: alloy_primitives::Address) -> reth_storage_errors::provider::ProviderResult<Option<reth_primitives::Account>>;
+                fn basic_account(&self, address: &alloy_primitives::Address) -> reth_storage_errors::provider::ProviderResult<Option<reth_primitives::Account>>;
             }
             BlockHashReader $(where [$($generics)*])? {
                 fn block_hash(&self, number: u64) -> reth_storage_errors::provider::ProviderResult<Option<alloy_primitives::B256>>;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -577,8 +577,8 @@ impl BlockReaderIdExt for MockEthProvider {
 }
 
 impl AccountReader for MockEthProvider {
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
-        Ok(self.accounts.lock().get(&address).cloned().map(|a| a.account))
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(self.accounts.lock().get(address).cloned().map(|a| a.account))
     }
 }
 

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -361,12 +361,12 @@ mod tests {
 
         // Check plain state
         assert_eq!(
-            provider.basic_account(address_a).expect("Could not read account state"),
+            provider.basic_account(&address_a).expect("Could not read account state"),
             Some(reth_account_a),
             "Account A state is wrong"
         );
         assert_eq!(
-            provider.basic_account(address_b).expect("Could not read account state"),
+            provider.basic_account(&address_b).expect("Could not read account state"),
             Some(reth_account_b_changed),
             "Account B state is wrong"
         );
@@ -422,7 +422,7 @@ mod tests {
 
         // Check new plain state for account B
         assert_eq!(
-            provider.basic_account(address_b).expect("Could not read account state"),
+            provider.basic_account(&address_b).expect("Could not read account state"),
             None,
             "Account B should be deleted"
         );

--- a/crates/storage/storage-api/src/account.rs
+++ b/crates/storage/storage-api/src/account.rs
@@ -14,7 +14,7 @@ pub trait AccountReader: Send + Sync {
     /// Get basic account information.
     ///
     /// Returns `None` if the account doesn't exist.
-    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>>;
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>>;
 }
 
 /// Account reader

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -357,7 +357,7 @@ impl<C: Send + Sync, N: NodePrimitives> HeaderProvider for NoopProvider<C, N> {
 }
 
 impl<C: Send + Sync, N: NodePrimitives> AccountReader for NoopProvider<C, N> {
-    fn basic_account(&self, _address: Address) -> ProviderResult<Option<Account>> {
+    fn basic_account(&self, _address: &Address) -> ProviderResult<Option<Account>> {
         Ok(None)
     }
 }

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -40,7 +40,7 @@ pub trait StateProvider:
     /// Get account code by its address.
     ///
     /// Returns `None` if the account doesn't exist or account is not a contract
-    fn account_code(&self, addr: Address) -> ProviderResult<Option<Bytecode>> {
+    fn account_code(&self, addr: &Address) -> ProviderResult<Option<Bytecode>> {
         // Get basic account information
         // Returns None if acc doesn't exist
         let acc = match self.basic_account(addr)? {
@@ -63,7 +63,7 @@ pub trait StateProvider:
     /// Get account balance by its address.
     ///
     /// Returns `None` if the account doesn't exist
-    fn account_balance(&self, addr: Address) -> ProviderResult<Option<U256>> {
+    fn account_balance(&self, addr: &Address) -> ProviderResult<Option<U256>> {
         // Get basic account information
         // Returns None if acc doesn't exist
         match self.basic_account(addr)? {
@@ -75,7 +75,7 @@ pub trait StateProvider:
     /// Get account nonce by its address.
     ///
     /// Returns `None` if the account doesn't exist
-    fn account_nonce(&self, addr: Address) -> ProviderResult<Option<u64>> {
+    fn account_nonce(&self, addr: &Address) -> ProviderResult<Option<u64>> {
         // Get basic account information
         // Returns None if acc doesn't exist
         match self.basic_account(addr)? {

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -535,7 +535,7 @@ where
         Err(err) => return Err(Box::new((addresses.collect(), err))),
     };
     for addr in addresses {
-        if let Ok(maybe_acc) = state.basic_account(addr) {
+        if let Ok(maybe_acc) = state.basic_account(&addr) {
             let acc = maybe_acc
                 .map(|acc| ChangedAccount { address: addr, nonce: acc.nonce, balance: acc.balance })
                 .unwrap_or_else(|| ChangedAccount::empty(addr));

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -367,7 +367,7 @@ where
         let state = maybe_state.as_deref().expect("provider is set");
 
         // Use provider to get account info
-        let account = match state.basic_account(transaction.sender()) {
+        let account = match state.basic_account(transaction.sender_ref()) {
             Ok(account) => account.unwrap_or_default(),
             Err(err) => {
                 return TransactionValidationOutcome::Error(*transaction.hash(), Box::new(err))

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -234,8 +234,8 @@ fn state_provider_example<T: StateProvider + AccountReader>(provider: T) -> eyre
     let storage_key = B256::random();
 
     // Can get account / storage state with simple point queries
-    let _account = provider.basic_account(address)?;
-    let _code = provider.account_code(address)?;
+    let _account = provider.basic_account(&address)?;
+    let _code = provider.account_code(&address)?;
     let _storage = provider.storage(address, storage_key)?;
     // TODO: unimplemented.
     // let _proof = provider.proof(address, &[])?;


### PR DESCRIPTION
Following #13171 towards #12838.