### PR TITLE
chore(primitives): rename RecoveredTx functions to match alloy::…

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -192,7 +192,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
                     let pooled = transaction
                         .clone()
-                        .into_signed()
+                        .into_tx()
                         .try_into_pooled_eip4844(sidecar.clone())
                         .expect("should not fail to convert blob tx if it is already eip4844");
                     let encoded_length = pooled.encode_2718_len();

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1592,8 +1592,7 @@ mod tests {
                           body: Vec<RecoveredTx<TransactionSigned>>,
                           num_of_signer_txs: u64|
          -> SealedBlockWithSenders {
-            let signed_body =
-                body.clone().into_iter().map(|tx| tx.into_signed()).collect::<Vec<_>>();
+            let signed_body = body.clone().into_iter().map(|tx| tx.into_tx()).collect::<Vec<_>>();
             let transactions_root = calculate_transaction_root(&signed_body);
             let receipts = body
                 .iter()

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -145,7 +145,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             base_fee_per_gas: Some(INITIAL_BASE_FEE),
             transactions_root: calculate_transaction_root(
-                &transactions.clone().into_iter().map(|tx| tx.into_signed()).collect::<Vec<_>>(),
+                &transactions.clone().into_iter().map(|tx| tx.into_tx()).collect::<Vec<_>>(),
             ),
             receipts_root: calculate_receipt_root(&receipts),
             beneficiary: Address::random(),
@@ -171,7 +171,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         let block = SealedBlock::new(
             SealedHeader::seal(header),
             BlockBody {
-                transactions: transactions.into_iter().map(|tx| tx.into_signed()).collect(),
+                transactions: transactions.into_iter().map(|tx| tx.into_tx()).collect(),
                 ommers: Vec::new(),
                 withdrawals: Some(vec![].into()),
             },

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -285,7 +285,7 @@ where
         }
 
         // Configure the environment for the tx.
-        *evm.tx_mut() = evm_config.tx_env(tx.as_signed(), tx.signer());
+        *evm.tx_mut() = evm_config.tx_env(tx.tx(), tx.signer());
 
         let ResultAndState { result, state } = match evm.transact() {
             Ok(res) => res,
@@ -354,7 +354,7 @@ where
 
         // append sender and transaction to the respective lists
         executed_senders.push(tx.signer());
-        executed_txs.push(tx.into_signed());
+        executed_txs.push(tx.into_tx());
     }
 
     // check if we have a better block

--- a/crates/net/network/benches/broadcast.rs
+++ b/crates/net/network/benches/broadcast.rs
@@ -64,7 +64,7 @@ pub fn broadcast_ingress_bench(c: &mut Criterion) {
                                     tx.sender(),
                                     ExtendedAccount::new(0, U256::from(100_000_000)),
                                 );
-                                txs.push(Arc::new(tx.transaction().clone().into_signed()));
+                                txs.push(Arc::new(tx.transaction().clone().into_tx()));
                                 peer1.send_transactions(peer0_id, txs);
                             }
                         }

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1538,7 +1538,7 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
     {
         let size = tx.encoded_length();
         let transaction = tx.transaction.clone_into_consensus();
-        let transaction = Arc::new(transaction.into_signed());
+        let transaction = Arc::new(transaction.into_tx());
         Self { size, transaction }
     }
 

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -80,7 +80,7 @@ async fn test_4844_tx_gossip_penalization() {
     }
 
     let signed_txs: Vec<Arc<TransactionSigned>> =
-        txs.iter().map(|tx| Arc::new(tx.transaction().clone().into_signed())).collect();
+        txs.iter().map(|tx| Arc::new(tx.transaction().clone().into_tx())).collect();
 
     let network_handle = peer0.network();
 

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -58,9 +58,9 @@ impl TryFrom<RecoveredTx<OpTransactionSigned>> for OpPooledTransaction {
     type Error = TransactionConversionError;
 
     fn try_from(value: RecoveredTx<OpTransactionSigned>) -> Result<Self, Self::Error> {
-        let (tx, signer) = value.to_components();
+        let (tx, signer) = value.into_parts();
         let pooled: RecoveredTx<op_alloy_consensus::OpPooledTransaction> =
-            RecoveredTx::from_signed_transaction(tx.try_into()?, signer);
+            RecoveredTx::new_unchecked(tx.try_into()?, signer);
         Ok(pooled.into())
     }
 }
