### PR TITLE
feat(trie): allow to use Arc<Provider> for database cursor factories

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -63,7 +63,7 @@ use reth_trie::{
     updates::{StorageTrieUpdates, TrieUpdates},
     HashedPostStateSorted, Nibbles, StateRoot, StoredNibbles,
 };
-use reth_trie_db::{DatabaseStateRoot, DatabaseStorageTrieCursor};
+use reth_trie_db::{DatabaseRef, DatabaseStateRoot, DatabaseStorageTrieCursor};
 use revm::db::states::{
     PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
 };
@@ -3148,5 +3148,13 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
 
     fn prune_modes_ref(&self) -> &PruneModes {
         self.prune_modes_ref()
+    }
+}
+
+impl<TX: DbTx, N: NodeTypes> DatabaseRef for DatabaseProvider<TX, N> {
+    type Tx = TX;
+
+    fn tx_reference(&self) -> &Self::Tx {
+        &self.tx
     }
 }

--- a/crates/trie/db/src/commitment.rs
+++ b/crates/trie/db/src/commitment.rs
@@ -28,12 +28,12 @@ pub struct MerklePatriciaTrie;
 
 impl StateCommitment for MerklePatriciaTrie {
     type StateRoot<'a, TX: DbTx + 'a> =
-        StateRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        StateRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type StorageRoot<'a, TX: DbTx + 'a> =
-        StorageRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        StorageRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type StateProof<'a, TX: DbTx + 'a> =
-        Proof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        Proof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type StateWitness<'a, TX: DbTx + 'a> =
-        TrieWitness<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>;
+        TrieWitness<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>;
     type KeyHasher = KeccakKeyHasher;
 }

--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -1,5 +1,7 @@
 //! An integration of [`reth-trie`] with [`reth-db`].
 
+use reth_db::transaction::DbTx;
+
 mod commitment;
 mod hashed_cursor;
 mod prefix_set;
@@ -21,3 +23,20 @@ pub use trie_cursor::{
     DatabaseAccountTrieCursor, DatabaseStorageTrieCursor, DatabaseTrieCursorFactory,
 };
 pub use witness::DatabaseTrieWitness;
+
+/// Trait for database operations needed by the trie cursor factories
+pub trait DatabaseRef: Send + Sync {
+    /// The concrete transaction type
+    type Tx: DbTx;
+
+    /// Returns a reference to the underlying database transaction
+    fn tx_reference(&self) -> &Self::Tx;
+}
+
+impl<T: DbTx> DatabaseRef for &'_ T {
+    type Tx = T;
+
+    fn tx_reference(&self) -> &Self::Tx {
+        self
+    }
+}

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -32,7 +32,7 @@ pub trait DatabaseProof<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseProof<'a, TX>
-    for Proof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for Proof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     /// Create a new [Proof] instance from database transaction.
     fn from_tx(tx: &'a TX) -> Self {
@@ -104,7 +104,7 @@ pub trait DatabaseStorageProof<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
-    for StorageProof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StorageProof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX, address: Address) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx), address)

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -130,7 +130,7 @@ pub trait DatabaseHashedPostState<TX>: Sized {
 }
 
 impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
-    for StateRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StateRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx))

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -34,7 +34,7 @@ pub trait DatabaseHashedStorage<TX>: Sized {
 }
 
 impl<'a, TX: DbTx> DatabaseStorageRoot<'a, TX>
-    for StorageRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StorageRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX, address: Address) -> Self {
         Self::new(

--- a/crates/trie/db/src/witness.rs
+++ b/crates/trie/db/src/witness.rs
@@ -21,7 +21,7 @@ pub trait DatabaseTrieWitness<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseTrieWitness<'a, TX>
-    for TrieWitness<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for TrieWitness<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx))


### PR DESCRIPTION
Extracted from #13749

The `DbTx` reference parameter in `DatabaseTrieCursorFactory` and `DatabaseHashedCursorFactory` cause lifetime problems when they are used to create and spawn `StateRootTask`.

This PR introduces a helper trait `DatabaseRef` that is implemented for both `DatabaseProvider` and `&DbTx` and the `TrieCursorFactory` and `DatabaseHashedCursorFactory` are implemented using that helper trait, so that we can avoid the issues with the transaction reference.