### PR TITLE
feat: add `StaticFileSegment::BlockMeta` to `StaticFileProducer` and `Pruner`

### DIFF
--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -9,7 +9,7 @@ use reth_provider::{errors::provider::ProviderResult, BlockReader, PruneCheckpoi
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
 pub use set::SegmentSet;
 pub use static_file::{
-    Headers as StaticFileHeaders, Receipts as StaticFileReceipts,
+    BlockMeta as StaticFileBlockMeta, Headers as StaticFileHeaders, Receipts as StaticFileReceipts,
     Transactions as StaticFileTransactions,
 };
 use std::{fmt::Debug, ops::RangeInclusive};

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -1,3 +1,4 @@
+use super::{StaticFileBlockMeta, StaticFileHeaders, StaticFileReceipts, StaticFileTransactions};
 use crate::segments::{
     AccountHistory, ReceiptsByLogs, Segment, SenderRecovery, StorageHistory, TransactionLookup,
     UserReceipts,
@@ -10,8 +11,6 @@ use reth_provider::{
     StaticFileProviderFactory,
 };
 use reth_prune_types::PruneModes;
-
-use super::{StaticFileHeaders, StaticFileReceipts, StaticFileTransactions};
 
 /// Collection of [`Segment`]. Thread-safe, allocated on the heap.
 #[derive(Debug)]
@@ -73,7 +72,9 @@ where
             // Static file transactions
             .segment(StaticFileTransactions::new(static_file_provider.clone()))
             // Static file receipts
-            .segment(StaticFileReceipts::new(static_file_provider))
+            .segment(StaticFileReceipts::new(static_file_provider.clone()))
+            //  Static file block meta
+            .segment(StaticFileBlockMeta::new(static_file_provider))
             // Account history
             .segment_opt(account_history.map(AccountHistory::new))
             // Storage history

--- a/crates/prune/prune/src/segments/static_file/block_meta.rs
+++ b/crates/prune/prune/src/segments/static_file/block_meta.rs
@@ -1,0 +1,372 @@
+use crate::{
+    db_ext::DbTxPruneExt,
+    segments::{PruneInput, Segment},
+    PruneLimiter, PrunerError,
+};
+use alloy_primitives::BlockNumber;
+use reth_db::{
+    cursor::{DbCursorRO, DbCursorRW, RangeWalker},
+    tables,
+    transaction::DbTxMut,
+};
+use reth_primitives_traits::{HeaderTy, NodePrimitives};
+use reth_provider::{
+    providers::StaticFileProvider, DBProvider, NodePrimitivesProvider, StaticFileProviderFactory,
+};
+use reth_prune_types::{
+    PruneMode, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
+};
+use reth_static_file_types::StaticFileSegment;
+use std::num::NonZeroUsize;
+use tracing::trace;
+
+/// Number of tables to prune in one step.
+///
+/// `BlockBodyIndices`, `BlockOmmers` and `BlockWithdrawals`.
+const TABLES_TO_PRUNE: usize = 3;
+
+#[derive(Debug)]
+pub struct BlockMeta<N> {
+    static_file_provider: StaticFileProvider<N>,
+}
+
+impl<N> BlockMeta<N> {
+    pub const fn new(static_file_provider: StaticFileProvider<N>) -> Self {
+        Self { static_file_provider }
+    }
+}
+
+impl<Provider: StaticFileProviderFactory + DBProvider<Tx: DbTxMut>> Segment<Provider>
+    for BlockMeta<Provider::Primitives>
+{
+    fn segment(&self) -> PruneSegment {
+        PruneSegment::BlockMeta
+    }
+
+    fn mode(&self) -> Option<PruneMode> {
+        self.static_file_provider
+            .get_highest_static_file_block(StaticFileSegment::BlockMeta)
+            .map(PruneMode::before_inclusive)
+    }
+
+    fn purpose(&self) -> PrunePurpose {
+        PrunePurpose::StaticFile
+    }
+
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
+        let (block_range_start, block_range_end) = match input.get_next_block_range() {
+            Some(range) => (*range.start(), *range.end()),
+            None => {
+                trace!(target: "pruner", "No headers to prune");
+                return Ok(SegmentOutput::done())
+            }
+        };
+
+        let last_pruned_block =
+            if block_range_start == 0 { None } else { Some(block_range_start - 1) };
+
+        let range = last_pruned_block.map_or(0, |block| block + 1)..=block_range_end;
+
+        // Get relevant table cursors
+        let mut indices_cursor = provider.tx_ref().cursor_write::<tables::BlockBodyIndices>()?;
+        let ommers_cursor =
+            provider.tx_ref().cursor_write::<tables::BlockOmmers<<Provider::Primitives as NodePrimitives>::BlockHeader>>()?;
+        let withdrawals_cursor = provider.tx_ref().cursor_write::<tables::BlockWithdrawals>()?;
+
+        let mut limiter = input.limiter.floor_deleted_entries_limit_to_multiple_of(
+            NonZeroUsize::new(TABLES_TO_PRUNE).unwrap(),
+        );
+
+        let tables_iter = BlockMetaTablesIter::new(
+            provider,
+            &mut limiter,
+            indices_cursor.walk_range(range)?,
+            ommers_cursor,
+            withdrawals_cursor,
+        );
+
+        let mut last_pruned_block: Option<u64> = None;
+        let mut pruned = 0;
+
+        // Each iteration results in a block being pruned from DB. It stops once we have hit the
+        // requested end range or the max number of allow pruned entries as defined on limiter.
+        for res in tables_iter {
+            let BlockMetaTablesIterItem { pruned_block, entries_pruned } = res?;
+            last_pruned_block = Some(pruned_block);
+            pruned += entries_pruned;
+        }
+
+        let done = last_pruned_block == Some(block_range_end);
+        let progress = limiter.progress(done);
+
+        Ok(SegmentOutput {
+            progress,
+            pruned,
+            checkpoint: Some(SegmentOutputCheckpoint {
+                block_number: last_pruned_block,
+                tx_number: None,
+            }),
+        })
+    }
+}
+type Walker<'a, Provider, T> =
+    RangeWalker<'a, T, <<Provider as DBProvider>::Tx as DbTxMut>::CursorMut<T>>;
+
+/// An iterator over the block meta tables that will prune a number of entries according to
+/// [`PruneLimiter`].
+#[allow(missing_debug_implementations)]
+struct BlockMetaTablesIter<'a, Provider, C1, C2>
+where
+    Provider: NodePrimitivesProvider + DBProvider<Tx: DbTxMut>,
+{
+    provider: &'a Provider,
+    limiter: &'a mut PruneLimiter,
+    indices_walker: Walker<'a, Provider, tables::BlockBodyIndices>,
+    ommers_cursor: C1,
+    withdrawals_cursor: C2,
+}
+
+struct BlockMetaTablesIterItem {
+    pruned_block: BlockNumber,
+    entries_pruned: usize,
+}
+
+impl<'a, Provider, C1, C2> BlockMetaTablesIter<'a, Provider, C1, C2>
+where
+    Provider: NodePrimitivesProvider + DBProvider<Tx: DbTxMut>,
+{
+    fn new(
+        provider: &'a Provider,
+        limiter: &'a mut PruneLimiter,
+        indices_cursor: Walker<'a, Provider, tables::BlockBodyIndices>,
+        ommers_cursor: C1,
+        withdrawals_cursor: C2,
+    ) -> Self {
+        Self {
+            provider,
+            limiter,
+            indices_walker: indices_cursor,
+            ommers_cursor,
+            withdrawals_cursor,
+        }
+    }
+}
+
+impl<Provider, C1, C2> Iterator for BlockMetaTablesIter<'_, Provider, C1, C2>
+where
+    Provider: NodePrimitivesProvider + DBProvider<Tx: DbTxMut>,
+    C1: DbCursorRW<tables::BlockOmmers<HeaderTy<Provider::Primitives>>>
+        + DbCursorRO<tables::BlockOmmers<HeaderTy<Provider::Primitives>>>,
+    C2: DbCursorRW<tables::BlockWithdrawals> + DbCursorRO<tables::BlockWithdrawals>,
+{
+    type Item = Result<BlockMetaTablesIterItem, PrunerError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.limiter.is_limit_reached() {
+            return None
+        }
+
+        let mut pruned_block_indices = None;
+
+        // Prune BlockBodyIndices table
+        if let Err(err) = self.provider.tx_ref().prune_table_with_range_step(
+            &mut self.indices_walker,
+            self.limiter,
+            &mut |_| false,
+            &mut |(block, _)| {
+                pruned_block_indices = Some(block);
+            },
+        ) {
+            return Some(Err(err.into()))
+        }
+
+        let mut entries_pruned = 1;
+
+        // Prune Ommers table. Can't use prune_table_with_range_step, since there are blocks without
+        // a respective entry.
+        if let Some(block) = &pruned_block_indices.clone() {
+            match self.ommers_cursor.seek_exact(*block) {
+                Ok(v) if v.is_some() => {
+                    if let Err(err) = self.ommers_cursor.delete_current() {
+                        return Some(Err(err.into()))
+                    }
+                    entries_pruned += 1;
+                    self.limiter.increment_deleted_entries_count();
+                }
+                Err(err) => return Some(Err(err.into())),
+                Ok(_) => {}
+            };
+        }
+
+        // Prune Withdrawals table. Can't use prune_table_with_range_step, since there are blocks
+        // without a respective entry.
+        if let Some(block) = &pruned_block_indices.clone() {
+            match self.withdrawals_cursor.seek_exact(*block) {
+                Ok(v) if v.is_some() => {
+                    if let Err(err) = self.withdrawals_cursor.delete_current() {
+                        return Some(Err(err.into()))
+                    }
+                    entries_pruned += 1;
+                    self.limiter.increment_deleted_entries_count();
+                }
+                Err(err) => return Some(Err(err.into())),
+                Ok(_) => {}
+            };
+        }
+
+        pruned_block_indices
+            .map(move |block| Ok(BlockMetaTablesIterItem { pruned_block: block, entries_pruned }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::segments::{PruneInput, PruneLimiter, Segment, SegmentOutput};
+    use alloy_eips::eip4895::{Withdrawal, Withdrawals};
+    use alloy_primitives::{BlockNumber, B256};
+    use assert_matches::assert_matches;
+    use reth_db::{
+        models::{StoredBlockBodyIndices, StoredBlockOmmers, StoredBlockWithdrawals},
+        tables,
+        transaction::DbTxMut,
+    };
+    use reth_db_api::transaction::DbTx;
+    use reth_provider::{
+        DatabaseProviderFactory, PruneCheckpointReader, PruneCheckpointWriter,
+        StaticFileProviderFactory,
+    };
+    use reth_prune_types::{
+        PruneInterruptReason, PruneMode, PruneProgress, PruneSegment, SegmentOutputCheckpoint,
+    };
+    use reth_stages::test_utils::TestStageDB;
+    use reth_testing_utils::{generators, generators::random_header_range};
+    use tracing::trace;
+
+    #[test]
+    fn prune() {
+        reth_tracing::init_test_tracing();
+
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let headers = random_header_range(&mut rng, 0..100, B256::ZERO);
+        let tx = db.factory.provider_rw().unwrap().into_tx();
+
+        for header in &headers {
+            // One tx per block
+            tx.put::<tables::BlockBodyIndices>(
+                header.number,
+                StoredBlockBodyIndices {
+                    first_tx_num: header.number.saturating_sub(1),
+                    tx_count: 1,
+                },
+            )
+            .unwrap();
+
+            // Not all blocks have ommers,
+            if header.number % 2 == 0 {
+                tx.put::<tables::BlockOmmers>(
+                    header.number,
+                    StoredBlockOmmers { ommers: vec![header.clone_header()] },
+                )
+                .unwrap();
+            }
+
+            // Not all blocks have withdrawals
+            if header.number % 3 == 0 {
+                tx.put::<tables::BlockWithdrawals>(
+                    header.number,
+                    StoredBlockWithdrawals {
+                        withdrawals: Withdrawals::new(vec![Withdrawal::default()]),
+                    },
+                )
+                .unwrap();
+            }
+        }
+        tx.commit().unwrap();
+
+        let initial_ommer_entries = headers.len() / 2;
+        let initial_withdrawal_entries = headers.len() / 3 + 1;
+
+        assert_eq!(db.table::<tables::BlockBodyIndices>().unwrap().len(), headers.len());
+        // We have only inserted every 2 blocks
+        assert_eq!(db.table::<tables::BlockOmmers>().unwrap().len(), initial_ommer_entries);
+        // We have only inserted every 3 blocks
+        assert_eq!(
+            db.table::<tables::BlockWithdrawals>().unwrap().len(),
+            initial_withdrawal_entries
+        );
+
+        let test_prune = |to_block: BlockNumber, expected_result: (PruneProgress, usize)| {
+            let segment = super::BlockMeta::new(db.factory.static_file_provider());
+            let input = PruneInput {
+                previous_checkpoint: db
+                    .factory
+                    .provider()
+                    .unwrap()
+                    .get_prune_checkpoint(PruneSegment::BlockMeta)
+                    .unwrap(),
+                to_block,
+                limiter: PruneLimiter::default().set_deleted_entries_limit(5),
+            };
+
+            let provider = db.factory.database_provider_rw().unwrap();
+            let result = segment.prune(&provider, input).unwrap();
+
+            trace!(target: "pruner::test",
+                expected_prune_progress=?expected_result.0,
+                expected_pruned=?expected_result.1,
+                result=?result,
+                "SegmentOutput"
+            );
+
+            assert_matches!(
+                result,
+                SegmentOutput {progress, pruned, checkpoint: Some(_)}
+                    if (progress, pruned) == expected_result
+            );
+
+            provider
+                .save_prune_checkpoint(
+                    PruneSegment::BlockMeta,
+                    result.checkpoint.unwrap().as_prune_checkpoint(PruneMode::Before(to_block + 1)),
+                )
+                .unwrap();
+            provider.commit().expect("commit");
+        };
+
+        test_prune(
+            3,
+            (PruneProgress::HasMoreData(PruneInterruptReason::DeletedEntriesLimitReached), 3),
+        );
+        test_prune(
+            3,
+            (PruneProgress::HasMoreData(PruneInterruptReason::DeletedEntriesLimitReached), 3),
+        );
+        test_prune(3, (PruneProgress::Finished, 2));
+    }
+
+    #[test]
+    fn prune_cannot_be_done() {
+        let db = TestStageDB::default();
+
+        let limiter = PruneLimiter::default().set_deleted_entries_limit(0);
+
+        let input = PruneInput {
+            previous_checkpoint: None,
+            to_block: 1,
+            // Less than total number of tables for `BlockMeta` segment
+            limiter,
+        };
+
+        let provider = db.factory.database_provider_rw().unwrap();
+        let segment = super::BlockMeta::new(db.factory.static_file_provider());
+        let result = segment.prune(&provider, input).unwrap();
+        assert_eq!(
+            result,
+            SegmentOutput::not_done(
+                PruneInterruptReason::DeletedEntriesLimitReached,
+                Some(SegmentOutputCheckpoint::default())
+            )
+        );
+    }
+}

--- a/crates/prune/prune/src/segments/static_file/mod.rs
+++ b/crates/prune/prune/src/segments/static_file/mod.rs
@@ -1,7 +1,9 @@
+mod block_meta;
 mod headers;
 mod receipts;
 mod transactions;
 
+pub use block_meta::BlockMeta;
 pub use headers::Headers;
 pub use receipts::Receipts;
 pub use transactions::Transactions;

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -39,15 +39,20 @@ pub enum PruneSegment {
     Headers,
     /// Prune segment responsible for the `Transactions` table.
     Transactions,
+    /// Prune segment responsible for the `BlockBodyIndices`, `BlockOmmers` and `BlockWithdrawals`
+    /// table.
+    BlockMeta,
 }
 
 impl PruneSegment {
     /// Returns minimum number of blocks to left in the database for this segment.
     pub const fn min_blocks(&self, purpose: PrunePurpose) -> u64 {
         match self {
-            Self::SenderRecovery | Self::TransactionLookup | Self::Headers | Self::Transactions => {
-                0
-            }
+            Self::SenderRecovery |
+            Self::TransactionLookup |
+            Self::Headers |
+            Self::BlockMeta |
+            Self::Transactions => 0,
             Self::Receipts if purpose.is_static_file() => 0,
             Self::ContractLogs | Self::AccountHistory | Self::StorageHistory => {
                 MINIMUM_PRUNING_DISTANCE

--- a/crates/static-file/static-file/src/segments/block_meta.rs
+++ b/crates/static-file/static-file/src/segments/block_meta.rs
@@ -1,0 +1,63 @@
+use crate::segments::Segment;
+use alloy_primitives::BlockNumber;
+use reth_codecs::Compact;
+use reth_db::{table::Value, tables};
+use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
+use reth_primitives_traits::NodePrimitives;
+use reth_provider::{providers::StaticFileWriter, DBProvider, StaticFileProviderFactory};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_errors::provider::ProviderResult;
+use std::ops::RangeInclusive;
+
+/// Static File segment responsible for [`StaticFileSegment::BlockMeta`] part of data.
+#[derive(Debug, Default)]
+pub struct BlockMeta;
+
+impl<Provider> Segment<Provider> for BlockMeta
+where
+    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Compact + Value>>
+        + DBProvider,
+{
+    fn segment(&self) -> StaticFileSegment {
+        StaticFileSegment::BlockMeta
+    }
+
+    fn copy_to_static_files(
+        &self,
+        provider: Provider,
+        block_range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<()> {
+        let static_file_provider = provider.static_file_provider();
+        let mut static_file_writer =
+            static_file_provider.get_writer(*block_range.start(), StaticFileSegment::BlockMeta)?;
+
+        // Get relevant table cursors
+        let mut indices_cursor = provider.tx_ref().cursor_read::<tables::BlockBodyIndices>()?;
+        let indices_walker = indices_cursor.walk_range(block_range)?;
+
+        let mut ommers_cursor = provider
+            .tx_ref()
+            .cursor_read::<tables::BlockOmmers<<Provider::Primitives as NodePrimitives>::BlockHeader>>(
+            )?;
+
+        let mut withdrawals_cursor = provider.tx_ref().cursor_read::<tables::BlockWithdrawals>()?;
+
+        // Iterate over table rows and push to the static file
+        for entry in indices_walker {
+            let (block_number, indices) = entry?;
+            let ommers =
+                ommers_cursor.seek_exact(block_number)?.map(|(_, l)| l).unwrap_or_default();
+            let withdrawals =
+                withdrawals_cursor.seek_exact(block_number)?.map(|(_, l)| l).unwrap_or_default();
+
+            static_file_writer.append_eth_block_meta(
+                &indices,
+                &ommers,
+                &withdrawals,
+                block_number,
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/static-file/static-file/src/segments/mod.rs
+++ b/crates/static-file/static-file/src/segments/mod.rs
@@ -9,6 +9,9 @@ pub use headers::Headers;
 mod receipts;
 pub use receipts::Receipts;
 
+mod block_meta;
+pub use block_meta::BlockMeta;
+
 use alloy_primitives::BlockNumber;
 use reth_provider::StaticFileProviderFactory;
 use reth_static_file_types::StaticFileSegment;

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -140,6 +140,9 @@ where
         if let Some(block_range) = targets.receipts.clone() {
             segments.push((Box::new(segments::Receipts), block_range));
         }
+        if let Some(block_range) = targets.block_meta.clone() {
+            segments.push((Box::new(segments::BlockMeta), block_range));
+        }
 
         segments.par_iter().try_for_each(|(segment, block_range)| -> ProviderResult<()> {
             debug!(target: "static_file", segment = %segment.segment(), ?block_range, "StaticFileProducer segment");
@@ -326,7 +329,7 @@ mod tests {
                 headers: Some(1),
                 receipts: Some(1),
                 transactions: Some(1),
-                block_meta: None,
+                block_meta: Some(1),
             })
             .expect("get static file targets");
         assert_eq!(
@@ -335,7 +338,7 @@ mod tests {
                 headers: Some(0..=1),
                 receipts: Some(0..=1),
                 transactions: Some(0..=1),
-                block_meta: None
+                block_meta: Some(0..=1)
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
@@ -345,7 +348,7 @@ mod tests {
                 headers: Some(1),
                 receipts: Some(1),
                 transactions: Some(1),
-                block_meta: None
+                block_meta: Some(1)
             }
         );
 
@@ -354,7 +357,7 @@ mod tests {
                 headers: Some(3),
                 receipts: Some(3),
                 transactions: Some(3),
-                block_meta: None,
+                block_meta: Some(3),
             })
             .expect("get static file targets");
         assert_eq!(
@@ -363,7 +366,7 @@ mod tests {
                 headers: Some(2..=3),
                 receipts: Some(2..=3),
                 transactions: Some(2..=3),
-                block_meta: None
+                block_meta: Some(2..=3)
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
@@ -373,7 +376,7 @@ mod tests {
                 headers: Some(3),
                 receipts: Some(3),
                 transactions: Some(3),
-                block_meta: None
+                block_meta: Some(3)
             }
         );
 
@@ -382,7 +385,7 @@ mod tests {
                 headers: Some(4),
                 receipts: Some(4),
                 transactions: Some(4),
-                block_meta: None,
+                block_meta: Some(4),
             })
             .expect("get static file targets");
         assert_eq!(
@@ -391,7 +394,7 @@ mod tests {
                 headers: Some(4..=4),
                 receipts: Some(4..=4),
                 transactions: Some(4..=4),
-                block_meta: None
+                block_meta: Some(4..=4)
             }
         );
         assert_matches!(
@@ -404,7 +407,7 @@ mod tests {
                 headers: Some(3),
                 receipts: Some(3),
                 transactions: Some(3),
-                block_meta: None
+                block_meta: Some(3)
             }
         );
     }
@@ -433,7 +436,7 @@ mod tests {
                         headers: Some(1),
                         receipts: Some(1),
                         transactions: Some(1),
-                        block_meta: None,
+                        block_meta: Some(1),
                     })
                     .expect("get static file targets");
                 assert_matches!(locked_producer.run(targets.clone()), Ok(_));

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -30,10 +30,10 @@ pub struct HighestStaticFiles {
     /// Highest static file block of receipts, inclusive.
     /// If [`None`], no static file is available.
     pub receipts: Option<BlockNumber>,
-    /// Highest static file block of transactions, inclusive.
+    /// Highest static file block of block meta, inclusive.
     /// If [`None`], no static file is available.
     pub transactions: Option<BlockNumber>,
-    /// Highest static file block of transactions, inclusive.
+    /// Highest static file block of block meta, inclusive.
     /// If [`None`], no static file is available.
     pub block_meta: Option<BlockNumber>,
 }

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -1,6 +1,9 @@
 use crate::{
     add_static_file_mask,
-    static_file::mask::{ColumnSelectorOne, ColumnSelectorTwo},
+    static_file::{
+        mask::{ColumnSelectorOne, ColumnSelectorTwo},
+        ColumnSelectorThree,
+    },
     BlockBodyIndices, BlockWithdrawals, HeaderTerminalDifficulties,
 };
 use alloy_primitives::BlockHash;
@@ -55,4 +58,8 @@ add_static_file_mask! {
 add_static_file_mask! {
     #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]
     WithdrawalsMask, <BlockWithdrawals as Table>::Value, 0b100
+}
+add_static_file_mask! {
+    #[doc = "Mask for selecting all columns from BlockMeta static file segment"]
+    AllBlockMetaMask<H>, <BlockBodyIndices as Table>::Value, StoredBlockOmmers::<H>, <BlockWithdrawals as Table>::Value, 0b111
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -562,7 +562,12 @@ impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ProviderFactory<N> {
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.provider()?.block_body_indices(number)
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::BlockMeta,
+            number,
+            |static_file| static_file.block_body_indices(number),
+            || self.provider()?.block_body_indices(number),
+        )
     }
 
     fn block_body_indices_range(


### PR DESCRIPTION
on top of #13226

* Enable **lz4** for the segment
* Adds handling of the segment in the `StaticFileProducer` and `Pruner`.
* Enables **copying (BodyIndices, Withdrawals and Ommers) from database to static files. This will happen during a new start of the node. It does not append during any pipeline stage or live sync though.**
* Adds provider handling with `get_with_static_file_or_database` for the relevant types.
* Add to `reth db get static-file block-meta ...`

holesky before
![image](https://github.com/user-attachments/assets/b052497f-1163-40fb-afe3-3a23d99f0883)

holesky after
![image](https://github.com/user-attachments/assets/4e29cc46-af98-4955-a411-8588eba871c5)
