### PR TITLE
refactor: use `EvmEnv` when setting up `Evm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,7 +2985,9 @@ dependencies = [
  "clap",
  "futures-util",
  "reth",
+ "reth-evm",
  "reth-node-ethereum",
+ "revm-primitives",
 ]
 
 [[package]]

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -198,7 +198,7 @@ mod tests {
         primitives::{BlockEnv, CfgEnv, SpecId},
         JournaledState,
     };
-    use revm_primitives::{EnvWithHandlerCfg, HandlerCfg};
+    use revm_primitives::HandlerCfg;
     use std::collections::HashSet;
 
     #[test]
@@ -272,12 +272,13 @@ mod tests {
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let env_with_handler = EnvWithHandlerCfg::default();
+        let evm_env = EvmEnv::default();
 
-        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+        let evm = evm_config.evm_with_env(db, evm_env.clone(), Default::default());
 
         // Check that the EVM environment
-        assert_eq!(evm.context.evm.env, env_with_handler.env);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
 
         // Default spec ID
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -296,16 +297,15 @@ mod tests {
         // Create a custom configuration environment with a chain ID of 111
         let cfg = CfgEnv::default().with_chain_id(111);
 
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env {
-                cfg: cfg.clone(),
-                block: BlockEnv::default(),
-                tx: TxEnv::default(),
-            }),
-            handler_cfg: Default::default(),
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: cfg.clone(),
+                handler_cfg: Default::default(),
+            },
+            ..Default::default()
         };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler);
+        let evm = evm_config.evm_with_env(db, evm_env, Default::default());
 
         // Check that the EVM environment is initialized with the custom environment
         assert_eq!(evm.context.evm.inner.env.cfg, cfg);
@@ -333,16 +333,19 @@ mod tests {
         };
         let tx = TxEnv { gas_limit: 5_000_000, gas_price: U256::from(50), ..Default::default() };
 
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env { cfg: CfgEnv::default(), block, tx }),
-            handler_cfg: Default::default(),
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: CfgEnv::default(),
+                handler_cfg: Default::default(),
+            },
+            block_env: block,
         };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+        let evm = evm_config.evm_with_env(db, evm_env.clone(), tx.clone());
 
         // Verify that the block and transaction environments are set correctly
-        assert_eq!(evm.context.evm.env.block, env_with_handler.env.block);
-        assert_eq!(evm.context.evm.env.tx, env_with_handler.env.tx);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.tx, tx);
 
         // Default spec ID
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -360,9 +363,15 @@ mod tests {
 
         let handler_cfg = HandlerCfg { spec_id: SpecId::CONSTANTINOPLE, ..Default::default() };
 
-        let env_with_handler = EnvWithHandlerCfg { env: Box::new(Env::default()), handler_cfg };
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: Default::default(),
+                handler_cfg,
+            },
+            ..Default::default()
+        };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler);
+        let evm = evm_config.evm_with_env(db, evm_env, Default::default());
 
         // Check that the spec ID is setup properly
         assert_eq!(evm.handler.spec_id(), SpecId::CONSTANTINOPLE);
@@ -422,13 +431,18 @@ mod tests {
         let evm_config = EthEvmConfig::new(MAINNET.clone());
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let env_with_handler = EnvWithHandlerCfg::default();
+        let evm_env = EvmEnv::default();
 
-        let evm =
-            evm_config.evm_with_env_and_inspector(db, env_with_handler.clone(), NoOpInspector);
+        let evm = evm_config.evm_with_env_and_inspector(
+            db,
+            evm_env.clone(),
+            Default::default(),
+            NoOpInspector,
+        );
 
         // Check that the EVM environment is set to default values
-        assert_eq!(evm.context.evm.env, env_with_handler.env);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -442,18 +456,21 @@ mod tests {
         let evm_config = EthEvmConfig::new(MAINNET.clone());
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let cfg = CfgEnv::default().with_chain_id(111);
+        let cfg_env = CfgEnv::default().with_chain_id(111);
         let block = BlockEnv::default();
         let tx = TxEnv::default();
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env { cfg: cfg.clone(), block, tx }),
-            handler_cfg: Default::default(),
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: cfg_env.clone(),
+                handler_cfg: Default::default(),
+            },
+            block_env: block,
         };
 
-        let evm = evm_config.evm_with_env_and_inspector(db, env_with_handler, NoOpInspector);
+        let evm = evm_config.evm_with_env_and_inspector(db, evm_env, tx, NoOpInspector);
 
         // Check that the EVM environment is set with custom configuration
-        assert_eq!(evm.context.evm.env.cfg, cfg);
+        assert_eq!(evm.context.evm.env.cfg, cfg_env);
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -475,17 +492,14 @@ mod tests {
             ..Default::default()
         };
         let tx = TxEnv { gas_limit: 5_000_000, gas_price: U256::from(50), ..Default::default() };
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env { cfg: CfgEnv::default(), block, tx }),
-            handler_cfg: Default::default(),
-        };
+        let evm_env = EvmEnv { block_env: block, ..Default::default() };
 
         let evm =
-            evm_config.evm_with_env_and_inspector(db, env_with_handler.clone(), NoOpInspector);
+            evm_config.evm_with_env_and_inspector(db, evm_env.clone(), tx.clone(), NoOpInspector);
 
         // Verify that the block and transaction environments are set correctly
-        assert_eq!(evm.context.evm.env.block, env_with_handler.env.block);
-        assert_eq!(evm.context.evm.env.tx, env_with_handler.env.tx);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.tx, tx);
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -500,14 +514,26 @@ mod tests {
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let handler_cfg = HandlerCfg { spec_id: SpecId::CONSTANTINOPLE, ..Default::default() };
-        let env_with_handler = EnvWithHandlerCfg { env: Box::new(Env::default()), handler_cfg };
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                handler_cfg,
+                cfg_env: Default::default(),
+            },
+            ..Default::default()
+        };
 
-        let evm =
-            evm_config.evm_with_env_and_inspector(db, env_with_handler.clone(), NoOpInspector);
+        let evm = evm_config.evm_with_env_and_inspector(
+            db,
+            evm_env.clone(),
+            Default::default(),
+            NoOpInspector,
+        );
 
         // Check that the spec ID is set properly
         assert_eq!(evm.handler.spec_id(), SpecId::CONSTANTINOPLE);
-        assert_eq!(evm.context.evm.env, env_with_handler.env);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.tx, Default::default());
         assert_eq!(evm.context.external, NoOpInspector);
 
         // No Optimism

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -74,7 +74,7 @@ impl<EvmConfig> EthereumPayloadBuilder<EvmConfig>
 where
     EvmConfig: ConfigureEvm<Header = Header>,
 {
-    /// Returns the configured [`CfgEnvWithHandlerCfg`] and [`BlockEnv`] for the targeted payload
+    /// Returns the configured [`EvmEnv`] for the targeted payload
     /// (that has the `parent` as its parent).
     fn cfg_and_block_env(
         &self,

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -41,10 +41,7 @@ use reth_transaction_pool::{
 };
 use revm::{
     db::{states::bundle_state::BundleRetention, State},
-    primitives::{
-        BlockEnv, CfgEnvWithHandlerCfg, EVMError, EnvWithHandlerCfg, InvalidTransaction,
-        ResultAndState, TxEnv,
-    },
+    primitives::{EVMError, InvalidTransaction, ResultAndState},
     DatabaseCommit,
 };
 use std::sync::Arc;
@@ -108,7 +105,7 @@ where
         &self,
         args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
     ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError> {
-        let EvmEnv { cfg_env_with_handler_cfg, block_env } = self
+        let evm_env = self
             .cfg_and_block_env(&args.config, &args.config.parent_header)
             .map_err(PayloadBuilderError::other)?;
 
@@ -117,8 +114,7 @@ where
             self.evm_config.clone(),
             self.builder_config.clone(),
             args,
-            cfg_env_with_handler_cfg,
-            block_env,
+            evm_env,
             |attributes| pool.best_transactions_with_attributes(attributes),
         )
     }
@@ -138,7 +134,7 @@ where
             None,
         );
 
-        let EvmEnv { cfg_env_with_handler_cfg, block_env } = self
+        let evm_env = self
             .cfg_and_block_env(&args.config, &args.config.parent_header)
             .map_err(PayloadBuilderError::other)?;
 
@@ -148,8 +144,7 @@ where
             self.evm_config.clone(),
             self.builder_config.clone(),
             args,
-            cfg_env_with_handler_cfg,
-            block_env,
+            evm_env,
             |attributes| pool.best_transactions_with_attributes(attributes),
         )?
         .into_payload()
@@ -167,8 +162,7 @@ pub fn default_ethereum_payload<EvmConfig, Pool, Client, F>(
     evm_config: EvmConfig,
     builder_config: EthereumBuilderConfig,
     args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
-    initialized_cfg: CfgEnvWithHandlerCfg,
-    initialized_block_env: BlockEnv,
+    evm_env: EvmEnv,
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
@@ -189,19 +183,20 @@ where
     debug!(target: "payload_builder", id=%attributes.id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
     let mut cumulative_gas_used = 0;
     let mut sum_blob_gas_used = 0;
-    let block_gas_limit: u64 = initialized_block_env.gas_limit.to::<u64>();
-    let base_fee = initialized_block_env.basefee.to::<u64>();
+    let block_gas_limit: u64 = evm_env.block_env.gas_limit.to::<u64>();
+    let base_fee = evm_env.block_env.basefee.to::<u64>();
 
     let mut executed_txs = Vec::new();
     let mut executed_senders = Vec::new();
 
     let mut best_txs = best_txs(BestTransactionsAttributes::new(
         base_fee,
-        initialized_block_env.get_blob_gasprice().map(|gasprice| gasprice as u64),
+        evm_env.block_env.get_blob_gasprice().map(|gasprice| gasprice as u64),
     ));
     let mut total_fees = U256::ZERO;
 
-    let block_number = initialized_block_env.number.to::<u64>();
+    let block_number = evm_env.block_env.number.to::<u64>();
+    let beneficiary = evm_env.block_env.coinbase;
 
     let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
 
@@ -209,8 +204,8 @@ where
     system_caller
         .pre_block_beacon_root_contract_call(
             &mut db,
-            &initialized_cfg,
-            &initialized_block_env,
+            evm_env.cfg_env_with_handler_cfg(),
+            evm_env.block_env(),
             attributes.parent_beacon_block_root,
         )
         .map_err(|err| {
@@ -225,8 +220,8 @@ where
     // apply eip-2935 blockhashes update
     system_caller.pre_block_blockhashes_contract_call(
         &mut db,
-        &initialized_cfg,
-        &initialized_block_env,
+        evm_env.cfg_env_with_handler_cfg(),
+        evm_env.block_env(),
         parent_header.hash(),
     )
     .map_err(|err| {
@@ -234,12 +229,7 @@ where
         PayloadBuilderError::Internal(err.into())
     })?;
 
-    let env = EnvWithHandlerCfg::new_with_cfg_env(
-        initialized_cfg.clone(),
-        initialized_block_env.clone(),
-        TxEnv::default(),
-    );
-    let mut evm = evm_config.evm_with_env(&mut db, env);
+    let mut evm = evm_config.evm_with_env(&mut db, evm_env, Default::default());
 
     let mut receipts = Vec::new();
     while let Some(pool_tx) = best_txs.next() {
@@ -458,7 +448,7 @@ where
     let header = Header {
         parent_hash: parent_header.hash(),
         ommers_hash: EMPTY_OMMER_ROOT_HASH,
-        beneficiary: initialized_block_env.coinbase,
+        beneficiary,
         state_root,
         transactions_root,
         receipts_root,

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -9,6 +9,18 @@ pub struct EvmEnv {
     pub block_env: BlockEnv,
 }
 
+impl Default for EvmEnv {
+    fn default() -> Self {
+        Self {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: Default::default(),
+                handler_cfg: Default::default(),
+            },
+            block_env: BlockEnv::default(),
+        }
+    }
+}
+
 impl EvmEnv {
     /// Create a new `EvmEnv` from its components.
     ///

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -14,6 +14,7 @@ impl Default for EvmEnv {
         Self {
             cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
                 cfg_env: Default::default(),
+                // Will set `is_optimism` if `revm/optimism-default-handler` is enabled.
                 handler_cfg: Default::default(),
             },
             block_env: BlockEnv::default(),

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -52,7 +52,7 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
-    /// including the spec id.
+    /// including the spec id and transaction environment.
     ///
     /// This will preserve any handler modifications
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB> {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -18,19 +18,18 @@
 extern crate alloc;
 
 use crate::builder::RethEvmBuilder;
-use alloc::boxed::Box;
 use alloy_consensus::BlockHeader as _;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_primitives_traits::{BlockHeader, SignedTransaction};
 use revm::{Database, Evm, GetInspector};
-use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, SpecId, TxEnv};
+use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, SpecId, TxEnv};
 
 pub mod builder;
 pub mod either;
 /// EVM environment configuration.
 pub mod env;
 pub mod execute;
-use env::EvmEnv;
+pub use env::EvmEnv;
 
 #[cfg(feature = "std")]
 pub mod metrics;
@@ -56,10 +55,11 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     /// including the spec id.
     ///
     /// This will preserve any handler modifications
-    fn evm_with_env<DB: Database>(&self, db: DB, env: EnvWithHandlerCfg) -> Evm<'_, (), DB> {
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB> {
         let mut evm = self.evm(db);
-        evm.modify_spec_id(env.spec_id());
-        evm.context.evm.env = env.env;
+        evm.modify_spec_id(evm_env.cfg_env_with_handler_cfg.handler_cfg.spec_id);
+        evm.context.evm.env =
+            Env::boxed(evm_env.cfg_env_with_handler_cfg.cfg_env, evm_env.block_env, tx);
         evm
     }
 
@@ -71,17 +71,8 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     ///
     /// This does not initialize the tx environment.
     fn evm_for_block<DB: Database>(&self, db: DB, header: &Self::Header) -> Evm<'_, (), DB> {
-        let EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg { cfg_env, handler_cfg },
-            block_env,
-        } = self.cfg_and_block_env(header);
-        self.evm_with_env(
-            db,
-            EnvWithHandlerCfg {
-                env: Box::new(Env { cfg: cfg_env, block: block_env, tx: Default::default() }),
-                handler_cfg,
-            },
-        )
+        let evm_env = self.cfg_and_block_env(header);
+        self.evm_with_env(db, evm_env, Default::default())
     }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
@@ -93,7 +84,8 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
-        env: EnvWithHandlerCfg,
+        evm_env: EvmEnv,
+        tx: TxEnv,
         inspector: I,
     ) -> Evm<'_, I, DB>
     where
@@ -101,8 +93,9 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         I: GetInspector<DB>,
     {
         let mut evm = self.evm_with_inspector(db, inspector);
-        evm.modify_spec_id(env.spec_id());
-        evm.context.evm.env = env.env;
+        evm.modify_spec_id(evm_env.cfg_env_with_handler_cfg.handler_cfg.spec_id);
+        evm.context.evm.env =
+            Env::boxed(evm_env.cfg_env_with_handler_cfg.cfg_env, evm_env.block_env, tx);
         evm
     }
 
@@ -133,21 +126,22 @@ where
         (*self).evm_for_block(db, header)
     }
 
-    fn evm_with_env<DB: Database>(&self, db: DB, env: EnvWithHandlerCfg) -> Evm<'_, (), DB> {
-        (*self).evm_with_env(db, env)
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB> {
+        (*self).evm_with_env(db, evm_env, tx)
     }
 
     fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
-        env: EnvWithHandlerCfg,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         inspector: I,
     ) -> Evm<'_, I, DB>
     where
         DB: Database,
         I: GetInspector<DB>,
     {
-        (*self).evm_with_env_and_inspector(db, env, inspector)
+        (*self).evm_with_env_and_inspector(db, evm_env, tx_env, inspector)
     }
 
     fn evm_with_inspector<DB, I>(&self, db: DB, inspector: I) -> Evm<'_, I, DB>

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -438,7 +438,13 @@ mod tests {
         let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let evm_env = EvmEnv::default();
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: Default::default(),
+                handler_cfg: HandlerCfg { is_optimism: true, ..Default::default() },
+            },
+            ..Default::default()
+        };
 
         let evm = evm_config.evm_with_env_and_inspector(
             db,

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -211,7 +211,7 @@ mod tests {
         primitives::{AccountInfo, BlockEnv, CfgEnv, SpecId},
         JournaledState,
     };
-    use revm_primitives::{EnvWithHandlerCfg, HandlerCfg};
+    use revm_primitives::HandlerCfg;
     use std::sync::Arc;
 
     fn test_evm_config() -> OpEvmConfig {
@@ -291,12 +291,12 @@ mod tests {
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let env_with_handler = EnvWithHandlerCfg::default();
+        let evm_env = EvmEnv::default();
 
-        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+        let evm = evm_config.evm_with_env(db, evm_env.clone(), Default::default());
 
         // Check that the EVM environment
-        assert_eq!(evm.context.evm.env, env_with_handler.env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
 
         // Default spec ID
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -314,16 +314,15 @@ mod tests {
         // Create a custom configuration environment with a chain ID of 111
         let cfg = CfgEnv::default().with_chain_id(111);
 
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env {
-                cfg: cfg.clone(),
-                block: BlockEnv::default(),
-                tx: TxEnv::default(),
-            }),
-            handler_cfg: Default::default(),
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: cfg.clone(),
+                handler_cfg: Default::default(),
+            },
+            ..Default::default()
         };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler);
+        let evm = evm_config.evm_with_env(db, evm_env, Default::default());
 
         // Check that the EVM environment is initialized with the custom environment
         assert_eq!(evm.context.evm.inner.env.cfg, cfg);
@@ -350,16 +349,13 @@ mod tests {
         };
         let tx = TxEnv { gas_limit: 5_000_000, gas_price: U256::from(50), ..Default::default() };
 
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env { cfg: CfgEnv::default(), block, tx }),
-            handler_cfg: Default::default(),
-        };
+        let evm_env = EvmEnv { block_env: block, ..Default::default() };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler.clone());
+        let evm = evm_config.evm_with_env(db, evm_env.clone(), tx.clone());
 
         // Verify that the block and transaction environments are set correctly
-        assert_eq!(evm.context.evm.env.block, env_with_handler.env.block);
-        assert_eq!(evm.context.evm.env.tx, env_with_handler.env.tx);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.tx, tx);
 
         // Default spec ID
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -376,9 +372,15 @@ mod tests {
 
         let handler_cfg = HandlerCfg { spec_id: SpecId::ECOTONE, ..Default::default() };
 
-        let env_with_handler = EnvWithHandlerCfg { env: Box::new(Env::default()), handler_cfg };
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                handler_cfg,
+                cfg_env: Default::default(),
+            },
+            ..Default::default()
+        };
 
-        let evm = evm_config.evm_with_env(db, env_with_handler);
+        let evm = evm_config.evm_with_env(db, evm_env, Default::default());
 
         // Check that the spec ID is setup properly
         assert_eq!(evm.handler.spec_id(), SpecId::ECOTONE);
@@ -436,13 +438,19 @@ mod tests {
         let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let env_with_handler = EnvWithHandlerCfg::default();
+        let evm_env = EvmEnv::default();
 
-        let evm =
-            evm_config.evm_with_env_and_inspector(db, env_with_handler.clone(), NoOpInspector);
+        let evm = evm_config.evm_with_env_and_inspector(
+            db,
+            evm_env.clone(),
+            Default::default(),
+            NoOpInspector,
+        );
 
         // Check that the EVM environment is set to default values
-        assert_eq!(evm.context.evm.env, env_with_handler.env);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.tx, Default::default());
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -458,15 +466,21 @@ mod tests {
         let cfg = CfgEnv::default().with_chain_id(111);
         let block = BlockEnv::default();
         let tx = TxEnv::default();
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env { cfg: cfg.clone(), block, tx }),
-            handler_cfg: Default::default(),
+        let evm_env = EvmEnv {
+            block_env: block,
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: cfg.clone(),
+                handler_cfg: Default::default(),
+            },
         };
 
-        let evm = evm_config.evm_with_env_and_inspector(db, env_with_handler, NoOpInspector);
+        let evm =
+            evm_config.evm_with_env_and_inspector(db, evm_env.clone(), tx.clone(), NoOpInspector);
 
         // Check that the EVM environment is set with custom configuration
         assert_eq!(evm.context.evm.env.cfg, cfg);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.tx, tx);
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -487,17 +501,14 @@ mod tests {
             ..Default::default()
         };
         let tx = TxEnv { gas_limit: 5_000_000, gas_price: U256::from(50), ..Default::default() };
-        let env_with_handler = EnvWithHandlerCfg {
-            env: Box::new(Env { cfg: CfgEnv::default(), block, tx }),
-            handler_cfg: Default::default(),
-        };
+        let evm_env = EvmEnv { block_env: block, ..Default::default() };
 
         let evm =
-            evm_config.evm_with_env_and_inspector(db, env_with_handler.clone(), NoOpInspector);
+            evm_config.evm_with_env_and_inspector(db, evm_env.clone(), tx.clone(), NoOpInspector);
 
         // Verify that the block and transaction environments are set correctly
-        assert_eq!(evm.context.evm.env.block, env_with_handler.env.block);
-        assert_eq!(evm.context.evm.env.tx, env_with_handler.env.tx);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
+        assert_eq!(evm.context.evm.env.tx, tx);
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -511,14 +522,25 @@ mod tests {
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let handler_cfg = HandlerCfg { spec_id: SpecId::ECOTONE, ..Default::default() };
-        let env_with_handler = EnvWithHandlerCfg { env: Box::new(Env::default()), handler_cfg };
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: Default::default(),
+                handler_cfg,
+            },
+            ..Default::default()
+        };
 
-        let evm =
-            evm_config.evm_with_env_and_inspector(db, env_with_handler.clone(), NoOpInspector);
+        let evm = evm_config.evm_with_env_and_inspector(
+            db,
+            evm_env.clone(),
+            Default::default(),
+            NoOpInspector,
+        );
 
         // Check that the spec ID is set properly
         assert_eq!(evm.handler.spec_id(), SpecId::ECOTONE);
-        assert_eq!(evm.context.evm.env, env_with_handler.env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.block, evm_env.block_env);
         assert_eq!(evm.context.external, NoOpInspector);
 
         // Check that the spec ID is setup properly

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -41,6 +41,7 @@ use reth_rpc_eth_types::{
 };
 use revm::{Database, DatabaseCommit, GetInspector};
 use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
+use revm_primitives::Env;
 use tracing::trace;
 
 /// Result type for `eth_simulateV1` RPC method.
@@ -86,8 +87,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             }
 
             // Build cfg and block env, we'll reuse those.
-            let (evm_env, block) = self.evm_env_at(block.unwrap_or_default()).await?;
-            let EvmEnv { mut cfg_env_with_handler_cfg, mut block_env } = evm_env;
+            let (mut evm_env, block) = self.evm_env_at(block.unwrap_or_default()).await?;
 
             // Gas cap for entire operation
             let total_gas_limit = self.call_gas_limit();
@@ -97,9 +97,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let mut parent_hash = base_block.hash();
 
             // Only enforce base fee if validation is enabled
-            cfg_env_with_handler_cfg.disable_base_fee = !validation;
+            evm_env.cfg_env_with_handler_cfg.disable_base_fee = !validation;
             // Always disable EIP-3607
-            cfg_env_with_handler_cfg.disable_eip3607 = true;
+            evm_env.cfg_env_with_handler_cfg.disable_eip3607 = true;
 
             let this = self.clone();
             self.spawn_with_state_at_block(block, move |state| {
@@ -110,13 +110,13 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let mut block_state_calls = block_state_calls.into_iter().peekable();
                 while let Some(block) = block_state_calls.next() {
                     // Increase number and timestamp for every new block
-                    block_env.number += U256::from(1);
-                    block_env.timestamp += U256::from(1);
+                    evm_env.block_env.number += U256::from(1);
+                    evm_env.block_env.timestamp += U256::from(1);
 
                     if validation {
                         let chain_spec = RpcNodeCore::provider(&this).chain_spec();
-                        let base_fee_params =
-                            chain_spec.base_fee_params_at_timestamp(block_env.timestamp.to());
+                        let base_fee_params = chain_spec
+                            .base_fee_params_at_timestamp(evm_env.block_env.timestamp.to());
                         let base_fee = if let Some(latest) = blocks.last() {
                             let header = &latest.inner.header;
                             calc_next_block_base_fee(
@@ -128,21 +128,21 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         } else {
                             base_block.next_block_base_fee(base_fee_params).unwrap_or_default()
                         };
-                        block_env.basefee = U256::from(base_fee);
+                        evm_env.block_env.basefee = U256::from(base_fee);
                     } else {
-                        block_env.basefee = U256::ZERO;
+                        evm_env.block_env.basefee = U256::ZERO;
                     }
 
                     let SimBlock { block_overrides, state_overrides, calls } = block;
 
                     if let Some(block_overrides) = block_overrides {
-                        apply_block_overrides(block_overrides, &mut db, &mut block_env);
+                        apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
                     }
                     if let Some(state_overrides) = state_overrides {
                         apply_state_overrides(state_overrides, &mut db)?;
                     }
 
-                    if (total_gas_limit - gas_used) < block_env.gas_limit.to() {
+                    if (total_gas_limit - gas_used) < evm_env.block_env.gas_limit.to() {
                         return Err(
                             EthApiError::Other(Box::new(EthSimulateError::GasLimitReached)).into()
                         )
@@ -153,7 +153,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         let txs_without_gas_limit =
                             calls.iter().filter(|tx| tx.gas.is_none()).count();
 
-                        if total_specified_gas > block_env.gas_limit.to() {
+                        if total_specified_gas > evm_env.block_env.gas_limit.to() {
                             return Err(EthApiError::Other(Box::new(
                                 EthSimulateError::BlockGasLimitExceeded,
                             ))
@@ -161,7 +161,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         }
 
                         if txs_without_gas_limit > 0 {
-                            (block_env.gas_limit.to::<u64>() - total_specified_gas) /
+                            (evm_env.block_env.gas_limit.to::<u64>() - total_specified_gas) /
                                 txs_without_gas_limit as u64
                         } else {
                             0
@@ -182,27 +182,23 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             call,
                             validation,
                             default_gas_limit,
-                            cfg_env_with_handler_cfg.chain_id,
+                            evm_env.cfg_env_with_handler_cfg.chain_id,
                             &mut db,
                             this.tx_resp_builder(),
                         )?;
 
                         let tx_env = this.evm_config().tx_env(&tx, sender);
-                        let env = EnvWithHandlerCfg::new_with_cfg_env(
-                            cfg_env_with_handler_cfg.clone(),
-                            block_env.clone(),
-                            tx_env,
-                        );
 
-                        let (res, env) = {
+                        let (res, (_, tx_env)) = {
                             if trace_transfers {
                                 this.transact_with_inspector(
                                     &mut db,
-                                    env,
+                                    evm_env.clone(),
+                                    tx_env,
                                     TransferInspector::new(false).with_logs(true),
                                 )?
                             } else {
-                                this.transact(&mut db, env)?
+                                this.transact(&mut db, evm_env.clone(), tx_env.clone())?
                             }
                         };
 
@@ -213,12 +209,12 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         }
 
                         transactions.push(tx);
-                        senders.push(env.tx.caller);
+                        senders.push(tx_env.caller);
                         results.push(res.result);
                     }
 
                     let (block, _) = this.assemble_block_and_receipts(
-                        &block_env,
+                        &evm_env.block_env,
                         parent_hash,
                         // state root calculation is skipped for performance reasons
                         B256::ZERO,
@@ -300,7 +296,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 self.evm_env_at(target_block),
                 self.block_with_senders(target_block)
             )?;
-            let EvmEnv { cfg_env_with_handler_cfg, block_env } = evm_env;
 
             let block = block.ok_or(EthApiError::HeaderNotFound(target_block))?;
 
@@ -330,12 +325,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     // to be replayed
                     let transactions = block.transactions_with_sender().take(num_txs);
                     for (signer, tx) in transactions {
-                        let env = EnvWithHandlerCfg::new_with_cfg_env(
-                            cfg_env_with_handler_cfg.clone(),
-                            block_env.clone(),
-                            RpcNodeCore::evm_config(&this).tx_env(tx, *signer),
-                        );
-                        let (res, _) = this.transact(&mut db, env)?;
+                        let tx_env = RpcNodeCore::evm_config(&this).tx_env(tx, *signer);
+                        let (res, _) = this.transact(&mut db, evm_env.clone(), tx_env)?;
                         db.commit(res.state);
                     }
                 }
@@ -348,14 +339,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     let state_overrides = state_override.take();
                     let overrides = EvmOverrides::new(state_overrides, block_overrides.clone());
 
-                    let env = this.prepare_call_env(
-                        cfg_env_with_handler_cfg.clone(),
-                        block_env.clone(),
-                        tx,
-                        &mut db,
-                        overrides,
-                    )?;
-                    let (res, _) = this.transact(&mut db, env)?;
+                    let (evm_env, tx) =
+                        this.prepare_call_env(evm_env.clone(), tx, &mut db, overrides)?;
+                    let (res, _) = this.transact(&mut db, evm_env, tx)?;
 
                     match ensure_success(res.result) {
                         Ok(output) => {
@@ -395,12 +381,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         async move {
             let block_id = block_number.unwrap_or_default();
             let (evm_env, at) = self.evm_env_at(block_id).await?;
-            let EvmEnv { cfg_env_with_handler_cfg, block_env } = evm_env;
 
-            self.spawn_blocking_io(move |this| {
-                this.create_access_list_with(cfg_env_with_handler_cfg, block_env, at, request)
-            })
-            .await
+            self.spawn_blocking_io(move |this| this.create_access_list_with(evm_env, at, request))
+                .await
         }
     }
 
@@ -408,8 +391,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     /// [`BlockId`].
     fn create_access_list_with(
         &self,
-        cfg: CfgEnvWithHandlerCfg,
-        block: BlockEnv,
+        mut evm_env: EvmEnv,
         at: BlockId,
         mut request: TransactionRequest,
     ) -> Result<AccessListResult, Self::Error>
@@ -418,23 +400,23 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     {
         let state = self.state_at_block_id(at)?;
 
-        let mut env = self.build_call_evm_env(cfg, block, request.clone())?;
+        let mut tx_env = self.create_txn_env(&evm_env.block_env, request.clone())?;
 
         // we want to disable this in eth_createAccessList, since this is common practice used by
         // other node impls and providers <https://github.com/foundry-rs/foundry/issues/4388>
-        env.cfg.disable_block_gas_limit = true;
+        evm_env.cfg_env_with_handler_cfg.disable_block_gas_limit = true;
 
         // The basefee should be ignored for eth_createAccessList
         // See:
         // <https://github.com/ethereum/go-ethereum/blob/8990c92aea01ca07801597b00c0d83d4e2d9b811/internal/ethapi/api.go#L1476-L1476>
-        env.cfg.disable_base_fee = true;
+        evm_env.cfg_env_with_handler_cfg.disable_base_fee = true;
 
         let mut db = CacheDB::new(StateProviderDatabase::new(state));
 
-        if request.gas.is_none() && env.tx.gas_price > U256::ZERO {
-            let cap = caller_gas_allowance(&mut db, &env.tx)?;
+        if request.gas.is_none() && tx_env.gas_price > U256::ZERO {
+            let cap = caller_gas_allowance(&mut db, &tx_env)?;
             // no gas limit was provided in the request, so we need to cap the request's gas limit
-            env.tx.gas_limit = cap.min(env.block.gas_limit).saturating_to();
+            tx_env.gas_limit = cap.min(evm_env.block_env.gas_limit).saturating_to();
         }
 
         let from = request.from.unwrap_or_default();
@@ -449,16 +431,17 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         // can consume the list since we're not using the request anymore
         let initial = request.access_list.take().unwrap_or_default();
 
-        let precompiles = get_precompiles(env.handler_cfg.spec_id);
+        let precompiles = get_precompiles(evm_env.cfg_env_with_handler_cfg.handler_cfg.spec_id);
         let mut inspector = AccessListInspector::new(initial, from, to, precompiles);
 
-        let (result, mut env) = self.inspect(&mut db, env, &mut inspector)?;
+        let (result, (evm_env, mut tx_env)) =
+            self.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
         let access_list = inspector.into_access_list();
-        env.tx.access_list = access_list.to_vec();
+        tx_env.access_list = access_list.to_vec();
         match result.result {
             ExecutionResult::Halt { reason, gas_used } => {
                 let error =
-                    Some(RpcInvalidTransactionError::halt(reason, env.tx.gas_limit).to_string());
+                    Some(RpcInvalidTransactionError::halt(reason, tx_env.gas_limit).to_string());
                 return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
             }
             ExecutionResult::Revert { output, gas_used } => {
@@ -469,11 +452,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         };
 
         // transact again to get the exact gas used
-        let (result, env) = self.transact(&mut db, env)?;
+        let (result, (_, tx_env)) = self.transact(&mut db, evm_env, tx_env)?;
         let res = match result.result {
             ExecutionResult::Halt { reason, gas_used } => {
                 let error =
-                    Some(RpcInvalidTransactionError::halt(reason, env.tx.gas_limit).to_string());
+                    Some(RpcInvalidTransactionError::halt(reason, tx_env.gas_limit).to_string());
                 AccessListResult { access_list, gas_used: U256::from(gas_used), error }
             }
             ExecutionResult::Revert { output, gas_used } => {
@@ -515,16 +498,25 @@ pub trait Call:
     fn transact<DB>(
         &self,
         db: DB,
-        env: EnvWithHandlerCfg,
-    ) -> Result<(ResultAndState, EnvWithHandlerCfg), Self::Error>
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
+    ) -> Result<(ResultAndState, (EvmEnv, TxEnv)), Self::Error>
     where
         DB: Database,
         EthApiError: From<DB::Error>,
     {
-        let mut evm = self.evm_config().evm_with_env(db, env);
+        let mut evm = self.evm_config().evm_with_env(db, evm_env, tx_env);
         let res = evm.transact().map_err(Self::Error::from_evm_err)?;
         let (_, env) = evm.into_db_and_env_with_handler_cfg();
-        Ok((res, env))
+
+        let EnvWithHandlerCfg { env, handler_cfg } = env;
+        let Env { cfg, block, tx } = *env;
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg { cfg_env: cfg, handler_cfg },
+            block_env: block,
+        };
+
+        Ok((res, (evm_env, tx)))
     }
 
     /// Executes the [`EnvWithHandlerCfg`] against the given [Database] without committing state
@@ -532,17 +524,26 @@ pub trait Call:
     fn transact_with_inspector<DB>(
         &self,
         db: DB,
-        env: EnvWithHandlerCfg,
+        evm_env: EvmEnv,
+        tx_env: TxEnv,
         inspector: impl GetInspector<DB>,
-    ) -> Result<(ResultAndState, EnvWithHandlerCfg), Self::Error>
+    ) -> Result<(ResultAndState, (EvmEnv, TxEnv)), Self::Error>
     where
         DB: Database,
         EthApiError: From<DB::Error>,
     {
-        let mut evm = self.evm_config().evm_with_env_and_inspector(db, env, inspector);
+        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, tx_env, inspector);
         let res = evm.transact().map_err(Self::Error::from_evm_err)?;
         let (_, env) = evm.into_db_and_env_with_handler_cfg();
-        Ok((res, env))
+
+        let EnvWithHandlerCfg { env, handler_cfg } = env;
+        let Env { cfg, block, tx } = *env;
+        let evm_env = EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg { cfg_env: cfg, handler_cfg },
+            block_env: block,
+        };
+
+        Ok((res, (evm_env, tx)))
     }
 
     /// Executes the call request at the given [`BlockId`].
@@ -551,12 +552,14 @@ pub trait Call:
         request: TransactionRequest,
         at: BlockId,
         overrides: EvmOverrides,
-    ) -> impl Future<Output = Result<(ResultAndState, EnvWithHandlerCfg), Self::Error>> + Send
+    ) -> impl Future<Output = Result<(ResultAndState, (EvmEnv, TxEnv)), Self::Error>> + Send
     where
         Self: LoadPendingBlock,
     {
         let this = self.clone();
-        self.spawn_with_call_at(request, at, overrides, move |db, env| this.transact(db, env))
+        self.spawn_with_call_at(request, at, overrides, move |db, evm_env, tx_env| {
+            this.transact(db, evm_env, tx_env)
+        })
     }
 
     /// Executes the closure with the state that corresponds to the given [`BlockId`] on a new task
@@ -599,29 +602,23 @@ pub trait Call:
     ) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
         Self: LoadPendingBlock,
-        F: FnOnce(StateCacheDbRefMutWrapper<'_, '_>, EnvWithHandlerCfg) -> Result<R, Self::Error>
+        F: FnOnce(StateCacheDbRefMutWrapper<'_, '_>, EvmEnv, TxEnv) -> Result<R, Self::Error>
             + Send
             + 'static,
         R: Send + 'static,
     {
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
-            let EvmEnv { cfg_env_with_handler_cfg, block_env } = evm_env;
             let this = self.clone();
             self.spawn_blocking_io(move |_| {
                 let state = this.state_at_block_id(at)?;
                 let mut db =
                     CacheDB::new(StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)));
 
-                let env = this.prepare_call_env(
-                    cfg_env_with_handler_cfg,
-                    block_env,
-                    request,
-                    &mut db,
-                    overrides,
-                )?;
+                let (evm_env, tx_env) =
+                    this.prepare_call_env(evm_env, request, &mut db, overrides)?;
 
-                f(StateCacheDbRefMutWrapper(&mut db), env)
+                f(StateCacheDbRefMutWrapper(&mut db), evm_env, tx_env)
             })
             .await
         }
@@ -656,7 +653,6 @@ pub trait Call:
             let (tx, tx_info) = transaction.split();
 
             let (evm_env, _) = self.evm_env_at(block.hash().into()).await?;
-            let EvmEnv { cfg_env_with_handler_cfg, block_env } = evm_env;
 
             // we need to get the state of the parent block because we're essentially replaying the
             // block the transaction is included in
@@ -668,21 +664,11 @@ pub trait Call:
                 let block_txs = block.transactions_with_sender();
 
                 // replay all transactions prior to the targeted transaction
-                this.replay_transactions_until(
-                    &mut db,
-                    cfg_env_with_handler_cfg.clone(),
-                    block_env.clone(),
-                    block_txs,
-                    *tx.tx_hash(),
-                )?;
+                this.replay_transactions_until(&mut db, evm_env.clone(), block_txs, *tx.tx_hash())?;
 
-                let env = EnvWithHandlerCfg::new_with_cfg_env(
-                    cfg_env_with_handler_cfg,
-                    block_env,
-                    RpcNodeCore::evm_config(&this).tx_env(tx.tx(), tx.signer()),
-                );
+                let tx_env = RpcNodeCore::evm_config(&this).tx_env(tx.tx(), tx.signer());
 
-                let (res, _) = this.transact(&mut db, env)?;
+                let (res, _) = this.transact(&mut db, evm_env, tx_env)?;
                 f(tx_info, res, db)
             })
             .await
@@ -700,8 +686,7 @@ pub trait Call:
     fn replay_transactions_until<'a, DB, I>(
         &self,
         db: &mut DB,
-        cfg: CfgEnvWithHandlerCfg,
-        block_env: BlockEnv,
+        evm_env: EvmEnv,
         transactions: I,
         target_tx_hash: B256,
     ) -> Result<usize, Self::Error>
@@ -711,9 +696,7 @@ pub trait Call:
         I: IntoIterator<Item = (&'a Address, &'a <Self::Evm as ConfigureEvmEnv>::Transaction)>,
         <Self::Evm as ConfigureEvmEnv>::Transaction: SignedTransaction,
     {
-        let env = EnvWithHandlerCfg::new_with_cfg_env(cfg, block_env, Default::default());
-
-        let mut evm = self.evm_config().evm_with_env(db, env);
+        let mut evm = self.evm_config().evm_with_env(db, evm_env, Default::default());
         let mut index = 0;
         for (sender, tx) in transactions {
             if *tx.tx_hash() == target_tx_hash {
@@ -807,20 +790,6 @@ pub trait Call:
         Ok(env)
     }
 
-    /// Creates a new [`EnvWithHandlerCfg`] to be used for executing the [`TransactionRequest`] in
-    /// `eth_call`.
-    ///
-    /// Note: this does _not_ access the Database to check the sender.
-    fn build_call_evm_env(
-        &self,
-        cfg: CfgEnvWithHandlerCfg,
-        block: BlockEnv,
-        request: TransactionRequest,
-    ) -> Result<EnvWithHandlerCfg, Self::Error> {
-        let tx = self.create_txn_env(&block, request)?;
-        Ok(EnvWithHandlerCfg::new_with_cfg_env(cfg, block, tx))
-    }
-
     /// Prepares the [`EnvWithHandlerCfg`] for execution of calls.
     ///
     /// Does not commit any changes to the underlying database.
@@ -836,12 +805,11 @@ pub trait Call:
     /// In addition, this changes the block's gas limit to the configured [`Self::call_gas_limit`].
     fn prepare_call_env<DB>(
         &self,
-        mut cfg: CfgEnvWithHandlerCfg,
-        mut block: BlockEnv,
+        mut evm_env: EvmEnv,
         mut request: TransactionRequest,
         db: &mut CacheDB<DB>,
         overrides: EvmOverrides,
-    ) -> Result<EnvWithHandlerCfg, Self::Error>
+    ) -> Result<(EvmEnv, TxEnv), Self::Error>
     where
         DB: DatabaseRef,
         EthApiError: From<<DB as DatabaseRef>::Error>,
@@ -854,41 +822,41 @@ pub trait Call:
         }
 
         // apply configured gas cap
-        block.gas_limit = U256::from(self.call_gas_limit());
+        evm_env.block_env.gas_limit = U256::from(self.call_gas_limit());
 
         // Disabled because eth_call is sometimes used with eoa senders
         // See <https://github.com/paradigmxyz/reth/issues/1959>
-        cfg.disable_eip3607 = true;
+        evm_env.cfg_env_with_handler_cfg.disable_eip3607 = true;
 
         // The basefee should be ignored for eth_call
         // See:
         // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
-        cfg.disable_base_fee = true;
+        evm_env.cfg_env_with_handler_cfg.disable_base_fee = true;
 
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.nonce = None;
 
         if let Some(block_overrides) = overrides.block {
-            apply_block_overrides(*block_overrides, db, &mut block);
+            apply_block_overrides(*block_overrides, db, &mut evm_env.block_env);
         }
         if let Some(state_overrides) = overrides.state {
             apply_state_overrides(state_overrides, db)?;
         }
 
         let request_gas = request.gas;
-        let mut env = self.build_call_evm_env(cfg, block, request)?;
+        let mut tx_env = self.create_txn_env(&evm_env.block_env, request)?;
 
         if request_gas.is_none() {
             // No gas limit was provided in the request, so we need to cap the transaction gas limit
-            if env.tx.gas_price > U256::ZERO {
+            if tx_env.gas_price > U256::ZERO {
                 // If gas price is specified, cap transaction gas limit with caller allowance
-                trace!(target: "rpc::eth::call", ?env, "Applying gas limit cap with caller allowance");
-                let cap = caller_gas_allowance(db, &env.tx)?;
+                trace!(target: "rpc::eth::call", ?tx_env, "Applying gas limit cap with caller allowance");
+                let cap = caller_gas_allowance(db, &tx_env)?;
                 // ensure we cap gas_limit to the block's
-                env.tx.gas_limit = cap.min(env.block.gas_limit).saturating_to();
+                tx_env.gas_limit = cap.min(evm_env.block_env.gas_limit).saturating_to();
             }
         }
 
-        Ok(env)
+        Ok((evm_env, tx_env))
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -11,14 +11,14 @@ use reth_provider::StateProvider;
 use reth_revm::{
     database::StateProviderDatabase,
     db::CacheDB,
-    primitives::{BlockEnv, CfgEnvWithHandlerCfg, ExecutionResult, HaltReason, TransactTo},
+    primitives::{ExecutionResult, HaltReason, TransactTo},
 };
 use reth_rpc_eth_types::{
     revm_utils::{apply_state_overrides, caller_gas_allowance},
     EthApiError, RevertError, RpcInvalidTransactionError,
 };
 use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO};
-use revm_primitives::{db::Database, EnvWithHandlerCfg};
+use revm_primitives::{db::Database, TxEnv};
 use tracing::trace;
 
 /// Gas execution estimates
@@ -36,8 +36,7 @@ pub trait EstimateCall: Call {
     ///  - `nonce` is set to `None`
     fn estimate_gas_with<S>(
         &self,
-        mut cfg: CfgEnvWithHandlerCfg,
-        block: BlockEnv,
+        mut evm_env: EvmEnv,
         mut request: TransactionRequest,
         state: S,
         state_override: Option<StateOverride>,
@@ -47,12 +46,12 @@ pub trait EstimateCall: Call {
     {
         // Disabled because eth_estimateGas is sometimes used with eoa senders
         // See <https://github.com/paradigmxyz/reth/issues/1959>
-        cfg.disable_eip3607 = true;
+        evm_env.cfg_env_with_handler_cfg.disable_eip3607 = true;
 
         // The basefee should be ignored for eth_estimateGas and similar
         // See:
         // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
-        cfg.disable_base_fee = true;
+        evm_env.cfg_env_with_handler_cfg.disable_base_fee = true;
 
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.nonce = None;
@@ -61,7 +60,7 @@ pub trait EstimateCall: Call {
         let tx_request_gas_limit = request.gas.map(U256::from);
         let tx_request_gas_price = request.gas_price;
         // the gas limit of the corresponding block
-        let block_env_gas_limit = block.gas_limit;
+        let block_env_gas_limit = evm_env.block_env.gas_limit;
 
         // Determine the highest possible gas limit, considering both the request's specified limit
         // and the block's limit.
@@ -76,7 +75,7 @@ pub trait EstimateCall: Call {
             .unwrap_or(block_env_gas_limit);
 
         // Configure the evm env
-        let mut env = self.build_call_evm_env(cfg, block, request)?;
+        let mut tx_env = self.create_txn_env(&evm_env.block_env, request)?;
         let mut db = CacheDB::new(StateProviderDatabase::new(state));
 
         // Apply any state overrides if specified.
@@ -85,8 +84,8 @@ pub trait EstimateCall: Call {
         }
 
         // Optimize for simple transfer transactions, potentially reducing the gas estimate.
-        if env.tx.data.is_empty() {
-            if let TransactTo::Call(to) = env.tx.transact_to {
+        if tx_env.data.is_empty() {
+            if let TransactTo::Call(to) = tx_env.transact_to {
                 if let Ok(code) = db.db.account_code(&to) {
                     let no_code_callee = code.map(|code| code.is_empty()).unwrap_or(true);
                     if no_code_callee {
@@ -95,9 +94,9 @@ pub trait EstimateCall: Call {
                         // `MIN_TRANSACTION_GAS` is dangerous because there might be additional
                         // field combos that bump the price up, so we try executing the function
                         // with the minimum gas limit to make sure.
-                        let mut env = env.clone();
-                        env.tx.gas_limit = MIN_TRANSACTION_GAS;
-                        if let Ok((res, _)) = self.transact(&mut db, env) {
+                        let mut tx_env = tx_env.clone();
+                        tx_env.gas_limit = MIN_TRANSACTION_GAS;
+                        if let Ok((res, _)) = self.transact(&mut db, evm_env.clone(), tx_env) {
                             if res.result.is_success() {
                                 return Ok(U256::from(MIN_TRANSACTION_GAS))
                             }
@@ -110,35 +109,41 @@ pub trait EstimateCall: Call {
         // Check funds of the sender (only useful to check if transaction gas price is more than 0).
         //
         // The caller allowance is check by doing `(account.balance - tx.value) / tx.gas_price`
-        if env.tx.gas_price > U256::ZERO {
+        if tx_env.gas_price > U256::ZERO {
             // cap the highest gas limit by max gas caller can afford with given gas price
             highest_gas_limit = highest_gas_limit
-                .min(caller_gas_allowance(&mut db, &env.tx).map_err(Self::Error::from_eth_err)?);
+                .min(caller_gas_allowance(&mut db, &tx_env).map_err(Self::Error::from_eth_err)?);
         }
 
         // We can now normalize the highest gas limit to a u64
         let mut highest_gas_limit = highest_gas_limit.saturating_to::<u64>();
 
         // If the provided gas limit is less than computed cap, use that
-        env.tx.gas_limit = env.tx.gas_limit.min(highest_gas_limit);
+        tx_env.gas_limit = tx_env.gas_limit.min(highest_gas_limit);
 
-        trace!(target: "rpc::eth::estimate", ?env, "Starting gas estimation");
+        trace!(target: "rpc::eth::estimate", ?evm_env, ?tx_env, "Starting gas estimation");
 
         // Execute the transaction with the highest possible gas limit.
-        let (mut res, mut env) = match self.transact(&mut db, env.clone()) {
-            // Handle the exceptional case where the transaction initialization uses too much gas.
-            // If the gas price or gas limit was specified in the request, retry the transaction
-            // with the block's gas limit to determine if the failure was due to
-            // insufficient gas.
-            Err(err)
-                if err.is_gas_too_high() &&
-                    (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
-            {
-                return Err(self.map_out_of_gas_err(block_env_gas_limit, env, &mut db))
-            }
-            // Propagate other results (successful or other errors).
-            ethres => ethres?,
-        };
+        let (mut res, (mut evm_env, mut tx_env)) =
+            match self.transact(&mut db, evm_env.clone(), tx_env.clone()) {
+                // Handle the exceptional case where the transaction initialization uses too much
+                // gas. If the gas price or gas limit was specified in the request,
+                // retry the transaction with the block's gas limit to determine if
+                // the failure was due to insufficient gas.
+                Err(err)
+                    if err.is_gas_too_high() &&
+                        (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
+                {
+                    return Err(self.map_out_of_gas_err(
+                        block_env_gas_limit,
+                        evm_env,
+                        tx_env,
+                        &mut db,
+                    ))
+                }
+                // Propagate other results (successful or other errors).
+                ethres => ethres?,
+            };
 
         let gas_refund = match res.result {
             ExecutionResult::Success { gas_refunded, .. } => gas_refunded,
@@ -151,7 +156,7 @@ pub trait EstimateCall: Call {
                 // if price or limit was included in the request then we can execute the request
                 // again with the block's gas limit to check if revert is gas related or not
                 return if tx_request_gas_limit.is_some() || tx_request_gas_price.is_some() {
-                    Err(self.map_out_of_gas_err(block_env_gas_limit, env, &mut db))
+                    Err(self.map_out_of_gas_err(block_env_gas_limit, evm_env, tx_env, &mut db))
                 } else {
                     // the transaction did revert
                     Err(RpcInvalidTransactionError::Revert(RevertError::new(output)).into_eth_err())
@@ -164,7 +169,7 @@ pub trait EstimateCall: Call {
 
         // we know the tx succeeded with the configured gas limit, so we can use that as the
         // highest, in case we applied a gas cap due to caller allowance above
-        highest_gas_limit = env.tx.gas_limit;
+        highest_gas_limit = tx_env.gas_limit;
 
         // NOTE: this is the gas the transaction used, which is less than the
         // transaction requires to succeed.
@@ -181,10 +186,10 @@ pub trait EstimateCall: Call {
         let optimistic_gas_limit = (gas_used + gas_refund + CALL_STIPEND_GAS) * 64 / 63;
         if optimistic_gas_limit < highest_gas_limit {
             // Set the transaction's gas limit to the calculated optimistic gas limit.
-            env.tx.gas_limit = optimistic_gas_limit;
+            tx_env.gas_limit = optimistic_gas_limit;
             // Re-execute the transaction with the new gas limit and update the result and
             // environment.
-            (res, env) = self.transact(&mut db, env)?;
+            (res, (evm_env, tx_env)) = self.transact(&mut db, evm_env, tx_env)?;
             // Update the gas used based on the new result.
             gas_used = res.result.gas_used();
             // Update the gas limit estimates (highest and lowest) based on the execution result.
@@ -202,7 +207,7 @@ pub trait EstimateCall: Call {
             ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64,
         );
 
-        trace!(target: "rpc::eth::estimate", ?env, ?highest_gas_limit, ?lowest_gas_limit, ?mid_gas_limit, "Starting binary search for gas");
+        trace!(target: "rpc::eth::estimate", ?evm_env, ?tx_env, ?highest_gas_limit, ?lowest_gas_limit, ?mid_gas_limit, "Starting binary search for gas");
 
         // Binary search narrows the range to find the minimum gas limit needed for the transaction
         // to succeed.
@@ -216,10 +221,10 @@ pub trait EstimateCall: Call {
                 break
             };
 
-            env.tx.gas_limit = mid_gas_limit;
+            tx_env.gas_limit = mid_gas_limit;
 
             // Execute transaction and handle potential gas errors, adjusting limits accordingly.
-            match self.transact(&mut db, env.clone()) {
+            match self.transact(&mut db, evm_env.clone(), tx_env.clone()) {
                 Err(err) if err.is_gas_too_high() => {
                     // Decrease the highest gas limit if gas is too high
                     highest_gas_limit = mid_gas_limit;
@@ -231,7 +236,7 @@ pub trait EstimateCall: Call {
                 // Handle other cases, including successful transactions.
                 ethres => {
                     // Unpack the result and environment if the transaction was successful.
-                    (res, env) = ethres?;
+                    (res, (evm_env, tx_env)) = ethres?;
                     // Update the estimated gas range based on the transaction result.
                     update_estimated_gas_range(
                         res.result,
@@ -261,18 +266,10 @@ pub trait EstimateCall: Call {
     {
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
-            let EvmEnv { cfg_env_with_handler_cfg, block_env } = evm_env;
 
             self.spawn_blocking_io(move |this| {
                 let state = this.state_at_block_id(at)?;
-                EstimateCall::estimate_gas_with(
-                    &this,
-                    cfg_env_with_handler_cfg,
-                    block_env,
-                    request,
-                    state,
-                    state_override,
-                )
+                EstimateCall::estimate_gas_with(&this, evm_env, request, state, state_override)
             })
             .await
         }
@@ -284,16 +281,17 @@ pub trait EstimateCall: Call {
     fn map_out_of_gas_err<DB>(
         &self,
         env_gas_limit: U256,
-        mut env: EnvWithHandlerCfg,
+        evm_env: EvmEnv,
+        mut tx_env: TxEnv,
         db: &mut DB,
     ) -> Self::Error
     where
         DB: Database,
         EthApiError: From<DB::Error>,
     {
-        let req_gas_limit = env.tx.gas_limit;
-        env.tx.gas_limit = env_gas_limit.try_into().unwrap_or(u64::MAX);
-        let (res, _) = match self.transact(db, env) {
+        let req_gas_limit = tx_env.gas_limit;
+        tx_env.gas_limit = env_gas_limit.try_into().unwrap_or(u64::MAX);
+        let (res, _) = match self.transact(db, evm_env, tx_env) {
             Ok(res) => res,
             Err(err) => return err,
         };

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -10,7 +10,7 @@ use alloy_rpc_types_mev::{
 };
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthChainSpec;
-use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv};
+use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_provider::{ChainSpecProvider, HeaderProvider, ProviderTx};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::MevSimApiServer;
@@ -23,7 +23,7 @@ use reth_tasks::pool::BlockingTaskGuard;
 use reth_transaction_pool::{PoolConsensusTx, PoolPooledTx, PoolTransaction, TransactionPool};
 use revm::{
     db::CacheDB,
-    primitives::{Address, EnvWithHandlerCfg, ResultAndState, SpecId, TxEnv},
+    primitives::{Address, ResultAndState, SpecId},
     DatabaseCommit, DatabaseRef,
 };
 use std::{sync::Arc, time::Duration};
@@ -244,42 +244,44 @@ where
         let flattened_bundle = self.parse_and_flatten_bundle(&request)?;
 
         let block_id = parent_block.unwrap_or(BlockId::Number(BlockNumberOrTag::Pending));
-        let (evm_env, current_block) = self.eth_api().evm_env_at(block_id).await?;
-        let EvmEnv { cfg_env_with_handler_cfg, mut block_env } = evm_env;
+        let (mut evm_env, current_block) = self.eth_api().evm_env_at(block_id).await?;
 
         let parent_header = RpcNodeCore::provider(&self.inner.eth_api)
-            .header_by_number(block_env.number.saturating_to::<u64>())
+            .header_by_number(evm_env.block_env.number.saturating_to::<u64>())
             .map_err(EthApiError::from_eth_err)? // Explicitly map the error
             .ok_or_else(|| {
-                EthApiError::HeaderNotFound((block_env.number.saturating_to::<u64>()).into())
+                EthApiError::HeaderNotFound(
+                    (evm_env.block_env.number.saturating_to::<u64>()).into(),
+                )
             })?;
 
         // apply overrides
         if let Some(block_number) = block_number {
-            block_env.number = U256::from(block_number);
+            evm_env.block_env.number = U256::from(block_number);
         }
 
         if let Some(coinbase) = coinbase {
-            block_env.coinbase = coinbase;
+            evm_env.block_env.coinbase = coinbase;
         }
 
         if let Some(timestamp) = timestamp {
-            block_env.timestamp = U256::from(timestamp);
+            evm_env.block_env.timestamp = U256::from(timestamp);
         }
 
         if let Some(gas_limit) = gas_limit {
-            block_env.gas_limit = U256::from(gas_limit);
+            evm_env.block_env.gas_limit = U256::from(gas_limit);
         }
 
         if let Some(base_fee) = base_fee {
-            block_env.basefee = U256::from(base_fee);
-        } else if cfg_env_with_handler_cfg.handler_cfg.spec_id.is_enabled_in(SpecId::LONDON) {
+            evm_env.block_env.basefee = U256::from(base_fee);
+        } else if evm_env.cfg_env_with_handler_cfg.handler_cfg.spec_id.is_enabled_in(SpecId::LONDON)
+        {
             if let Some(base_fee) = parent_header.next_block_base_fee(
                 RpcNodeCore::provider(&self.inner.eth_api)
                     .chain_spec()
-                    .base_fee_params_at_block(block_env.number.saturating_to::<u64>()),
+                    .base_fee_params_at_block(evm_env.block_env.number.saturating_to::<u64>()),
             ) {
-                block_env.basefee = U256::from(base_fee);
+                evm_env.block_env.basefee = U256::from(base_fee);
             }
         }
 
@@ -291,13 +293,8 @@ where
             .spawn_with_state_at_block(current_block, move |state| {
                 // Setup environment
                 let current_block_number = current_block.as_u64().unwrap();
-                let coinbase = block_env.coinbase;
-                let basefee = block_env.basefee;
-                let env = EnvWithHandlerCfg::new_with_cfg_env(
-                    cfg_env_with_handler_cfg,
-                    block_env,
-                    TxEnv::default(),
-                );
+                let coinbase = evm_env.block_env.coinbase;
+                let basefee = evm_env.block_env.basefee;
                 let db = CacheDB::new(StateProviderDatabase::new(state));
 
                 let initial_coinbase_balance = DatabaseRef::basic_ref(&db, coinbase)
@@ -311,7 +308,7 @@ where
                 let mut refundable_value = U256::ZERO;
                 let mut body_logs: Vec<SimBundleLogs> = Vec::new();
 
-                let mut evm = eth_api.evm_config().evm_with_env(db, env);
+                let mut evm = eth_api.evm_config().evm_with_env(db, evm_env, Default::default());
 
                 for item in &flattened_bundle {
                     // Check inclusion constraints

--- a/examples/custom-inspector/Cargo.toml
+++ b/examples/custom-inspector/Cargo.toml
@@ -7,7 +7,9 @@ license.workspace = true
 
 [dependencies]
 reth.workspace = true
+reth-evm.workspace = true
 reth-node-ethereum.workspace = true
+revm-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
 clap = { workspace = true, features = ["derive"] }
 futures-util.workspace = true


### PR DESCRIPTION
We've introduced `EvmEnv` to encapsulate Evm configuration not related to transaction, however most of the logic still operates on it directly to convert into `revm::Env`. This makes abstracting over `EvmEnv` and `TxEnv` not feasible

This PR changes logic to operate directly on `EvmEnv` as much as possible, only converting it to `revm::Env` when Evm is actually being created

This allows us to 
1. Make parts of the logic generic over `TxEnv` because it is now always passed separately
2. Makes future abstraction over `EvmEnv` easier because it is now also properly separated