### PR TITLE
chore: correct typo docs

### DIFF
--- a/crates/consensus/beacon/src/engine/error.rs
+++ b/crates/consensus/beacon/src/engine/error.rs
@@ -45,7 +45,7 @@ impl From<DatabaseError> for BeaconConsensusEngineError {
 
 /// Represents error cases for an applied forkchoice update.
 ///
-/// This represents all possible error cases, that must be returned as JSON RCP errors back to the
+/// This represents all possible error cases, that must be returned as JSON RPC errors back to the
 /// beacon node.
 #[derive(Debug, thiserror::Error)]
 pub enum BeaconForkChoiceUpdateError {

--- a/crates/engine/tree/src/lib.rs
+++ b/crates/engine/tree/src/lib.rs
@@ -47,7 +47,7 @@
 //! ## Handling consensus messages
 //!
 //! Consensus message handling is performed by three main components:
-//! 1. The [`EngineHandler`](engine::EngineHandler), which takes incoming consensus mesesages and
+//! 1. The [`EngineHandler`](engine::EngineHandler), which takes incoming consensus messages and
 //!    manages any requested backfill or download work.
 //! 2. The [`EngineApiRequestHandler`](engine::EngineApiRequestHandler), which processes messages
 //!    from the [`EngineHandler`](engine::EngineHandler) and delegates them to the

--- a/crates/ethereum/evm/src/dao_fork.rs
+++ b/crates/ethereum/evm/src/dao_fork.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{address, Address};
 pub static DAO_HARDFORK_BENEFICIARY: Address = address!("bf4ed7b27f1d666546e30d74d50d173d20bca754");
 
 /// DAO hardfork account that ether was taken and added to beneficiary
-pub static DAO_HARDKFORK_ACCOUNTS: [Address; 116] = [
+pub static DAO_HARDFORK_ACCOUNTS: [Address; 116] = [
     address!("d4fe7bc31cedb7bfb8a345f31e668033056b2728"),
     address!("b3fb0e5aba0e20e5c49d252dfd30e102b171a425"),
     address!("2c19c7f9ae8b751e37aeb2d93a699722395ae18f"),

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -1,7 +1,7 @@
 //! Ethereum block execution strategy.
 
 use crate::{
-    dao_fork::{DAO_HARDFORK_BENEFICIARY, DAO_HARDFORK_ACCOUNTS},
+    dao_fork::{DAO_HARDFORK_ACCOUNTS, DAO_HARDFORK_BENEFICIARY},
     EthEvmConfig,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -1,7 +1,7 @@
 //! Ethereum block execution strategy.
 
 use crate::{
-    dao_fork::{DAO_HARDFORK_BENEFICIARY, DAO_HARDKFORK_ACCOUNTS},
+    dao_fork::{DAO_HARDFORK_BENEFICIARY, DAO_HARDFORK_ACCOUNTS},
     EthEvmConfig,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
@@ -255,7 +255,7 @@ where
             // drain balances from hardcoded addresses.
             let drained_balance: u128 = self
                 .state
-                .drain_balances(DAO_HARDKFORK_ACCOUNTS)
+                .drain_balances(DAO_HARDFORK_ACCOUNTS)
                 .map_err(|_| BlockValidationError::IncrementBalanceFailed)?
                 .into_iter()
                 .sum();


### PR DESCRIPTION
**Description**  

- Corrected `RCP ` to `RPC `
- Corrected `mesesages ` to `messages ` 
- Corrected `DAO_HARDKFORK_ACCOUNTS` to `DAO_HARDFORK_ACCOUNTS` 

I fixed the typos in the comments and also one in the function. I tried really hard—happy to help, thank you!