### PR TITLE
test: Add ValidBlocks and InvalidBlocks blockchain tests

### DIFF
--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -79,3 +79,20 @@ mod general_state_tests {
 }
 
 // TODO: Add ValidBlocks and InvalidBlocks tests
+
+macro_rules! blockchain_test {
+    ($test_name:ident, $dir:ident) => {
+        #[test]
+        fn $test_name() {
+            BlockchainTests::new(format!("BlockchainTests/{}", stringify!($dir))).run();
+        }
+    };
+}
+
+#[allow(missing_docs)]
+mod blockchain_tests {
+    use super::*;
+
+    blockchain_test!(valid_blocks, ValidBlocks);
+    blockchain_test!(invalid_blocks, InvalidBlocks);
+}


### PR DESCRIPTION
Implements the TODO in tests.rs by adding test coverage for ValidBlocks and  InvalidBlocks test suites from the Ethereum test cases. This enhances our test  coverage by including these important blockchain test cases that verify valid  and invalid block processing.

The implementation:
- Adds a new blockchain_test! macro for running blockchain tests
- Creates a new blockchain_tests module
- Implements tests for both ValidBlocks and InvalidBlocks test suites