### PR TITLE
draft(optimism): sendRawTransactionConditional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8422,6 +8422,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "arbitrary",
  "bytes",
  "derive_more",

--- a/crates/optimism/node/src/args.rs
+++ b/crates/optimism/node/src/args.rs
@@ -10,6 +10,10 @@ pub struct RollupArgs {
     #[arg(long = "rollup.sequencer-http", value_name = "HTTP_URL")]
     pub sequencer_http: Option<String>,
 
+    /// Enable transaction conditional support on sequencer
+    #[arg(long = "rollup.sequencer-transaction-conditional-enabled", default_value = "false")]
+    pub sequencer_transaction_conditional_enabled: bool,
+
     /// Disable transaction pool gossip
     #[arg(long = "rollup.disable-tx-pool-gossip")]
     pub disable_txpool_gossip: bool,

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -46,6 +46,13 @@ pub struct OpPooledTransaction {
     inner: EthPooledTransaction<OpTransactionSigned>,
     /// The estimated size of this transaction, lazily computed.
     estimated_tx_compressed_size: OnceLock<u64>,
+
+    /// Optional conditional attached to this transaction. Is this
+    /// needed if this field is on OpTransactionSigned?
+    conditional: Option<TransactionConditional>,
+
+    /// Indiciator if this transaction has been marked as rejected
+    rejected: AtomicBool // (is AtomicBool appropriate here?)
 }
 
 impl OpPooledTransaction {
@@ -54,6 +61,7 @@ impl OpPooledTransaction {
         Self {
             inner: EthPooledTransaction::new(transaction, encoded_length),
             estimated_tx_compressed_size: Default::default(),
+            conditional: None,
         }
     }
 
@@ -64,6 +72,21 @@ impl OpPooledTransaction {
         *self
             .estimated_tx_compressed_size
             .get_or_init(|| tx_estimated_size_fjord(&self.inner.transaction().encoded_2718()))
+    }
+
+    // TODO: Setter with the conditional
+    pub fn conditional(&self) -> Option<&TransactionConditional> {
+        self.conditional.as_ref()
+    }
+
+    /// Mark this transaction as rejected
+    pub fn reject(&self) {
+        self.rejected.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns true if this transaction has been marked as rejected
+    pub fn rejected(&self) -> bool {
+        self.rejected.load(Ordering::Relaxed)
     }
 }
 
@@ -343,6 +366,19 @@ where
             )
         }
 
+        // If validated at the RPC layer pre-submission, this is not needed. The pool simply
+        // needs handle the rejected status on the pooled transaction set by the builder
+        if let Some(conditional) = transaction.conditional() {
+            //let client = self.client();
+            //let header = client.latest_header()?.header();
+            //if !conditional.matches_block_number(header.number()) {
+            //    return TransactionValidationOutcome::Invalid(
+            //        transaction,
+            //        InvalidTransactionError::TxTypeNotSupported.into(),
+            //    )
+            //}
+        }
+
         let outcome = self.inner.validate_one(origin, transaction);
 
         if !self.requires_l1_data_gas_fee() {
@@ -387,6 +423,13 @@ where
                     .into(),
                 )
             }
+
+            // Conditional transactions should not be propagated
+            // let propagate = if transaction.transaction_conditional().is_some() {
+            //     false
+            // } else {
+            //     propagate
+            // };
 
             return TransactionValidationOutcome::Valid {
                 balance,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -873,6 +873,17 @@ where
                 return Ok(Some(()))
             }
 
+            // check the conditional if present on the transaction
+            if let Some(conditional) = tx.transaction_conditional() {
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+
+                // This rejected transaction should be removed by the pool. Can we effectively
+                // do this with the pool wrapper? Can `best_transactions` yield non-rejected txs
+                tx.reject();
+
+                continue
+            }
+
             // Configure the environment for the tx.
             let tx_env = self.evm_config.tx_env(tx.tx(), tx.signer());
 

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -21,6 +21,7 @@ reth-zstd-compressors = { workspace = true, optional = true }
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true
+alloy-rpc-types-eth.workspace = true
 alloy-eips.workspace = true
 revm-primitives = { workspace = true, optional = true }
 secp256k1 = { workspace = true, optional = true }


### PR DESCRIPTION
Leaving a few comments in the different places that might require changes. Will flesh out an implementation after a soft approval/guidance in the right direction

1. `OpTransactionSigned` / `OpPooledTransaction`. References to `conditional` and notion of `rejected`
    - The builder interfaces with `OpTransactionSigned`. We need reference to the conditional to validate during `execute_best_transactions` and a means to invalidate from the pool.
 
2. `L2EthApiExt` & `OpTransactionSigned`: Can the conditional be attached as an optional field on the deserialized tx? This way `pool::add_transaction` is simply used. Or should a pool wrapper have a separate interface for submission.

3. PoolWrapper -> If we wrap the `Pool` interface, should this filter out the rejected txs and in a background task remove them from the pool?
    - We could implement the validation logic in `validate_one` which would duplicate the conditional checks
