### PR TITLE
feat: add `WithdrawalsProvider::withdrawals_by_block_range`

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -457,6 +457,14 @@ impl<N: ProviderNodeTypes> WithdrawalsProvider for BlockchainProvider<N> {
     ) -> ProviderResult<Option<Withdrawals>> {
         self.consistent_provider()?.withdrawals_by_block(id, timestamp)
     }
+
+    fn withdrawals_by_block_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+        timestamps: &[(BlockNumber, u64)],
+    ) -> ProviderResult<Vec<Option<Withdrawals>>> {
+        self.consistent_provider()?.withdrawals_by_block_range(range, timestamps)
+    }
 }
 
 impl<N: ProviderNodeTypes> OmmersProvider for BlockchainProvider<N> {

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1151,6 +1151,21 @@ impl<N: ProviderNodeTypes> WithdrawalsProvider for ConsistentProvider<N> {
             },
         )
     }
+
+    fn withdrawals_by_block_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+        timestamps: &[(BlockNumber, u64)],
+    ) -> ProviderResult<Vec<Option<Withdrawals>>> {
+        self.get_in_memory_or_storage_by_block_range_while(
+            range,
+            |db_provider, range, _| db_provider.withdrawals_by_block_range(range, timestamps),
+            |block_state, _| {
+                Some(block_state.block_ref().recovered_block().body().withdrawals().cloned())
+            },
+            |_| true,
+        )
+    }
 }
 
 impl<N: ProviderNodeTypes> OmmersProvider for ConsistentProvider<N> {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -769,6 +769,14 @@ impl WithdrawalsProvider for MockEthProvider {
     ) -> ProviderResult<Option<Withdrawals>> {
         Ok(None)
     }
+
+    fn withdrawals_by_block_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+        _timestamps: &[(BlockNumber, u64)],
+    ) -> ProviderResult<Vec<Option<Withdrawals>>> {
+        Ok(vec![])
+    }
 }
 
 impl OmmersProvider for MockEthProvider {

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -538,6 +538,14 @@ impl<C: Send + Sync, N: NodePrimitives> WithdrawalsProvider for NoopProvider<C, 
     ) -> ProviderResult<Option<Withdrawals>> {
         Ok(None)
     }
+
+    fn withdrawals_by_block_range(
+        &self,
+        _range: RangeInclusive<BlockNumber>,
+        _timestamps: &[(BlockNumber, u64)],
+    ) -> ProviderResult<Vec<Option<Withdrawals>>> {
+        Ok(vec![])
+    }
 }
 
 impl<C: Send + Sync, N: NodePrimitives> OmmersProvider for NoopProvider<C, N> {

--- a/crates/storage/storage-api/src/withdrawals.rs
+++ b/crates/storage/storage-api/src/withdrawals.rs
@@ -1,5 +1,7 @@
 use alloy_eips::{eip4895::Withdrawals, BlockHashOrNumber};
+use alloy_primitives::BlockNumber;
 use reth_storage_errors::provider::ProviderResult;
+use std::ops::RangeInclusive;
 
 ///  Client trait for fetching [`alloy_eips::eip4895::Withdrawal`] related data.
 #[auto_impl::auto_impl(&, Arc)]
@@ -10,4 +12,14 @@ pub trait WithdrawalsProvider: Send + Sync {
         id: BlockHashOrNumber,
         timestamp: u64,
     ) -> ProviderResult<Option<Withdrawals>>;
+
+    /// Returns the withdrawals per block within the requested block range.
+    ///
+    /// If it's dealing with a pre-shangai block, the withdrawal element will be `None`, otherwise
+    /// `Some`.
+    fn withdrawals_by_block_range(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+        timestamps: &[(BlockNumber, u64)],
+    ) -> ProviderResult<Vec<Option<Withdrawals>>>;
 }


### PR DESCRIPTION
Allows using it on `read_block_bodies` with the provider, and not rely solely on DB cursors

for `StaticFileSegment::BlockMeta`

on top of https://github.com/paradigmxyz/reth/pull/13894