### PR TITLE
fix(reth-trie-parallel): bump alloy-primitives and enable rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
+ "rayon",
  "ruint",
  "rustc-hash 2.1.0",
  "serde",
@@ -3641,6 +3642,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "rayon",
  "serde",
 ]
 
@@ -4185,6 +4187,7 @@ dependencies = [
  "arbitrary",
  "equivalent",
  "hashbrown 0.15.2",
+ "rayon",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,13 +431,13 @@ revm-inspectors = "0.14.1"
 
 # eth
 alloy-chains = { version = "0.1.32", default-features = false }
-alloy-dyn-abi = "0.8.15"
+alloy-dyn-abi = "0.8.18"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-primitives = { version = "0.8.15", default-features = false, features = [
+alloy-primitives = { version = "0.8.18", default-features = false, features = [
     "map-foldhash",
 ] }
 alloy-rlp = { version = "0.3.10", default-features = false }
-alloy-sol-types = "0.8.15"
+alloy-sol-types = "0.8.18"
 alloy-trie = { version = "0.7", default-features = false }
 
 alloy-consensus = { version = "0.9.2", default-features = false }

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -23,7 +23,7 @@ reth-provider.workspace = true
 
 # alloy
 alloy-rlp.workspace = true
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["rayon"] }
 
 # tracing
 tracing.workspace = true

--- a/crates/trie/parallel/src/storage_root_targets.rs
+++ b/crates/trie/parallel/src/storage_root_targets.rs
@@ -36,7 +36,7 @@ impl IntoIterator for StorageRootTargets {
 }
 
 impl rayon::iter::IntoParallelIterator for StorageRootTargets {
-    type Iter = rayon::collections::hash_map::IntoIter<B256, PrefixSet>;
+    type Iter = alloy_primitives::map::rayon::IntoIter<B256, PrefixSet>;
     type Item = (B256, PrefixSet);
 
     fn into_par_iter(self) -> Self::Iter {


### PR DESCRIPTION
`reth-trie-parallel` crate uses `HashMap::into_par_iter()`, when hashbrown backend (`alloy_primitives::map::HashMap`) is used, the `rayon` feature needs to be enabled.

This feature is exported in `0.8.16`, see also alloy-rs/core#827

Also, the rayon `IntoIter` type depends on which `HashMap` backend in used, `0.8.18` fix this, see also alloy-rs/core#836