### PR TITLE
docs(ci): remove moved deny workflow

### DIFF
--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -15,8 +15,6 @@ The CI runs a couple of workflows:
 - **[book]**: Builds, tests, and deploys the book.
 
 ### Meta
-
-- **[deny]**: Runs `cargo deny` to check for license conflicts and security advisories in our dependencies
 - **[release]**: Runs the release workflow
 - **[release-dist]**: Publishes Reth to external package managers
 - **[dependencies]**: Runs `cargo update` periodically to keep dependencies current
@@ -40,7 +38,6 @@ The CI runs a couple of workflows:
 [sync]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/sync.yml
 [stage]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/stage.yml
 [book]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/book.yml
-[deny]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/deny.yml
 [release]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/release.yml
 [release-dist]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/release-dist.yml
 [dependencies]: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/dependencies.yml


### PR DESCRIPTION
- Removed the `deny` workflow from docs as it was moved under the `lint` workflow in #13230
- Since `lint` description already mentions "other checks", don't think it's necessary to mention `deny` there