### PR TITLE
chore: use exported oncelock

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -16,6 +16,7 @@ crates_to_check=(
     ## optimism
     reth-optimism-chainspec
     reth-optimism-forks
+    reth-optimism-primitives
 )
 
 # Array to hold the results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8406,7 +8406,6 @@ dependencies = [
  "bytes",
  "derive_more",
  "modular-bitfield",
- "once_cell",
  "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -35,7 +35,6 @@ serde = { workspace = true, optional = true }
 
 # misc
 derive_more = { workspace = true, features = ["deref", "from", "into", "constructor"] }
-once_cell.workspace = true
 rand = { workspace = true, optional = true }
 
 # test
@@ -67,7 +66,6 @@ std = [
 	"alloy-rlp/std",
 	"reth-zstd-compressors?/std",
 	"op-alloy-consensus/std",
-	"once_cell/std"
 ]
 reth-codec = [
     "dep:reth-codecs",

--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -38,5 +38,3 @@ impl reth_primitives_traits::NodePrimitives for OpPrimitives {
     type SignedTx = OpTransactionSigned;
     type Receipt = OpReceipt;
 }
-
-use once_cell as _;

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -20,18 +20,15 @@ use core::{
     mem,
 };
 use derive_more::{AsRef, Deref};
-#[cfg(not(feature = "std"))]
-use once_cell::sync::OnceCell as OnceLock;
 use op_alloy_consensus::{DepositTransaction, OpPooledTransaction, OpTypedTransaction, TxDeposit};
 #[cfg(any(test, feature = "reth-codec"))]
 use proptest as _;
 use reth_primitives_traits::{
     crypto::secp256k1::{recover_signer, recover_signer_unchecked},
+    sync::OnceLock,
     transaction::error::TransactionConversionError,
     InMemorySize, SignedTransaction,
 };
-#[cfg(feature = "std")]
-use std::sync::OnceLock;
 
 /// Signed transaction.
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(rlp))]


### PR DESCRIPTION
we've moved this feature gated lock type to reth-primitives-traits and can reuse that here