### PR TITLE
feat(root): compare trie updates of state root task with regular root

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -26,6 +26,7 @@ use reth_chain_state::{
     CanonicalInMemoryState, ExecutedBlock, MemoryOverlayStateProvider, NewCanonicalChain,
 };
 use reth_consensus::{Consensus, FullConsensus, PostExecutionInput};
+pub use reth_engine_primitives::InvalidBlockHook;
 use reth_engine_primitives::{
     BeaconEngineMessage, BeaconOnNewPayloadError, EngineApiMessageVersion, EngineTypes,
     EngineValidator, ForkchoiceStateTracker, OnForkChoiceUpdated,
@@ -80,12 +81,13 @@ pub mod config;
 mod invalid_block_hook;
 mod metrics;
 mod persistence_state;
+pub mod root;
+mod trie_updates;
+
 pub use config::TreeConfig;
 pub use invalid_block_hook::{InvalidBlockHooks, NoopInvalidBlockHook};
 pub use persistence_state::PersistenceState;
-pub use reth_engine_primitives::InvalidBlockHook;
-
-pub mod root;
+use trie_updates::compare_trie_updates;
 
 /// Keeps track of the state of the tree.
 ///
@@ -2350,6 +2352,19 @@ where
                                 task_elapsed = ?time_from_last_update,
                                 "Task state root finished"
                             );
+
+                            if task_state_root != block.header().state_root() {
+                                debug!(target: "engine::tree", "Task state root does not match block state root");
+                                let (regular_root, regular_updates) =
+                                    state_provider.state_root_with_updates(hashed_state.clone())?;
+
+                                if regular_root == block.header().state_root() {
+                                    compare_trie_updates(&task_trie_updates, &regular_updates);
+                                } else {
+                                    debug!(target: "engine::tree", "Regular state root does not match block state root");
+                                }
+                            }
+
                             (task_state_root, task_trie_updates, time_from_last_update)
                         }
                         Err(error) => {

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -52,6 +52,10 @@ impl StorageTrieDiffEntry {
                 debug!(target: "engine::tree", ?address, ?task, ?regular, "Difference in storage trie existence");
             }
             Self::Value(mut storage_diff) => {
+                if let Some((task, regular)) = storage_diff.is_deleted {
+                    debug!(target: "engine::tree", ?address, ?task, ?regular, "Difference in storage trie deletion");
+                }
+
                 for (path, (task, regular)) in &mut storage_diff.storage_nodes {
                     debug!(target: "engine::tree", ?address, ?path, ?task, ?regular, "Difference in storage trie updates");
                 }

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -41,7 +41,10 @@ impl TrieUpdatesDiff {
 
 #[derive(Debug)]
 enum StorageTrieDiffEntry {
+    /// Storage Trie entry exists for one of the task or regular trie updates, but not the other.
     Existence(bool, bool),
+    /// Storage Trie entries exists for both task and regular trie updates, but their values
+    /// differ.
     Value(StorageTrieUpdatesDiff),
 }
 


### PR DESCRIPTION
Helps to debug the issues in sparse trie by comparing its trie updates to regular root trie updates. Only triggered when the state root from the task doesn't match the header state root.