### PR TITLE
fix(ci): install missing deps for wasm build checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,9 @@ jobs:
           cache-on-failure: true
       - uses: dcarbone/install-jq-action@v3
       - name: Run Wasm checks
-        run: .github/assets/check_wasm.sh
+        run: |
+          sudo apt update && sudo apt install gcc-multilib
+          .github/assets/check_wasm.sh
 
   riscv:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix:
```
  warning: zstd-sys@2.0.13+zstd.1.5.6: In file included from zstd/lib/common/entropy_common.c:18:
  warning: zstd-sys@2.0.13+zstd.1.5.6: In file included from zstd/lib/common/mem.h:24:
  warning: zstd-sys@2.0.13+zstd.1.5.6: In file included from zstd/lib/common/zstd_deps.h:27:
  warning: zstd-sys@2.0.13+zstd.1.5.6: In file included from /usr/lib/llvm-18/lib/clang/18/include/limits.h:21:
  warning: zstd-sys@2.0.13+zstd.1.5.6: /usr/include/limits.h:26:10: fatal error: 'bits/libc-header-start.h' file not found
  warning: zstd-sys@2.0.13+zstd.1.5.6:    26 | #include <bits/libc-header-start.h>
  warning: zstd-sys@2.0.13+zstd.1.5.6:       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
  warning: zstd-sys@2.0.13+zstd.1.5.6: 1 error generated.
```

in recent CI runs like in https://github.com/paradigmxyz/reth/actions/runs/12682438237/job/35347819955?pr=13622.