### PR TITLE
fix: typos in documentation files

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -77,12 +77,12 @@ pub struct Cli<C: ChainSpecParser = EthereumChainSpecParser, Ext: clap::Args + f
 }
 
 impl Cli {
-    /// Parsers only the default CLI arguments
+    /// Parses only the default CLI arguments
     pub fn parse_args() -> Self {
         Self::parse()
     }
 
-    /// Parsers only the default CLI arguments from the given iterator
+    /// Parses only the default CLI arguments from the given iterator
     pub fn try_parse_args_from<I, T>(itr: I) -> Result<Self, clap::error::Error>
     where
         I: IntoIterator<Item = T>,

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -84,7 +84,7 @@ pub struct Command<C: ChainSpecParser> {
 }
 
 impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
-    /// Fetches the best block block from the database.
+    /// Fetches the best block from the database.
     ///
     /// If the database is empty, returns the genesis block.
     fn lookup_best_block<N: ProviderNodeTypes<ChainSpec = C::ChainSpec>>(

--- a/crates/cli/commands/src/test_vectors/tables.rs
+++ b/crates/cli/commands/src/test_vectors/tables.rs
@@ -124,19 +124,19 @@ where
     // We want to control our repeated keys
     let mut seen_keys = HashSet::new();
 
-    let strat_values = proptest::collection::vec(arb::<T::Value>(), 100..300).no_shrink().boxed();
+    let start_values = proptest::collection::vec(arb::<T::Value>(), 100..300).no_shrink().boxed();
 
-    let strat_keys = arb::<T::Key>().no_shrink().boxed();
+    let start_keys = arb::<T::Key>().no_shrink().boxed();
 
     while rows.len() < per_table {
-        let key: T::Key = strat_keys.new_tree(runner).map_err(|e| eyre::eyre!("{e}"))?.current();
+        let key: T::Key = start_keys.new_tree(runner).map_err(|e| eyre::eyre!("{e}"))?.current();
 
         if !seen_keys.insert(key.clone()) {
             continue
         }
 
         let mut values: Vec<T::Value> =
-            strat_values.new_tree(runner).map_err(|e| eyre::eyre!("{e}"))?.current();
+            start_values.new_tree(runner).map_err(|e| eyre::eyre!("{e}"))?.current();
 
         values.sort();
 

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
@@ -3928,7 +3928,7 @@ typedef struct MDBX_node {
 #error "Oops, some flags overlapped or wrong"
 #endif
 
-/* Max length of iov-vector passed to writev() call, used for auxilary writes */
+/* Max length of iov-vector passed to writev() call, used for auxiliary writes */
 #define MDBX_AUXILARY_IOV_MAX 64
 #if defined(IOV_MAX) && IOV_MAX < MDBX_AUXILARY_IOV_MAX
 #undef MDBX_AUXILARY_IOV_MAX

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
@@ -2246,7 +2246,7 @@ enum MDBX_option_t {
    * And for serie of lazy writes with flush is:
    *  latency = N * (emit + storage-execution) + flush + round-trip-to-storage.
    *
-   * So, for large N and/or noteable round-trip-to-storage the write+flush
+   * So, for large N and/or notable round-trip-to-storage the write+flush
    * approach is win. But for small N and/or near-zero NVMe-like latency
    * the write-through is better.
    *

--- a/testing/ef-tests/src/suite.rs
+++ b/testing/ef-tests/src/suite.rs
@@ -21,7 +21,7 @@ pub trait Suite {
     /// - `BlockchainTests/TransitionTests`
     fn suite_name(&self) -> String;
 
-    /// Load an run each contained test case.
+    /// Load and run each contained test case.
     ///
     /// # Note
     ///


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `Parsers` to `Parses` x2
Corrected `best block block from` to `best block from`
Corrected `strat` to `start` x4
Corrected `auxilary` to `auxiliary`
Corrected `noteable` to `notable`
Corrected `Load an run` to `Load and run`

I would like to be helpful. Please review the changes and merge the PR.