### PR TITLE
perf: remove TrieUpdates::removed_nodes and StorageTrieUpdates::removed_nodes (attempt 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6527,6 +6527,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "codspeed-criterion-compat",
  "derive_more",
  "metrics",
  "parking_lot",

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -197,9 +197,9 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         // Compare updates
         let mut in_mem_mismatched = Vec::new();
         let mut incremental_mismatched = Vec::new();
-        let mut in_mem_updates_iter = in_memory_updates.account_nodes_ref().iter().peekable();
+        let mut in_mem_updates_iter = in_memory_updates.changed_nodes_ref().iter().peekable();
         let mut incremental_updates_iter =
-            incremental_trie_updates.account_nodes_ref().iter().peekable();
+            incremental_trie_updates.changed_nodes_ref().iter().peekable();
 
         while in_mem_updates_iter.peek().is_some() || incremental_updates_iter.peek().is_some() {
             match (in_mem_updates_iter.next(), incremental_updates_iter.next()) {

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -52,6 +52,7 @@ reth-testing-utils.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 alloy-consensus.workspace = true
+criterion.workspace = true
 rand.workspace = true
 
 [features]
@@ -65,3 +66,7 @@ test-utils = [
     "reth-trie/test-utils",
     "revm/test-utils",
 ]
+
+[[bench]]
+name = "trie_state"
+harness = false

--- a/crates/chain-state/benches/trie_state.rs
+++ b/crates/chain-state/benches/trie_state.rs
@@ -1,0 +1,296 @@
+//! Usage: `cargo bench --package reth-chain-state --bench trie_state`
+
+#![allow(missing_docs)]
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use alloy_primitives::{Address, B256, U256};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{seq::SliceRandom, Rng};
+use reth_chain_state::{
+    ExecutedBlock, ExecutedBlockWithTrieUpdates, MemoryOverlayStateProviderRef,
+};
+use reth_primitives::{Account, NodePrimitives};
+use reth_storage_api::{noop::NoopProvider, StorageRootProvider};
+use reth_trie::{
+    updates::{StorageTrieUpdates, TrieUpdates},
+    BranchNodeCompact, HashedPostState, HashedStorage, Nibbles,
+};
+
+struct HashedPostStateFactory {
+    num_updated_accounts: usize,
+    num_removed_accounts: usize,
+    hashed_address_choices: Vec<B256>,
+    num_storages: usize,
+    num_changes_per_storage: usize,
+    storage_key_choices: Vec<B256>,
+}
+
+impl HashedPostStateFactory {
+    fn erc20() -> Self {
+        Self {
+            num_updated_accounts: 30000,
+            num_removed_accounts: 0,
+            hashed_address_choices: (0..100000).map(|_| B256::random()).collect(),
+            num_storages: 30000,
+            num_changes_per_storage: 1,
+            storage_key_choices: vec![B256::random()],
+        }
+    }
+
+    fn raw_transfer() -> Self {
+        Self {
+            num_updated_accounts: 75000,
+            num_removed_accounts: 0,
+            hashed_address_choices: (0..100000).map(|_| B256::random()).collect(),
+            num_storages: 75000,
+            num_changes_per_storage: 0,
+            storage_key_choices: Vec::new(),
+        }
+    }
+
+    fn uniswap() -> Self {
+        Self {
+            num_updated_accounts: 6360,
+            num_removed_accounts: 0,
+            hashed_address_choices: (0..100000).map(|_| B256::random()).collect(),
+            num_storages: 6360,
+            num_changes_per_storage: 3,
+            storage_key_choices: vec![B256::random(), B256::random(), B256::random()],
+        }
+    }
+
+    fn generate<R: Rng>(&self, rng: &mut R) -> HashedPostState {
+        HashedPostState {
+            accounts: self
+                .hashed_address_choices
+                .choose_multiple(rng, self.num_updated_accounts + self.num_removed_accounts)
+                .enumerate()
+                .map(|(i, k)| (*k, (i < self.num_updated_accounts).then_some(Account::default())))
+                .collect(),
+            storages: self
+                .hashed_address_choices
+                .choose_multiple(rng, self.num_storages)
+                .map(|k| {
+                    (
+                        *k,
+                        HashedStorage {
+                            wiped: false,
+                            storage: self
+                                .storage_key_choices
+                                .choose_multiple(rng, self.num_changes_per_storage)
+                                .map(|k| (*k, U256::ZERO))
+                                .collect(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+struct TrieUpdatesFactory {
+    num_updated_nodes: usize,
+    num_removed_nodes: usize,
+    account_nibbles_choices: Vec<Nibbles>,
+    num_storage_tries: usize,
+    hashed_address_choices: Vec<B256>,
+    storage_nibbles_choices: Vec<Nibbles>,
+    num_updated_nodes_per_storage_trie: usize,
+    num_removed_nodes_per_storage_trie: usize,
+}
+
+impl TrieUpdatesFactory {
+    fn erc20() -> Self {
+        Self {
+            num_updated_nodes: 6600,
+            num_removed_nodes: 0,
+            account_nibbles_choices: (0..7600)
+                .map(|_| Nibbles::unpack(B256::random().as_slice()))
+                .collect(),
+            num_storage_tries: 70000,
+            hashed_address_choices: (0..100000).map(|_| B256::random()).collect(),
+            storage_nibbles_choices: vec![Nibbles::unpack(B256::random().as_slice())],
+            num_updated_nodes_per_storage_trie: 1,
+            num_removed_nodes_per_storage_trie: 0,
+        }
+    }
+
+    fn raw_transfer() -> Self {
+        Self {
+            num_updated_nodes: 7500,
+            num_removed_nodes: 0,
+            account_nibbles_choices: (0..7600)
+                .map(|_| Nibbles::unpack(B256::random().as_slice()))
+                .collect(),
+            num_storage_tries: 100000,
+            hashed_address_choices: (0..100000).map(|_| B256::random()).collect(),
+            storage_nibbles_choices: Vec::new(),
+            num_updated_nodes_per_storage_trie: 0,
+            num_removed_nodes_per_storage_trie: 0,
+        }
+    }
+
+    fn uniswap() -> Self {
+        Self {
+            num_updated_nodes: 4200,
+            num_removed_nodes: 0,
+            account_nibbles_choices: (0..6000)
+                .map(|_| Nibbles::unpack(B256::random().as_slice()))
+                .collect(),
+            num_storage_tries: 32000,
+            hashed_address_choices: (0..60000).map(|_| B256::random()).collect(),
+            storage_nibbles_choices: vec![Nibbles::unpack(B256::random().as_slice())],
+            num_updated_nodes_per_storage_trie: 1,
+            num_removed_nodes_per_storage_trie: 0,
+        }
+    }
+
+    fn generate<R: Rng>(&self, rng: &mut R) -> TrieUpdates {
+        TrieUpdates {
+            changed_nodes: self
+                .account_nibbles_choices
+                .choose_multiple(rng, self.num_updated_nodes + self.num_removed_nodes)
+                .enumerate()
+                .map(|(i, k)| {
+                    (
+                        k.clone(),
+                        (i < self.num_updated_nodes).then_some(BranchNodeCompact::default()),
+                    )
+                })
+                .collect(),
+            storage_tries: self
+                .hashed_address_choices
+                .choose_multiple(rng, self.num_storage_tries)
+                .map(|k| {
+                    (
+                        *k,
+                        StorageTrieUpdates {
+                            is_deleted: false,
+                            changed_nodes: (self
+                                .storage_nibbles_choices
+                                .choose_multiple(
+                                    rng,
+                                    self.num_updated_nodes_per_storage_trie +
+                                        self.num_removed_nodes_per_storage_trie,
+                                )
+                                .enumerate()
+                                .map(|(i, k)| {
+                                    (
+                                        k.clone(),
+                                        (i < self.num_updated_nodes_per_storage_trie)
+                                            .then_some(BranchNodeCompact::default()),
+                                    )
+                                })
+                                .collect()),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+fn generate_erc20_blocks<N: NodePrimitives>(len: usize) -> Vec<ExecutedBlockWithTrieUpdates<N>> {
+    let mut rng = rand::thread_rng();
+    let hashed_post_state_factory = HashedPostStateFactory::erc20();
+    let trie_updates_factory = TrieUpdatesFactory::erc20();
+    (0..len)
+        .map(|_| ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock {
+                recovered_block: Arc::default(),
+                execution_output: Arc::default(),
+                hashed_state: Arc::new(hashed_post_state_factory.generate(&mut rng)),
+            },
+            trie: Arc::new(trie_updates_factory.generate(&mut rng)),
+        })
+        .collect()
+}
+
+fn generate_raw_transfer_blocks<N: NodePrimitives>(
+    len: usize,
+) -> Vec<ExecutedBlockWithTrieUpdates<N>> {
+    let mut rng = rand::thread_rng();
+    let hashed_post_state_factory = HashedPostStateFactory::raw_transfer();
+    let trie_updates_factory = TrieUpdatesFactory::raw_transfer();
+    (0..len)
+        .map(|_| ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock {
+                recovered_block: Arc::default(),
+                execution_output: Arc::default(),
+                hashed_state: Arc::new(hashed_post_state_factory.generate(&mut rng)),
+            },
+            trie: Arc::new(trie_updates_factory.generate(&mut rng)),
+        })
+        .collect()
+}
+
+fn generate_uniswap_blocks<N: NodePrimitives>(len: usize) -> Vec<ExecutedBlockWithTrieUpdates<N>> {
+    let mut rng = rand::thread_rng();
+    let hashed_post_state_factory = HashedPostStateFactory::uniswap();
+    let trie_updates_factory = TrieUpdatesFactory::uniswap();
+    (0..len)
+        .map(|_| ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock {
+                recovered_block: Arc::default(),
+                execution_output: Arc::default(),
+                hashed_state: Arc::new(hashed_post_state_factory.generate(&mut rng)),
+            },
+            trie: Arc::new(trie_updates_factory.generate(&mut rng)),
+        })
+        .collect()
+}
+
+#[inline]
+fn run_trie_state<N: NodePrimitives>(executed_blocks: Vec<ExecutedBlockWithTrieUpdates<N>>) {
+    let provider =
+        MemoryOverlayStateProviderRef::<N>::new(Box::new(NoopProvider::default()), executed_blocks);
+
+    // Because `trie_state` is a private function, instead of calling it, we have to do this:
+    provider.storage_root(Address::ZERO, HashedStorage::default()).unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("ERC20", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let blocks = generate_erc20_blocks(11);
+                let start = Instant::now();
+                run_trie_state::<reth_primitives::EthPrimitives>(black_box(blocks));
+                total += start.elapsed();
+            }
+            total
+        })
+    });
+    c.bench_function("Raw Transfer", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let blocks = generate_raw_transfer_blocks(10);
+                let start = Instant::now();
+                run_trie_state::<reth_primitives::EthPrimitives>(black_box(blocks));
+                total += start.elapsed();
+            }
+            total
+        })
+    });
+    c.bench_function("Uniswap", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let blocks = generate_uniswap_blocks(3);
+                let start = Instant::now();
+                run_trie_state::<reth_primitives::EthPrimitives>(black_box(blocks));
+                total += start.elapsed();
+            }
+            total
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -16,36 +16,29 @@ struct EntryDiff<T> {
     database: T,
 }
 
+#[derive(Debug)]
+struct BranchNodeCompactDiff {
+    task: Option<Option<BranchNodeCompact>>,
+    regular: Option<Option<BranchNodeCompact>>,
+    database: Option<BranchNodeCompact>,
+}
+
 #[derive(Debug, Default)]
 struct TrieUpdatesDiff {
-    account_nodes: HashMap<Nibbles, EntryDiff<Option<BranchNodeCompact>>>,
-    removed_nodes: HashMap<Nibbles, EntryDiff<bool>>,
+    changed_nodes: HashMap<Nibbles, BranchNodeCompactDiff>,
     storage_tries: HashMap<B256, StorageTrieDiffEntry>,
 }
 
 impl TrieUpdatesDiff {
-    fn has_differences(&self) -> bool {
-        !self.account_nodes.is_empty() ||
-            !self.removed_nodes.is_empty() ||
-            !self.storage_tries.is_empty()
+    fn is_empty(&self) -> bool {
+        self.changed_nodes.is_empty() && self.storage_tries.is_empty()
     }
 
     pub(super) fn log_differences(mut self) {
-        if self.has_differences() {
-            for (path, EntryDiff { task, regular, database }) in &mut self.account_nodes {
-                debug!(target: "engine::tree", ?path, ?task, ?regular, ?database, "Difference in account trie updates");
-            }
-
-            for (
-                path,
-                EntryDiff {
-                    task: task_removed,
-                    regular: regular_removed,
-                    database: database_not_exists,
-                },
-            ) in &self.removed_nodes
+        if !self.is_empty() {
+            for (path, BranchNodeCompactDiff { task, regular, database }) in &mut self.changed_nodes
             {
-                debug!(target: "engine::tree", ?path, ?task_removed, ?regular_removed, ?database_not_exists, "Difference in removed account trie nodes");
+                debug!(target: "engine::tree", ?path, ?task, ?regular, ?database, "Difference in account trie updates");
             }
 
             for (address, storage_diff) in self.storage_tries {
@@ -75,21 +68,10 @@ impl StorageTrieDiffEntry {
                     debug!(target: "engine::tree", ?address, ?task, ?regular, ?database, "Difference in storage trie deletion");
                 }
 
-                for (path, EntryDiff { task, regular, database }) in &mut storage_diff.storage_nodes
+                for (path, BranchNodeCompactDiff { task, regular, database }) in
+                    &mut storage_diff.changed_nodes
                 {
                     debug!(target: "engine::tree", ?address, ?path, ?task, ?regular, ?database, "Difference in storage trie updates");
-                }
-
-                for (
-                    path,
-                    EntryDiff {
-                        task: task_removed,
-                        regular: regular_removed,
-                        database: database_not_exists,
-                    },
-                ) in &storage_diff.removed_nodes
-                {
-                    debug!(target: "engine::tree", ?address, ?path, ?task_removed, ?regular_removed, ?database_not_exists, "Difference in removed storage trie nodes");
                 }
             }
         }
@@ -99,15 +81,12 @@ impl StorageTrieDiffEntry {
 #[derive(Debug, Default)]
 struct StorageTrieUpdatesDiff {
     is_deleted: Option<EntryDiff<bool>>,
-    storage_nodes: HashMap<Nibbles, EntryDiff<Option<BranchNodeCompact>>>,
-    removed_nodes: HashMap<Nibbles, EntryDiff<bool>>,
+    changed_nodes: HashMap<Nibbles, BranchNodeCompactDiff>,
 }
 
 impl StorageTrieUpdatesDiff {
-    fn has_differences(&self) -> bool {
-        self.is_deleted.is_some() ||
-            !self.storage_nodes.is_empty() ||
-            !self.removed_nodes.is_empty()
+    fn is_empty(&self) -> bool {
+        self.is_deleted.is_none() && self.changed_nodes.is_empty()
     }
 }
 
@@ -115,58 +94,31 @@ impl StorageTrieUpdatesDiff {
 /// and logs the differences if there's any.
 pub(super) fn compare_trie_updates(
     trie_cursor_factory: impl TrieCursorFactory,
-    task: TrieUpdates,
-    regular: TrieUpdates,
+    mut task: TrieUpdates,
+    mut regular: TrieUpdates,
 ) -> Result<(), DatabaseError> {
-    let mut task = adjust_trie_updates(task);
-    let mut regular = adjust_trie_updates(regular);
-
     let mut diff = TrieUpdatesDiff::default();
 
     // compare account nodes
     let mut account_trie_cursor = trie_cursor_factory.account_trie_cursor()?;
-    for key in task
-        .account_nodes
-        .keys()
-        .chain(regular.account_nodes.keys())
+    for key in Iterator::chain(task.changed_nodes.keys(), regular.changed_nodes.keys())
         .cloned()
         .collect::<BTreeSet<_>>()
     {
-        let (task, regular) = (task.account_nodes.remove(&key), regular.account_nodes.remove(&key));
+        let task = task.changed_nodes.remove(&key);
+        let regular = regular.changed_nodes.remove(&key);
         let database = account_trie_cursor.seek_exact(key.clone())?.map(|x| x.1);
-
-        if !branch_nodes_equal(task.as_ref(), regular.as_ref(), database.as_ref())? {
-            diff.account_nodes.insert(key, EntryDiff { task, regular, database });
+        if !branch_nodes_equal(&task, &regular, &database) {
+            diff.changed_nodes.insert(key, BranchNodeCompactDiff { task, regular, database });
         }
     }
 
-    // compare removed nodes
-    let mut account_trie_cursor = trie_cursor_factory.account_trie_cursor()?;
-    for key in task
-        .removed_nodes
-        .iter()
-        .chain(regular.removed_nodes.iter())
-        .cloned()
-        .collect::<BTreeSet<_>>()
-    {
-        let (task, regular) =
-            (task.removed_nodes.contains(&key), regular.removed_nodes.contains(&key));
-        let database = account_trie_cursor.seek_exact(key.clone())?.is_none();
-        if task != regular {
-            diff.removed_nodes.insert(key, EntryDiff { task, regular, database });
-        }
-    }
-
-    // compare storage tries
-    for key in task
-        .storage_tries
-        .keys()
-        .chain(regular.storage_tries.keys())
+    for key in Iterator::chain(task.storage_tries.keys(), regular.storage_tries.keys())
         .copied()
         .collect::<BTreeSet<_>>()
     {
-        let (mut task, mut regular) =
-            (task.storage_tries.remove(&key), regular.storage_tries.remove(&key));
+        let mut task = task.storage_tries.remove(&key);
+        let mut regular = regular.storage_tries.remove(&key);
         if task != regular {
             if let Some((task, regular)) = task.as_mut().zip(regular.as_mut()) {
                 let storage_diff = compare_storage_trie_updates(
@@ -174,7 +126,7 @@ pub(super) fn compare_trie_updates(
                     task,
                     regular,
                 )?;
-                if storage_diff.has_differences() {
+                if !storage_diff.is_empty() {
                     diff.storage_tries.insert(key, StorageTrieDiffEntry::Value(storage_diff));
                 }
             } else {
@@ -209,68 +161,19 @@ fn compare_storage_trie_updates<C: TrieCursor>(
 
     // compare storage nodes
     let mut storage_trie_cursor = trie_cursor()?;
-    for key in task
-        .storage_nodes
-        .keys()
-        .chain(regular.storage_nodes.keys())
+    for key in Iterator::chain(task.changed_nodes.keys(), regular.changed_nodes.keys())
         .cloned()
         .collect::<BTreeSet<_>>()
     {
-        let (task, regular) = (task.storage_nodes.remove(&key), regular.storage_nodes.remove(&key));
+        let task = task.changed_nodes.remove(&key);
+        let regular = regular.changed_nodes.remove(&key);
         let database = storage_trie_cursor.seek_exact(key.clone())?.map(|x| x.1);
-        if !branch_nodes_equal(task.as_ref(), regular.as_ref(), database.as_ref())? {
-            diff.storage_nodes.insert(key, EntryDiff { task, regular, database });
-        }
-    }
-
-    // compare removed nodes
-    let mut storage_trie_cursor = trie_cursor()?;
-    for key in task
-        .removed_nodes
-        .iter()
-        .chain(regular.removed_nodes.iter())
-        .cloned()
-        .collect::<BTreeSet<_>>()
-    {
-        let (task, regular) =
-            (task.removed_nodes.contains(&key), regular.removed_nodes.contains(&key));
-        let database = storage_trie_cursor.seek_exact(key.clone())?.map(|x| x.1).is_none();
-        if task != regular {
-            diff.removed_nodes.insert(key, EntryDiff { task, regular, database });
+        if !branch_nodes_equal(&task, &regular, &database) {
+            diff.changed_nodes.insert(key, BranchNodeCompactDiff { task, regular, database });
         }
     }
 
     Ok(diff)
-}
-
-/// Filters the removed nodes of both account trie updates and storage trie updates, so that they
-/// don't include those nodes that were also updated.
-fn adjust_trie_updates(trie_updates: TrieUpdates) -> TrieUpdates {
-    TrieUpdates {
-        removed_nodes: trie_updates
-            .removed_nodes
-            .into_iter()
-            .filter(|key| !trie_updates.account_nodes.contains_key(key))
-            .collect(),
-        storage_tries: trie_updates
-            .storage_tries
-            .into_iter()
-            .map(|(address, updates)| {
-                (
-                    address,
-                    StorageTrieUpdates {
-                        removed_nodes: updates
-                            .removed_nodes
-                            .into_iter()
-                            .filter(|key| !updates.storage_nodes.contains_key(key))
-                            .collect(),
-                        ..updates
-                    },
-                )
-            })
-            .collect(),
-        ..trie_updates
-    }
 }
 
 /// Compares the branch nodes from state root task and regular state root calculation.
@@ -280,25 +183,9 @@ fn adjust_trie_updates(trie_updates: TrieUpdates) -> TrieUpdates {
 ///
 /// Returns `true` if they are equal.
 fn branch_nodes_equal(
-    task: Option<&BranchNodeCompact>,
-    regular: Option<&BranchNodeCompact>,
-    database: Option<&BranchNodeCompact>,
-) -> Result<bool, DatabaseError> {
-    Ok(match (task, regular) {
-        (Some(task), Some(regular)) => {
-            task.state_mask == regular.state_mask &&
-                task.tree_mask == regular.tree_mask &&
-                task.hash_mask == regular.hash_mask &&
-                task.hashes == regular.hashes &&
-                task.root_hash == regular.root_hash
-        }
-        (None, None) => true,
-        _ => {
-            if task.is_some() {
-                task == database
-            } else {
-                regular == database
-            }
-        }
-    })
+    task: &Option<Option<BranchNodeCompact>>,
+    regular: &Option<Option<BranchNodeCompact>>,
+    database: &Option<BranchNodeCompact>,
+) -> bool {
+    regular.as_ref().unwrap_or(database) == task.as_ref().unwrap_or(database)
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2306,18 +2306,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
         // Track the number of inserted entries.
         let mut num_entries = 0;
 
-        // Merge updated and removed nodes. Updated nodes must take precedence.
-        let mut account_updates = trie_updates
-            .removed_nodes_ref()
-            .iter()
-            .filter_map(|n| {
-                (!trie_updates.account_nodes_ref().contains_key(n)).then_some((n, None))
-            })
-            .collect::<Vec<_>>();
-        account_updates.extend(
-            trie_updates.account_nodes_ref().iter().map(|(nibbles, node)| (nibbles, Some(node))),
-        );
         // Sort trie node updates.
+        let mut account_updates: Vec<_> = trie_updates.changed_nodes_ref().iter().collect();
         account_updates.sort_unstable_by(|a, b| a.0.cmp(b.0));
 
         let tx = self.tx_ref();

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -11,10 +11,7 @@ use alloy_primitives::{
 pub struct TrieUpdates {
     /// Collection of updated intermediate account nodes indexed by full path.
     #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_map"))]
-    pub account_nodes: HashMap<Nibbles, BranchNodeCompact>,
-    /// Collection of removed intermediate account nodes indexed by full path.
-    #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_set"))]
-    pub removed_nodes: HashSet<Nibbles>,
+    pub changed_nodes: HashMap<Nibbles, Option<BranchNodeCompact>>,
     /// Collection of updated storage tries indexed by the hashed address.
     pub storage_tries: B256HashMap<StorageTrieUpdates>,
 }
@@ -22,19 +19,12 @@ pub struct TrieUpdates {
 impl TrieUpdates {
     /// Returns `true` if the updates are empty.
     pub fn is_empty(&self) -> bool {
-        self.account_nodes.is_empty() &&
-            self.removed_nodes.is_empty() &&
-            self.storage_tries.is_empty()
+        self.changed_nodes.is_empty() && self.storage_tries.is_empty()
     }
 
     /// Returns reference to updated account nodes.
-    pub const fn account_nodes_ref(&self) -> &HashMap<Nibbles, BranchNodeCompact> {
-        &self.account_nodes
-    }
-
-    /// Returns a reference to removed account nodes.
-    pub const fn removed_nodes_ref(&self) -> &HashSet<Nibbles> {
-        &self.removed_nodes
+    pub const fn changed_nodes_ref(&self) -> &HashMap<Nibbles, Option<BranchNodeCompact>> {
+        &self.changed_nodes
     }
 
     /// Returns a reference to updated storage tries.
@@ -44,9 +34,7 @@ impl TrieUpdates {
 
     /// Extends the trie updates.
     pub fn extend(&mut self, other: Self) {
-        self.extend_common(&other);
-        self.account_nodes.extend(exclude_empty_from_pair(other.account_nodes));
-        self.removed_nodes.extend(exclude_empty(other.removed_nodes));
+        self.changed_nodes.extend(exclude_empty_from_pair(other.changed_nodes));
         for (hashed_address, storage_trie) in other.storage_tries {
             self.storage_tries.entry(hashed_address).or_default().extend(storage_trie);
         }
@@ -56,18 +44,12 @@ impl TrieUpdates {
     ///
     /// Slightly less efficient than [`Self::extend`], but preferred to `extend(other.clone())`.
     pub fn extend_ref(&mut self, other: &Self) {
-        self.extend_common(other);
-        self.account_nodes.extend(exclude_empty_from_pair(
-            other.account_nodes.iter().map(|(k, v)| (k.clone(), v.clone())),
+        self.changed_nodes.extend(exclude_empty_from_pair(
+            other.changed_nodes.iter().map(|(k, v)| (k.clone(), v.clone())),
         ));
-        self.removed_nodes.extend(exclude_empty(other.removed_nodes.iter().cloned()));
         for (hashed_address, storage_trie) in &other.storage_tries {
             self.storage_tries.entry(*hashed_address).or_default().extend_ref(storage_trie);
         }
-    }
-
-    fn extend_common(&mut self, other: &Self) {
-        self.account_nodes.retain(|nibbles, _| !other.removed_nodes.contains(nibbles));
     }
 
     /// Insert storage updates for a given hashed address.
@@ -90,12 +72,12 @@ impl TrieUpdates {
         removed_keys: HashSet<Nibbles>,
         destroyed_accounts: B256HashSet,
     ) {
-        // Retrieve updated nodes from hash builder.
+        // Update nodes
         let (_, updated_nodes) = hash_builder.split();
-        self.account_nodes.extend(exclude_empty_from_pair(updated_nodes));
-
-        // Add deleted node paths.
-        self.removed_nodes.extend(exclude_empty(removed_keys));
+        self.changed_nodes.extend(Iterator::chain(
+            exclude_empty(removed_keys).map(|k| (k, None)), // first
+            exclude_empty_from_pair(updated_nodes).map(|(k, v)| (k, Some(v))), // second
+        ));
 
         // Add deleted storage tries for destroyed accounts.
         for destroyed in destroyed_accounts {
@@ -105,14 +87,25 @@ impl TrieUpdates {
 
     /// Converts trie updates into [`TrieUpdatesSorted`].
     pub fn into_sorted(self) -> TrieUpdatesSorted {
-        let mut account_nodes = Vec::from_iter(self.account_nodes);
+        let mut removed_nodes = HashSet::default();
+        let mut account_nodes = Vec::new();
+
+        for (k, v) in self.changed_nodes {
+            if let Some(v) = v {
+                account_nodes.push((k, v));
+            } else {
+                removed_nodes.insert(k);
+            }
+        }
+
         account_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
         let storage_tries = self
             .storage_tries
             .into_iter()
             .map(|(hashed_address, updates)| (hashed_address, updates.into_sorted()))
             .collect();
-        TrieUpdatesSorted { removed_nodes: self.removed_nodes, account_nodes, storage_tries }
+        TrieUpdatesSorted { removed_nodes, account_nodes, storage_tries }
     }
 }
 
@@ -124,33 +117,26 @@ pub struct StorageTrieUpdates {
     pub is_deleted: bool,
     /// Collection of updated storage trie nodes.
     #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_map"))]
-    pub storage_nodes: HashMap<Nibbles, BranchNodeCompact>,
-    /// Collection of removed storage trie nodes.
-    #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_set"))]
-    pub removed_nodes: HashSet<Nibbles>,
+    pub changed_nodes: HashMap<Nibbles, Option<BranchNodeCompact>>,
 }
 
 #[cfg(feature = "test-utils")]
 impl StorageTrieUpdates {
     /// Creates a new storage trie updates that are not marked as deleted.
-    pub fn new(updates: impl IntoIterator<Item = (Nibbles, BranchNodeCompact)>) -> Self {
-        Self { storage_nodes: exclude_empty_from_pair(updates).collect(), ..Default::default() }
+    pub fn new(updates: impl IntoIterator<Item = (Nibbles, Option<BranchNodeCompact>)>) -> Self {
+        Self { changed_nodes: exclude_empty_from_pair(updates).collect(), ..Default::default() }
     }
 }
 
 impl StorageTrieUpdates {
     /// Returns empty storage trie updates with `deleted` set to `true`.
     pub fn deleted() -> Self {
-        Self {
-            is_deleted: true,
-            storage_nodes: HashMap::default(),
-            removed_nodes: HashSet::default(),
-        }
+        Self { is_deleted: true, changed_nodes: HashMap::default() }
     }
 
     /// Returns the length of updated nodes.
     pub fn len(&self) -> usize {
-        (self.is_deleted as usize) + self.storage_nodes.len() + self.removed_nodes.len()
+        (self.is_deleted as usize) + self.changed_nodes.len()
     }
 
     /// Returns `true` if the trie was deleted.
@@ -159,18 +145,13 @@ impl StorageTrieUpdates {
     }
 
     /// Returns reference to updated storage nodes.
-    pub const fn storage_nodes_ref(&self) -> &HashMap<Nibbles, BranchNodeCompact> {
-        &self.storage_nodes
-    }
-
-    /// Returns reference to removed storage nodes.
-    pub const fn removed_nodes_ref(&self) -> &HashSet<Nibbles> {
-        &self.removed_nodes
+    pub const fn changed_nodes_ref(&self) -> &HashMap<Nibbles, Option<BranchNodeCompact>> {
+        &self.changed_nodes
     }
 
     /// Returns `true` if storage updates are empty.
     pub fn is_empty(&self) -> bool {
-        !self.is_deleted && self.storage_nodes.is_empty() && self.removed_nodes.is_empty()
+        !self.is_deleted && self.changed_nodes.is_empty()
     }
 
     /// Sets `deleted` flag on the storage trie.
@@ -181,8 +162,7 @@ impl StorageTrieUpdates {
     /// Extends storage trie updates.
     pub fn extend(&mut self, other: Self) {
         self.extend_common(&other);
-        self.storage_nodes.extend(exclude_empty_from_pair(other.storage_nodes));
-        self.removed_nodes.extend(exclude_empty(other.removed_nodes));
+        self.changed_nodes.extend(exclude_empty_from_pair(other.changed_nodes));
     }
 
     /// Extends storage trie updates.
@@ -190,80 +170,41 @@ impl StorageTrieUpdates {
     /// Slightly less efficient than [`Self::extend`], but preferred to `extend(other.clone())`.
     pub fn extend_ref(&mut self, other: &Self) {
         self.extend_common(other);
-        self.storage_nodes.extend(exclude_empty_from_pair(
-            other.storage_nodes.iter().map(|(k, v)| (k.clone(), v.clone())),
+        self.changed_nodes.extend(exclude_empty_from_pair(
+            other.changed_nodes.iter().map(|(k, v)| (k.clone(), v.clone())),
         ));
-        self.removed_nodes.extend(exclude_empty(other.removed_nodes.iter().cloned()));
     }
 
     fn extend_common(&mut self, other: &Self) {
         if other.is_deleted {
-            self.storage_nodes.clear();
-            self.removed_nodes.clear();
+            self.changed_nodes.clear();
         }
         self.is_deleted |= other.is_deleted;
-        self.storage_nodes.retain(|nibbles, _| !other.removed_nodes.contains(nibbles));
     }
 
     /// Finalize storage trie updates for by taking updates from walker and hash builder.
     pub fn finalize(&mut self, hash_builder: HashBuilder, removed_keys: HashSet<Nibbles>) {
         // Retrieve updated nodes from hash builder.
         let (_, updated_nodes) = hash_builder.split();
-        self.storage_nodes.extend(exclude_empty_from_pair(updated_nodes));
-
-        // Add deleted node paths.
-        self.removed_nodes.extend(exclude_empty(removed_keys));
+        self.changed_nodes.extend(Iterator::chain(
+            exclude_empty(removed_keys).map(|k| (k, None)), // first
+            exclude_empty_from_pair(updated_nodes).map(|(k, v)| (k, Some(v))), // second
+        ));
     }
 
     /// Convert storage trie updates into [`StorageTrieUpdatesSorted`].
     pub fn into_sorted(self) -> StorageTrieUpdatesSorted {
-        let mut storage_nodes = Vec::from_iter(self.storage_nodes);
-        storage_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-        StorageTrieUpdatesSorted {
-            is_deleted: self.is_deleted,
-            removed_nodes: self.removed_nodes,
-            storage_nodes,
+        let mut storage_nodes = Vec::new();
+        let mut removed_nodes = HashSet::default();
+        for (k, v) in self.changed_nodes {
+            if let Some(v) = v {
+                storage_nodes.push((k, v))
+            } else {
+                removed_nodes.insert(k);
+            }
         }
-    }
-}
-
-/// Serializes and deserializes any [`HashSet`] that includes [`Nibbles`] elements, by using the
-/// hex-encoded packed representation.
-///
-/// This also sorts the set before serializing.
-#[cfg(any(test, feature = "serde"))]
-mod serde_nibbles_set {
-    use crate::Nibbles;
-    use alloc::{
-        string::{String, ToString},
-        vec::Vec,
-    };
-    use alloy_primitives::map::HashSet;
-    use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-
-    pub(super) fn serialize<S>(map: &HashSet<Nibbles>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut storage_nodes =
-            map.iter().map(|elem| alloy_primitives::hex::encode(elem.pack())).collect::<Vec<_>>();
-        storage_nodes.sort_unstable();
-        storage_nodes.serialize(serializer)
-    }
-
-    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<HashSet<Nibbles>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Vec::<String>::deserialize(deserializer)?
-            .into_iter()
-            .map(|node| {
-                Ok(Nibbles::unpack(
-                    alloy_primitives::hex::decode(node)
-                        .map_err(|err| D::Error::custom(err.to_string()))?,
-                ))
-            })
-            .collect::<Result<HashSet<_>, _>>()
+        storage_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        StorageTrieUpdatesSorted { is_deleted: self.is_deleted, removed_nodes, storage_nodes }
     }
 }
 
@@ -424,7 +365,7 @@ fn exclude_empty_from_pair<V>(
 pub mod serde_bincode_compat {
     use crate::{BranchNodeCompact, Nibbles};
     use alloc::borrow::Cow;
-    use alloy_primitives::map::{B256HashMap, HashMap, HashSet};
+    use alloy_primitives::map::{B256HashMap, HashMap};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
@@ -445,16 +386,14 @@ pub mod serde_bincode_compat {
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
     pub struct TrieUpdates<'a> {
-        account_nodes: Cow<'a, HashMap<Nibbles, BranchNodeCompact>>,
-        removed_nodes: Cow<'a, HashSet<Nibbles>>,
+        changed_nodes: Cow<'a, HashMap<Nibbles, Option<BranchNodeCompact>>>,
         storage_tries: B256HashMap<StorageTrieUpdates<'a>>,
     }
 
     impl<'a> From<&'a super::TrieUpdates> for TrieUpdates<'a> {
         fn from(value: &'a super::TrieUpdates) -> Self {
             Self {
-                account_nodes: Cow::Borrowed(&value.account_nodes),
-                removed_nodes: Cow::Borrowed(&value.removed_nodes),
+                changed_nodes: Cow::Borrowed(&value.changed_nodes),
                 storage_tries: value.storage_tries.iter().map(|(k, v)| (*k, v.into())).collect(),
             }
         }
@@ -463,8 +402,7 @@ pub mod serde_bincode_compat {
     impl<'a> From<TrieUpdates<'a>> for super::TrieUpdates {
         fn from(value: TrieUpdates<'a>) -> Self {
             Self {
-                account_nodes: value.account_nodes.into_owned(),
-                removed_nodes: value.removed_nodes.into_owned(),
+                changed_nodes: value.changed_nodes.into_owned(),
                 storage_tries: value
                     .storage_tries
                     .into_iter()
@@ -510,27 +448,21 @@ pub mod serde_bincode_compat {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct StorageTrieUpdates<'a> {
         is_deleted: bool,
-        storage_nodes: Cow<'a, HashMap<Nibbles, BranchNodeCompact>>,
-        removed_nodes: Cow<'a, HashSet<Nibbles>>,
+        changed_nodes: Cow<'a, HashMap<Nibbles, Option<BranchNodeCompact>>>,
     }
 
     impl<'a> From<&'a super::StorageTrieUpdates> for StorageTrieUpdates<'a> {
         fn from(value: &'a super::StorageTrieUpdates) -> Self {
             Self {
                 is_deleted: value.is_deleted,
-                storage_nodes: Cow::Borrowed(&value.storage_nodes),
-                removed_nodes: Cow::Borrowed(&value.removed_nodes),
+                changed_nodes: Cow::Borrowed(&value.changed_nodes),
             }
         }
     }
 
     impl<'a> From<StorageTrieUpdates<'a>> for super::StorageTrieUpdates {
         fn from(value: StorageTrieUpdates<'a>) -> Self {
-            Self {
-                is_deleted: value.is_deleted,
-                storage_nodes: value.storage_nodes.into_owned(),
-                removed_nodes: value.removed_nodes.into_owned(),
-            }
+            Self { is_deleted: value.is_deleted, changed_nodes: value.changed_nodes.into_owned() }
         }
     }
 
@@ -580,14 +512,16 @@ pub mod serde_bincode_compat {
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
             assert_eq!(decoded, data);
 
-            data.trie_updates.removed_nodes.insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]));
+            data.trie_updates
+                .changed_nodes
+                .insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]), None);
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
             assert_eq!(decoded, data);
 
-            data.trie_updates.account_nodes.insert(
+            data.trie_updates.changed_nodes.insert(
                 Nibbles::from_vec(vec![0x0d, 0x0e, 0x0a, 0x0d]),
-                BranchNodeCompact::default(),
+                Some(BranchNodeCompact::default()),
             );
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
@@ -613,14 +547,16 @@ pub mod serde_bincode_compat {
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
             assert_eq!(decoded, data);
 
-            data.trie_updates.removed_nodes.insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]));
+            data.trie_updates
+                .changed_nodes
+                .insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]), None);
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
             assert_eq!(decoded, data);
 
-            data.trie_updates.storage_nodes.insert(
+            data.trie_updates.changed_nodes.insert(
                 Nibbles::from_vec(vec![0x0d, 0x0e, 0x0a, 0x0d]),
-                BranchNodeCompact::default(),
+                Some(BranchNodeCompact::default()),
             );
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
@@ -640,14 +576,15 @@ mod tests {
         let updates_deserialized: TrieUpdates = serde_json::from_str(&updates_serialized).unwrap();
         assert_eq!(updates_deserialized, default_updates);
 
-        default_updates.removed_nodes.insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]));
+        default_updates.changed_nodes.insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]), None);
         let updates_serialized = serde_json::to_string(&default_updates).unwrap();
         let updates_deserialized: TrieUpdates = serde_json::from_str(&updates_serialized).unwrap();
         assert_eq!(updates_deserialized, default_updates);
 
-        default_updates
-            .account_nodes
-            .insert(Nibbles::from_vec(vec![0x0d, 0x0e, 0x0a, 0x0d]), BranchNodeCompact::default());
+        default_updates.changed_nodes.insert(
+            Nibbles::from_vec(vec![0x0d, 0x0e, 0x0a, 0x0d]),
+            Some(BranchNodeCompact::default()),
+        );
         let updates_serialized = serde_json::to_string(&default_updates).unwrap();
         let updates_deserialized: TrieUpdates = serde_json::from_str(&updates_serialized).unwrap();
         assert_eq!(updates_deserialized, default_updates);
@@ -666,15 +603,16 @@ mod tests {
             serde_json::from_str(&updates_serialized).unwrap();
         assert_eq!(updates_deserialized, default_updates);
 
-        default_updates.removed_nodes.insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]));
+        default_updates.changed_nodes.insert(Nibbles::from_vec(vec![0x0b, 0x0e, 0x0e, 0x0f]), None);
         let updates_serialized = serde_json::to_string(&default_updates).unwrap();
         let updates_deserialized: StorageTrieUpdates =
             serde_json::from_str(&updates_serialized).unwrap();
         assert_eq!(updates_deserialized, default_updates);
 
-        default_updates
-            .storage_nodes
-            .insert(Nibbles::from_vec(vec![0x0d, 0x0e, 0x0a, 0x0d]), BranchNodeCompact::default());
+        default_updates.changed_nodes.insert(
+            Nibbles::from_vec(vec![0x0d, 0x0e, 0x0a, 0x0d]),
+            Some(BranchNodeCompact::default()),
+        );
         let updates_serialized = serde_json::to_string(&default_updates).unwrap();
         let updates_deserialized: StorageTrieUpdates =
             serde_json::from_str(&updates_serialized).unwrap();

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -127,17 +127,8 @@ where
             self.cursor.delete_current_duplicates()?;
         }
 
-        // Merge updated and removed nodes. Updated nodes must take precedence.
-        let mut storage_updates = updates
-            .removed_nodes_ref()
-            .iter()
-            .filter_map(|n| (!updates.storage_nodes_ref().contains_key(n)).then_some((n, None)))
-            .collect::<Vec<_>>();
-        storage_updates.extend(
-            updates.storage_nodes_ref().iter().map(|(nibbles, node)| (nibbles, Some(node))),
-        );
-
         // Sort trie node updates.
+        let mut storage_updates = updates.changed_nodes_ref().iter().collect::<Vec<_>>();
         storage_updates.sort_unstable_by(|a, b| a.0.cmp(b.0));
 
         let mut num_entries = 0;

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -106,7 +106,9 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                             hb.root();
 
                             let (_, updates) = hb.split();
-                            let trie_updates = StorageTrieUpdates::new(updates);
+                            let trie_updates = StorageTrieUpdates::new(
+                                updates.into_iter().map(|(k, v)| (k, Some(v))),
+                            );
                             (init_storage, storage_updates, trie_updates)
                         },
                         |(init_storage, storage_updates, mut trie_updates)| {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1440,6 +1440,13 @@ mod tests {
         nibbles
     }
 
+    /// Convert `changed_nodes` to `updated_nodes`
+    fn to_updated_nodes(
+        changed_nodes: HashMap<Nibbles, Option<BranchNodeCompact>>,
+    ) -> HashMap<Nibbles, BranchNodeCompact> {
+        changed_nodes.into_iter().filter_map(|(k, v)| v.map(|v| (k, v))).collect()
+    }
+
     /// Calculate the state root by feeding the provided state to the hash builder and retaining the
     /// proofs for the provided targets.
     ///
@@ -1590,7 +1597,10 @@ mod tests {
         let sparse_updates = sparse.take_updates();
 
         assert_eq!(sparse_root, hash_builder_root);
-        assert_eq!(sparse_updates.updated_nodes, hash_builder_updates.account_nodes);
+        assert_eq!(
+            sparse_updates.updated_nodes,
+            to_updated_nodes(hash_builder_updates.changed_nodes)
+        );
         assert_eq_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
     }
 
@@ -1622,7 +1632,10 @@ mod tests {
         let sparse_updates = sparse.take_updates();
 
         assert_eq!(sparse_root, hash_builder_root);
-        assert_eq!(sparse_updates.updated_nodes, hash_builder_updates.account_nodes);
+        assert_eq!(
+            sparse_updates.updated_nodes,
+            to_updated_nodes(hash_builder_updates.changed_nodes)
+        );
         assert_eq_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
     }
 
@@ -1652,7 +1665,10 @@ mod tests {
         let sparse_updates = sparse.take_updates();
 
         assert_eq!(sparse_root, hash_builder_root);
-        assert_eq!(sparse_updates.updated_nodes, hash_builder_updates.account_nodes);
+        assert_eq!(
+            sparse_updates.updated_nodes,
+            to_updated_nodes(hash_builder_updates.changed_nodes)
+        );
         assert_eq_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
     }
 
@@ -1692,7 +1708,7 @@ mod tests {
         assert_eq!(sparse_root, hash_builder_root);
         pretty_assertions::assert_eq!(
             BTreeMap::from_iter(sparse_updates.updated_nodes),
-            BTreeMap::from_iter(hash_builder_updates.account_nodes)
+            BTreeMap::from_iter(to_updated_nodes(hash_builder_updates.changed_nodes))
         );
         assert_eq_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
     }
@@ -1729,7 +1745,10 @@ mod tests {
         let sparse_updates = sparse.updates_ref();
 
         assert_eq!(sparse_root, hash_builder_root);
-        assert_eq!(sparse_updates.updated_nodes, hash_builder_updates.account_nodes);
+        assert_eq!(
+            sparse_updates.updated_nodes,
+            to_updated_nodes(hash_builder_updates.changed_nodes)
+        );
         assert_eq_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
 
         let (hash_builder_root, hash_builder_updates, hash_builder_proof_nodes, _, _) =
@@ -1747,7 +1766,10 @@ mod tests {
         let sparse_updates = sparse.take_updates();
 
         assert_eq!(sparse_root, hash_builder_root);
-        assert_eq!(sparse_updates.updated_nodes, hash_builder_updates.account_nodes);
+        assert_eq!(
+            sparse_updates.updated_nodes,
+            to_updated_nodes(hash_builder_updates.changed_nodes)
+        );
         assert_eq_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
     }
 
@@ -2108,7 +2130,7 @@ mod tests {
                     // Assert that the sparse trie updates match the hash builder updates
                     pretty_assertions::assert_eq!(
                         BTreeMap::from_iter(sparse_updates.updated_nodes),
-                        BTreeMap::from_iter(hash_builder_updates.account_nodes)
+                        BTreeMap::from_iter(to_updated_nodes(hash_builder_updates.changed_nodes))
                     );
                     // Assert that the sparse trie nodes match the hash builder proof nodes
                     assert_eq_sparse_trie_proof_nodes(&updated_sparse, hash_builder_proof_nodes);
@@ -2150,7 +2172,7 @@ mod tests {
                     // Assert that the sparse trie updates match the hash builder updates
                     pretty_assertions::assert_eq!(
                         BTreeMap::from_iter(sparse_updates.updated_nodes),
-                        BTreeMap::from_iter(hash_builder_updates.account_nodes)
+                        BTreeMap::from_iter(to_updated_nodes(hash_builder_updates.changed_nodes))
                     );
                     // Assert that the sparse trie nodes match the hash builder proof nodes
                     assert_eq_sparse_trie_proof_nodes(&updated_sparse, hash_builder_proof_nodes);
@@ -2558,7 +2580,10 @@ mod tests {
         let sparse_updates = sparse.take_updates();
 
         assert_eq!(sparse_root, hash_builder_root);
-        assert_eq!(sparse_updates.updated_nodes, hash_builder_updates.account_nodes);
+        assert_eq!(
+            sparse_updates.updated_nodes,
+            to_updated_nodes(hash_builder_updates.changed_nodes)
+        );
     }
 
     #[test]

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -234,9 +234,13 @@ where
                         hash_builder.updates_len();
                     if retain_updates && total_updates_len as u64 >= self.threshold {
                         let (walker_stack, walker_deleted_keys) = account_node_iter.walker.split();
-                        trie_updates.removed_nodes.extend(walker_deleted_keys);
+                        trie_updates
+                            .changed_nodes
+                            .extend(walker_deleted_keys.into_iter().map(|k| (k, None)));
                         let (hash_builder, hash_builder_updates) = hash_builder.split();
-                        trie_updates.account_nodes.extend(hash_builder_updates);
+                        trie_updates
+                            .changed_nodes
+                            .extend(hash_builder_updates.into_iter().map(|(k, v)| (k, Some(v))));
 
                         let state = IntermediateStateRootState {
                             hash_builder,


### PR DESCRIPTION
Replaces https://github.com/paradigmxyz/reth/pull/13872. This PR is only *slightly* worse than https://github.com/paradigmxyz/reth/pull/13872, but the code changes are minimal.

<details>
<summary>Checklist</summary>

- [x] E2E Benchmarks
- [x] Add `benches/*`
- [x] Improve PR description

</details>

## Motivation

Under high load (TPS > 50,000), `MemoryOverlayStateProviderRef::trie_state` is taking a considerable amount of time (over 200ms). One factor contributing to this is the `TrieUpdates::extend_ref` function. Optimizing the struct definition of `TrieUpdates` could help improve the performance of the `extend_ref` function.

## Solution

First, this PR changes the struct definitions of `TrieUpdates` and `StorageTrieUpdates`:

```diff
pub struct TrieUpdates {
-    pub account_nodes: HashMap<Nibbles, BranchNodeCompact>,
-    pub removed_nodes: HashSet<Nibbles>,
+    pub changed_nodes: HashMap<Nibbles, Option<BranchNodeCompact>>,
     pub storage_tries: B256HashMap<StorageTrieUpdates>,
 }

pub struct StorageTrieUpdates {
     pub is_deleted: bool,
-    pub storage_nodes: HashMap<Nibbles, BranchNodeCompact>,
-    pub removed_nodes: HashSet<Nibbles>,
+    pub changed_nodes: HashMap<Nibbles, Option<BranchNodeCompact>>,
 }
```

Next, this PR replaces the following steps in fn `TrieUpdates::extend_ref`:

1. `self.account_nodes.retain(|nibbles, _| !other.removed_nodes.contains(nibbles));`
2. `self.account_nodes.extend(exclude_empty_from_pair(other.account_nodes.iter().map(|(k, v)| (k.clone(), v.clone()))));`
3. `self.removed_nodes.extend(exclude_empty(other.removed_nodes.iter().cloned()));`

by

1. `self.account_nodes.extend(exclude_empty_from_pair(other.account_nodes.iter().map(|(k, v)| (k.clone(), v.clone()))));`

Similar changes is applied to `StorageTrieUpdates::extend_ref`.

## Criterion Benchmarks

> Note: the current criterion benchmark does not produce very stable results.

<details>
<summary>Outdated</summary>

----
```
[Before]
ERC20                   time:   [503.56 ms 503.85 ms 504.13 ms]
Raw Transfer            time:   [205.55 ms 205.87 ms 206.19 ms]
Uniswap                 time:   [55.124 ms 55.255 ms 55.393 ms]

[After]
ERC20                   time:   [476.01 ms 476.36 ms 476.72 ms]
Raw Transfer            time:   [112.22 ms 112.33 ms 112.49 ms]
Uniswap                 time:   [31.368 ms 31.551 ms 31.738 ms]
```
----

</details>

## E2E Benchmarks

![Total run time for state root calculation](https://github.com/user-attachments/assets/171c70b3-50bd-4490-873c-321f133ddb1f)

(unit: μs) | Before | After | Ratio
-- | -- | -- | --
ERC20 | 559541496 | 515041545 | 0.9204706866
Raw Transfer | 330763242 | 271971019 | 0.8222528518
Uniswap | 1114770107 | 1037325457 | 0.930528591



<details>
<summary>Other benchmarks</summary>

```
"785bc168-9976731c-erc20-30600"
{"tps": 30601.0, "gps": 1056921850.8367347, "is_chain_lagged": false, "chain_lag_distance": 0}
"785bc168-9976731c-erc20-31000"
{"tps": 31001.0, "gps": 1070736094.1406412, "is_chain_lagged": false, "chain_lag_distance": 0}
"785bc168-9976731c-erc20-32000"
{"tps": 32001.0, "gps": 1105272921.4311633, "is_chain_lagged": false, "chain_lag_distance": 1}
"785bc168-9976731c-erc20-33000"
{"tps": 33001.0, "gps": 1139812889.5115511, "is_chain_lagged": false, "chain_lag_distance": 1}
"785bc168-9976731c-erc20-34000"
{"tps": 34001.0, "gps": 1174346187.1292517, "is_chain_lagged": true, "chain_lag_distance": 4}
"785bc168-9976731c-erc20-36000"
{"tps": 36001.0, "gps": 1243424508.7788463, "is_chain_lagged": true, "chain_lag_distance": 20}
"785bc168-9976731c-erc20-40000"
{"tps": 40001.0, "gps": 1381586516.224, "is_chain_lagged": true, "chain_lag_distance": 61}
"785bc168-9976731c-raw-transfer-54600"
{"tps": 54601.0, "gps": 1146644512.2513661, "is_chain_lagged": false, "chain_lag_distance": 1}
"785bc168-9976731c-raw-transfer-55000"
{"tps": 55001.0, "gps": 1155044519.4926472, "is_chain_lagged": false, "chain_lag_distance": 0}
"785bc168-9976731c-raw-transfer-56000"
{"tps": 56001.0, "gps": 1176044515.2560747, "is_chain_lagged": false, "chain_lag_distance": 1}
"785bc168-9976731c-raw-transfer-57000"
{"tps": 57001.0, "gps": 1197044511.5361216, "is_chain_lagged": false, "chain_lag_distance": 0}
"785bc168-9976731c-raw-transfer-58000"
{"tps": 58001.0, "gps": 1218044525.3953488, "is_chain_lagged": false, "chain_lag_distance": 1}
"785bc168-9976731c-raw-transfer-60000"
{"tps": 60001.0, "gps": 1260044514.0, "is_chain_lagged": true, "chain_lag_distance": 5}
"785bc168-9976731c-raw-transfer-64000"
{"tps": 64001.0, "gps": 1344044510.4796574, "is_chain_lagged": true, "chain_lag_distance": 26}
"785bc168-9976731c-uniswap-6330"
{"tps": 6331.0, "gps": 882450529.3786408, "is_chain_lagged": false, "chain_lag_distance": 0}
"785bc168-9976731c-uniswap-6400"
{"tps": 6401.0, "gps": 892212483.2733675, "is_chain_lagged": false, "chain_lag_distance": 0}
"785bc168-9976731c-uniswap-6480"
{"tps": 6481.0, "gps": 903381443.1144955, "is_chain_lagged": false, "chain_lag_distance": 1}
"785bc168-9976731c-uniswap-6500"
{"tps": 6501.0, "gps": 906146040.2489707, "is_chain_lagged": false, "chain_lag_distance": 0}
"785bc168-9976731c-uniswap-6540"
{"tps": 6541.0, "gps": 911705913.7027911, "is_chain_lagged": true, "chain_lag_distance": 2}
"785bc168-9976731c-uniswap-6580"
{"tps": 6581.0, "gps": 917291024.3644142, "is_chain_lagged": false, "chain_lag_distance": 1}

"fc28b62f-e11e1f30-bddfae28-erc20-16900/realtime-block.stdout.log"
{"tps": 16901.0, "gps": 583739164.9385916, "is_chain_lagged": false, "chain_lag_distance": 1}
"fc28b62f-e11e1f30-bddfae28-raw-transfer-23000/realtime-block.stdout.log"
{"tps": 23001.0, "gps": 483044502.0552147, "is_chain_lagged": false, "chain_lag_distance": 0}
"fc28b62f-e11e1f30-bddfae28-uniswap-6700/realtime-block.stdout.log"
{"tps": 6701.0, "gps": 934019908.1760107, "is_chain_lagged": true, "chain_lag_distance": 10}

["fc28b62f-a75b99d2-bddfae28-erc20-16900/realtime-block.stdout.log", "515041545 μs"]
{"tps": 16901.0, "gps": 583739134.7166197, "is_chain_lagged": true, "chain_lag_distance": 2}
["fc28b62f-a75b99d2-bddfae28-raw-transfer-23000/realtime-block.stdout.log", "271971019 μs"]
{"tps": 23001.0, "gps": 483044502.34969324, "is_chain_lagged": true, "chain_lag_distance": 7}
["fc28b62f-a75b99d2-bddfae28-uniswap-6700/realtime-block.stdout.log", "1037325457 μs"]
{"tps": 6701.0, "gps": 934018910.3569355, "is_chain_lagged": false, "chain_lag_distance": 1}

["fc28b62f-e11e1f30-412de5a2-erc20-16900/realtime-block.stdout.log", "559541496 μs"]
{"tps": 16901.0, "gps": 583740567.6405634, "is_chain_lagged": true, "chain_lag_distance": 11}
["fc28b62f-e11e1f30-412de5a2-raw-transfer-23000/realtime-block.stdout.log", "330763242 μs"]
{"tps": 23001.0, "gps": 483044502.0828221, "is_chain_lagged": false, "chain_lag_distance": 0}
["fc28b62f-e11e1f30-412de5a2-uniswap-6700/realtime-block.stdout.log", "1114770107 μs"]
{"tps": 6701.0, "gps": 934022094.8027697, "is_chain_lagged": true, "chain_lag_distance": 8}
```
</details>