### PR TITLE
eth_sendRawTransactionConditional L2 RPC endpoint

### DIFF
--- a/crates/rpc/rpc-eth-api/src/ext.rs
+++ b/crates/rpc/rpc-eth-api/src/ext.rs
@@ -32,7 +32,7 @@ where
         bytes: Bytes,
         condition: ConditionalOptions,
     ) -> RpcResult<B256> {
-        trace!(target: "rpc::eth", ?bytes, "Serving eth_sendRawTransaction");
+        trace!(target: "rpc::eth", ?bytes, "Serving eth_sendRawTransactionConditional");
         Ok(EthTransactions::send_raw_transaction(self, bytes).await?)
     }
 }

--- a/crates/rpc/rpc-eth-api/src/ext.rs
+++ b/crates/rpc/rpc-eth-api/src/ext.rs
@@ -30,7 +30,7 @@ where
     async fn send_raw_transaction_conditional(
         &self,
         bytes: Bytes,
-        condition: ConditionalOptions,
+        _condition: ConditionalOptions,
     ) -> RpcResult<B256> {
         trace!(target: "rpc::eth", ?bytes, "Serving eth_sendRawTransactionConditional");
         Ok(EthTransactions::send_raw_transaction(self, bytes).await?)

--- a/crates/rpc/rpc-eth-api/src/ext.rs
+++ b/crates/rpc/rpc-eth-api/src/ext.rs
@@ -3,6 +3,9 @@
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_eth::erc4337::ConditionalOptions;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use tracing::trace;
+
+use crate::helpers::{EthTransactions, FullEthApi};
 
 /// Extension trait for `eth_` namespace for L2s.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
@@ -15,4 +18,21 @@ pub trait L2EthApiExt {
         bytes: Bytes,
         condition: ConditionalOptions,
     ) -> RpcResult<B256>;
+}
+
+#[async_trait::async_trait]
+impl<T> L2EthApiExtServer for T
+where
+    T: FullEthApi,
+    jsonrpsee_types::error::ErrorObject<'static>: From<T::Error>,
+{
+    /// Handler for: `eth_sendRawTransactionConditional`
+    async fn send_raw_transaction_conditional(
+        &self,
+        bytes: Bytes,
+        condition: ConditionalOptions,
+    ) -> RpcResult<B256> {
+        trace!(target: "rpc::eth", ?bytes, "Serving eth_sendRawTransaction");
+        Ok(EthTransactions::send_raw_transaction(self, bytes).await?)
+    }
 }


### PR DESCRIPTION
This is a draft pr for [13488](https://github.com/paradigmxyz/reth/issues/13488#issuecomment-2581307420). 

So far I just implemented a blanket implementation of `L2EthApiExtServer` without using the `ConditionalOptions`. Im not exactly sure how to extract the information from the `bytes` argument to check against `condition`. I think I am missing something and would definitely love a push in the right direction.