### PR TITLE
chore: make block field private

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -78,7 +78,7 @@ impl Command {
             let block_number = block.header.number;
 
             let versioned_hashes: Vec<B256> =
-                block.body.blob_versioned_hashes_iter().copied().collect();
+                block.body().blob_versioned_hashes_iter().copied().collect();
             let parent_beacon_block_root = block.parent_beacon_block_root;
             let payload = block_to_payload(block).0;
 

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -62,7 +62,7 @@ impl Command {
             let gas_used = block.gas_used;
 
             let versioned_hashes: Vec<B256> =
-                block.body.blob_versioned_hashes_iter().copied().collect();
+                block.body().blob_versioned_hashes_iter().copied().collect();
             let parent_beacon_block_root = block.parent_beacon_block_root;
             let payload = block_to_payload(block).0;
 

--- a/book/sources/exex/tracking-state/src/bin/2.rs
+++ b/book/sources/exex/tracking-state/src/bin/2.rs
@@ -36,7 +36,7 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
         while let Some(notification) = ready!(this.ctx.notifications.try_next().poll_unpin(cx))? {
             if let Some(reverted_chain) = notification.reverted_chain() {
                 this.transactions = this.transactions.saturating_sub(
-                    reverted_chain.blocks_iter().map(|b| b.body.transactions.len() as u64).sum(),
+                    reverted_chain.blocks_iter().map(|b| b.body().transactions.len() as u64).sum(),
                 );
             }
 
@@ -45,7 +45,7 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
 
                 this.transactions += committed_chain
                     .blocks_iter()
-                    .map(|b| b.body.transactions.len() as u64)
+                    .map(|b| b.body().transactions.len() as u64)
                     .sum::<u64>();
 
                 this.ctx

--- a/crates/blockchain-tree-api/src/error.rs
+++ b/crates/blockchain-tree-api/src/error.rs
@@ -206,7 +206,7 @@ impl<B: Block> std::fmt::Debug for InsertBlockErrorDataTwo<B> {
             .field("hash", &self.block.hash())
             .field("number", &self.block.number())
             .field("parent_hash", &self.block.parent_hash())
-            .field("num_txs", &self.block.body.transactions().len())
+            .field("num_txs", &self.block.body().transactions().len())
             .finish_non_exhaustive()
     }
 }

--- a/crates/blockchain-tree/src/block_indices.rs
+++ b/crates/blockchain-tree/src/block_indices.rs
@@ -572,23 +572,23 @@ mod tests {
 
         // Define blocks with their numbers and parent hashes.
         let block_1 = SealedBlockWithSenders {
-            block: SealedBlock {
-                header: SealedHeader::new(
+            block: SealedBlock::new(
+                SealedHeader::new(
                     Header { parent_hash, number: 1, ..Default::default() },
                     block_hash_1,
                 ),
-                ..Default::default()
-            },
+                Default::default(),
+            ),
             ..Default::default()
         };
         let block_2 = SealedBlockWithSenders {
-            block: SealedBlock {
-                header: SealedHeader::new(
+            block: SealedBlock::new(
+                SealedHeader::new(
                     Header { parent_hash: block_hash_1, number: 2, ..Default::default() },
                     block_hash_2,
                 ),
-                ..Default::default()
-            },
+                Default::default(),
+            ),
             ..Default::default()
         };
 

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1635,14 +1635,14 @@ mod tests {
             };
 
             SealedBlockWithSenders::new(
-                SealedBlock {
-                    header: SealedHeader::seal(header),
-                    body: BlockBody {
+                SealedBlock::new(
+                    SealedHeader::seal(header),
+                    BlockBody {
                         transactions: signed_body,
                         ommers: Vec::new(),
                         withdrawals: Some(Withdrawals::default()),
                     },
-                },
+                ),
                 body.iter().map(|tx| tx.signer()).collect(),
             )
             .unwrap()

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -549,7 +549,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
             if let Some(tx) = block_state
                 .block_ref()
                 .block()
-                .body
+                .body()
                 .transactions()
                 .iter()
                 .find(|tx| tx.trie_hash() == hash)
@@ -573,7 +573,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
             if let Some((index, tx)) = block_state
                 .block_ref()
                 .block()
-                .body
+                .body()
                 .transactions()
                 .iter()
                 .enumerate()
@@ -758,7 +758,7 @@ impl<N: NodePrimitives> BlockState<N> {
             block_state
                 .block_ref()
                 .block()
-                .body
+                .body()
                 .transactions()
                 .iter()
                 .find(|tx| tx.trie_hash() == hash)
@@ -778,7 +778,7 @@ impl<N: NodePrimitives> BlockState<N> {
             block_state
                 .block_ref()
                 .block()
-                .body
+                .body()
                 .transactions()
                 .iter()
                 .enumerate()

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -168,14 +168,14 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
             ..Default::default()
         };
 
-        let block = SealedBlock {
-            header: SealedHeader::seal(header),
-            body: BlockBody {
+        let block = SealedBlock::new(
+            SealedHeader::seal(header),
+            BlockBody {
                 transactions: transactions.into_iter().map(|tx| tx.into_signed()).collect(),
                 ommers: Vec::new(),
                 withdrawals: Some(vec![].into()),
             },
-        };
+        );
 
         SealedBlockWithSenders::new(block, vec![self.signer; num_txs as usize]).unwrap()
     }
@@ -259,7 +259,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
     /// updated.
     pub fn get_execution_outcome(&mut self, block: SealedBlockWithSenders) -> ExecutionOutcome {
         let receipts = block
-            .body
+            .body()
             .transactions
             .iter()
             .enumerate()
@@ -273,7 +273,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
 
         let mut bundle_state_builder = BundleState::builder(block.number..=block.number);
 
-        for tx in &block.body.transactions {
+        for tx in &block.body().transactions {
             self.signer_execute_account_info.balance -= Self::single_tx_cost();
             bundle_state_builder = bundle_state_builder.state_present_account_info(
                 self.signer,

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -2774,8 +2774,7 @@ mod tests {
                 .with_real_consensus()
                 .build();
 
-            let genesis =
-                SealedBlock { header: chain_spec.sealed_genesis_header(), ..Default::default() };
+            let genesis = SealedBlock::new(chain_spec.sealed_genesis_header(), Default::default());
             let block1 = random_block(
                 &mut rng,
                 1,

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -42,7 +42,7 @@ pub fn validate_header_base_fee<H: BlockHeader, ChainSpec: EthereumHardforks>(
 pub fn validate_shanghai_withdrawals<H: BlockHeader, B: BlockBody>(
     block: &SealedBlock<H, B>,
 ) -> Result<(), ConsensusError> {
-    let withdrawals = block.body.withdrawals().ok_or(ConsensusError::BodyWithdrawalsMissing)?;
+    let withdrawals = block.body().withdrawals().ok_or(ConsensusError::BodyWithdrawalsMissing)?;
     let withdrawals_root = alloy_consensus::proofs::calculate_withdrawals_root(withdrawals);
     let header_withdrawals_root =
         block.withdrawals_root().ok_or(ConsensusError::WithdrawalsRootMissing)?;
@@ -67,7 +67,7 @@ pub fn validate_cancun_gas<H: BlockHeader, B: BlockBody>(
     // blob tx
     let header_blob_gas_used =
         block.header().blob_gas_used().ok_or(ConsensusError::BlobGasUsedMissing)?;
-    let total_blob_gas = block.body.blob_gas_used();
+    let total_blob_gas = block.body().blob_gas_used();
     if total_blob_gas != header_blob_gas_used {
         return Err(ConsensusError::BlobGasUsedDiff(GotExpected {
             got: header_blob_gas_used,
@@ -139,7 +139,7 @@ where
     ChainSpec: EthereumHardforks,
 {
     // Check ommers hash
-    let ommers_hash = block.body.calculate_ommers_root();
+    let ommers_hash = block.body().calculate_ommers_root();
     if Some(block.header.ommers_hash()) != ommers_hash {
         return Err(ConsensusError::BodyOmmersHashDiff(
             GotExpected {
@@ -514,10 +514,10 @@ mod tests {
         let transactions = Vec::new();
 
         (
-            SealedBlock {
-                header: SealedHeader::seal(header),
-                body: BlockBody { transactions, ommers, withdrawals: None },
-            },
+            SealedBlock::new(
+                SealedHeader::seal(header),
+                BlockBody { transactions, ommers, withdrawals: None },
+            ),
             parent,
         )
     }
@@ -539,10 +539,10 @@ mod tests {
                 ..Default::default()
             };
 
-            SealedBlock {
-                header: SealedHeader::seal(header),
-                body: BlockBody { withdrawals: Some(withdrawals), ..Default::default() },
-            }
+            SealedBlock::new(
+                SealedHeader::seal(header),
+                BlockBody { withdrawals: Some(withdrawals), ..Default::default() },
+            )
         };
 
         // Single withdrawal

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -58,7 +58,7 @@ impl<T: PayloadTypes> PayloadTestContext<T> {
     pub async fn wait_for_built_payload(&self, payload_id: PayloadId) {
         loop {
             let payload = self.payload_builder.best_payload(payload_id).await.unwrap().unwrap();
-            if payload.block().body.transactions().is_empty() {
+            if payload.block().body().transactions().is_empty() {
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
                 continue
             }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -269,7 +269,7 @@ where
 
     // Fetch reorg target block depending on its depth and its parent.
     let mut previous_hash = next_block.parent_hash;
-    let mut candidate_transactions = next_block.body.transactions;
+    let mut candidate_transactions = next_block.into_body().transactions;
     let reorg_target = 'target: {
         loop {
             let reorg_target = provider

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -254,7 +254,7 @@ impl<N: NodePrimitives> Chain<N> {
             self.blocks().iter().zip(self.execution_outcome.receipts().iter())
         {
             let mut tx_receipts = Vec::with_capacity(receipts.len());
-            for (tx, receipt) in block.body.transactions().iter().zip(receipts.iter()) {
+            for (tx, receipt) in block.body().transactions().iter().zip(receipts.iter()) {
                 tx_receipts.push((
                     tx.trie_hash(),
                     receipt.as_ref().expect("receipts have not been pruned").clone(),
@@ -437,7 +437,7 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
     /// Returns an iterator over all transactions in the chain.
     #[inline]
     pub fn transactions(&self) -> impl Iterator<Item = &<B::Body as BlockBody>::Transaction> + '_ {
-        self.blocks.values().flat_map(|block| block.body.transactions().iter())
+        self.blocks.values().flat_map(|block| block.body().transactions().iter())
     }
 
     /// Returns an iterator over all transactions and their senders.

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -101,15 +101,16 @@ where
             cumulative_gas += block.gas_used();
 
             // Configure the executor to use the current state.
-            trace!(target: "exex::backfill", number = block_number, txs = block.body.transactions().len(), "Executing block");
+            trace!(target: "exex::backfill", number = block_number, txs = block.body().transactions().len(), "Executing block");
 
             // Execute the block
             let execute_start = Instant::now();
 
             // Unseal the block for execution
             let (block, senders) = block.into_components();
-            let (unsealed_header, hash) = block.header.split();
-            let block = P::Block::new(unsealed_header, block.body).with_senders_unchecked(senders);
+            let (header, body) = block.split_header_body();
+            let (unsealed_header, hash) = header.split();
+            let block = P::Block::new(unsealed_header, body).with_senders_unchecked(senders);
 
             executor.execute_and_verify_one(&block)?;
             execution_duration += execute_start.elapsed();

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -678,8 +678,10 @@ mod tests {
         );
 
         let headers = blocks.iter().map(|block| block.header.clone()).collect::<Vec<_>>();
-        let bodies =
-            blocks.into_iter().map(|block| (block.hash(), block.body)).collect::<HashMap<_, _>>();
+        let bodies = blocks
+            .into_iter()
+            .map(|block| (block.hash(), block.into_body()))
+            .collect::<HashMap<_, _>>();
 
         insert_headers(db.db(), &headers);
 

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -21,7 +21,7 @@ pub(crate) fn zip_blocks<'a, H: Clone + BlockHeader + 'a, B>(
             if header.is_empty() {
                 BlockResponse::Empty(header.clone())
             } else {
-                BlockResponse::Full(SealedBlock { header: header.clone(), body })
+                BlockResponse::Full(SealedBlock::new(header.clone(), body))
             }
         })
         .collect()

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn generate_bodies(
     );
 
     let headers = blocks.iter().map(|block| block.header.clone()).collect();
-    let bodies = blocks.into_iter().map(|block| (block.hash(), block.body)).collect();
+    let bodies = blocks.into_iter().map(|block| (block.hash(), block.into_body())).collect();
 
     (headers, bodies)
 }

--- a/crates/net/p2p/src/bodies/response.rs
+++ b/crates/net/p2p/src/bodies/response.rs
@@ -40,7 +40,7 @@ where
     /// Return the reference to the response body
     pub fn into_body(self) -> Option<B> {
         match self {
-            Self::Full(block) => Some(block.body),
+            Self::Full(block) => Some(block.into_body()),
             Self::Empty(_) => None,
         }
     }

--- a/crates/node/core/src/utils.rs
+++ b/crates/node/core/src/utils.rs
@@ -84,7 +84,7 @@ where
         eyre::bail!("Invalid number of bodies received. Expected: 1. Received: 0")
     };
 
-    let block = SealedBlock { header, body };
+    let block = SealedBlock::new(header, body);
     consensus.validate_block_pre_execution(&block)?;
 
     Ok(block)

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -254,7 +254,7 @@ impl NodeState {
                     number=block.number(),
                     hash=?block.hash(),
                     peers=self.num_connected_peers(),
-                    txs=block.body.transactions().len(),
+                    txs=block.body().transactions().len(),
                     gas=%format_gas(block.header.gas_used()),
                     gas_throughput=%format_gas_throughput(block.header.gas_used(), elapsed),
                     full=%format!("{:.1}%", block.header.gas_used() as f64 * 100.0 / block.header.gas_limit() as f64),

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -74,7 +74,7 @@ impl Consensus<Header, OpBlockBody> for OpBeaconConsensus {
         block: &SealedBlockFor<OpBlock>,
     ) -> Result<(), ConsensusError> {
         // Check ommers hash
-        let ommers_hash = reth_primitives::proofs::calculate_ommers_root(&block.body.ommers);
+        let ommers_hash = block.body().calculate_ommers_root();
         if block.header.ommers_hash != ommers_hash {
             return Err(ConsensusError::BodyOmmersHashDiff(
                 GotExpected { got: ommers_hash, expected: block.header.ommers_hash }.into(),

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -408,7 +408,7 @@ where
         self.inner.on_new_head_block(new_tip_block);
         self.update_l1_block_info(
             new_tip_block.header(),
-            new_tip_block.body.transactions().first(),
+            new_tip_block.body().transactions().first(),
         );
     }
 }

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -187,10 +187,10 @@ async fn test_custom_block_priority_config() {
     assert_eq!(block_payloads.len(), 1);
     let (block_payload, _) = block_payloads.first().unwrap();
     let block_payload = block_payload.block().clone();
-    assert_eq!(block_payload.body.transactions.len(), 2); // L1 block info tx + end-of-block custom tx
+    assert_eq!(block_payload.body().transactions.len(), 2); // L1 block info tx + end-of-block custom tx
 
     // Check that last transaction in the block looks like a transfer to a random address.
-    let end_of_block_tx = block_payload.body.transactions.last().unwrap();
+    let end_of_block_tx = block_payload.body().transactions.last().unwrap();
     let OpTypedTransaction::Eip1559(end_of_block_tx) = &end_of_block_tx.transaction else {
         panic!("expected EIP-1559 transaction");
     };

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -42,10 +42,10 @@ where
             let timestamp = block.timestamp();
 
             let l1_block_info =
-                reth_optimism_evm::extract_l1_info(&block.body).map_err(OpEthApiError::from)?;
+                reth_optimism_evm::extract_l1_info(block.body()).map_err(OpEthApiError::from)?;
 
             return block
-                .body
+                .body()
                 .transactions()
                 .iter()
                 .zip(receipts.iter())

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -41,7 +41,7 @@ where
             )))?;
 
         let l1_block_info =
-            reth_optimism_evm::extract_l1_info(&block.body).map_err(OpEthApiError::from)?;
+            reth_optimism_evm::extract_l1_info(block.body()).map_err(OpEthApiError::from)?;
 
         Ok(OpReceiptBuilder::new(
             &self.inner.eth_api.provider().chain_spec(),

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -144,7 +144,7 @@ impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
                 return Err(PayloadError::PostCancunWithoutCancunFields)
             }
         } else {
-            if sealed_block.body.has_eip4844_transactions() {
+            if sealed_block.body().has_eip4844_transactions() {
                 // cancun not active but blob transactions present
                 return Err(PayloadError::PreCancunBlockWithBlobTransactions)
             }
@@ -163,13 +163,13 @@ impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
         }
 
         let shanghai_active = self.is_shanghai_active_at_timestamp(sealed_block.timestamp);
-        if !shanghai_active && sealed_block.body.withdrawals.is_some() {
+        if !shanghai_active && sealed_block.body().withdrawals.is_some() {
             // shanghai not active but withdrawals present
             return Err(PayloadError::PreShanghaiBlockWithWithdrawals)
         }
 
         if !self.is_prague_active_at_timestamp(sealed_block.timestamp) &&
-            sealed_block.body.has_eip7702_transactions()
+            sealed_block.body().has_eip7702_transactions()
         {
             return Err(PayloadError::PrePragueBlockWithEip7702Transactions)
         }

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -16,14 +16,14 @@ impl TryFrom<AnyRpcBlock> for SealedBlock {
         let block_hash = block.header.hash;
         let block = block.try_map_transactions(|tx| tx.try_into())?;
 
-        Ok(Self {
-            header: SealedHeader::new(block.header.inner.into_header_with_defaults(), block_hash),
-            body: BlockBody {
+        Ok(Self::new(
+            SealedHeader::new(block.header.inner.into_header_with_defaults(), block_hash),
+            BlockBody {
                 transactions: block.transactions.into_transactions().collect(),
                 ommers: Default::default(),
                 withdrawals: block.withdrawals.map(|w| w.into_inner().into()),
             },
-        })
+        ))
     }
 }
 

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -169,7 +169,7 @@ pub struct SealedBlock<H = Header, B = BlockBody> {
     #[deref_mut]
     pub header: SealedHeader<H>,
     /// Block body.
-    pub body: B,
+    body: B,
 }
 
 impl<H, B> SealedBlock<H, B> {

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -190,6 +190,16 @@ impl<H, B> SealedBlock<H, B> {
         &self.body
     }
 
+    /// Consumes the block and returns the header.
+    pub fn into_header(self) -> H {
+        self.header.unseal()
+    }
+
+    /// Consumes the block and returns the body.
+    pub fn into_body(self) -> B {
+        self.body
+    }
+
     /// Splits the [`BlockBody`] and [`SealedHeader`] into separate components
     #[inline]
     pub fn split_header_body(self) -> (SealedHeader<H>, B) {

--- a/crates/primitives/src/traits.rs
+++ b/crates/primitives/src/traits.rs
@@ -13,7 +13,7 @@ pub trait BlockExt: Block {
     /// Calculate the header hash and seal the block so that it can't be changed.
     fn seal_slow(self) -> SealedBlock<Self::Header, Self::Body> {
         let (header, body) = self.split();
-        SealedBlock { header: SealedHeader::seal(header), body }
+        SealedBlock::new(SealedHeader::seal(header), body)
     }
 
     /// Seal the block with a known hash.
@@ -21,7 +21,7 @@ pub trait BlockExt: Block {
     /// WARNING: This method does not perform validation whether the hash is correct.
     fn seal(self, hash: B256) -> SealedBlock<Self::Header, Self::Body> {
         let (header, body) = self.split();
-        SealedBlock { header: SealedHeader::new(header, hash), body }
+        SealedBlock::new(SealedHeader::new(header, hash), body)
     }
 
     /// Expensive operation that recovers transaction signer.

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -242,7 +242,8 @@ mod tests {
         let range = input.get_next_tx_num_range(&provider).expect("Expected range").unwrap();
 
         // Calculate the total number of transactions
-        let num_txs = blocks.iter().map(|block| block.body.transactions.len() as u64).sum::<u64>();
+        let num_txs =
+            blocks.iter().map(|block| block.body().transactions.len() as u64).sum::<u64>();
 
         assert_eq!(range, 0..=num_txs - 1);
     }
@@ -288,7 +289,8 @@ mod tests {
         let range = input.get_next_tx_num_range(&provider).expect("Expected range").unwrap();
 
         // Calculate the total number of transactions
-        let num_txs = blocks.iter().map(|block| block.body.transactions.len() as u64).sum::<u64>();
+        let num_txs =
+            blocks.iter().map(|block| block.body().transactions.len() as u64).sum::<u64>();
 
         assert_eq!(range, 0..=num_txs - 1,);
     }
@@ -322,7 +324,8 @@ mod tests {
 
         // Get the last tx number
         // Calculate the total number of transactions
-        let num_txs = blocks.iter().map(|block| block.body.transactions.len() as u64).sum::<u64>();
+        let num_txs =
+            blocks.iter().map(|block| block.body().transactions.len() as u64).sum::<u64>();
         let max_range = num_txs - 1;
 
         // Create a prune input with a previous checkpoint that is the last tx number

--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -113,8 +113,8 @@ mod tests {
 
         let mut receipts = Vec::new();
         for block in &blocks {
-            receipts.reserve_exact(block.body.transactions.len());
-            for transaction in &block.body.transactions {
+            receipts.reserve_exact(block.body().transactions.len());
+            for transaction in &block.body().transactions {
                 receipts
                     .push((receipts.len() as u64, random_receipt(&mut rng, transaction, Some(0))));
             }
@@ -124,7 +124,7 @@ mod tests {
 
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
-            blocks.iter().map(|block| block.body.transactions.len()).sum::<usize>()
+            blocks.iter().map(|block| block.body().transactions.len()).sum::<usize>()
         );
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
@@ -158,7 +158,7 @@ mod tests {
             let last_pruned_tx_number = blocks
                 .iter()
                 .take(to_block as usize)
-                .map(|block| block.body.transactions.len())
+                .map(|block| block.body().transactions.len())
                 .sum::<usize>()
                 .min(
                     next_tx_number_to_prune as usize +
@@ -186,7 +186,7 @@ mod tests {
             let last_pruned_block_number = blocks
                 .iter()
                 .fold_while((0, 0), |(_, mut tx_count), block| {
-                    tx_count += block.body.transactions.len();
+                    tx_count += block.body().transactions.len();
 
                     if tx_count > last_pruned_tx_number {
                         Done((block.number, tx_count))

--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -124,7 +124,7 @@ mod tests {
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         let transactions =
-            blocks.iter().flat_map(|block| &block.body.transactions).collect::<Vec<_>>();
+            blocks.iter().flat_map(|block| &block.body().transactions).collect::<Vec<_>>();
 
         assert_eq!(db.table::<tables::Transactions>().unwrap().len(), transactions.len());
 
@@ -174,7 +174,7 @@ mod tests {
             let last_pruned_tx_number = blocks
                 .iter()
                 .take(to_block as usize)
-                .map(|block| block.body.transactions.len())
+                .map(|block| block.body().transactions.len())
                 .sum::<usize>()
                 .min(
                     next_tx_number_to_prune as usize +
@@ -185,7 +185,7 @@ mod tests {
             let last_pruned_block_number = blocks
                 .iter()
                 .fold_while((0, 0), |(_, mut tx_count), block| {
-                    tx_count += block.body.transactions.len();
+                    tx_count += block.body().transactions.len();
 
                     if tx_count > last_pruned_tx_number {
                         Done((block.number, tx_count))

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -273,12 +273,12 @@ mod tests {
 
         let (deposit_contract_addr, _) = random_eoa_account(&mut rng);
         for block in &blocks {
-            receipts.reserve_exact(block.body.size());
-            for (txi, transaction) in block.body.transactions.iter().enumerate() {
+            receipts.reserve_exact(block.body().size());
+            for (txi, transaction) in block.body().transactions.iter().enumerate() {
                 let mut receipt = random_receipt(&mut rng, transaction, Some(1));
                 receipt.logs.push(random_log(
                     &mut rng,
-                    (txi == (block.body.transactions.len() - 1)).then_some(deposit_contract_addr),
+                    (txi == (block.body().transactions.len() - 1)).then_some(deposit_contract_addr),
                     Some(1),
                 ));
                 receipts.push((receipts.len() as u64, receipt));
@@ -288,7 +288,7 @@ mod tests {
 
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
-            blocks.iter().map(|block| block.body.transactions.len()).sum::<usize>()
+            blocks.iter().map(|block| block.body().transactions.len()).sum::<usize>()
         );
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
@@ -337,7 +337,7 @@ mod tests {
 
             assert_eq!(
                 db.table::<tables::Receipts>().unwrap().len(),
-                blocks.iter().map(|block| block.body.transactions.len()).sum::<usize>() -
+                blocks.iter().map(|block| block.body().transactions.len()).sum::<usize>() -
                     ((pruned_tx + 1) - unprunable) as usize
             );
 

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -111,8 +111,8 @@ mod tests {
 
         let mut transaction_senders = Vec::new();
         for block in &blocks {
-            transaction_senders.reserve_exact(block.body.transactions.len());
-            for transaction in &block.body.transactions {
+            transaction_senders.reserve_exact(block.body().transactions.len());
+            for transaction in &block.body().transactions {
                 transaction_senders.push((
                     transaction_senders.len() as u64,
                     transaction.recover_signer().expect("recover signer"),
@@ -124,7 +124,7 @@ mod tests {
 
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
-            blocks.iter().map(|block| block.body.transactions.len()).sum::<usize>()
+            blocks.iter().map(|block| block.body().transactions.len()).sum::<usize>()
         );
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
@@ -159,7 +159,7 @@ mod tests {
             let last_pruned_tx_number = blocks
                 .iter()
                 .take(to_block as usize)
-                .map(|block| block.body.transactions.len())
+                .map(|block| block.body().transactions.len())
                 .sum::<usize>()
                 .min(
                     next_tx_number_to_prune as usize +
@@ -170,7 +170,7 @@ mod tests {
             let last_pruned_block_number = blocks
                 .iter()
                 .fold_while((0, 0), |(_, mut tx_count), block| {
-                    tx_count += block.body.transactions.len();
+                    tx_count += block.body().transactions.len();
 
                     if tx_count > last_pruned_tx_number {
                         Done((block.number, tx_count))

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -139,8 +139,8 @@ mod tests {
 
         let mut tx_hash_numbers = Vec::new();
         for block in &blocks {
-            tx_hash_numbers.reserve_exact(block.body.transactions.len());
-            for transaction in &block.body.transactions {
+            tx_hash_numbers.reserve_exact(block.body().transactions.len());
+            for transaction in &block.body().transactions {
                 tx_hash_numbers.push((transaction.hash(), tx_hash_numbers.len() as u64));
             }
         }
@@ -149,7 +149,7 @@ mod tests {
 
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
-            blocks.iter().map(|block| block.body.transactions.len()).sum::<usize>()
+            blocks.iter().map(|block| block.body().transactions.len()).sum::<usize>()
         );
         assert_eq!(
             db.table::<tables::Transactions>().unwrap().len(),
@@ -184,7 +184,7 @@ mod tests {
             let last_pruned_tx_number = blocks
                 .iter()
                 .take(to_block as usize)
-                .map(|block| block.body.transactions.len())
+                .map(|block| block.body().transactions.len())
                 .sum::<usize>()
                 .min(
                     next_tx_number_to_prune as usize +
@@ -195,7 +195,7 @@ mod tests {
             let last_pruned_block_number = blocks
                 .iter()
                 .fold_while((0, 0), |(_, mut tx_count), block| {
-                    tx_count += block.body.transactions.len();
+                    tx_count += block.body().transactions.len();
 
                     if tx_count > last_pruned_tx_number {
                         Done((block.number, tx_count))

--- a/crates/rpc/rpc-engine-api/tests/it/payload.rs
+++ b/crates/rpc/rpc-engine-api/tests/it/payload.rs
@@ -23,11 +23,7 @@ fn transform_block<F: FnOnce(Block) -> Block>(src: SealedBlock, f: F) -> Executi
     transformed.header.transactions_root =
         proofs::calculate_transaction_root(&transformed.body.transactions);
     transformed.header.ommers_hash = proofs::calculate_ommers_root(&transformed.body.ommers);
-    block_to_payload(SealedBlock {
-        header: SealedHeader::seal(transformed.header),
-        body: transformed.body,
-    })
-    .0
+    block_to_payload(SealedBlock::new(SealedHeader::seal(transformed.header), transformed.body)).0
 }
 
 #[test]
@@ -42,7 +38,7 @@ fn payload_body_roundtrip() {
         let payload_body: ExecutionPayloadBodyV1 = convert_to_payload_body_v1(unsealed);
 
         assert_eq!(
-            Ok(block.body.transactions),
+            Ok(block.body().transactions.clone()),
             payload_body
                 .transactions
                 .iter()
@@ -50,7 +46,7 @@ fn payload_body_roundtrip() {
                 .collect::<Result<Vec<_>, _>>(),
         );
         let withdraw = payload_body.withdrawals.map(Withdrawals::new);
-        assert_eq!(block.body.withdrawals, withdraw);
+        assert_eq!(block.body().withdrawals.clone(), withdraw);
     }
 }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -88,7 +88,7 @@ pub trait EthBlocks: LoadBlock {
                     .provider()
                     .pending_block()
                     .map_err(Self::Error::from_eth_err)?
-                    .map(|block| block.body.transactions().len()))
+                    .map(|block| block.body().transactions().len()))
             }
 
             let block_hash = match self
@@ -105,7 +105,7 @@ pub trait EthBlocks: LoadBlock {
                 .get_sealed_block_with_senders(block_hash)
                 .await
                 .map_err(Self::Error::from_eth_err)?
-                .map(|b| b.body.transactions().len()))
+                .map(|b| b.body().transactions().len()))
         }
     }
 
@@ -188,7 +188,7 @@ pub trait EthBlocks: LoadBlock {
                 self.provider()
                     .pending_block()
                     .map_err(Self::Error::from_eth_err)?
-                    .and_then(|block| block.body.ommers().map(|o| o.to_vec()))
+                    .and_then(|block| block.body().ommers().map(|o| o.to_vec()))
             } else {
                 self.provider().ommers_by_id(block_id).map_err(Self::Error::from_eth_err)?
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -314,11 +314,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let mut replay_block_txs = true;
 
             let num_txs =
-                transaction_index.index().unwrap_or_else(|| block.body.transactions().len());
+                transaction_index.index().unwrap_or_else(|| block.body().transactions().len());
             // but if all transactions are to be replayed, we can use the state at the block itself,
             // however only if we're not targeting the pending block, because for pending we can't
             // rely on the block's state being available
-            if !is_block_target_pending && num_txs == block.body.transactions().len() {
+            if !is_block_target_pending && num_txs == block.body().transactions().len() {
                 at = block.hash();
                 replay_block_txs = false;
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -185,7 +185,7 @@ pub trait EthFees: LoadFee {
                                 percentiles,
                                 header.gas_used(),
                                 header.base_fee_per_gas().unwrap_or_default(),
-                                block.body.transactions(),
+                                block.body().transactions(),
                                 &receipts,
                             )
                             .unwrap_or_default(),

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -320,7 +320,7 @@ pub trait Trace:
 
             let Some(block) = block else { return Ok(None) };
 
-            if block.body.transactions().is_empty() {
+            if block.body().transactions().is_empty() {
                 // nothing to trace
                 return Ok(Some(Vec::new()))
             }
@@ -350,7 +350,7 @@ pub trait Trace:
                 // prepare transactions, we do everything upfront to reduce time spent with open
                 // state
                 let max_transactions =
-                    highest_index.map_or(block.body.transactions().len(), |highest| {
+                    highest_index.map_or(block.body().transactions().len(), |highest| {
                         // we need + 1 because the index is 0-based
                         highest as usize + 1
                     });

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -94,7 +94,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             self.cache()
                 .get_sealed_block_with_senders(block)
                 .await
-                .map(|b| b.map(|b| b.body.transactions().to_vec()))
+                .map(|b| b.map(|b| b.body().transactions().to_vec()))
                 .map_err(Self::Error::from_eth_err)
         }
     }

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -304,7 +304,7 @@ where
                     }
                     Either::Right(transaction_tx) => {
                         let _ = transaction_tx.send(res.clone().map(|maybe_block| {
-                            maybe_block.map(|block| block.block.body.transactions().to_vec())
+                            maybe_block.map(|block| block.block.body().transactions().to_vec())
                         }));
                     }
                 }
@@ -350,7 +350,7 @@ where
                     }
                     Either::Right(transaction_tx) => {
                         let _ = transaction_tx.send(res.clone().map(|maybe_block| {
-                            maybe_block.map(|block| block.block.body.transactions().to_vec())
+                            maybe_block.map(|block| block.block.body().transactions().to_vec())
                         }));
                     }
                 }

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -89,7 +89,7 @@ impl FeeHistoryCache {
                 &percentiles,
                 fee_history_entry.gas_used,
                 fee_history_entry.base_fee_per_gas,
-                block.body.transactions(),
+                block.body().transactions(),
                 &receipts,
             )
             .unwrap_or_default();
@@ -370,7 +370,7 @@ impl FeeHistoryEntry {
             base_fee_per_blob_gas: block
                 .excess_blob_gas()
                 .map(alloy_eips::eip4844::calc_blob_gasprice),
-            blob_gas_used_ratio: block.body.blob_gas_used() as f64 /
+            blob_gas_used_ratio: block.body().blob_gas_used() as f64 /
                 alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK as f64,
             excess_blob_gas: block.excess_blob_gas(),
             blob_gas_used: block.blob_gas_used(),

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -226,7 +226,7 @@ where
         let parent_hash = block.parent_hash();
 
         // sort the functions by ascending effective tip first
-        let sorted_transactions = block.body.transactions().iter().sorted_by_cached_key(|tx| {
+        let sorted_transactions = block.body().transactions().iter().sorted_by_cached_key(|tx| {
             if let Some(base_fee) = base_fee_per_gas {
                 (*tx).effective_tip_per_gas(base_fee)
             } else {

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -92,7 +92,7 @@ where
                 if transaction_hash.is_none() {
                     transaction_hash = match &provider_or_block {
                         ProviderOrBlock::Block(block) => {
-                            block.body.transactions().get(receipt_idx).map(|t| t.trie_hash())
+                            block.body().transactions().get(receipt_idx).map(|t| t.trie_hash())
                         }
                         ProviderOrBlock::Provider(provider) => {
                             let first_tx_num = match loaded_first_tx_num {

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -19,7 +19,7 @@ pub fn block_to_payload<T: SignedTransaction>(
     let cancun = if let Some(parent_beacon_block_root) = value.parent_beacon_block_root {
         Some(CancunPayloadFields {
             parent_beacon_block_root,
-            versioned_hashes: value.body.blob_versioned_hashes_iter().copied().collect(),
+            versioned_hashes: value.body().blob_versioned_hashes_iter().copied().collect(),
         })
     } else {
         None
@@ -38,7 +38,7 @@ pub fn block_to_payload<T: SignedTransaction>(
     let execution_payload = if value.header.parent_beacon_block_root.is_some() {
         // block with parent beacon block root: V3
         ExecutionPayload::V3(block_to_payload_v3(value))
-    } else if value.body.withdrawals.is_some() {
+    } else if value.body().withdrawals.is_some() {
         // block with withdrawals: V2
         ExecutionPayload::V2(block_to_payload_v2(value))
     } else {
@@ -54,7 +54,7 @@ pub fn block_to_payload_v1<T: Encodable2718>(
     value: SealedBlock<Header, BlockBody<T>>,
 ) -> ExecutionPayloadV1 {
     let transactions =
-        value.body.transactions.iter().map(|tx| tx.encoded_2718().into()).collect::<Vec<_>>();
+        value.body().transactions.iter().map(|tx| tx.encoded_2718().into()).collect::<Vec<_>>();
     ExecutionPayloadV1 {
         parent_hash: value.parent_hash,
         fee_recipient: value.beneficiary,
@@ -78,7 +78,7 @@ pub fn block_to_payload_v2<T: Encodable2718>(
     mut value: SealedBlock<Header, BlockBody<T>>,
 ) -> ExecutionPayloadV2 {
     ExecutionPayloadV2 {
-        withdrawals: value.body.withdrawals.take().unwrap_or_default().into_inner(),
+        withdrawals: value.body().withdrawals.clone().map(Withdrawals::into_inner).unwrap_or_default(),
         payload_inner: block_to_payload_v1(value),
     }
 }
@@ -99,7 +99,7 @@ pub fn convert_block_to_payload_field_v2<T: Encodable2718>(
     value: SealedBlock<Header, BlockBody<T>>,
 ) -> ExecutionPayloadFieldV2 {
     // if there are withdrawals, return V2
-    if value.body.withdrawals.is_some() {
+    if value.body().withdrawals.is_some() {
         ExecutionPayloadFieldV2::V2(block_to_payload_v2(value))
     } else {
         ExecutionPayloadFieldV2::V1(block_to_payload_v1(value))
@@ -109,7 +109,7 @@ pub fn convert_block_to_payload_field_v2<T: Encodable2718>(
 /// Converts [`SealedBlock`] to [`ExecutionPayloadInputV2`]
 pub fn convert_block_to_payload_input_v2(value: SealedBlock) -> ExecutionPayloadInputV2 {
     ExecutionPayloadInputV2 {
-        withdrawals: value.body.withdrawals.clone().map(Withdrawals::into_inner),
+        withdrawals: value.body().withdrawals.clone().map(Withdrawals::into_inner),
         execution_payload: block_to_payload_v1(value),
     }
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -103,7 +103,7 @@ where
         let this = self.clone();
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash().into(), move |state| {
-                let mut results = Vec::with_capacity(block.body.transactions().len());
+                let mut results = Vec::with_capacity(block.body().transactions().len());
                 let mut db = CacheDB::new(StateProviderDatabase::new(state));
 
                 this.eth_api().apply_pre_execution_changes(&block, &mut db, &cfg, &block_env)?;
@@ -527,11 +527,12 @@ where
         let mut replay_block_txs = true;
 
         // if a transaction index is provided, we need to replay the transactions until the index
-        let num_txs = transaction_index.index().unwrap_or_else(|| block.body.transactions().len());
+        let num_txs =
+            transaction_index.index().unwrap_or_else(|| block.body().transactions().len());
         // but if all transactions are to be replayed, we can use the state at the block itself
         // this works with the exception of the PENDING block, because its state might not exist if
         // built locally
-        if !target_block.is_pending() && num_txs == block.body.transactions().len() {
+        if !target_block.is_pending() && num_txs == block.body().transactions().len() {
             at = block.hash();
             replay_block_txs = false;
         }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -40,7 +40,7 @@ where
             let timestamp = block.timestamp();
 
             return block
-                .body
+                .body()
                 .transactions()
                 .iter()
                 .zip(receipts.iter())

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -315,7 +315,7 @@ where
                 all_traces.extend(
                     self.extract_reward_traces(
                         block.header.header(),
-                        block.body.ommers(),
+                        block.body().ommers(),
                         base_block_reward,
                     )
                     .into_iter()
@@ -396,7 +396,7 @@ where
             {
                 traces.extend(self.extract_reward_traces(
                     block.block.header(),
-                    block.body.ommers(),
+                    block.body().ommers(),
                     base_block_reward,
                 ));
             }

--- a/crates/stages/stages/benches/setup/mod.rs
+++ b/crates/stages/stages/benches/setup/mod.rs
@@ -151,9 +151,10 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> TestStageDB {
             .unwrap();
         let second_block = blocks.get_mut(1).unwrap();
         let cloned_second = second_block.clone();
-        let mut updated_header = cloned_second.header.unseal();
+        let mut updated_header = cloned_second.header.clone().unseal();
         updated_header.state_root = root;
-        *second_block = SealedBlock { header: SealedHeader::seal(updated_header), ..cloned_second };
+        *second_block =
+            SealedBlock::new(SealedHeader::seal(updated_header), cloned_second.into_body());
 
         let offset = transitions.len() as u64;
 
@@ -184,9 +185,9 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> TestStageDB {
 
         let last_block = blocks.last_mut().unwrap();
         let cloned_last = last_block.clone();
-        let mut updated_header = cloned_last.header.unseal();
+        let mut updated_header = cloned_last.header.clone().unseal();
         updated_header.state_root = root;
-        *last_block = SealedBlock { header: SealedHeader::seal(updated_header), ..cloned_last };
+        *last_block = SealedBlock::new(SealedHeader::seal(updated_header), cloned_last.into_body());
 
         db.insert_blocks(blocks.iter(), StorageKind::Static).unwrap();
 

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -519,7 +519,7 @@ mod tests {
 
         /// A helper to create a collection of block bodies keyed by their hash.
         pub(crate) fn body_by_hash(block: &SealedBlock) -> (B256, BlockBody) {
-            (block.hash(), block.body.clone())
+            (block.hash(), block.body().clone())
         }
 
         /// A helper struct for running the [`BodyStage`].
@@ -592,7 +592,7 @@ mod tests {
 
                         let body = StoredBlockBodyIndices {
                             first_tx_num: 0,
-                            tx_count: progress.body.transactions.len() as u64,
+                            tx_count: progress.body().transactions.len() as u64,
                         };
 
                         static_file_producer.set_block_range(0..=progress.number);
@@ -614,7 +614,7 @@ mod tests {
                         if !progress.ommers_hash_is_empty() {
                             tx.put::<tables::BlockOmmers>(
                                 progress.number,
-                                StoredBlockOmmers { ommers: progress.body.ommers.clone() },
+                                StoredBlockOmmers { ommers: progress.body().ommers.clone() },
                             )?;
                         }
 
@@ -801,7 +801,7 @@ mod tests {
                     } else {
                         let body =
                             this.responses.remove(&header.hash()).expect("requested unknown body");
-                        response.push(BlockResponse::Full(SealedBlock { header, body }));
+                        response.push(BlockResponse::Full(SealedBlock::new(header, body)));
                     }
 
                     if response.len() as u64 >= this.batch_size {

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -353,7 +353,7 @@ mod tests {
                 // Insert last progress data
                 let block_number = progress.number;
                 self.db.commit(|tx| {
-                    progress.body.transactions.iter().try_for_each(
+                    progress.body().transactions.iter().try_for_each(
                         |transaction| -> Result<(), reth_db::DatabaseError> {
                             tx.put::<tables::TransactionHashNumbers>(
                                 transaction.hash(),
@@ -398,7 +398,7 @@ mod tests {
 
                     let body = StoredBlockBodyIndices {
                         first_tx_num,
-                        tx_count: progress.body.transactions.len() as u64,
+                        tx_count: progress.body().transactions.len() as u64,
                     };
 
                     first_tx_num = next_tx_num;

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -520,11 +520,12 @@ mod tests {
                 accounts.iter().map(|(addr, acc)| (*addr, (*acc, std::iter::empty()))),
             )?;
 
-            let SealedBlock { header, body } = random_block(
+            let (header, body) = random_block(
                 &mut rng,
                 stage_progress,
                 BlockParams { parent: preblocks.last().map(|b| b.hash()), ..Default::default() },
-            );
+            )
+            .split_header_body();
             let mut header = header.unseal();
 
             header.state_root = state_root(
@@ -533,7 +534,7 @@ mod tests {
                     .into_iter()
                     .map(|(address, account)| (address, (account, std::iter::empty()))),
             );
-            let sealed_head = SealedBlock { header: SealedHeader::seal(header), body };
+            let sealed_head = SealedBlock::new(SealedHeader::seal(header), body);
 
             let head_hash = sealed_head.hash();
             let mut blocks = vec![sealed_head];

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -267,8 +267,8 @@ mod tests {
         let mut receipts = Vec::with_capacity(blocks.len());
         let mut tx_num = 0u64;
         for block in &blocks {
-            let mut block_receipts = Vec::with_capacity(block.body.transactions.len());
-            for transaction in &block.body.transactions {
+            let mut block_receipts = Vec::with_capacity(block.body().transactions.len());
+            for transaction in &block.body().transactions {
                 block_receipts.push((tx_num, random_receipt(&mut rng, transaction, Some(0))));
                 tx_num += 1;
             }

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -216,7 +216,7 @@ mod tests {
             );
             self.db.insert_blocks(blocks.iter(), StorageKind::Static)?;
             self.db.insert_transaction_senders(
-                blocks.iter().flat_map(|block| block.body.transactions.iter()).enumerate().map(
+                blocks.iter().flat_map(|block| block.body().transactions.iter()).enumerate().map(
                     |(i, tx)| (i as u64, tx.recover_signer().expect("failed to recover signer")),
                 ),
             )?;

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -477,7 +477,7 @@ mod tests {
         let expected_progress = seed
             .iter()
             .find(|x| {
-                tx_count += x.body.transactions.len();
+                tx_count += x.body().transactions.len();
                 tx_count as u64 > threshold
             })
             .map(|x| x.number)
@@ -536,7 +536,7 @@ mod tests {
         let mut tx_senders = Vec::new();
         let mut tx_number = 0;
         for block in &blocks[..=max_processed_block] {
-            for transaction in &block.body.transactions {
+            for transaction in &block.body().transactions {
                 if block.number > max_pruned_block {
                     tx_senders
                         .push((tx_number, transaction.recover_signer().expect("recover signer")));
@@ -555,7 +555,7 @@ mod tests {
                     tx_number: Some(
                         blocks[..=max_pruned_block as usize]
                             .iter()
-                            .map(|block| block.body.transactions.len() as u64)
+                            .map(|block| block.body().transactions.len() as u64)
                             .sum(),
                     ),
                     prune_mode: PruneMode::Full,
@@ -570,9 +570,9 @@ mod tests {
             EntitiesCheckpoint {
                 processed: blocks[..=max_processed_block]
                     .iter()
-                    .map(|block| block.body.transactions.len() as u64)
+                    .map(|block| block.body().transactions.len() as u64)
                     .sum(),
-                total: blocks.iter().map(|block| block.body.transactions.len() as u64).sum()
+                total: blocks.iter().map(|block| block.body().transactions.len() as u64).sum()
             }
         );
     }

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -385,7 +385,7 @@ mod tests {
         let mut tx_hash_numbers = Vec::new();
         let mut tx_hash_number = 0;
         for block in &blocks[..=max_processed_block] {
-            for transaction in &block.body.transactions {
+            for transaction in &block.body().transactions {
                 if block.number > max_pruned_block {
                     tx_hash_numbers.push((transaction.hash(), tx_hash_number));
                 }
@@ -403,7 +403,7 @@ mod tests {
                     tx_number: Some(
                         blocks[..=max_pruned_block as usize]
                             .iter()
-                            .map(|block| block.body.transactions.len() as u64)
+                            .map(|block| block.body().transactions.len() as u64)
                             .sum::<u64>()
                             .sub(1), // `TxNumber` is 0-indexed
                     ),
@@ -419,9 +419,9 @@ mod tests {
             EntitiesCheckpoint {
                 processed: blocks[..=max_processed_block]
                     .iter()
-                    .map(|block| block.body.transactions.len() as u64)
+                    .map(|block| block.body().transactions.len() as u64)
                     .sum(),
-                total: blocks.iter().map(|block| block.body.transactions.len() as u64).sum()
+                total: blocks.iter().map(|block| block.body().transactions.len() as u64).sum()
             }
         );
     }

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -252,10 +252,10 @@ impl TestStageDB {
                 // Insert into body tables.
                 let block_body_indices = StoredBlockBodyIndices {
                     first_tx_num: next_tx_num,
-                    tx_count: block.body.transactions.len() as u64,
+                    tx_count: block.body().transactions.len() as u64,
                 };
 
-                if !block.body.transactions.is_empty() {
+                if !block.body().transactions.is_empty() {
                     tx.put::<tables::TransactionBlocks>(
                         block_body_indices.last_tx_num(),
                         block.number,
@@ -263,7 +263,7 @@ impl TestStageDB {
                 }
                 tx.put::<tables::BlockBodyIndices>(block.number, block_body_indices)?;
 
-                let res = block.body.transactions.iter().try_for_each(|body_tx| {
+                let res = block.body().transactions.iter().try_for_each(|body_tx| {
                     if let Some(txs_writer) = &mut txs_writer {
                         txs_writer.append_transaction(next_tx_num, body_tx)?;
                     } else {

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -299,7 +299,7 @@ mod tests {
 
         let mut receipts = Vec::new();
         for block in &blocks {
-            for transaction in &block.body.transactions {
+            for transaction in &block.body().transactions {
                 receipts
                     .push((receipts.len() as u64, random_receipt(&mut rng, transaction, Some(0))));
             }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -882,7 +882,7 @@ mod tests {
         let receipts: Vec<Vec<_>> = database_blocks
             .iter()
             .chain(in_memory_blocks.iter())
-            .map(|block| block.body.transactions.iter())
+            .map(|block| block.body().transactions.iter())
             .map(|tx| tx.map(|tx| random_receipt(rng, tx, Some(2))).collect())
             .collect();
 
@@ -1253,11 +1253,11 @@ mod tests {
         // First in memory block ommers should be found
         assert_eq!(
             provider.ommers(first_in_mem_block.number.into())?,
-            Some(first_in_mem_block.body.ommers.clone())
+            Some(first_in_mem_block.body().ommers.clone())
         );
         assert_eq!(
             provider.ommers(first_in_mem_block.hash().into())?,
-            Some(first_in_mem_block.body.ommers.clone())
+            Some(first_in_mem_block.body().ommers.clone())
         );
 
         // A random hash should return None as the block number is not found
@@ -1468,7 +1468,7 @@ mod tests {
                         shainghai_timestamp
                     )?
                     .unwrap(),
-                block.body.withdrawals.unwrap(),
+                block.body().withdrawals.clone().unwrap(),
                 "Expected withdrawals_by_block to return correct withdrawals"
             );
         }
@@ -1478,7 +1478,7 @@ mod tests {
 
         assert_eq!(
             Some(provider.latest_withdrawal()?.unwrap()),
-            canonical_block.body.withdrawals.clone().unwrap().pop(),
+            canonical_block.body().withdrawals.clone().unwrap().pop(),
             "Expected latest withdrawal to be equal to last withdrawal entry in canonical block"
         );
 
@@ -1675,11 +1675,11 @@ mod tests {
 
         assert_eq!(
             provider.ommers_by_id(block_number.into()).unwrap().unwrap_or_default(),
-            database_block.body.ommers
+            database_block.body().ommers
         );
         assert_eq!(
             provider.ommers_by_id(block_hash.into()).unwrap().unwrap_or_default(),
-            database_block.body.ommers
+            database_block.body().ommers
         );
 
         let block_number = in_memory_block.number;
@@ -1687,11 +1687,11 @@ mod tests {
 
         assert_eq!(
             provider.ommers_by_id(block_number.into()).unwrap().unwrap_or_default(),
-            in_memory_block.body.ommers
+            in_memory_block.body().ommers
         );
         assert_eq!(
             provider.ommers_by_id(block_hash.into()).unwrap().unwrap_or_default(),
-            in_memory_block.body.ommers
+            in_memory_block.body().ommers
         );
 
         Ok(())
@@ -2168,9 +2168,9 @@ mod tests {
             $(
                 // Since data moves for each tried method, need to recalculate everything
                 let db_tx_count =
-                    database_blocks.iter().map(|b| b.body.transactions.len()).sum::<usize>() as u64;
+                    database_blocks.iter().map(|b| b.body().transactions.len()).sum::<usize>() as u64;
                 let in_mem_tx_count =
-                    in_memory_blocks.iter().map(|b| b.body.transactions.len()).sum::<usize>() as u64;
+                    in_memory_blocks.iter().map(|b| b.body().transactions.len()).sum::<usize>() as u64;
 
                 let db_range = 0..=(db_tx_count - 1);
                 let in_mem_range = db_tx_count..=(in_mem_tx_count + db_range.end());
@@ -2249,7 +2249,7 @@ mod tests {
                 .senders()
                 .unwrap()),
             (transactions_by_tx_range, |block: &SealedBlock, _: &Vec<Vec<Receipt>>| block
-                .body
+                .body()
                 .transactions
                 .clone()),
             (receipts_by_tx_range, |block: &SealedBlock, receipts: &Vec<Vec<Receipt>>| receipts
@@ -2348,7 +2348,7 @@ mod tests {
             (sealed_block_with_senders_range, |block: &SealedBlock| block
                 .clone()
                 .with_senders_unchecked(vec![])),
-            (transactions_by_block_range, |block: &SealedBlock| block.body.transactions.clone()),
+            (transactions_by_block_range, |block: &SealedBlock| block.body().transactions.clone()),
         ]);
 
         Ok(())
@@ -2405,13 +2405,13 @@ mod tests {
         let mut in_memory_blocks: std::collections::VecDeque<_> = in_memory_blocks.into();
 
         $(
-            let tx_hash = |block: &SealedBlock| block.body.transactions[0].hash();
+            let tx_hash = |block: &SealedBlock| block.body().transactions[0].hash();
             let tx_num = |block: &SealedBlock| {
                 database_blocks
                     .iter()
                     .chain(in_memory_blocks.iter())
                     .take_while(|b| b.number < block.number)
-                    .map(|b| b.body.transactions.len())
+                    .map(|b| b.body().transactions.len())
                     .sum::<usize>() as u64
             };
 
@@ -2432,7 +2432,7 @@ mod tests {
                     .iter()
                     .chain(in_memory_blocks.iter())
                     .take_while(|b| b.number < block.number)
-                    .map(|b| b.body.transactions.len())
+                    .map(|b| b.body().transactions.len())
                     .sum::<usize>() as u64
             };
 
@@ -2528,7 +2528,7 @@ mod tests {
                     block.number,
                     Some(StoredBlockBodyIndices {
                         first_tx_num: tx_num,
-                        tx_count: block.body.transactions.len() as u64
+                        tx_count: block.body().transactions.len() as u64
                     })
                 ),
                 u64::MAX
@@ -2597,7 +2597,7 @@ mod tests {
                 transaction_by_id,
                 |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
                     tx_num,
-                    Some(block.body.transactions[test_tx_index].clone())
+                    Some(block.body().transactions[test_tx_index].clone())
                 ),
                 u64::MAX
             ),
@@ -2606,7 +2606,7 @@ mod tests {
                 transaction_by_id_unhashed,
                 |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
                     tx_num,
-                    Some(block.body.transactions[test_tx_index].clone())
+                    Some(block.body().transactions[test_tx_index].clone())
                 ),
                 u64::MAX
             ),
@@ -2615,7 +2615,7 @@ mod tests {
                 transaction_by_hash,
                 |block: &SealedBlock, _: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
                     tx_hash,
-                    Some(block.body.transactions[test_tx_index].clone())
+                    Some(block.body().transactions[test_tx_index].clone())
                 ),
                 B256::random()
             ),
@@ -2633,7 +2633,7 @@ mod tests {
                 transactions_by_block,
                 |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
                     BlockHashOrNumber::Number(block.number),
-                    Some(block.body.transactions.clone())
+                    Some(block.body().transactions.clone())
                 ),
                 BlockHashOrNumber::Number(u64::MAX)
             ),
@@ -2642,7 +2642,7 @@ mod tests {
                 transactions_by_block,
                 |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
                     BlockHashOrNumber::Hash(block.hash()),
-                    Some(block.body.transactions.clone())
+                    Some(block.body().transactions.clone())
                 ),
                 BlockHashOrNumber::Number(u64::MAX)
             ),
@@ -2651,7 +2651,7 @@ mod tests {
                 transaction_sender,
                 |block: &SealedBlock, tx_num: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
                     tx_num,
-                    block.body.transactions[test_tx_index].recover_signer()
+                    block.body().transactions[test_tx_index].recover_signer()
                 ),
                 u64::MAX
             ),
@@ -2737,7 +2737,7 @@ mod tests {
             // This will persist block 1 AFTER a database is created. Moving it from memory to
             // storage.
             persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
-            let to_be_persisted_tx = in_memory_blocks[0].body.transactions[0].clone();
+            let to_be_persisted_tx = in_memory_blocks[0].body().transactions[0].clone();
 
             // Even though the block exists, given the order of provider queries done in the method
             // above, we do not see it.
@@ -2756,7 +2756,7 @@ mod tests {
             // This will persist block 1 AFTER a database is created. Moving it from memory to
             // storage.
             persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[1].number);
-            let to_be_persisted_tx = in_memory_blocks[1].body.transactions[0].clone();
+            let to_be_persisted_tx = in_memory_blocks[1].body().transactions[0].clone();
 
             assert_eq!(
                 correct_transaction_hash_fn(

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -718,10 +718,10 @@ mod tests {
             );
             assert_matches!(
                 provider.transaction_sender(0), Ok(Some(sender))
-                if sender == block.body.transactions[0].recover_signer().unwrap()
+                if sender == block.body().transactions[0].recover_signer().unwrap()
             );
             assert_matches!(
-                provider.transaction_id(block.body.transactions[0].hash()),
+                provider.transaction_id(block.body().transactions[0].hash()),
                 Ok(Some(0))
             );
         }
@@ -741,7 +741,7 @@ mod tests {
                 Ok(_)
             );
             assert_matches!(provider.transaction_sender(0), Ok(None));
-            assert_matches!(provider.transaction_id(block.body.transactions[0].hash()), Ok(None));
+            assert_matches!(provider.transaction_id(block.body().transactions[0].hash()), Ok(None));
         }
     }
 
@@ -772,7 +772,7 @@ mod tests {
                     .clone()
                     .map(|tx_number| (
                         tx_number,
-                        block.body.transactions[tx_number as usize].recover_signer().unwrap()
+                        block.body().transactions[tx_number as usize].recover_signer().unwrap()
                     ))
                     .collect())
             );

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -46,7 +46,7 @@ impl BlobStoreCanonTracker {
     {
         let blob_txs = blocks.iter().map(|(num, block)| {
             let iter = block
-                .body
+                .body()
                 .transactions()
                 .iter()
                 .filter(|tx| tx.is_eip4844())
@@ -128,12 +128,9 @@ mod tests {
 
         // Creating a first block with EIP-4844 transactions
         let block1 = SealedBlockWithSenders {
-            block: SealedBlock {
-                header: SealedHeader::new(
-                    Header { number: 10, ..Default::default() },
-                    B256::random(),
-                ),
-                body: BlockBody {
+            block: SealedBlock::new(
+                SealedHeader::new(Header { number: 10, ..Default::default() }, B256::random()),
+                BlockBody {
                     transactions: vec![
                         TransactionSigned::new(
                             Transaction::Eip4844(Default::default()),
@@ -154,19 +151,16 @@ mod tests {
                     ],
                     ..Default::default()
                 },
-            },
+            ),
             ..Default::default()
         };
 
         // Creating a second block with EIP-1559 and EIP-2930 transactions
         // Note: This block does not contain any EIP-4844 transactions
         let block2 = SealedBlockWithSenders {
-            block: SealedBlock {
-                header: SealedHeader::new(
-                    Header { number: 11, ..Default::default() },
-                    B256::random(),
-                ),
-                body: BlockBody {
+            block: SealedBlock::new(
+                SealedHeader::new(Header { number: 11, ..Default::default() }, B256::random()),
+                BlockBody {
                     transactions: vec![
                         TransactionSigned::new(
                             Transaction::Eip1559(Default::default()),
@@ -181,7 +175,7 @@ mod tests {
                     ],
                     ..Default::default()
                 },
-            },
+            ),
             ..Default::default()
         };
 

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -232,10 +232,10 @@ pub fn random_block<R: Rng>(rng: &mut R, number: u64, block_params: BlockParams)
         ..Default::default()
     };
 
-    SealedBlock {
-        header: SealedHeader::seal(header),
-        body: BlockBody { transactions, ommers, withdrawals: withdrawals.map(Withdrawals::new) },
-    }
+    SealedBlock::new(
+        SealedHeader::seal(header),
+        BlockBody { transactions, ommers, withdrawals: withdrawals.map(Withdrawals::new) },
+    )
 }
 
 /// Generate a range of random blocks.


### PR DESCRIPTION
towards #13626

this was a bit horrible...

we should enforce trait usage and the first step towards `Sealed<Block>` would be making the fields private, then we can change internals more easily.

this also highlights things we can extract into helper functions, like `tx_count` etc...

haven't done the same for header yet, because this is enough for 1pr
