### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -296,11 +296,11 @@ impl ChainSpec {
             timestamp: self.genesis.timestamp,
             mix_hash: self.genesis.mix_hash,
             beneficiary: self.genesis.coinbase,
-            base_fee_per_gas: base_fee_per_gas.map(Into::into),
+            base_fee_per_gas,
             withdrawals_root,
             parent_beacon_block_root,
-            blob_gas_used: blob_gas_used.map(Into::into),
-            excess_blob_gas: excess_blob_gas.map(Into::into),
+            blob_gas_used,
+            excess_blob_gas,
             requests_hash,
             ..Default::default()
         }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -358,7 +358,7 @@ where
             tx_type: tx.tx_type(),
             success: exec_result.result.is_success(),
             cumulative_gas_used,
-            logs: exec_result.result.into_logs().into_iter().map(Into::into).collect(),
+            logs: exec_result.result.into_logs().into_iter().collect(),
             ..Default::default()
         }));
 
@@ -422,8 +422,8 @@ where
             receipts_root: outcome.ethereum_receipts_root(reorg_target.header.number).unwrap(),
             logs_bloom: outcome.block_logs_bloom(reorg_target.header.number).unwrap(),
             gas_used: cumulative_gas_used,
-            blob_gas_used: blob_gas_used.map(Into::into),
-            excess_blob_gas: excess_blob_gas.map(Into::into),
+            blob_gas_used,
+            excess_blob_gas,
             state_root: state_provider.state_root(hashed_state)?,
             requests_hash: None,          // TODO(prague)
             target_blobs_per_block: None, // TODO(prague)

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -341,7 +341,7 @@ where
             tx_type: tx.tx_type(),
             success: result.is_success(),
             cumulative_gas_used,
-            logs: result.into_logs().into_iter().map(Into::into).collect(),
+            logs: result.into_logs().into_iter().collect(),
             ..Default::default()
         }));
 
@@ -469,8 +469,8 @@ where
         gas_used: cumulative_gas_used,
         extra_data: builder_config.extra_data,
         parent_beacon_block_root: attributes.parent_beacon_block_root,
-        blob_gas_used: blob_gas_used.map(Into::into),
-        excess_blob_gas: excess_blob_gas.map(Into::into),
+        blob_gas_used,
+        excess_blob_gas,
         requests_hash,
         target_blobs_per_block: None,
     };

--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -119,7 +119,7 @@ where
     ) -> impl Iterator<Item = eyre::Result<(u32, u64, ExExNotification<N>)>> + '_ {
         range.map(move |id| {
             let (notification, size) =
-                self.read_notification(id)?.ok_or_eyre("notification {id} not found")?;
+                self.read_notification(id)?.ok_or_eyre(format!("notification {id} not found"))?;
 
             Ok((id, size, notification))
         })

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -24,7 +24,7 @@ use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::Gauge;
 use reth_eth_wire::{
     capability::RawCapabilityMessage,
-    errors::{EthHandshakeError, EthStreamError, P2PStreamError},
+    errors::{EthHandshakeError, EthStreamError},
     message::{EthBroadcastMessage, RequestPair},
     Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives,
 };
@@ -390,11 +390,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
 
     /// Starts the disconnect process
     fn start_disconnect(&mut self, reason: DisconnectReason) -> Result<(), EthStreamError> {
-        self.conn
-            .inner_mut()
-            .start_disconnect(reason)
-            .map_err(P2PStreamError::from)
-            .map_err(Into::into)
+        Ok(self.conn.inner_mut().start_disconnect(reason)?)
     }
 
     /// Flushes the disconnect message and emits the corresponding message

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -821,7 +821,7 @@ where
                 tx_type: sequencer_tx.tx_type(),
                 success: result.is_success(),
                 cumulative_gas_used: info.cumulative_gas_used,
-                logs: result.into_logs().into_iter().map(Into::into).collect(),
+                logs: result.into_logs().into_iter().collect(),
                 deposit_nonce: depositor.map(|account| account.nonce),
                 // The deposit receipt version was introduced in Canyon to indicate an update to how
                 // receipt hashes should be computed when set. The state transition process
@@ -922,7 +922,7 @@ where
                 tx_type: tx.tx_type(),
                 success: result.is_success(),
                 cumulative_gas_used: info.cumulative_gas_used,
