### PR TITLE
fix(engine): cleanup leaked context

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -63,7 +63,7 @@ use reth_trie::{
     updates::{StorageTrieUpdates, TrieUpdates},
     HashedPostStateSorted, Nibbles, StateRoot, StoredNibbles,
 };
-use reth_trie_db::{DatabaseStateRoot, DatabaseStorageTrieCursor};
+use reth_trie_db::{DatabaseRef, DatabaseStateRoot, DatabaseStorageTrieCursor};
 use revm::db::states::{
     PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
 };
@@ -3148,5 +3148,13 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
 
     fn prune_modes_ref(&self) -> &PruneModes {
         self.prune_modes_ref()
+    }
+}
+
+impl<TX: DbTx, N: NodeTypes> DatabaseRef for DatabaseProvider<TX, N> {
+    type Tx = TX;
+
+    fn tx_reference(&self) -> &Self::Tx {
+        &self.tx
     }
 }

--- a/crates/trie/db/src/commitment.rs
+++ b/crates/trie/db/src/commitment.rs
@@ -28,12 +28,12 @@ pub struct MerklePatriciaTrie;
 
 impl StateCommitment for MerklePatriciaTrie {
     type StateRoot<'a, TX: DbTx + 'a> =
-        StateRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        StateRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type StorageRoot<'a, TX: DbTx + 'a> =
-        StorageRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        StorageRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type StateProof<'a, TX: DbTx + 'a> =
-        Proof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        Proof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type StateWitness<'a, TX: DbTx + 'a> =
-        TrieWitness<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        TrieWitness<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type KeyHasher = KeccakKeyHasher;
 }

--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -1,5 +1,7 @@
 //! An integration of [`reth-trie`] with [`reth-db`].
 
+use reth_db::transaction::DbTx;
+
 mod commitment;
 mod hashed_cursor;
 mod prefix_set;
@@ -21,3 +23,20 @@ pub use trie_cursor::{
     DatabaseAccountTrieCursor, DatabaseStorageTrieCursor, DatabaseTrieCursorFactory,
 };
 pub use witness::DatabaseTrieWitness;
