### PR TITLE
chore: remove broken link layout.md

### DIFF
--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -82,7 +82,6 @@ The networking component mainly lives in [`net/network`](../../crates/net/networ
 Different consensus mechanisms.
 
 - [`consensus/common`](../../crates/consensus/common): Common consensus functions and traits (e.g. fee calculation)
-- [`consensus/beacon`](../../crates/consensus/beacon): Consensus mechanism that handles messages from a beacon node ("eth2")
 
 ### Execution
 


### PR DESCRIPTION
Hi! Removed an incorrect link in `layout.md` that pointed to a missing file. The change was made based on the discussion and information from [reth PR #13723](https://github.com/paradigmxyz/reth/pull/13723). The file was removed from the repository, and the link is no longer relevant.