### PR TITLE
feat: add `Evm` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,6 +7514,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-sol-types",
+ "derive_more",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-consensus",

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -58,5 +58,6 @@ std = [
 	"reth-ethereum-forks/std",
 	"serde_json/std",
 	"reth-primitives-traits/std",
-	"reth-chainspec/std"
+	"reth-chainspec/std",
+	"derive_more/std"
 ]

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -30,6 +30,9 @@ alloy-eips.workspace = true
 alloy-sol-types.workspace = true
 alloy-consensus.workspace = true
 
+# Misc
+derive_more.workspace = true
+
 [dev-dependencies]
 reth-testing-utils.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -19,7 +19,7 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, SystemCaller},
-    ConfigureEvm, TxEnvOverrides,
+    ConfigureEvm, Evm, TxEnvOverrides,
 };
 use reth_primitives::{EthPrimitives, Receipt, RecoveredBlock};
 use reth_primitives_traits::{BlockBody, SignedTransaction};
@@ -166,14 +166,14 @@ where
                 .into())
             }
 
-            self.evm_config.fill_tx_env(evm.tx_mut(), transaction, *sender);
+            let mut tx_env = self.evm_config.tx_env(transaction, *sender);
 
             if let Some(tx_env_overrides) = &mut self.tx_env_overrides {
-                tx_env_overrides.apply(evm.tx_mut());
+                tx_env_overrides.apply(&mut tx_env);
             }
 
             // Execute transaction.
-            let result_and_state = evm.transact().map_err(move |err| {
+            let result_and_state = evm.transact(tx_env).map_err(move |err| {
                 let new_err = err.map_db_err(|e| e.into());
                 // Ensure hash is calculated for error log, if not already done
                 BlockValidationError::EVM {

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -17,18 +17,18 @@
 
 extern crate alloc;
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
-use alloy_primitives::{Address, Bytes, TxKind, U256};
-use core::convert::Infallible;
+use alloy_primitives::{Address, U256};
+use core::{convert::Infallible, fmt::Debug};
 use reth_chainspec::ChainSpec;
 use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Evm, NextBlockEnvAttributes};
 use reth_primitives::TransactionSigned;
 use reth_primitives_traits::transaction::execute::FillTxEnv;
 use reth_revm::{inspector_handle_register, Database, EvmBuilder};
 use revm_primitives::{
-    AnalysisKind, BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, EVMError, Env,
-    SpecId, TxEnv,
+    AnalysisKind, BlobExcessGasAndPrice, BlockEnv, Bytes, CfgEnv, CfgEnvWithHandlerCfg, EVMError,
+    Env, ResultAndState, SpecId, TxEnv, TxKind,
 };
 
 mod config;
@@ -43,6 +43,90 @@ pub mod dao_fork;
 
 /// [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) handling.
 pub mod eip6110;
+
+/// Ethereum EVM implementation.
+#[derive(derive_more::Debug, derive_more::Deref, derive_more::DerefMut, derive_more::From)]
+#[debug(bound(DB::Error: Debug))]
+pub struct EthEvm<'a, EXT, DB: Database>(reth_revm::Evm<'a, EXT, DB>);
+
+impl<EXT, DB: Database> Evm for EthEvm<'_, EXT, DB> {
+    type DB = DB;
+    type Tx = TxEnv;
+    type Error = EVMError<DB::Error>;
+
+    fn block(&self) -> &BlockEnv {
+        self.0.block()
+    }
+
+    fn into_env(self) -> EvmEnv {
+        let Env { cfg, block, tx: _ } = *self.0.context.evm.inner.env;
+        EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: cfg,
+                handler_cfg: self.0.handler.cfg,
+            },
+            block_env: block,
+        }
+    }
+
+    fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
+        *self.tx_mut() = tx;
+        self.0.transact()
+    }
+
+    fn transact_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState, Self::Error> {
+        #[allow(clippy::needless_update)] // side-effect of optimism fields
+        let tx_env = TxEnv {
+            caller,
+            transact_to: TxKind::Call(contract),
+            // Explicitly set nonce to None so revm does not do any nonce checks
+            nonce: None,
+            gas_limit: 30_000_000,
+            value: U256::ZERO,
+            data,
+            // Setting the gas price to zero enforces that no value is transferred as part of the
+            // call, and that the call will not count against the block's gas limit
+            gas_price: U256::ZERO,
+            // The chain ID check is not relevant here and is disabled if set to None
+            chain_id: None,
+            // Setting the gas priority fee to None ensures the effective gas price is derived from
+            // the `gas_price` field, which we need to be zero
+            gas_priority_fee: None,
+            access_list: Vec::new(),
+            // blob fields can be None for this tx
+            blob_hashes: Vec::new(),
+            max_fee_per_blob_gas: None,
+            // TODO remove this once this crate is no longer built with optimism
+            ..Default::default()
+        };
+
+        *self.tx_mut() = tx_env;
+
+        let prev_block_env = self.block().clone();
+
+        // ensure the block gas limit is >= the tx
+        self.block_mut().gas_limit = U256::from(self.tx().gas_limit);
+
+        // disable the base fee check for this call by setting the base fee to zero
+        self.block_mut().basefee = U256::ZERO;
+
+        let res = self.0.transact();
+
+        // re-set the block env
+        *self.block_mut() = prev_block_env;
+
+        res
+    }
+
+    fn db_mut(&mut self) -> &mut Self::DB {
+        &mut self.context.evm.db
+    }
+}
 
 /// Ethereum-related EVM configuration.
 #[derive(Debug, Clone)]