+
+/// Trait for database operations needed by the trie cursor factories
+pub trait DatabaseRef: Send + Sync {
+    /// The concrete transaction type
+    type Tx: DbTx;
+
+    /// Returns a reference to the underlying database transaction
+    fn tx_reference(&self) -> &Self::Tx;
+}
+
+impl<T: DbTx> DatabaseRef for &'_ T {
+    type Tx = T;
+
+    fn tx_reference(&self) -> &Self::Tx {
+        self
+    }
+}

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -10,6 +10,9 @@ use reth_trie::{
     StorageMultiProof, TrieInput,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Extends [`Proof`] with operations specific for working with a database transaction.
 pub trait DatabaseProof<'a, TX> {
     /// Create a new [Proof] from database transaction.
@@ -32,7 +35,7 @@ pub trait DatabaseProof<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseProof<'a, TX>
-    for Proof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for Proof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     /// Create a new [Proof] instance from database transaction.
     fn from_tx(tx: &'a TX) -> Self {
@@ -50,11 +53,11 @@ impl<'a, TX: DbTx> DatabaseProof<'a, TX>
         Self::from_tx(tx)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
                 DatabaseTrieCursorFactory::new(tx),
-                &nodes_sorted,
+                Arc::new(nodes_sorted),
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_sets_mut(input.prefix_sets)
             .account_proof(address, slots)
@@ -70,11 +73,11 @@ impl<'a, TX: DbTx> DatabaseProof<'a, TX>
         Self::from_tx(tx)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
                 DatabaseTrieCursorFactory::new(tx),
-                &nodes_sorted,
+                Arc::new(nodes_sorted),
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_sets_mut(input.prefix_sets)
             .multiproof(targets)
@@ -104,7 +107,7 @@ pub trait DatabaseStorageProof<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
-    for StorageProof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StorageProof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX, address: Address) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx), address)
@@ -125,7 +128,7 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
         Self::from_tx(tx, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_set_mut(prefix_set)
             .storage_proof(slot)
@@ -147,7 +150,7 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
         Self::from_tx(tx, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_set_mut(prefix_set)
             .storage_multiproof(targets)

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -19,6 +19,9 @@ use reth_trie::{
 use std::{collections::HashMap, ops::RangeInclusive};
 use tracing::debug;
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Extends [`StateRoot`] with operations specific for working with a database transaction.
 pub trait DatabaseStateRoot<'a, TX>: Sized {
     /// Create a new [`StateRoot`] instance.
@@ -130,7 +133,7 @@ pub trait DatabaseHashedPostState<TX>: Sized {
 }
 
 impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
-    for StateRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StateRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx))
@@ -173,7 +176,10 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = post_state.into_sorted();
         StateRoot::new(
             DatabaseTrieCursorFactory::new(tx),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(prefix_sets)
         .root()
@@ -187,7 +193,10 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = post_state.into_sorted();
         StateRoot::new(
             DatabaseTrieCursorFactory::new(tx),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(prefix_sets)
         .root_with_updates()
@@ -197,8 +206,14 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         StateRoot::new(
-            InMemoryTrieCursorFactory::new(DatabaseTrieCursorFactory::new(tx), &nodes_sorted),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            InMemoryTrieCursorFactory::new(
+                DatabaseTrieCursorFactory::new(tx),
+                Arc::new(nodes_sorted),
+            ),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(input.prefix_sets.freeze())
         .root()
@@ -211,8 +226,14 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         StateRoot::new(
-            InMemoryTrieCursorFactory::new(DatabaseTrieCursorFactory::new(tx), &nodes_sorted),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            InMemoryTrieCursorFactory::new(
+                DatabaseTrieCursorFactory::new(tx),
+                Arc::new(nodes_sorted),
+            ),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(input.prefix_sets.freeze())
         .root_with_updates()

--- a/crates/trie/db/src/witness.rs
+++ b/crates/trie/db/src/witness.rs
@@ -7,6 +7,9 @@ use reth_trie::{
     witness::TrieWitness, HashedPostState, TrieInput,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Extends [`TrieWitness`] with operations specific for working with a database transaction.
 pub trait DatabaseTrieWitness<'a, TX> {
     /// Create a new [`TrieWitness`] from database transaction.
@@ -21,7 +24,7 @@ pub trait DatabaseTrieWitness<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseTrieWitness<'a, TX>
-    for TrieWitness<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for TrieWitness<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx))
@@ -37,11 +40,11 @@ impl<'a, TX: DbTx> DatabaseTrieWitness<'a, TX>
         Self::from_tx(tx)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
                 DatabaseTrieCursorFactory::new(tx),
-                &nodes_sorted,
+                Arc::new(nodes_sorted),
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_sets_mut(input.prefix_sets)
             .compute(target)

--- a/crates/trie/db/tests/post_state.rs
+++ b/crates/trie/db/tests/post_state.rs
@@ -13,7 +13,7 @@ use reth_trie::{
     HashedPostState, HashedStorage,
 };
 use reth_trie_db::DatabaseHashedCursorFactory;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 fn assert_account_cursor_order(
     factory: &impl HashedCursorFactory,
@@ -66,7 +66,8 @@ fn post_state_only_accounts() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
 
@@ -87,7 +88,7 @@ fn db_only_accounts() {
     let tx = db.tx().unwrap();
     let factory = HashedPostStateCursorFactory::new(
         DatabaseHashedCursorFactory::new(&tx),
-        &sorted_post_state,
+        Arc::new(sorted_post_state),
     );
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
@@ -113,7 +114,8 @@ fn account_cursor_correct_order() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
 
@@ -143,7 +145,8 @@ fn removed_accounts_are_discarded() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = accounts.into_iter().filter(|x| !removed_keys.contains(&x.0));
     assert_account_cursor_order(&factory, expected);
 }
@@ -170,7 +173,8 @@ fn post_state_accounts_take_precedence() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
 
@@ -202,7 +206,7 @@ fn fuzz_hashed_account_cursor() {
 
             let sorted = hashed_post_state.into_sorted();
             let tx = db.tx().unwrap();
-            let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+            let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
             assert_account_cursor_order(&factory, expected.into_iter());
         }
     );
@@ -217,8 +221,10 @@ fn storage_is_empty() {
     {
         let sorted = HashedPostState::default().into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(cursor.is_storage_empty().unwrap());
     }
@@ -238,8 +244,10 @@ fn storage_is_empty() {
     {
         let sorted = HashedPostState::default().into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(!cursor.is_storage_empty().unwrap());
     }
@@ -254,8 +262,10 @@ fn storage_is_empty() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(cursor.is_storage_empty().unwrap());
     }
@@ -271,8 +281,10 @@ fn storage_is_empty() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(cursor.is_storage_empty().unwrap());
     }
@@ -288,8 +300,10 @@ fn storage_is_empty() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(!cursor.is_storage_empty().unwrap());
     }
@@ -325,7 +339,8 @@ fn storage_cursor_correct_order() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected =
         std::iter::once((address, db_storage.into_iter().chain(post_state_storage).collect()));
     assert_storage_cursor_order(&factory, expected);
@@ -362,7 +377,8 @@ fn zero_value_storage_entries_are_discarded() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = std::iter::once((
         address,
         post_state_storage.into_iter().filter(|(_, value)| *value > U256::ZERO).collect(),
@@ -399,7 +415,8 @@ fn wiped_storage_is_discarded() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = std::iter::once((address, post_state_storage));
     assert_storage_cursor_order(&factory, expected);
 }
@@ -434,7 +451,8 @@ fn post_state_storages_take_precedence() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = std::iter::once((address, storage));
     assert_storage_cursor_order(&factory, expected);
 }
@@ -481,7 +499,7 @@ fn fuzz_hashed_storage_cursor() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
         assert_storage_cursor_order(&factory, expected.into_iter());
     });
 }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -162,12 +162,13 @@ where
                     let cursor_start = Instant::now();
                     let trie_cursor_factory = InMemoryTrieCursorFactory::new(
                         DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-                        &trie_nodes_sorted,
+                        trie_nodes_sorted,
                     );
                     let hashed_cursor_factory = HashedPostStateCursorFactory::new(
                         DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-                        &hashed_state_sorted,
+                        hashed_state_sorted,
                     );
