### PR TITLE
feat: add snmalloc support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codspeed"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6680,6 +6689,7 @@ dependencies = [
  "reth-fs-util",
  "secp256k1",
  "serde",
+ "snmalloc-rs",
  "thiserror 2.0.9",
  "tikv-jemallocator",
  "tracy-client",
@@ -10415,6 +10425,25 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snmalloc-rs"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43ff92911d7d9705d1c0203300a3edfd00d16c8b8b0c27c56f9407a3f31e7a6"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954e1f984860770475196be81a547ed1517d34fcb8a15cb87bdb37cff3353230"
+dependencies = [
+ "cc",
+ "cmake",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -604,9 +604,11 @@ tempfile = "3.8"
 test-fuzz = "6"
 rstest = "0.23.0"
 
+# allocators
 tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
+snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 
 # [patch.crates-io]
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "5492e40" }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -118,6 +118,12 @@ jemalloc-prof = [
 ]
 tracy-allocator = ["reth-cli-util/tracy-allocator"]
 
+# Because jemalloc is default and preferred over snmalloc when both features are
+# enabled, `--no-default-features` should be used when enabling snmalloc or
+# snmalloc-native.
+snmalloc = ["reth-cli-util/snmalloc"]
+snmalloc-native = ["reth-cli-util/snmalloc-native"]
+
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]
 min-info-logs = ["tracing/release_max_level_info"]

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -30,10 +30,21 @@ tracy-client = { workspace = true, optional = true, features = ["demangle"] }
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }
+snmalloc-rs = { workspace = true, optional = true }
 libc = "0.2"
 
 [features]
 jemalloc = ["dep:tikv-jemallocator"]
+
+# Enables jemalloc profiling features
 jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
 
+# Wraps the selected allocator in the tracy profiling allocator
 tracy-allocator = ["dep:tracy-client"]
+
+snmalloc = ["dep:snmalloc-rs"]
+
+# Enables the snmalloc-rs `native-cpu` feature, which optimizes snmalloc for the
+# native CPU of the host machine. Not sure why this feature is not derived from
+# RUSTFLAGS or enabled when `target-cpu=native`.
+snmalloc-native = ["snmalloc", "snmalloc-rs/native-cpu"]


### PR DESCRIPTION
This enables optional snmalloc support. I have not benchmarked our performance with snmalloc yet. This is implemented by adding a `snmalloc` feature to `reth-cli-util` and the `reth` bin, like we do with the `jemalloc` feature.

Instead of making these mutually exclusive features that would compile error if both are enabled, we just add a preference for jemalloc in the `reth-cli-util` crate. This also introduces `snmalloc-native`, which passes down snmalloc's `native-cpu` feature. This preference is explicitly documented in `reth-cli-util`.