### PR TITLE
feat: add ConfigureEvmFor, ConfigureEvmEnvFor helper traits

### DIFF
--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -7,8 +7,9 @@ use std::{
     sync::Arc,
 };
 
+use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_network::NetworkPrimitives;
-use reth_node_api::{BlockBody, EngineTypes, FullNodeComponents};
+use reth_node_api::{BlockBody, EngineTypes, FullNodeComponents, NodePrimitives};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     node_config::NodeConfig,
@@ -233,5 +234,33 @@ where
         Transaction = <N::BlockBody as BlockBody>::Transaction,
         Receipt = N::Receipt,
     >,
+{
+}
+
+/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
+/// [`ConfigureEvmEnv`] whose associated types match the [`NodePrimitives`] associated types.
+pub trait ConfigureEvmEnvFor<N: NodePrimitives>:
+    ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>
+{
+}
+
+impl<N, C> ConfigureEvmEnvFor<N> for C
+where
+    N: NodePrimitives,
+    C: ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>,
+{
+}
+
+/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
+/// [`ConfigureEvm`] whose associated types match the [`NodePrimitives`] associated types.
+pub trait ConfigureEvmFor<N: NodePrimitives>:
+    ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
+{
+}
+
+impl<N, C> ConfigureEvmFor<N> for C
+where
+    N: NodePrimitives,
+    C: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
 {
 }


### PR DESCRIPTION
This adds some more helper traits that can simplify bounds when we have both `NodePrimitives` and `ConfigureEvm`