### PR TITLE
fix(trie): sparse trie tree masks

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -748,7 +748,7 @@ where
         config.prefix_sets,
         thread_pool,
     )
-    .with_branch_node_hash_masks(true)
+    .with_branch_node_masks(true)
     .multiproof(proof_targets)?)
 }
 

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -198,7 +198,7 @@ fn branch_nodes_equal(
 ) -> bool {
     if let (Some(task), Some(regular)) = (task.as_ref(), regular.as_ref()) {
         task.state_mask == regular.state_mask &&
-        // We do not compare the tree mask because it is known to be mismatching
+            task.tree_mask == regular.tree_mask &&
             task.hash_mask == regular.hash_mask &&
             task.hashes == regular.hashes &&
             task.root_hash == regular.root_hash

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -29,6 +29,8 @@ pub struct MultiProof {
     pub account_subtree: ProofNodes,
     /// The hash masks of the branch nodes in the account proof.
     pub branch_node_hash_masks: HashMap<Nibbles, TrieMask>,
+    /// The tree masks of the branch nodes in the account proof.
+    pub branch_node_tree_masks: HashMap<Nibbles, TrieMask>,
     /// Storage trie multiproofs.
     pub storages: B256HashMap<StorageMultiProof>,
 }
@@ -115,6 +117,7 @@ impl MultiProof {
         self.account_subtree.extend_from(other.account_subtree);
 
         self.branch_node_hash_masks.extend(other.branch_node_hash_masks);
+        self.branch_node_tree_masks.extend(other.branch_node_tree_masks);
 
         for (hashed_address, storage) in other.storages {
             match self.storages.entry(hashed_address) {
@@ -123,6 +126,7 @@ impl MultiProof {
                     let entry = entry.get_mut();
                     entry.subtree.extend_from(storage.subtree);
                     entry.branch_node_hash_masks.extend(storage.branch_node_hash_masks);
+                    entry.branch_node_tree_masks.extend(storage.branch_node_tree_masks);
                 }
                 hash_map::Entry::Vacant(entry) => {
                     entry.insert(storage);
@@ -141,6 +145,8 @@ pub struct StorageMultiProof {
     pub subtree: ProofNodes,
     /// The hash masks of the branch nodes in the storage proof.
     pub branch_node_hash_masks: HashMap<Nibbles, TrieMask>,
+    /// The tree masks of the branch nodes in the storage proof.
+    pub branch_node_tree_masks: HashMap<Nibbles, TrieMask>,
 }
 
 impl StorageMultiProof {
@@ -153,6 +159,7 @@ impl StorageMultiProof {
                 Bytes::from([EMPTY_STRING_CODE]),
             )]),
             branch_node_hash_masks: HashMap::default(),
+            branch_node_tree_masks: HashMap::default(),
         }
     }
 
@@ -398,6 +405,7 @@ mod tests {
                 root,
                 subtree: subtree1,
                 branch_node_hash_masks: HashMap::default(),
+                branch_node_tree_masks: HashMap::default(),
             },
         );
 
@@ -412,6 +420,7 @@ mod tests {
                 root,
                 subtree: subtree2,
                 branch_node_hash_masks: HashMap::default(),
+                branch_node_tree_masks: HashMap::default(),
             },
         );
 

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -301,18 +301,24 @@ where
         self.metrics.record_state_trie(tracker.finish());
 
         let account_subtree = hash_builder.take_proof_nodes();
-        let branch_node_hash_masks = if self.collect_branch_node_hash_masks {
-            hash_builder
-                .updated_branch_nodes
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(path, node)| (path, node.hash_mask))
-                .collect()
-        } else {
-            HashMap::default()
-        };
+        let (branch_node_hash_masks, branch_node_tree_masks) =
+            if self.collect_branch_node_hash_masks {
+                let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
+                (
+                    updated_branch_nodes
+                        .iter()
+                        .map(|(path, node)| (path.clone(), node.hash_mask))
+                        .collect(),
+                    updated_branch_nodes
+                        .into_iter()
+                        .map(|(path, node)| (path, node.tree_mask))
+                        .collect(),
+                )
+            } else {
+                (HashMap::default(), HashMap::default())
+            };
 
