### PR TITLE
chore: simplify evm setup

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -230,18 +230,12 @@ impl ConfigureEvmEnv for EthEvmConfig {
 impl ConfigureEvm for EthEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
 
-    fn evm_with_env<DB: Database>(
-        &self,
-        db: DB,
-        evm_env: EvmEnv,
-        tx: TxEnv,
-    ) -> Self::Evm<'_, DB, ()> {
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         EthEvm(
             EvmBuilder::default()
                 .with_db(db)
                 .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
                 .with_block_env(evm_env.block_env)
-                .with_tx_env(tx)
                 .build(),
         )
     }
@@ -250,7 +244,6 @@ impl ConfigureEvm for EthEvmConfig {
         &self,
         db: DB,
         evm_env: EvmEnv,
-        tx: TxEnv,
         inspector: I,
     ) -> Self::Evm<'_, DB, I>
     where
@@ -263,7 +256,6 @@ impl ConfigureEvm for EthEvmConfig {
                 .with_external_context(inspector)
                 .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
                 .with_block_env(evm_env.block_env)
-                .with_tx_env(tx)
                 .append_handler_register(inspector_handle_register)
                 .build(),
         )
@@ -319,7 +311,7 @@ mod tests {
 
         let evm_env = EvmEnv::default();
 
-        let evm = evm_config.evm_with_env(db, evm_env.clone(), Default::default());
+        let evm = evm_config.evm_with_env(db, evm_env.clone());
 
         // Check that the EVM environment
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
@@ -350,7 +342,7 @@ mod tests {
             ..Default::default()
         };
 
-        let evm = evm_config.evm_with_env(db, evm_env, Default::default());
+        let evm = evm_config.evm_with_env(db, evm_env);
 
         // Check that the EVM environment is initialized with the custom environment
         assert_eq!(evm.context.evm.inner.env.cfg, cfg);
@@ -376,7 +368,6 @@ mod tests {
             number: U256::from(42),
             ..Default::default()
         };
-        let tx = TxEnv { gas_limit: 5_000_000, gas_price: U256::from(50), ..Default::default() };
 
         let evm_env = EvmEnv {
             cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
@@ -386,11 +377,10 @@ mod tests {
             block_env: block,
         };
 
-        let evm = evm_config.evm_with_env(db, evm_env.clone(), tx.clone());
+        let evm = evm_config.evm_with_env(db, evm_env.clone());
 
         // Verify that the block and transaction environments are set correctly
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
-        assert_eq!(evm.context.evm.env.tx, tx);
 
         // Default spec ID
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -416,7 +406,7 @@ mod tests {
             ..Default::default()
         };
 
-        let evm = evm_config.evm_with_env(db, evm_env, Default::default());
+        let evm = evm_config.evm_with_env(db, evm_env);
 
         // Check that the spec ID is setup properly
         assert_eq!(evm.handler.spec_id(), SpecId::PETERSBURG);
@@ -436,12 +426,7 @@ mod tests {
 
         let evm_env = EvmEnv::default();
 
-        let evm = evm_config.evm_with_env_and_inspector(
-            db,
-            evm_env.clone(),
-            Default::default(),
-            NoOpInspector,
-        );
+        let evm = evm_config.evm_with_env_and_inspector(db, evm_env.clone(), NoOpInspector);
 
         // Check that the EVM environment is set to default values
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
@@ -461,7 +446,6 @@ mod tests {
 
         let cfg_env = CfgEnv::default().with_chain_id(111);
         let block = BlockEnv::default();
-        let tx = TxEnv::default();
         let evm_env = EvmEnv {
             cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
                 cfg_env: cfg_env.clone(),
@@ -470,7 +454,7 @@ mod tests {
             block_env: block,
         };
 
-        let evm = evm_config.evm_with_env_and_inspector(db, evm_env, tx, NoOpInspector);
+        let evm = evm_config.evm_with_env_and_inspector(db, evm_env, NoOpInspector);
 
         // Check that the EVM environment is set with custom configuration
         assert_eq!(evm.context.evm.env.cfg, cfg_env);
@@ -494,15 +478,12 @@ mod tests {
             number: U256::from(42),
             ..Default::default()
         };
-        let tx = TxEnv { gas_limit: 5_000_000, gas_price: U256::from(50), ..Default::default() };
         let evm_env = EvmEnv { block_env: block, ..Default::default() };
 
-        let evm =
-            evm_config.evm_with_env_and_inspector(db, evm_env.clone(), tx.clone(), NoOpInspector);
+        let evm = evm_config.evm_with_env_and_inspector(db, evm_env.clone(), NoOpInspector);
 
         // Verify that the block and transaction environments are set correctly
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
-        assert_eq!(evm.context.evm.env.tx, tx);
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -525,12 +506,7 @@ mod tests {
             ..Default::default()
         };
 
-        let evm = evm_config.evm_with_env_and_inspector(
-            db,
-            evm_env.clone(),
-            Default::default(),
-            NoOpInspector,
-        );
+        let evm = evm_config.evm_with_env_and_inspector(db, evm_env.clone(), NoOpInspector);
 
         // Check that the spec ID is set properly
         assert_eq!(evm.handler.spec_id(), SpecId::PETERSBURG);

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -226,7 +226,7 @@ where
         PayloadBuilderError::Internal(err.into())
     })?;
 
-    let mut evm = evm_config.evm_with_env(&mut db, evm_env, Default::default());
+    let mut evm = evm_config.evm_with_env(&mut db, evm_env);
 
     let mut receipts = Vec::new();
     while let Some(pool_tx) = best_txs.next() {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -90,12 +90,7 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     /// including the spec id and transaction environment.
     ///
     /// This will preserve any handler modifications
-    fn evm_with_env<DB: Database>(
-        &self,
-        db: DB,
-        evm_env: EvmEnv,
-        tx: TxEnv,
-    ) -> Self::Evm<'_, DB, ()>;
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()>;
 
     /// Returns a new EVM with the given database configured with `cfg` and `block_env`
     /// configuration derived from the given header. Relies on
@@ -106,7 +101,7 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     /// This does not initialize the tx environment.
     fn evm_for_block<DB: Database>(&self, db: DB, header: &Self::Header) -> Self::Evm<'_, DB, ()> {
         let evm_env = self.cfg_and_block_env(header);
-        self.evm_with_env(db, evm_env, Default::default())
+        self.evm_with_env(db, evm_env)
     }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
@@ -119,7 +114,6 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
         &self,
         db: DB,
         evm_env: EvmEnv,
-        tx: TxEnv,
         inspector: I,
     ) -> Self::Evm<'_, DB, I>
     where
@@ -138,27 +132,21 @@ where
         (*self).evm_for_block(db, header)
     }
 
-    fn evm_with_env<DB: Database>(
-        &self,
-        db: DB,
-        evm_env: EvmEnv,
-        tx: TxEnv,
-    ) -> Self::Evm<'_, DB, ()> {
-        (*self).evm_with_env(db, evm_env, tx)
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
+        (*self).evm_with_env(db, evm_env)
     }
 
     fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
         evm_env: EvmEnv,
