### PR TITLE
feat(trie): use Arc instead of references for nodes and state cursor factories

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -247,11 +247,11 @@ fn bench_state_root(c: &mut Criterion) {
                         let blinded_provider_factory = ProofBlindedProviderFactory::new(
                             InMemoryTrieCursorFactory::new(
                                 DatabaseTrieCursorFactory::new(provider.tx_ref()),
-                                &nodes_sorted,
+                                nodes_sorted,
                             ),
                             HashedPostStateCursorFactory::new(
                                 DatabaseHashedCursorFactory::new(provider.tx_ref()),
-                                &state_sorted,
+                                state_sorted,
                             ),
                             prefix_sets,
                         );

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2311,13 +2311,13 @@ where
 
                     let in_memory_trie_cursor = InMemoryTrieCursorFactory::new(
                         DatabaseTrieCursorFactory::new(context.provider_ro.tx_ref()),
-                        &context.nodes_sorted,
+                        context.nodes_sorted.clone(),
                     );
                     let blinded_provider_factory = ProofBlindedProviderFactory::new(
                         in_memory_trie_cursor.clone(),
                         HashedPostStateCursorFactory::new(
                             DatabaseHashedCursorFactory::new(context.provider_ro.tx_ref()),
-                            &context.state_sorted,
+                            context.state_sorted.clone(),
                         ),
                         context.prefix_sets.clone(),
                     );

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -973,11 +973,11 @@ mod tests {
         let blinded_provider_factory = ProofBlindedProviderFactory::new(
             InMemoryTrieCursorFactory::new(
                 DatabaseTrieCursorFactory::new(provider.tx_ref()),
-                &nodes_sorted,
+                nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(provider.tx_ref()),
-                &state_sorted,
+                state_sorted,
             ),
             config.prefix_sets.clone(),
         );

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -10,6 +10,9 @@ use reth_trie::{
     StorageMultiProof, TrieInput,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Extends [`Proof`] with operations specific for working with a database transaction.
 pub trait DatabaseProof<'a, TX> {
     /// Create a new [Proof] from database transaction.
@@ -50,11 +53,11 @@ impl<'a, TX: DbTx> DatabaseProof<'a, TX>
         Self::from_tx(tx)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
                 DatabaseTrieCursorFactory::new(tx),
-                &nodes_sorted,
+                Arc::new(nodes_sorted),
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_sets_mut(input.prefix_sets)
             .account_proof(address, slots)
@@ -70,11 +73,11 @@ impl<'a, TX: DbTx> DatabaseProof<'a, TX>
         Self::from_tx(tx)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
                 DatabaseTrieCursorFactory::new(tx),
-                &nodes_sorted,
+                Arc::new(nodes_sorted),
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_sets_mut(input.prefix_sets)
             .multiproof(targets)
@@ -125,7 +128,7 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
         Self::from_tx(tx, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_set_mut(prefix_set)
             .storage_proof(slot)
@@ -147,7 +150,7 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
         Self::from_tx(tx, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_set_mut(prefix_set)
             .storage_multiproof(targets)

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -19,6 +19,9 @@ use reth_trie::{
 use std::{collections::HashMap, ops::RangeInclusive};
 use tracing::debug;
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Extends [`StateRoot`] with operations specific for working with a database transaction.
 pub trait DatabaseStateRoot<'a, TX>: Sized {
     /// Create a new [`StateRoot`] instance.
@@ -173,7 +176,10 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = post_state.into_sorted();
         StateRoot::new(
             DatabaseTrieCursorFactory::new(tx),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(prefix_sets)
         .root()
@@ -187,7 +193,10 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = post_state.into_sorted();
         StateRoot::new(
             DatabaseTrieCursorFactory::new(tx),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(prefix_sets)
         .root_with_updates()
@@ -197,8 +206,14 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         StateRoot::new(
-            InMemoryTrieCursorFactory::new(DatabaseTrieCursorFactory::new(tx), &nodes_sorted),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            InMemoryTrieCursorFactory::new(
+                DatabaseTrieCursorFactory::new(tx),
+                Arc::new(nodes_sorted),
+            ),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(input.prefix_sets.freeze())
         .root()
@@ -211,8 +226,14 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         let state_sorted = input.state.into_sorted();
         let nodes_sorted = input.nodes.into_sorted();
         StateRoot::new(
-            InMemoryTrieCursorFactory::new(DatabaseTrieCursorFactory::new(tx), &nodes_sorted),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            InMemoryTrieCursorFactory::new(
+                DatabaseTrieCursorFactory::new(tx),
+                Arc::new(nodes_sorted),
+            ),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
         )
         .with_prefix_sets(input.prefix_sets.freeze())
         .root_with_updates()

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -7,6 +7,9 @@ use reth_trie::{
     hashed_cursor::HashedPostStateCursorFactory, HashedPostState, HashedStorage, StorageRoot,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 #[cfg(feature = "metrics")]
 use reth_trie::metrics::{TrieRootMetrics, TrieType};
 
@@ -68,7 +71,10 @@ impl<'a, TX: DbTx> DatabaseStorageRoot<'a, TX>
             HashedPostState::from_hashed_storage(keccak256(address), hashed_storage).into_sorted();
         StorageRoot::new(
             DatabaseTrieCursorFactory::new(tx),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(tx),
+                Arc::new(state_sorted),
+            ),
             address,
             prefix_set,
             #[cfg(feature = "metrics")]

--- a/crates/trie/db/src/witness.rs
+++ b/crates/trie/db/src/witness.rs
@@ -7,6 +7,9 @@ use reth_trie::{
     witness::TrieWitness, HashedPostState, TrieInput,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Extends [`TrieWitness`] with operations specific for working with a database transaction.
 pub trait DatabaseTrieWitness<'a, TX> {
     /// Create a new [`TrieWitness`] from database transaction.
@@ -37,11 +40,11 @@ impl<'a, TX: DbTx> DatabaseTrieWitness<'a, TX>
         Self::from_tx(tx)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
                 DatabaseTrieCursorFactory::new(tx),
-                &nodes_sorted,
+                Arc::new(nodes_sorted),
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
+                Arc::new(state_sorted),
             ))
             .with_prefix_sets_mut(input.prefix_sets)
             .compute(target)

--- a/crates/trie/db/tests/post_state.rs
+++ b/crates/trie/db/tests/post_state.rs
@@ -13,7 +13,7 @@ use reth_trie::{
     HashedPostState, HashedStorage,
 };
 use reth_trie_db::DatabaseHashedCursorFactory;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 fn assert_account_cursor_order(
     factory: &impl HashedCursorFactory,
@@ -66,7 +66,8 @@ fn post_state_only_accounts() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
 
@@ -87,7 +88,7 @@ fn db_only_accounts() {
     let tx = db.tx().unwrap();
     let factory = HashedPostStateCursorFactory::new(
         DatabaseHashedCursorFactory::new(&tx),
-        &sorted_post_state,
+        Arc::new(sorted_post_state),
     );
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
@@ -113,7 +114,8 @@ fn account_cursor_correct_order() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
 
@@ -143,7 +145,8 @@ fn removed_accounts_are_discarded() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = accounts.into_iter().filter(|x| !removed_keys.contains(&x.0));
     assert_account_cursor_order(&factory, expected);
 }
@@ -170,7 +173,8 @@ fn post_state_accounts_take_precedence() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     assert_account_cursor_order(&factory, accounts.into_iter());
 }
 
@@ -202,7 +206,7 @@ fn fuzz_hashed_account_cursor() {
 
             let sorted = hashed_post_state.into_sorted();
             let tx = db.tx().unwrap();
-            let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+            let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
             assert_account_cursor_order(&factory, expected.into_iter());
         }
     );
@@ -217,8 +221,10 @@ fn storage_is_empty() {
     {
         let sorted = HashedPostState::default().into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(cursor.is_storage_empty().unwrap());
     }
@@ -238,8 +244,10 @@ fn storage_is_empty() {
     {
         let sorted = HashedPostState::default().into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(!cursor.is_storage_empty().unwrap());
     }
@@ -254,8 +262,10 @@ fn storage_is_empty() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(cursor.is_storage_empty().unwrap());
     }
@@ -271,8 +281,10 @@ fn storage_is_empty() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(cursor.is_storage_empty().unwrap());
     }
@@ -288,8 +300,10 @@ fn storage_is_empty() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&tx),
+            Arc::new(sorted),
+        );
         let mut cursor = factory.hashed_storage_cursor(address).unwrap();
         assert!(!cursor.is_storage_empty().unwrap());
     }
@@ -325,7 +339,8 @@ fn storage_cursor_correct_order() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected =
         std::iter::once((address, db_storage.into_iter().chain(post_state_storage).collect()));
     assert_storage_cursor_order(&factory, expected);
@@ -362,7 +377,8 @@ fn zero_value_storage_entries_are_discarded() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = std::iter::once((
         address,
         post_state_storage.into_iter().filter(|(_, value)| *value > U256::ZERO).collect(),
@@ -399,7 +415,8 @@ fn wiped_storage_is_discarded() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = std::iter::once((address, post_state_storage));
     assert_storage_cursor_order(&factory, expected);
 }
@@ -434,7 +451,8 @@ fn post_state_storages_take_precedence() {
 
     let sorted = hashed_post_state.into_sorted();
     let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+    let factory =
+        HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
     let expected = std::iter::once((address, storage));
     assert_storage_cursor_order(&factory, expected);
 }
@@ -481,7 +499,7 @@ fn fuzz_hashed_storage_cursor() {
 
         let sorted = hashed_post_state.into_sorted();
         let tx = db.tx().unwrap();
-        let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), Arc::new(sorted));
         assert_storage_cursor_order(&factory, expected.into_iter());
     });
 }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -162,12 +162,13 @@ where
                     let cursor_start = Instant::now();
                     let trie_cursor_factory = InMemoryTrieCursorFactory::new(
                         DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-                        &trie_nodes_sorted,
+                        trie_nodes_sorted,
                     );
                     let hashed_cursor_factory = HashedPostStateCursorFactory::new(
                         DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-                        &hashed_state_sorted,
+                        hashed_state_sorted,
                     );
+
                     trace!(
                         target: "trie::parallel",
                         ?hashed_address,
@@ -215,11 +216,11 @@ where
         let provider_ro = self.view.provider_ro()?;
         let trie_cursor_factory = InMemoryTrieCursorFactory::new(
             DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-            &self.nodes_sorted,
+            self.nodes_sorted,
         );
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-            &self.state_sorted,
+            self.state_sorted,
         );
 
         // Create the walker.

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -111,15 +111,16 @@ where
                     let provider_ro = view.provider_ro()?;
                     let trie_cursor_factory = InMemoryTrieCursorFactory::new(
                         DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-                        &trie_nodes_sorted,
+                        trie_nodes_sorted,
                     );
-                    let hashed_state = HashedPostStateCursorFactory::new(
+                    let hashed_cursor_factory = HashedPostStateCursorFactory::new(
                         DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-                        &hashed_state_sorted,
+                        hashed_state_sorted,
                     );
+
                     Ok(StorageRoot::new_hashed(
                         trie_cursor_factory,
-                        hashed_state,
+                        hashed_cursor_factory,
                         hashed_address,
                         prefix_set,
                         #[cfg(feature = "metrics")]
@@ -138,11 +139,11 @@ where
         let provider_ro = self.view.provider_ro()?;
         let trie_cursor_factory = InMemoryTrieCursorFactory::new(
             DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-            &trie_nodes_sorted,
+            trie_nodes_sorted,
         );
         let hashed_cursor_factory = HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(provider_ro.tx_ref()),
-            &hashed_state_sorted,
+            hashed_state_sorted,
         );
 
         let walker = TrieWalker::new(

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -14,6 +14,7 @@ use reth_trie::{
 };
 use reth_trie_common::{HashBuilder, Nibbles};
 use reth_trie_sparse::SparseTrie;
+use std::sync::Arc;
 
 fn calculate_root_from_leaves(c: &mut Criterion) {
     let mut group = c.benchmark_group("calculate root from leaves");
@@ -133,7 +134,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     InMemoryStorageTrieCursor::new(
                                         B256::ZERO,
                                         NoopStorageTrieCursor::default(),
-                                        Some(&trie_updates_sorted),
+                                        Some(Arc::new(trie_updates_sorted)),
                                     ),
                                     prefix_set,
                                 );
@@ -141,7 +142,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     walker,
                                     HashedPostStateStorageCursor::new(
                                         NoopHashedStorageCursor::default(),
-                                        Some(&storage_sorted),
+                                        Some(Arc::new(storage_sorted)),
                                     ),
                                 );
 

--- a/crates/trie/trie/src/forward_cursor.rs
+++ b/crates/trie/trie/src/forward_cursor.rs
@@ -1,17 +1,20 @@
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// The implementation of forward-only in memory cursor over the entries.
 /// The cursor operates under the assumption that the supplied collection is pre-sorted.
 #[derive(Debug)]
-pub struct ForwardInMemoryCursor<'a, K, V> {
+pub struct ForwardInMemoryCursor<K, V> {
     /// The reference to the pre-sorted collection of entries.
-    entries: &'a Vec<(K, V)>,
+    entries: Arc<Vec<(K, V)>>,
     /// The index where cursor is currently positioned.
     index: usize,
 }
 
-impl<'a, K, V> ForwardInMemoryCursor<'a, K, V> {
+impl<K, V> ForwardInMemoryCursor<K, V> {
     /// Create new forward cursor positioned at the beginning of the collection.
     /// The cursor expects all of the entries have been sorted in advance.
-    pub const fn new(entries: &'a Vec<(K, V)>) -> Self {
+    pub const fn new(entries: Arc<Vec<(K, V)>>) -> Self {
         Self { entries, index: 0 }
     }
 
@@ -21,7 +24,7 @@ impl<'a, K, V> ForwardInMemoryCursor<'a, K, V> {
     }
 }
 
-impl<K, V> ForwardInMemoryCursor<'_, K, V>
+impl<K, V> ForwardInMemoryCursor<K, V>
 where
     K: PartialOrd + Clone,
     V: Clone,


### PR DESCRIPTION
Extracted from #13749

The reference parameters in `InMemoryTrieCursorFactory` and `HashedPostStateCursorFactory` cause lifetime problems when they are used to create and spawn `StateRootTask`, this PR changes those parameters to `Arc`s. 