-                logs: result.into_logs().into_iter().map(Into::into).collect(),
+                logs: result.into_logs().into_iter().collect(),
                 deposit_nonce: None,
                 deposit_receipt_version: None,
             }));

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -267,7 +267,7 @@ impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV3 {
             // Spec:
             // <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#specification-2>
             should_override_builder: false,
-            blobs_bundle: sidecars.into_iter().map(Into::into).collect::<Vec<_>>().into(),
+            blobs_bundle: sidecars.into_iter().collect::<Vec<_>>().into(),
             parent_beacon_block_root,
         }
     }
@@ -294,7 +294,7 @@ impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV4 {
             // Spec:
             // <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#specification-2>
             should_override_builder: false,
-            blobs_bundle: sidecars.into_iter().map(Into::into).collect::<Vec<_>>().into(),
+            blobs_bundle: sidecars.into_iter().collect::<Vec<_>>().into(),
             parent_beacon_block_root,
             execution_requests: vec![],
         }

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -122,7 +122,7 @@ where
             blob_gas_used: is_cancun.then(|| {
                 transactions.iter().map(|tx| tx.blob_gas_used().unwrap_or_default()).sum::<u64>()
             }),
-            excess_blob_gas: block_env.get_blob_excess_gas().map(Into::into),
+            excess_blob_gas: block_env.get_blob_excess_gas(),
             extra_data: Default::default(),
             parent_beacon_block_root: is_cancun.then_some(B256::ZERO),
             requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
@@ -147,7 +147,7 @@ where
             tx_type: tx.tx_type(),
             success: result.is_success(),
             cumulative_gas_used,
-            logs: result.into_logs().into_iter().map(Into::into).collect(),
+            logs: result.into_logs().into_iter().collect(),
             ..Default::default()
         }
     }

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -75,10 +75,7 @@ impl AuthServerConfig {
                 .clone()
                 .unwrap_or_else(|| constants::DEFAULT_ENGINE_API_IPC_ENDPOINT.to_string());
             let ipc_server = ipc_server_config.build(ipc_endpoint_str);
-            let res = ipc_server
-                .start(module.inner)
-                .await
-                .map_err(reth_ipc::server::IpcServerStartError::from)?;
+            let res = ipc_server.start(module.inner).await?;
             ipc_handle = Some(res);
         }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -351,15 +351,13 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     let state_overrides = state_override.take();
                     let overrides = EvmOverrides::new(state_overrides, block_overrides.clone());
 
-                    let env = this
-                        .prepare_call_env(
-                            cfg_env_with_handler_cfg.clone(),
-                            block_env.clone(),
-                            tx,
-                            &mut db,
-                            overrides,
-                        )
-                        .map(Into::into)?;
+                    let env = this.prepare_call_env(
+                        cfg_env_with_handler_cfg.clone(),
+                        block_env.clone(),
+                        tx,
+                        &mut db,
+                        overrides,
+                    )?;
                     let (res, _) = this.transact(&mut db, env)?;
 
                     match ensure_success(res.result) {

--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -20,7 +20,7 @@ use super::{EthApiError, EthResult, RpcInvalidTransactionError};
 #[inline]
 pub fn get_precompiles(spec_id: SpecId) -> impl IntoIterator<Item = Address> {
     let spec = PrecompileSpecId::from_spec_id(spec_id);
-    Precompiles::new(spec).addresses().copied().map(Address::from)
+    Precompiles::new(spec).addresses().copied()
 }
 
 /// Calculates the caller gas allowance.

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -537,7 +537,7 @@ mod tests {
                 number: newest_block - i,
                 gas_limit,
                 gas_used,
-                base_fee_per_gas: base_fee_per_gas.map(Into::into),
+                base_fee_per_gas,
                 parent_hash,
                 ..Default::default()
             };

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -93,7 +93,7 @@ where
             blob_gas_used: is_cancun.then(|| {
                 transactions.iter().map(|tx| tx.blob_gas_used().unwrap_or_default()).sum::<u64>()
             }),
-            excess_blob_gas: block_env.get_blob_excess_gas().map(Into::into),
+            excess_blob_gas: block_env.get_blob_excess_gas(),
             extra_data: Default::default(),
             parent_beacon_block_root: is_cancun.then_some(B256::ZERO),
             requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
@@ -118,7 +118,7 @@ where
             tx_type: tx.tx_type(),
             success: result.is_success(),
             cumulative_gas_used,
-            logs: result.into_logs().into_iter().map(Into::into).collect(),
+            logs: result.into_logs().into_iter().collect(),
             ..Default::default()
         }
     }

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -171,8 +171,7 @@ where
             while idx < body.len() {
                 match &body[idx] {
                     BundleItem::Tx { tx, can_revert } => {
-                        let recovered_tx = recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(tx)
-                            .map_err(EthApiError::from)?;
+                        let recovered_tx = recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(tx)?;
                         let (tx, signer) = recovered_tx.to_components();
                         let tx: PoolConsensusTx<Eth::Pool> =
                             <Eth::Pool as TransactionPool>::Transaction::pooled_into_consensus(tx);

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -526,10 +526,7 @@ mod tests {
 
                             // validate the header total difficulty
                             td += header.difficulty;
-                            assert_eq!(
-                                provider.header_td_by_number(block_num)?.map(Into::into),
-                                Some(td)
-                            );
+                            assert_eq!(provider.header_td_by_number(block_num)?, Some(td));
                         }
                     }
                     _ => self.check_no_header_entry_above(initial_checkpoint)?,

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -917,14 +917,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
             id.into(),
             |provider| provider.transaction_by_id(id),
             |tx_index, _, block_state| {
-                Ok(block_state
-                    .block_ref()
-                    .block()
-                    .body
-                    .transactions()
-                    .get(tx_index)
-                    .cloned()
-                    .map(Into::into))
+                Ok(block_state.block_ref().block().body.transactions().get(tx_index).cloned())
             },
         )
     }
