### PR TITLE
feat(tree): --engine.state-root-task-compare-updates

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -43,6 +43,11 @@ pub struct EngineArgs {
     /// Enable state root task
     #[arg(long = "engine.state-root-task", conflicts_with = "legacy")]
     pub state_root_task_enabled: bool,
+
+    /// Enable comparing trie updates from the state root task to the trie updates from the regular
+    /// state root calculation.
+    #[arg(long = "engine.state-root-task-compare-updates", conflicts_with = "legacy")]
+    pub state_root_task_compare_updates: bool,
 }
 
 impl Default for EngineArgs {
@@ -53,6 +58,7 @@ impl Default for EngineArgs {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             state_root_task_enabled: false,
+            state_root_task_compare_updates: false,
         }
     }
 }
@@ -77,7 +83,8 @@ fn main() {
                     let engine_tree_config = TreeConfig::default()
                         .with_persistence_threshold(engine_args.persistence_threshold)
                         .with_memory_block_buffer_target(engine_args.memory_block_buffer_target)
-                        .with_state_root_task(engine_args.state_root_task_enabled);
+                        .with_state_root_task(engine_args.state_root_task_enabled)
+                        .with_always_compare_trie_updates(engine_args.state_root_task_compare_updates);
                     let handle = builder
                         .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
                         .with_components(EthereumNode::components())

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -703,6 +703,9 @@ Engine:
       --engine.state-root-task
           Enable state root task
 
+      --engine.state-root-task-compare-updates
+          Enable comparing trie updates from the state root task to the trie updates from the regular state root calculation
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/crates/engine/tree/src/tree/config.rs
+++ b/crates/engine/tree/src/tree/config.rs
@@ -43,6 +43,9 @@ pub struct TreeConfig {
     max_execute_block_batch_size: usize,
     /// Whether to use the new state root task calculation method instead of parallel calculation
     use_state_root_task: bool,
+    /// Whether to always compare trie updates from the state root task to the trie updates from
+    /// the regular state root calculation.
+    always_compare_trie_updates: bool,
 }
 
 impl Default for TreeConfig {
@@ -54,6 +57,7 @@ impl Default for TreeConfig {
             max_invalid_header_cache_length: DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH,
             max_execute_block_batch_size: DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE,
             use_state_root_task: false,
+            always_compare_trie_updates: false,
         }
     }
 }
@@ -67,6 +71,7 @@ impl TreeConfig {
         max_invalid_header_cache_length: u32,
         max_execute_block_batch_size: usize,
         use_state_root_task: bool,
+        always_compare_trie_updates: bool,
     ) -> Self {
         Self {
             persistence_threshold,
@@ -75,6 +80,7 @@ impl TreeConfig {
             max_invalid_header_cache_length,
             max_execute_block_batch_size,
             use_state_root_task,
+            always_compare_trie_updates,
         }
     }
 
@@ -106,6 +112,12 @@ impl TreeConfig {
     /// Returns whether to use the state root task calculation method.
     pub const fn use_state_root_task(&self) -> bool {
         self.use_state_root_task
+    }
+
+    /// Returns whether to always compare trie updates from the state root task to the trie updates
+    /// from the regular state root calculation.
+    pub const fn always_compare_trie_updates(&self) -> bool {
+        self.always_compare_trie_updates
     }
 
     /// Setter for persistence threshold.
@@ -150,6 +162,16 @@ impl TreeConfig {
     /// Setter for whether to use the new state root task calculation method.
     pub const fn with_state_root_task(mut self, use_state_root_task: bool) -> Self {
         self.use_state_root_task = use_state_root_task;
+        self
+    }
+
+    /// Setter for whether to always compare trie updates from the state root task to the trie
+    /// updates from the regular state root calculation.
+    pub const fn with_always_compare_trie_updates(
+        mut self,
+        always_compare_trie_updates: bool,
+    ) -> Self {
+        self.always_compare_trie_updates = always_compare_trie_updates;
         self
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2372,8 +2372,13 @@ where
                                 "Task state root finished"
                             );
 
-                            if task_state_root != block.header().state_root() {
-                                debug!(target: "engine::tree", "Task state root does not match block state root");
+                            if task_state_root != block.header().state_root() ||
+                                self.config.always_compare_trie_updates()
+                            {
+                                if task_state_root != block.header().state_root() {
+                                    debug!(target: "engine::tree", "Task state root does not match block state root");
+                                }
+
                                 let (regular_root, regular_updates) =
                                     state_provider.state_root_with_updates(hashed_state.clone())?;
 


### PR DESCRIPTION
Useful for debugging when we want to always compare trie updates against the hash builder