### PR TITLE
Fix grammar and clarity in engine API comment

### DIFF
--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -6,7 +6,7 @@
 //! cargo run -p bsc-p2p
 //! ```
 //!
-//! This launch the regular reth node overriding the engine api payload builder with our custom.
+//! This launches the regular reth node, overriding the engine API payload builder with our custom one.
 //!
 //! Credits to: <https://blog.merkle.io/blog/fastest-transaction-network-eth-polygon-bsc>
 


### PR DESCRIPTION
I addressed a grammatical issue and improved the clarity of a key comment related to the engine API payload builder.  

#### Changes Made:  
1. Corrected the verb form from "launch" to "launches" to ensure grammatical agreement with the subject.  
2. Added a comma after "node" to improve readability.  
3. Clarified the phrase "with our custom" by completing it as "with our custom one."  

The revised comment now reads:  
```rust  
//! This launches the regular reth node, overriding the engine API payload builder with our custom one.  
```  

I believe this adjustment improves both readability and accuracy, ensuring the intent is clear for anyone reading or maintaining the code.