-        Ok(MultiProof { account_subtree, branch_node_hash_masks, storages })
+        Ok(MultiProof { account_subtree, branch_node_hash_masks, branch_node_tree_masks, storages })
     }
 }
 

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -44,8 +44,8 @@ pub struct ParallelProof<Factory> {
     /// invalidate the in-memory nodes, not all keys from `state_sorted` might be present here,
     /// if we have cached nodes for them.
     pub prefix_sets: Arc<TriePrefixSetsMut>,
-    /// Flag indicating whether to include branch node hash masks in the proof.
-    collect_branch_node_hash_masks: bool,
+    /// Flag indicating whether to include branch node masks in the proof.
+    collect_branch_node_masks: bool,
     /// Thread pool for local tasks
     thread_pool: Arc<rayon::ThreadPool>,
     /// Parallel state root metrics.
@@ -67,16 +67,16 @@ impl<Factory> ParallelProof<Factory> {
             nodes_sorted,
             state_sorted,
             prefix_sets,
-            collect_branch_node_hash_masks: false,
+            collect_branch_node_masks: false,
             thread_pool,
             #[cfg(feature = "metrics")]
             metrics: ParallelStateRootMetrics::default(),
         }
     }
 
-    /// Set the flag indicating whether to include branch node hash masks in the proof.
-    pub const fn with_branch_node_hash_masks(mut self, branch_node_hash_masks: bool) -> Self {
-        self.collect_branch_node_hash_masks = branch_node_hash_masks;
+    /// Set the flag indicating whether to include branch node masks in the proof.
+    pub const fn with_branch_node_masks(mut self, branch_node_masks: bool) -> Self {
+        self.collect_branch_node_masks = branch_node_masks;
         self
     }
 }
@@ -137,7 +137,7 @@ where
             let target_slots = targets.get(&hashed_address).cloned().unwrap_or_default();
             let trie_nodes_sorted = self.nodes_sorted.clone();
             let hashed_state_sorted = self.state_sorted.clone();
-            let collect_masks = self.collect_branch_node_hash_masks;
+            let collect_masks = self.collect_branch_node_masks;
 
             let (tx, rx) = std::sync::mpsc::sync_channel(1);
 
@@ -182,7 +182,7 @@ where
                         hashed_address,
                     )
                     .with_prefix_set_mut(PrefixSetMut::from(prefix_set.iter().cloned()))
-                    .with_branch_node_hash_masks(collect_masks)
+                    .with_branch_node_masks(collect_masks)
                     .storage_multiproof(target_slots)
                     .map_err(|e| ParallelStateRootError::Other(e.to_string()));
 
@@ -233,7 +233,7 @@ where
         let retainer: ProofRetainer = targets.keys().map(Nibbles::unpack).collect();
         let mut hash_builder = HashBuilder::default()
             .with_proof_retainer(retainer)
-            .with_updates(self.collect_branch_node_hash_masks);
+            .with_updates(self.collect_branch_node_masks);
 
         // Initialize all storage multiproofs as empty.
         // Storage multiproofs for non empty tries will be overwritten if necessary.
@@ -301,22 +301,21 @@ where
         self.metrics.record_state_trie(tracker.finish());
 
         let account_subtree = hash_builder.take_proof_nodes();
-        let (branch_node_hash_masks, branch_node_tree_masks) =
-            if self.collect_branch_node_hash_masks {
-                let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
-                (
-                    updated_branch_nodes
-                        .iter()
-                        .map(|(path, node)| (path.clone(), node.hash_mask))
-                        .collect(),
-                    updated_branch_nodes
-                        .into_iter()
-                        .map(|(path, node)| (path, node.tree_mask))
-                        .collect(),
-                )
-            } else {
-                (HashMap::default(), HashMap::default())
-            };
+        let (branch_node_hash_masks, branch_node_tree_masks) = if self.collect_branch_node_masks {
+            let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
+            (
+                updated_branch_nodes
+                    .iter()
+                    .map(|(path, node)| (path.clone(), node.hash_mask))
+                    .collect(),
+                updated_branch_nodes
+                    .into_iter()
+                    .map(|(path, node)| (path, node.tree_mask))
+                    .collect(),
+            )
+        } else {
+            (HashMap::default(), HashMap::default())
+        };
 
         Ok(MultiProof { account_subtree, branch_node_hash_masks, branch_node_tree_masks, storages })
     }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -680,6 +680,7 @@ mod tests {
                         Nibbles::from_nibbles([0x1]),
                         TrieMask::new(0b00),
                     )]),