@@ -937,14 +930,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
             id.into(),
             |provider| provider.transaction_by_id_unhashed(id),
             |tx_index, _, block_state| {
-                Ok(block_state
-                    .block_ref()
-                    .block()
-                    .body
-                    .transactions()
-                    .get(tx_index)
-                    .cloned()
-                    .map(Into::into))
+                Ok(block_state.block_ref().block().body.transactions().get(tx_index).cloned())
             },
         )
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1042,9 +1042,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
             StaticFileSegment::Headers,
             to_range(range),
             |static_file, range, _| static_file.headers_range(range),
-            |range, _| {
-                self.cursor_read_collect::<tables::Headers<Self::Header>>(range).map_err(Into::into)
-            },
+            |range, _| self.cursor_read_collect::<tables::Headers<Self::Header>>(range),
             |_| true,
         )
     }
@@ -1120,9 +1118,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> BlockHashReader for DatabaseProvider<TX, 
             StaticFileSegment::Headers,
             start..end,
             |static_file, range, _| static_file.canonical_hashes_range(range.start, range.end),
-            |range, _| {
-                self.cursor_read_collect::<tables::CanonicalHeaders>(range).map_err(Into::into)
-            },
+            |range, _| self.cursor_read_collect::<tables::CanonicalHeaders>(range),
             |_| true,
         )
     }
@@ -1517,7 +1513,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
         &self,
         range: impl RangeBounds<TxNumber>,
     ) -> ProviderResult<Vec<Address>> {
-        self.cursor_read_collect::<tables::TransactionSenders>(range).map_err(Into::into)
+        self.cursor_read_collect::<tables::TransactionSenders>(range)
     }
 
     fn transaction_sender(&self, id: TxNumber) -> ProviderResult<Option<Address>> {
@@ -1570,10 +1566,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
             StaticFileSegment::Receipts,
             to_range(range),
             |static_file, range, _| static_file.receipts_by_tx_range(range),
-            |range, _| {
-                self.cursor_read_collect::<tables::Receipts<Self::Receipt>>(range)
-                    .map_err(Into::into)
-            },
+            |range, _| self.cursor_read_collect::<tables::Receipts<Self::Receipt>>(range),
             |_| true,
         )
     }


### PR DESCRIPTION
fixes errors like these with latest clippy:
```
warning: useless conversion to the same type: `reth_errors::ProviderError`
    --> crates/storage/provider/src/providers/database/provider.rs:1046:81
     |
1046 |                   self.cursor_read_collect::<tables::Headers<Self::Header>>(range).map_err(Into::into)
     |  _________________________________________________________________________________-^^^^^^^^^^^^^^^^^^^
1047 | |             },
     | |____________- help: consider removing
     |
```
and
```
warning: this looks like a formatting argument but it is not part of a formatting macro
   --> crates/exex/exex/src/wal/storage.rs:122:70
    |
122 |                 self.read_notification(id)?.ok_or_eyre("notification {id} not found")?;
    |                                                                      ^^^^
    |
```