### PR TITLE
**Fix Typo in `mdbx.c`**

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
@@ -3928,7 +3928,7 @@ typedef struct MDBX_node {
 #error "Oops, some flags overlapped or wrong"
 #endif
 
-/* Max length of iov-vector passed to writev() call, used for auxilary writes */
+/* Max length of iov-vector passed to writev() call, used for auxiliary writes */
 #define MDBX_AUXILARY_IOV_MAX 64
 #if defined(IOV_MAX) && IOV_MAX < MDBX_AUXILARY_IOV_MAX
 #undef MDBX_AUXILARY_IOV_MAX


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `mdbx.c`**

## Description  
This pull request corrects a typo in the `mdbx.c` file. The word "auxilary" has been corrected to "auxiliary" to ensure proper spelling in the code comments.

### Changes Made:
- **File Modified:** `mdbx.c`
- **Summary of Changes:**  
  - Corrected the typo from "auxilary" to "auxiliary" in the comment on line 3928.

## Checklist  
- [x] Fixed the typo in the file.
- [x] Verified that the code comment is now correctly spelled.

## Additional Notes  
This change improves the readability and professionalism of the code comments.

---

**Allow edits by maintainers:** [x]
