### PR TITLE
fix(ci): Enable wasm check for `reth-optimism-primitives`

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -94,12 +94,7 @@ for crate in "${crates[@]}"; do
     continue
   fi
 
-  if [ $crate == "reth-optimism-primitives" ]; then
-    cmd="cargo +stable build -p $crate --target wasm32-wasip1 --no-default-features \
-    --features serde"
-  else
-    cmd="cargo +stable build -p $crate --target wasm32-wasip1 --no-default-features"
-  fi
+  cmd="cargo +stable build -p $crate --target wasm32-wasip1 --no-default-features"
 
   if [ -n "$CI" ]; then
     echo "::group::$cmd"

--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -45,7 +45,6 @@ exclude_crates=(
   reth-optimism-node
   reth-optimism-payload-builder
   reth-optimism-rpc
-  reth-optimism-primitives
   reth-rpc
   reth-rpc-api
   reth-rpc-api-testing-util
@@ -95,7 +94,12 @@ for crate in "${crates[@]}"; do
     continue
   fi
 
-  cmd="cargo +stable build -p $crate --target wasm32-wasip1 --no-default-features"
+  if [ $crate == "reth-optimism-primitives" ]; then
+    cmd="cargo +stable build -p $crate --target wasm32-wasip1 --no-default-features \
+    --features serde"
+  else
+    cmd="cargo +stable build -p $crate --target wasm32-wasip1 --no-default-features"
+  fi
 
   if [ -n "$CI" ]; then
     echo "::group::$cmd"


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/13041

Re-enables default feature `serde`, required for wasm check on `reth-optimism-primitives` to pass