+                    branch_node_tree_masks: HashMap::default(),
                     storages: HashMap::from_iter([
                         (
                             address_1,
@@ -687,6 +688,7 @@ mod tests {
                                 root,
                                 subtree: storage_proof_nodes.clone(),
                                 branch_node_hash_masks: storage_branch_node_hash_masks.clone(),
+                                branch_node_tree_masks: HashMap::default(),
                             },
                         ),
                         (
@@ -695,6 +697,7 @@ mod tests {
                                 root,
                                 subtree: storage_proof_nodes,
                                 branch_node_hash_masks: storage_branch_node_hash_masks,
+                                branch_node_tree_masks: HashMap::default(),
                             },
                         ),
                     ]),

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -155,13 +155,14 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
             self.provider_factory.account_node_provider(),
             root_node,
             None,
+            None,
             self.retain_updates,
         )?;
 
         // Reveal the remaining proof nodes.
         for (path, bytes) in proof {
             let node = TrieNode::decode(&mut &bytes[..])?;
-            trie.reveal_node(path, node, None)?;
+            trie.reveal_node(path, node, None, None)?;
         }
 
         // Mark leaf path as revealed.
@@ -196,13 +197,14 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
             self.provider_factory.storage_node_provider(account),
             root_node,
             None,
+            None,
             self.retain_updates,
         )?;
 
         // Reveal the remaining proof nodes.
         for (path, bytes) in proof {
             let node = TrieNode::decode(&mut &bytes[..])?;
-            trie.reveal_node(path, node, None)?;
+            trie.reveal_node(path, node, None, None)?;
         }
 
         // Mark leaf path as revealed.
@@ -227,20 +229,24 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                 self.provider_factory.account_node_provider(),
                 root_node,
                 multiproof.branch_node_hash_masks.get(&Nibbles::default()).copied(),
+                multiproof.branch_node_tree_masks.get(&Nibbles::default()).copied(),
                 self.retain_updates,
             )?;
 
             // Reveal the remaining proof nodes.
             for (path, bytes) in account_nodes {
                 let node = TrieNode::decode(&mut &bytes[..])?;
-                let hash_mask = if let TrieNode::Branch(_) = node {
-                    multiproof.branch_node_hash_masks.get(&path).copied()
+                let (hash_mask, tree_mask) = if let TrieNode::Branch(_) = node {
+                    (
+                        multiproof.branch_node_hash_masks.get(&path).copied(),
+                        multiproof.branch_node_tree_masks.get(&path).copied(),
+                    )
                 } else {
-                    None
+                    (None, None)
                 };
 
-                trace!(target: "trie::sparse", ?path, ?node, ?hash_mask, "Revealing account node");
-                trie.reveal_node(path, node, hash_mask)?;
+                trace!(target: "trie::sparse", ?path, ?node, ?hash_mask, ?tree_mask, "Revealing account node");
+                trie.reveal_node(path, node, hash_mask, tree_mask)?;
             }
         }
 
@@ -254,20 +260,24 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                     self.provider_factory.storage_node_provider(account),
                     root_node,
                     storage_subtree.branch_node_hash_masks.get(&Nibbles::default()).copied(),
+                    storage_subtree.branch_node_tree_masks.get(&Nibbles::default()).copied(),
                     self.retain_updates,
                 )?;
 
                 // Reveal the remaining proof nodes.
                 for (path, bytes) in nodes {
                     let node = TrieNode::decode(&mut &bytes[..])?;
-                    let hash_mask = if let TrieNode::Branch(_) = node {
-                        storage_subtree.branch_node_hash_masks.get(&path).copied()
+                    let (hash_mask, tree_mask) = if let TrieNode::Branch(_) = node {
+                        (
+                            storage_subtree.branch_node_hash_masks.get(&path).copied(),
+                            storage_subtree.branch_node_tree_masks.get(&path).copied(),
+                        )
                     } else {
-                        None
+                        (None, None)
                     };
 
-                    trace!(target: "trie::sparse", ?account, ?path, ?node, ?hash_mask, "Revealing storage node");
-                    trie.reveal_node(path, node, hash_mask)?;
+                    trace!(target: "trie::sparse", ?account, ?path, ?node, ?hash_mask, ?tree_mask, "Revealing storage node");
+                    trie.reveal_node(path, node, hash_mask, tree_mask)?;
                 }
             }
         }
