### PR TITLE
fix: typo in thread name

### DIFF
--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -94,7 +94,7 @@ impl TxnManager {
                 }
             }
         };
-        std::thread::Builder::new().name("mbdx-rs-txn-manager".to_string()).spawn(task).unwrap();
+        std::thread::Builder::new().name("mdbx-rs-txn-manager".to_string()).spawn(task).unwrap();
     }
 
     pub(crate) fn send_message(&self, message: TxnManagerMessage) {


### PR DESCRIPTION
We should name more threads like this, very helpful in profilers!

![image](https://github.com/user-attachments/assets/14d549e9-4e57-4d51-81bd-ac31ff4153aa)
