### PR TITLE
Discussion draft: change DB Writer to take value references

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -287,7 +287,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                 let provider_rw = provider_factory.provider_rw()?;
                 provider_rw.append_blocks_with_state(
                     Vec::from([block_with_senders]),
-                    execution_outcome,
+                    &execution_outcome,
                     hashed_post_state.into_sorted(),
                     trie_updates,
                 )?;

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -177,7 +177,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                 .map_err(|_| BlockValidationError::SenderRecoveryError)?,
         )?;
         provider_rw.write_state(
-            execution_outcome,
+            &execution_outcome,
             OriginalValuesKnown::No,
             StorageLocation::Database,
         )?;

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -169,7 +169,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             let execution_outcome = executor.finalize();
 
             provider_rw.write_state(
-                execution_outcome,
+                &execution_outcome,
                 OriginalValuesKnown::Yes,
                 StorageLocation::Database,
             )?;

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1260,7 +1260,7 @@ where
         provider_rw
             .append_blocks_with_state(
                 blocks.into_blocks().collect(),
-                state,
+                &state,
                 hashed_state_sorted,
                 trie_updates,
             )

--- a/crates/exex/exex/src/backfill/test_utils.rs
+++ b/crates/exex/exex/src/backfill/test_utils.rs
@@ -80,7 +80,7 @@ where
     let block = block.clone().seal_slow();
     provider_rw.append_blocks_with_state(
         vec![block],
-        execution_outcome,
+        &execution_outcome,
         Default::default(),
         Default::default(),
     )?;
@@ -214,7 +214,7 @@ where
     let provider_rw = provider_factory.provider_rw()?;
     provider_rw.append_blocks_with_state(
         vec![block1.clone(), block2.clone()],
-        execution_outcome.clone(),
+        &execution_outcome,
         Default::default(),
         Default::default(),
     )?;

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -223,7 +223,7 @@ where
 
         // finally, write the receipts
         provider.write_state(
-            execution_outcome,
+            &execution_outcome,
             OriginalValuesKnown::Yes,
             StorageLocation::StaticFiles,
         )?;

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -125,7 +125,7 @@ where
                         cursor.delete_current()?;
                         // Upsert will replace the last shard for this sharded key with
                         // the previous value.
-                        cursor.upsert(RawKey::new(key), prev_value)?;
+                        cursor.upsert(RawKey::new(key), &prev_value)?;
                         Ok(PruneShardOutcome::Updated)
                     }
                     // If there's no previous shard for this sharded key,
@@ -151,7 +151,7 @@ where
         } else {
             cursor.upsert(
                 RawKey::new(key),
-                RawValue::new(BlockNumberList::new_pre_sorted(higher_blocks)),
+                &RawValue::new(BlockNumberList::new_pre_sorted(higher_blocks)),
             )?;
             Ok(PruneShardOutcome::Updated)
         }

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -442,7 +442,7 @@ where
         let time = Instant::now();
 
         // write output
