### PR TITLE
fix(trie): set sparse trie branch tree mask bit only for extension and branch nodes

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -720,13 +720,17 @@ impl<P> RevealedSparseTrie<P> {
 
                                 // Determine whether we need to set trie mask bit.
                                 let should_set_tree_mask_bit =
-                                    // A branch or an extension node explicitly set the
-                                    // `store_in_db_trie` flag
-                                    node_type.store_in_db_trie() ||
-                                    // Set the flag according to whether a child node was
-                                    // pre-calculated (`calculated = false`), meaning that it wasn't
-                                    // in the database
-                                    !calculated;
+                                    // The node should be a branch or an extension node
+                                    (node_type.is_branch() || node_type.is_extension()) &&
+                                    (
+                                        // A branch or an extension node explicitly set the
+                                        // `store_in_db_trie` flag
+                                        node_type.store_in_db_trie() ||
+                                        // Set the flag according to whether a child node was
+                                        // pre-calculated (`calculated = false`), meaning that it wasn't
+                                        // in the database
+                                        !calculated
+                                    );
                                 if should_set_tree_mask_bit {
                                     tree_mask.set_bit(last_child_nibble);
                                 }
@@ -1145,6 +1149,10 @@ enum SparseNodeType {
 impl SparseNodeType {
     const fn is_hash(&self) -> bool {
         matches!(self, Self::Hash)
+    }
+
+    const fn is_extension(&self) -> bool {
+        matches!(self, Self::Extension { .. })
     }
 
     const fn is_branch(&self) -> bool {


### PR DESCRIPTION
Tree masks shouldn't be set for non-branch nodes (in the case of sparse trie, for non-branch and non-extension nodes)

https://github.com/alloy-rs/trie/blob/f7f6febfc7e69c949434ad0776b1a9ce29cf9869/src/hash_builder/mod.rs#L257-L287