### PR TITLE
chore: remove Block generic from apply_pre_execution_changes

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -95,7 +95,7 @@ where
             SystemCaller::new(self.evm_config.clone(), self.provider.chain_spec());
 
         // Apply pre-block system contract calls.
-        system_caller.apply_pre_execution_changes(&block.clone().unseal().block, &mut evm)?;
+        system_caller.apply_pre_execution_changes(block.header(), &mut evm)?;
 
         // Re-execute all of the transactions in the block to load all touched accounts into
         // the cache DB.

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -5,7 +5,7 @@ use crate::{
     EthEvmConfig,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use alloy_consensus::Transaction as _;
+use alloy_consensus::Transaction;
 use alloy_eips::{eip6110, eip7685::Requests};
 use core::fmt::Display;
 use reth_chainspec::{ChainSpec, EthereumHardfork, EthereumHardforks, MAINNET};
@@ -116,14 +116,14 @@ where
 impl<DB, EvmConfig> EthExecutionStrategy<DB, EvmConfig>
 where
     DB: Database<Error: Into<ProviderError> + Display>,
-    EvmConfig: ConfigureEvm<Header = alloy_consensus::Header>,
+    EvmConfig: ConfigureEvm,
 {
     /// Configures a new evm configuration and block environment for the given block.
     ///
     /// # Caution
     ///
     /// This does not initialize the tx environment.
-    fn evm_env_for_block(&self, header: &alloy_consensus::Header) -> EnvWithHandlerCfg {
+    fn evm_env_for_block(&self, header: &EvmConfig::Header) -> EnvWithHandlerCfg {
         let EvmEnv { cfg_env_with_handler_cfg, block_env } =
             self.evm_config.cfg_and_block_env(header);
         EnvWithHandlerCfg::new_with_cfg_env(cfg_env_with_handler_cfg, block_env, Default::default())
@@ -156,7 +156,7 @@ where
         let env = self.evm_env_for_block(&block.header);
         let mut evm = self.evm_config.evm_with_env(&mut self.state, env);
 
-        self.system_caller.apply_pre_execution_changes(&block.block, &mut evm)?;
+        self.system_caller.apply_pre_execution_changes(&block.header, &mut evm)?;
 
         Ok(())
     }

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -94,26 +94,25 @@ where
     Chainspec: EthereumHardforks,
 {
     /// Apply pre execution changes.
-    pub fn apply_pre_execution_changes<DB, Ext, Block>(
+    pub fn apply_pre_execution_changes<DB, Ext>(
         &mut self,
-        block: &Block,
+        header: &EvmConfig::Header,
         evm: &mut Evm<'_, Ext, DB>,
     ) -> Result<(), BlockExecutionError>
     where
         DB: Database + DatabaseCommit,
         DB::Error: Display,
-        Block: reth_primitives_traits::Block<Header = EvmConfig::Header>,
     {
         self.apply_blockhashes_contract_call(
-            block.header().timestamp(),
-            block.header().number(),
-            block.header().parent_hash(),
+            header.timestamp(),
+            header.number(),
+            header.parent_hash(),
             evm,
         )?;
         self.apply_beacon_root_contract_call(
-            block.header().timestamp(),
-            block.header().number(),
-            block.header().parent_beacon_block_root(),
+            header.timestamp(),
+            header.number(),
+            header.parent_beacon_block_root(),
             evm,
         )?;
 


### PR DESCRIPTION
This removes the `Block` generic from `SystemCaller::apply_pre_execution_changes`. It only really used header fields, and the associated header type was restricted to be `EvmConfig::Header`. Now it just takes the header