@@ -69,46 +153,6 @@ impl ConfigureEvmEnv for EthEvmConfig {
 
     fn fill_tx_env(&self, tx_env: &mut TxEnv, transaction: &TransactionSigned, sender: Address) {
         transaction.fill_tx_env(tx_env, sender);
-    }
-
-    fn fill_tx_env_system_contract_call(
-        &self,
-        env: &mut Env,
-        caller: Address,
-        contract: Address,
-        data: Bytes,
-    ) {
-        #[allow(clippy::needless_update)] // side-effect of optimism fields
-        let tx = TxEnv {
-            caller,
-            transact_to: TxKind::Call(contract),
-            // Explicitly set nonce to None so revm does not do any nonce checks
-            nonce: None,
-            gas_limit: 30_000_000,
-            value: U256::ZERO,
-            data,
-            // Setting the gas price to zero enforces that no value is transferred as part of the
-            // call, and that the call will not count against the block's gas limit
-            gas_price: U256::ZERO,
-            // The chain ID check is not relevant here and is disabled if set to None
-            chain_id: None,
-            // Setting the gas priority fee to None ensures the effective gas price is derived from
-            // the `gas_price` field, which we need to be zero
-            gas_priority_fee: None,
-            access_list: Vec::new(),
-            // blob fields can be None for this tx
-            blob_hashes: Vec::new(),
-            max_fee_per_blob_gas: None,
-            // TODO remove this once this crate is no longer built with optimism
-            ..Default::default()
-        };
-        env.tx = tx;
-
-        // ensure the block gas limit is >= the tx
-        env.block.gas_limit = U256::from(env.tx.gas_limit);
-
-        // disable the base fee check for this call by setting the base fee to zero
-        env.block.basefee = U256::ZERO;
     }
 
     fn fill_cfg_env(&self, cfg_env: &mut CfgEnvWithHandlerCfg, header: &Header) {
@@ -184,39 +228,45 @@ impl ConfigureEvmEnv for EthEvmConfig {
 }
 
 impl ConfigureEvm for EthEvmConfig {
-    fn evm_with_env<'a, DB: Database + 'a>(
+    type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
+
+    fn evm_with_env<DB: Database>(
         &self,
         db: DB,
         evm_env: EvmEnv,
         tx: TxEnv,
-    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a {
-        EvmBuilder::default()
-            .with_db(db)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
-            .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
-            .build()
+    ) -> Self::Evm<'_, DB, ()> {
+        EthEvm(
+            EvmBuilder::default()
+                .with_db(db)
+                .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+                .with_block_env(evm_env.block_env)
+                .with_tx_env(tx)
+                .build(),
+        )
     }
 
-    fn evm_with_env_and_inspector<'a, DB, I>(
+    fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
         evm_env: EvmEnv,
         tx: TxEnv,
         inspector: I,
-    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a
+    ) -> Self::Evm<'_, DB, I>
     where
-        DB: Database + 'a,
-        I: reth_revm::GetInspector<DB> + 'a,
+        DB: Database,
+        I: reth_revm::GetInspector<DB>,
     {
-        EvmBuilder::default()
-            .with_db(db)
-            .with_external_context(inspector)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
-            .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
-            .append_handler_register(inspector_handle_register)
-            .build()
+        EthEvm(
+            EvmBuilder::default()
+                .with_db(db)
+                .with_external_context(inspector)
+                .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+                .with_block_env(evm_env.block_env)
+                .with_tx_env(tx)
+                .append_handler_register(inspector_handle_register)
+                .build(),
+        )
     }
 }
 

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -17,7 +17,7 @@
 
 extern crate alloc;
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::{Address, U256};
 use core::{convert::Infallible, fmt::Debug};

--- a/crates/ethereum/node/src/evm.rs
+++ b/crates/ethereum/node/src/evm.rs
@@ -5,4 +5,4 @@ pub use reth_evm::execute::BasicBlockExecutorProvider;
 #[doc(inline)]
 pub use reth_evm_ethereum::execute::{EthExecutionStrategyFactory, EthExecutorProvider};
 #[doc(inline)]
-pub use reth_evm_ethereum::EthEvmConfig;
+pub use reth_evm_ethereum::{EthEvm, EthEvmConfig};

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -22,7 +22,9 @@ use reth_basic_payload_builder::{
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::{ChainSpec, ChainSpecProvider};
 use reth_errors::RethError;
-use reth_evm::{env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, NextBlockEnvAttributes};
+use reth_evm::{
+    env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, Evm, NextBlockEnvAttributes,
+};
 use reth_evm_ethereum::{eip6110::parse_deposits_from_receipts, EthEvmConfig};
 use reth_execution_types::ExecutionOutcome;
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
@@ -270,9 +272,9 @@ where
         }
 
         // Configure the environment for the tx.
-        *evm.tx_mut() = evm_config.tx_env(tx.tx(), tx.signer());
+        let tx_env = evm_config.tx_env(tx.tx(), tx.signer());
 
-        let ResultAndState { result, state } = match evm.transact() {
+        let ResultAndState { result, state } = match evm.transact(tx_env) {
             Ok(res) => res,
             Err(err) => {
                 match err {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -39,6 +39,8 @@ pub mod system_calls;
 pub mod test_utils;
 
 /// An abstraction over EVM.
+///
+/// At this point, assumed to be implemented on wrappers around [`revm::Evm`].
 pub trait Evm {
     /// Database type held by the EVM.
     type DB;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -20,8 +20,10 @@ extern crate alloc;
 use alloy_consensus::BlockHeader as _;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_primitives_traits::{BlockHeader, SignedTransaction};
-use revm::{Database, Evm, GetInspector};
-use revm_primitives::{BlockEnv, CfgEnvWithHandlerCfg, Env, SpecId, TxEnv};
+use revm::{Database, DatabaseCommit, GetInspector};
+use revm_primitives::{
+    BlockEnv, CfgEnvWithHandlerCfg, EVMError, Env, ResultAndState, SpecId, TxEnv, TxKind,
+};
 
 pub mod either;
 /// EVM environment configuration.
@@ -38,13 +40,141 @@ pub mod system_calls;
 /// test helpers for mocking executor
 pub mod test_utils;
 
+/// An abstraction over EVM.
+pub trait Evm {
+    /// Database type held by the EVM.
+    type DB;
+    /// Transaction environment
+    type Tx;
+    /// Error type.
+    type Error;
+
+    /// Reference to [`BlockEnv`].
+    fn block(&self) -> &BlockEnv;
+
+    /// Consumes the type and returns the underlying [`EvmEnv`].
+    fn into_env(self) -> EvmEnv;
+
+    /// Executes the given transaction.
+    fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error>;
+
+    /// Executes a system call.
+    fn transact_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState, Self::Error>;
+
+    /// Returns a mutable reference to the underlying database.
+    fn db_mut(&mut self) -> &mut Self::DB;
+
+    /// Executes a transaction and commits the state changes to the underlying database.
+    fn transact_commit(&mut self, tx_env: Self::Tx) -> Result<ResultAndState, Self::Error>
+    where
+        Self::DB: DatabaseCommit,
+    {
+        let result = self.transact(tx_env)?;
+        self.db_mut().commit(result.state.clone());
+
+        Ok(result)
+    }
+}
+
+impl<EXT, DB> Evm for revm::Evm<'_, EXT, DB>
+where
+    DB: Database,
+{
+    type DB = DB;
+    type Tx = TxEnv;
+    type Error = EVMError<DB::Error>;
+
+    fn block(&self) -> &BlockEnv {
+        self.block()
+    }
+
+    fn into_env(self) -> EvmEnv {
+        let Env { cfg, block, tx: _ } = *self.context.evm.inner.env;
+        EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: cfg,
+                handler_cfg: self.handler.cfg,
+            },
+            block_env: block,
+        }
+    }
+
+    fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
+        *self.tx_mut() = tx;
+        self.transact()
+    }
+
+    fn transact_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState, Self::Error> {
+        #[allow(clippy::needless_update)] // side-effect of optimism fields
+        let tx_env = TxEnv {
+            caller,
+            transact_to: TxKind::Call(contract),
+            // Explicitly set nonce to None so revm does not do any nonce checks
+            nonce: None,
+            gas_limit: 30_000_000,
+            value: U256::ZERO,
+            data,
+            // Setting the gas price to zero enforces that no value is transferred as part of the
+            // call, and that the call will not count against the block's gas limit
+            gas_price: U256::ZERO,
+            // The chain ID check is not relevant here and is disabled if set to None
+            chain_id: None,
+            // Setting the gas priority fee to None ensures the effective gas price is derived from
+            // the `gas_price` field, which we need to be zero
+            gas_priority_fee: None,
+            access_list: Vec::new(),
+            // blob fields can be None for this tx
+            blob_hashes: Vec::new(),
+            max_fee_per_blob_gas: None,
+            // TODO remove this once this crate is no longer built with optimism
+            ..Default::default()
+        };
+
+        *self.tx_mut() = tx_env;
+
+        let prev_block_env = self.block().clone();
+
+        // ensure the block gas limit is >= the tx
+        self.block_mut().gas_limit = U256::from(self.tx().gas_limit);
+
+        // disable the base fee check for this call by setting the base fee to zero
+        self.block_mut().basefee = U256::ZERO;
+
+        let res = self.transact();
+
+        // re-set the block env
+        *self.block_mut() = prev_block_env;
+
+        res
+    }
+
+    fn db_mut(&mut self) -> &mut Self::DB {
+        &mut self.context.evm.db
+    }
+}
+
 /// Trait for configuring the EVM for executing full blocks.
 pub trait ConfigureEvm: ConfigureEvmEnv {
     /// Returns a new EVM with the given database configured with the given environment settings,
     /// including the spec id and transaction environment.
     ///
     /// This will preserve any handler modifications
-    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB>;
+    fn evm_with_env<'a, DB: Database + 'a>(
+        &self,
+        db: DB,
+        evm_env: EvmEnv,
+        tx: TxEnv,
+    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a;
 
     /// Returns a new EVM with the given database configured with `cfg` and `block_env`
     /// configuration derived from the given header. Relies on
@@ -53,7 +183,11 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     /// # Caution
     ///
     /// This does not initialize the tx environment.
-    fn evm_for_block<DB: Database>(&self, db: DB, header: &Self::Header) -> Evm<'_, (), DB> {
+    fn evm_for_block<'a, DB: Database + 'a>(
+        &self,
+        db: DB,
+        header: &Self::Header,
+    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a {
         let evm_env = self.cfg_and_block_env(header);
         self.evm_with_env(db, evm_env, Default::default())
     }
@@ -64,16 +198,16 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     /// This will use the given external inspector as the EVM external context.
     ///
     /// This will preserve any handler modifications
-    fn evm_with_env_and_inspector<DB, I>(
+    fn evm_with_env_and_inspector<'a, DB, I>(
         &self,
         db: DB,
         evm_env: EvmEnv,
         tx: TxEnv,
         inspector: I,
-    ) -> Evm<'_, I, DB>
+    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a
     where
-        DB: Database,
-        I: GetInspector<DB>;
+        DB: Database + 'a,
+        I: GetInspector<DB> + 'a;
 }
 
 impl<'b, T> ConfigureEvm for &'b T
@@ -81,24 +215,33 @@ where
     T: ConfigureEvm,
     &'b T: ConfigureEvmEnv<Header = T::Header>,
 {
-    fn evm_for_block<DB: Database>(&self, db: DB, header: &Self::Header) -> Evm<'_, (), DB> {
+    fn evm_for_block<'a, DB: Database + 'a>(
+        &self,
+        db: DB,
+        header: &Self::Header,
+    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a {
         (*self).evm_for_block(db, header)
     }
 
-    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB> {
+    fn evm_with_env<'a, DB: Database + 'a>(
+        &self,
+        db: DB,
+        evm_env: EvmEnv,
+        tx: TxEnv,
+    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a {
         (*self).evm_with_env(db, evm_env, tx)
     }
 
-    fn evm_with_env_and_inspector<DB, I>(
+    fn evm_with_env_and_inspector<'a, DB, I>(
         &self,
         db: DB,
         evm_env: EvmEnv,
         tx_env: TxEnv,
         inspector: I,
-    ) -> Evm<'_, I, DB>
+    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a
     where
-        DB: Database,
-        I: GetInspector<DB>,
+        DB: Database + 'a,
+        I: GetInspector<DB> + 'a,
     {
         (*self).evm_with_env_and_inspector(db, evm_env, tx_env, inspector)
     }

--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -1,13 +1,14 @@
 //! [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) system call implementation.
 
-use alloc::{boxed::Box, string::ToString};
+use core::fmt::Display;
+
+use alloc::string::ToString;
 use alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS;
 
-use crate::ConfigureEvm;
+use crate::Evm;
 use alloy_primitives::B256;
 use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
-use revm::{interpreter::Host, Database, Evm};
 use revm_primitives::ResultAndState;
 
 /// Applies the pre-block call to the [EIP-2935] blockhashes contract, using the given block,
@@ -23,19 +24,13 @@ use revm_primitives::ResultAndState;
 ///
 /// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
 #[inline]
-pub(crate) fn transact_blockhashes_contract_call<EvmConfig, EXT, DB>(
-    evm_config: &EvmConfig,
+pub(crate) fn transact_blockhashes_contract_call(
     chain_spec: impl EthereumHardforks,
     block_timestamp: u64,
     block_number: u64,
     parent_block_hash: B256,
-    evm: &mut Evm<'_, EXT, DB>,
-) -> Result<Option<ResultAndState>, BlockExecutionError>
-where
-    DB: Database,
-    DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm,
-{
+    evm: &mut impl Evm<Error: Display>,
+) -> Result<Option<ResultAndState>, BlockExecutionError> {
     if !chain_spec.is_prague_active_at_timestamp(block_timestamp) {
         return Ok(None)
     }
@@ -46,21 +41,13 @@ where
         return Ok(None)
     }
 
-    // get previous env
-    let previous_env = Box::new(evm.context.env().clone());
-
-    // modify env for pre block call
-    evm_config.fill_tx_env_system_contract_call(
-        &mut evm.context.evm.env,
+    let mut res = match evm.transact_system_call(
         alloy_eips::eip4788::SYSTEM_ADDRESS,
         HISTORY_STORAGE_ADDRESS,
         parent_block_hash.0.into(),
-    );
-
-    let mut res = match evm.transact() {
+    ) {
         Ok(res) => res,
         Err(e) => {
-            evm.context.evm.env = previous_env;
             return Err(BlockValidationError::BlockHashContractCall { message: e.to_string() }.into())
         }
     };
@@ -72,9 +59,6 @@ where
     // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
-
-    // re-set the previous env
-    evm.context.evm.env = previous_env;
 
     Ok(Some(res))
 }

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -1,12 +1,11 @@
 //! [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) system call implementation.
+use crate::Evm;
 use alloc::{boxed::Box, string::ToString};
-
-use crate::ConfigureEvm;
 use alloy_eips::eip4788::BEACON_ROOTS_ADDRESS;
 use alloy_primitives::B256;
+use core::fmt::Display;
 use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
-use revm::{interpreter::Host, Database, Evm};
 use revm_primitives::ResultAndState;
 
 /// Applies the pre-block call to the [EIP-4788] beacon block root contract, using the given block,
@@ -19,20 +18,13 @@ use revm_primitives::ResultAndState;
 ///
 /// [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788
 #[inline]
-pub(crate) fn transact_beacon_root_contract_call<EvmConfig, EXT, DB, Spec>(
-    evm_config: &EvmConfig,
-    chain_spec: &Spec,
+pub(crate) fn transact_beacon_root_contract_call(
+    chain_spec: impl EthereumHardforks,
     block_timestamp: u64,
     block_number: u64,
     parent_beacon_block_root: Option<B256>,
-    evm: &mut Evm<'_, EXT, DB>,
-) -> Result<Option<ResultAndState>, BlockExecutionError>
-where
-    DB: Database,
-    DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm,
-    Spec: EthereumHardforks,
-{
+    evm: &mut impl Evm<Error: Display>,
+) -> Result<Option<ResultAndState>, BlockExecutionError> {
     if !chain_spec.is_cancun_active_at_timestamp(block_timestamp) {
         return Ok(None)
     }
@@ -52,21 +44,13 @@ where
         return Ok(None)
     }
 
-    // get previous env
-    let previous_env = Box::new(evm.context.env().clone());
-
-    // modify env for pre block call
-    evm_config.fill_tx_env_system_contract_call(
-        &mut evm.context.evm.env,
+    let mut res = match evm.transact_system_call(
         alloy_eips::eip4788::SYSTEM_ADDRESS,
         BEACON_ROOTS_ADDRESS,
         parent_beacon_block_root.0.into(),
-    );
-
-    let mut res = match evm.transact() {
+    ) {
         Ok(res) => res,
         Err(e) => {
-            evm.context.evm.env = previous_env;
             return Err(BlockValidationError::BeaconRootContractCall {
                 parent_beacon_block_root: Box::new(parent_beacon_block_root),
                 message: e.to_string(),
@@ -82,9 +66,6 @@ where
     // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
-
-    // re-set the previous env
-    evm.context.evm.env = previous_env;
 
     Ok(Some(res))
 }

--- a/crates/evm/src/system_calls/eip7002.rs
+++ b/crates/evm/src/system_calls/eip7002.rs
@@ -1,10 +1,10 @@
 //! [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) system call implementation.
-use crate::ConfigureEvm;
-use alloc::{boxed::Box, format};
+use crate::Evm;
+use alloc::format;
 use alloy_eips::eip7002::WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS;
 use alloy_primitives::Bytes;
+use core::fmt::Display;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
-use revm::{interpreter::Host, Database, Evm};
 use revm_primitives::{ExecutionResult, ResultAndState};
 
 /// Applies the post-block call to the EIP-7002 withdrawal requests contract.
@@ -13,19 +13,10 @@ use revm_primitives::{ExecutionResult, ResultAndState};
 ///
 /// Note: this does not commit the state changes to the database, it only transact the call.
 #[inline]
-pub(crate) fn transact_withdrawal_requests_contract_call<EvmConfig, EXT, DB>(
-    evm_config: &EvmConfig,
-    evm: &mut Evm<'_, EXT, DB>,
-) -> Result<ResultAndState, BlockExecutionError>
-where
-    DB: Database,
-    DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm,
-{
-    // get previous env
-    let previous_env = Box::new(evm.context.env().clone());
-
-    // Fill transaction environment with the EIP-7002 withdrawal requests contract message data.
+pub(crate) fn transact_withdrawal_requests_contract_call(
+    evm: &mut impl Evm<Error: Display>,
+) -> Result<ResultAndState, BlockExecutionError> {
+    // Execute EIP-7002 withdrawal requests contract message data.
     //
     // This requirement for the withdrawal requests contract call defined by
     // [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) is:
@@ -33,17 +24,13 @@ where
     // At the end of processing any execution block where `block.timestamp >= FORK_TIMESTAMP` (i.e.
     // after processing all transactions and after performing the block body withdrawal requests
     // validations), call the contract as `SYSTEM_ADDRESS`.
-    evm_config.fill_tx_env_system_contract_call(
-        &mut evm.context.evm.env,
+    let mut res = match evm.transact_system_call(
         alloy_eips::eip7002::SYSTEM_ADDRESS,
         WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
         Bytes::new(),
-    );
-
-    let mut res = match evm.transact() {
+    ) {
         Ok(res) => res,
         Err(e) => {
-            evm.context.evm.env = previous_env;
             return Err(BlockValidationError::WithdrawalRequestsContractCall {
                 message: format!("execution failed: {e}"),
             }
@@ -58,9 +45,6 @@ where
     // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip7002::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
-
-    // re-set the previous env
-    evm.context.evm.env = previous_env;
 
     Ok(res)
 }

--- a/crates/evm/src/system_calls/eip7251.rs
+++ b/crates/evm/src/system_calls/eip7251.rs
@@ -1,10 +1,10 @@
 //! [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) system call implementation.
-use crate::ConfigureEvm;
-use alloc::{boxed::Box, format};
+use crate::Evm;
+use alloc::format;
 use alloy_eips::eip7251::CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS;
 use alloy_primitives::Bytes;
+use core::fmt::Display;
 use reth_execution_errors::{BlockExecutionError, BlockValidationError};
-use revm::{interpreter::Host, Database, Evm};
 use revm_primitives::{ExecutionResult, ResultAndState};
 
 /// Applies the post-block call to the EIP-7251 consolidation requests contract.
@@ -14,19 +14,10 @@ use revm_primitives::{ExecutionResult, ResultAndState};
 ///
 /// Note: this does not commit the state changes to the database, it only transact the call.
 #[inline]
-pub(crate) fn transact_consolidation_requests_contract_call<EvmConfig, EXT, DB>(
-    evm_config: &EvmConfig,
-    evm: &mut Evm<'_, EXT, DB>,
-) -> Result<ResultAndState, BlockExecutionError>
-where
-    DB: Database,
-    DB::Error: core::fmt::Display,
-    EvmConfig: ConfigureEvm,
-{
-    // get previous env
-    let previous_env = Box::new(evm.context.env().clone());
-
-    // Fill transaction environment with the EIP-7251 consolidation requests contract message data.
+pub(crate) fn transact_consolidation_requests_contract_call(
+    evm: &mut impl Evm<Error: Display>,
+) -> Result<ResultAndState, BlockExecutionError> {
+    // Execute EIP-7251 consolidation requests contract message data.
     //
     // This requirement for the consolidation requests contract call defined by
     // [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) is:
@@ -35,17 +26,13 @@ where
     // after processing all transactions and after performing the block body requests validations)
     // clienst software MUST [..] call the contract as `SYSTEM_ADDRESS` and empty input data to
     // trigger the system subroutine execute.
-    evm_config.fill_tx_env_system_contract_call(
-        &mut evm.context.evm.env,
+    let mut res = match evm.transact_system_call(
         alloy_eips::eip7002::SYSTEM_ADDRESS,
         CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
         Bytes::new(),
-    );
-
-    let mut res = match evm.transact() {
+    ) {
         Ok(res) => res,
         Err(e) => {
-            evm.context.evm.env = previous_env;
             return Err(BlockValidationError::ConsolidationRequestsContractCall {
                 message: format!("execution failed: {e}"),
             }
@@ -60,9 +47,6 @@ where
     // so we can just remove them from the state returned.
     res.state.remove(&alloy_eips::eip7002::SYSTEM_ADDRESS);
     res.state.remove(&evm.block().coinbase);
-
-    // re-set the previous env
-    evm.context.evm.env = previous_env;
 
     Ok(res)
 }

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -1,6 +1,6 @@
 //! System contract call functions.
 
-use crate::{ConfigureEvm, EvmEnv};
+use crate::{ConfigureEvm, Evm, EvmEnv};
 use alloc::{boxed::Box, sync::Arc};
 use alloy_consensus::BlockHeader;
 use alloy_eips::{
@@ -10,7 +10,7 @@ use alloy_primitives::Bytes;
 use core::fmt::Display;
 use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::BlockExecutionError;
-use revm::{Database, DatabaseCommit, Evm};
+use revm::{Database, DatabaseCommit};
 use revm_primitives::{EvmState, B256};
 
 mod eip2935;
@@ -76,15 +76,11 @@ where
     Chainspec: EthereumHardforks,
 {
     /// Apply pre execution changes.
-    pub fn apply_pre_execution_changes<DB, Ext>(
+    pub fn apply_pre_execution_changes(
         &mut self,
         header: &EvmConfig::Header,
-        evm: &mut Evm<'_, Ext, DB>,
-    ) -> Result<(), BlockExecutionError>
-    where
-        DB: Database + DatabaseCommit,
-        DB::Error: Display,
-    {
+        evm: &mut impl Evm<DB: DatabaseCommit, Error: Display>,
+    ) -> Result<(), BlockExecutionError> {
         self.apply_blockhashes_contract_call(
             header.timestamp(),
             header.number(),
@@ -102,14 +98,10 @@ where
     }
 
     /// Apply post execution changes.
-    pub fn apply_post_execution_changes<DB, Ext>(
+    pub fn apply_post_execution_changes(
         &mut self,
-        evm: &mut Evm<'_, Ext, DB>,
-    ) -> Result<Requests, BlockExecutionError>
-    where
-        DB: Database + DatabaseCommit,
-        DB::Error: Display,
-    {
+        evm: &mut impl Evm<DB: DatabaseCommit, Error: Display>,
+    ) -> Result<Requests, BlockExecutionError> {
         let mut requests = Requests::default();
 
         // Collect all EIP-7685 requests
@@ -152,19 +144,14 @@ where
     }
 
     /// Applies the pre-block call to the EIP-2935 blockhashes contract.
-    pub fn apply_blockhashes_contract_call<DB, Ext>(
+    pub fn apply_blockhashes_contract_call(
         &mut self,
         timestamp: u64,
         block_number: u64,
         parent_block_hash: B256,
-        evm: &mut Evm<'_, Ext, DB>,
-    ) -> Result<(), BlockExecutionError>
-    where
-        DB: Database + DatabaseCommit,
-        DB::Error: Display,
-    {
+        evm: &mut impl Evm<DB: DatabaseCommit, Error: Display>,
+    ) -> Result<(), BlockExecutionError> {
         let result_and_state = eip2935::transact_blockhashes_contract_call(
-            &self.evm_config,
             &self.chain_spec,
             timestamp,
             block_number,
@@ -176,7 +163,7 @@ where
             if let Some(ref mut hook) = self.hook {
                 hook.on_state(&res.state);
             }
-            evm.context.evm.db.commit(res.state);
+            evm.db_mut().commit(res.state);
         }
 
         Ok(())
@@ -207,19 +194,14 @@ where
     }
 
     /// Applies the pre-block call to the EIP-4788 beacon root contract.
-    pub fn apply_beacon_root_contract_call<DB, Ext>(
+    pub fn apply_beacon_root_contract_call(
         &mut self,
         timestamp: u64,
         block_number: u64,
         parent_block_hash: Option<B256>,
-        evm: &mut Evm<'_, Ext, DB>,
-    ) -> Result<(), BlockExecutionError>
-    where
-        DB: Database + DatabaseCommit,
-        DB::Error: Display,
-    {
+        evm: &mut impl Evm<DB: DatabaseCommit, Error: Display>,
+    ) -> Result<(), BlockExecutionError> {
         let result_and_state = eip4788::transact_beacon_root_contract_call(
-            &self.evm_config,
             &self.chain_spec,
             timestamp,
             block_number,
@@ -231,7 +213,7 @@ where
             if let Some(ref mut hook) = self.hook {
                 hook.on_state(&res.state);
             }
-            evm.context.evm.db.commit(res.state);
+            evm.db_mut().commit(res.state);
         }
 
         Ok(())
@@ -256,21 +238,16 @@ where
     }
 
     /// Applies the post-block call to the EIP-7002 withdrawal request contract.
-    pub fn apply_withdrawal_requests_contract_call<DB, Ext>(
+    pub fn apply_withdrawal_requests_contract_call(
         &mut self,
-        evm: &mut Evm<'_, Ext, DB>,
-    ) -> Result<Bytes, BlockExecutionError>
-    where
-        DB: Database + DatabaseCommit,
-        DB::Error: Display,
-    {
-        let result_and_state =
-            eip7002::transact_withdrawal_requests_contract_call(&self.evm_config.clone(), evm)?;
+        evm: &mut impl Evm<DB: DatabaseCommit, Error: Display>,
+    ) -> Result<Bytes, BlockExecutionError> {
+        let result_and_state = eip7002::transact_withdrawal_requests_contract_call(evm)?;
 
         if let Some(ref mut hook) = self.hook {
             hook.on_state(&result_and_state.state);
         }
-        evm.context.evm.db.commit(result_and_state.state);
+        evm.db_mut().commit(result_and_state.state);
 
         eip7002::post_commit(result_and_state.result)
     }
@@ -294,21 +271,16 @@ where
     }
 
     /// Applies the post-block call to the EIP-7251 consolidation requests contract.
-    pub fn apply_consolidation_requests_contract_call<DB, Ext>(
+    pub fn apply_consolidation_requests_contract_call(
         &mut self,
-        evm: &mut Evm<'_, Ext, DB>,
-    ) -> Result<Bytes, BlockExecutionError>
-    where
-        DB: Database + DatabaseCommit,
-        DB::Error: Display,
-    {
-        let result_and_state =
-            eip7251::transact_consolidation_requests_contract_call(&self.evm_config.clone(), evm)?;
+        evm: &mut impl Evm<DB: DatabaseCommit, Error: Display>,
+    ) -> Result<Bytes, BlockExecutionError> {
+        let result_and_state = eip7251::transact_consolidation_requests_contract_call(evm)?;
 
         if let Some(ref mut hook) = self.hook {
             hook.on_state(&result_and_state.state);
         }
-        evm.context.evm.db.commit(result_and_state.state);
+        evm.db_mut().commit(result_and_state.state);
 
         eip7251::post_commit(result_and_state.result)
     }

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -19,9 +19,8 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, SystemCaller},
-    ConfigureEvm, TxEnvOverrides,
+    ConfigureEvm, Evm, TxEnvOverrides,
 };
-use reth_evm::Evm;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::validate_block_post_execution;
 use reth_optimism_forks::OpHardfork;

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -12,10 +12,11 @@
 
 extern crate alloc;
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
 use alloy_consensus::Header;
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, U256};
+use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
 use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Evm, NextBlockEnvAttributes};
 use reth_optimism_chainspec::OpChainSpec;
@@ -39,44 +40,48 @@ pub use receipts::*;
 mod error;
 pub use error::OpBlockExecutionError;
 use revm_primitives::{
-    BlobExcessGasAndPrice, BlockEnv, Bytes, CfgEnv, EVMError, Env, HandlerCfg, OptimismFields, SpecId, TxKind
+    BlobExcessGasAndPrice, BlockEnv, Bytes, CfgEnv, EVMError, Env, HandlerCfg, OptimismFields,
+    ResultAndState, SpecId, TxKind,
 };
 
-/// Optimism-related EVM configuration.
-#[derive(Debug, Clone)]
-pub struct OpEvmConfig {
-    chain_spec: Arc<OpChainSpec>,
-}
+/// OP EVM implementation.
+#[derive(derive_more::Debug, derive_more::Deref, derive_more::DerefMut, derive_more::From)]
+#[debug(bound(DB::Error: Debug))]
+pub struct OpEvm<'a, EXT, DB: Database>(reth_revm::Evm<'a, EXT, DB>);
 
-impl OpEvmConfig {
-    /// Creates a new [`OpEvmConfig`] with the given chain spec.
-    pub const fn new(chain_spec: Arc<OpChainSpec>) -> Self {
-        Self { chain_spec }
+impl<EXT, DB: Database> Evm for OpEvm<'_, EXT, DB> {
+    type DB = DB;
+    type Tx = TxEnv;
+    type Error = EVMError<DB::Error>;
+
+    fn block(&self) -> &BlockEnv {
+        self.0.block()
     }
 
-    /// Returns the chain spec associated with this configuration.
-    pub const fn chain_spec(&self) -> &Arc<OpChainSpec> {
-        &self.chain_spec
-    }
-}
-
-impl ConfigureEvmEnv for OpEvmConfig {
-    type Header = Header;
-    type Transaction = OpTransactionSigned;
-    type Error = EIP1559ParamError;
-
-    fn fill_tx_env(&self, tx_env: &mut TxEnv, transaction: &OpTransactionSigned, sender: Address) {
-        transaction.fill_tx_env(tx_env, sender);
+    fn into_env(self) -> EvmEnv {
+        let Env { cfg, block, tx: _ } = *self.0.context.evm.inner.env;
+        EvmEnv {
+            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
+                cfg_env: cfg,
+                handler_cfg: self.0.handler.cfg,
+            },
+            block_env: block,
+        }
     }
 
-    fn fill_tx_env_system_contract_call(
-        &self,
-        env: &mut Env,
+    fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
+        *self.tx_mut() = tx;
+        self.0.transact()
+    }
+
+    fn transact_system_call(
+        &mut self,
         caller: Address,
         contract: Address,
         data: Bytes,
-    ) {
-        env.tx = TxEnv {
+    ) -> Result<ResultAndState, Self::Error> {
+        #[allow(clippy::needless_update)] // side-effect of optimism fields
+        let tx_env = TxEnv {
             caller,
             transact_to: TxKind::Call(contract),
             // Explicitly set nonce to None so revm does not do any nonce checks
@@ -107,11 +112,54 @@ impl ConfigureEvmEnv for OpEvmConfig {
             },
         };
 
+        *self.tx_mut() = tx_env;
+
+        let prev_block_env = self.block().clone();
+
         // ensure the block gas limit is >= the tx
-        env.block.gas_limit = U256::from(env.tx.gas_limit);
+        self.block_mut().gas_limit = U256::from(self.tx().gas_limit);
 
         // disable the base fee check for this call by setting the base fee to zero
-        env.block.basefee = U256::ZERO;
+        self.block_mut().basefee = U256::ZERO;
+
+        let res = self.0.transact();
+
+        // re-set the block env
+        *self.block_mut() = prev_block_env;
+
+        res
+    }
+
+    fn db_mut(&mut self) -> &mut Self::DB {
+        &mut self.context.evm.db
+    }
+}
+
+/// Optimism-related EVM configuration.
+#[derive(Debug, Clone)]
+pub struct OpEvmConfig {
+    chain_spec: Arc<OpChainSpec>,
+}
+
+impl OpEvmConfig {
+    /// Creates a new [`OpEvmConfig`] with the given chain spec.
+    pub const fn new(chain_spec: Arc<OpChainSpec>) -> Self {
+        Self { chain_spec }
+    }
+
+    /// Returns the chain spec associated with this configuration.
+    pub const fn chain_spec(&self) -> &Arc<OpChainSpec> {
+        &self.chain_spec
+    }
+}
+
+impl ConfigureEvmEnv for OpEvmConfig {
+    type Header = Header;
+    type Transaction = OpTransactionSigned;
+    type Error = EIP1559ParamError;
+
+    fn fill_tx_env(&self, tx_env: &mut TxEnv, transaction: &OpTransactionSigned, sender: Address) {
+        transaction.fill_tx_env(tx_env, sender);
     }
 
     fn fill_cfg_env(&self, cfg_env: &mut CfgEnvWithHandlerCfg, header: &Self::Header) {
@@ -168,12 +216,14 @@ impl ConfigureEvmEnv for OpEvmConfig {
 }
 
 impl ConfigureEvm for OpEvmConfig {
-    fn evm_with_env<'a, DB: Database + 'a>(
+    type Evm<'a, DB: Database + 'a, I: 'a> = OpEvm<'a, I, DB>;
+
+    fn evm_with_env<DB: Database>(
         &self,
         db: DB,
         mut evm_env: EvmEnv,
         tx: TxEnv,
-    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a {
+    ) -> Self::Evm<'_, DB, ()> {
         evm_env.cfg_env_with_handler_cfg.handler_cfg.is_optimism = true;
 
         EvmBuilder::default()
@@ -182,18 +232,19 @@ impl ConfigureEvm for OpEvmConfig {
             .with_block_env(evm_env.block_env)
             .with_tx_env(tx)
             .build()
+            .into()
     }
 
-    fn evm_with_env_and_inspector<'a, DB, I>(
+    fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
         mut evm_env: EvmEnv,
         tx: TxEnv,
         inspector: I,
-    ) -> impl Evm<Tx = TxEnv, DB = DB, Error = EVMError<DB::Error>> + 'a
+    ) -> Self::Evm<'_, DB, I>
     where
-        DB: Database + 'a,
-        I: GetInspector<DB> + 'a,
+        DB: Database,
+        I: GetInspector<DB>,
     {
         evm_env.cfg_env_with_handler_cfg.handler_cfg.is_optimism = true;
 
@@ -205,6 +256,7 @@ impl ConfigureEvm for OpEvmConfig {
             .with_tx_env(tx)
             .append_handler_register(inspector_handle_register)
             .build()
+            .into()
     }
 }
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -13,10 +13,11 @@ use alloy_rpc_types_engine::PayloadId;
 use op_alloy_consensus::{OpDepositReceipt, OpTxType};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_basic_payload_builder::*;
-use reth_evm::Evm;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_evm::{env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, NextBlockEnvAttributes};
+use reth_evm::{
+    env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, Evm, NextBlockEnvAttributes,
+};
 use reth_execution_types::ExecutionOutcome;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -13,6 +13,7 @@ use alloy_rpc_types_engine::PayloadId;
 use op_alloy_consensus::{OpDepositReceipt, OpTxType};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_basic_payload_builder::*;
+use reth_evm::Evm;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_evm::{env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, NextBlockEnvAttributes};
@@ -777,9 +778,9 @@ where
                     ))
                 })?;
 
-            *evm.tx_mut() = self.evm_config.tx_env(sequencer_tx.tx(), sequencer_tx.signer());
+            let tx_env = self.evm_config.tx_env(sequencer_tx.tx(), sequencer_tx.signer());
 
-            let ResultAndState { result, state } = match evm.transact() {
+            let ResultAndState { result, state } = match evm.transact(tx_env) {
                 Ok(res) => res,
                 Err(err) => {
                     match err {
@@ -874,9 +875,9 @@ where
             }
 
             // Configure the environment for the tx.
-            *evm.tx_mut() = self.evm_config.tx_env(tx.tx(), tx.signer());
+            let tx_env = self.evm_config.tx_env(tx.tx(), tx.signer());
 
-            let ResultAndState { result, state } = match evm.transact() {
+            let ResultAndState { result, state } = match evm.transact(tx_env) {
                 Ok(res) => res,
                 Err(err) => {
                     match err {

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -17,16 +17,14 @@ use alloy_rpc_types_eth::{
 };
 use futures::Future;
 use reth_chainspec::EthChainSpec;
-use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv};
+use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Evm};
 use reth_node_api::BlockBody;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::{BlockIdReader, ChainSpecProvider, ProviderHeader};
 use reth_revm::{
     database::StateProviderDatabase,
     db::CacheDB,
-    primitives::{
-        BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ExecutionResult, ResultAndState, TxEnv,
-    },
+    primitives::{BlockEnv, ExecutionResult, ResultAndState, TxEnv},
     DatabaseRef,
 };
 use reth_rpc_eth_types::{
@@ -41,7 +39,6 @@ use reth_rpc_eth_types::{
 };
 use revm::{Database, DatabaseCommit, GetInspector};
 use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
-use revm_primitives::Env;
 use tracing::trace;
 
 /// Result type for `eth_simulateV1` RPC method.
@@ -505,18 +502,11 @@ pub trait Call:
         DB: Database,
         EthApiError: From<DB::Error>,
     {
-        let mut evm = self.evm_config().evm_with_env(db, evm_env, tx_env);
-        let res = evm.transact().map_err(Self::Error::from_evm_err)?;
-        let (_, env) = evm.into_db_and_env_with_handler_cfg();
+        let mut evm = self.evm_config().evm_with_env(db, evm_env, Default::default());
+        let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
+        let evm_env = evm.into_env();
 
-        let EnvWithHandlerCfg { env, handler_cfg } = env;
-        let Env { cfg, block, tx } = *env;
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg { cfg_env: cfg, handler_cfg },
-            block_env: block,
-        };
-
-        Ok((res, (evm_env, tx)))
+        Ok((res, (evm_env, tx_env)))
     }
 
     /// Executes the [`EnvWithHandlerCfg`] against the given [Database] without committing state
@@ -532,18 +522,16 @@ pub trait Call:
         DB: Database,
         EthApiError: From<DB::Error>,
     {
-        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, tx_env, inspector);
-        let res = evm.transact().map_err(Self::Error::from_evm_err)?;
-        let (_, env) = evm.into_db_and_env_with_handler_cfg();
+        let mut evm = self.evm_config().evm_with_env_and_inspector(
+            db,
+            evm_env,
+            Default::default(),
+            inspector,
+        );
+        let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
+        let evm_env = evm.into_env();
 
-        let EnvWithHandlerCfg { env, handler_cfg } = env;
-        let Env { cfg, block, tx } = *env;
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg { cfg_env: cfg, handler_cfg },
-            block_env: block,
-        };
-
-        Ok((res, (evm_env, tx)))
+        Ok((res, (evm_env, tx_env)))
     }
 
     /// Executes the call request at the given [`BlockId`].
@@ -704,8 +692,8 @@ pub trait Call:
                 break
             }
 
-            self.evm_config().fill_tx_env(evm.tx_mut(), tx, *sender);
-            evm.transact_commit().map_err(Self::Error::from_evm_err)?;
+            let tx_env = self.evm_config().tx_env(tx, *sender);
+            evm.transact_commit(tx_env).map_err(Self::Error::from_evm_err)?;
             index += 1;
         }
         Ok(index)

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -490,7 +490,7 @@ pub trait Call:
         f(StateProviderTraitObjWrapper(&state))
     }
 
-    /// Executes the [`EnvWithHandlerCfg`] against the given [Database] without committing state
+    /// Executes the [`TxEnv`] against the given [Database] without committing state
     /// changes.
     fn transact<DB>(
         &self,
@@ -509,7 +509,7 @@ pub trait Call:
         Ok((res, (evm_env, tx_env)))
     }
 
-    /// Executes the [`EnvWithHandlerCfg`] against the given [Database] without committing state
+    /// Executes the [`EvmEnv`] against the given [Database] without committing state
     /// changes.
     fn transact_with_inspector<DB>(
         &self,
@@ -569,7 +569,7 @@ pub trait Call:
     /// Prepares the state and env for the given [`TransactionRequest`] at the given [`BlockId`] and
     /// executes the closure on a new task returning the result of the closure.
     ///
-    /// This returns the configured [`EnvWithHandlerCfg`] for the given [`TransactionRequest`] at
+    /// This returns the configured [`EvmEnv`] for the given [`TransactionRequest`] at
     /// the given [`BlockId`] and with configured call settings: `prepare_call_env`.
     ///
     /// This is primarily used by `eth_call`.
@@ -778,7 +778,7 @@ pub trait Call:
         Ok(env)
     }
 
-    /// Prepares the [`EnvWithHandlerCfg`] for execution of calls.
+    /// Prepares the [`EvmEnv`] for execution of calls.
     ///
     /// Does not commit any changes to the underlying database.
     ///

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -13,7 +13,7 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
 use reth_evm::{
     env::EvmEnv, state_change::post_block_withdrawals_balance_increments,
-    system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, NextBlockEnvAttributes,
+    system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, Evm, NextBlockEnvAttributes,
 };
 use reth_primitives::{InvalidTransactionError, RecoveredBlock};
 use reth_primitives_traits::Receipt;
@@ -325,9 +325,10 @@ pub trait LoadPendingBlock:
             }
 
             let tx_env = self.evm_config().tx_env(tx.tx(), tx.signer());
-            let mut evm = self.evm_config().evm_with_env(&mut db, evm_env.clone(), tx_env);
+            let mut evm =
+                self.evm_config().evm_with_env(&mut db, evm_env.clone(), Default::default());
 
-            let ResultAndState { result, state } = match evm.transact() {
+            let ResultAndState { result, state } = match evm.transact(tx_env) {
                 Ok(res) => res,
                 Err(err) => {
                     match err {

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -31,7 +31,7 @@ pub trait Trace:
     >,
 >
 {
-    /// Executes the [`EnvWithHandlerCfg`] against the given [Database] without committing state
+    /// Executes the [`EvmEnv`] against the given [Database] without committing state
     /// changes.
     fn inspect<DB, I>(
         &self,
@@ -60,7 +60,7 @@ pub trait Trace:
     /// config.
     ///
     /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`EnvWithHandlerCfg`] was inspected.
+    /// the configured [`EvmEnv`] was inspected.
     ///
     /// Caution: this is blocking
     fn trace_at<F, R>(
@@ -89,7 +89,7 @@ pub trait Trace:
     /// config.
     ///
     /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`EnvWithHandlerCfg`] was inspected.
+    /// the configured [`EvmEnv`] was inspected.
     fn spawn_trace_at_with_state<F, R>(
         &self,
         evm_env: EvmEnv,

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -7,7 +7,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
 use futures::Future;
 use reth_chainspec::ChainSpecProvider;
-use reth_evm::{env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv};
+use reth_evm::{env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, Evm};
 use reth_primitives::RecoveredBlock;
 use reth_primitives_traits::{BlockBody, SignedTransaction};
 use reth_provider::{BlockReader, ProviderBlock, ProviderHeader, ProviderTx};
@@ -18,9 +18,7 @@ use reth_rpc_eth_types::{
 };
 use revm::{db::CacheDB, Database, DatabaseCommit, GetInspector, Inspector};
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
-use revm_primitives::{
-    CfgEnvWithHandlerCfg, Env, EnvWithHandlerCfg, EvmState, ExecutionResult, ResultAndState, TxEnv,
-};
+use revm_primitives::{EvmState, ExecutionResult, ResultAndState, TxEnv};
 use std::{fmt::Display, sync::Arc};
 
 /// Executes CPU heavy tasks.
@@ -47,16 +45,15 @@ pub trait Trace:
         EthApiError: From<DB::Error>,
         I: GetInspector<DB>,
     {
-        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, tx_env, inspector);
-        let res = evm.transact().map_err(Self::Error::from_evm_err)?;
-        let (_, env) = evm.into_db_and_env_with_handler_cfg();
-        let EnvWithHandlerCfg { env, handler_cfg } = env;
-        let Env { cfg, block, tx } = *env;
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg { cfg_env: cfg, handler_cfg },
-            block_env: block,
-        };
-        Ok((res, (evm_env, tx)))
+        let mut evm = self.evm_config().evm_with_env_and_inspector(
+            db,
+            evm_env,
+            Default::default(),
+            inspector,
+        );
+        let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
+        let evm_env = evm.into_env();
+        Ok((res, (evm_env, tx_env)))
     }
 
     /// Executes the transaction on top of the given [`BlockId`] with a tracer configured by the

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -10,7 +10,7 @@ use alloy_rpc_types_mev::{
 };
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::EthChainSpec;
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
+use reth_evm::{ConfigureEvm, ConfigureEvmEnv, Evm};
 use reth_provider::{ChainSpecProvider, HeaderProvider, ProviderTx};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::MevSimApiServer;
@@ -324,10 +324,10 @@ where
                         )
                         .into());
                     }
-                    eth_api.evm_config().fill_tx_env(evm.tx_mut(), &item.tx, item.signer);
 
-                    let ResultAndState { result, state } =
-                        evm.transact().map_err(EthApiError::from_eth_err)?;
+                    let ResultAndState { result, state } = evm
+                        .transact(eth_api.evm_config().tx_env(&item.tx, item.signer))
+                        .map_err(EthApiError::from_eth_err)?;
 
                     if !result.is_success() && !item.can_revert {
                         return Err(EthApiError::InvalidParams(
@@ -366,7 +366,7 @@ where
                     }
 
                     // Apply state changes
-                    evm.context.evm.db.commit(state);
+                    evm.db_mut().commit(state);
                 }
 
                 // After processing all transactions, process refunds

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -7,23 +7,23 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::{eip4895::Withdrawal, eip7685::Requests};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
-#[cfg(feature = "optimism")]
-use reth::revm::primitives::OptimismFields;
 use reth::{
     api::{ConfigureEvm, NodeTypesWithEngine},
     builder::{components::ExecutorBuilder, BuilderContext, FullNodeTypes},
     cli::Cli,
     providers::ProviderError,
     revm::{
-        interpreter::Host,
-        primitives::{address, Address, Bytes, Env, TransactTo, TxEnv, U256},
-        Database, DatabaseCommit, Evm, State,
+        primitives::{address, Address},
+        Database, DatabaseCommit, State,
     },
 };
 use reth_chainspec::{ChainSpec, EthereumHardforks};
-use reth_evm::execute::{
-    BlockExecutionError, BlockExecutionStrategy, BlockExecutionStrategyFactory, ExecuteOutput,
-    InternalBlockExecutionError,
+use reth_evm::{
+    execute::{
+        BlockExecutionError, BlockExecutionStrategy, BlockExecutionStrategyFactory, ExecuteOutput,
+        InternalBlockExecutionError,
+    },
+    Evm,
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_ethereum::{node::EthereumAddOns, BasicBlockExecutorProvider, EthereumNode};
@@ -177,19 +177,11 @@ sol!(
 
 /// Applies the post-block call to the withdrawal / deposit contract, using the given block,
 /// [`ChainSpec`], EVM.
-pub fn apply_withdrawals_contract_call<EXT, DB: Database + DatabaseCommit>(
+pub fn apply_withdrawals_contract_call(
     withdrawals: &[Withdrawal],
-    evm: &mut Evm<'_, EXT, DB>,
-) -> Result<(), BlockExecutionError>
-where
-    DB::Error: std::fmt::Display,
-{
-    // get previous env
-    let previous_env = Box::new(evm.context.env().clone());
-
-    // modify env for pre block call
-    fill_tx_env_with_system_contract_call(
-        &mut evm.context.evm.env,
+    evm: &mut impl Evm<Error: Display, DB: DatabaseCommit>,
+) -> Result<(), BlockExecutionError> {
+    let mut state = match evm.transact_system_call(
         SYSTEM_ADDRESS,
         WITHDRAWALS_ADDRESS,
         withdrawalsCall {
@@ -198,12 +190,9 @@ where
         }
         .abi_encode()
         .into(),
-    );
-
-    let mut state = match evm.transact() {
+    ) {
         Ok(res) => res.state,
         Err(e) => {
-            evm.context.evm.env = previous_env;
             return Err(BlockExecutionError::Internal(InternalBlockExecutionError::Other(
                 format!("withdrawal contract system call revert: {}", e).into(),
             )))
@@ -213,47 +202,8 @@ where
     // Clean-up post system tx context
     state.remove(&SYSTEM_ADDRESS);
     state.remove(&evm.block().coinbase);
-    evm.context.evm.db.commit(state);
-    // re-set the previous env
-    evm.context.evm.env = previous_env;
+
+    evm.db_mut().commit(state);
 
     Ok(())
-}
-
-fn fill_tx_env_with_system_contract_call(
-    env: &mut Env,
-    caller: Address,
-    contract: Address,
-    data: Bytes,
-) {
-    env.tx = TxEnv {
-        caller,
-        transact_to: TransactTo::Call(contract),
-        // Explicitly set nonce to None so revm does not do any nonce checks
-        nonce: None,
-        gas_limit: 30_000_000,
-        value: U256::ZERO,
-        data,
-        // Setting the gas price to zero enforces that no value is transferred as part of the call,
-        // and that the call will not count against the block's gas limit
-        gas_price: U256::ZERO,
-        // The chain ID check is not relevant here and is disabled if set to None
-        chain_id: None,
-        // Setting the gas priority fee to None ensures the effective gas price is derived from the
-        // `gas_price` field, which we need to be zero
-        gas_priority_fee: None,
-        access_list: Vec::new(),
-        // blob fields can be None for this tx
-        blob_hashes: Vec::new(),
-        max_fee_per_blob_gas: None,
-        authorization_list: None,
-        #[cfg(feature = "optimism")]
-        optimism: OptimismFields::default(),
-    };
-
-    // ensure the block gas limit is >= the tx
-    env.block.gas_limit = U256::from(env.tx.gas_limit);
-
-    // disable the base fee check for this call by setting the base fee to zero
-    env.block.basefee = U256::ZERO;
 }

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -16,7 +16,7 @@ use reth::{
         inspector_handle_register,
         precompile::{Precompile, PrecompileOutput, PrecompileSpecId},
         primitives::{CfgEnvWithHandlerCfg, Env, PrecompileResult, TxEnv},
-        ContextPrecompiles, Database, Evm, EvmBuilder, GetInspector,
+        ContextPrecompiles, Database, EvmBuilder, GetInspector,
     },
     rpc::types::engine::PayloadAttributes,
     tasks::TaskManager,
@@ -24,7 +24,7 @@ use reth::{
 };
 use reth_chainspec::{Chain, ChainSpec};
 use reth_evm::env::EvmEnv;
-use reth_evm_ethereum::EthEvmConfig;
+use reth_evm_ethereum::{EthEvm, EthEvmConfig};
 use reth_node_api::{
     ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NextBlockEnvAttributes, NodeTypes,
     NodeTypesWithEngine, PayloadTypes,
@@ -107,7 +107,14 @@ impl ConfigureEvmEnv for MyEvmConfig {
 }
 
 impl ConfigureEvm for MyEvmConfig {
-    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB> {
+    type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
+
+    fn evm_with_env<DB: Database>(
+        &self,
+        db: DB,
+        evm_env: EvmEnv,
+        tx: TxEnv,
+    ) -> Self::Evm<'_, DB, ()> {
         EvmBuilder::default()
             .with_db(db)
             .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
@@ -116,6 +123,7 @@ impl ConfigureEvm for MyEvmConfig {
             // add additional precompiles
             .append_handler_register(MyEvmConfig::set_precompiles)
             .build()
+            .into()
     }
 
     fn evm_with_env_and_inspector<DB, I>(
@@ -124,7 +132,7 @@ impl ConfigureEvm for MyEvmConfig {
         evm_env: EvmEnv,
         tx: TxEnv,
         inspector: I,
-    ) -> Evm<'_, I, DB>
+    ) -> Self::Evm<'_, DB, I>
     where
         DB: Database,
         I: GetInspector<DB>,
@@ -139,6 +147,7 @@ impl ConfigureEvm for MyEvmConfig {
             .append_handler_register(MyEvmConfig::set_precompiles)
             .append_handler_register(inspector_handle_register)
             .build()
+            .into()
     }
 }
 

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -93,16 +93,6 @@ impl ConfigureEvmEnv for MyEvmConfig {
         self.inner.fill_tx_env(tx_env, transaction, sender);
     }
 
-    fn fill_tx_env_system_contract_call(
-        &self,
-        env: &mut Env,
-        caller: Address,
-        contract: Address,
-        data: Bytes,
-    ) {
-        self.inner.fill_tx_env_system_contract_call(env, caller, contract, data);
-    }
-
     fn fill_cfg_env(&self, cfg_env: &mut CfgEnvWithHandlerCfg, header: &Self::Header) {
         self.inner.fill_cfg_env(cfg_env, header);
     }

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -16,7 +16,7 @@ use reth::{
         primitives::{
             CfgEnvWithHandlerCfg, Env, PrecompileResult, SpecId, StatefulPrecompileMut, TxEnv,
         },
-        ContextPrecompile, ContextPrecompiles, Database, Evm, EvmBuilder, GetInspector,
+        ContextPrecompile, ContextPrecompiles, Database, EvmBuilder, GetInspector,
     },
     tasks::TaskManager,
 };
@@ -25,8 +25,8 @@ use reth_evm::env::EvmEnv;
 use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{
-    node::EthereumAddOns, BasicBlockExecutorProvider, EthEvmConfig, EthExecutionStrategyFactory,
-    EthereumNode,
+    evm::EthEvm, node::EthereumAddOns, BasicBlockExecutorProvider, EthEvmConfig,
+    EthExecutionStrategyFactory, EthereumNode,
 };
 use reth_primitives::{EthPrimitives, TransactionSigned};
 use reth_tracing::{RethTracer, Tracer};
@@ -169,7 +169,14 @@ impl ConfigureEvmEnv for MyEvmConfig {
 }
 
 impl ConfigureEvm for MyEvmConfig {
-    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv, tx: TxEnv) -> Evm<'_, (), DB> {
+    type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
+
+    fn evm_with_env<DB: Database>(
+        &self,
+        db: DB,
+        evm_env: EvmEnv,
+        tx: TxEnv,
+    ) -> Self::Evm<'_, DB, ()> {
         let new_cache = self.precompile_cache.clone();
         EvmBuilder::default()
             .with_db(db)
@@ -181,6 +188,7 @@ impl ConfigureEvm for MyEvmConfig {
                 MyEvmConfig::set_precompiles(handler, new_cache.clone())
             }))
             .build()
+            .into()
     }
 
     fn evm_with_env_and_inspector<DB, I>(
@@ -189,7 +197,7 @@ impl ConfigureEvm for MyEvmConfig {
         evm_env: EvmEnv,
         tx: TxEnv,
         inspector: I,
-    ) -> Evm<'_, I, DB>
+    ) -> Self::Evm<'_, DB, I>
     where
         DB: Database,
         I: GetInspector<DB>,
@@ -207,6 +215,7 @@ impl ConfigureEvm for MyEvmConfig {
             }))
             .append_handler_register(inspector_handle_register)
             .build()
+            .into()
     }
 }
 

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -155,16 +155,6 @@ impl ConfigureEvmEnv for MyEvmConfig {
         self.inner.fill_tx_env(tx_env, transaction, sender)
     }
 
-    fn fill_tx_env_system_contract_call(
-        &self,
-        env: &mut Env,
-        caller: Address,
-        contract: Address,
-        data: Bytes,
-    ) {
-        self.inner.fill_tx_env_system_contract_call(env, caller, contract, data)
-    }
-
     fn fill_cfg_env(&self, cfg_env: &mut CfgEnvWithHandlerCfg, header: &Self::Header) {
         self.inner.fill_cfg_env(cfg_env, header)
     }


### PR DESCRIPTION
We need to introduce `Evm` trait ASAP if we want to start abstracting any of Evm inputs (e.g `TxEnv` can't be abstracted until we need to set it directly to `revm::Evm`)

This PR experiments with a `Evm` trait similar to the one we've introduced in alloy-evm but with more helper methods making it sufficient to completely replace revm's Evm in reth.
