### PR TITLE
chore: add ChainSpec::from_genesis

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -223,6 +223,11 @@ impl Default for ChainSpec {
 }
 
 impl ChainSpec {
+    /// Converts the given [`Genesis`] into a [`ChainSpec`].
+    pub fn from_genesis(genesis: Genesis) -> Self {
+        genesis.into()
+    }
+
     /// Get information about the chain itself
     pub const fn chain(&self) -> Chain {
         self.chain


### PR DESCRIPTION
this saves me time when I need to navigate to the from impl

