### PR TITLE
feat(bench): make benchmark inputs deterministic using fixed seed

### DIFF
--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -50,9 +50,6 @@ fn fee_jump_bench(
 }
 
 fn blob_priority_calculation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("priority");
-    group.sample_size(10);
-
     let mut group = c.benchmark_group("Blob priority calculation");
     let fee_jump_input = generate_test_data_fee_delta();
 

--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -7,14 +7,12 @@ use reth_transaction_pool::{blob_tx_priority, fee_delta};
 use std::hint::black_box;
 
 fn generate_test_data_fee_delta() -> (u128, u128) {
-    let config = ProptestConfig::default();
-    let mut runner = TestRunner::new(config);
+    let mut runner = TestRunner::deterministic();
     prop::arbitrary::any::<(u128, u128)>().new_tree(&mut runner).unwrap().current()
 }
 
 fn generate_test_data_priority() -> (u128, u128, u128, u128) {
-    let config = ProptestConfig::default();
-    let mut runner = TestRunner::new(config);
+    let mut runner = TestRunner::deterministic();
     prop::arbitrary::any::<(u128, u128, u128, u128)>().new_tree(&mut runner).unwrap().current()
 }
 
@@ -52,27 +50,8 @@ fn fee_jump_bench(
 }
 
 fn blob_priority_calculation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Blob priority calculation");
-    let fee_jump_input = generate_test_data_fee_delta();
-
-    // Unstable sorting of unsorted collection
-    fee_jump_bench(&mut group, "BenchmarkDynamicFeeJumpCalculation", fee_jump_input);
-
-    let blob_priority_input = generate_test_data_priority();
-
-    // BinaryHeap that is resorted on each update
-    priority_bench(&mut group, "BenchmarkPriorityCalculation", blob_priority_input);
-}
-
-fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("priority");
     group.sample_size(10);
-
-    let config = ProptestConfig {
-        rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
-        seed: 12345,
-        ..Default::default()
-    };
 
     let mut group = c.benchmark_group("Blob priority calculation");
     let fee_jump_input = generate_test_data_fee_delta();

--- a/crates/transaction-pool/benches/priority.rs
+++ b/crates/transaction-pool/benches/priority.rs
@@ -1,68 +1,84 @@
-#![allow(missing_docs)]
-use criterion::{
-    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
-};
+#![allow(missing_docs, unreachable_pub)]
+use alloy_primitives::B256;
+use criterion::{criterion_group, criterion_main, Criterion};
 use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
-use reth_transaction_pool::{blob_tx_priority, fee_delta};
+use proptest_arbitrary_interop::arb;
+use reth_primitives::{Receipt, ReceiptWithBloom};
+use reth_trie::triehash::KeccakHasher;
 use std::hint::black_box;
 
-fn generate_test_data_fee_delta() -> (u128, u128) {
-    let config = ProptestConfig::default();
-    let mut runner = TestRunner::new(config);
-    prop::arbitrary::any::<(u128, u128)>().new_tree(&mut runner).unwrap().current()
-}
+/// Benchmarks different implementations of the root calculation.
+pub fn trie_root_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Receipts root calculation");
 
