### PR TITLE
chore: move and integrate ConfigureEvmFor

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -6,7 +6,7 @@ use pretty_assertions::Comparison;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::InvalidBlockHook;
 use reth_evm::{
-    state_change::post_block_balance_increments, system_calls::SystemCaller, ConfigureEvm, Evm,
+    state_change::post_block_balance_increments, system_calls::SystemCaller, ConfigureEvmFor, Evm,
 };
 use reth_primitives::{NodePrimitives, RecoveredBlock, SealedHeader};
 use reth_primitives_traits::{BlockBody, SignedTransaction};
@@ -63,7 +63,7 @@ where
     ) -> eyre::Result<()>
     where
         N: NodePrimitives,
-        EvmConfig: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+        EvmConfig: ConfigureEvmFor<N>,
     {
         // TODO(alexey): unify with `DebugApi::debug_execution_witness`
 
@@ -289,7 +289,7 @@ where
         + Send
         + Sync
         + 'static,
-    EvmConfig: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+    EvmConfig: ConfigureEvmFor<N>,
 {
     fn on_invalid_block(
         &self,

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -6,9 +6,9 @@ use reth_ethereum_engine_primitives::{
     EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
 };
 use reth_ethereum_payload_builder::EthereumBuilderConfig;
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmFor;
 use reth_evm_ethereum::EthEvmConfig;
-use reth_node_api::{FullNodeTypes, HeaderTy, NodeTypesWithEngine, TxTy};
+use reth_node_api::{FullNodeTypes, NodeTypesWithEngine, TxTy};
 use reth_node_builder::{
     components::PayloadServiceBuilder, BuilderContext, PayloadBuilderConfig, PayloadTypes,
 };
@@ -33,7 +33,7 @@ impl EthereumPayloadBuilder {
     where
         Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
         Node: FullNodeTypes<Types = Types>,
-        Evm: ConfigureEvm<Header = HeaderTy<Types>, Transaction = TxTy<Node::Types>>,
+        Evm: ConfigureEvmFor<Types::Primitives>,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,

--- a/crates/evm/src/aliases.rs
+++ b/crates/evm/src/aliases.rs
@@ -1,0 +1,31 @@
+//! Helper aliases when working with [`NodePrimitives`] and the traits in this crate.
+use crate::{ConfigureEvm, ConfigureEvmEnv};
+use reth_primitives_traits::NodePrimitives;
+
+/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
+/// [`ConfigureEvmEnv`] whose associated types match the [`NodePrimitives`] associated types.
+pub trait ConfigureEvmEnvFor<N: NodePrimitives>:
+    ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>
+{
+}
+
+impl<N, C> ConfigureEvmEnvFor<N> for C
+where
+    N: NodePrimitives,
+    C: ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>,
+{
+}
+
+/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
+/// [`ConfigureEvm`] whose associated types match the [`NodePrimitives`] associated types.
+pub trait ConfigureEvmFor<N: NodePrimitives>:
+    ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
+{
+}
+
+impl<N, C> ConfigureEvmFor<N> for C
+where
+    N: NodePrimitives,
+    C: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+{
+}

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -29,6 +29,9 @@ pub mod env;
 pub mod execute;
 pub use env::EvmEnv;
 
+mod aliases;
+pub use aliases::*;
+
 #[cfg(feature = "std")]
 pub mod metrics;
 pub mod noop;

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -1,6 +1,5 @@
 //! Traits for configuring a node.
 
-use crate::ConfigureEvm;
 use alloy_rpc_types_engine::JwtSecret;
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_db_api::{
@@ -8,10 +7,10 @@ use reth_db_api::{
     Database,
 };
 use reth_engine_primitives::BeaconConsensusEngineHandle;
-use reth_evm::execute::BlockExecutorProvider;
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
-use reth_node_types::{HeaderTy, NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine, TxTy};
+use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine, TxTy};
 use reth_payload_builder_primitives::PayloadBuilder;
 use reth_provider::FullProvider;
 use reth_tasks::TaskExecutor;
@@ -52,7 +51,7 @@ pub trait FullNodeComponents: FullNodeTypes + Clone + 'static {
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvm<Header = HeaderTy<Self::Types>, Transaction = TxTy<Self::Types>>;
+    type Evm: ConfigureEvmFor<<Self::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <Self::Types as NodeTypes>::Primitives>;

--- a/crates/node/builder/src/aliases.rs
+++ b/crates/node/builder/src/aliases.rs
@@ -1,6 +1,5 @@
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv};
 use reth_network::NetworkPrimitives;
-use reth_node_api::{BlockBody, NodePrimitives};
+use reth_node_api::BlockBody;
 use reth_provider::BlockReader;
 
 /// This is a type alias to make type bounds simpler, when we have a [`NetworkPrimitives`] and need
@@ -24,33 +23,5 @@ where
         Transaction = <N::BlockBody as BlockBody>::Transaction,
         Receipt = N::Receipt,
     >,
-{
-}
-
-/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
-/// [`ConfigureEvmEnv`] whose associated types match the [`NodePrimitives`] associated types.
-pub trait ConfigureEvmEnvFor<N: NodePrimitives>:
-    ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>
-{
-}
-
-impl<N, C> ConfigureEvmEnvFor<N> for C
-where
-    N: NodePrimitives,
-    C: ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>,
-{
-}
-
-/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
-/// [`ConfigureEvm`] whose associated types match the [`NodePrimitives`] associated types.
-pub trait ConfigureEvmFor<N: NodePrimitives>:
-    ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
-{
-}
-
-impl<N, C> ConfigureEvmFor<N> for C
-where
-    N: NodePrimitives,
-    C: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
 {
 }

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -5,10 +5,10 @@ use crate::{
         Components, ConsensusBuilder, ExecutorBuilder, NetworkBuilder, NodeComponents,
         PayloadServiceBuilder, PoolBuilder,
     },
-    BuilderContext, ConfigureEvm, FullNodeTypes,
+    BuilderContext, FullNodeTypes,
 };
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::execute::BlockExecutorProvider;
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
 use reth_network::NetworkPrimitives;
 use reth_node_api::{BlockTy, BodyTy, HeaderTy, NodeTypes, NodeTypesWithEngine, TxTy};
 use reth_payload_builder::PayloadBuilderHandle;
@@ -405,7 +405,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: ConfigureEvm<Header = HeaderTy<Node::Types>, Transaction = TxTy<Node::Types>>,
+    EVM: ConfigureEvmFor<<Node::Types as NodeTypes>::Primitives>,
     Executor: BlockExecutorProvider<Primitives = <Node::Types as NodeTypes>::Primitives>,
     Cons: FullConsensus<<Node::Types as NodeTypes>::Primitives, Error = ConsensusError>
         + Clone

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -1,7 +1,7 @@
 //! EVM component for the node builder.
 use crate::{BuilderContext, FullNodeTypes};
-use reth_evm::execute::BlockExecutorProvider;
-use reth_node_api::{ConfigureEvm, HeaderTy, TxTy};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
+use reth_node_api::NodeTypes;
 use std::future::Future;
 
 /// A type that knows how to build the executor types.
@@ -9,7 +9,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
     /// The EVM config to use.
     ///
     /// This provides the node with the necessary configuration to configure an EVM.
-    type EVM: ConfigureEvm<Header = HeaderTy<Node::Types>, Transaction = TxTy<Node::Types>>;
+    type EVM: ConfigureEvmFor<<Node::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<
@@ -26,7 +26,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
 impl<Node, F, Fut, EVM, Executor> ExecutorBuilder<Node> for F
 where
     Node: FullNodeTypes,
-    EVM: ConfigureEvm<Header = HeaderTy<Node::Types>, Transaction = TxTy<Node::Types>>,
+    EVM: ConfigureEvmFor<<Node::Types as NodeTypes>::Primitives>,
     Executor:
         BlockExecutorProvider<Primitives = <Node::Types as reth_node_api::NodeTypes>::Primitives>,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -24,7 +24,7 @@ use reth_network_p2p::BlockClient;
 
 use crate::{ConfigureEvm, FullNodeTypes};
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::execute::BlockExecutorProvider;
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
 use reth_network::{NetworkHandle, NetworkPrimitives};
 use reth_network_api::FullNetwork;
 use reth_node_api::{
@@ -43,7 +43,7 @@ pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'stati
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<T::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvm<Header = HeaderTy<T::Types>, Transaction = TxTy<T::Types>>;
+    type Evm: ConfigureEvmFor<<T::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <T::Types as NodeTypes>::Primitives>;

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -19,7 +19,7 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, SystemCaller},
-    ConfigureEvm, Evm, TxEnvOverrides,
+    ConfigureEvmFor, Evm, TxEnvOverrides,
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::validate_block_post_execution;
@@ -73,12 +73,7 @@ where
         Receipt = OpReceipt,
         SignedTx: OpTransaction,
     >,
-    EvmConfig: Clone
-        + Unpin
-        + Sync
-        + Send
-        + 'static
-        + ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+    EvmConfig: Clone + Unpin + Sync + Send + 'static + ConfigureEvmFor<N>,
 {
     type Primitives = N;
     type Strategy<DB: Database<Error: Into<ProviderError> + Display>> =
@@ -151,7 +146,7 @@ where
         SignedTx: OpTransaction,
         Receipt: DepositReceipt,
     >,
-    EvmConfig: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+    EvmConfig: ConfigureEvmFor<N>,
 {
     type DB = DB;
     type Primitives = N;

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -9,9 +9,9 @@ use crate::{
 use op_alloy_consensus::OpPooledTransaction;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_chainspec::{EthChainSpec, Hardforks};
-use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
+use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvmFor};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
-use reth_node_api::{AddOnsContext, FullNodeComponents, HeaderTy, NodeAddOns, TxTy};
+use reth_node_api::{AddOnsContext, FullNodeComponents, NodeAddOns, TxTy};
 use reth_node_builder::{
     components::{
         ComponentsBuilder, ConsensusBuilder, ExecutorBuilder, NetworkBuilder,
@@ -484,7 +484,7 @@ where
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,
-        Evm: ConfigureEvm<Header = HeaderTy<Node::Types>, Transaction = TxTy<Node::Types>>,
+        Evm: ConfigureEvmFor<<Node::Types as NodeTypes>::Primitives>,
     {
         let payload_builder = reth_optimism_payload_builder::OpPayloadBuilder::with_builder_config(
             evm_config,


### PR DESCRIPTION
This trait was actually not in a place where it could be used properly (it would have caused cyclic deps), it's now moved to `reth_evm` where the `ConfigureEvm` trait actually is. the evm crate also imports primitives-traits, so we can define it there for no extra deps on `ConfigureEvm` consumers. Node-builder only really makes sense when we need to connect e.g. reth-provider and network.