-        tx_env: TxEnv,
         inspector: I,
     ) -> Self::Evm<'_, DB, I>
     where
         DB: Database,
         I: GetInspector<DB>,
     {
-        (*self).evm_with_env_and_inspector(db, evm_env, tx_env, inspector)
+        (*self).evm_with_env_and_inspector(db, evm_env, inspector)
     }
 }
 

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -131,7 +131,7 @@ where
         DB::Error: Display,
     {
         let evm_config = self.evm_config.clone();
-        let mut evm = evm_config.evm_with_env(db, evm_env.clone(), Default::default());
+        let mut evm = evm_config.evm_with_env(db, evm_env.clone());
 
         self.apply_blockhashes_contract_call(
             evm_env.block_env.timestamp.to(),
@@ -181,7 +181,7 @@ where
         DB::Error: Display,
     {
         let evm_config = self.evm_config.clone();
-        let mut evm = evm_config.evm_with_env(db, evm_env.clone(), Default::default());
+        let mut evm = evm_config.evm_with_env(db, evm_env.clone());
 
         self.apply_beacon_root_contract_call(
             evm_env.block_env.timestamp.to(),
@@ -230,7 +230,7 @@ where
         DB::Error: Display,
     {
         let evm_config = self.evm_config.clone();
-        let mut evm = evm_config.evm_with_env(db, evm_env.clone(), Default::default());
+        let mut evm = evm_config.evm_with_env(db, evm_env.clone());
 
         let result = self.apply_withdrawal_requests_contract_call(&mut evm)?;
 
@@ -263,7 +263,7 @@ where
         DB::Error: Display,
     {
         let evm_config = self.evm_config.clone();
-        let mut evm = evm_config.evm_with_env(db, evm_env.clone(), Default::default());
+        let mut evm = evm_config.evm_with_env(db, evm_env.clone());
 
         let res = self.apply_consolidation_requests_contract_call(&mut evm)?;
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -741,8 +741,7 @@ where
         DB: Database<Error = ProviderError>,
     {
         let mut info = ExecutionInfo::with_capacity(self.attributes().transactions.len());
-        let mut evm =
-            self.evm_config.evm_with_env(&mut *db, self.evm_env.clone(), Default::default());
+        let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
 
         for sequencer_tx in &self.attributes().transactions {
             // A sequencer's block should never contain blob transactions.
@@ -851,8 +850,7 @@ where
         let block_gas_limit = self.block_gas_limit();
         let base_fee = self.base_fee();
 
-        let mut evm =
-            self.evm_config.evm_with_env(&mut *db, self.evm_env.clone(), Default::default());
+        let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
 
         while let Some(tx) = best_txs.next(()) {
             // ensure we still have capacity for this transaction

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -502,7 +502,7 @@ pub trait Call:
         DB: Database,
         EthApiError: From<DB::Error>,
     {
-        let mut evm = self.evm_config().evm_with_env(db, evm_env, Default::default());
+        let mut evm = self.evm_config().evm_with_env(db, evm_env);
         let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
         let evm_env = evm.into_env();
 
@@ -522,12 +522,7 @@ pub trait Call:
         DB: Database,
         EthApiError: From<DB::Error>,
     {
-        let mut evm = self.evm_config().evm_with_env_and_inspector(
-            db,
-            evm_env,
-            Default::default(),
-            inspector,
-        );
+        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
         let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
         let evm_env = evm.into_env();
 
@@ -684,7 +679,7 @@ pub trait Call:
         I: IntoIterator<Item = (&'a Address, &'a <Self::Evm as ConfigureEvmEnv>::Transaction)>,
         <Self::Evm as ConfigureEvmEnv>::Transaction: SignedTransaction,
     {
-        let mut evm = self.evm_config().evm_with_env(db, evm_env, Default::default());
+        let mut evm = self.evm_config().evm_with_env(db, evm_env);
         let mut index = 0;
         for (sender, tx) in transactions {
             if *tx.tx_hash() == target_tx_hash {

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -325,8 +325,7 @@ pub trait LoadPendingBlock:
             }
 
             let tx_env = self.evm_config().tx_env(tx.tx(), tx.signer());
-            let mut evm =
-                self.evm_config().evm_with_env(&mut db, evm_env.clone(), Default::default());
+            let mut evm = self.evm_config().evm_with_env(&mut db, evm_env.clone());
 
             let ResultAndState { result, state } = match evm.transact(tx_env) {
                 Ok(res) => res,

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -45,12 +45,7 @@ pub trait Trace:
         EthApiError: From<DB::Error>,
         I: GetInspector<DB>,
     {
-        let mut evm = self.evm_config().evm_with_env_and_inspector(
-            db,
-            evm_env,
-            Default::default(),
-            inspector,
-        );
+        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
         let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
         let evm_env = evm.into_env();
         Ok((res, (evm_env, tx_env)))

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -172,7 +172,7 @@ where
                 let mut total_gas_fess = U256::ZERO;
                 let mut hasher = Keccak256::new();
 
-                let mut evm = eth_api.evm_config().evm_with_env(db, evm_env, Default::default());
+                let mut evm = eth_api.evm_config().evm_with_env(db, evm_env);
 
                 let mut results = Vec::with_capacity(transactions.len());
                 let mut transactions = transactions.into_iter().peekable();

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -308,7 +308,7 @@ where
                 let mut refundable_value = U256::ZERO;
                 let mut body_logs: Vec<SimBundleLogs> = Vec::new();
 
-                let mut evm = eth_api.evm_config().evm_with_env(db, evm_env, Default::default());
+                let mut evm = eth_api.evm_config().evm_with_env(db, evm_env);
 
                 for item in &flattened_bundle {
                     // Check inclusion constraints

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -109,17 +109,11 @@ impl ConfigureEvmEnv for MyEvmConfig {
 impl ConfigureEvm for MyEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
 
-    fn evm_with_env<DB: Database>(
-        &self,
-        db: DB,
-        evm_env: EvmEnv,
-        tx: TxEnv,
-    ) -> Self::Evm<'_, DB, ()> {
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         EvmBuilder::default()
             .with_db(db)
             .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
             // add additional precompiles
             .append_handler_register(MyEvmConfig::set_precompiles)
             .build()
@@ -130,7 +124,6 @@ impl ConfigureEvm for MyEvmConfig {
         &self,
         db: DB,
         evm_env: EvmEnv,
-        tx: TxEnv,
         inspector: I,
     ) -> Self::Evm<'_, DB, I>
     where
@@ -142,7 +135,6 @@ impl ConfigureEvm for MyEvmConfig {
             .with_external_context(inspector)
             .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
             // add additional precompiles
             .append_handler_register(MyEvmConfig::set_precompiles)
             .append_handler_register(inspector_handle_register)

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -171,18 +171,12 @@ impl ConfigureEvmEnv for MyEvmConfig {
 impl ConfigureEvm for MyEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
 
-    fn evm_with_env<DB: Database>(
-        &self,
-        db: DB,
-        evm_env: EvmEnv,
-        tx: TxEnv,
-    ) -> Self::Evm<'_, DB, ()> {
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let new_cache = self.precompile_cache.clone();
         EvmBuilder::default()
             .with_db(db)
             .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
             // add additional precompiles
             .append_handler_register_box(Box::new(move |handler| {
                 MyEvmConfig::set_precompiles(handler, new_cache.clone())
@@ -195,7 +189,6 @@ impl ConfigureEvm for MyEvmConfig {
         &self,
         db: DB,
         evm_env: EvmEnv,
-        tx: TxEnv,
         inspector: I,
     ) -> Self::Evm<'_, DB, I>
     where
@@ -208,7 +201,6 @@ impl ConfigureEvm for MyEvmConfig {
             .with_external_context(inspector)
             .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
-            .with_tx_env(tx)
             // add additional precompiles
             .append_handler_register_box(Box::new(move |handler| {
                 MyEvmConfig::set_precompiles(handler, new_cache.clone())


### PR DESCRIPTION
We no longer need `TxEnv` arg when setting up an Evm, so we can simplify some code a bit