### PR TITLE
fix: correct gas limit and gas used results in trace API

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -427,11 +427,11 @@ where
                             .inner
                             .eth_api
                             .spawn_with_call_at(call, at, overrides, move |db, env| {
-                                let (_res, env) =
-                                    this.eth_api().inspect(db, env, &mut inspector)?;
+                                let (res, env) = this.eth_api().inspect(db, env, &mut inspector)?;
                                 let tx_info = TransactionInfo::default();
                                 let frame: FlatCallFrame = inspector
                                     .with_transaction_gas_limit(env.tx.gas_limit)
+                                    .with_transaction_gas_used(res.result.gas_used())
                                     .into_parity_builder()
                                     .into_localized_transaction_traces(tx_info);
                                 Ok(frame)

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -100,7 +100,7 @@ where
             .spawn_trace_transaction_in_block_with_inspector(
                 tx_hash,
                 TransferInspector::new(false),
-                |_tx_info, inspector, _, _| Ok(inspector.into_transfers()),
+                |_tx_info, _tx_gas_limit, inspector, _, _| Ok(inspector.into_transfers()),
             )
             .await
             .map_err(Into::into)?
@@ -146,7 +146,9 @@ where
             .spawn_trace_transaction_in_block(
                 tx_hash,
                 TracingInspectorConfig::default_parity(),
-                move |_tx_info, inspector, _, _| Ok(inspector.into_traces().into_nodes()),
+                move |_tx_info, _tx_gas_limit, inspector, _, _| {
+                    Ok(inspector.into_traces().into_nodes())
+                },
             )
             .await
             .map_err(Into::into)?
@@ -351,7 +353,7 @@ where
                 num.into(),
                 None,
                 TracingInspectorConfig::default_parity(),
-                |tx_info, inspector, _, _, _| {
+                |tx_info, _, inspector, _, _, _| {
                     Ok(inspector.into_parity_builder().into_localized_transaction_traces(tx_info))
                 },
             )


### PR DESCRIPTION
Due to the revm inspector's inability to record a transaction's initial gas used, all trace-related methods were returning incorrect gas and gas used values. To properly handle this situation, the gas and gas used values for the root trace should be manually set after the transaction completes. While this fix was implemented in the debug API, it was missing from the trace API.