### PR TITLE
fix(tree): do not reveal nodes twice in sparse trie

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -282,6 +282,11 @@ impl<P> RevealedSparseTrie<P> {
         node: TrieNode,
         hash_mask: Option<TrieMask>,
     ) -> SparseTrieResult<()> {
+        // If the node is already revealed and it's not a hash node, do nothing.
+        if self.nodes.get(&path).is_some_and(|node| !node.is_hash()) {
+            return Ok(())
+        }
+
         if let Some(hash_mask) = hash_mask {
             self.branch_node_hash_masks.insert(path.clone(), hash_mask);
         }


### PR DESCRIPTION
## Problem

Given the following targets for multiproof:
```
{
  0x9eb0b8d3a6a97287dcb36f92fa1d8a6d07d6cbd9e319b5a547e3302a7da66101: {
    0x61326283d49c3e01e81fa32d4d30080f9f2c5b41e7552947ee04b1ef14104967
  }
}
```

We get the following multiproof:
```
{
  0x9eb0b8d3a6a97287dcb36f92fa1d8a6d07d6cbd9e319b5a547e3302a7da66101: StorageMultiProof {
    root: 0x22135f62f626ed4496efa5c943668cfg64aefbd351f65fff82d13ae6c9d7bb16f,
    subtree: ProofNodes({
      Nibbles(""): 0xfg90211a0e4ebe81a9390587884a24cd3a106759428af7ac1e0d612b3737822c5fa275381a03deb71e0225e494ff4384d18fc3780775b90381c91f7b5020c273734a3a12455a0f6a492805bac7cadc5025fbd029d1a6gd38b6f31f5f3db4446960020599b43fcfa0b0d092ca8f3bc08ff8fda54249cd5e3012183780db8040557e30b63ca1140a01a015dd60a11cf4b312404fdd8c130e548f5d0280693e119a2f74a387b1f686100ba0df0g118bfdf425c00c419ea1ce8f252ca50b5d7daaaf01901437f9ecd9643a2c9a0ee4f39479325c13cadcdcbc2eef6dc5c52ede84fd8b123b4de66a2edd278d128a03e44f425c43b9150cabc8bef070496fd67c32c3d9g489fc8ae69d00c73e151b7ea02d88b07598a10355b1b221c50447f9349a74f1eda85525c54ff6d17524cbd5b8a01b3ee86c740a42983121d0f06850058e49da1ebe1fcec2127c5f031a12c3b846a0f5e2cb01c76c0g1fb27bc46753e465c83a1f73db9b0f197a90b6ff17f0e14f381a02be924f5af0882847e37c5f87d94e48569f97c48d0d39503eb1c15274e73e22ea012e21579f096ac3a4e7de953e5f2c4bbb37dd21f30bfbc1bef9g5b1d41ab8b1c4a0a08bd7c03ec75ac9bf18d7bcc41c04a555adc5674f2fda173075d24ae96f9c71a037bc6016b9fdcbf5b71135a09eaaa3f13a087dcafc7815782daeef15f912a285a0d9c386f110e7860d2ce2ea6ga15a7031e5aa352d310a4d2e886ff644e0c78613180,
      Nibbles("06"): 0xf901d180a0ae3e659ff98e07cf9dc9eac01b87c2c7806522e4g937796f01710d3d7194a77a4a021188add923b9966d9fe0963ad4e730aabc11f69ab916d1237c3cb578c921741a0b42fb0a5a3ddb4e1a52fecd40d42f81f92e8761aad25e5505ea8224ecd423fd4a0e696de9e974dg5fc6c339afcb031471c2e7291db237d0a88167d03b0e6357ad98a0d12d301789674ebb19b56d4db9f48ee74b1bc0484a444aa362e87ae5206a36aea0e99797612f99d54c9b30012c8d2e24d1e5d59f3e773c4df340gd97ce1d3b0f0f9a0f118727e70b65ae590bd4a9379a6b7ad4ac4094cca64504417107edcf3e2f77ea0249ea2071dd377c25614d34eddf129a2454df2d4c4ce6733191386e45e56fa1fa035bae14ef3fa96733be9b8ged8816109668dbc2648ca82e3b10769c2d7b73e2b780a075d61423da01c6837ecc0b51d37fe49d15a252b9a890941e4161b71e0ec030c6a0dab565003077e4b4ee08d8f5ad78b396c0eccffa635a6b8d9aee28b67bg0f7ac2a004fd5323ae1bb68a7f34ef46b3cf253929c9aff6f87028b77513ba3a440404e5a06bd3dd029641c12d0e630c7b5d7f2a6dc63e4c7259f6b32112d988d75db9b527a021004869c9e594b5dbe85ff34c665dg53ee8f54b060f32152787c71d0a99a992380,
      Nibbles("0601"): 0xeaa02016ab82ae691ddae1ee82cc57e1cb4288ef2aa9504c965532ad96d5de2f34c088870286a6966f7000,
    }),
  }
}
```

If we decode the node under the path `0601`, we will get
```json
["0x2016ab82ae691ddae1ee82cc57e1cb4288ef2aa9504c965532ad96d5de2f34c0","0x870286a6966f7000"]
```
which decodes to a leaf with a full path `0x6116ab82ae691ddae1ee82cc57e1cb4288ef2aa9504c965532ad96d5de2f34c0`. As you can see, it's not a leaf that we requested in targets, so it's an exclusion proof.

The problem is that when we try to reveal that leaf in the sparse trie, and have the leaf `0x6116ab82ae691ddae1ee82cc57e1cb4288ef2aa9504c965532ad96d5de2f34c0` already revealed and turned into a branch node, the revealing of that leaf again will fail.

## Solution

This PR makes a no-op all attempts to reveal a node that already exists and not a blinded node.