### PR TITLE
feat: add transactions_recovered iter

### DIFF
--- a/crates/primitives-traits/src/block/recovered.rs
+++ b/crates/primitives-traits/src/block/recovered.rs
@@ -291,9 +291,17 @@ impl<B: Block> RecoveredBlock<B> {
         self.senders.iter().zip(self.block.body().transactions())
     }
 
-    /// Returns an iterator over all transactions in the block.
+    /// Returns an iterator over `Recovered<&Transaction>`
     #[inline]
-    pub fn into_transactions_ecrecovered(
+    pub fn transactions_recovered(
+        &self,
+    ) -> impl Iterator<Item = Recovered<&'_ <B::Body as BlockBody>::Transaction>> {
+        self.transactions_with_sender().map(|(sender, tx)| Recovered::new_unchecked(tx, *sender))
+    }
+
+    /// Consumes the type and returns an iterator over all [`Recovered`] transactions in the block.
+    #[inline]
+    pub fn into_transactions_recovered(
         self,
     ) -> impl Iterator<Item = Recovered<<B::Body as BlockBody>::Transaction>> {
         self.block

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -872,7 +872,7 @@ where
             .block_with_senders_by_id(block_id, TransactionVariant::NoHash)
             .to_rpc_result()?
             .unwrap_or_default();
-        Ok(block.into_transactions_ecrecovered().map(|tx| tx.encoded_2718().into()).collect())
+        Ok(block.into_transactions_recovered().map(|tx| tx.encoded_2718().into()).collect())
     }
 
     /// Handler for `debug_getRawReceipts`


### PR DESCRIPTION
adds a helper function that returns `Recovered<&Tx>`, which can be beneficial since most tx traits are also implemented for &Tx