@@ -348,6 +358,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                         self.provider_factory.storage_node_provider(account),
                         trie_node,
                         None,
+                        None,
                         self.retain_updates,
                     )?;
                 } else {
@@ -355,13 +366,14 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                     storage_trie_entry
                         .as_revealed_mut()
                         .ok_or(SparseTrieErrorKind::Blind)?
-                        .reveal_node(path, trie_node, None)?;
+                        .reveal_node(path, trie_node, None, None)?;
                 }
             } else if path.is_empty() {
                 // Handle special state root node case.
                 self.state.reveal_root_with_provider(
                     self.provider_factory.account_node_provider(),
                     trie_node,
+                    None,
                     None,
                     self.retain_updates,
                 )?;
@@ -370,7 +382,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                 self.state
                     .as_revealed_mut()
                     .ok_or(SparseTrieErrorKind::Blind)?
-                    .reveal_node(path, trie_node, None)?;
+                    .reveal_node(path, trie_node, None, None)?;
             }
         }
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -742,13 +742,22 @@ impl<P> RevealedSparseTrie<P> {
 
                                 // Determine whether we need to set trie mask bit.
                                 let should_set_tree_mask_bit =
-                                    // A branch or an extension node explicitly set the
-                                    // `store_in_db_trie` flag
-                                    node_type.store_in_db_trie() ||
-                                    // Set the flag according to whether a child node was
-                                    // pre-calculated (`calculated = false`), meaning that it wasn't
-                                    // in the database
-                                    !calculated;
+                                    // A blinded node has the tree mask bit set
+                                    (
+                                        node_type.is_hash() &&
+                                        self.branch_node_tree_masks
+                                            .get(&path)
+                                            .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
+                                    ) ||
+                                    (
+                                        // A branch or an extension node explicitly set the
+                                        // `store_in_db_trie` flag
+                                        node_type.store_in_db_trie() ||
+                                        // Set the flag according to whether a child node was
+                                        // pre-calculated (`calculated = false`), meaning that it wasn't
+                                        // in the database
+                                        !calculated
+                                    );
                                 if should_set_tree_mask_bit {
                                     tree_mask.set_bit(last_child_nibble);
                                 }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -746,11 +746,9 @@ impl<P> RevealedSparseTrie<P> {
                                             .get(&path)
                                             .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
                                     ) ||
-                                    (
-                                        // A branch or an extension node explicitly set the
-                                        // `store_in_db_trie` flag
-                                        child_node_type.store_in_db_trie()
-                                    );
+                                    // A branch or an extension node explicitly set the
+                                    // `store_in_db_trie` flag
+                                    child_node_type.store_in_db_trie();
                                 if should_set_tree_mask_bit {
                                     tree_mask.set_bit(last_child_nibble);
                                 }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -343,7 +343,10 @@ impl<P> RevealedSparseTrie<P> {
                                 // Memoize the hash of a previously blinded node in a new branch
                                 // node.
                                 hash: Some(*hash),
-                                store_in_db_trie: None,
+                                store_in_db_trie: Some(
+                                    hash_mask.is_some_and(|mask| !mask.is_empty()) ||
+                                        tree_mask.is_some_and(|mask| !mask.is_empty()),
+                                ),
                             });
                         }
                         // Branch node already exists, or an extension node was placed where a

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -752,11 +752,11 @@ impl<P> RevealedSparseTrie<P> {
                                     (
                                         // A branch or an extension node explicitly set the
                                         // `store_in_db_trie` flag
-                                        node_type.store_in_db_trie() ||
+                                        node_type.store_in_db_trie()
                                         // Set the flag according to whether a child node was
                                         // pre-calculated (`calculated = false`), meaning that it wasn't
                                         // in the database
-                                        !calculated
+                                        // !calculated
                                     );
                                 if should_set_tree_mask_bit {
                                     tree_mask.set_bit(last_child_nibble);

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -60,9 +60,16 @@ impl SparseTrie {
         &mut self,
         root: TrieNode,
         hash_mask: Option<TrieMask>,
+        tree_mask: Option<TrieMask>,
         retain_updates: bool,
     ) -> SparseTrieResult<&mut RevealedSparseTrie> {
-        self.reveal_root_with_provider(Default::default(), root, hash_mask, retain_updates)
+        self.reveal_root_with_provider(
+            Default::default(),
+            root,
+            hash_mask,
+            tree_mask,
+            retain_updates,
+        )
     }
 }
 
@@ -100,6 +107,7 @@ impl<P> SparseTrie<P> {
         provider: P,
         root: TrieNode,
         hash_mask: Option<TrieMask>,
+        tree_mask: Option<TrieMask>,
         retain_updates: bool,
     ) -> SparseTrieResult<&mut RevealedSparseTrie<P>> {
         if self.is_blind() {
@@ -107,6 +115,7 @@ impl<P> SparseTrie<P> {
                 provider,
                 root,
                 hash_mask,
+                tree_mask,
                 retain_updates,
             )?))
         }
