### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -204,7 +204,7 @@ impl<T: Clone + Sync + Send + 'static> Stream for ForkChoiceStream<T> {
         loop {
             match ready!(self.as_mut().project().st.poll_next(cx)) {
                 Some(Some(notification)) => return Poll::Ready(Some(notification)),
-                Some(None) => continue,
+                Some(None) => {}
                 None => return Poll::Ready(None),
             }
         }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -611,7 +611,7 @@ impl ChainSpec {
                             return Some(block_num);
                         }
                     }
-                    ForkCondition::Block(_) | ForkCondition::Never => continue,
+                    ForkCondition::Block(_) | ForkCondition::Never => {}
                 }
             }
         }

--- a/crates/e2e-test-utils/src/network.rs
+++ b/crates/e2e-test-utils/src/network.rs
@@ -49,7 +49,7 @@ where
                     info!("Session established with peer: {:?}", peer_id);
                     return Some(peer_id)
                 }
-                _ => continue,
+                _ => {}
             }
         }
         None

--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -117,7 +117,6 @@ where
                         HandlerEvent::BackfillAction(action) => {
                             // forward action to backfill_sync
                             this.backfill_sync.on_action(action);
-                            continue 'outer
                         }
                         HandlerEvent::Event(ev) => {
                             // bubble up the event

--- a/crates/ethereum-forks/src/display.rs
+++ b/crates/ethereum-forks/src/display.rs
@@ -160,7 +160,7 @@ impl DisplayHardforks {
                 ForkCondition::Timestamp(_) => {
                     post_merge.push(display_fork);
                 }
-                ForkCondition::Never => continue,
+                ForkCondition::Never => {}
             }
         }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -622,7 +622,6 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                     OnIncomingMessageOutcome::NoCapacity(msg) => {
                                         // failed to send due to lack of capacity
                                         this.pending_message_to_session = Some(msg);
-                                        continue 'receive
                                     }
                                 }
                             }

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -698,11 +698,8 @@ impl NetworkEventStream {
     /// Awaits the next event for a session to be closed
     pub async fn next_session_closed(&mut self) -> Option<(PeerId, Option<DisconnectReason>)> {
         while let Some(ev) = self.inner.next().await {
-            match ev {
-                NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, reason }) => {
-                    return Some((peer_id, reason))
-                }
-                _ => continue,
+            if let NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, reason }) = ev {
+                return Some((peer_id, reason))
             }
         }
         None
@@ -716,7 +713,7 @@ impl NetworkEventStream {
                 NetworkEvent::Peer(PeerEvent::SessionEstablished(info)) => {
                     return Some(info.peer_id)
                 }
-                _ => continue,
+                _ => {}
             }
         }
         None
