### PR TITLE
chore: use correct compressed size estimation fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8333,6 +8333,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
+ "maili-flz",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,9 +472,11 @@ alloy-transport-ws = { version = "0.9.2", default-features = false }
 # op
 op-alloy-rpc-types = { version = "0.9.0", default-features = false }
 op-alloy-rpc-types-engine = { version =  "0.9.0", default-features = false }
-maili-rpc = { version =  "0.1.6", default-features = false }
 op-alloy-network = { version =  "0.9.0", default-features = false }
 op-alloy-consensus = { version =  "0.9.0", default-features = false }
+## op-maili
+maili-rpc = { version =  "0.1.6", default-features = false }
+maili-flz = { version =  "0.1.6", default-features = false }
 
 # misc
 aquamarine = "0.6"

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -52,6 +52,7 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true
+maili-flz.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-consensus.workspace = true
 

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -45,7 +45,7 @@ pub struct OpPooledTransaction {
     #[deref]
     inner: EthPooledTransaction<OpTransactionSigned>,
     /// The estimated size of this transaction, lazily computed.
-    estimated_tx_compressed_size: OnceLock<u32>,
+    estimated_tx_compressed_size: OnceLock<u64>,
 }
 
 impl OpPooledTransaction {
@@ -60,7 +60,7 @@ impl OpPooledTransaction {
     /// Returns the estimated compressed size of a transaction in bytes scaled by 1e6.
     /// This value is computed based on the following formula:
     /// `max(minTransactionSize, intercept + fastlzCoef*fastlzSize)`
-    pub fn estimated_compressed_size(&self) -> u32 {
+    pub fn estimated_compressed_size(&self) -> u64 {
         *self
             .estimated_tx_compressed_size
             .get_or_init(|| tx_estimated_size_fjord(&self.inner.transaction().encoded_2718()))
@@ -71,8 +71,8 @@ impl OpPooledTransaction {
 /// This value is computed based on the following formula:
 /// max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
 // TODO(mattsse): replace with library fn from revm or maili once available
-fn tx_estimated_size_fjord(input: &[u8]) -> u32 {
-    let fastlz_size = maili_flz::flz_compress_len(input);
+fn tx_estimated_size_fjord(input: &[u8]) -> u64 {
+    let fastlz_size = maili_flz::flz_compress_len(input) as u64;
 
     fastlz_size.saturating_mul(836_500).saturating_sub(42_585_600).max(100_000_000)
 }


### PR DESCRIPTION
unblocks #13757

this duplicates the estimate fn from 

https://github.com/op-rs/maili/blob/624e63c2393ed2026bd5220cd8a65ce43ca63b0f/crates/protocol/src/fee.rs#L41-L51

until we can easily import this 