### PR TITLE
fix: Fix incorrect attribute reference Update main.rs

### DIFF
--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -236,7 +236,7 @@ where
         validate_version_specific_fields(self.chain_spec(), version, attributes.into())?;
 
         // custom validation logic - ensure that the custom field is not zero
-        if attributes.custom == 0 {
+        if attributes.inner.custom == 0 {
             return Err(EngineObjectValidationError::invalid_params(
                 CustomError::CustomFieldIsNotZero,
             ))


### PR DESCRIPTION
I corrected an issue where the code attempted to access the `custom` field directly on `attributes`.

Since `attributes` is a reference to `CustomPayloadAttributes`, which encapsulates the actual `custom` field within the `inner` field, the correct reference is `attributes.inner.custom`.

This change ensures proper access to the `custom` attribute, and the issue should now be resolved.