### PR TITLE
feat: add SealedBlock::clone_sealed_header

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -182,7 +182,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
     ) -> Self {
         let in_memory_state = InMemoryState::new(blocks, numbers, pending);
         let header = in_memory_state.head_state().map_or_else(SealedHeader::default, |state| {
-            state.block_ref().block().sealed_header().clone()
+            state.block_ref().block().clone_sealed_header()
         });
         let chain_info_tracker = ChainInfoTracker::new(header, finalized, safe);
         let (canon_state_notification_sender, _) =
@@ -229,7 +229,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
 
     /// Returns the header corresponding to the given hash.
     pub fn header_by_hash(&self, hash: B256) -> Option<SealedHeader<N::BlockHeader>> {
-        self.state_by_hash(hash).map(|block| block.block_ref().block.sealed_header().clone())
+        self.state_by_hash(hash).map(|block| block.block_ref().block.clone_sealed_header())
     }
 
     /// Clears all entries in the in memory state.
@@ -462,7 +462,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
 
     /// Returns the `SealedHeader` corresponding to the pending state.
     pub fn pending_sealed_header(&self) -> Option<SealedHeader<N::BlockHeader>> {
-        self.pending_state().map(|h| h.block_ref().block().sealed_header().clone())
+        self.pending_state().map(|h| h.block_ref().block().clone_sealed_header())
     }
 
     /// Returns the `Header` corresponding to the pending state.
@@ -1321,7 +1321,7 @@ mod tests {
         assert_eq!(state.pending_header().unwrap(), block2.block().header().clone());
 
         // Check the pending sealed header
-        assert_eq!(state.pending_sealed_header().unwrap(), block2.block().sealed_header().clone());
+        assert_eq!(state.pending_sealed_header().unwrap(), block2.block().clone_sealed_header());
 
         // Check the pending block with senders
         assert_eq!(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1087,7 +1087,7 @@ where
 
         // 2. ensure we can apply a new chain update for the head block
         if let Some(chain_update) = self.on_new_head(state.head_block_hash)? {
-            let tip = chain_update.tip().sealed_header().clone();
+            let tip = chain_update.tip().clone_sealed_header();
             self.on_canonical_chain_update(chain_update);
 
             // update the safe and finalized blocks and ensure their values are valid
@@ -1626,7 +1626,7 @@ where
             .state
             .tree_state
             .block_by_hash(hash)
-            .map(|block| block.as_ref().sealed_header().clone());
+            .map(|block| block.as_ref().clone_sealed_header());
 
         if block.is_some() {
             Ok(block)
@@ -2039,7 +2039,7 @@ where
         // update the tracked canonical head
         self.state.tree_state.set_canonical_head(chain_update.tip().num_hash());
 
-        let tip = chain_update.tip().sealed_header().clone();
+        let tip = chain_update.tip().clone_sealed_header();
         let notification = chain_update.to_chain_notification();
 
         // reinsert any missing reorged blocks

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -91,7 +91,7 @@ impl<N: NodePrimitives> Chain<N> {
 
     /// Returns an iterator over all headers in the block with increasing block numbers.
     pub fn headers(&self) -> impl Iterator<Item = SealedHeader<N::BlockHeader>> + '_ {
-        self.blocks.values().map(|block| block.sealed_header().clone())
+        self.blocks.values().map(|block| block.clone_sealed_header())
     }
 
     /// Get cached trie updates for this chain.

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -1327,7 +1327,7 @@ mod tests {
         };
 
         let (finalized_headers_tx, rx) = watch::channel(None);
-        finalized_headers_tx.send(Some(genesis_block.sealed_header().clone()))?;
+        finalized_headers_tx.send(Some(genesis_block.clone_sealed_header()))?;
         let finalized_header_stream = ForkChoiceStream::new(rx);
 
         let mut exex_manager = std::pin::pin!(ExExManager::new(
@@ -1361,7 +1361,7 @@ mod tests {
             [notification.clone()]
         );
 
-        finalized_headers_tx.send(Some(block.sealed_header().clone()))?;
+        finalized_headers_tx.send(Some(block.clone_sealed_header()))?;
         assert!(exex_manager.as_mut().poll(&mut cx).is_pending());
         // WAL isn't finalized because the ExEx didn't emit the `FinishedHeight` event
         assert_eq!(
@@ -1374,7 +1374,7 @@ mod tests {
             .send(ExExEvent::FinishedHeight((rng.gen::<u64>(), rng.gen::<B256>()).into()))
             .unwrap();
 
-        finalized_headers_tx.send(Some(block.sealed_header().clone()))?;
+        finalized_headers_tx.send(Some(block.clone_sealed_header()))?;
         assert!(exex_manager.as_mut().poll(&mut cx).is_pending());
         // WAL isn't finalized because the ExEx emitted a `FinishedHeight` event with a
         // non-canonical block
@@ -1386,7 +1386,7 @@ mod tests {
         // Send a `FinishedHeight` event with a canonical block
         events_tx.send(ExExEvent::FinishedHeight(block.num_hash())).unwrap();
 
-        finalized_headers_tx.send(Some(block.sealed_header().clone()))?;
+        finalized_headers_tx.send(Some(block.clone_sealed_header()))?;
         assert!(exex_manager.as_mut().poll(&mut cx).is_pending());
         // WAL is finalized
         assert_eq!(exex_manager.wal.iter_notifications()?.next().transpose()?, None);

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -677,7 +677,7 @@ mod tests {
             BlockRangeParams { parent: Some(B256::ZERO), tx_count: 1..2, ..Default::default() },
         );
 
-        let headers = blocks.iter().map(|block| block.sealed_header().clone()).collect::<Vec<_>>();
+        let headers = blocks.iter().map(|block| block.clone_sealed_header()).collect::<Vec<_>>();
         let bodies = blocks
             .into_iter()
             .map(|block| (block.hash(), block.into_body()))

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn generate_bodies(
         BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..2, ..Default::default() },
     );
 
-    let headers = blocks.iter().map(|block| block.sealed_header().clone()).collect();
+    let headers = blocks.iter().map(|block| block.clone_sealed_header()).collect();
     let bodies = blocks.into_iter().map(|block| (block.hash(), block.into_body())).collect();
 
     (headers, bodies)

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -195,6 +195,14 @@ impl<H, B> SealedBlock<H, B> {
         &self.header
     }
 
+    /// Clones the wrapped header and returns a [`SealedHeader`] sealed with the hash.
+    pub fn clone_sealed_header(&self) -> SealedHeader<H>
+    where
+        H: Clone,
+    {
+        self.header.clone()
+    }
+
     /// Consumes the block and returns the sealed header.
     pub fn into_sealed_header(self) -> SealedHeader<H> {
         self.header

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -946,9 +946,9 @@ mod tests {
         let finalized_block = blocks.get(block_count - 3).unwrap();
 
         // Set the canonical head, safe, and finalized blocks
-        provider.set_canonical_head(canonical_block.sealed_header().clone());
-        provider.set_safe(safe_block.sealed_header().clone());
-        provider.set_finalized(finalized_block.sealed_header().clone());
+        provider.set_canonical_head(canonical_block.clone_sealed_header());
+        provider.set_safe(safe_block.clone_sealed_header());
+        provider.set_finalized(finalized_block.clone_sealed_header());
 
         Ok((provider, database_blocks.clone(), in_memory_blocks.clone(), receipts))
     }
@@ -1355,7 +1355,7 @@ mod tests {
         let in_memory_block = in_memory_blocks.last().unwrap().clone();
         // make sure that the finalized block is on db
         let finalized_block = database_blocks.get(database_blocks.len() - 3).unwrap();
-        provider.set_finalized(finalized_block.sealed_header().clone());
+        provider.set_finalized(finalized_block.clone_sealed_header());
 
         let blocks = [database_blocks, in_memory_blocks].concat();
 
@@ -1374,7 +1374,7 @@ mod tests {
             blocks
                 .iter()
                 .take_while(|header| header.number <= 8)
-                .map(|b| b.sealed_header().clone())
+                .map(|b| b.clone_sealed_header())
                 .collect::<Vec<_>>()
         );
 
@@ -1550,7 +1550,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_number_or_tag(block_number.into())?,
-            Some(database_block.sealed_header().clone())
+            Some(database_block.clone_sealed_header())
         );
 
         assert_eq!(
@@ -1559,7 +1559,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Latest).unwrap(),
-            Some(canonical_block.sealed_header().clone())
+            Some(canonical_block.clone_sealed_header())
         );
 
         assert_eq!(
@@ -1568,7 +1568,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Safe).unwrap(),
-            Some(safe_block.sealed_header().clone())
+            Some(safe_block.clone_sealed_header())
         );
 
         assert_eq!(
@@ -1577,7 +1577,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Finalized).unwrap(),
-            Some(finalized_block.sealed_header().clone())
+            Some(finalized_block.clone_sealed_header())
         );
 
         Ok(())
@@ -1605,7 +1605,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_id(block_number.into()).unwrap(),
-            Some(database_block.sealed_header().clone())
+            Some(database_block.clone_sealed_header())
         );
 
         assert_eq!(
@@ -1614,7 +1614,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_id(block_hash.into()).unwrap(),
-            Some(database_block.sealed_header().clone())
+            Some(database_block.clone_sealed_header())
         );
 
         let block_number = in_memory_block.number;
@@ -1626,7 +1626,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_id(block_number.into()).unwrap(),
-            Some(in_memory_block.sealed_header().clone())
+            Some(in_memory_block.clone_sealed_header())
         );
 
         assert_eq!(
@@ -1635,7 +1635,7 @@ mod tests {
         );
         assert_eq!(
             provider.sealed_header_by_id(block_hash.into()).unwrap(),
-            Some(in_memory_block.sealed_header().clone())
+            Some(in_memory_block.clone_sealed_header())
         );
 
         Ok(())
@@ -2021,7 +2021,7 @@ mod tests {
         );
         // test state by block tag for safe block
         let safe_block = in_memory_blocks[in_memory_blocks.len() - 2].clone();
-        in_memory_provider.canonical_in_memory_state.set_safe(safe_block.sealed_header().clone());
+        in_memory_provider.canonical_in_memory_state.set_safe(safe_block.clone_sealed_header());
         assert_eq!(
             safe_block.hash(),
             in_memory_provider
@@ -2033,7 +2033,7 @@ mod tests {
         let finalized_block = in_memory_blocks[in_memory_blocks.len() - 3].clone();
         in_memory_provider
             .canonical_in_memory_state
-            .set_finalized(finalized_block.sealed_header().clone());
+            .set_finalized(finalized_block.clone_sealed_header());
         assert_eq!(
             finalized_block.hash(),
             in_memory_provider
@@ -2106,11 +2106,11 @@ mod tests {
 
         // Set the safe block in memory
         let safe_block = in_memory_blocks[in_memory_blocks.len() - 2].clone();
-        provider.canonical_in_memory_state.set_safe(safe_block.sealed_header().clone());
+        provider.canonical_in_memory_state.set_safe(safe_block.clone_sealed_header());
 
         // Set the finalized block in memory
         let finalized_block = in_memory_blocks[in_memory_blocks.len() - 3].clone();
-        provider.canonical_in_memory_state.set_finalized(finalized_block.sealed_header().clone());
+        provider.canonical_in_memory_state.set_finalized(finalized_block.clone_sealed_header());
 
         // Verify the pending block number and hash
         assert_eq!(
@@ -2325,7 +2325,7 @@ mod tests {
         // instead start end
         test_by_block_range!([
             (headers_range, |block: &SealedBlock| block.header().clone()),
-            (sealed_headers_range, |block: &SealedBlock| block.sealed_header().clone()),
+            (sealed_headers_range, |block: &SealedBlock| block.clone_sealed_header()),
             (block_range, |block: &SealedBlock| block.clone().unseal()),
             (block_with_senders_range, |block: &SealedBlock| block
                 .clone()
@@ -2467,7 +2467,7 @@ mod tests {
                 sealed_header,
                 |block: &SealedBlock, _: TxNumber, _: B256, _: &Vec<Vec<Receipt>>| (
                     block.number,
-                    Some(block.sealed_header().clone())
+                    Some(block.clone_sealed_header())
                 ),
                 u64::MAX
             ),

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -693,7 +693,7 @@ impl<N: ProviderNodeTypes> HeaderProvider for ConsistentProvider<N> {
         self.get_in_memory_or_storage_by_block(
             number.into(),
             |db_provider| db_provider.sealed_header(number),
-            |block_state| Ok(Some(block_state.block_ref().block().sealed_header().clone())),
+            |block_state| Ok(Some(block_state.block_ref().block().clone_sealed_header())),
         )
     }
 
@@ -704,7 +704,7 @@ impl<N: ProviderNodeTypes> HeaderProvider for ConsistentProvider<N> {
         self.get_in_memory_or_storage_by_block_range_while(
             range,
             |db_provider, range, _| db_provider.sealed_headers_range(range),
-            |block_state, _| Some(block_state.block_ref().block().sealed_header().clone()),
+            |block_state, _| Some(block_state.block_ref().block().clone_sealed_header()),
             |_| true,
         )
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -440,7 +440,7 @@ impl<
         let segment_header = writer.user_header();
         if segment_header.block_end().is_none() && segment_header.expected_block_start() == 0 {
             for block_number in 0..block.number() {
-                let mut prev = block.sealed_header().clone().unseal();
+                let mut prev = block.clone_sealed_header().unseal();
                 prev.number = block_number;
                 writer.append_header(&prev, U256::ZERO, &B256::ZERO)?;
             }


### PR DESCRIPTION
prep for #13735

with #13735 `fn sealed_header` will be slightly problematic, luckily we can mostly call this to obtain a clone