-        provider.write_state(state, OriginalValuesKnown::Yes, StorageLocation::StaticFiles)?;
+        provider.write_state(&state, OriginalValuesKnown::Yes, StorageLocation::StaticFiles)?;
 
         let db_write_duration = time.elapsed();
         debug!(

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -202,7 +202,7 @@ where
 
                 let (key, value) = item?;
                 hashed_account_cursor
-                    .append(RawKey::<B256>::from_vec(key), RawValue::<Account>::from_vec(value))?;
+                    .append(RawKey::<B256>::from_vec(key), &RawValue::<Account>::from_vec(value))?;
             }
         } else {
             // Aggregate all transition changesets and make a list of accounts that have been

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -100,7 +100,7 @@ impl AccountHashingStage {
                 provider.tx_ref().cursor_write::<tables::PlainAccountState>()?;
             accounts.sort_by(|a, b| a.0.cmp(&b.0));
             for (addr, acc) in &accounts {
-                account_cursor.append(*addr, *acc)?;
+                account_cursor.append(*addr, acc)?;
             }
 
             let mut acc_changeset_cursor =
@@ -113,7 +113,7 @@ impl AccountHashingStage {
                     bytecode_hash: None,
                 };
                 let acc_before_tx = AccountBeforeTx { address: *addr, info: Some(prev_acc) };
-                acc_changeset_cursor.append(t, acc_before_tx)?;
+                acc_changeset_cursor.append(t, &acc_before_tx)?;
             }
         }
 

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -533,7 +533,7 @@ mod tests {
                     }
 
                     if !entry.value.is_zero() {
-                        storage_cursor.upsert(bn_address.address(), entry)?;
+                        storage_cursor.upsert(bn_address.address(), &entry)?;
                     }
                 }
                 Ok(())

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -184,7 +184,7 @@ where
             if first_sync {
                 cursor_header_numbers.append(
                     RawKey::<BlockHash>::from_vec(hash),
-                    RawValue::<BlockNumber>::from_vec(number),
+                    &RawValue::<BlockNumber>::from_vec(number),
                 )?;
             } else {
                 cursor_header_numbers.insert(

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -189,7 +189,7 @@ where
             } else {
                 cursor_header_numbers.insert(
                     RawKey::<BlockHash>::from_vec(hash),
-                    RawValue::<BlockNumber>::from_vec(number),
+                    &RawValue::<BlockNumber>::from_vec(number),
                 )?;
             }
         }

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -660,7 +660,7 @@ mod tests {
         provider
             .append_blocks_with_state(
                 sealed_blocks,
-                ExecutionOutcome::default(),
+                &ExecutionOutcome::default(),
                 HashedPostStateSorted::default(),
                 TrieUpdates::default(),
             )

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -648,7 +648,7 @@ mod tests {
 
                             if !value.is_zero() {
                                 let storage_entry = StorageEntry { key: hashed_slot, value };
-                                storage_cursor.upsert(hashed_address, storage_entry).unwrap();
+                                storage_cursor.upsert(hashed_address, &storage_entry).unwrap();
                             }
                         }
                     }

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -357,7 +357,7 @@ mod tests {
     {
         let provider_rw = db.factory.provider_rw().unwrap();
         let mut cursor = provider_rw.tx_ref().cursor_write::<T>().unwrap();
-        cursor.insert(key, Default::default()).unwrap();
+        cursor.insert(key, &Default::default()).unwrap();
         provider_rw.commit().unwrap();
 
         assert!(matches!(

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -207,7 +207,7 @@ where
                     }
                 }
             };
-            senders_cursor.append(tx_id, sender)?;
+            senders_cursor.append(tx_id, &sender)?;
             processed_transactions += 1;
         }
     }

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -164,7 +164,7 @@ where
 
                     let key = RawKey::<TxHash>::from_vec(hash);
                     if append_only {
-                        txhash_cursor.append(key, RawValue::<TxNumber>::from_vec(number))?
+                        txhash_cursor.append(key, &RawValue::<TxNumber>::from_vec(number))?
                     } else {
                         txhash_cursor.insert(key, RawValue::<TxNumber>::from_vec(number))?
                     }

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -166,7 +166,7 @@ where
                     if append_only {
                         txhash_cursor.append(key, &RawValue::<TxNumber>::from_vec(number))?
                     } else {
-                        txhash_cursor.insert(key, RawValue::<TxNumber>::from_vec(number))?
+                        txhash_cursor.insert(key, &RawValue::<TxNumber>::from_vec(number))?
                     }
                 }
 

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -224,7 +224,7 @@ where
                 let value = BlockNumberList::new_pre_sorted(chunk);
 
                 if append_only {
-                    cursor.append(key, value)?;
+                    cursor.append(key, &value)?;
                 } else {
                     cursor.upsert(key, value)?;
                 }

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -226,7 +226,7 @@ where
                 if append_only {
                     cursor.append(key, &value)?;
                 } else {
-                    cursor.upsert(key, value)?;
+                    cursor.upsert(key, &value)?;
                 }
             }
         }

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -396,7 +396,7 @@ impl TestStageDB {
                     {
                         cursor.delete_current()?;
                     }
-                    cursor.upsert(address, entry)?;
+                    cursor.upsert(address, &entry)?;
 
                     let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>()?;
                     if cursor
@@ -406,7 +406,7 @@ impl TestStageDB {
                     {
                         cursor.delete_current()?;
                     }
-                    cursor.upsert(hashed_address, hashed_entry)?;
+                    cursor.upsert(hashed_address, &hashed_entry)?;
 
                     Ok(())
                 })

--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -104,11 +104,11 @@ pub trait DbDupCursorRO<T: DupSort> {
 pub trait DbCursorRW<T: Table> {
     /// Database operation that will update an existing row if a specified value already
     /// exists in a table, and insert a new row if the specified value doesn't already exist
-    fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+    fn upsert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
 
     /// Database operation that will insert a row at a given key. If the key is already
     /// present, the operation will result in an error.
-    fn insert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+    fn insert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
 
     /// Append value to next cursor item.
     ///

--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -114,7 +114,7 @@ pub trait DbCursorRW<T: Table> {
     ///
     /// This is efficient for pre-sorted data. If the data is not pre-sorted, use
     /// [`DbCursorRW::insert`].
-    fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+    fn append(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
 
     /// Delete current value that cursor points to
     fn delete_current(&mut self) -> Result<(), DatabaseError>;

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -220,7 +220,7 @@ impl<T: Table> DbCursorRW<T> for CursorMock {
     fn upsert(
         &mut self,
         _key: <T as Table>::Key,
-        _value: <T as Table>::Value,
+        _value: &<T as Table>::Value,
     ) -> Result<(), DatabaseError> {
         Ok(())
     }
@@ -228,7 +228,7 @@ impl<T: Table> DbCursorRW<T> for CursorMock {
     fn insert(
         &mut self,
         _key: <T as Table>::Key,
-        _value: <T as Table>::Value,
+        _value: &<T as Table>::Value,
     ) -> Result<(), DatabaseError> {
         Ok(())
     }

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -236,7 +236,7 @@ impl<T: Table> DbCursorRW<T> for CursorMock {
     fn append(
         &mut self,
         _key: <T as Table>::Key,
-        _value: <T as Table>::Value,
+        _value: &<T as Table>::Value,
     ) -> Result<(), DatabaseError> {
         Ok(())
     }

--- a/crates/storage/db-api/src/models/integer_list.rs
+++ b/crates/storage/db-api/src/models/integer_list.rs
@@ -165,7 +165,7 @@ impl Compress for IntegerList {
         self.to_bytes()
     }
 
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         self.to_mut_bytes(buf)
     }
 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -194,8 +194,8 @@ macro_rules! impl_compression_for_compact {
             impl$(<$($generic: core::fmt::Debug + Send + Sync + Compact),*>)? Compress for $name$(<$($generic),*>)? {
                 type Compressed = Vec<u8>;
 
-                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
-                    let _ = Compact::to_compact(&self, buf);
+                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
+                    let _ = Compact::to_compact(self, buf);
                 }
             }
 
@@ -253,8 +253,8 @@ macro_rules! impl_compression_fixed_compact {
                     Some(self.as_ref())
                 }
 
-                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
-                    let _  = Compact::to_compact(&self, buf);
+                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
+                    let _  = Compact::to_compact(self, buf);
                 }
             }
 

--- a/crates/storage/db-api/src/scale.rs
+++ b/crates/storage/db-api/src/scale.rs
@@ -21,7 +21,7 @@ where
         parity_scale_codec::Encode::encode(&self)
     }
 
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         parity_scale_codec::Encode::encode_to(&self, OutputCompat::wrap_mut(buf));
     }
 }

--- a/crates/storage/db-api/src/table.rs
+++ b/crates/storage/db-api/src/table.rs
@@ -32,7 +32,7 @@ pub trait Compress: Send + Sync + Sized + Debug {
     }
 
     /// Compresses data to a given buffer.
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B);
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B);
 }
 
 /// Trait that will transform the data to be read from the DB.
