### PR TITLE
chore: update WASM build exclusion list

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -8,8 +8,6 @@ crates=($(cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name'
 # Used with the `contains` function.
 # shellcheck disable=SC2034
 exclude_crates=(
-  # The following are not working yet, but known to be fixable
-  reth-exex-types # https://github.com/paradigmxyz/reth/issues/9946
   # The following require investigation if they can be fixed
   reth-basic-payload-builder
   reth-beacon-consensus
@@ -70,7 +68,6 @@ exclude_crates=(
   reth-transaction-pool # c-kzg
   reth-trie-parallel # tokio
   reth-testing-utils
-  reth-network-peers
 )
 
 # Array to hold the results


### PR DESCRIPTION
`reth-exex-types` and `reth-network-peers` now build for `wasm32-wasip1` target