### PR TITLE
chore: add `Hardfork::boxed`

### DIFF
--- a/crates/ethereum-forks/src/hardfork/dev.rs
+++ b/crates/ethereum-forks/src/hardfork/dev.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy as LazyLock;
 #[cfg(feature = "std")]
 use std::sync::LazyLock;
 
-use crate::{ChainHardforks, EthereumHardfork, ForkCondition};
+use crate::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
 
 /// Dev hardforks
 pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {

--- a/crates/ethereum-forks/src/hardfork/macros.rs
+++ b/crates/ethereum-forks/src/hardfork/macros.rs
@@ -17,11 +17,6 @@ macro_rules! hardfork {
                     $( $enum::$variant => stringify!($variant), )*
                 }
             }
-
-            /// Boxes `self` and returns it as `Box<dyn Hardfork>`.
-            pub fn boxed(self) -> Box<dyn Hardfork> {
-                Box::new(self)
-            }
         }
 
         impl FromStr for $enum {

--- a/crates/ethereum-forks/src/hardfork/mod.rs
+++ b/crates/ethereum-forks/src/hardfork/mod.rs
@@ -17,6 +17,11 @@ use dyn_clone::DynClone;
 pub trait Hardfork: Any + DynClone + Send + Sync + 'static {
     /// Fork name.
     fn name(&self) -> &'static str;
+
+    /// Returns boxed value.
+    fn boxed(&self) -> Box<dyn Hardfork + '_> {
+        Box::new(self)
+    }
 }
 
 dyn_clone::clone_trait_object!(Hardfork);

--- a/crates/ethereum-forks/src/hardfork/mod.rs
+++ b/crates/ethereum-forks/src/hardfork/mod.rs
@@ -6,6 +6,7 @@ pub use ethereum::EthereumHardfork;
 mod dev;
 pub use dev::DEV_HARDFORKS;
 
+use alloc::boxed::Box;
 use core::{
     any::Any,
     hash::{Hash, Hasher},

--- a/crates/optimism/chainspec/src/base.rs
+++ b/crates/optimism/chainspec/src/base.rs
@@ -5,7 +5,7 @@ use alloc::{sync::Arc, vec};
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
 use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
-use reth_ethereum_forks::EthereumHardfork;
+use reth_ethereum_forks::{EthereumHardfork, Hardfork};
 use reth_optimism_forks::OpHardfork;
 
 use crate::{LazyLock, OpChainSpec};

--- a/crates/optimism/chainspec/src/base_sepolia.rs
+++ b/crates/optimism/chainspec/src/base_sepolia.rs
@@ -4,7 +4,7 @@ use alloc::{sync::Arc, vec};
 
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_optimism_forks::OpHardfork;
 

--- a/crates/optimism/chainspec/src/op.rs
+++ b/crates/optimism/chainspec/src/op.rs
@@ -4,7 +4,7 @@ use crate::{LazyLock, OpChainSpec};
 use alloc::{sync::Arc, vec};
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_optimism_forks::OpHardfork;
 

--- a/crates/optimism/chainspec/src/op_sepolia.rs
+++ b/crates/optimism/chainspec/src/op_sepolia.rs
@@ -4,7 +4,7 @@ use crate::{LazyLock, OpChainSpec};
 use alloc::{sync::Arc, vec};
 use alloy_chains::{Chain, NamedChain};
 use alloy_primitives::{b256, U256};
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_optimism_forks::OpHardfork;
 

--- a/crates/optimism/hardforks/src/dev.rs
+++ b/crates/optimism/hardforks/src/dev.rs
@@ -1,6 +1,6 @@
 use alloc::vec;
 use alloy_primitives::U256;
-use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
+use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
 
 #[cfg(not(feature = "std"))]
 use once_cell::sync::Lazy as LazyLock;

--- a/crates/optimism/hardforks/src/hardfork.rs
+++ b/crates/optimism/hardforks/src/hardfork.rs
@@ -1,6 +1,6 @@
 //! Hard forks of optimism protocol.
 
-use alloc::{boxed::Box, format, string::String, vec};
+use alloc::{format, string::String, vec};
 use core::{
     any::Any,
     fmt::{self, Display, Formatter},

--- a/examples/bsc-p2p/src/chainspec.rs
+++ b/examples/bsc-p2p/src/chainspec.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::{b256, B256};
 use reth_chainspec::{
-    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
+    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork,
+    ForkCondition, Hardfork,
 };
 use reth_network_peers::NodeRecord;
 

--- a/examples/polygon-p2p/src/chain_cfg.rs
+++ b/examples/polygon-p2p/src/chain_cfg.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::{b256, B256};
 use reth_chainspec::{
-    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork, ForkCondition,
+    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork,
+    ForkCondition, Hardfork,
 };
 use reth_discv4::NodeRecord;
 use reth_primitives::Head;


### PR DESCRIPTION
RIght now `hardforks!` macro adds `boxed` method to enum impl block which won't be possible if we move `EthereumHardforks` enum out of reth while keeping `Hardforks`