@@ -163,6 +172,8 @@ pub struct RevealedSparseTrie<P = DefaultBlindedProvider> {
     nodes: HashMap<Nibbles, SparseNode>,
     /// All branch node hash masks.
     branch_node_hash_masks: HashMap<Nibbles, TrieMask>,
+    /// All branch node tree masks.
+    branch_node_tree_masks: HashMap<Nibbles, TrieMask>,
     /// All leaf values.
     values: HashMap<Nibbles, Vec<u8>>,
     /// Prefix set.
@@ -178,6 +189,7 @@ impl<P> fmt::Debug for RevealedSparseTrie<P> {
         f.debug_struct("RevealedSparseTrie")
             .field("nodes", &self.nodes)
             .field("branch_hash_masks", &self.branch_node_hash_masks)
+            .field("branch_tree_masks", &self.branch_node_tree_masks)
             .field("values", &self.values)
             .field("prefix_set", &self.prefix_set)
             .field("updates", &self.updates)
@@ -192,6 +204,7 @@ impl Default for RevealedSparseTrie {
             provider: Default::default(),
             nodes: HashMap::from_iter([(Nibbles::default(), SparseNode::Empty)]),
             branch_node_hash_masks: HashMap::default(),
+            branch_node_tree_masks: HashMap::default(),
             values: HashMap::default(),
             prefix_set: PrefixSetMut::default(),
             updates: None,
@@ -205,19 +218,21 @@ impl RevealedSparseTrie {
     pub fn from_root(
         node: TrieNode,
         hash_mask: Option<TrieMask>,
+        tree_mask: Option<TrieMask>,
         retain_updates: bool,
     ) -> SparseTrieResult<Self> {
         let mut this = Self {
             provider: Default::default(),
             nodes: HashMap::default(),
             branch_node_hash_masks: HashMap::default(),
+            branch_node_tree_masks: HashMap::default(),
             values: HashMap::default(),
             prefix_set: PrefixSetMut::default(),
             rlp_buf: Vec::new(),
             updates: None,
         }
         .with_updates(retain_updates);
-        this.reveal_node(Nibbles::default(), node, hash_mask)?;
+        this.reveal_node(Nibbles::default(), node, hash_mask, tree_mask)?;
         Ok(this)
     }
 }
@@ -228,19 +243,21 @@ impl<P> RevealedSparseTrie<P> {
         provider: P,
         node: TrieNode,
         hash_mask: Option<TrieMask>,
+        tree_mask: Option<TrieMask>,
         retain_updates: bool,
     ) -> SparseTrieResult<Self> {
         let mut this = Self {
             provider,
             nodes: HashMap::default(),
             branch_node_hash_masks: HashMap::default(),
+            branch_node_tree_masks: HashMap::default(),
             values: HashMap::default(),
             prefix_set: PrefixSetMut::default(),
             rlp_buf: Vec::new(),
             updates: None,
         }
         .with_updates(retain_updates);
-        this.reveal_node(Nibbles::default(), node, hash_mask)?;
+        this.reveal_node(Nibbles::default(), node, hash_mask, tree_mask)?;
         Ok(this)
     }
 
@@ -250,6 +267,7 @@ impl<P> RevealedSparseTrie<P> {
             provider,
             nodes: self.nodes,
             branch_node_hash_masks: self.branch_node_hash_masks,
+            branch_node_tree_masks: self.branch_node_tree_masks,
             values: self.values,
             prefix_set: self.prefix_set,
             updates: self.updates,
@@ -286,6 +304,7 @@ impl<P> RevealedSparseTrie<P> {
         path: Nibbles,
         node: TrieNode,
         hash_mask: Option<TrieMask>,
+        tree_mask: Option<TrieMask>,
     ) -> SparseTrieResult<()> {
         // If the node is already revealed and it's not a hash node, do nothing.
         if self.nodes.get(&path).is_some_and(|node| !node.is_hash()) {
@@ -294,6 +313,9 @@ impl<P> RevealedSparseTrie<P> {
 
         if let Some(hash_mask) = hash_mask {
             self.branch_node_hash_masks.insert(path.clone(), hash_mask);
+        }
+        if let Some(tree_mask) = tree_mask {
+            self.branch_node_tree_masks.insert(path.clone(), tree_mask);
         }
 
         match node {
@@ -433,7 +455,7 @@ impl<P> RevealedSparseTrie<P> {
             return Ok(())
         }
 
-        self.reveal_node(path, TrieNode::decode(&mut &child[..])?, None)
+        self.reveal_node(path, TrieNode::decode(&mut &child[..])?, None, None)
     }
 
     /// Traverse trie nodes down to the leaf node and collect all nodes along the path.
@@ -894,7 +916,7 @@ impl<P: BlindedProvider> RevealedSparseTrie<P> {
                                     // remove or do nothing, so
                                     // we can safely ignore the hash mask here and
                                     // pass `None`.
-                                    self.reveal_node(current.clone(), decoded, None)?;
+                                    self.reveal_node(current.clone(), decoded, None, None)?;
                                 }
                             }
                         }
@@ -1046,7 +1068,7 @@ impl<P: BlindedProvider> RevealedSparseTrie<P> {
                                 // We'll never have to update the revealed branch node, only remove
                                 // or do nothing, so we can safely ignore the hash mask here and
                                 // pass `None`.
-                                self.reveal_node(child_path.clone(), decoded, None)?;
+                                self.reveal_node(child_path.clone(), decoded, None, None)?;
                             }
                         }
 

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -164,18 +164,24 @@ where
         }
         let _ = hash_builder.root();
         let account_subtree = hash_builder.take_proof_nodes();
-        let branch_node_hash_masks = if self.collect_branch_node_hash_masks {
-            hash_builder
-                .updated_branch_nodes
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(path, node)| (path, node.hash_mask))
-                .collect()
-        } else {
-            HashMap::default()
-        };
+        let (branch_node_hash_masks, branch_node_tree_masks) =
+            if self.collect_branch_node_hash_masks {
+                let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
+                (
+                    updated_branch_nodes
+                        .iter()
+                        .map(|(path, node)| (path.clone(), node.hash_mask))
+                        .collect(),
+                    updated_branch_nodes
+                        .into_iter()
+                        .map(|(path, node)| (path, node.tree_mask))
+                        .collect(),
+                )
+            } else {
+                (HashMap::default(), HashMap::default())
+            };
 
-        Ok(MultiProof { account_subtree, branch_node_hash_masks, storages })
+        Ok(MultiProof { account_subtree, branch_node_hash_masks, branch_node_tree_masks, storages })
     }
 }
 
