### PR TITLE
fix(trie): check branch node masks if `store_in_db_trie` is `None`

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -680,7 +680,10 @@ impl<P> RevealedSparseTrie<P> {
                     if let Some((hash, store_in_db_trie)) =
                         hash.zip(*store_in_db_trie).filter(|_| !prefix_set_contains(&path))
                     {
-                        (RlpNode::word_rlp(&hash), SparseNodeType::Extension { store_in_db_trie })
+                        (
+                            RlpNode::word_rlp(&hash),
+                            SparseNodeType::Extension { store_in_db_trie: Some(store_in_db_trie) },
+                        )
                     } else if buffers.rlp_node_stack.last().is_some_and(|e| e.0 == child_path) {
                         let (_, child, child_node_type) = buffers.rlp_node_stack.pop().unwrap();
                         self.rlp_buf.clear();
@@ -697,7 +700,7 @@ impl<P> RevealedSparseTrie<P> {
                             "Extension node"
                         );
 
-                        *store_in_db_trie = Some(store_in_db_trie_value);
+                        *store_in_db_trie = store_in_db_trie_value;
 
                         (
                             rlp_node,
@@ -720,7 +723,7 @@ impl<P> RevealedSparseTrie<P> {
                         buffers.rlp_node_stack.push((
                             path,
                             RlpNode::word_rlp(&hash),
-                            SparseNodeType::Branch { store_in_db_trie },
+                            SparseNodeType::Branch { store_in_db_trie: Some(store_in_db_trie) },
                         ));
                         continue
                     }
@@ -755,17 +758,18 @@ impl<P> RevealedSparseTrie<P> {
                                 let last_child_nibble = child_path.last().unwrap();
 
                                 // Determine whether we need to set trie mask bit.
-                                let should_set_tree_mask_bit =
-                                    // A blinded node has the tree mask bit set
-                                    (
-                                        child_node_type.is_hash() &&
-                                        self.branch_node_tree_masks
-                                            .get(&path)
-                                            .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
-                                    ) ||
+                                let should_set_tree_mask_bit = if let Some(store_in_db_trie) =
+                                    child_node_type.store_in_db_trie()
+                                {
                                     // A branch or an extension node explicitly set the
                                     // `store_in_db_trie` flag
-                                    child_node_type.store_in_db_trie();
+                                    store_in_db_trie
+                                } else {
+                                    // A blinded node has the tree mask bit set
+                                    self.branch_node_tree_masks
+                                        .get(&path)
+                                        .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
+                                };
                                 if should_set_tree_mask_bit {
                                     tree_mask.set_bit(last_child_nibble);
                                 }
@@ -868,7 +872,10 @@ impl<P> RevealedSparseTrie<P> {
                     };
                     *store_in_db_trie = Some(store_in_db_trie_value);
 
-                    (rlp_node, SparseNodeType::Branch { store_in_db_trie: store_in_db_trie_value })
+                    (
+                        rlp_node,
+                        SparseNodeType::Branch { store_in_db_trie: Some(store_in_db_trie_value) },
+                    )
                 }
             };
             buffers.rlp_node_stack.push((path, rlp_node, node_type));
@@ -1191,12 +1198,12 @@ enum SparseNodeType {
     /// Sparse extension node.
     Extension {
         /// A flag indicating whether the extension node should be stored in the database.
-        store_in_db_trie: bool,
+        store_in_db_trie: Option<bool>,
     },
     /// Sparse branch node.
     Branch {
         /// A flag indicating whether the branch node should be stored in the database.
-        store_in_db_trie: bool,
+        store_in_db_trie: Option<bool>,
     },
 }
 
@@ -1209,12 +1216,12 @@ impl SparseNodeType {
         matches!(self, Self::Branch { .. })
     }
 
-    const fn store_in_db_trie(&self) -> bool {
+    const fn store_in_db_trie(&self) -> Option<bool> {
         match *self {
             Self::Extension { store_in_db_trie } | Self::Branch { store_in_db_trie } => {
                 store_in_db_trie
             }
-            _ => false,
+            _ => None,
         }
     }
 }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -766,9 +766,10 @@ impl<P> RevealedSparseTrie<P> {
                                     store_in_db_trie
                                 } else {
                                     // A blinded node has the tree mask bit set
-                                    self.branch_node_tree_masks
-                                        .get(&path)
-                                        .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
+                                    child_node_type.is_hash() &&
+                                        self.branch_node_tree_masks.get(&path).is_some_and(
+                                            |mask| mask.is_bit_set(last_child_nibble),
+                                        )
                                 };
                                 if should_set_tree_mask_bit {
                                     tree_mask.set_bit(last_child_nibble);


### PR DESCRIPTION
Returning `false` is not correct here https://github.com/paradigmxyz/reth/blob/7e972ea23dc31bb1cb97fd50b96f9a30201f0cb2/crates/trie/sparse/src/trie.rs#L1212-L1219


Imagine we have the following situation:
```
Branch (revealed) -> Extension (revealed) -> Hash (blinded, so it's a Hash)
```

On a call to `rlp_node`, the extension node will have its `store_in_db_trie` set to `false` because its child node is a `Hash` node that returned `false` on a call to `store_in_db_trie()`. This will result in incorrect tree mask for the root branch node.

This PR fixes the trie updates mismatch on Mainnet block 21638721.