### PR TITLE
perf: relax condition in seek_inner

### DIFF
--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -78,7 +78,7 @@ impl<'a, C: TrieCursor> InMemoryAccountTrieCursor<'a, C> {
         exact: bool,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         let in_memory = self.in_memory_cursor.seek(&key);
-        if exact && in_memory.as_ref().is_some_and(|entry| entry.0 == key) {
+        if in_memory.as_ref().is_some_and(|entry| entry.0 == key) {
             return Ok(in_memory)
         }
 
@@ -202,9 +202,7 @@ impl<C: TrieCursor> InMemoryStorageTrieCursor<'_, C> {
         exact: bool,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         let in_memory = self.in_memory_cursor.as_mut().and_then(|c| c.seek(&key));
-        if self.storage_trie_cleared ||
-            (exact && in_memory.as_ref().is_some_and(|entry| entry.0 == key))
-        {
+        if self.storage_trie_cleared || in_memory.as_ref().is_some_and(|entry| entry.0 == key) {
             return Ok(in_memory.filter(|(nibbles, _)| !exact || nibbles == &key))
         }
 


### PR DESCRIPTION
Towards #13560

This PR optimizes the state root calculation.

![Effect of relaxing condition](https://github.com/user-attachments/assets/0f7837d6-e972-4028-b824-35dbeb4b40bb)

  | Before | After | Ratio
-- | -- | -- | --
Raw transfers | 846006 | 651852 | 77.05%
ERC20 | 1109015 | 756521 | 68.22%
Uniswap | 1398771 | 1332109 | 95.23%

