### PR TITLE
chore(trie): simplify blinded provider

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -17,7 +17,7 @@ use reth_trie::{
 use reth_trie_parallel::{proof::ParallelProof, root::ParallelStateRootError};
 use reth_trie_sparse::{
     blinded::{BlindedProvider, BlindedProviderFactory},
-    errors::{SparseStateTrieError, SparseStateTrieResult, SparseTrieError, SparseTrieErrorKind},
+    errors::{SparseStateTrieError, SparseStateTrieResult, SparseTrieErrorKind},
     SparseStateTrie,
 };
 use revm_primitives::{keccak256, EvmState, B256};
@@ -286,8 +286,8 @@ where
         + Send
         + Sync
         + 'static,
-    ABP: BlindedProvider<Error = SparseTrieError> + Send + Sync + 'env,
-    SBP: BlindedProvider<Error = SparseTrieError> + Send + Sync + 'env,
+    ABP: BlindedProvider + Send + Sync + 'env,
+    SBP: BlindedProvider + Send + Sync + 'env,
     BPF: BlindedProviderFactory<AccountNodeProvider = ABP, StorageNodeProvider = SBP>
         + Send
         + Sync
@@ -759,16 +759,17 @@ where
 
 /// Updates the sparse trie with the given proofs and state, and returns the updated trie and the
 /// time it took.
-fn update_sparse_trie<
-    ABP: BlindedProvider<Error = SparseTrieError> + Send + Sync,
-    SBP: BlindedProvider<Error = SparseTrieError> + Send + Sync,
-    BPF: BlindedProviderFactory<AccountNodeProvider = ABP, StorageNodeProvider = SBP> + Send + Sync,
->(
+fn update_sparse_trie<ABP, SBP, BPF>(
     mut trie: Box<SparseStateTrie<BPF>>,
     multiproof: MultiProof,
     targets: MultiProofTargets,
     state: HashedPostState,
-) -> SparseStateTrieResult<(Box<SparseStateTrie<BPF>>, Duration)> {
+) -> SparseStateTrieResult<(Box<SparseStateTrie<BPF>>, Duration)>
+where
+    ABP: BlindedProvider + Send + Sync,
+    SBP: BlindedProvider + Send + Sync,
+    BPF: BlindedProviderFactory<AccountNodeProvider = ABP, StorageNodeProvider = SBP> + Send + Sync,
+{
     trace!(target: "engine::root::sparse", "Updating sparse trie");
     let started_at = Instant::now();
 

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -278,7 +278,7 @@ pub struct StateRootTask<'env, Factory, BPF: BlindedProviderFactory> {
     thread_pool: &'env rayon::ThreadPool,
 }
 
-impl<'env, Factory, ABP, SBP, BPF> StateRootTask<'env, Factory, BPF>
+impl<'env, Factory, BPF> StateRootTask<'env, Factory, BPF>
 where
     Factory: DatabaseProviderFactory<Provider: BlockReader>
         + StateCommitmentProvider
@@ -286,12 +286,9 @@ where
         + Send
         + Sync
         + 'static,
-    ABP: BlindedProvider + Send + Sync + 'env,
-    SBP: BlindedProvider + Send + Sync + 'env,
-    BPF: BlindedProviderFactory<AccountNodeProvider = ABP, StorageNodeProvider = SBP>
-        + Send
-        + Sync
-        + 'env,
+    BPF: BlindedProviderFactory + Send + Sync + 'env,
+    BPF::AccountNodeProvider: BlindedProvider + Send + Sync + 'env,
+    BPF::StorageNodeProvider: BlindedProvider + Send + Sync + 'env,
 {
     /// Creates a new state root task with the unified message channel
     pub fn new(
@@ -759,16 +756,16 @@ where
 
 /// Updates the sparse trie with the given proofs and state, and returns the updated trie and the
 /// time it took.
-fn update_sparse_trie<ABP, SBP, BPF>(
+fn update_sparse_trie<BPF>(
     mut trie: Box<SparseStateTrie<BPF>>,
     multiproof: MultiProof,
     targets: MultiProofTargets,
     state: HashedPostState,
 ) -> SparseStateTrieResult<(Box<SparseStateTrie<BPF>>, Duration)>
 where
-    ABP: BlindedProvider + Send + Sync,
-    SBP: BlindedProvider + Send + Sync,
-    BPF: BlindedProviderFactory<AccountNodeProvider = ABP, StorageNodeProvider = SBP> + Send + Sync,
+    BPF: BlindedProviderFactory + Send + Sync,
+    BPF::AccountNodeProvider: BlindedProvider + Send + Sync,
+    BPF::StorageNodeProvider: BlindedProvider + Send + Sync,
 {
     trace!(target: "engine::root::sparse", "Updating sparse trie");
     let started_at = Instant::now();

--- a/crates/trie/sparse/src/blinded.rs
+++ b/crates/trie/sparse/src/blinded.rs
@@ -20,11 +20,8 @@ pub trait BlindedProviderFactory {
 
 /// Trie node provider for retrieving blinded nodes.
 pub trait BlindedProvider {
-    /// The error type for the provider.
-    type Error: Into<SparseTrieError>;
-
     /// Retrieve blinded node by path.
-    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, Self::Error>;
+    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, SparseTrieError>;
 }
 
 /// Default blinded node provider factory that creates [`DefaultBlindedProvider`].
@@ -49,9 +46,7 @@ impl BlindedProviderFactory for DefaultBlindedProviderFactory {
 pub struct DefaultBlindedProvider;
 
 impl BlindedProvider for DefaultBlindedProvider {
-    type Error = SparseTrieError;
-
-    fn blinded_node(&mut self, _path: &Nibbles) -> Result<Option<Bytes>, Self::Error> {
+    fn blinded_node(&mut self, _path: &Nibbles) -> Result<Option<Bytes>, SparseTrieError> {
         Ok(None)
     }
 }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    blinded::{BlindedProvider, BlindedProviderFactory, DefaultBlindedProviderFactory},
+    blinded::{BlindedProviderFactory, DefaultBlindedProviderFactory},
     RevealedSparseTrie, SparseTrie,
 };
 use alloy_primitives::{
@@ -8,9 +8,7 @@ use alloy_primitives::{
     Bytes, B256,
 };
 use alloy_rlp::{Decodable, Encodable};
-use reth_execution_errors::{
-    SparseStateTrieErrorKind, SparseStateTrieResult, SparseTrieError, SparseTrieErrorKind,
-};
+use reth_execution_errors::{SparseStateTrieErrorKind, SparseStateTrieResult, SparseTrieErrorKind};
 use reth_primitives_traits::Account;
 use reth_tracing::tracing::trace;
 use reth_trie_common::{
@@ -452,12 +450,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         })
     }
 }
-impl<F> SparseStateTrie<F>
-where
-    F: BlindedProviderFactory,
-    SparseTrieError: From<<F::AccountNodeProvider as BlindedProvider>::Error>
-        + From<<F::StorageNodeProvider as BlindedProvider>::Error>,
-{
+impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     /// Update the account leaf node.
     pub fn update_account_leaf(
         &mut self,

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
     B256,
 };
 use alloy_rlp::Decodable;
-use reth_execution_errors::{SparseTrieError, SparseTrieErrorKind, SparseTrieResult};
+use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
 use reth_tracing::tracing::trace;
 use reth_trie_common::{
     prefix_set::{PrefixSet, PrefixSetMut},
@@ -73,7 +73,7 @@ impl<P> SparseTrie<P> {
     }
 
     /// Returns reference to revealed sparse trie if the trie is not blind.
-    pub fn as_revealed_ref(&self) -> Option<&RevealedSparseTrie<P>> {
+    pub const fn as_revealed_ref(&self) -> Option<&RevealedSparseTrie<P>> {
         if let Self::Revealed(revealed) = self {
             Some(revealed)
         } else {
@@ -131,11 +131,7 @@ impl<P> SparseTrie<P> {
     }
 }
 
-impl<P> SparseTrie<P>
-where
-    P: BlindedProvider,
-    SparseTrieError: From<P::Error>,
-{
+impl<P: BlindedProvider> SparseTrie<P> {
     /// Update the leaf node.
     pub fn update_leaf(&mut self, path: Nibbles, value: Vec<u8>) -> SparseTrieResult<()> {
         let revealed = self.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;
@@ -825,11 +821,7 @@ impl<P> RevealedSparseTrie<P> {
     }
 }
 
-impl<P> RevealedSparseTrie<P>
-where
-    P: BlindedProvider,
-    SparseTrieError: From<P::Error>,
-{
+impl<P: BlindedProvider> RevealedSparseTrie<P> {
     /// Update the leaf node with provided value.
     pub fn update_leaf(&mut self, path: Nibbles, value: Vec<u8>) -> SparseTrieResult<()> {
         self.prefix_set.insert(path.clone());

--- a/crates/trie/trie/src/proof/blinded.rs
+++ b/crates/trie/trie/src/proof/blinded.rs
@@ -84,9 +84,7 @@ where
     T: TrieCursorFactory + Clone + Send + Sync,
     H: HashedCursorFactory + Clone + Send + Sync,
 {
-    type Error = SparseTrieError;
-
-    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, Self::Error> {
+    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, SparseTrieError> {
         let targets = HashMap::from_iter([(pad_path_to_key(path), HashSet::default())]);
         let proof =
             Proof::new(self.trie_cursor_factory.clone(), self.hashed_cursor_factory.clone())
@@ -128,9 +126,7 @@ where
     T: TrieCursorFactory + Clone + Send + Sync,
     H: HashedCursorFactory + Clone + Send + Sync,
 {
-    type Error = SparseTrieError;
-
-    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, Self::Error> {
+    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, SparseTrieError> {
         let targets = HashSet::from_iter([pad_path_to_key(path)]);
         let storage_prefix_set =
             self.prefix_sets.storage_prefix_sets.get(&self.account).cloned().unwrap_or_default();

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -212,8 +212,8 @@ impl<F> WitnessBlindedProviderFactory<F> {
 impl<F> BlindedProviderFactory for WitnessBlindedProviderFactory<F>
 where
     F: BlindedProviderFactory,
-    F::AccountNodeProvider: BlindedProvider<Error = SparseTrieError>,
-    F::StorageNodeProvider: BlindedProvider<Error = SparseTrieError>,
+    F::AccountNodeProvider: BlindedProvider,
+    F::StorageNodeProvider: BlindedProvider,
 {
     type AccountNodeProvider = WitnessBlindedProvider<F::AccountNodeProvider>;
     type StorageNodeProvider = WitnessBlindedProvider<F::StorageNodeProvider>;
@@ -243,13 +243,8 @@ impl<P> WitnessBlindedProvider<P> {
     }
 }
 
-impl<P> BlindedProvider for WitnessBlindedProvider<P>
-where
-    P: BlindedProvider<Error = SparseTrieError>,
-{
-    type Error = P::Error;
-
-    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, Self::Error> {
+impl<P: BlindedProvider> BlindedProvider for WitnessBlindedProvider<P> {
+    fn blinded_node(&mut self, path: &Nibbles) -> Result<Option<Bytes>, SparseTrieError> {
         let maybe_node = self.provider.blinded_node(path)?;
         if let Some(node) = &maybe_node {
             self.tx


### PR DESCRIPTION
## Description

Remove `Error` ast from `BlindedProvider`. Simplify some trait bounds.