### PR TITLE
feat(tree): when comparing trie updates, check the database

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 reth-chain-state.workspace = true
 reth-chainspec = { workspace = true, optional = true }
 reth-consensus.workspace = true
+reth-db = { workspace = true, features = ["test-utils"] }
 reth-engine-primitives.workspace = true
 reth-errors.workspace = true
 reth-evm.workspace = true
@@ -22,8 +23,8 @@ reth-network-p2p.workspace = true
 reth-payload-builder-primitives.workspace = true
 reth-payload-builder.workspace = true
 reth-payload-primitives.workspace = true
-reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
+reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-prune.workspace = true
 reth-revm.workspace = true
@@ -71,7 +72,6 @@ reth-tracing = { workspace = true, optional = true }
 # reth
 reth-chain-state = { workspace = true, features = ["test-utils"] }
 reth-chainspec.workspace = true
-reth-db = { workspace = true, features = ["test-utils"] }
 reth-ethereum-engine-primitives.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 reth-chain-state.workspace = true
 reth-chainspec = { workspace = true, optional = true }
 reth-consensus.workspace = true
-reth-db = { workspace = true, features = ["test-utils"] }
+reth-db.workspace = true
 reth-engine-primitives.workspace = true
 reth-errors.workspace = true
 reth-evm.workspace = true

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2381,8 +2381,8 @@ where
                                     let provider = self.provider.database_provider_ro()?;
                                     compare_trie_updates(
                                         provider.tx_ref(),
-                                        &task_trie_updates,
-                                        &regular_updates,
+                                        task_trie_updates.clone(),
+                                        regular_updates,
                                     )
                                     .map_err(ProviderError::from)?;
                                 } else {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2378,7 +2378,13 @@ where
                                     state_provider.state_root_with_updates(hashed_state.clone())?;
 
                                 if regular_root == block.header().state_root() {
-                                    compare_trie_updates(&task_trie_updates, &regular_updates);
+                                    let provider = self.provider.database_provider_ro()?;
+                                    compare_trie_updates(
+                                        provider.tx_ref(),
+                                        &task_trie_updates,
+                                        &regular_updates,
+                                    )
+                                    .map_err(ProviderError::from)?;
                                 } else {
                                     debug!(target: "engine::tree", "Regular state root does not match block state root");
                                 }

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -145,23 +145,20 @@ pub(super) fn compare_trie_updates(
         let (task, regular) = (task.storage_tries.remove(&key), regular.storage_tries.remove(&key));
         if task != regular {
             let mut storage_trie_cursor = trie_cursor_factory.storage_trie_cursor(key)?;
-            if let Some((left, right)) = task.as_ref().zip(regular.as_ref()) {
-                let storage_diff =
-                    compare_storage_trie_updates(&mut storage_trie_cursor, left, right)?;
-                if storage_diff.has_differences() {
-                    diff.storage_tries.insert(key, StorageTrieDiffEntry::Value(storage_diff));
-                }
-            } else if compare_storage_trie_updates(
-                &mut storage_trie_cursor,
-                &task.clone().unwrap_or_default(),
-                &regular.clone().unwrap_or_default(),
-            )?
-            .has_differences()
-            {
+            if task.is_some() != regular.is_some() {
                 diff.storage_tries.insert(
                     key,
                     StorageTrieDiffEntry::Existence(task.is_some(), regular.is_some()),
                 );
+            }
+
+            let storage_diff = compare_storage_trie_updates(
+                &mut storage_trie_cursor,
+                &task.unwrap_or_default(),
+                &regular.unwrap_or_default(),
+            )?;
+            if storage_diff.has_differences() {
+                diff.storage_tries.insert(key, StorageTrieDiffEntry::Value(storage_diff));
             }
         }
     }


### PR DESCRIPTION
We have a bunch of trie update mismatches that are caused by the fact that either Sparse Trie or Hash Builder update a branch node with the same value as it is in the database, which is basically a no-op.

The changes in this PR check the database and if the node didn't change, don't add to diffs. Additionally, we now log the database entry for branch nodes.