### PR TITLE
feat: add `StaticFileBlockWithdrawals` to `db-model`

### DIFF
--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -17,7 +17,10 @@ use reth_codecs::alloy::{
     withdrawal::Withdrawal,
 };
 use reth_db::{
-    models::{AccountBeforeTx, StoredBlockBodyIndices, StoredBlockOmmers, StoredBlockWithdrawals},
+    models::{
+        AccountBeforeTx, StaticFileBlockWithdrawals, StoredBlockBodyIndices, StoredBlockOmmers,
+        StoredBlockWithdrawals,
+    },
     ClientVersion,
 };
 use reth_fs_util as fs;
@@ -110,6 +113,7 @@ compact_types!(
         StoredBlockOmmers,
         StoredBlockBodyIndices,
         StoredBlockWithdrawals,
+        StaticFileBlockWithdrawals,
         // Manual implementations
         TransactionSigned,
         // Bytecode, // todo revm arbitrary

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -25,7 +25,8 @@ pub use accounts::*;
 pub use blocks::*;
 pub use integer_list::IntegerList;
 pub use reth_db_models::{
-    AccountBeforeTx, ClientVersion, StoredBlockBodyIndices, StoredBlockWithdrawals,
+    blocks::StaticFileBlockWithdrawals, AccountBeforeTx, ClientVersion, StoredBlockBodyIndices,
+    StoredBlockWithdrawals,
 };
 pub use sharded_key::ShardedKey;
 
@@ -224,6 +225,7 @@ impl_compression_for_compact!(
     StoredBlockBodyIndices,
     StoredBlockOmmers<H>,
     StoredBlockWithdrawals,
+    StaticFileBlockWithdrawals,
     Bytecode,
     AccountBeforeTx,
     TransactionSigned,

--- a/crates/storage/db-models/src/blocks.rs
+++ b/crates/storage/db-models/src/blocks.rs
@@ -1,9 +1,9 @@
-use std::ops::Range;
-
 use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::TxNumber;
+use bytes::Buf;
 use reth_codecs::{add_arbitrary_tests, Compact};
 use serde::{Deserialize, Serialize};
+use std::ops::Range;
 
 /// Total number of transactions.
 pub type NumTransactions = u64;
@@ -74,6 +74,37 @@ impl StoredBlockBodyIndices {
 pub struct StoredBlockWithdrawals {
     /// The block withdrawals.
     pub withdrawals: Withdrawals,
+}
+
+/// A storage representation of block withdrawals that is static file friendly. An inner `None`
+/// represents a pre-merge block.
+#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(compact)]
+pub struct StaticFileBlockWithdrawals {
+    /// The block withdrawals. A `None` value represents a pre-merge block.
+    pub withdrawals: Option<Withdrawals>,
+}
+
+impl Compact for StaticFileBlockWithdrawals {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        buf.put_u8(self.withdrawals.is_some() as u8);
+        if let Some(withdrawals) = &self.withdrawals {
+            return 1 + withdrawals.to_compact(buf);
+        }
+        1
+    }
+    fn from_compact(mut buf: &[u8], _: usize) -> (Self, &[u8]) {
+        if buf.get_u8() == 1 {
+            let (w, buf) = Withdrawals::from_compact(buf, buf.len());
+            (Self { withdrawals: Some(w) }, buf)
+        } else {
+            (Self { withdrawals: None }, buf)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage/db-models/src/lib.rs
+++ b/crates/storage/db-models/src/lib.rs
@@ -6,7 +6,7 @@ pub use accounts::AccountBeforeTx;
 
 /// Blocks
 pub mod blocks;
-pub use blocks::{StoredBlockBodyIndices, StoredBlockWithdrawals};
+pub use blocks::{StaticFileBlockWithdrawals, StoredBlockBodyIndices, StoredBlockWithdrawals};
 
 /// Client Version
 pub mod client_version;

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -1,10 +1,13 @@
 use crate::{
     add_static_file_mask,
     static_file::mask::{ColumnSelectorOne, ColumnSelectorTwo},
-    BlockBodyIndices, BlockWithdrawals, HeaderTerminalDifficulties,
+    BlockBodyIndices, HeaderTerminalDifficulties,
 };
 use alloy_primitives::BlockHash;
-use reth_db_api::{models::StoredBlockOmmers, table::Table};
+use reth_db_api::{
+    models::{StaticFileBlockWithdrawals, StoredBlockOmmers},
+    table::Table,
+};
 
 // HEADER MASKS
 add_static_file_mask! {
@@ -53,6 +56,6 @@ add_static_file_mask! {
     OmmersMask<H>, StoredBlockOmmers<H>, 0b010
 }
 add_static_file_mask! {
-    #[doc = "Mask for a `StoredBlockWithdrawals` from BlockMeta static file segment"]
-    WithdrawalsMask, <BlockWithdrawals as Table>::Value, 0b100
+    #[doc = "Mask for a `StaticFileBlockWithdrawals` from BlockMeta static file segment"]
+    WithdrawalsMask, StaticFileBlockWithdrawals, 0b100
 }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -362,7 +362,10 @@ impl<N: NodePrimitives> WithdrawalsProvider for StaticFileJarProvider<'_, N> {
         _: u64,
     ) -> ProviderResult<Option<Withdrawals>> {
         if let Some(num) = id.as_number() {
-            return Ok(self.cursor()?.get_one::<WithdrawalsMask>(num.into())?.map(|s| s.withdrawals))
+            return Ok(self
+                .cursor()?
+                .get_one::<WithdrawalsMask>(num.into())?
+                .and_then(|s| s.withdrawals))
         }
         // Only accepts block number queries
         Err(ProviderError::UnsupportedProvider)


### PR DESCRIPTION
Adds a type that will be used to de/serialize withdrawals from/to `StaticFile::BlockMeta`. This is used instead of `StoredBlockWithdrawals` because:

* pre merge block withdrawals are `None`, which are different than `[]`
* static file columns/rows always require some kinda of value
* primitive `Option` cannot be used as a `Compact` row value, and needs a wrapper struct. (eg. `CompactU256`, `CompactU64`)