### PR TITLE
chore: remove optimism feature from execution-types tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7704,6 +7704,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "rand 0.8.5",
+ "reth-ethereum-primitives",
  "reth-execution-errors",
  "reth-primitives",
  "reth-primitives-traits",

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -32,6 +32,7 @@ arbitrary.workspace = true
 bincode.workspace = true
 rand.workspace = true
 reth-primitives = { workspace = true, features = ["arbitrary", "test-utils"] }
+reth-ethereum-primitives.workspace = true
 
 [features]
 default = ["std"]
@@ -65,5 +66,6 @@ std = [
 	"reth-primitives-traits/std",
 	"alloy-consensus/std",
 	"serde_with?/std",
-	"reth-trie-common?/std"
+	"reth-trie-common?/std",
+    "reth-ethereum-primitives/std"
 ]

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -694,8 +694,25 @@ pub(super) mod serde_bincode_compat {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
+    use alloy_consensus::TxType;
+    use alloy_primitives::{Address, B256};
+    use reth_ethereum_primitives::Receipt;
+    use reth_primitives::Receipts;
     use revm::primitives::{AccountInfo, HashMap};
+
+    // TODO: this is temporary, until we fully switch over to `reth_ethereum_primitives` for the
+    // `Receipt` type in `EthPrimitives`.
+    #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    #[non_exhaustive]
+    struct TestPrimitives;
+
+    impl reth_primitives_traits::NodePrimitives for TestPrimitives {
+        type Block = reth_primitives::Block;
+        type BlockHeader = alloy_consensus::Header;
+        type BlockBody = reth_primitives::BlockBody;
+        type SignedTx = reth_primitives::TransactionSigned;
+        type Receipt = Receipt;
+    }
 
     #[test]
     fn chain_append() {
@@ -828,10 +845,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn receipts_by_block_hash() {
-        use reth_primitives::{Receipt, Receipts, TxType};
-
         // Create a default SealedBlockWithSenders object
         let block: SealedBlockWithSenders = Default::default();
 
@@ -878,7 +892,7 @@ mod tests {
 
         // Create a Chain object with a BTreeMap of blocks mapped to their block numbers,
         // including block1_hash and block2_hash, and the execution_outcome
-        let chain: Chain = Chain {
+        let chain: Chain<TestPrimitives> = Chain {
             blocks: BTreeMap::from([(10, block1), (11, block2)]),
             execution_outcome: execution_outcome.clone(),
             ..Default::default()

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -381,17 +381,11 @@ impl<T> From<(BlockExecutionOutput<T>, BlockNumber)> for ExecutionOutcome<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(feature = "optimism"))]
-    use alloy_primitives::bytes;
-    #[cfg(not(feature = "optimism"))]
-    use alloy_primitives::LogData;
-    use alloy_primitives::{Address, B256};
+    use alloy_consensus::TxType;
+    use alloy_primitives::{bytes, Address, LogData, B256};
     use reth_primitives::Receipts;
-    #[cfg(not(feature = "optimism"))]
-    use reth_primitives::TxType;
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_initialisation() {
         // Create a new BundleState object with initial data
         let bundle = BundleState::new(
@@ -402,7 +396,7 @@ mod tests {
 
         // Create a Receipts object with a vector of receipt vectors
         let receipts = Receipts {
-            receipt_vec: vec![vec![Some(reth_primitives::Receipt {
+            receipt_vec: vec![vec![Some(reth_ethereum_primitives::Receipt {
                 tx_type: TxType::Legacy,
                 cumulative_gas_used: 46913,
                 logs: vec![],
@@ -460,11 +454,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_block_number_to_index() {
         // Create a Receipts object with a vector of receipt vectors
         let receipts = Receipts {
-            receipt_vec: vec![vec![Some(reth_primitives::Receipt {
+            receipt_vec: vec![vec![Some(reth_ethereum_primitives::Receipt {
                 tx_type: TxType::Legacy,
                 cumulative_gas_used: 46913,
                 logs: vec![],
@@ -495,11 +488,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_get_logs() {
         // Create a Receipts object with a vector of receipt vectors
         let receipts = Receipts {
-            receipt_vec: vec![vec![Some(reth_primitives::Receipt {
+            receipt_vec: vec![vec![Some(reth_ethereum_primitives::Receipt {
                 tx_type: TxType::Legacy,
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
@@ -527,11 +519,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_receipts_by_block() {
         // Create a Receipts object with a vector of receipt vectors
         let receipts = Receipts {
-            receipt_vec: vec![vec![Some(reth_primitives::Receipt {
+            receipt_vec: vec![vec![Some(reth_ethereum_primitives::Receipt {
                 tx_type: TxType::Legacy,
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
@@ -557,7 +548,7 @@ mod tests {
         // Assert that the receipts for block number 123 match the expected receipts
         assert_eq!(
             receipts_by_block,
-            vec![&Some(reth_primitives::Receipt {
+            vec![&Some(reth_ethereum_primitives::Receipt {
                 tx_type: TxType::Legacy,
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
@@ -567,11 +558,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_receipts_len() {
         // Create a Receipts object with a vector of receipt vectors
         let receipts = Receipts {
-            receipt_vec: vec![vec![Some(reth_primitives::Receipt {
+            receipt_vec: vec![vec![Some(reth_ethereum_primitives::Receipt {
                 tx_type: TxType::Legacy,
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
@@ -616,10 +606,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_revert_to() {
         // Create a random receipt object
-        let receipt = reth_primitives::Receipt {
+        let receipt = reth_ethereum_primitives::Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 46913,
             logs: vec![],
@@ -665,10 +654,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_extend_execution_outcome() {
         // Create a Receipt object with specific attributes.
-        let receipt = reth_primitives::Receipt {
+        let receipt = reth_ethereum_primitives::Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 46913,
             logs: vec![],
@@ -709,10 +697,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "optimism"))]
     fn test_split_at_execution_outcome() {
         // Create a random receipt object
-        let receipt = reth_primitives::Receipt {
+        let receipt = reth_ethereum_primitives::Receipt {
             tx_type: TxType::Legacy,
             cumulative_gas_used: 46913,
             logs: vec![],


### PR DESCRIPTION
Previously we were using `reth_primitives::Receipt` for these tests, and receipt init would require us to feature gate the test. This removes the optimism feature flags on the tests, by using `reth_eth_primitives::Receipt` in tests, also creating `TestPrimitives` just for this crate. We can remove it when we start using `reth_eth_primitives::Receipt` in `EthPrimitives`