### PR TITLE
feat(tx-pool): make benchmark inputs deterministic

### DIFF
--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -7,14 +7,12 @@ use reth_transaction_pool::{blob_tx_priority, fee_delta};
 use std::hint::black_box;
 
 fn generate_test_data_fee_delta() -> (u128, u128) {
-    let config = ProptestConfig::default();
-    let mut runner = TestRunner::new(config);
+    let mut runner = TestRunner::deterministic();
     prop::arbitrary::any::<(u128, u128)>().new_tree(&mut runner).unwrap().current()
 }
 
 fn generate_test_data_priority() -> (u128, u128, u128, u128) {
-    let config = ProptestConfig::default();
-    let mut runner = TestRunner::new(config);
+    let mut runner = TestRunner::deterministic();
     prop::arbitrary::any::<(u128, u128, u128, u128)>().new_tree(&mut runner).unwrap().current()
 }
 

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -94,8 +94,7 @@ fn generate_test_data(
     seed_size: usize,
     input_size: usize,
 ) -> (Vec<MockTransaction>, Vec<MockTransaction>, u64) {
-    let config = ProptestConfig::default();
-    let mut runner = TestRunner::new(config);
+    let mut runner = TestRunner::deterministic();
 
     let txs = prop::collection::vec(any::<MockTransaction>(), seed_size)
         .new_tree(&mut runner)


### PR DESCRIPTION
Partially addresses #13535

Use runner with deterministic runner for `transaction-pool` benches