### PR TITLE
feat: `SparseStateTrie::reveal_witness`

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -304,13 +304,15 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                 }
                 TrieNode::Extension(ext) => {
                     if ext.child.len() == B256::len_bytes() + 1 {
-                        let child_hash = B256::from_slice(&&ext.child[1..]);
+                        let child_hash = B256::from_slice(&ext.child[1..]);
                         let mut child_path = path.clone();
                         child_path.extend_from_slice_unchecked(&ext.key);
                         queue.push_back((child_hash, child_path, maybe_account));
                     }
                 }
                 TrieNode::Leaf(leaf) => {
+                    let mut full_path = path.clone();
+                    full_path.extend_from_slice_unchecked(&leaf.key);
                     if let Some(hashed_address) = maybe_account {
                         // Record storage slot in revealed.
                         let hashed_slot = B256::from_slice(&full_path.pack());
@@ -319,9 +321,6 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                         let hashed_address = B256::from_slice(&full_path.pack());
                         let account = TrieAccount::decode(&mut &leaf.value[..])?;
                         if account.storage_root != EMPTY_ROOT_HASH {
-                            let mut full_path = path.clone();
-                            full_path.extend_from_slice_unchecked(&leaf.key);
-
                             queue.push_back((
                                 account.storage_root,
                                 Nibbles::default(),

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -18,7 +18,7 @@ use reth_trie_common::{
     MultiProof, MultiProofTargets, Nibbles, TrieAccount, TrieNode, EMPTY_ROOT_HASH,
     TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use std::{fmt, iter::Peekable};
+use std::{collections::VecDeque, fmt, iter::Peekable};
 
 /// Sparse state trie representing lazy-loaded Ethereum state trie.
 pub struct SparseStateTrie<F: BlindedProviderFactory = DefaultBlindedProviderFactory> {
@@ -266,6 +266,109 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
 
         for (account, slots) in targets {
             self.revealed.entry(account).or_default().extend(slots);
+        }
+
+        Ok(())
+    }
+
+    /// Reveal state witness with the given state root.
+    /// The state witness is expected to be a map of `keccak(rlp(node)): rlp(node).`
+    /// NOTE: This method does not extensively validate the witness.
+    pub fn reveal_witness(
+        &mut self,
+        state_root: B256,
+        witness: B256HashMap<Bytes>,
+    ) -> SparseStateTrieResult<()> {
+        // Create a `(hash, path, maybe_account)` queue for traversing witness trie nodes
+        // starting from the root node.
+        let mut queue = VecDeque::from([(state_root, Nibbles::default(), None)]);
+
+        while let Some((hash, path, maybe_account)) = queue.pop_front() {
+            // Retrieve the trie node and decode it.
+            let Some(trie_node_bytes) = witness.get(&hash) else { continue };
+            let trie_node = TrieNode::decode(&mut &trie_node_bytes[..])?;
+
+            // Push children nodes into the queue.
+            match &trie_node {
+                TrieNode::Branch(branch) => {
+                    for (idx, maybe_child) in branch.as_ref().children() {
+                        if let Some(child) =
+                            maybe_child.filter(|ch| ch.len() == B256::len_bytes() + 1)
+                        {
+                            let child_hash = B256::from_slice(&child[1..]);
+                            let mut child_path = path.clone();
+                            child_path.push_unchecked(idx);
+                            queue.push_back((child_hash, child_path, maybe_account));
+                        }
+                    }
+                }
+                TrieNode::Extension(ext) => {
+                    if ext.child.len() == B256::len_bytes() + 1 {
+                        let child_hash = B256::from_slice(&&ext.child[1..]);
+                        let mut child_path = path.clone();
+                        child_path.extend_from_slice_unchecked(&ext.key);
+                        queue.push_back((child_hash, child_path, maybe_account));
+                    }
+                }
+                TrieNode::Leaf(leaf) => {
+                    if let Some(hashed_address) = maybe_account {
+                        // Record storage slot in revealed.
+                        let hashed_slot = B256::from_slice(&full_path.pack());
+                        self.revealed.entry(hashed_address).or_default().insert(hashed_slot);
+                    } else {
+                        let hashed_address = B256::from_slice(&full_path.pack());
+                        let account = TrieAccount::decode(&mut &leaf.value[..])?;
+                        if account.storage_root != EMPTY_ROOT_HASH {
+                            let mut full_path = path.clone();
+                            full_path.extend_from_slice_unchecked(&leaf.key);
+
+                            queue.push_back((
+                                account.storage_root,
+                                Nibbles::default(),
+                                Some(hashed_address),
+                            ));
+                        }
+
+                        // Record account in revealed.
+                        self.revealed.entry(hashed_address).or_default();
+                    }
+                }
+                TrieNode::EmptyRoot => {} // nothing to do here
+            };
+
+            // Reveal the node itself.
+            if let Some(account) = maybe_account {
+                let storage_trie_entry = self.storages.entry(account).or_default();
+                if path.is_empty() {
+                    // Handle special storage state root node case.
+                    storage_trie_entry.reveal_root_with_provider(
+                        self.provider_factory.storage_node_provider(account),
+                        trie_node,
+                        None,
+                        self.retain_updates,
+                    )?;
+                } else {
+                    // Reveal non-root storage trie node.
+                    storage_trie_entry
+                        .as_revealed_mut()
+                        .ok_or(SparseTrieErrorKind::Blind)?
+                        .reveal_node(path, trie_node, None)?;
+                }
+            } else if path.is_empty() {
+                // Handle special state root node case.
+                self.state.reveal_root_with_provider(
+                    self.provider_factory.account_node_provider(),
+                    trie_node,
+                    None,
+                    self.retain_updates,
+                )?;
+            } else {
+                // Reveal non-root state trie node.
+                self.state
+                    .as_revealed_mut()
+                    .ok_or(SparseTrieErrorKind::Blind)?
+                    .reveal_node(path, trie_node, None)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Description

Implements `SparseStateTrie::reveal_witness` capable of revealing trie nodes from state witness. 