### PR TITLE
chore: use generics for RecoveredTx

### DIFF
--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1572,7 +1572,7 @@ mod tests {
         }
 
         let single_tx_cost = U256::from(INITIAL_BASE_FEE * MIN_TRANSACTION_GAS);
-        let mock_tx = |nonce: u64| -> RecoveredTx {
+        let mock_tx = |nonce: u64| -> RecoveredTx<_> {
             TransactionSigned::new_unhashed(
                 Transaction::Eip1559(TxEip1559 {
                     chain_id: chain_spec.chain.id(),
@@ -1589,7 +1589,7 @@ mod tests {
 
         let mock_block = |number: u64,
                           parent: Option<B256>,
-                          body: Vec<RecoveredTx>,
+                          body: Vec<RecoveredTx<TransactionSigned>>,
                           num_of_signer_txs: u64|
          -> SealedBlockWithSenders {
             let signed_body =

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -94,7 +94,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
     ) -> SealedBlockWithSenders {
         let mut rng = thread_rng();
 
-        let mock_tx = |nonce: u64| -> RecoveredTx {
+        let mock_tx = |nonce: u64| -> RecoveredTx<_> {
             let tx = Transaction::Eip1559(TxEip1559 {
                 chain_id: self.chain_spec.chain.id(),
                 nonce,
@@ -112,7 +112,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
 
         let num_txs = rng.gen_range(0..5);
         let signer_balance_decrease = Self::single_tx_cost() * U256::from(num_txs);
-        let transactions: Vec<RecoveredTx> = (0..num_txs)
+        let transactions: Vec<RecoveredTx<_>> = (0..num_txs)
             .map(|_| {
                 let tx = mock_tx(self.signer_build_account_info.nonce);
                 self.signer_build_account_info.nonce += 1;

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -911,14 +911,14 @@ impl TransactionSigned {
 
     /// Returns the [`RecoveredTx`] transaction with the given sender.
     #[inline]
-    pub const fn with_signer(self, signer: Address) -> RecoveredTx {
+    pub const fn with_signer(self, signer: Address) -> RecoveredTx<Self> {
         RecoveredTx::from_signed_transaction(self, signer)
     }
 
     /// Consumes the type, recover signer and return [`RecoveredTx`]
     ///
     /// Returns `None` if the transaction's signature is invalid, see also [`Self::recover_signer`].
-    pub fn into_ecrecovered(self) -> Option<RecoveredTx> {
+    pub fn into_ecrecovered(self) -> Option<RecoveredTx<Self>> {
         let signer = self.recover_signer()?;
         Some(RecoveredTx { signed_transaction: self, signer })
     }
@@ -928,7 +928,7 @@ impl TransactionSigned {
     ///
     /// Returns `None` if the transaction's signature is invalid, see also
     /// [`Self::recover_signer_unchecked`].
-    pub fn into_ecrecovered_unchecked(self) -> Option<RecoveredTx> {
+    pub fn into_ecrecovered_unchecked(self) -> Option<RecoveredTx<Self>> {
         let signer = self.recover_signer_unchecked()?;
         Some(RecoveredTx { signed_transaction: self, signer })
     }
@@ -938,7 +938,7 @@ impl TransactionSigned {
     ///
     /// Returns `Err(Self)` if the transaction's signature is invalid, see also
     /// [`Self::recover_signer_unchecked`].
-    pub fn try_into_ecrecovered_unchecked(self) -> Result<RecoveredTx, Self> {
+    pub fn try_into_ecrecovered_unchecked(self) -> Result<RecoveredTx<Self>, Self> {
         match self.recover_signer_unchecked() {
             None => Err(self),
             Some(signer) => Ok(RecoveredTx { signed_transaction: self, signer }),
@@ -1182,8 +1182,8 @@ impl alloy_consensus::Transaction for TransactionSigned {
     }
 }
 
-impl From<RecoveredTx> for TransactionSigned {
-    fn from(recovered: RecoveredTx) -> Self {
+impl From<RecoveredTx<Self>> for TransactionSigned {
+    fn from(recovered: RecoveredTx<Self>) -> Self {
         recovered.signed_transaction
     }
 }

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -1,7 +1,7 @@
 //! Defines the types for blob transactions, legacy, and other EIP-2718 transactions included in a
 //! response to `GetPooledTransactions`.
 
-use crate::RecoveredTx;
+use crate::{RecoveredTx, TransactionSigned};
 use alloy_consensus::transaction::PooledTransaction;
 use alloy_eips::eip4844::BlobTransactionSidecar;
 use reth_primitives_traits::transaction::error::TransactionConversionError;
@@ -11,7 +11,7 @@ pub type PooledTransactionsElementEcRecovered<T = PooledTransaction> = Recovered
 
 impl PooledTransactionsElementEcRecovered {
     /// Transform back to [`RecoveredTx`]
-    pub fn into_ecrecovered_transaction(self) -> RecoveredTx {
+    pub fn into_ecrecovered_transaction(self) -> RecoveredTx<TransactionSigned> {
         let (tx, signer) = self.to_components();
         RecoveredTx::from_signed_transaction(tx.into(), signer)
     }
@@ -21,9 +21,9 @@ impl PooledTransactionsElementEcRecovered {
     ///
     /// Returns the transaction is not an EIP-4844 transaction.
     pub fn try_from_blob_transaction(
-        tx: RecoveredTx,
+        tx: RecoveredTx<TransactionSigned>,
         sidecar: BlobTransactionSidecar,
-    ) -> Result<Self, RecoveredTx> {
+    ) -> Result<Self, RecoveredTx<TransactionSigned>> {
         let RecoveredTx { signer, signed_transaction } = tx;
         let transaction = signed_transaction
             .try_into_pooled_eip4844(sidecar)
@@ -33,10 +33,10 @@ impl PooledTransactionsElementEcRecovered {
 }
 
 /// Converts a `Recovered` into a `PooledTransactionsElementEcRecovered`.
-impl TryFrom<RecoveredTx> for PooledTransactionsElementEcRecovered {
+impl TryFrom<RecoveredTx<TransactionSigned>> for PooledTransactionsElementEcRecovered {
     type Error = TransactionConversionError;
 
-    fn try_from(tx: RecoveredTx) -> Result<Self, Self::Error> {
+    fn try_from(tx: RecoveredTx<TransactionSigned>) -> Result<Self, Self::Error> {
         match PooledTransaction::try_from(tx.signed_transaction) {
             Ok(pooled_transaction) => {
                 Ok(Self::from_signed_transaction(pooled_transaction, tx.signer))

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -39,7 +39,7 @@ where
 
     fn fill(
         &self,
-        tx: RecoveredTx,
+        tx: RecoveredTx<TransactionSigned>,
         tx_info: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -904,10 +904,10 @@ impl EthPoolTransaction for MockTransaction {
     }
 }
 
-impl TryFrom<RecoveredTx> for MockTransaction {
+impl TryFrom<RecoveredTx<TransactionSigned>> for MockTransaction {
     type Error = TryFromRecoveredTransactionError;
 
-    fn try_from(tx: RecoveredTx) -> Result<Self, Self::Error> {
+    fn try_from(tx: RecoveredTx<TransactionSigned>) -> Result<Self, Self::Error> {
         let sender = tx.signer();
         let transaction = tx.into_signed();
         let hash = transaction.hash();
@@ -1053,7 +1053,7 @@ impl From<PooledTransactionsElementEcRecovered> for MockTransaction {
     }
 }
 
-impl From<MockTransaction> for RecoveredTx {
+impl From<MockTransaction> for RecoveredTx<TransactionSigned> {
     fn from(tx: MockTransaction) -> Self {
         let signed_tx =
             TransactionSigned::new(tx.clone().into(), Signature::test_signature(), *tx.hash());

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1453,10 +1453,10 @@ impl EthPoolTransaction for EthPooledTransaction {
     }
 }
 
-impl TryFrom<RecoveredTx> for EthPooledTransaction {
+impl TryFrom<RecoveredTx<TransactionSigned>> for EthPooledTransaction {
     type Error = TryFromRecoveredTransactionError;
 
-    fn try_from(tx: RecoveredTx) -> Result<Self, Self::Error> {
+    fn try_from(tx: RecoveredTx<TransactionSigned>) -> Result<Self, Self::Error> {
         // ensure we can handle the transaction type and its format
         match tx.ty() {
             0..=EIP1559_TX_TYPE_ID | EIP7702_TX_TYPE_ID => {
@@ -1480,7 +1480,7 @@ impl TryFrom<RecoveredTx> for EthPooledTransaction {
     }
 }
 
-impl From<EthPooledTransaction> for RecoveredTx {
+impl From<EthPooledTransaction> for RecoveredTx<TransactionSigned> {
     fn from(tx: EthPooledTransaction) -> Self {
         tx.transaction
     }


### PR DESCRIPTION
towards #13631

this is prep for moving this type to `primitives-traits`

I kept the the `T= TransactionSigned` default for now but it now compiles without