### PR TITLE
chore: rm blockchaintree dep from engine-tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7195,7 +7195,6 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rayon",
- "reth-blockchain-tree-api",
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [dependencies]
 # reth
-reth-blockchain-tree-api.workspace = true
 reth-chain-state.workspace = true
 reth-chainspec = { workspace = true, optional = true }
 reth-consensus.workspace = true

--- a/crates/engine/tree/src/lib.rs
+++ b/crates/engine/tree/src/lib.rs
@@ -92,9 +92,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-/// Re-export of the blockchain tree API.
-pub use reth_blockchain_tree_api::*;
-
 /// Support for backfill sync mode.
 pub mod backfill;
 /// The type that drives the chain forward.

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -1,0 +1,199 @@
+//! Internal errors for the tree module.
+
+use alloy_consensus::BlockHeader;
+use reth_consensus::ConsensusError;
+use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError};
+use reth_evm::execute::InternalBlockExecutionError;
+use reth_primitives::SealedBlockFor;
+use reth_primitives_traits::{Block, BlockBody};
+use tokio::sync::oneshot::error::TryRecvError;
+
+/// This is an error that can come from advancing persistence. Either this can be a
+/// [`TryRecvError`], or this can be a [`ProviderError`]
+#[derive(Debug, thiserror::Error)]
+pub enum AdvancePersistenceError {
+    /// An error that can be from failing to receive a value from persistence
+    #[error(transparent)]
+    RecvError(#[from] TryRecvError),
+    /// A provider error
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+}
+
+#[derive(thiserror::Error)]
+#[error("Failed to insert block (hash={}, number={}, parent_hash={}): {}",
+    .block.hash(),
+    .block.number(),
+    .block.parent_hash(),
+    .kind)]
+struct InsertBlockErrorDataTwo<B: Block> {
+    block: SealedBlockFor<B>,
+    #[source]
+    kind: InsertBlockErrorKindTwo,
+}
+
+impl<B: Block> std::fmt::Debug for InsertBlockErrorDataTwo<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InsertBlockError")
+            .field("error", &self.kind)
+            .field("hash", &self.block.hash())
+            .field("number", &self.block.number())
+            .field("parent_hash", &self.block.parent_hash())
+            .field("num_txs", &self.block.body().transactions().len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Block> InsertBlockErrorDataTwo<B> {
+    const fn new(block: SealedBlockFor<B>, kind: InsertBlockErrorKindTwo) -> Self {
+        Self { block, kind }
+    }
+
+    fn boxed(block: SealedBlockFor<B>, kind: InsertBlockErrorKindTwo) -> Box<Self> {
+        Box::new(Self::new(block, kind))
+    }
+}
+
+/// Error thrown when inserting a block failed because the block is considered invalid.
+#[derive(thiserror::Error)]
+#[error(transparent)]
+pub struct InsertBlockErrorTwo<B: Block> {
+    inner: Box<InsertBlockErrorDataTwo<B>>,
+}
+
+// === impl InsertBlockErrorTwo ===
+
+impl<B: Block> InsertBlockErrorTwo<B> {
+    /// Create a new `InsertInvalidBlockErrorTwo`
+    pub fn new(block: SealedBlockFor<B>, kind: InsertBlockErrorKindTwo) -> Self {
+        Self { inner: InsertBlockErrorDataTwo::boxed(block, kind) }
+    }
+
+    /// Create a new `InsertInvalidBlockError` from a consensus error
+    pub fn consensus_error(error: ConsensusError, block: SealedBlockFor<B>) -> Self {
+        Self::new(block, InsertBlockErrorKindTwo::Consensus(error))
+    }
+
+    /// Create a new `InsertInvalidBlockError` from a consensus error
+    pub fn sender_recovery_error(block: SealedBlockFor<B>) -> Self {
+        Self::new(block, InsertBlockErrorKindTwo::SenderRecovery)
+    }
+
+    /// Consumes the error and returns the block that resulted in the error
+    #[inline]
+    pub fn into_block(self) -> SealedBlockFor<B> {
+        self.inner.block
+    }
+
+    /// Returns the error kind
+    #[inline]
+    pub const fn kind(&self) -> &InsertBlockErrorKindTwo {
+        &self.inner.kind
+    }
+
+    /// Returns the block that resulted in the error
+    #[inline]
+    pub const fn block(&self) -> &SealedBlockFor<B> {
+        &self.inner.block
+    }
+
+    /// Consumes the type and returns the block and error kind.
+    #[inline]
+    pub fn split(self) -> (SealedBlockFor<B>, InsertBlockErrorKindTwo) {
+        let inner = *self.inner;
+        (inner.block, inner.kind)
+    }
+}
+
+impl<B: Block> std::fmt::Debug for InsertBlockErrorTwo<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+/// All error variants possible when inserting a block
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockErrorKindTwo {
+    /// Failed to recover senders for the block
+    #[error("failed to recover senders for block")]
+    SenderRecovery,
+    /// Block violated consensus rules.
+    #[error(transparent)]
+    Consensus(#[from] ConsensusError),
+    /// Block execution failed.
+    #[error(transparent)]
+    Execution(#[from] BlockExecutionError),
+    /// Provider error.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    /// Other errors.
+    #[error(transparent)]
+    Other(#[from] Box<dyn core::error::Error + Send + Sync + 'static>),
+}
+
+impl InsertBlockErrorKindTwo {
+    /// Returns an [`InsertBlockValidationError`] if the error is caused by an invalid block.
+    ///
+    /// Returns an [`InsertBlockFatalError`] if the error is caused by an error that is not
+    /// validation related or is otherwise fatal.
+    ///
+    /// This is intended to be used to determine if we should respond `INVALID` as a response when
+    /// processing a new block.
+    pub fn ensure_validation_error(
+        self,
+    ) -> Result<InsertBlockValidationError, InsertBlockFatalError> {
+        match self {
+            Self::SenderRecovery => Ok(InsertBlockValidationError::SenderRecovery),
+            Self::Consensus(err) => Ok(InsertBlockValidationError::Consensus(err)),
+            // other execution errors that are considered internal errors
+            Self::Execution(err) => {
+                match err {
+                    BlockExecutionError::Validation(err) => {
+                        Ok(InsertBlockValidationError::Validation(err))
+                    }
+                    BlockExecutionError::Consensus(err) => {
+                        Ok(InsertBlockValidationError::Consensus(err))
+                    }
+                    // these are internal errors, not caused by an invalid block
+                    BlockExecutionError::Internal(error) => {
+                        Err(InsertBlockFatalError::BlockExecutionError(error))
+                    }
+                }
+            }
+            Self::Provider(err) => Err(InsertBlockFatalError::Provider(err)),
+            Self::Other(err) => Err(InternalBlockExecutionError::Other(err).into()),
+        }
+    }
+}
+
+/// Error variants that are not caused by invalid blocks
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockFatalError {
+    /// A provider error
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    /// An internal / fatal block execution error
+    #[error(transparent)]
+    BlockExecutionError(#[from] InternalBlockExecutionError),
+}
+
+/// Error variants that are caused by invalid blocks
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockValidationError {
+    /// Failed to recover senders for the block
+    #[error("failed to recover senders for block")]
+    SenderRecovery,
+    /// Block violated consensus rules.
+    #[error(transparent)]
+    Consensus(#[from] ConsensusError),
+    /// Validation error, transparently wrapping [`BlockValidationError`]
+    #[error(transparent)]
+    Validation(#[from] BlockValidationError),
+}
+
+impl InsertBlockValidationError {
+    /// Returns true if this is a block pre merge error.
+    pub const fn is_block_pre_merge(&self) -> bool {
+        matches!(self, Self::Validation(BlockValidationError::BlockPreMerge { .. }))
+    }
+}


### PR DESCRIPTION
towards https://github.com/paradigmxyz/reth/issues/13701

duplicates the imported types from blockchaintree crate in engine-tree, this duplicates, so we can wipe blockchaintree-api in one go

rename (drop Two suffix) as followup.
