### PR TITLE
chore(ci): set --rpc.eth-proof-window for kurtosis-op

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -1,6 +1,8 @@
 ethereum_package:
   participants:
     - el_type: reth
+      el_extra_params:
+        - "--rpc.eth-proof-window 100"
       cl_type: lighthouse
 optimism_package:
   chains:


### PR DESCRIPTION
Failed build: https://github.com/paradigmxyz/reth/actions/runs/12898439809, in the logs:

`t=2025-01-22T00:42:27+0000 lvl=crit msg="Application failed" message="failed to setup: unable to create the rollup node: failed to init the runtime config: failed to load runtime configuration repeatedly, last error: operation failed permanently after 5 attempts: failed to fetch unsafe block signing address from system config: failed to fetch proof of storage slot 0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08 at block 0x68d7469a2cf13687976be0d9cd40824a6e792f0ffdd11ba0277b984b4c983419: distance to target block exceeds maximum proof window"`

this is from one of the L2 op-node trying to get proofs from L1's reth. The changes in this PR set `--rpc.eth-proof-window` for L1's reth to a value high enough.