### PR TITLE
feat: add `evm_for_block` helper to simplify EVM setup

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -6,15 +6,14 @@ use pretty_assertions::Comparison;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::InvalidBlockHook;
 use reth_evm::{
-    env::EvmEnv, state_change::post_block_balance_increments, system_calls::SystemCaller,
-    ConfigureEvm,
+    state_change::post_block_balance_increments, system_calls::SystemCaller, ConfigureEvm,
 };
 use reth_primitives::{NodePrimitives, SealedBlockWithSenders, SealedHeader};
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::{BlockExecutionOutput, ChainSpecProvider, StateProviderFactory};
 use reth_revm::{
-    database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
-    primitives::EnvWithHandlerCfg, DatabaseCommit, StateBuilder,
+    database::StateProviderDatabase, db::states::bundle_state::BundleRetention, DatabaseCommit,
+    StateBuilder,
 };
 use reth_rpc_api::DebugApiClient;
 use reth_tracing::tracing::warn;
@@ -77,19 +76,8 @@ where
             .with_bundle_update()
             .build();
 
-        // Setup environment for the execution.
-        let EvmEnv { cfg_env_with_handler_cfg, block_env } =
-            self.evm_config.cfg_and_block_env(block.header());
-
         // Setup EVM
-        let mut evm = self.evm_config.evm_with_env(
-            &mut db,
-            EnvWithHandlerCfg::new_with_cfg_env(
-                cfg_env_with_handler_cfg,
-                block_env,
-                Default::default(),
-            ),
-        );
+        let mut evm = self.evm_config.evm_for_block(&mut db, block.header());
 
         let mut system_caller =
             SystemCaller::new(self.evm_config.clone(), self.provider.chain_spec());

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -14,8 +14,8 @@ use reth_engine_primitives::{
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResult};
 use reth_ethereum_forks::EthereumHardforks;
 use reth_evm::{
-    env::EvmEnv, state_change::post_block_withdrawals_balance_increments,
-    system_calls::SystemCaller, ConfigureEvm,
+    state_change::post_block_withdrawals_balance_increments, system_calls::SystemCaller,
+    ConfigureEvm,
 };
 use reth_payload_validator::ExecutionPayloadValidator;
 use reth_primitives::{
@@ -29,7 +29,7 @@ use reth_revm::{
     DatabaseCommit,
 };
 use reth_rpc_types_compat::engine::payload::block_to_payload;
-use revm_primitives::{EVMError, EnvWithHandlerCfg};
+use revm_primitives::EVMError;
 use std::{
     collections::VecDeque,
     future::Future,
@@ -297,15 +297,8 @@ where
         .with_bundle_update()
         .build();
 
-    // Configure environments
-    let EvmEnv { cfg_env_with_handler_cfg, block_env } =
-        evm_config.cfg_and_block_env(&reorg_target.header);
-    let env = EnvWithHandlerCfg::new_with_cfg_env(
-        cfg_env_with_handler_cfg,
-        block_env,
-        Default::default(),
-    );
-    let mut evm = evm_config.evm_with_env(&mut state, env);
+    // Configure EVM
+    let mut evm = evm_config.evm_for_block(&mut state, &reorg_target.header);
 
     // apply eip-4788 pre block contract call
     let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -41,7 +41,6 @@ pub mod system_calls;
 pub mod test_utils;
 
 /// Trait for configuring the EVM for executing full blocks.
-#[auto_impl::auto_impl(&, Arc)]
 pub trait ConfigureEvm: ConfigureEvmEnv {
     /// Associated type for the default external context that should be configured for the EVM.
     type DefaultExternalContext<'a>;
@@ -68,6 +67,31 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         evm.modify_spec_id(env.spec_id());
         evm.context.evm.env = env.env;
         evm
+    }
+
+    /// Returns a new EVM with the given database configured with `cfg` and `block_env`
+    /// configuration derived from the given header. Relies on
+    /// [`ConfigureEvmEnv::cfg_and_block_env`].
+    ///
+    /// # Caution
+    ///
+    /// This does not initialize the tx environment.
+    fn evm_for_block<DB: Database>(
+        &self,
+        db: DB,
+        header: &Self::Header,
+    ) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
+        let EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg { cfg_env, handler_cfg },
+            block_env,
+        } = self.cfg_and_block_env(header);
+        self.evm_with_env(
+            db,
+            EnvWithHandlerCfg {
+                env: Box::new(Env { cfg: cfg_env, block: block_env, tx: Default::default() }),
+                handler_cfg,
+            },
+        )
     }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
@@ -107,6 +131,59 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
 
     /// Provides the default external context.
     fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a>;
+}
+
+impl<'b, T> ConfigureEvm for &'b T
+where
+    T: ConfigureEvm,
+    &'b T: ConfigureEvmEnv<Header = T::Header>,
+{
+    type DefaultExternalContext<'a> = T::DefaultExternalContext<'a>;
+
+    fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a> {
+        (*self).default_external_context()
+    }
+
+    fn evm<DB: Database>(&self, db: DB) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
+        (*self).evm(db)
+    }
+
+    fn evm_for_block<DB: Database>(
+        &self,
+        db: DB,
+        header: &Self::Header,
+    ) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
+        (*self).evm_for_block(db, header)
+    }
+
+    fn evm_with_env<DB: Database>(
+        &self,
+        db: DB,
+        env: EnvWithHandlerCfg,
+    ) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
+        (*self).evm_with_env(db, env)
+    }
+
+    fn evm_with_env_and_inspector<DB, I>(
+        &self,
+        db: DB,
+        env: EnvWithHandlerCfg,
+        inspector: I,
+    ) -> Evm<'_, I, DB>
+    where
+        DB: Database,
+        I: GetInspector<DB>,
+    {
+        (*self).evm_with_env_and_inspector(db, env, inspector)
+    }
+
+    fn evm_with_inspector<DB, I>(&self, db: DB, inspector: I) -> Evm<'_, I, DB>
+    where
+        DB: Database,
+        I: GetInspector<DB>,
+    {
+        (*self).evm_with_inspector(db, inspector)
+    }
 }
 
 /// This represents the set of methods used to configure the EVM's environment before block

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -18,6 +18,7 @@
 extern crate alloc;
 
 use crate::builder::RethEvmBuilder;
+use alloc::boxed::Box;
 use alloy_consensus::BlockHeader as _;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_primitives_traits::{BlockHeader, SignedTransaction};


### PR DESCRIPTION
Adds `ConfigureEvm::evm_for_block` which allowed to simplify some executors code paths and avoid dealing with Env types directly