### PR TITLE
fix(cmd): initialize `StaticFileProducer` with config `PruneModes` unwind command

### DIFF
--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -19,7 +19,6 @@ use reth_provider::{
     ChainStateBlockReader, ChainStateBlockWriter, ProviderFactory, StaticFileProviderFactory,
     StorageLocation,
 };
-use reth_prune::PruneModes;
 use reth_stages::{
     sets::{DefaultStages, OfflineStages},
     stages::ExecutionStage,
@@ -124,7 +123,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 
         let builder = if self.offline {
             Pipeline::<N>::builder().add_stages(
-                OfflineStages::new(executor, config.stages, PruneModes::default())
+                OfflineStages::new(executor, config.stages, prune_modes.clone())
                     .builder()
                     .disable(reth_stages::StageId::SenderRecovery),
             )
@@ -149,7 +148,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
                         max_duration: None,
                     },
                     stage_conf.execution_external_clean_threshold(),
-                    prune_modes,
+                    prune_modes.clone(),
                     ExExManagerHandle::empty(),
                 )),
             )
@@ -157,7 +156,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 
         let pipeline = builder.build(
             provider_factory.clone(),
-            StaticFileProducer::new(provider_factory, PruneModes::default()),
+            StaticFileProducer::new(provider_factory, prune_modes),
         );
         Ok(pipeline)
     }


### PR DESCRIPTION
Static file producer should be initialized with the real prune mode configuration. Otherwise, if dealing with a full node it will error out since receipts are only supposed to be in database.