### PR TITLE
chore(trie): derive `Clone` on noop cursor factories

### DIFF
--- a/crates/trie/trie/src/hashed_cursor/noop.rs
+++ b/crates/trie/trie/src/hashed_cursor/noop.rs
@@ -4,7 +4,7 @@ use reth_primitives::Account;
 use reth_storage_errors::db::DatabaseError;
 
 /// Noop hashed cursor factory.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 #[non_exhaustive]
 pub struct NoopHashedCursorFactory;
 

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -4,7 +4,7 @@ use alloy_primitives::B256;
 use reth_storage_errors::db::DatabaseError;
 
 /// Noop trie cursor factory.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 #[non_exhaustive]
 pub struct NoopTrieCursorFactory;
 


### PR DESCRIPTION
## Description

Currently, noop cursor factories do not implement `Clone` making them unusable root or proof structs.