@@ -729,15 +726,12 @@ impl NetworkEventStream {
         }
         let mut peers = Vec::with_capacity(num);
         while let Some(ev) = self.inner.next().await {
-            match ev {
-                NetworkEvent::ActivePeerSession { info: SessionInfo { peer_id, .. }, .. } => {
-                    peers.push(peer_id);
-                    num -= 1;
-                    if num == 0 {
-                        return peers;
-                    }
+            if let NetworkEvent::ActivePeerSession { info: SessionInfo { peer_id, .. }, .. } = ev {
+                peers.push(peer_id);
+                num -= 1;
+                if num == 0 {
+                    return peers;
                 }
-                _ => continue,
             }
         }
         peers

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -2026,7 +2026,7 @@ mod tests {
                     transactions
                         .on_network_event(NetworkEvent::Peer(PeerEvent::SessionEstablished(info)))
                 }
-                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => continue,
+                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => {}
                 ev => {
                     error!("unexpected event {ev:?}")
                 }
@@ -2097,7 +2097,7 @@ mod tests {
                     // to insert a new peer in transactions peerset
                     transactions.on_network_event(ev);
                 }
-                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => continue,
+                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => {}
                 _ => {
                     error!("unexpected event {ev:?}")
                 }
@@ -2166,7 +2166,7 @@ mod tests {
                     // to insert a new peer in transactions peerset
                     transactions.on_network_event(ev);
                 }
-                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => continue,
+                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => {}
                 ev => {
                     error!("unexpected event {ev:?}")
                 }
@@ -2241,7 +2241,7 @@ mod tests {
                 NetworkEvent::Peer(PeerEvent::SessionEstablished(_)) => {
                     transactions.on_network_event(ev);
                 }
-                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => continue,
+                NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => {}
                 ev => {
                     error!("unexpected event {ev:?}")
                 }

--- a/crates/net/p2p/src/test_utils/headers.rs
+++ b/crates/net/p2p/src/test_utils/headers.rs
@@ -169,7 +169,6 @@ impl Stream for TestDownload {
                     headers.sort_unstable_by_key(|h| h.number);
                     headers.into_iter().for_each(|h| this.buffer.push(h));
                     this.done = true;
-                    continue
                 }
                 Err(err) => {
                     this.done = true;

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -253,7 +253,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             }
 
             // Check if the sender is a contract
-            if self.get_code(sender, None).await?.len() > 0 {
+            if !self.get_code(sender, None).await?.is_empty() {
                 return Ok(None);
             }
 

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -101,7 +101,7 @@ impl FeeHistoryCache {
             entries.pop_first();
         }
 
-        if entries.len() == 0 {
+        if entries.is_empty() {
             self.inner.upper_bound.store(0, SeqCst);
             self.inner.lower_bound.store(0, SeqCst);
             return

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -297,7 +297,7 @@ impl DebugTraceTransactionsStream<'_> {
     pub async fn next_err(&mut self) -> Option<(RpcError, TxHash)> {
         loop {
             match self.next().await? {
-                Ok(_) => continue,
+                Ok(_) => {}
                 Err(err) => return Some(err),
             }
         }
@@ -329,7 +329,7 @@ impl DebugTraceBlockStream<'_> {
     pub async fn next_err(&mut self) -> Option<(RpcError, BlockId)> {
         loop {
             match self.next().await? {
-                Ok(_) => continue,
+                Ok(_) => {}
                 Err(err) => return Some(err),
             }
         }

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -421,7 +421,7 @@ impl TraceBlockStream<'_> {
     pub async fn next_err(&mut self) -> Option<(RpcError, BlockId)> {
         loop {
             match self.next().await? {
-                Ok(_) => continue,
+                Ok(_) => {}
                 Err(err) => return Some(err),
             }
         }
@@ -453,7 +453,7 @@ impl TraceBlockOpcodeGasStream<'_> {
     pub async fn next_err(&mut self) -> Option<(RpcError, BlockId)> {
         loop {
             match self.next().await? {
-                Ok(_) => continue,
+                Ok(_) => {}
                 Err(err) => return Some(err),
             }
         }

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -986,7 +986,7 @@ mod tests {
             let db = tx.open_db(None).unwrap();
             for i in 1_000usize..1_000_000 {
                 match tx.put(db.dbi(), i.to_le_bytes(), b"0", WriteFlags::empty()) {
-                    Ok(_) => continue,
+                    Ok(_) => {}
                     Err(Error::MapFull) => break,
                     result @ Err(_) => result.unwrap(),
                 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1867,7 +1867,7 @@ mod tests {
             provider.account_block_changeset(last_database_block).unwrap(),
             database_changesets
                 .into_iter()
-                .last()
+                .next_back()
                 .unwrap()
                 .into_iter()
                 .sorted_by_key(|(address, _, _)| *address)

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1791,7 +1791,7 @@ mod tests {
             consistent_provider.account_block_changeset(last_database_block).unwrap(),
             database_changesets
                 .into_iter()
-                .last()
+                .next_back()
                 .unwrap()
                 .into_iter()
                 .sorted_by_key(|(address, _, _)| *address)

--- a/crates/tokio-util/src/event_stream.rs
+++ b/crates/tokio-util/src/event_stream.rs
@@ -36,7 +36,6 @@ where
                 Poll::Ready(Some(Ok(item))) => return Poll::Ready(Some(item)),
                 Poll::Ready(Some(Err(e))) => {
                     warn!("BroadcastStream lagged: {e:?}");
-                    continue
                 }
                 Poll::Ready(None) => return Poll::Ready(None),
                 Poll::Pending => return Poll::Pending,

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -130,7 +130,6 @@ impl<T: TransactionOrdering> BestTransactions<T> {
                 Err(TryRecvError::Lagged(_)) => {
                     // Handle the case where the receiver lagged too far behind.
                     // `num_skipped` indicates the number of messages that were skipped.
-                    continue
                 }
 
                 // this case is still better than the existing iterator behavior where no new

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -817,7 +817,7 @@ impl<P> RevealedSparseTrie<P> {
                                 tree_mask,
                                 hash_mask,
                                 hashes,
-                                hash.filter(|_| path.len() == 0),
+                                hash.filter(|_| path.is_empty()),
                             );
                             updates.updated_nodes.insert(path.clone(), branch_node);
                         }


### PR DESCRIPTION
prevents warnings like these with latest clippy:
```
warning: this `continue` expression is redundant
   --> crates/ethereum-forks/src/display.rs:163:41
    |
163 |                 ForkCondition::Never => continue,
    |                                         ^^^^^^^^
    |
    = help: consider dropping the `continue` expression
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
    = note: requested on the command line with `-W clippy::needless-continue`
```

```
warning: `reth-chainspec` (lib) generated 1 warning
warning: length comparison to zero
   --> crates/trie/sparse/src/trie.rs:820:49
    |
820 | ...                   hash.filter(|_| path.len() == 0),
    |                                       ^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `path.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
    = note: `#[warn(clippy::len_zero)]` on by default
```

```
warning: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
    --> crates/storage/provider/src/providers/blockchain_provider.rs:1870:18
     |
1870 |                 .last()
     |                  ^^^^^^ help: try: `next_back()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
     = note: `#[warn(clippy::double_ended_iterator_last)]` on by default
```