### PR TITLE
chore: 404 link `layout.md`

### DIFF
--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -96,7 +96,6 @@ Crates related to transaction execution.
 
 These crates implement the main syncing drivers of reth.
 
-- [`blockchain-tree`](../../crates/blockchain-tree): A tree-like structure for handling multiple chains of unfinalized blocks. This is the main component during live sync (i.e. syncing at the tip)
 - [`stages`](../../crates/stages): A pipelined sync, including implementation of various stages. This is used during initial sync and is faster than the tree-like structure for longer sync ranges.
 
 ### RPC


### PR DESCRIPTION
Hi! I noticed a broken link in `layout.md` pointing to a file that no longer exists in the repository. Based on the updates from [#13731](https://github.com/paradigmxyz/reth/pull/13731).