-fn generate_test_data_priority() -> (u128, u128, u128, u128) {
-    let config = ProptestConfig::default();
-    let mut runner = TestRunner::new(config);
-    prop::arbitrary::any::<(u128, u128, u128, u128)>().new_tree(&mut runner).unwrap().current()
-}
+    for size in [10, 100, 1_000] {
+        let group_name =
+            |description: &str| format!("receipts root | size: {size} | {description}");
 
-fn priority_bench(
-    group: &mut BenchmarkGroup<'_, WallTime>,
-    description: &str,
-    input_data: (u128, u128, u128, u128),
-) {
-    let group_id = format!("txpool | {description}");
+        let receipts = &generate_test_data(size)[..];
+        assert_eq!(trie_hash_ordered_trie_root(receipts), hash_builder_root(receipts));
 
-    group.bench_function(group_id, |b| {
-        b.iter(|| {
-            black_box(blob_tx_priority(
-                black_box(input_data.0),
-                black_box(input_data.1),
-                black_box(input_data.2),
-                black_box(input_data.3),
-            ));
+        group.bench_function(group_name("triehash::ordered_trie_root"), |b| {
+            b.iter(|| trie_hash_ordered_trie_root(black_box(receipts)));
         });
-    });
-}
 
-fn fee_jump_bench(
-    group: &mut BenchmarkGroup<'_, WallTime>,
-    description: &str,
-    input_data: (u128, u128),
-) {
-    let group_id = format!("txpool | {description}");
-
-    group.bench_function(group_id, |b| {
-        b.iter(|| {
-            black_box(fee_delta(black_box(input_data.0), black_box(input_data.1)));
+        group.bench_function(group_name("HashBuilder"), |b| {
+            b.iter(|| hash_builder_root(black_box(receipts)));
         });
-    });
+    }
 }
 
-fn blob_priority_calculation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Blob priority calculation");
-    let fee_jump_input = generate_test_data_fee_delta();
-
-    // Unstable sorting of unsorted collection
-    fee_jump_bench(&mut group, "BenchmarkDynamicFeeJumpCalculation", fee_jump_input);
-
-    let blob_priority_input = generate_test_data_priority();
-
-    // BinaryHeap that is resorted on each update
-    priority_bench(&mut group, "BenchmarkPriorityCalculation", blob_priority_input);
+fn generate_test_data(size: usize) -> Vec<ReceiptWithBloom<Receipt>> {
+    prop::collection::vec(arb::<ReceiptWithBloom<Receipt>>(), size)
+        .new_tree(&mut TestRunner::new(ProptestConfig {
+            rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
+            seed: 12345,
+            ..Default::default()
+        }))
+        .unwrap()
+        .current()
 }
 
-criterion_group!(priority, blob_priority_calculation);
-criterion_main!(priority);
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = trie_root_benchmark
+}
+criterion_main!(benches);
+
+mod implementations {
+    use super::*;
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_rlp::Encodable;
+    use alloy_trie::root::adjust_index_for_rlp;
+    use reth_primitives::Receipt;
+    use reth_trie_common::{HashBuilder, Nibbles};
+
+    pub fn trie_hash_ordered_trie_root(receipts: &[ReceiptWithBloom<Receipt>]) -> B256 {
+        triehash::ordered_trie_root::<KeccakHasher, _>(
+            receipts.iter().map(|receipt_with_bloom| receipt_with_bloom.encoded_2718()),
+        )
+    }
+
+    pub fn hash_builder_root(receipts: &[ReceiptWithBloom<Receipt>]) -> B256 {
+        let mut index_buffer = Vec::new();
+        let mut value_buffer = Vec::new();
+
+        let mut hb = HashBuilder::default();
+        let receipts_len = receipts.len();
+        for i in 0..receipts_len {
+            let index = adjust_index_for_rlp(i, receipts_len);
+
+            index_buffer.clear();
+            index.encode(&mut index_buffer);
+
+            value_buffer.clear();
+            receipts[index].encode_2718(&mut value_buffer);
+
+            hb.add_leaf(Nibbles::unpack(&index_buffer), &value_buffer);
+        }
+
+        hb.root()
+    }
+}
+use implementations::*;

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -10,13 +10,17 @@ use reth_trie::Nibbles;
 use reth_trie_sparse::RevealedSparseTrie;
 
 fn update_rlp_node_level(c: &mut Criterion) {
-    let mut rng = generators::rng();
+    let mut rng = generators::rng_with_seed(12345);
 
     let mut group = c.benchmark_group("update rlp node level");
     group.sample_size(20);
 
     for size in [100_000] {
-        let mut runner = TestRunner::new(ProptestConfig::default());
+        let mut runner = TestRunner::new(ProptestConfig {
+            rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
+            seed: 12345,
+            ..Default::default()
+        });
         let state = proptest::collection::hash_map(any::<B256>(), any::<U256>(), size)
             .new_tree(&mut runner)
             .unwrap()

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -16,11 +16,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
     group.sample_size(20);
 
     for size in [100_000] {
-        let mut runner = TestRunner::new(ProptestConfig {
-            rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
-            seed: 12345,
-            ..Default::default()
-        });
+        let mut runner = TestRunner::deterministic();
         let state = proptest::collection::hash_map(any::<B256>(), any::<U256>(), size)
             .new_tree(&mut runner)
             .unwrap()

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -10,8 +10,7 @@ use reth_trie::Nibbles;
 use reth_trie_sparse::RevealedSparseTrie;
 
 fn update_rlp_node_level(c: &mut Criterion) {
-    let mut rng = generators::rng_with_seed(12345);
-
+    let mut rng = generators::rng_with_seed(&12345_u16.to_be_bytes());
     let mut group = c.benchmark_group("update rlp node level");
     group.sample_size(20);
 

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -214,7 +214,11 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
 }
 
 fn generate_test_data(size: usize) -> B256HashMap<U256> {
-    let mut runner = TestRunner::new(ProptestConfig::default());
+    let mut runner = TestRunner::new(ProptestConfig {
+        rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
+        seed: 12345,
+        ..Default::default()
+    });
     proptest::collection::hash_map(any::<B256>(), any::<U256>(), size)
         .new_tree(&mut runner)
         .unwrap()

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -214,11 +214,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
 }
 
 fn generate_test_data(size: usize) -> B256HashMap<U256> {
-    let mut runner = TestRunner::new(ProptestConfig {
-        rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
-        seed: 12345,
-        ..Default::default()
-    });
+    let mut runner = TestRunner::deterministic();
     proptest::collection::hash_map(any::<B256>(), any::<U256>(), size)
         .new_tree(&mut runner)
         .unwrap()

--- a/crates/trie/trie/benches/trie_root.rs
+++ b/crates/trie/trie/benches/trie_root.rs
@@ -30,11 +30,7 @@ pub fn trie_root_benchmark(c: &mut Criterion) {
 
 fn generate_test_data(size: usize) -> Vec<ReceiptWithBloom<Receipt>> {
     prop::collection::vec(arb::<ReceiptWithBloom<Receipt>>(), size)
-        .new_tree(&mut TestRunner::new(ProptestConfig {
-            rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
-            seed: 12345,
-            ..Default::default()
-        }))
+        .new_tree(&mut TestRunner::deterministic())
         .unwrap()
         .current()
 }

--- a/crates/trie/trie/benches/trie_root.rs
+++ b/crates/trie/trie/benches/trie_root.rs
@@ -30,7 +30,11 @@ pub fn trie_root_benchmark(c: &mut Criterion) {
 
 fn generate_test_data(size: usize) -> Vec<ReceiptWithBloom<Receipt>> {
     prop::collection::vec(arb::<ReceiptWithBloom<Receipt>>(), size)
-        .new_tree(&mut TestRunner::new(ProptestConfig::default()))
+        .new_tree(&mut TestRunner::new(ProptestConfig {
+            rng_algorithm: prop::test_runner::RngAlgorithm::ChaCha,
+            seed: 12345,
+            ..Default::default()
+        }))
         .unwrap()
         .current()
 }

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -69,12 +69,17 @@ impl Default for BlockRangeParams {
 /// If `SEED` is not set, a random seed is used.
 pub fn rng() -> StdRng {
     if let Ok(seed) = std::env::var("SEED") {
-        let mut hasher = DefaultHasher::new();
-        hasher.write(seed.as_bytes());
-        StdRng::seed_from_u64(hasher.finish())
+        rng_with_seed(seed.as_bytes())
     } else {
         StdRng::from_rng(thread_rng()).expect("could not build rng")
     }
+}
+
+/// Returns a random number generator from a specific seed, as bytes.
+pub fn rng_with_seed(seed: &[u8]) -> StdRng {
+    let mut hasher = DefaultHasher::new();
+    hasher.write(seed);
+    StdRng::seed_from_u64(hasher.finish())
 }
 
 /// Generates a range of random [`SealedHeader`]s.


### PR DESCRIPTION
Towards #13535

## Description of Changes
Made benchmark inputs deterministic by using a fixed seed for all random number generators. This resolves the issue of noise in test results on codspeed.

The changes include:
- Added a fixed seed (12345) for all `TestRunner` instances.
- Used the ChaCha algorithm for RNG, ensuring deterministic results.
- Updated the following benchmarks:
  - `crates/trie/sparse/benches/rlp_node.rs`
  - `crates/trie/sparse/benches/root.rs`
  - `crates/trie/trie/benches/trie_root.rs`
  - `crates/transaction-pool/benches/priority.rs`

## Testing
- Ran benchmarks multiple times to verify reproducibility of results.
- Confirmed that results remain stable across runs.

## Additional Notes
This change does not affect the functionality of the code itself but ensures that benchmark results are more stable and reproducible.
