### PR TITLE
feat: get `BlockMeta` table values from static file or database

### DIFF
--- a/crates/storage/provider/src/providers/database/chain.rs
+++ b/crates/storage/provider/src/providers/database/chain.rs
@@ -23,6 +23,7 @@ where
     T: FullSignedTx,
     N: FullNodePrimitives<
         Block = reth_primitives::Block<T>,
+        BlockHeader = alloy_consensus::Header,
         BlockBody = reth_primitives::BlockBody<T>,
         SignedTx = T,
     >,

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -562,14 +562,29 @@ impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ProviderFactory<N> {
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.provider()?.block_body_indices(number)
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::BlockMeta,
+            number,
+            |static_file| static_file.block_body_indices(number),
+            || self.provider()?.block_body_indices(number),
+        )
     }
 
     fn block_body_indices_range(
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
-        self.provider()?.block_body_indices_range(range)
+        self.static_file_provider.get_range_with_static_file_or_database(
+            StaticFileSegment::BlockMeta,
+            *range.start()..*range.end() + 1,
+            |static_file, range, _| {
+                static_file.block_body_indices_range(range.start..=range.end.saturating_sub(1))
+            },
+            |range, _| {
+                self.provider()?.block_body_indices_range(range.start..=range.end.saturating_sub(1))
+            },
+            |_| true,
+        )
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -17,8 +17,8 @@ use reth_chainspec::{ChainInfo, ChainSpecProvider};
 use reth_db::{
     lockfile::StorageLock,
     static_file::{
-        iter_static_files, BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask,
-        StaticFileCursor, TDWithHashMask, TransactionMask,
+        iter_static_files, BlockHashMask, BodyIndicesMask, HeaderMask, HeaderWithHashMask,
+        ReceiptMask, StaticFileCursor, TDWithHashMask, TransactionMask,
     },
     table::{Decompress, Value},
     tables,
@@ -1027,7 +1027,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                                 "Could not find block or tx number on a range request"
                             );
 
-                            let err = if segment.is_headers() {
+                            let err = if segment.is_block_based() {
                                 ProviderError::MissingStaticFileBlock(segment, number)
                             } else {
                                 ProviderError::MissingStaticFileTx(segment, number)
@@ -1732,10 +1732,14 @@ impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileProvider<N> {
 
     fn block_body_indices_range(
         &self,
-        _range: RangeInclusive<BlockNumber>,
+        range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
-        // Required data not present in static_files
-        Err(ProviderError::UnsupportedProvider)
+        self.fetch_range_with_predicate(
+            StaticFileSegment::BlockMeta,
+            *range.start()..*range.end() + 1,
+            |cursor, number| cursor.get_one::<BodyIndicesMask>(number.into()),
+            |_| true,
+        )
     }
 }
 


### PR DESCRIPTION
Uses `get_with_static_file_or_database` and `get_range_with_static_file_or_database` in provider implementations for `Ommers`, `Withdrawals` and `BlockBodyIndices`. 

Since the block meta static file isn't being written to yet, it shouldn't have any meaningful effect. Just spreading out the change into smaller PRs.