### PR TITLE
chore: deprecate recoveredtx alias

### DIFF
--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -20,7 +20,7 @@ use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_primitives::{
     proofs::{calculate_receipt_root, calculate_transaction_root, calculate_withdrawals_root},
     transaction::SignedTransactionIntoRecoveredExt,
-    BlockBody, EthPrimitives, NodePrimitives, Receipt, Receipts, RecoveredBlock, RecoveredTx,
+    BlockBody, EthPrimitives, NodePrimitives, Receipt, Receipts, Recovered, RecoveredBlock,
     SealedBlock, SealedHeader, Transaction, TransactionSigned,
 };
 use reth_primitives_traits::Account;
@@ -97,7 +97,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
     ) -> RecoveredBlock<reth_primitives::Block> {
         let mut rng = thread_rng();
 
-        let mock_tx = |nonce: u64| -> RecoveredTx<_> {
+        let mock_tx = |nonce: u64| -> Recovered<_> {
             let tx = Transaction::Eip1559(TxEip1559 {
                 chain_id: self.chain_spec.chain.id(),
                 nonce,
@@ -115,7 +115,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
 
         let num_txs = rng.gen_range(0..5);
         let signer_balance_decrease = Self::single_tx_cost() * U256::from(num_txs);
-        let transactions: Vec<RecoveredTx<_>> = (0..num_txs)
+        let transactions: Vec<Recovered<_>> = (0..num_txs)
             .map(|_| {
                 let tx = mock_tx(self.signer_build_account_info.nonce);
                 self.signer_build_account_info.nonce += 1;

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash};
 use core::{fmt, ops::RangeInclusive};
 use reth_execution_errors::{BlockExecutionError, InternalBlockExecutionError};
 use reth_primitives::{
-    transaction::SignedTransactionIntoRecoveredExt, RecoveredBlock, RecoveredTx, SealedHeader,
+    transaction::SignedTransactionIntoRecoveredExt, Recovered, RecoveredBlock, SealedHeader,
 };
 use reth_primitives_traits::{Block, BlockBody, NodePrimitives, SignedTransaction};
 use reth_trie::updates::TrieUpdates;
@@ -442,13 +442,13 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
         self.blocks.values().flat_map(|block| block.transactions_with_sender())
     }
 
-    /// Returns an iterator over all [`RecoveredTx`] in the blocks
+    /// Returns an iterator over all [`Recovered`] in the blocks
     ///
     /// Note: This clones the transactions since it is assumed this is part of a shared [Chain].
     #[inline]
     pub fn transactions_ecrecovered(
         &self,
-    ) -> impl Iterator<Item = RecoveredTx<<B::Body as BlockBody>::Transaction>> + '_ {
+    ) -> impl Iterator<Item = Recovered<<B::Body as BlockBody>::Transaction>> + '_ {
         self.transactions_with_sender().map(|(signer, tx)| tx.clone().with_signer(*signer))
     }
 

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -28,7 +28,7 @@ use reth_optimism_node::{
 use reth_optimism_payload_builder::builder::OpPayloadTransactions;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_payload_util::{PayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
-use reth_primitives::RecoveredTx;
+use reth_primitives::Recovered;
 use reth_provider::providers::BlockchainProvider;
 use reth_tasks::TaskManager;
 use reth_transaction_pool::{pool::BestPayloadTransactions, PoolTransaction};
@@ -67,7 +67,7 @@ impl OpPayloadTransactions for CustomTxPriority {
             ..Default::default()
         };
         let signature = sender.sign_transaction_sync(&mut end_of_block_tx).unwrap();
-        let end_of_block_tx = RecoveredTx::new_unchecked(
+        let end_of_block_tx = Recovered::new_unchecked(
             OpTransactionSigned::new_unhashed(
                 OpTypedTransaction::Eip1559(end_of_block_tx),
                 signature,

--- a/crates/optimism/payload/src/error.rs
+++ b/crates/optimism/payload/src/error.rs
@@ -4,7 +4,7 @@
 #[derive(Debug, thiserror::Error)]
 pub enum OpPayloadBuilderError {
     /// Thrown when a transaction fails to convert to a
-    /// [`reth_primitives::RecoveredTx`].
+    /// [`reth_primitives::Recovered`].
     #[error("failed to convert deposit transaction to RecoveredTx")]
     TransactionEcRecoverFailed,
     /// Thrown when the L1 block info could not be parsed from the calldata of the

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -7,7 +7,7 @@ use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
 use op_alloy_rpc_types::{OpTransactionRequest, Transaction};
 use reth_node_api::FullNodeComponents;
 use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
-use reth_primitives::RecoveredTx;
+use reth_primitives::Recovered;
 use reth_primitives_traits::transaction::signed::SignedTransaction;
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ProviderTx, ReceiptProvider, TransactionsProvider,
@@ -84,7 +84,7 @@ where
 
     fn fill(
         &self,
-        tx: RecoveredTx<OpTransactionSigned>,
+        tx: Recovered<OpTransactionSigned>,
         tx_info: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use reth_primitives::RecoveredTx;
+use reth_primitives::Recovered;
 
 /// Iterator that returns transactions for the block building process in the order they should be
 /// included in the block.
@@ -15,7 +15,7 @@ pub trait PayloadTransactions {
         &mut self,
         // In the future, `ctx` can include access to state for block building purposes.
         ctx: (),
-    ) -> Option<RecoveredTx<Self::Transaction>>;
+    ) -> Option<Recovered<Self::Transaction>>;
 
     /// Exclude descendants of the transaction with given sender and nonce from the iterator,
     /// because this transaction won't be included in the block.
@@ -35,7 +35,7 @@ impl<T> Default for NoopPayloadTransactions<T> {
 impl<T> PayloadTransactions for NoopPayloadTransactions<T> {
     type Transaction = T;
 
-    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx<Self::Transaction>> {
+    fn next(&mut self, _ctx: ()) -> Option<Recovered<Self::Transaction>> {
         None
     }
 

--- a/crates/payload/util/src/transaction.rs
+++ b/crates/payload/util/src/transaction.rs
@@ -1,7 +1,7 @@
 use crate::PayloadTransactions;
 use alloy_consensus::Transaction;
 use alloy_primitives::Address;
-use reth_primitives::RecoveredTx;
+use reth_primitives::Recovered;
 
 /// An implementation of [`crate::traits::PayloadTransactions`] that yields
 /// a pre-defined set of transactions.
@@ -26,10 +26,10 @@ impl<T> PayloadTransactionsFixed<T> {
     }
 }
 
-impl<T: Clone> PayloadTransactions for PayloadTransactionsFixed<RecoveredTx<T>> {
+impl<T: Clone> PayloadTransactions for PayloadTransactionsFixed<Recovered<T>> {
     type Transaction = T;
 
-    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx<T>> {
+    fn next(&mut self, _ctx: ()) -> Option<Recovered<T>> {
         (self.index < self.transactions.len()).then(|| {
             let tx = self.transactions[self.index].clone();
             self.index += 1;
@@ -96,7 +96,7 @@ where
 {
     type Transaction = A::Transaction;
 
-    fn next(&mut self, ctx: ()) -> Option<RecoveredTx<Self::Transaction>> {
+    fn next(&mut self, ctx: ()) -> Option<Recovered<Self::Transaction>> {
         while let Some(tx) = self.before.next(ctx) {
             if let Some(before_max_gas) = self.before_max_gas {
                 if self.before_gas + tx.tx().gas_limit() <= before_max_gas {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -40,9 +40,14 @@ pub use reth_primitives_traits::{
 pub use static_file::StaticFileSegment;
 
 pub use alloy_consensus::{
-    transaction::{PooledTransaction, Recovered as RecoveredTx, TransactionMeta},
+    transaction::{PooledTransaction, Recovered, TransactionMeta},
     ReceiptWithBloom,
 };
+
+/// Recovered transaction
+#[deprecated(note = "use `Recovered` instead")]
+pub type RecoveredTx<T> = Recovered<T>;
+
 pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
     InvalidTransactionError, Transaction, TransactionSigned, TxType,

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,6 +1,6 @@
 //! Transaction types.
 
-use crate::RecoveredTx;
+use crate::Recovered;
 pub use alloy_consensus::transaction::PooledTransaction;
 use once_cell as _;
 #[allow(deprecated)]
@@ -31,4 +31,4 @@ pub use reth_ethereum_primitives::{Transaction, TransactionSigned};
 
 /// Type alias kept for backward compatibility.
 #[deprecated(note = "Use `Recovered` instead")]
-pub type TransactionSignedEcRecovered<T = TransactionSigned> = RecoveredTx<T>;
+pub type TransactionSignedEcRecovered<T = TransactionSigned> = Recovered<T>;

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -1,9 +1,9 @@
 //! Defines the types for blob transactions, legacy, and other EIP-2718 transactions included in a
 //! response to `GetPooledTransactions`.
 
-use crate::RecoveredTx;
+use crate::Recovered;
 use alloy_consensus::transaction::PooledTransaction;
 
 /// A signed pooled transaction with recovered signer.
 #[deprecated(note = "use `Recovered` instead")]
-pub type PooledTransactionsElementEcRecovered<T = PooledTransaction> = RecoveredTx<T>;
+pub type PooledTransactionsElementEcRecovered<T = PooledTransaction> = Recovered<T>;

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -4,7 +4,7 @@
 
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
-use reth_primitives::{RecoveredTx, TransactionSigned};
+use reth_primitives::{Recovered, TransactionSigned};
 use reth_primitives_traits::SignedTransaction;
 use reth_rpc_types_compat::TransactionCompat;
 
@@ -12,13 +12,13 @@ use reth_rpc_types_compat::TransactionCompat;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TransactionSource<T = TransactionSigned> {
     /// Transaction exists in the pool (Pending)
-    Pool(RecoveredTx<T>),
+    Pool(Recovered<T>),
     /// Transaction already included in a block
     ///
     /// This can be a historical block or a pending block (received from the CL)
     Block {
         /// Transaction fetched via provider
-        transaction: RecoveredTx<T>,
+        transaction: Recovered<T>,
         /// Index of the transaction in the block
         index: u64,
         /// Hash of the block.
@@ -34,7 +34,7 @@ pub enum TransactionSource<T = TransactionSigned> {
 
 impl<T: SignedTransaction> TransactionSource<T> {
     /// Consumes the type and returns the wrapped transaction.
-    pub fn into_recovered(self) -> RecoveredTx<T> {
+    pub fn into_recovered(self) -> Recovered<T> {
         self.into()
     }
 
@@ -60,7 +60,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     }
 
     /// Returns the transaction and block related info, if not pending
-    pub fn split(self) -> (RecoveredTx<T>, TransactionInfo) {
+    pub fn split(self) -> (Recovered<T>, TransactionInfo) {
         match self {
             Self::Pool(tx) => {
                 let hash = tx.trie_hash();
@@ -83,7 +83,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     }
 }
 
-impl<T> From<TransactionSource<T>> for RecoveredTx<T> {
+impl<T> From<TransactionSource<T>> for Recovered<T> {
     fn from(value: TransactionSource<T>) -> Self {
         match value {
             TransactionSource::Pool(tx) => tx,

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -1,7 +1,7 @@
 //! Commonly used code snippets
 
 use super::{EthApiError, EthResult};
-use reth_primitives::{transaction::SignedTransactionIntoRecoveredExt, RecoveredTx};
+use reth_primitives::{transaction::SignedTransactionIntoRecoveredExt, Recovered};
 use reth_primitives_traits::SignedTransaction;
 use std::future::Future;
 
@@ -11,7 +11,7 @@ use std::future::Future;
 /// malformed.
 ///
 /// See [`alloy_eips::eip2718::Decodable2718::decode_2718`]
-pub fn recover_raw_transaction<T: SignedTransaction>(mut data: &[u8]) -> EthResult<RecoveredTx<T>> {
+pub fn recover_raw_transaction<T: SignedTransaction>(mut data: &[u8]) -> EthResult<Recovered<T>> {
     if data.is_empty() {
         return Err(EthApiError::EmptyRawTransactionData)
     }

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -4,7 +4,7 @@ use core::error;
 use std::fmt;
 
 use alloy_rpc_types_eth::{request::TransactionRequest, TransactionInfo};
-use reth_primitives::{RecoveredTx, TransactionSigned};
+use reth_primitives::{Recovered, TransactionSigned};
 use serde::{Deserialize, Serialize};
 
 /// Builds RPC transaction w.r.t. network.
@@ -26,7 +26,7 @@ pub trait TransactionCompat<T = TransactionSigned>:
     /// Wrapper for `fill()` with default `TransactionInfo`
     /// Create a new rpc transaction result for a _pending_ signed transaction, setting block
     /// environment related fields to `None`.
-    fn fill_pending(&self, tx: RecoveredTx<T>) -> Result<Self::Transaction, Self::Error> {
+    fn fill_pending(&self, tx: Recovered<T>) -> Result<Self::Transaction, Self::Error> {
         self.fill(tx, TransactionInfo::default())
     }
 
@@ -37,7 +37,7 @@ pub trait TransactionCompat<T = TransactionSigned>:
     /// transaction was mined.
     fn fill(
         &self,
-        tx: RecoveredTx<T>,
+        tx: Recovered<T>,
         tx_inf: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error>;
 
@@ -51,9 +51,9 @@ pub trait TransactionCompat<T = TransactionSigned>:
     fn otterscan_api_truncate_input(tx: &mut Self::Transaction);
 }
 
-/// Convert [`RecoveredTx`] to [`TransactionRequest`]
+/// Convert [`Recovered`] to [`TransactionRequest`]
 pub fn transaction_to_call_request<T: alloy_consensus::Transaction>(
-    tx: RecoveredTx<T>,
+    tx: Recovered<T>,
 ) -> TransactionRequest {
     let from = tx.signer();
     TransactionRequest::from_transaction_with_sender(tx.into_tx(), from)

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -5,7 +5,7 @@ use alloy_network::{Ethereum, Network};
 use alloy_primitives::PrimitiveSignature as Signature;
 use alloy_rpc_types::TransactionRequest;
 use alloy_rpc_types_eth::{Transaction, TransactionInfo};
-use reth_primitives::{RecoveredTx, TransactionSigned};
+use reth_primitives::{Recovered, TransactionSigned};
 use reth_primitives_traits::SignedTransaction;
 use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
@@ -40,7 +40,7 @@ where
 
     fn fill(
         &self,
-        tx: RecoveredTx<TransactionSigned>,
+        tx: Recovered<TransactionSigned>,
         tx_info: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -176,7 +176,7 @@ use alloy_primitives::{Address, TxHash, B256, U256};
 use aquamarine as _;
 use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
-use reth_primitives::RecoveredTx;
+use reth_primitives::Recovered;
 use reth_primitives_traits::Block;
 use reth_storage_api::StateProviderFactory;
 use std::{collections::HashSet, sync::Arc};
@@ -423,7 +423,7 @@ where
     fn get_pooled_transaction_element(
         &self,
         tx_hash: TxHash,
-    ) -> Option<RecoveredTx<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
+    ) -> Option<Recovered<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
     {
         self.pool.get_pooled_transaction_element(tx_hash)
     }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -22,7 +22,7 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, TxHash, B256, U256};
 use reth_eth_wire_types::HandleMempoolData;
-use reth_primitives::RecoveredTx;
+use reth_primitives::Recovered;
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 use tokio::sync::{mpsc, mpsc::Receiver};
 
@@ -143,7 +143,7 @@ impl TransactionPool for NoopTransactionPool {
     fn get_pooled_transaction_element(
         &self,
         _tx_hash: TxHash,
-    ) -> Option<RecoveredTx<<Self::Transaction as PoolTransaction>::Pooled>> {
+    ) -> Option<Recovered<<Self::Transaction as PoolTransaction>::Pooled>> {
         None
     }
 

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy_primitives::Address;
 use core::fmt;
 use reth_payload_util::PayloadTransactions;
-use reth_primitives::{InvalidTransactionError, RecoveredTx};
+use reth_primitives::{InvalidTransactionError, Recovered};
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
     sync::Arc,
@@ -251,7 +251,7 @@ where
 {
     type Transaction = T::Consensus;
 
-    fn next(&mut self, _ctx: ()) -> Option<RecoveredTx<Self::Transaction>> {
+    fn next(&mut self, _ctx: ()) -> Option<Recovered<Self::Transaction>> {
         loop {
             let tx = self.best.next()?;
             if self.invalid.contains(&tx.sender()) {

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -88,7 +88,7 @@ use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
 
 use alloy_eips::eip4844::BlobTransactionSidecar;
-use reth_primitives::RecoveredTx;
+use reth_primitives::Recovered;
 use rustc_hash::FxHashMap;
 use std::{collections::HashSet, fmt, sync::Arc, time::Instant};
 use tokio::sync::mpsc;
@@ -316,7 +316,7 @@ where
     fn to_pooled_transaction(
         &self,
         transaction: Arc<ValidPoolTransaction<T::Transaction>>,
-    ) -> Option<RecoveredTx<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
+    ) -> Option<Recovered<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
     where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
     {
@@ -371,7 +371,7 @@ where
     pub fn get_pooled_transaction_element(
         &self,
         tx_hash: TxHash,
-    ) -> Option<RecoveredTx<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
+    ) -> Option<Recovered<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
     where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
     {

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_eips::eip4844::BlobTransactionSidecar;
 use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
-use reth_primitives::{RecoveredTx, SealedBlock};
+use reth_primitives::{Recovered, SealedBlock};
 use std::{fmt, future::Future, time::Instant};
 
 mod constants;
@@ -391,7 +391,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     /// Converts to this type into the consensus transaction of the pooled transaction.
     ///
     /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
-    pub fn to_consensus(&self) -> RecoveredTx<T::Consensus> {
+    pub fn to_consensus(&self) -> Recovered<T::Consensus> {
         self.transaction.clone_into_consensus()
     }
 


### PR DESCRIPTION
we introduced this alias to smooth the transition to alloy types.

we can now remove this and mark the alias as deprecated