@@ -132,7 +132,7 @@ pub trait TableImporter: DbTxMut {
 
         for kv in source_tx.cursor_read::<T>()?.walk(None)? {
             let (k, v) = kv?;
-            destination_cursor.append(k, v)?;
+            destination_cursor.append(k, &v)?;
         }
 
         Ok(())
@@ -157,7 +157,7 @@ pub trait TableImporter: DbTxMut {
         };
         for row in source_range? {
             let (key, value) = row?;
-            destination_cursor.append(key, value)?;
+            destination_cursor.append(key, &value)?;
         }
 
         Ok(())

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -252,7 +252,11 @@ where
         Vec::new(),
     );
 
-    provider.write_state(execution_outcome, OriginalValuesKnown::Yes, StorageLocation::Database)?;
+    provider.write_state(
+        &execution_outcome,
+        OriginalValuesKnown::Yes,
+        StorageLocation::Database,
+    )?;
 
     trace!(target: "reth::cli", "Inserted state");
 

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -137,7 +137,7 @@ where
                 let tx = db.tx_mut().expect("tx");
                 let mut crsr = tx.cursor_write::<T>().expect("cursor");
                 for (k, _, v, _) in input {
-                    crsr.append(k, v).expect("submit");
+                    crsr.append(k, &v).expect("submit");
                 }
                 tx.inner.commit().unwrap()
             },
