### PR TITLE
chore: remove duplicated compact consts

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -52,12 +52,6 @@ pub(crate) mod access_list;
 mod pooled;
 mod tx_type;
 
-#[cfg(any(test, feature = "reth-codec"))]
-pub use tx_type::{
-    COMPACT_EXTENDED_IDENTIFIER_FLAG, COMPACT_IDENTIFIER_EIP1559, COMPACT_IDENTIFIER_EIP2930,
-    COMPACT_IDENTIFIER_LEGACY,
-};
-
 /// Expected number of transactions where we can expect a speed-up by recovering the senders in
 /// parallel.
 pub static PARALLEL_SENDER_RECOVERY_THRESHOLD: LazyLock<usize> =

--- a/crates/primitives/src/transaction/tx_type.rs
+++ b/crates/primitives/src/transaction/tx_type.rs
@@ -11,24 +11,6 @@ use derive_more::Display;
 use reth_primitives_traits::InMemorySize;
 use serde::{Deserialize, Serialize};
 
-/// Identifier parameter for legacy transaction
-#[cfg(any(test, feature = "reth-codec"))]
-pub const COMPACT_IDENTIFIER_LEGACY: usize = 0;
-
-/// Identifier parameter for EIP-2930 transaction
-#[cfg(any(test, feature = "reth-codec"))]
-pub const COMPACT_IDENTIFIER_EIP2930: usize = 1;
-
-/// Identifier parameter for EIP-1559 transaction
-#[cfg(any(test, feature = "reth-codec"))]
-pub const COMPACT_IDENTIFIER_EIP1559: usize = 2;
-
-/// For backwards compatibility purposes only 2 bits of the type are encoded in the identifier
-/// parameter. In the case of a [`COMPACT_EXTENDED_IDENTIFIER_FLAG`], the full transaction type is
-/// read from the buffer as a single byte.
-#[cfg(any(test, feature = "reth-codec"))]
-pub const COMPACT_EXTENDED_IDENTIFIER_FLAG: usize = 3;
-
 /// Transaction Type
 ///
 /// Currently being used as 2-bit type when encoding it to `reth_codecs::Compact` on
@@ -256,7 +238,7 @@ impl Decodable for TxType {
 mod tests {
     use super::*;
     use alloy_primitives::hex;
-    use reth_codecs::Compact;
+    use reth_codecs::{txtype::*, Compact};
     use rstest::rstest;
 
     #[rstest]


### PR DESCRIPTION
we can use the ones defined in codecs