@@ -300,17 +306,23 @@ where
 
         let root = hash_builder.root();
         let subtree = hash_builder.take_proof_nodes();
-        let branch_node_hash_masks = if self.collect_branch_node_hash_masks {
-            hash_builder
-                .updated_branch_nodes
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(path, node)| (path, node.hash_mask))
-                .collect()
-        } else {
-            HashMap::default()
-        };
+        let (branch_node_hash_masks, branch_node_tree_masks) =
+            if self.collect_branch_node_hash_masks {
+                let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
+                (
+                    updated_branch_nodes
+                        .iter()
+                        .map(|(path, node)| (path.clone(), node.hash_mask))
+                        .collect(),
+                    updated_branch_nodes
+                        .into_iter()
+                        .map(|(path, node)| (path, node.tree_mask))
+                        .collect(),
+                )
+            } else {
+                (HashMap::default(), HashMap::default())
+            };
 
-        Ok(StorageMultiProof { root, subtree, branch_node_hash_masks })
+        Ok(StorageMultiProof { root, subtree, branch_node_hash_masks, branch_node_tree_masks })
     }
 }

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -33,8 +33,8 @@ pub struct Proof<T, H> {
     hashed_cursor_factory: H,
     /// A set of prefix sets that have changes.
     prefix_sets: TriePrefixSetsMut,
-    /// Flag indicating whether to include branch node hash masks in the proof.
-    collect_branch_node_hash_masks: bool,
+    /// Flag indicating whether to include branch node masks in the proof.
+    collect_branch_node_masks: bool,
 }
 
 impl<T, H> Proof<T, H> {
@@ -44,7 +44,7 @@ impl<T, H> Proof<T, H> {
             trie_cursor_factory: t,
             hashed_cursor_factory: h,
             prefix_sets: TriePrefixSetsMut::default(),
-            collect_branch_node_hash_masks: false,
+            collect_branch_node_masks: false,
         }
     }
 