@@ -83,8 +83,8 @@ impl PoolTransaction for OpPooledTransaction {
     fn try_consensus_into_pooled(
         tx: RecoveredTx<Self::Consensus>,
     ) -> Result<RecoveredTx<Self::Pooled>, Self::TryFromConsensusError> {
-        let (tx, signer) = tx.to_components();
-        Ok(RecoveredTx::from_signed_transaction(tx.try_into()?, signer))
+        let (tx, signer) = tx.into_parts();
+        Ok(RecoveredTx::new_unchecked(tx.try_into()?, signer))
     }
 
     fn hash(&self) -> &TxHash {
@@ -459,7 +459,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = OpTransactionSigned::new_unhashed(deposit_tx, signature);
-        let signed_recovered = RecoveredTx::from_signed_transaction(signed_tx, signer);
+        let signed_recovered = RecoveredTx::new_unchecked(signed_tx, signer);
         let len = signed_recovered.encode_2718_len();
         let pooled_tx = OpPooledTransaction::new(signed_recovered, len);
         let outcome = validator.validate_one(origin, pooled_tx);

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -67,7 +67,7 @@ impl OpPayloadTransactions for CustomTxPriority {
             ..Default::default()
         };
         let signature = sender.sign_transaction_sync(&mut end_of_block_tx).unwrap();
-        let end_of_block_tx = RecoveredTx::from_signed_transaction(
+        let end_of_block_tx = RecoveredTx::new_unchecked(
             OpTransactionSigned::new_unhashed(
                 OpTypedTransaction::Eip1559(end_of_block_tx),
                 signature,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -790,7 +790,7 @@ where
                     ))
                 })?;
 
-            *evm.tx_mut() = self.evm_config.tx_env(sequencer_tx.as_signed(), sequencer_tx.signer());
+            *evm.tx_mut() = self.evm_config.tx_env(sequencer_tx.tx(), sequencer_tx.signer());
 
             let ResultAndState { result, state } = match evm.transact() {
                 Ok(res) => res,
@@ -841,7 +841,7 @@ where
 
             // append sender and transaction to the respective lists
             info.executed_senders.push(sequencer_tx.signer());
-            info.executed_transactions.push(sequencer_tx.into_signed());
+            info.executed_transactions.push(sequencer_tx.into_tx());
         }
 
         Ok(info)
@@ -891,7 +891,7 @@ where
             }
 
             // Configure the environment for the tx.
-            *evm.tx_mut() = self.evm_config.tx_env(tx.as_signed(), tx.signer());
+            *evm.tx_mut() = self.evm_config.tx_env(tx.tx(), tx.signer());
 
             let ResultAndState { result, state } = match evm.transact() {
                 Ok(res) => res,
@@ -954,7 +954,7 @@ where
 
             // append sender and transaction to the respective lists
             info.executed_senders.push(tx.signer());
-            info.executed_transactions.push(tx.into_signed());
+            info.executed_transactions.push(tx.into_tx());
         }
 
         Ok(None)

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -89,7 +89,7 @@ where
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();
         let hash = *tx.tx_hash();
-        let OpTransactionSigned { transaction, signature, .. } = tx.into_signed();
+        let OpTransactionSigned { transaction, signature, .. } = tx.into_tx();
         let mut deposit_receipt_version = None;
         let mut deposit_nonce = None;
 

