### PR TITLE
fix: pin clippy to nightly-2025-01-16

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
         with:
+          toolchain: nightly-2025-01-16
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2025-01-16
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Pinning clippy to yesterday as we're failing in new PRs due to:
https://github.com/rust-lang/rust-clippy/issues/14013

see for example: https://github.com/paradigmxyz/reth/actions/runs/12823286591/job/35757537443
