### PR TITLE
fix(storage): update proptest configuration for deterministic bench runs

### DIFF
--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -8,7 +8,7 @@ use criterion::{
 use pprof::criterion::{Output, PProfProfiler};
 use proptest::{
     arbitrary::Arbitrary,
-    prelude::{any_with, ProptestConfig},
+    prelude::any_with,
     strategy::{Strategy, ValueTree},
     test_runner::TestRunner,
 };
@@ -164,7 +164,7 @@ where
     .no_shrink()
     .boxed();
 
-    let mut runner = TestRunner::new(ProptestConfig::default());
+    let mut runner = TestRunner::deterministic();
     let mut preload = strategy.new_tree(&mut runner).unwrap().current();
     let mut input = strategy.new_tree(&mut runner).unwrap().current();
 


### PR DESCRIPTION
towards #13535 

uses the deterministic proptest runner in `generate_batches`