--- a/crates/payload/util/src/transaction.rs
+++ b/crates/payload/util/src/transaction.rs
@@ -99,12 +99,12 @@ where
     fn next(&mut self, ctx: ()) -> Option<RecoveredTx<Self::Transaction>> {
         while let Some(tx) = self.before.next(ctx) {
             if let Some(before_max_gas) = self.before_max_gas {
-                if self.before_gas + tx.as_signed().gas_limit() <= before_max_gas {
-                    self.before_gas += tx.as_signed().gas_limit();
+                if self.before_gas + tx.tx().gas_limit() <= before_max_gas {
+                    self.before_gas += tx.tx().gas_limit();
                     return Some(tx);
                 }
-                self.before.mark_invalid(tx.signer(), tx.as_signed().nonce());
-                self.after.mark_invalid(tx.signer(), tx.as_signed().nonce());
+                self.before.mark_invalid(tx.signer(), tx.tx().nonce());
+                self.after.mark_invalid(tx.signer(), tx.tx().nonce());
             } else {
                 return Some(tx);
             }
@@ -112,11 +112,11 @@ where
 
         while let Some(tx) = self.after.next(ctx) {
             if let Some(after_max_gas) = self.after_max_gas {
-                if self.after_gas + tx.as_signed().gas_limit() <= after_max_gas {
-                    self.after_gas += tx.as_signed().gas_limit();
+                if self.after_gas + tx.tx().gas_limit() <= after_max_gas {
+                    self.after_gas += tx.tx().gas_limit();
                     return Some(tx);
                 }
-                self.after.mark_invalid(tx.signer(), tx.as_signed().nonce());
+                self.after.mark_invalid(tx.signer(), tx.tx().nonce());
             } else {
                 return Some(tx);
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -682,7 +682,7 @@ pub trait Call:
                 let env = EnvWithHandlerCfg::new_with_cfg_env(
                     cfg_env_with_handler_cfg,
                     block_env,
-                    RpcNodeCore::evm_config(&this).tx_env(tx.as_signed(), tx.signer()),
+                    RpcNodeCore::evm_config(&this).tx_env(tx.tx(), tx.signer()),
                 );
 
                 let (res, _) = this.transact(&mut db, env)?;

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -341,7 +341,7 @@ pub trait LoadPendingBlock:
             let env = Env::boxed(
                 cfg.cfg_env.clone(),
                 block_env.clone(),
-                Self::evm_config(self).tx_env(tx.as_signed(), tx.signer()),
+                Self::evm_config(self).tx_env(tx.tx(), tx.signer()),
             );
 
             let mut evm = revm::Evm::builder().with_env(env).with_db(&mut db).build();
@@ -393,7 +393,7 @@ pub trait LoadPendingBlock:
             cumulative_gas_used += gas_used;
 
             // append transaction to the list of executed transactions
-            let (tx, sender) = tx.to_components();
+            let (tx, sender) = tx.into_parts();
             executed_txs.push(tx);
             senders.push(sender);
             results.push(result);

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -226,7 +226,7 @@ pub trait Trace:
                 let env = EnvWithHandlerCfg::new_with_cfg_env(
                     cfg_env_with_handler_cfg,
                     block_env,
-                    RpcNodeCore::evm_config(&this).tx_env(tx.as_signed(), tx.signer()),
+                    RpcNodeCore::evm_config(&this).tx_env(tx.tx(), tx.signer()),
                 );
                 let (res, _) =
                     this.inspect(StateCacheDbRefMutWrapper(&mut db), env, &mut inspector)?;

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -68,5 +68,5 @@ pub fn transaction_to_call_request<T: alloy_consensus::Transaction>(
     tx: RecoveredTx<T>,
 ) -> TransactionRequest {
     let from = tx.signer();
-    TransactionRequest::from_transaction_with_sender(tx.into_signed(), from)
+    TransactionRequest::from_transaction_with_sender(tx.into_tx(), from)
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -273,7 +273,7 @@ where
                     env: Env::boxed(
                         cfg_env_with_handler_cfg.cfg_env.clone(),
                         block_env,
-                        this.eth_api().evm_config().tx_env(tx.as_signed(), tx.signer()),
+                        this.eth_api().evm_config().tx_env(tx.tx(), tx.signer()),
                     ),
                     handler_cfg: cfg_env_with_handler_cfg.handler_cfg,
                 };

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -44,7 +44,7 @@ where
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();
         let hash = tx.hash();
-        let TransactionSigned { transaction, signature, .. } = tx.into_signed();
+        let TransactionSigned { transaction, signature, .. } = tx.into_tx();
 
         let inner: TxEnvelope = match transaction {
             reth_primitives::Transaction::Legacy(tx) => {

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -172,7 +172,7 @@ where
                 match &body[idx] {
                     BundleItem::Tx { tx, can_revert } => {
                         let recovered_tx = recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(tx)?;
-                        let (tx, signer) = recovered_tx.to_components();
+                        let (tx, signer) = recovered_tx.into_parts();
                         let tx: PoolConsensusTx<Eth::Pool> =
                             <Eth::Pool as TransactionPool>::Transaction::pooled_into_consensus(tx);
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -121,7 +121,7 @@ where
         let env = EnvWithHandlerCfg::new_with_cfg_env(
             cfg_env_with_handler_cfg,
             block_env,
-            self.eth_api().evm_config().tx_env(tx.as_signed(), tx.signer()),
+            self.eth_api().evm_config().tx_env(tx.tx(), tx.signer()),
         );
 
         let config = TracingInspectorConfig::from_parity_config(&trace_types);

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -103,7 +103,7 @@ where
         ) {
             let entry = inspect.entry(tx.sender()).or_default();
             let tx = tx.clone_into_consensus();
-            entry.insert(tx.nonce().to_string(), tx.into_signed().into());
+            entry.insert(tx.nonce().to_string(), tx.into_tx().into());
         }
 
         let AllPoolTransactions { pending, queued } = self.pool.all_transactions();

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -600,7 +600,7 @@ where
 
     let local_transactions = local_transactions
         .into_iter()
-        .map(|tx| tx.transaction.clone_into_consensus().into_signed())
+        .map(|tx| tx.transaction.clone_into_consensus().into_tx())
         .collect::<Vec<_>>();
 
     let num_txs = local_transactions.len();

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -357,7 +357,7 @@ where
             };
 
             size += encoded_len;
-            elements.push(pooled.into_signed());
+            elements.push(pooled.into_tx());
 
             if limit.exceeds(size) {
                 break

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -685,7 +685,7 @@ impl PoolTransaction for MockTransaction {
     fn try_consensus_into_pooled(
         tx: RecoveredTx<Self::Consensus>,
     ) -> Result<RecoveredTx<Self::Pooled>, Self::TryFromConsensusError> {
-        let (tx, signer) = tx.to_components();
+        let (tx, signer) = tx.into_parts();
         Self::Pooled::try_from(tx)
             .map(|tx| tx.with_signer(signer))
             .map_err(|_| TryFromRecoveredTransactionError::BlobSidecarMissing)
@@ -871,7 +871,7 @@ impl EthPoolTransaction for MockTransaction {
         self,
         sidecar: Arc<BlobTransactionSidecar>,
     ) -> Option<RecoveredTx<Self::Pooled>> {
-        let (tx, signer) = self.into_consensus().to_components();
+        let (tx, signer) = self.into_consensus().into_parts();
         tx.try_into_pooled_eip4844(Arc::unwrap_or_clone(sidecar))
             .map(|tx| tx.with_signer(signer))
             .ok()
@@ -881,7 +881,7 @@ impl EthPoolTransaction for MockTransaction {
         tx: RecoveredTx<Self::Consensus>,
         sidecar: BlobTransactionSidecar,
     ) -> Option<Self> {
-        let (tx, signer) = tx.to_components();
+        let (tx, signer) = tx.into_parts();
         tx.try_into_pooled_eip4844(sidecar)
             .map(|tx| tx.with_signer(signer))
             .ok()
@@ -909,7 +909,7 @@ impl TryFrom<RecoveredTx<TransactionSigned>> for MockTransaction {
 
     fn try_from(tx: RecoveredTx<TransactionSigned>) -> Result<Self, Self::Error> {
         let sender = tx.signer();
-        let transaction = tx.into_signed();
+        let transaction = tx.into_tx();
         let hash = transaction.hash();
         let size = transaction.size();
 
@@ -1058,7 +1058,7 @@ impl From<MockTransaction> for RecoveredTx<TransactionSigned> {
         let signed_tx =
             TransactionSigned::new(tx.clone().into(), Signature::test_signature(), *tx.hash());
 
-        Self::from_signed_transaction(signed_tx, tx.sender())
+        Self::new_unchecked(signed_tx, tx.sender())
     }
 }
 
@@ -1180,7 +1180,7 @@ impl proptest::arbitrary::Arbitrary for MockTransaction {
 
         arb::<(TransactionSigned, Address)>()
             .prop_map(|(signed_transaction, signer)| {
-                RecoveredTx::from_signed_transaction(signed_transaction, signer)
+                RecoveredTx::new_unchecked(signed_transaction, signer)
                     .try_into()
                     .expect("Failed to create an Arbitrary MockTransaction via RecoveredTx")
             })

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1245,21 +1245,21 @@ impl<T: SignedTransaction> EthPooledTransaction<T> {
 impl From<PooledTransactionsElementEcRecovered> for EthPooledTransaction {
     fn from(tx: PooledTransactionsElementEcRecovered) -> Self {
         let encoded_length = tx.encode_2718_len();
-        let (tx, signer) = tx.to_components();
+        let (tx, signer) = tx.into_parts();
         match tx {
             PooledTransaction::Eip4844(tx) => {
                 // include the blob sidecar
                 let (tx, sig, hash) = tx.into_parts();
                 let (tx, blob) = tx.into_parts();
                 let tx = TransactionSigned::new(tx.into(), sig, hash);
-                let tx = RecoveredTx::from_signed_transaction(tx, signer);
+                let tx = RecoveredTx::new_unchecked(tx, signer);
                 let mut pooled = Self::new(tx, encoded_length);
                 pooled.blob_sidecar = EthBlobTransactionSidecar::Present(blob);
                 pooled
             }
             tx => {
                 // no blob sidecar
-                let tx = RecoveredTx::from_signed_transaction(tx.into(), signer);
+                let tx = RecoveredTx::new_unchecked(tx.into(), signer);
                 Self::new(tx, encoded_length)
             }
         }
@@ -1280,11 +1280,11 @@ impl PoolTransaction for EthPooledTransaction {
     fn try_consensus_into_pooled(
         tx: RecoveredTx<Self::Consensus>,
     ) -> Result<RecoveredTx<Self::Pooled>, Self::TryFromConsensusError> {
-        let (tx, signer) = tx.to_components();
+        let (tx, signer) = tx.into_parts();
         let pooled = tx
             .try_into_pooled()
             .map_err(|_| TryFromRecoveredTransactionError::BlobSidecarMissing)?;
-        Ok(RecoveredTx::from_signed_transaction(pooled, signer))
+        Ok(RecoveredTx::new_unchecked(pooled, signer))
     }
 
     /// Returns hash of the transaction.
@@ -1427,7 +1427,7 @@ impl EthPoolTransaction for EthPooledTransaction {
         tx: RecoveredTx<Self::Consensus>,
         sidecar: BlobTransactionSidecar,
     ) -> Option<Self> {
-        let (tx, signer) = tx.to_components();
+        let (tx, signer) = tx.into_parts();
         tx.try_into_pooled_eip4844(sidecar)
             .ok()
             .map(|tx| tx.with_signer(signer))
@@ -1692,7 +1692,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1713,7 +1713,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1734,7 +1734,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1757,7 +1757,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 300);
 
         // Check that the pooled transaction is created correctly
@@ -1780,7 +1780,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly


### PR DESCRIPTION
This is the first part of https://github.com/paradigmxyz/reth/issues/13651 : rename Reth `RecoveredTx`'s methods to match [`alloy::consensus::Recovered's`](https://github.com/alloy-rs/alloy/blob/6979285ca35ec9daedc30ab1ee40174e4a211194/crates/consensus/src/transaction/recovered.rs#L17-L71).