### PR TITLE
chore: remove outdated `as _;` imports

### DIFF
--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -6,7 +6,6 @@ pub use reth_execution_errors::{
     BlockExecutionError, BlockValidationError, InternalBlockExecutionError,
 };
 pub use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
-use reth_primitives_traits::Block as _;
 pub use reth_storage_errors::provider::ProviderError;
 
 use crate::{system_calls::OnStateHook, TxEnvOverrides};
@@ -19,6 +18,7 @@ use alloy_primitives::{
 use core::fmt::Display;
 use reth_consensus::ConsensusError;
 use reth_primitives::{BlockWithSenders, NodePrimitives, Receipt};
+use reth_primitives_traits::Block;
 use reth_prune_types::PruneModes;
 use reth_revm::batch::BlockBatchRecord;
 use revm::{

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -30,7 +30,7 @@ use reth_primitives::{
     Account, Block, BlockWithSenders, EthPrimitives, NodePrimitives, Receipt, SealedBlock,
     SealedBlockFor, SealedBlockWithSenders, SealedHeader, StorageEntry, TransactionSigned,
 };
-use reth_primitives_traits::BlockBody as _;
+use reth_primitives_traits::BlockBody;
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
@@ -795,7 +795,7 @@ mod tests {
     use reth_errors::ProviderError;
     use reth_execution_types::{Chain, ExecutionOutcome};
     use reth_primitives::{BlockExt, EthPrimitives, Receipt, SealedBlock, StaticFileSegment};
-    use reth_primitives_traits::{BlockBody as _, SignedTransaction};
+    use reth_primitives_traits::{BlockBody, SignedTransaction};
     use reth_storage_api::{
         BlockBodyIndicesProvider, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
         BlockReaderIdExt, BlockSource, ChangeSetReader, DatabaseProviderFactory, HeaderProvider,


### PR DESCRIPTION
IIRC these were required because we were either importing concrete types or other traits of the same name, which we are not doing any more