### PR TITLE
feat(primitives): re-export alloy Recovered

### DIFF
--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -60,7 +60,7 @@ impl TryFrom<RecoveredTx<OpTransactionSigned>> for OpPooledTransaction {
     fn try_from(value: RecoveredTx<OpTransactionSigned>) -> Result<Self, Self::Error> {
         let (tx, signer) = value.into_parts();
         let pooled: RecoveredTx<op_alloy_consensus::OpPooledTransaction> =
-            RecoveredTx::from_signed_transaction(tx.try_into()?, signer);
+            RecoveredTx::new_unchecked(tx.try_into()?, signer);
         Ok(pooled.into())
     }
 }
@@ -84,7 +84,7 @@ impl PoolTransaction for OpPooledTransaction {
         tx: RecoveredTx<Self::Consensus>,
     ) -> Result<RecoveredTx<Self::Pooled>, Self::TryFromConsensusError> {
         let (tx, signer) = tx.into_parts();
-        Ok(RecoveredTx::from_signed_transaction(tx.try_into()?, signer))
+        Ok(RecoveredTx::new_unchecked(tx.try_into()?, signer))
     }
 
     fn hash(&self) -> &TxHash {
@@ -459,7 +459,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = OpTransactionSigned::new_unhashed(deposit_tx, signature);
-        let signed_recovered = RecoveredTx::from_signed_transaction(signed_tx, signer);
+        let signed_recovered = RecoveredTx::new_unchecked(signed_tx, signer);
         let len = signed_recovered.encode_2718_len();
         let pooled_tx = OpPooledTransaction::new(signed_recovered, len);
         let outcome = validator.validate_one(origin, pooled_tx);

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -67,7 +67,7 @@ impl OpPayloadTransactions for CustomTxPriority {
             ..Default::default()
         };
         let signature = sender.sign_transaction_sync(&mut end_of_block_tx).unwrap();
-        let end_of_block_tx = RecoveredTx::from_signed_transaction(
+        let end_of_block_tx = RecoveredTx::new_unchecked(
             OpTransactionSigned::new_unhashed(
                 OpTypedTransaction::Eip1559(end_of_block_tx),
                 signature,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -44,13 +44,13 @@ pub use reth_primitives_traits::{
 pub use static_file::StaticFileSegment;
 
 pub use alloy_consensus::{
-    transaction::{PooledTransaction, TransactionMeta},
+    transaction::{PooledTransaction, Recovered as RecoveredTx, TransactionMeta},
     ReceiptWithBloom,
 };
 pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
-    InvalidTransactionError, PooledTransactionsElementEcRecovered, RecoveredTx, Transaction,
-    TransactionSigned, TransactionSignedEcRecovered, TxType,
+    InvalidTransactionError, PooledTransactionsElementEcRecovered, Transaction, TransactionSigned,
+    TransactionSignedEcRecovered, TxType,
 };
 
 // Re-exports

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1803,7 +1803,7 @@ where
 mod tests {
     use crate::{
         transaction::{TxEip1559, TxKind, TxLegacy},
-        RecoveredTx, Transaction, TransactionSigned,
+        Transaction, TransactionSigned,
     };
     use alloy_consensus::Transaction as _;
     use alloy_eips::eip2718::{Decodable2718, Encodable2718};
@@ -2054,17 +2054,6 @@ mod tests {
 
         let encoded = decoded.encoded_2718();
         assert_eq!(encoded, input);
-    }
-
-    #[test]
-    fn test_decode_signed_ec_recovered_transaction() {
-        // random tx: <https://etherscan.io/getRawTx?tx=0x9448608d36e721ef403c53b00546068a6474d6cbab6816c3926de449898e7bce>
-        let input = hex!("02f871018302a90f808504890aef60826b6c94ddf4c5025d1a5742cf12f74eec246d4432c295e487e09c3bbcc12b2b80c080a0f21a4eacd0bf8fea9c5105c543be5a1d8c796516875710fafafdf16d16d8ee23a001280915021bb446d1973501a67f93d2b38894a514b976e7b46dc2fe54598d76");
-        let tx = TransactionSigned::decode(&mut &input[..]).unwrap();
-        let recovered = tx.into_ecrecovered().unwrap();
-
-        let decoded = RecoveredTx::decode(&mut &alloy_rlp::encode(&recovered)[..]).unwrap();
-        assert_eq!(recovered, decoded)
     }
 
     #[test]

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -1,50 +1,12 @@
 //! Defines the types for blob transactions, legacy, and other EIP-2718 transactions included in a
 //! response to `GetPooledTransactions`.
 
-use crate::{RecoveredTx, TransactionSigned};
+use crate::RecoveredTx;
 use alloy_consensus::transaction::PooledTransaction;
-use alloy_eips::eip4844::BlobTransactionSidecar;
-use reth_primitives_traits::transaction::error::TransactionConversionError;
 
+// TODO: remove this foreign type
 /// A signed pooled transaction with recovered signer.
 pub type PooledTransactionsElementEcRecovered<T = PooledTransaction> = RecoveredTx<T>;
-
-impl PooledTransactionsElementEcRecovered {
-    /// Transform back to [`RecoveredTx`]
-    pub fn into_ecrecovered_transaction(self) -> RecoveredTx<TransactionSigned> {
-        let (tx, signer) = self.into_parts();
-        RecoveredTx::from_signed_transaction(tx.into(), signer)
-    }
-
-    /// Converts from an EIP-4844 [`RecoveredTx`] to a
-    /// [`PooledTransactionsElementEcRecovered`] with the given sidecar.
-    ///
-    /// Returns the transaction is not an EIP-4844 transaction.
-    pub fn try_from_blob_transaction(
-        tx: RecoveredTx<TransactionSigned>,
-        sidecar: BlobTransactionSidecar,
-    ) -> Result<Self, RecoveredTx<TransactionSigned>> {
-        let RecoveredTx { signer, signed_transaction } = tx;
-        let transaction = signed_transaction
-            .try_into_pooled_eip4844(sidecar)
-            .map_err(|tx| RecoveredTx { signer, signed_transaction: tx })?;
-        Ok(Self::from_signed_transaction(transaction, signer))
-    }
-}
-
-/// Converts a `Recovered` into a `PooledTransactionsElementEcRecovered`.
-impl TryFrom<RecoveredTx<TransactionSigned>> for PooledTransactionsElementEcRecovered {
-    type Error = TransactionConversionError;
-
-    fn try_from(tx: RecoveredTx<TransactionSigned>) -> Result<Self, Self::Error> {
-        match PooledTransaction::try_from(tx.signed_transaction) {
-            Ok(pooled_transaction) => {
-                Ok(Self::from_signed_transaction(pooled_transaction, tx.signer))
-            }
-            Err(_) => Err(TransactionConversionError::UnsupportedForP2P),
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1047,7 +1047,10 @@ impl TryFrom<RecoveredTx<TransactionSigned>> for MockTransaction {
 
 impl From<PooledTransactionsElementEcRecovered> for MockTransaction {
     fn from(tx: PooledTransactionsElementEcRecovered) -> Self {
-        Self::from_pooled(tx)
+        let (tx, signer) = tx.into_parts();
+        RecoveredTx::<TransactionSigned>::new_unchecked(tx.into(), signer).try_into().expect(
+            "Failed to convert from PooledTransactionsElementEcRecovered to MockTransaction",
+        )
     }
 }
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1056,7 +1056,7 @@ impl From<MockTransaction> for RecoveredTx<TransactionSigned> {
         let signed_tx =
             TransactionSigned::new(tx.clone().into(), Signature::test_signature(), *tx.hash());
 
-        Self::from_signed_transaction(signed_tx, tx.sender())
+        Self::new_unchecked(signed_tx, tx.sender())
     }
 }
 
@@ -1178,7 +1178,7 @@ impl proptest::arbitrary::Arbitrary for MockTransaction {
 
         arb::<(TransactionSigned, Address)>()
             .prop_map(|(signed_transaction, signer)| {
-                RecoveredTx::from_signed_transaction(signed_transaction, signer)
+                RecoveredTx::new_unchecked(signed_transaction, signer)
                     .try_into()
                     .expect("Failed to create an Arbitrary MockTransaction via RecoveredTx")
             })

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1047,9 +1047,7 @@ impl TryFrom<RecoveredTx<TransactionSigned>> for MockTransaction {
 
 impl From<PooledTransactionsElementEcRecovered> for MockTransaction {
     fn from(tx: PooledTransactionsElementEcRecovered) -> Self {
-        tx.into_ecrecovered_transaction().try_into().expect(
-            "Failed to convert from PooledTransactionsElementEcRecovered to MockTransaction",
-        )
+        Self::from_pooled(tx)
     }
 }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1252,14 +1252,14 @@ impl From<PooledTransactionsElementEcRecovered> for EthPooledTransaction {
                 let (tx, sig, hash) = tx.into_parts();
                 let (tx, blob) = tx.into_parts();
                 let tx = TransactionSigned::new(tx.into(), sig, hash);
-                let tx = RecoveredTx::from_signed_transaction(tx, signer);
+                let tx = RecoveredTx::new_unchecked(tx, signer);
                 let mut pooled = Self::new(tx, encoded_length);
                 pooled.blob_sidecar = EthBlobTransactionSidecar::Present(blob);
                 pooled
             }
             tx => {
                 // no blob sidecar
-                let tx = RecoveredTx::from_signed_transaction(tx.into(), signer);
+                let tx = RecoveredTx::new_unchecked(tx.into(), signer);
                 Self::new(tx, encoded_length)
             }
         }
@@ -1284,7 +1284,7 @@ impl PoolTransaction for EthPooledTransaction {
         let pooled = tx
             .try_into_pooled()
             .map_err(|_| TryFromRecoveredTransactionError::BlobSidecarMissing)?;
-        Ok(RecoveredTx::from_signed_transaction(pooled, signer))
+        Ok(RecoveredTx::new_unchecked(pooled, signer))
     }
 
     /// Returns hash of the transaction.
@@ -1692,7 +1692,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1713,7 +1713,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1734,7 +1734,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly
@@ -1757,7 +1757,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 300);
 
         // Check that the pooled transaction is created correctly
@@ -1780,7 +1780,7 @@ mod tests {
         });
         let signature = Signature::test_signature();
         let signed_tx = TransactionSigned::new_unhashed(tx, signature);
-        let transaction = RecoveredTx::from_signed_transaction(signed_tx, Default::default());
+        let transaction = RecoveredTx::new_unchecked(signed_tx, Default::default());
         let pooled_tx = EthPooledTransaction::new(transaction.clone(), 200);
 
         // Check that the pooled transaction is created correctly

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1416,11 +1416,11 @@ impl EthPoolTransaction for EthPooledTransaction {
         self,
         sidecar: Arc<BlobTransactionSidecar>,
     ) -> Option<RecoveredTx<Self::Pooled>> {
-        PooledTransactionsElementEcRecovered::try_from_blob_transaction(
-            self.into_consensus(),
-            Arc::unwrap_or_clone(sidecar),
-        )
-        .ok()
+        let (signed_transaction, signer) = self.into_consensus().into_parts();
+        let pooled_transaction =
+            signed_transaction.try_into_pooled_eip4844(Arc::unwrap_or_clone(sidecar)).ok()?;
+
+        Some(RecoveredTx::new_unchecked(pooled_transaction, signer))
     }
 
     fn try_from_eip4844(


### PR DESCRIPTION
The second part of https://github.com/paradigmxyz/reth/issues/13651

1. [9659c68](https://github.com/paradigmxyz/reth/pull/13670/commits/9659c683b2715109ca69660b81478b0a336dc1be) removes reth `RecoveredTx`
2. [808cb97](https://github.com/paradigmxyz/reth/pull/13670/commits/808cb9715fd3d0906777987e0e9ea36e2505502f) re-exports `alloy::consensus::Recovered as RecoveredTx`, in order to replace the reth `RecoveredTx`
3. [4b944ae](https://github.com/paradigmxyz/reth/pull/13670/commits/4b944aee0b77071558b8787e1ba3c072d2bf069f) fix the Rust complication error cannot define inherent `impl` for foreign type
4. [77f476a](https://github.com/paradigmxyz/reth/pull/13670/commits/77f476a4856523458b63bb70302e8138b4019be2) fix clippy warnings

Note that I didn't impl the step "remove extension trait and integrate these functions in SignedTransaction directly", because I didn't see the reason to do that.