### PR TITLE
chore(ci): remove eth_feeHistory from hive's rpc-compat expected failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -7,7 +7,6 @@ rpc-compat:
   - debug_getRawTransaction/get-invalid-hash (reth)
 
   - eth_call/call-callenv (reth)
-  - eth_feeHistory/fee-history (reth)
   - eth_getStorageAt/get-storage-invalid-key-too-large (reth)
   - eth_getStorageAt/get-storage-invalid-key (reth)
   - eth_getTransactionReceipt/get-access-list (reth)


### PR DESCRIPTION
we are getting:
```
Unexpected Passes:
  eth_feeHistory/fee-history (reth)
```
like here https://github.com/paradigmxyz/reth/actions/runs/12843798054/job/35816311475