+
                     trace!(
                         target: "trie::parallel",
                         ?hashed_address,
@@ -215,11 +216,11 @@ where
         let provider_ro = self.view.provider_ro()?;
         let trie_cursor_factory = InMemoryTrieCursorFactory::new(
             DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-            &self.nodes_sorted,
+            self.nodes_sorted,
         );
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-            &self.state_sorted,
+            self.state_sorted,
         );
 
         // Create the walker.

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -111,15 +111,16 @@ where
                     let provider_ro = view.provider_ro()?;
                     let trie_cursor_factory = InMemoryTrieCursorFactory::new(
                         DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-                        &trie_nodes_sorted,
+                        trie_nodes_sorted,
                     );
-                    let hashed_state = HashedPostStateCursorFactory::new(
+                    let hashed_cursor_factory = HashedPostStateCursorFactory::new(
                         DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-                        &hashed_state_sorted,
+                        hashed_state_sorted,
                     );
+
                     Ok(StorageRoot::new_hashed(
                         trie_cursor_factory,
-                        hashed_state,
+                        hashed_cursor_factory,
                         hashed_address,
                         prefix_set,
                         #[cfg(feature = "metrics")]
@@ -138,11 +139,11 @@ where
         let provider_ro = self.view.provider_ro()?;
         let trie_cursor_factory = InMemoryTrieCursorFactory::new(
             DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-            &trie_nodes_sorted,
+            trie_nodes_sorted,
         );
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-            &hashed_state_sorted,
+            hashed_state_sorted,
         );
 
         let walker = TrieWalker::new(

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -14,6 +14,7 @@ use reth_trie::{
 };
 use reth_trie_common::{HashBuilder, Nibbles};
 use reth_trie_sparse::SparseTrie;
+use std::sync::Arc;
 
 fn calculate_root_from_leaves(c: &mut Criterion) {
     let mut group = c.benchmark_group("calculate root from leaves");
@@ -133,7 +134,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     InMemoryStorageTrieCursor::new(
                                         B256::ZERO,
                                         NoopStorageTrieCursor::default(),
-                                        Some(&trie_updates_sorted),
+                                        Some(Arc::new(trie_updates_sorted)),
                                     ),
                                     prefix_set,
                                 );
@@ -141,7 +142,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     walker,
                                     HashedPostStateStorageCursor::new(
                                         NoopHashedStorageCursor::default(),
-                                        Some(&storage_sorted),
+                                        Some(Arc::new(storage_sorted)),
                                     ),
                                 );
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1470,7 +1470,7 @@ mod tests {
             walker,
             HashedPostStateAccountCursor::new(
                 NoopHashedAccountCursor::default(),
-                hashed_post_state.accounts(),
+                hashed_post_state.accounts().clone(),
             ),
         );
 

--- a/crates/trie/trie/src/forward_cursor.rs
+++ b/crates/trie/trie/src/forward_cursor.rs
@@ -1,17 +1,20 @@
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// The implementation of forward-only in memory cursor over the entries.
 /// The cursor operates under the assumption that the supplied collection is pre-sorted.
 #[derive(Debug)]
-pub struct ForwardInMemoryCursor<'a, K, V> {
+pub struct ForwardInMemoryCursor<K, V> {
     /// The reference to the pre-sorted collection of entries.
-    entries: &'a Vec<(K, V)>,
+    entries: Arc<Vec<(K, V)>>,
     /// The index where cursor is currently positioned.
     index: usize,
 }
 
-impl<'a, K, V> ForwardInMemoryCursor<'a, K, V> {
+impl<K, V> ForwardInMemoryCursor<K, V> {
     /// Create new forward cursor positioned at the beginning of the collection.
     /// The cursor expects all of the entries have been sorted in advance.
-    pub const fn new(entries: &'a Vec<(K, V)>) -> Self {
+    pub const fn new(entries: Arc<Vec<(K, V)>>) -> Self {
         Self { entries, index: 0 }
     }
 
@@ -21,7 +24,7 @@ impl<'a, K, V> ForwardInMemoryCursor<'a, K, V> {
     }
 }
 
-impl<K, V> ForwardInMemoryCursor<'_, K, V>
+impl<K, V> ForwardInMemoryCursor<K, V>
 where
     K: PartialOrd + Clone,
     V: Clone,

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -7,27 +7,30 @@ use alloy_primitives::{map::B256HashSet, B256, U256};
 use reth_primitives::Account;
 use reth_storage_errors::db::DatabaseError;
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// The hashed cursor factory for the post state.
 #[derive(Clone, Debug)]
-pub struct HashedPostStateCursorFactory<'a, CF> {
+pub struct HashedPostStateCursorFactory<CF> {
     cursor_factory: CF,
-    post_state: &'a HashedPostStateSorted,
+    post_state: Arc<HashedPostStateSorted>,
 }
 
-impl<'a, CF> HashedPostStateCursorFactory<'a, CF> {
+impl<CF> HashedPostStateCursorFactory<CF> {
     /// Create a new factory.
-    pub const fn new(cursor_factory: CF, post_state: &'a HashedPostStateSorted) -> Self {
+    pub const fn new(cursor_factory: CF, post_state: Arc<HashedPostStateSorted>) -> Self {
         Self { cursor_factory, post_state }
     }
 }
 
-impl<'a, CF: HashedCursorFactory> HashedCursorFactory for HashedPostStateCursorFactory<'a, CF> {
-    type AccountCursor = HashedPostStateAccountCursor<'a, CF::AccountCursor>;
-    type StorageCursor = HashedPostStateStorageCursor<'a, CF::StorageCursor>;
+impl<CF: HashedCursorFactory> HashedCursorFactory for HashedPostStateCursorFactory<CF> {
+    type AccountCursor = HashedPostStateAccountCursor<CF::AccountCursor>;
+    type StorageCursor = HashedPostStateStorageCursor<CF::StorageCursor>;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError> {
         let cursor = self.cursor_factory.hashed_account_cursor()?;
-        Ok(HashedPostStateAccountCursor::new(cursor, &self.post_state.accounts))
+        Ok(HashedPostStateAccountCursor::new(cursor, self.post_state.accounts.clone()))
     }
 
     fn hashed_storage_cursor(
@@ -35,33 +38,37 @@ impl<'a, CF: HashedCursorFactory> HashedCursorFactory for HashedPostStateCursorF
         hashed_address: B256,
     ) -> Result<Self::StorageCursor, DatabaseError> {
         let cursor = self.cursor_factory.hashed_storage_cursor(hashed_address)?;
-        Ok(HashedPostStateStorageCursor::new(cursor, self.post_state.storages.get(&hashed_address)))
+        Ok(HashedPostStateStorageCursor::new(
+            cursor,
+            self.post_state.storages.get(&hashed_address).cloned().map(Arc::new),
+        ))
     }
 }
 
 /// The cursor to iterate over post state hashed accounts and corresponding database entries.
 /// It will always give precedence to the data from the hashed post state.
 #[derive(Debug)]
-pub struct HashedPostStateAccountCursor<'a, C> {
+pub struct HashedPostStateAccountCursor<C> {
     /// The database cursor.
     cursor: C,
     /// Forward-only in-memory cursor over accounts.
-    post_state_cursor: ForwardInMemoryCursor<'a, B256, Account>,
+    post_state_cursor: ForwardInMemoryCursor<B256, Account>,
     /// Reference to the collection of account keys that were destroyed.
-    destroyed_accounts: &'a B256HashSet,
+    destroyed_accounts: B256HashSet,
     /// The last hashed account that was returned by the cursor.
     /// De facto, this is a current cursor position.
     last_account: Option<B256>,
 }
 
-impl<'a, C> HashedPostStateAccountCursor<'a, C>
+impl<C> HashedPostStateAccountCursor<C>
 where
     C: HashedCursor<Value = Account>,
 {
     /// Create new instance of [`HashedPostStateAccountCursor`].
-    pub const fn new(cursor: C, post_state_accounts: &'a HashedAccountsSorted) -> Self {
-        let post_state_cursor = ForwardInMemoryCursor::new(&post_state_accounts.accounts);
-        let destroyed_accounts = &post_state_accounts.destroyed_accounts;
+    pub fn new(cursor: C, post_state_accounts: HashedAccountsSorted) -> Self {
+        let post_state_cursor =
+            ForwardInMemoryCursor::new(Arc::new(post_state_accounts.accounts.clone()));
+        let destroyed_accounts = post_state_accounts.destroyed_accounts;
         Self { cursor, post_state_cursor, destroyed_accounts, last_account: None }
     }
 
@@ -131,7 +138,7 @@ where
     }
 }
 
-impl<C> HashedCursor for HashedPostStateAccountCursor<'_, C>
+impl<C> HashedCursor for HashedPostStateAccountCursor<C>
 where
     C: HashedCursor<Value = Account>,
 {
@@ -176,13 +183,13 @@ where
 /// The cursor to iterate over post state hashed storages and corresponding database entries.
 /// It will always give precedence to the data from the post state.
 #[derive(Debug)]
-pub struct HashedPostStateStorageCursor<'a, C> {
+pub struct HashedPostStateStorageCursor<C> {
     /// The database cursor.
     cursor: C,
     /// Forward-only in-memory cursor over non zero-valued account storage slots.
-    post_state_cursor: Option<ForwardInMemoryCursor<'a, B256, U256>>,
+    post_state_cursor: Option<ForwardInMemoryCursor<B256, U256>>,
     /// Reference to the collection of storage slot keys that were cleared.
-    cleared_slots: Option<&'a B256HashSet>,
+    cleared_slots: Option<B256HashSet>,
     /// Flag indicating whether database storage was wiped.
     storage_wiped: bool,
     /// The last slot that has been returned by the cursor.
@@ -190,15 +197,16 @@ pub struct HashedPostStateStorageCursor<'a, C> {
     last_slot: Option<B256>,
 }
 
-impl<'a, C> HashedPostStateStorageCursor<'a, C>
+impl<C> HashedPostStateStorageCursor<C>
 where
     C: HashedStorageCursor<Value = U256>,
 {
     /// Create new instance of [`HashedPostStateStorageCursor`] for the given hashed address.
-    pub fn new(cursor: C, post_state_storage: Option<&'a HashedStorageSorted>) -> Self {
-        let post_state_cursor =
-            post_state_storage.map(|s| ForwardInMemoryCursor::new(&s.non_zero_valued_slots));
-        let cleared_slots = post_state_storage.map(|s| &s.zero_valued_slots);
+    pub fn new(cursor: C, post_state_storage: Option<Arc<HashedStorageSorted>>) -> Self {
+        let post_state_cursor = post_state_storage
+            .clone()
+            .map(|s| ForwardInMemoryCursor::new(Arc::new(s.non_zero_valued_slots.clone())));
+        let cleared_slots = post_state_storage.as_ref().map(|s| s.zero_valued_slots.clone());
         let storage_wiped = post_state_storage.is_some_and(|s| s.wiped);
         Self { cursor, post_state_cursor, cleared_slots, storage_wiped, last_slot: None }
     }
@@ -206,7 +214,7 @@ where
     /// Check if the slot was zeroed out in the post state.
     /// The database is not checked since it already has no zero-valued slots.
     fn is_slot_zero_valued(&self, slot: &B256) -> bool {
-        self.cleared_slots.is_some_and(|s| s.contains(slot))
+        self.cleared_slots.clone().is_some_and(|s| s.contains(slot))
     }
 
     /// Find the storage entry in post state or database that's greater or equal to provided subkey.
@@ -275,7 +283,7 @@ where
     }
 }
 
-impl<C> HashedCursor for HashedPostStateStorageCursor<'_, C>
+impl<C> HashedCursor for HashedPostStateStorageCursor<C>
 where
     C: HashedStorageCursor<Value = U256>,
 {
@@ -303,7 +311,7 @@ where
     }
 }
 
-impl<C> HashedStorageCursor for HashedPostStateStorageCursor<'_, C>
+impl<C> HashedStorageCursor for HashedPostStateStorageCursor<C>
 where
     C: HashedStorageCursor<Value = U256>,
 {


### PR DESCRIPTION
After the introduction on `std::thread::scope` for creating `StateRootTask`, we started using `Box::leak` to keep alive values required to return and move around the state hook closure. This caused the variables in the kept context to cause errors like:
```
WARN Long-lived read transaction has been timed out
``` 
This PR includes changes to the parameters needed to create the blinded provider factory required by `StateRootTask` using `Arc` instead of references, which don't have a big performance impact and are automatically cleaned up without lifetime issues.

A provider transaction reference was one of the parameters required to create the blinded provider factory. Instead of it, we are now passing an `Arc<Provider>`, which can obtain the transaction reference as needed and doesn't impose additional lifetime constraints. This change requires further changes in all the code that use the cursors, limited to the trie crates.