@@ -157,7 +157,7 @@ where
                 let mut crsr = tx.cursor_write::<T>().expect("cursor");
                 for index in RANDOM_INDEXES {
                     let (k, _, v, _) = input.get(index).unwrap().clone();
-                    crsr.insert(k, v).expect("submit");
+                    crsr.insert(k, &v).expect("submit");
                 }
 
                 tx.inner.commit().unwrap()

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -184,7 +184,7 @@ where
         let mut crsr = tx.cursor_write::<T>().expect("cursor");
         black_box({
             for (k, v) in input {
-                crsr.append(k, v).expect("submit");
+                crsr.append(k, &v).expect("submit");
             }
 
             tx.inner.commit().unwrap()
@@ -202,7 +202,7 @@ where
         let mut crsr = tx.cursor_write::<T>().expect("cursor");
         black_box({
             for (k, v) in input {
-                crsr.insert(k, v).expect("submit");
+                crsr.insert(k, &v).expect("submit");
             }
 
             tx.inner.commit().unwrap()

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -287,7 +287,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
 
     /// Appends the data to the end of the table. Consequently, the append operation
     /// will fail if the inserted key is less than the last table key
-    fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+    fn append(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         let value = compress_to_buf_or_ref!(self, value);
         self.execute_with_operation_metric(

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -241,7 +241,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
     /// it will append the value to the subkey, even if the subkeys are the same. So if you want
     /// to properly upsert, you'll need to `seek_exact` & `delete_current` if the key+subkey was
     /// found, before calling `upsert`.
-    fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+    fn upsert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         let value = compress_to_buf_or_ref!(self, value);
         self.execute_with_operation_metric(
@@ -263,7 +263,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
         )
     }
 
-    fn insert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+    fn insert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         let value = compress_to_buf_or_ref!(self, value);
         self.execute_with_operation_metric(

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -580,8 +580,8 @@ mod tests {
         let entry_0 = StorageEntry { key: B256::with_last_byte(1), value: U256::from(0) };
         let entry_1 = StorageEntry { key: B256::with_last_byte(1), value: U256::from(1) };
 
-        dup_cursor.upsert(Address::with_last_byte(1), entry_0).expect(ERROR_UPSERT);
-        dup_cursor.upsert(Address::with_last_byte(1), entry_1).expect(ERROR_UPSERT);
+        dup_cursor.upsert(Address::with_last_byte(1), &entry_0).expect(ERROR_UPSERT);
+        dup_cursor.upsert(Address::with_last_byte(1), &entry_1).expect(ERROR_UPSERT);
 
         assert_eq!(
             dup_cursor.walk(None).unwrap().collect::<Result<Vec<_>, _>>(),
@@ -910,12 +910,12 @@ mod tests {
         let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
 
         // INSERT
-        assert_eq!(cursor.insert(key_to_insert, B256::ZERO), Ok(()));
+        assert_eq!(cursor.insert(key_to_insert, &B256::ZERO), Ok(()));
         assert_eq!(cursor.current(), Ok(Some((key_to_insert, B256::ZERO))));
 
         // INSERT (failure)
         assert_eq!(
-            cursor.insert(key_to_insert, B256::ZERO),
+            cursor.insert(key_to_insert, &B256::ZERO),
             Err(DatabaseWriteError {
                 info: Error::KeyExist.into(),
                 operation: DatabaseWriteOperation::CursorInsert,
@@ -947,11 +947,11 @@ mod tests {
         let subkey2 = B256::random();
 
         let entry1 = StorageEntry { key: subkey1, value: U256::ZERO };
-        assert!(dup_cursor.insert(key, entry1).is_ok());
+        assert!(dup_cursor.insert(key, &entry1).is_ok());
 
         // Can't insert
         let entry2 = StorageEntry { key: subkey2, value: U256::ZERO };
-        assert!(dup_cursor.insert(key, entry2).is_err());
+        assert!(dup_cursor.insert(key, &entry2).is_err());
     }
 
     #[test]
@@ -964,9 +964,9 @@ mod tests {
         let key3 = Address::with_last_byte(3);
         let mut cursor = tx.cursor_write::<PlainAccountState>().unwrap();
 
-        assert!(cursor.insert(key1, Account::default()).is_ok());
-        assert!(cursor.insert(key2, Account::default()).is_ok());
-        assert!(cursor.insert(key3, Account::default()).is_ok());
+        assert!(cursor.insert(key1, &Account::default()).is_ok());
+        assert!(cursor.insert(key2, &Account::default()).is_ok());
+        assert!(cursor.insert(key3, &Account::default()).is_ok());
 
         // Seek & delete key2
         cursor.seek_exact(key2).unwrap();
@@ -1002,7 +1002,7 @@ mod tests {
         assert_eq!(cursor.current(), Ok(Some((9, B256::ZERO))));
 
         for pos in (2..=8).step_by(2) {
-            assert_eq!(cursor.insert(pos, B256::ZERO), Ok(()));
+            assert_eq!(cursor.insert(pos, &B256::ZERO), Ok(()));
             assert_eq!(cursor.current(), Ok(Some((pos, B256::ZERO))));
         }
         tx.commit().expect(ERROR_COMMIT);
@@ -1031,7 +1031,7 @@ mod tests {
         let key_to_append = 5;
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
-        assert_eq!(cursor.append(key_to_append, B256::ZERO), Ok(()));
+        assert_eq!(cursor.append(key_to_append, &B256::ZERO), Ok(()));
         tx.commit().expect(ERROR_COMMIT);
 
         // Confirm the result
@@ -1059,7 +1059,7 @@ mod tests {
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
         assert_eq!(
-            cursor.append(key_to_append, B256::ZERO),
+            cursor.append(key_to_append, &B256::ZERO),
             Err(DatabaseWriteError {
                 info: Error::KeyMismatch.into(),
                 operation: DatabaseWriteOperation::CursorAppend,
@@ -1088,15 +1088,15 @@ mod tests {
         let key = Address::random();
 
         let account = Account::default();
-        cursor.upsert(key, account).expect(ERROR_UPSERT);
+        cursor.upsert(key, &account).expect(ERROR_UPSERT);
         assert_eq!(cursor.seek_exact(key), Ok(Some((key, account))));
 
         let account = Account { nonce: 1, ..Default::default() };
-        cursor.upsert(key, account).expect(ERROR_UPSERT);
+        cursor.upsert(key, &account).expect(ERROR_UPSERT);
         assert_eq!(cursor.seek_exact(key), Ok(Some((key, account))));
 
         let account = Account { nonce: 2, ..Default::default() };
-        cursor.upsert(key, account).expect(ERROR_UPSERT);
+        cursor.upsert(key, &account).expect(ERROR_UPSERT);
         assert_eq!(cursor.seek_exact(key), Ok(Some((key, account))));
 
         let mut dup_cursor = tx.cursor_dup_write::<PlainStorageState>().unwrap();
@@ -1104,12 +1104,12 @@ mod tests {
 
         let value = U256::from(1);
         let entry1 = StorageEntry { key: subkey, value };
-        dup_cursor.upsert(key, entry1).expect(ERROR_UPSERT);
+        dup_cursor.upsert(key, &entry1).expect(ERROR_UPSERT);
         assert_eq!(dup_cursor.seek_by_key_subkey(key, subkey), Ok(Some(entry1)));
 
         let value = U256::from(2);
         let entry2 = StorageEntry { key: subkey, value };
-        dup_cursor.upsert(key, entry2).expect(ERROR_UPSERT);
+        dup_cursor.upsert(key, &entry2).expect(ERROR_UPSERT);
         assert_eq!(dup_cursor.seek_by_key_subkey(key, subkey), Ok(Some(entry1)));
         assert_eq!(dup_cursor.next_dup_val(), Ok(Some(entry2)));
     }
@@ -1127,7 +1127,7 @@ mod tests {
             .try_for_each(|val| {
                 cursor.append(
                     transition_id,
-                    AccountBeforeTx { address: Address::with_last_byte(val), info: None },
+                    &AccountBeforeTx { address: Address::with_last_byte(val), info: None },
                 )
             })
             .expect(ERROR_APPEND);
@@ -1153,7 +1153,7 @@ mod tests {
         assert_eq!(
             cursor.append(
                 transition_id - 1,
-                AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
+                &AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
             ),
             Err(DatabaseWriteError {
                 info: Error::KeyMismatch.into(),
@@ -1166,7 +1166,7 @@ mod tests {
         assert_eq!(
             cursor.append(
                 transition_id,
-                AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
+                &AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
             ),
             Ok(())
         );

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -479,7 +479,7 @@ impl DatabaseEnv {
         if Some(&version) != last_version.as_ref() {
             version_cursor.upsert(
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs(),
-                version,
+                &version,
             )?;
             tx.commit()?;
         }

--- a/crates/storage/db/src/tables/raw.rs
+++ b/crates/storage/db/src/tables/raw.rs
@@ -168,7 +168,7 @@ impl<V: Value> Compress for RawValue<V> {
         self.value
     }
 
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(self, buf: &mut B) {
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         buf.put_slice(self.value.as_slice())
     }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1823,7 +1823,7 @@ mod tests {
                 .into_iter()
                 .map(|b| b.seal_with_senders().expect("failed to seal block with senders"))
                 .collect(),
-            ExecutionOutcome {
+            &ExecutionOutcome {
                 bundle: BundleState::new(
                     database_state.into_iter().map(|(address, (account, _))| {
                         (address, None, Some(account.into()), Default::default())

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1749,7 +1749,7 @@ mod tests {
                 .into_iter()
                 .map(|b| b.seal_with_senders().expect("failed to seal block with senders"))
                 .collect(),
-            ExecutionOutcome {
+            &ExecutionOutcome {
                 bundle: BundleState::new(
                     database_state.into_iter().map(|(address, (account, _))| {
                         (address, None, Some(account.into()), Default::default())

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1808,11 +1808,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 .map(|(_, indices)| indices.first_tx_num())
                 .ok_or(ProviderError::BlockBodyIndicesNotFound(block_number))?;
 
-            for (idx, receipt) in receipts.into_iter().enumerate() {
+            for (idx, receipt) in receipts.iter().enumerate() {
                 let receipt_idx = first_tx_index + idx as u64;
                 if let Some(receipt) = receipt {
                     if let Some(writer) = &mut receipts_static_writer {
-                        writer.append_receipt(receipt_idx, &receipt)?;
+                        writer.append_receipt(receipt_idx, receipt)?;
                     }
 
                     if let Some(cursor) = &mut receipts_cursor {
@@ -2892,7 +2892,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
                     writer.append_transaction(next_tx_num, transaction)?;
                 }
                 if let Some(cursor) = tx_cursor.as_mut() {
-                    cursor.append(next_tx_num, &transaction)?;
+                    cursor.append(next_tx_num, transaction)?;
                 }
 
                 // Increment transaction id for each transaction.

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -133,7 +133,7 @@ pub trait BlockWriter: Send + Sync {
     fn append_blocks_with_state(
         &self,
         blocks: Vec<SealedBlockWithSenders<Self::Block>>,
-        execution_outcome: ExecutionOutcome<Self::Receipt>,
+        execution_outcome: &ExecutionOutcome<Self::Receipt>,
         hashed_state: HashedPostStateSorted,
         trie_updates: TrieUpdates,
     ) -> ProviderResult<()>;

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -18,7 +18,7 @@ pub trait StateWriter {
     /// `Some`. It should be `None` if there is any kind of pruning/filtering over the receipts.
     fn write_state(
         &self,
-        execution_outcome: ExecutionOutcome<Self::Receipt>,
+        execution_outcome: &ExecutionOutcome<Self::Receipt>,
         is_value_known: OriginalValuesKnown,
         write_receipts_to: StorageLocation,
     ) -> ProviderResult<()>;

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -169,7 +169,7 @@ where
             // Write state and changesets to the database.
             // Must be written after blocks because of the receipt lookup.
             self.database().write_state(
-                Arc::unwrap_or_clone(execution_output),
+                &execution_output,
                 OriginalValuesKnown::No,
                 StorageLocation::StaticFiles,
             )?;

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -273,10 +273,13 @@ mod tests {
             for address in addresses {
                 let hashed_address = keccak256(address);
                 accounts_cursor
-                    .insert(hashed_address, Account { nonce: 1, ..Default::default() })
+                    .insert(hashed_address, &Account { nonce: 1, ..Default::default() })
                     .unwrap();
                 storage_cursor
-                    .insert(hashed_address, StorageEntry { key: hashed_slot, value: U256::from(1) })
+                    .insert(
+                        hashed_address,
+                        &StorageEntry { key: hashed_slot, value: U256::from(1) },
+                    )
                     .unwrap();
             }
             provider_rw.commit().unwrap();
@@ -496,7 +499,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(state.take_bundle(), Receipts::default(), 1, Vec::new());
         provider
-            .write_state(outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
             .expect("Could not write bundle state to DB");
 
         // Check plain storage state
@@ -596,7 +599,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(state.take_bundle(), Receipts::default(), 2, Vec::new());
         provider
-            .write_state(outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
             .expect("Could not write bundle state to DB");
 
         assert_eq!(
@@ -663,7 +666,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Receipts::default(), 0, Vec::new());
         provider
-            .write_state(outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -811,7 +814,7 @@ mod tests {
         let outcome: ExecutionOutcome =
             ExecutionOutcome::new(bundle, Receipts::default(), 1, Vec::new());
         provider
-            .write_state(outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider
@@ -976,7 +979,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Receipts::default(), 0, Vec::new());
         provider
-            .write_state(outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -1023,7 +1026,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(state.take_bundle(), Receipts::default(), 1, Vec::new());
         provider
-            .write_state(outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StorageLocation::Database)
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -108,14 +108,14 @@ where
 
             // Write ommers if any
             if !body.ommers.is_empty() {
-                ommers_cursor.append(block_number, StoredBlockOmmers { ommers: body.ommers })?;
+                ommers_cursor.append(block_number, &StoredBlockOmmers { ommers: body.ommers })?;
             }
 
             // Write withdrawals if any
             if let Some(withdrawals) = body.withdrawals {
                 if !withdrawals.is_empty() {
                     withdrawals_cursor
-                        .append(block_number, StoredBlockWithdrawals { withdrawals })?;
+                        .append(block_number, &StoredBlockWithdrawals { withdrawals })?;
                 }
             }
         }

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -158,7 +158,7 @@ where
             if let Some(node) = maybe_updated {
                 self.cursor.upsert(
                     self.hashed_address,
-                    StorageTrieEntry { nibbles, node: node.clone() },
+                    &StorageTrieEntry { nibbles, node: node.clone() },
                 )?;
             }
         }

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -229,7 +229,7 @@ mod tests {
             cursor
                 .upsert(
                     key.into(),
-                    BranchNodeCompact::new(
+                    &BranchNodeCompact::new(
                         0b0000_0010_0000_0001,
                         0b0000_0010_0000_0001,
                         0,
@@ -264,7 +264,7 @@ mod tests {
         let value = BranchNodeCompact::new(1, 1, 1, vec![B256::random()], None);
 
         cursor
-            .upsert(hashed_address, StorageTrieEntry { nibbles: key.clone(), node: value.clone() })
+            .upsert(hashed_address, &StorageTrieEntry { nibbles: key.clone(), node: value.clone() })
             .unwrap();
 
         let mut cursor = DatabaseStorageTrieCursor::new(cursor, hashed_address);

--- a/crates/trie/db/tests/fuzz_in_memory_nodes.rs
+++ b/crates/trie/db/tests/fuzz_in_memory_nodes.rs
@@ -31,7 +31,7 @@ proptest! {
 
         // Insert init state into database
         for (hashed_address, balance) in init_state.clone() {
-            hashed_account_cursor.upsert(hashed_address, Account { balance, ..Default::default() }).unwrap();
+            hashed_account_cursor.upsert(hashed_address, &Account { balance, ..Default::default() }).unwrap();
         }
 
         // Compute initial root and updates
@@ -46,7 +46,7 @@ proptest! {
             for (hashed_address, balance) in state_update {
                 if let Some(balance) = balance {
                     let account = Account { balance, ..Default::default() };
-                    hashed_account_cursor.upsert(hashed_address, account).unwrap();
+                    hashed_account_cursor.upsert(hashed_address, &account).unwrap();
                     hashed_state.accounts.insert(hashed_address, Some(account));
                     state.insert(hashed_address, balance);
                 } else {
@@ -85,7 +85,7 @@ proptest! {
         // Insert init state into database
         for (hashed_slot, value) in init_storage.clone() {
             hashed_storage_cursor
-                .upsert(hashed_address, StorageEntry { key: hashed_slot, value })
+                .upsert(hashed_address, &StorageEntry { key: hashed_slot, value })
                 .unwrap();
         }
 
@@ -102,7 +102,7 @@ proptest! {
             let mut hashed_storage = HashedStorage::new(is_deleted);
             for (hashed_slot, value) in storage_update.clone() {
                 hashed_storage_cursor
-                    .upsert(hashed_address, StorageEntry { key: hashed_slot, value })
+                    .upsert(hashed_address, &StorageEntry { key: hashed_slot, value })
                     .unwrap();
                 hashed_storage.storage.insert(hashed_slot, value);
             }

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -57,7 +57,7 @@ fn incremental_vs_full_root(inputs: &[&str], modified: &str) {
     let data = inputs.iter().map(|x| B256::from_str(x).unwrap());
     let value = U256::from(0);
     for key in data {
-        hashed_storage_cursor.upsert(hashed_address, StorageEntry { key, value }).unwrap();
+        hashed_storage_cursor.upsert(hashed_address, &StorageEntry { key, value }).unwrap();
     }
 
     // Generate the intermediate nodes on the receiving end of the channel
@@ -71,7 +71,7 @@ fn incremental_vs_full_root(inputs: &[&str], modified: &str) {
         hashed_storage_cursor.delete_current().unwrap();
     }
     hashed_storage_cursor
-        .upsert(hashed_address, StorageEntry { key: modified_key, value })
+        .upsert(hashed_address, &StorageEntry { key: modified_key, value })
         .unwrap();
 
     // 2. Calculate full merkle root
@@ -313,7 +313,7 @@ fn storage_root_regression() {
     let mut hashed_storage_cursor =
         tx.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
     for (hashed_slot, value) in storage.clone() {
-        hashed_storage_cursor.upsert(key3, StorageEntry { key: hashed_slot, value }).unwrap();
+        hashed_storage_cursor.upsert(key3, &StorageEntry { key: hashed_slot, value }).unwrap();
     }
     tx.commit().unwrap();
     let tx = factory.provider_rw().unwrap();
@@ -349,7 +349,7 @@ fn account_and_storage_trie() {
     let key1 =
         B256::from_str("b000000000000000000000000000000000000000000000000000000000000000").unwrap();
     let account1 = Account { nonce: 0, balance: U256::from(3).mul(ether), bytecode_hash: None };
-    hashed_account_cursor.upsert(key1, account1).unwrap();
+    hashed_account_cursor.upsert(key1, &account1).unwrap();
     hash_builder.add_leaf(Nibbles::unpack(key1), &encode_account(account1, None));
 
     // Some address whose hash starts with 0xB040
@@ -358,7 +358,7 @@ fn account_and_storage_trie() {
     assert_eq!(key2[0], 0xB0);
     assert_eq!(key2[1], 0x40);
     let account2 = Account { nonce: 0, balance: ether, ..Default::default() };
-    hashed_account_cursor.upsert(key2, account2).unwrap();
+    hashed_account_cursor.upsert(key2, &account2).unwrap();
     hash_builder.add_leaf(Nibbles::unpack(key2), &encode_account(account2, None));
 
     // Some address whose hash starts with 0xB041
@@ -370,7 +370,7 @@ fn account_and_storage_trie() {
         B256::from_str("5be74cad16203c4905c068b012a2e9fb6d19d036c410f16fd177f337541440dd").unwrap();
     let account3 =
         Account { nonce: 0, balance: U256::from(2).mul(ether), bytecode_hash: Some(code_hash) };
-    hashed_account_cursor.upsert(key3, account3).unwrap();
+    hashed_account_cursor.upsert(key3, &account3).unwrap();
     for (hashed_slot, value) in storage {
         if hashed_storage_cursor
             .seek_by_key_subkey(key3, hashed_slot)
@@ -380,7 +380,7 @@ fn account_and_storage_trie() {
         {
             hashed_storage_cursor.delete_current().unwrap();
         }
-        hashed_storage_cursor.upsert(key3, StorageEntry { key: hashed_slot, value }).unwrap();
+        hashed_storage_cursor.upsert(key3, &StorageEntry { key: hashed_slot, value }).unwrap();
     }
     let account3_storage_root = StorageRoot::from_tx(tx.tx_ref(), address3).root().unwrap();
     hash_builder
@@ -389,19 +389,19 @@ fn account_and_storage_trie() {
     let key4a =
         B256::from_str("B1A0000000000000000000000000000000000000000000000000000000000000").unwrap();
     let account4a = Account { nonce: 0, balance: U256::from(4).mul(ether), ..Default::default() };
-    hashed_account_cursor.upsert(key4a, account4a).unwrap();
+    hashed_account_cursor.upsert(key4a, &account4a).unwrap();
     hash_builder.add_leaf(Nibbles::unpack(key4a), &encode_account(account4a, None));
 
     let key5 =
         B256::from_str("B310000000000000000000000000000000000000000000000000000000000000").unwrap();
     let account5 = Account { nonce: 0, balance: U256::from(8).mul(ether), ..Default::default() };
-    hashed_account_cursor.upsert(key5, account5).unwrap();
+    hashed_account_cursor.upsert(key5, &account5).unwrap();
     hash_builder.add_leaf(Nibbles::unpack(key5), &encode_account(account5, None));
 
     let key6 =
         B256::from_str("B340000000000000000000000000000000000000000000000000000000000000").unwrap();
     let account6 = Account { nonce: 0, balance: U256::from(1).mul(ether), ..Default::default() };
-    hashed_account_cursor.upsert(key6, account6).unwrap();
+    hashed_account_cursor.upsert(key6, &account6).unwrap();
     hash_builder.add_leaf(Nibbles::unpack(key6), &encode_account(account6, None));
 
     // Populate account & storage trie DB tables
@@ -452,7 +452,7 @@ fn account_and_storage_trie() {
     let key4b = keccak256(address4b);
     assert_eq!(key4b.0[0], key4a.0[0]);
     let account4b = Account { nonce: 0, balance: U256::from(5).mul(ether), bytecode_hash: None };
-    hashed_account_cursor.upsert(key4b, account4b).unwrap();
+    hashed_account_cursor.upsert(key4b, &account4b).unwrap();
 
     let mut prefix_set = PrefixSetMut::default();
     prefix_set.insert(Nibbles::unpack(key4b));
@@ -649,7 +649,7 @@ proptest! {
             let should_generate_changeset = !state.is_empty();
             let mut changes = PrefixSetMut::default();
             for (hashed_address, balance) in accounts.clone() {
-                hashed_account_cursor.upsert(hashed_address, Account { balance, ..Default::default() }).unwrap();
+                hashed_account_cursor.upsert(hashed_address, &Account { balance, ..Default::default() }).unwrap();
                 if should_generate_changeset {
                     changes.insert(Nibbles::unpack(hashed_address));
                 }
@@ -703,7 +703,9 @@ fn extension_node_storage_trie<N: ProviderNodeTypes>(
         hex!("30af8f0000000000000000000000000000000000000000000000000000000000"),
         hex!("3100000000000000000000000000000000000000000000000000000000000000"),
     ] {
-        hashed_storage.upsert(hashed_address, StorageEntry { key: B256::new(key), value }).unwrap();
+        hashed_storage
+            .upsert(hashed_address, &StorageEntry { key: B256::new(key), value })
+            .unwrap();
         hb.add_leaf(Nibbles::unpack(key), &alloy_rlp::encode_fixed_size(&value));
     }
 
@@ -730,7 +732,7 @@ fn extension_node_trie<N: ProviderNodeTypes>(
         hex!("30af8f0000000000000000000000000000000000000000000000000000000000"),
         hex!("3100000000000000000000000000000000000000000000000000000000000000"),
     ] {
-        hashed_accounts.upsert(B256::new(key), a).unwrap();
+        hashed_accounts.upsert(B256::new(key), &a).unwrap();
         hb.add_leaf(Nibbles::unpack(key), &val);
     }
 

--- a/crates/trie/db/tests/walker.rs
+++ b/crates/trie/db/tests/walker.rs
@@ -38,7 +38,7 @@ fn walk_nodes_with_common_prefix() {
 
     let mut account_cursor = tx.tx_ref().cursor_write::<tables::AccountsTrie>().unwrap();
     for (k, v) in &inputs {
-        account_cursor.upsert(k.clone().into(), v.clone()).unwrap();
+        account_cursor.upsert(k.clone().into(), &v.clone()).unwrap();
     }
     let account_trie = DatabaseAccountTrieCursor::new(account_cursor);
     test_cursor(account_trie, &expected);
@@ -47,7 +47,10 @@ fn walk_nodes_with_common_prefix() {
     let mut storage_cursor = tx.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
     for (k, v) in &inputs {
         storage_cursor
-            .upsert(hashed_address, StorageTrieEntry { nibbles: k.clone().into(), node: v.clone() })
+            .upsert(
+                hashed_address,
+                &StorageTrieEntry { nibbles: k.clone().into(), node: v.clone() },
+            )
             .unwrap();
     }
     let storage_trie = DatabaseStorageTrieCursor::new(storage_cursor, hashed_address);
@@ -106,7 +109,7 @@ fn cursor_rootnode_with_changesets() {
 
     let hashed_address = B256::random();
     for (k, v) in nodes {
-        cursor.upsert(hashed_address, StorageTrieEntry { nibbles: k.into(), node: v }).unwrap();
+        cursor.upsert(hashed_address, &StorageTrieEntry { nibbles: k.into(), node: v }).unwrap();
     }
 
     let mut trie = DatabaseStorageTrieCursor::new(cursor, hashed_address);

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -114,10 +114,10 @@ fn correctly_decodes_branch_node_values() {
     let mut hashed_storage_cursor =
         provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
     hashed_storage_cursor
-        .upsert(hashed_address, StorageEntry { key: hashed_slot1, value: U256::from(1) })
+        .upsert(hashed_address, &StorageEntry { key: hashed_slot1, value: U256::from(1) })
         .unwrap();
     hashed_storage_cursor
-        .upsert(hashed_address, StorageEntry { key: hashed_slot2, value: U256::from(1) })
+        .upsert(hashed_address, &StorageEntry { key: hashed_slot2, value: U256::from(1) })
         .unwrap();
 
     let state_root = StateRoot::from_tx(provider.tx_ref()).root().unwrap();


### PR DESCRIPTION
Includes the following changes:
- Changes `insert`, `upsert` and `append` to take a `&T::Value` instead of `T::Value`. 
- Deletes unnecessary clones
- example of benefit: Changes `StateWriter` to not take ownership of (potentially large?) `ExecutionOutcome`

