### PR TITLE
chore: use builtin launch fn for opnode

### DIFF
--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -5,8 +5,6 @@
 use clap::Parser;
 use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
 use reth_optimism_node::{args::RollupArgs, OpNode};
-
-use tracing as _;
 use tracing::info;
 
 #[global_allocator]

--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -3,12 +3,11 @@
 #![cfg(feature = "optimism")]
 
 use clap::Parser;
-use reth_node_builder::{engine_tree_config::TreeConfig, EngineNodeLauncher, Node};
 use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
 use reth_optimism_node::{args::RollupArgs, OpNode};
-use reth_provider::providers::BlockchainProvider;
 
 use tracing as _;
+use tracing::info;
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
@@ -23,29 +22,8 @@ fn main() {
 
     if let Err(err) =
         Cli::<OpChainSpecParser, RollupArgs>::parse().run(|builder, rollup_args| async move {
-            let engine_tree_config = TreeConfig::default()
-                .with_persistence_threshold(builder.config().engine.persistence_threshold)
-                .with_memory_block_buffer_target(builder.config().engine.memory_block_buffer_target)
-                .with_state_root_task(builder.config().engine.state_root_task_enabled)
-                .with_always_compare_trie_updates(
-                    builder.config().engine.state_root_task_compare_updates,
-                );
-
-            let op_node = OpNode::new(rollup_args.clone());
-            let handle = builder
-                .with_types_and_provider::<OpNode, BlockchainProvider<_>>()
-                .with_components(op_node.components())
-                .with_add_ons(op_node.add_ons())
-                .launch_with_fn(|builder| {
-                    let launcher = EngineNodeLauncher::new(
-                        builder.task_executor().clone(),
-                        builder.config().datadir(),
-                        engine_tree_config,
-                    );
-                    builder.launch_with(launcher)
-                })
-                .await?;
-
+            info!(target: "reth::cli", "Launching node");
+            let handle = builder.launch_node(OpNode::new(rollup_args)).await?;
             handle.node_exit_future.await
         })
     {


### PR DESCRIPTION
we relaxed some nodebuilder trait requirements in #13895 and can now use the builtin launch fn
