### PR TITLE
chore: use secp fns directly

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -332,9 +332,8 @@ mod tests {
         BasicBlockExecutorProvider, BatchExecutor, BlockExecutorProvider, Executor,
     };
     use reth_execution_types::BlockExecutionOutput;
-    use reth_primitives::{
-        public_key_to_address, Account, Block, BlockBody, BlockExt, Transaction,
-    };
+    use reth_primitives::{Account, Block, BlockBody, BlockExt, Transaction};
+    use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
     use reth_revm::{
         database::StateProviderDatabase, test_utils::StateProviderTest, TransitionState,
     };

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -227,8 +227,6 @@ impl<E, P> From<BackfillJob<E, P>> for SingleBlockBackfillJob<E, P> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use crate::{
         backfill::test_utils::{blocks_and_execution_outputs, chain_spec, to_execution_outcome},
         BackfillJobFactory,
@@ -236,12 +234,13 @@ mod tests {
     use reth_blockchain_tree::noop::NoopBlockchainTree;
     use reth_db_common::init::init_genesis;
     use reth_evm_ethereum::execute::EthExecutorProvider;
-    use reth_primitives::public_key_to_address;
+    use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
     use reth_provider::{
         providers::BlockchainProvider, test_utils::create_test_provider_factory_with_chain_spec,
     };
     use reth_testing_utils::generators;
     use secp256k1::Keypair;
+    use std::sync::Arc;
 
     #[test]
     fn test_backfill() -> eyre::Result<()> {

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -235,8 +235,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use crate::{
         backfill::test_utils::{
             blocks_and_execution_outcome, blocks_and_execution_outputs, chain_spec,
@@ -247,13 +245,14 @@ mod tests {
     use reth_blockchain_tree::noop::NoopBlockchainTree;
     use reth_db_common::init::init_genesis;
     use reth_evm_ethereum::execute::EthExecutorProvider;
-    use reth_primitives::public_key_to_address;
+    use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
     use reth_provider::{
         providers::BlockchainProvider, test_utils::create_test_provider_factory_with_chain_spec,
     };
     use reth_stages_api::ExecutionStageThresholds;
     use reth_testing_utils::generators;
     use secp256k1::Keypair;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_single_blocks() -> eyre::Result<()> {

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -26,7 +26,7 @@ use op_alloy_consensus::{OpPooledTransaction, OpTypedTransaction, TxDeposit};
 #[cfg(any(test, feature = "reth-codec"))]
 use proptest as _;
 use reth_primitives_traits::{
-    crypto::secp256k1::{recover_signer, recover_signer_unchecked},
+    crypto::secp256k1::{recover_signer, recover_signer_unchecked, sign_message},
     transaction::error::TransactionConversionError,
     InMemorySize, SignedTransaction,
 };
@@ -519,7 +519,7 @@ impl<'a> arbitrary::Arbitrary<'a> for OpTransactionSigned {
 
         let secp = secp256k1::Secp256k1::new();
         let key_pair = secp256k1::Keypair::new(&secp, &mut rand::thread_rng());
-        let signature = reth_primitives::transaction::util::secp256k1::sign_message(
+        let signature = sign_message(
             B256::from_slice(&key_pair.secret_bytes()[..]),
             signature_hash(&transaction),
         )

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1497,7 +1497,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
 
         let secp = secp256k1::Secp256k1::new();
         let key_pair = secp256k1::Keypair::new(&secp, &mut rand::thread_rng());
-        let signature = crate::sign_message(
+        let signature = reth_primitives_traits::crypto::secp256k1::sign_message(
             B256::from_slice(&key_pair.secret_bytes()[..]),
             transaction.signature_hash(),
         )

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -4,7 +4,8 @@ use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, eip2930
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use rand::Rng;
 use reth_chainspec::MAINNET;
-use reth_primitives::{sign_message, Transaction, TransactionSigned};
+use reth_primitives::{Transaction, TransactionSigned};
+use reth_primitives_traits::crypto::secp256k1::sign_message;
 
 /// A generator for transactions for testing purposes.
 #[derive(Debug)]

--- a/testing/testing-utils/Cargo.toml
+++ b/testing/testing-utils/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 reth-primitives = { workspace = true, features = ["secp256k1", "arbitrary"] }
+reth-primitives-traits = { workspace = true, features = ["secp256k1", "arbitrary"] }
 
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -12,9 +12,11 @@ use rand::{
     distributions::uniform::SampleRange, rngs::StdRng, seq::SliceRandom, thread_rng, SeedableRng,
 };
 use reth_primitives::{
-    proofs, sign_message, Account, BlockBody, Log, Receipt, SealedBlock, SealedHeader,
-    StorageEntry, Transaction, TransactionSigned,
+    proofs, Account, BlockBody, Log, Receipt, SealedBlock, SealedHeader, StorageEntry, Transaction,
+    TransactionSigned,
 };
+
+use reth_primitives_traits::crypto::secp256k1::sign_message;
 use secp256k1::{Keypair, Secp256k1};
 use std::{
     cmp::{max, min},
@@ -469,8 +471,10 @@ mod tests {
     use alloy_consensus::TxEip1559;
     use alloy_eips::eip2930::AccessList;
     use alloy_primitives::{hex, PrimitiveSignature as Signature};
-    use reth_primitives::public_key_to_address;
-    use reth_primitives_traits::SignedTransaction;
+    use reth_primitives_traits::{
+        crypto::secp256k1::{public_key_to_address, sign_message},
+        SignedTransaction,
+    };
     use std::str::FromStr;
 
     #[test]

--- a/testing/testing-utils/src/genesis_allocator.rs
+++ b/testing/testing-utils/src/genesis_allocator.rs
@@ -3,7 +3,7 @@
 
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, Bytes, B256, U256};
-use reth_primitives::public_key_to_address;
+use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
 use secp256k1::{
     rand::{thread_rng, RngCore},
     Keypair, Secp256k1,


### PR DESCRIPTION
use secp fns from reth-primitives-traits 

but keeps the re-export for now, this way we can phase out reth-primitives more easily