@@ -54,7 +54,7 @@ impl<T, H> Proof<T, H> {
             trie_cursor_factory,
             hashed_cursor_factory: self.hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
-            collect_branch_node_hash_masks: self.collect_branch_node_hash_masks,
+            collect_branch_node_masks: self.collect_branch_node_masks,
         }
     }
 
@@ -64,7 +64,7 @@ impl<T, H> Proof<T, H> {
             trie_cursor_factory: self.trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
-            collect_branch_node_hash_masks: self.collect_branch_node_hash_masks,
+            collect_branch_node_masks: self.collect_branch_node_masks,
         }
     }
 
@@ -74,9 +74,9 @@ impl<T, H> Proof<T, H> {
         self
     }
 
-    /// Set the flag indicating whether to include branch node hash masks in the proof.
-    pub const fn with_branch_node_hash_masks(mut self, branch_node_hash_masks: bool) -> Self {
-        self.collect_branch_node_hash_masks = branch_node_hash_masks;
+    /// Set the flag indicating whether to include branch node masks in the proof.
+    pub const fn with_branch_node_masks(mut self, branch_node_masks: bool) -> Self {
+        self.collect_branch_node_masks = branch_node_masks;
         self
     }
 }
@@ -117,7 +117,7 @@ where
         let retainer = targets.keys().map(Nibbles::unpack).collect();
         let mut hash_builder = HashBuilder::default()
             .with_proof_retainer(retainer)
-            .with_updates(self.collect_branch_node_hash_masks);
+            .with_updates(self.collect_branch_node_masks);
 
         // Initialize all storage multiproofs as empty.
         // Storage multiproofs for non empty tries will be overwritten if necessary.
@@ -144,7 +144,7 @@ where
                         hashed_address,
                     )
                     .with_prefix_set_mut(storage_prefix_set)
-                    .with_branch_node_hash_masks(self.collect_branch_node_hash_masks)
+                    .with_branch_node_masks(self.collect_branch_node_masks)
                     .storage_multiproof(proof_targets.unwrap_or_default())?;
 
                     // Encode account
@@ -164,22 +164,21 @@ where
         }
         let _ = hash_builder.root();
         let account_subtree = hash_builder.take_proof_nodes();
-        let (branch_node_hash_masks, branch_node_tree_masks) =
-            if self.collect_branch_node_hash_masks {
-                let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
-                (
-                    updated_branch_nodes
-                        .iter()
-                        .map(|(path, node)| (path.clone(), node.hash_mask))
-                        .collect(),
-                    updated_branch_nodes
-                        .into_iter()
-                        .map(|(path, node)| (path, node.tree_mask))
-                        .collect(),
-                )
-            } else {
-                (HashMap::default(), HashMap::default())
-            };
+        let (branch_node_hash_masks, branch_node_tree_masks) = if self.collect_branch_node_masks {
+            let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
+            (
+                updated_branch_nodes
+                    .iter()
+                    .map(|(path, node)| (path.clone(), node.hash_mask))
+                    .collect(),
+                updated_branch_nodes
+                    .into_iter()
+                    .map(|(path, node)| (path, node.tree_mask))
+                    .collect(),
+            )
+        } else {
+            (HashMap::default(), HashMap::default())
+        };
 
         Ok(MultiProof { account_subtree, branch_node_hash_masks, branch_node_tree_masks, storages })
     }
