### PR TITLE
chore: phase out reth-primitives from eth-wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7345,7 +7345,7 @@ dependencies = [
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-forks",
- "reth-primitives",
+ "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
  "thiserror 2.0.9",

--- a/crates/ethereum/primitives/src/lib.rs
+++ b/crates/ethereum/primitives/src/lib.rs
@@ -19,3 +19,9 @@ pub use transaction::*;
 
 #[cfg(feature = "alloy-compat")]
 mod alloy_compat;
+
+/// Type alias for the ethereum block
+pub type Block = alloy_consensus::Block<TransactionSigned>;
+
+/// Type alias for the ethereum blockbody
+pub type BlockBody = alloy_consensus::BlockBody<TransactionSigned>;

--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -1,8 +1,8 @@
 use alloc::vec::Vec;
+pub use alloy_consensus::{transaction::PooledTransaction, TxType};
 use alloy_consensus::{
-    transaction::{PooledTransaction, RlpEcdsaTx},
-    BlobTransactionSidecar, SignableTransaction, Signed, TxEip1559, TxEip2930, TxEip4844,
-    TxEip4844WithSidecar, TxEip7702, TxLegacy, TxType, Typed2718, TypedTransaction,
+    transaction::RlpEcdsaTx, BlobTransactionSidecar, SignableTransaction, Signed, TxEip1559,
+    TxEip2930, TxEip4844, TxEip4844WithSidecar, TxEip7702, TxLegacy, Typed2718, TypedTransaction,
 };
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # reth
 reth-chainspec.workspace = true
 reth-codecs-derive.workspace = true
-reth-primitives.workspace = true
+reth-ethereum-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-ethereum-forks.workspace = true
 
@@ -37,7 +37,7 @@ proptest = { workspace = true, optional = true }
 proptest-arbitrary-interop = { workspace = true, optional = true }
 
 [dev-dependencies]
-reth-primitives = { workspace = true, features = ["arbitrary"] }
+alloy-primitives = { workspace = true, features = ["arbitrary", "rand"] }
 alloy-genesis.workspace = true
 alloy-chains = { workspace = true, features = ["arbitrary"] }
 arbitrary = { workspace = true, features = ["derive"] }
@@ -57,14 +57,14 @@ std = [
 	"bytes/std",
 	"derive_more/std",
 	"reth-ethereum-forks/std",
-	"reth-primitives/std",
+	"reth-ethereum-primitives/std",
 	"reth-primitives-traits/std",
 	"serde?/std",
 	"thiserror/std",
 	"reth-chainspec/std"
 ]
 arbitrary = [
-	"reth-primitives/arbitrary",
+	"reth-ethereum-primitives/arbitrary",
 	"alloy-chains/arbitrary",
 	"dep:arbitrary",
 	"dep:proptest",

--- a/crates/net/eth-wire-types/src/blocks.rs
+++ b/crates/net/eth-wire-types/src/blocks.rs
@@ -76,12 +76,12 @@ impl From<Vec<B256>> for GetBlockBodies {
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-pub struct BlockBodies<B = reth_primitives::BlockBody>(
+pub struct BlockBodies<B = reth_ethereum_primitives::BlockBody>(
     /// The requested block bodies, each of which should correspond to a hash in the request.
     pub Vec<B>,
 );
 
-generate_tests!(#[rlp, 16] BlockBodies<reth_primitives::BlockBody>, EthBlockBodiesTests);
+generate_tests!(#[rlp, 16] BlockBodies<reth_ethereum_primitives::BlockBody>, EthBlockBodiesTests);
 
 impl<B> From<Vec<B>> for BlockBodies<B> {
     fn from(bodies: Vec<B>) -> Self {
@@ -99,7 +99,7 @@ mod tests {
     use alloy_eips::BlockHashOrNumber;
     use alloy_primitives::{hex, PrimitiveSignature as Signature, TxKind, U256};
     use alloy_rlp::{Decodable, Encodable};
-    use reth_primitives::{BlockBody, Transaction, TransactionSigned};
+    use reth_ethereum_primitives::{BlockBody, Transaction, TransactionSigned};
     use std::str::FromStr;
 
     #[test]

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -12,7 +12,7 @@ use alloy_rlp::{
 use core::mem;
 use derive_more::{Constructor, Deref, DerefMut, From, IntoIterator};
 use reth_codecs_derive::{add_arbitrary_tests, generate_tests};
-use reth_primitives::TransactionSigned;
+use reth_ethereum_primitives::TransactionSigned;
 use reth_primitives_traits::SignedTransaction;
 
 /// This informs peers of new blocks that have appeared on the network.
@@ -69,14 +69,14 @@ impl From<NewBlockHashes> for Vec<BlockHashNumber> {
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-pub struct NewBlock<B = reth_primitives::Block> {
+pub struct NewBlock<B = reth_ethereum_primitives::Block> {
     /// A new block.
     pub block: B,
     /// The current total difficulty.
     pub td: U128,
 }
 
-generate_tests!(#[rlp, 25] NewBlock<reth_primitives::Block>, EthNewBlockTests);
+generate_tests!(#[rlp, 25] NewBlock<reth_ethereum_primitives::Block>, EthNewBlockTests);
 
 /// This informs peers of transactions that have appeared on the network and are not yet included
 /// in a block.
@@ -351,7 +351,7 @@ impl proptest::prelude::Arbitrary for NewPooledTransactionHashes68 {
             .prop_flat_map(|len| {
                 // Use the generated length to create vectors of TxType, usize, and B256
                 let types_vec = vec(
-                    proptest_arbitrary_interop::arb::<reth_primitives::TxType>()
+                    proptest_arbitrary_interop::arb::<reth_ethereum_primitives::TxType>()
                         .prop_map(|ty| ty as u8),
                     len..=len,
                 );

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -3,8 +3,7 @@
 use alloy_consensus::{RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt};
 use alloy_rlp::{Decodable, Encodable};
 use core::fmt::Debug;
-use reth_primitives::NodePrimitives;
-use reth_primitives_traits::{Block, BlockBody, BlockHeader, SignedTransaction};
+use reth_primitives_traits::{Block, BlockBody, BlockHeader, NodePrimitives, SignedTransaction};
 
 /// Abstraction over primitive types which might appear in network messages. See
 /// [`crate::EthMessage`] for more context.
@@ -66,9 +65,9 @@ pub struct EthNetworkPrimitives;
 
 impl NetworkPrimitives for EthNetworkPrimitives {
     type BlockHeader = alloy_consensus::Header;
-    type BlockBody = reth_primitives::BlockBody;
-    type Block = reth_primitives::Block;
-    type BroadcastedTransaction = reth_primitives::TransactionSigned;
-    type PooledTransaction = reth_primitives::PooledTransaction;
-    type Receipt = reth_primitives::Receipt;
+    type BlockBody = reth_ethereum_primitives::BlockBody;
+    type Block = reth_ethereum_primitives::Block;
+    type BroadcastedTransaction = reth_ethereum_primitives::TransactionSigned;
+    type PooledTransaction = reth_ethereum_primitives::PooledTransaction;
+    type Receipt = reth_ethereum_primitives::Receipt;
 }

--- a/crates/net/eth-wire-types/src/receipts.rs
+++ b/crates/net/eth-wire-types/src/receipts.rs
@@ -1,11 +1,11 @@
 //! Implements the `GetReceipts` and `Receipts` message types.
 
 use alloc::vec::Vec;
-use alloy_consensus::{RlpDecodableReceipt, RlpEncodableReceipt};
+use alloy_consensus::{ReceiptWithBloom, RlpDecodableReceipt, RlpEncodableReceipt};
 use alloy_primitives::B256;
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 use reth_codecs_derive::add_arbitrary_tests;
-use reth_primitives::{Receipt, ReceiptWithBloom};
+use reth_ethereum_primitives::Receipt;
 
 /// A request for transaction receipts from the given block hashes.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
@@ -48,10 +48,11 @@ impl<T: RlpDecodableReceipt> alloy_rlp::Decodable for Receipts<T> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{message::RequestPair, GetReceipts, Receipts};
+    use alloy_consensus::TxType;
     use alloy_primitives::{hex, Log};
     use alloy_rlp::{Decodable, Encodable};
-    use reth_primitives::{Receipt, ReceiptWithBloom, TxType};
 
     #[test]
     fn roundtrip_eip1559() {

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -222,7 +222,7 @@ mod tests {
     use alloy_rlp::{Decodable, Encodable};
     use rand::Rng;
     use reth_chainspec::{Chain, ChainSpec, ForkCondition, NamedChain};
-    use reth_primitives::{EthereumHardfork, ForkHash, ForkId, Head};
+    use reth_ethereum_forks::{EthereumHardfork, ForkHash, ForkId, Head};
     use std::str::FromStr;
 
     #[test]

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -1,12 +1,12 @@
 //! Implements the `GetPooledTransactions` and `PooledTransactions` message types.
 
 use alloc::vec::Vec;
+use alloy_consensus::transaction::PooledTransaction;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::B256;
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 use derive_more::{Constructor, Deref, IntoIterator};
 use reth_codecs_derive::add_arbitrary_tests;
-use reth_primitives::PooledTransaction;
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
@@ -85,11 +85,11 @@ impl<T> Default for PooledTransactions<T> {
 #[cfg(test)]
 mod tests {
     use crate::{message::RequestPair, GetPooledTransactions, PooledTransactions};
-    use alloy_consensus::{TxEip1559, TxLegacy};
+    use alloy_consensus::{transaction::PooledTransaction, TxEip1559, TxLegacy};
     use alloy_primitives::{hex, PrimitiveSignature as Signature, TxKind, U256};
     use alloy_rlp::{Decodable, Encodable};
     use reth_chainspec::MIN_TRANSACTION_GAS;
-    use reth_primitives::{PooledTransaction, Transaction, TransactionSigned};
+    use reth_ethereum_primitives::{Transaction, TransactionSigned};
     use std::str::FromStr;
 
     #[test]


### PR DESCRIPTION
replace reth-primitives dep for default types with reth-ethereum-primitives

adds missing type aliases and exports in reth-ethereum-primitives