### PR TITLE
chore: move state root task spawning to fn

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -50,14 +50,14 @@ use reth_trie::{
     hashed_cursor::HashedPostStateCursorFactory,
     prefix_set::TriePrefixSetsMut,
     proof::ProofBlindedProviderFactory,
-    trie_cursor::InMemoryTrieCursorFactory,
+    trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
     updates::{TrieUpdates, TrieUpdatesSorted},
     HashedPostState, HashedPostStateSorted, TrieInput,
 };
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::EvmState;
-use root::{StateRootComputeOutcome, StateRootConfig, StateRootTask};
+use root::{StateRootComputeOutcome, StateRootConfig, StateRootHandle, StateRootTask};
 use std::{
     cmp::Ordering,
     collections::{btree_map, hash_map, BTreeMap, VecDeque},
@@ -2284,55 +2284,8 @@ where
         let state_root_result = std::thread::scope(|scope| {
             let (state_root_handle, in_memory_trie_cursor, state_hook) =
                 if persistence_not_in_progress && self.config.use_state_root_task() {
-                    let consistent_view =
-                        ConsistentDbView::new_with_latest_tip(self.provider.clone())?;
-
-                    let state_root_config = StateRootConfig::new_from_input(
-                        consistent_view.clone(),
-                        self.compute_trie_input(
-                            consistent_view.clone(),
-                            block.header().parent_hash(),
-                        )
-                        .map_err(|e| InsertBlockErrorKind::Other(Box::new(e)))?,
-                    );
-
-                    let provider_ro = consistent_view.provider_ro()?;
-                    let nodes_sorted = state_root_config.nodes_sorted.clone();
-                    let state_sorted = state_root_config.state_sorted.clone();
-                    let prefix_sets = state_root_config.prefix_sets.clone();
-
-                    // context will hold the values that need to be kept alive
-                    let context =
-                        StateHookContext { provider_ro, nodes_sorted, state_sorted, prefix_sets };
-
-                    // it is ok to leak here because we are in a scoped thread, the
-                    // memory will be freed when the thread completes
-                    let context = Box::leak(Box::new(context));
-
-                    let in_memory_trie_cursor = InMemoryTrieCursorFactory::new(
-                        DatabaseTrieCursorFactory::new(context.provider_ro.tx_ref()),
-                        &context.nodes_sorted,
-                    );
-                    let blinded_provider_factory = ProofBlindedProviderFactory::new(
-                        in_memory_trie_cursor.clone(),
-                        HashedPostStateCursorFactory::new(
-                            DatabaseHashedCursorFactory::new(context.provider_ro.tx_ref()),
-                            &context.state_sorted,
-                        ),
-                        context.prefix_sets.clone(),
-                    );
-
-                    let state_root_task = StateRootTask::new(
-                        state_root_config,
-                        blinded_provider_factory,
-                        self.state_root_task_pool.clone(),
-                    );
-                    let state_hook = state_root_task.state_hook();
-                    (
-                        Some(state_root_task.spawn(scope)),
-                        Some(in_memory_trie_cursor),
-                        Box::new(state_hook) as Box<dyn OnStateHook>,
-                    )
+                    let parent_hash = block.header().parent_hash();
+                    self.spawn_state_root_task_for_block(parent_hash, scope)?
                 } else {
                     (None, None, Box::new(|_state: &EvmState| {}) as Box<dyn OnStateHook>)
                 };
@@ -2525,6 +2478,63 @@ where
         input.append_ref(hashed_state);
 
         ParallelStateRoot::new(consistent_view, input).incremental_root_with_updates()
+    }
+
+    /// Spawns the state root task, returning the state root task handle, trie updates, and state
+    /// hook.
+    #[allow(clippy::type_complexity)]
+    fn spawn_state_root_task_for_block<'scope>(
+        &self,
+        parent_hash: B256,
+        scope: &'scope std::thread::Scope<'scope, '_>,
+    ) -> Result<
+        (Option<StateRootHandle>, Option<impl TrieCursorFactory>, Box<dyn OnStateHook>),
+        InsertBlockErrorKind,
+    > {
+        let consistent_view = ConsistentDbView::new_with_latest_tip(self.provider.clone())?;
+
+        let state_root_config = StateRootConfig::new_from_input(
+            consistent_view.clone(),
+            self.compute_trie_input(consistent_view.clone(), parent_hash)
+                .map_err(|e| InsertBlockErrorKind::Other(Box::new(e)))?,
+        );
+
+        let provider_ro = consistent_view.provider_ro()?;
+        let nodes_sorted = state_root_config.nodes_sorted.clone();
+        let state_sorted = state_root_config.state_sorted.clone();
+        let prefix_sets = state_root_config.prefix_sets.clone();
+
+        // context will hold the values that need to be kept alive
+        let context = StateHookContext { provider_ro, nodes_sorted, state_sorted, prefix_sets };
+
+        // it is ok to leak here because we are in a scoped thread, the
+        // memory will be freed when the thread completes
+        let context = Box::leak(Box::new(context));
+
+        let in_memory_trie_cursor = InMemoryTrieCursorFactory::new(
+            DatabaseTrieCursorFactory::new(context.provider_ro.tx_ref()),
+            &context.nodes_sorted,
+        );
+        let blinded_provider_factory = ProofBlindedProviderFactory::new(
+            in_memory_trie_cursor.clone(),
+            HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(context.provider_ro.tx_ref()),
+                &context.state_sorted,
+            ),
+            context.prefix_sets.clone(),
+        );
+
+        let state_root_task = StateRootTask::new(
+            state_root_config,
+            blinded_provider_factory,
+            self.state_root_task_pool.clone(),
+        );
+        let state_hook = state_root_task.state_hook();
+        Ok((
+            Some(state_root_task.spawn(scope)),
+            Some(in_memory_trie_cursor),
+            Box::new(state_hook) as Box<dyn OnStateHook>,
+        ))
     }
 
     /// Computes the trie input at the provided parent hash.


### PR DESCRIPTION
Moving this to a separate function makes it easier to move the logic for acquiring the state root task handle, which we'll need to move in prewarming

cc @fgimenez as this will cause slight conflicts with https://github.com/paradigmxyz/reth/pull/13749