### PR TITLE
chore: move node builder trait helpers to separate module

### DIFF
--- a/crates/node/builder/src/aliases.rs
+++ b/crates/node/builder/src/aliases.rs
@@ -1,0 +1,56 @@
+use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
+use reth_network::NetworkPrimitives;
+use reth_node_api::{BlockBody, NodePrimitives};
+use reth_provider::BlockReader;
+
+/// This is a type alias to make type bounds simpler, when we have a [`NetworkPrimitives`] and need
+/// a [`BlockReader`] whose associated types match the [`NetworkPrimitives`] associated types.
+pub trait BlockReaderFor<N: NetworkPrimitives>:
+    BlockReader<
+    Block = N::Block,
+    Header = N::BlockHeader,
+    Transaction = <N::BlockBody as BlockBody>::Transaction,
+    Receipt = N::Receipt,
+>
+{
+}
+
+impl<N, T> BlockReaderFor<N> for T
+where
+    N: NetworkPrimitives,
+    T: BlockReader<
+        Block = N::Block,
+        Header = N::BlockHeader,
+        Transaction = <N::BlockBody as BlockBody>::Transaction,
+        Receipt = N::Receipt,
+    >,
+{
+}
+
+/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
+/// [`ConfigureEvmEnv`] whose associated types match the [`NodePrimitives`] associated types.
+pub trait ConfigureEvmEnvFor<N: NodePrimitives>:
+    ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>
+{
+}
+
+impl<N, C> ConfigureEvmEnvFor<N> for C
+where
+    N: NodePrimitives,
+    C: ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>,
+{
+}
+
+/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
+/// [`ConfigureEvm`] whose associated types match the [`NodePrimitives`] associated types.
+pub trait ConfigureEvmFor<N: NodePrimitives>:
+    ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
+{
+}
+
+impl<N, C> ConfigureEvmFor<N> for C
+where
+    N: NodePrimitives,
+    C: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+{
+}

--- a/crates/node/builder/src/lib.rs
+++ b/crates/node/builder/src/lib.rs
@@ -38,6 +38,10 @@ pub mod rpc;
 
 pub mod setup;
 
+/// Type aliases for traits that are often used together
+pub mod aliases;
+pub use aliases::*;
+
 /// Support for installing the ExExs (execution extensions) in a node.
 pub mod exex;
 

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -7,15 +7,13 @@ use std::{
     sync::Arc,
 };
 
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
-use reth_network::NetworkPrimitives;
-use reth_node_api::{BlockBody, EngineTypes, FullNodeComponents, NodePrimitives};
+use reth_node_api::{EngineTypes, FullNodeComponents};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     node_config::NodeConfig,
 };
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_provider::{BlockReader, ChainSpecProvider};
+use reth_provider::ChainSpecProvider;
 use reth_rpc_api::EngineApiClient;
 use reth_rpc_builder::{auth::AuthServerHandle, RpcServerHandle};
 use reth_tasks::TaskExecutor;
@@ -211,56 +209,4 @@ impl<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> DerefMut for FullNode<N
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.add_ons_handle
     }
-}
-
-/// This is a type alias to make type bounds simpler, when we have a [`NetworkPrimitives`] and need
-/// a [`BlockReader`] whose associated types match the [`NetworkPrimitives`] associated types.
-pub trait BlockReaderFor<N: NetworkPrimitives>:
-    BlockReader<
-    Block = N::Block,
-    Header = N::BlockHeader,
-    Transaction = <N::BlockBody as BlockBody>::Transaction,
-    Receipt = N::Receipt,
->
-{
-}
-
-impl<N, T> BlockReaderFor<N> for T
-where
-    N: NetworkPrimitives,
-    T: BlockReader<
-        Block = N::Block,
-        Header = N::BlockHeader,
-        Transaction = <N::BlockBody as BlockBody>::Transaction,
-        Receipt = N::Receipt,
-    >,
-{
-}
-
-/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
-/// [`ConfigureEvmEnv`] whose associated types match the [`NodePrimitives`] associated types.
-pub trait ConfigureEvmEnvFor<N: NodePrimitives>:
-    ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>
-{
-}
-
-impl<N, C> ConfigureEvmEnvFor<N> for C
-where
-    N: NodePrimitives,
-    C: ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>,
-{
-}
-
-/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
-/// [`ConfigureEvm`] whose associated types match the [`NodePrimitives`] associated types.
-pub trait ConfigureEvmFor<N: NodePrimitives>:
-    ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
-{
-}
-
-impl<N, C> ConfigureEvmFor<N> for C
-where
-    N: NodePrimitives,
-    C: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
-{
 }


### PR DESCRIPTION
Just moves these types so they can all be found in one location