@@ -196,8 +195,8 @@ pub struct StorageProof<T, H> {
     hashed_address: B256,
     /// The set of storage slot prefixes that have changed.
     prefix_set: PrefixSetMut,
-    /// Flag indicating whether to include branch node hash masks in the proof.
-    collect_branch_node_hash_masks: bool,
+    /// Flag indicating whether to include branch node masks in the proof.
+    collect_branch_node_masks: bool,
 }
 
 impl<T, H> StorageProof<T, H> {
@@ -213,7 +212,7 @@ impl<T, H> StorageProof<T, H> {
             hashed_cursor_factory: h,
             hashed_address,
             prefix_set: PrefixSetMut::default(),
-            collect_branch_node_hash_masks: false,
+            collect_branch_node_masks: false,
         }
     }
 
@@ -224,7 +223,7 @@ impl<T, H> StorageProof<T, H> {
             hashed_cursor_factory: self.hashed_cursor_factory,
             hashed_address: self.hashed_address,
             prefix_set: self.prefix_set,
-            collect_branch_node_hash_masks: self.collect_branch_node_hash_masks,
+            collect_branch_node_masks: self.collect_branch_node_masks,
         }
     }
 
@@ -235,7 +234,7 @@ impl<T, H> StorageProof<T, H> {
             hashed_cursor_factory,
             hashed_address: self.hashed_address,
             prefix_set: self.prefix_set,
-            collect_branch_node_hash_masks: self.collect_branch_node_hash_masks,
+            collect_branch_node_masks: self.collect_branch_node_masks,
         }
     }
 
@@ -245,9 +244,9 @@ impl<T, H> StorageProof<T, H> {
         self
     }
 
-    /// Set the flag indicating whether to include branch node hash masks in the proof.
-    pub const fn with_branch_node_hash_masks(mut self, branch_node_hash_masks: bool) -> Self {
-        self.collect_branch_node_hash_masks = branch_node_hash_masks;
+    /// Set the flag indicating whether to include branch node masks in the proof.
+    pub const fn with_branch_node_masks(mut self, branch_node_masks: bool) -> Self {
+        self.collect_branch_node_masks = branch_node_masks;
         self
     }
 }
@@ -288,7 +287,7 @@ where
         let retainer = ProofRetainer::from_iter(target_nibbles);
         let mut hash_builder = HashBuilder::default()
             .with_proof_retainer(retainer)
-            .with_updates(self.collect_branch_node_hash_masks);
+            .with_updates(self.collect_branch_node_masks);
         let mut storage_node_iter = TrieNodeIter::new(walker, hashed_storage_cursor);
         while let Some(node) = storage_node_iter.try_next()? {
             match node {
@@ -306,22 +305,21 @@ where
 
         let root = hash_builder.root();
         let subtree = hash_builder.take_proof_nodes();
-        let (branch_node_hash_masks, branch_node_tree_masks) =
-            if self.collect_branch_node_hash_masks {
-                let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
-                (
-                    updated_branch_nodes
-                        .iter()
-                        .map(|(path, node)| (path.clone(), node.hash_mask))
-                        .collect(),
-                    updated_branch_nodes
-                        .into_iter()
-                        .map(|(path, node)| (path, node.tree_mask))
-                        .collect(),
-                )
-            } else {
-                (HashMap::default(), HashMap::default())
-            };
+        let (branch_node_hash_masks, branch_node_tree_masks) = if self.collect_branch_node_masks {
+            let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
+            (
+                updated_branch_nodes
+                    .iter()
+                    .map(|(path, node)| (path.clone(), node.hash_mask))
+                    .collect(),
+                updated_branch_nodes
+                    .into_iter()
+                    .map(|(path, node)| (path, node.tree_mask))
+                    .collect(),
+            )
+        } else {
+            (HashMap::default(), HashMap::default())
+        };
 
         Ok(StorageMultiProof { root, subtree, branch_node_hash_masks, branch_node_tree_masks })
     }


### PR DESCRIPTION
Two bugs:
1. `store_in_db_trie` for branch nodes wasn't set when revealing a node https://github.com/paradigmxyz/reth/blob/52f12917b79696cd250b07da7fb951b71f8d5600/crates/trie/sparse/src/trie.rs#L346-L349
2. Blinded children of a branch node should inherit the tree mask bit as-is https://github.com/paradigmxyz/reth/blob/52f12917b79696cd250b07da7fb951b71f8d5600/crates/trie/sparse/src/trie.rs#L740-L751