### PR TITLE
chore: disable op-consensus,primitives std default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,10 +377,10 @@ reth-optimism-node = { path = "crates/optimism/node" }
 reth-node-types = { path = "crates/node/types" }
 reth-optimism-chainspec = { path = "crates/optimism/chainspec" }
 reth-optimism-cli = { path = "crates/optimism/cli" }
-reth-optimism-consensus = { path = "crates/optimism/consensus" }
+reth-optimism-consensus = { path = "crates/optimism/consensus", default-features = false }
 reth-optimism-forks = { path = "crates/optimism/hardforks", default-features = false }
 reth-optimism-payload-builder = { path = "crates/optimism/payload" }
-reth-optimism-primitives = { path = "crates/optimism/primitives" }
+reth-optimism-primitives = { path = "crates/optimism/primitives", default-features = false }
 reth-optimism-rpc = { path = "crates/optimism/rpc" }
 reth-optimism-storage = { path = "crates/optimism/storage" }
 reth-payload-builder = { path = "crates/payload/builder" }

--- a/crates/optimism/consensus/Cargo.toml
+++ b/crates/optimism/consensus/Cargo.toml
@@ -40,16 +40,17 @@ reth-optimism-chainspec.workspace = true
 [features]
 default = ["std"]
 std = [
-    "reth-chainspec/std",
-    "reth-consensus/std",
-    "reth-primitives/std",
-    "reth-optimism-forks/std",
-    "reth-optimism-chainspec/std",
-    "reth-optimism-primitives/std",
-    "alloy-eips/std",
-    "alloy-primitives/std",
-    "alloy-consensus/std",
-    "alloy-trie/std",
-    "op-alloy-consensus/std",
+	"reth-chainspec/std",
+	"reth-consensus/std",
+	"reth-primitives/std",
+	"reth-optimism-forks/std",
+	"reth-optimism-chainspec/std",
+	"reth-optimism-primitives/std",
+	"alloy-eips/std",
+	"alloy-primitives/std",
+	"alloy-consensus/std",
+	"alloy-trie/std",
+	"op-alloy-consensus/std",
+	"reth-consensus-common/std"
 ]
 optimism = ["reth-primitives/optimism", "reth-optimism-primitives/optimism"]

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -74,7 +74,8 @@ std = [
 	"thiserror/std",
 	"op-alloy-consensus/std",
 	"reth-chainspec/std",
-	"reth-consensus-common/std"
+	"reth-consensus-common/std",
+	"reth-optimism-consensus/std"
 ]
 optimism = [
 	"reth-primitives/optimism",


### PR DESCRIPTION
we can disable these