### PR TITLE
chore: remove some unnecessary direct imports

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -158,9 +158,7 @@ where
         &self,
         _peer_id: PeerId,
         request: GetBlockBodies,
-        response: oneshot::Sender<
-            RequestResult<BlockBodies<<C::Block as reth_primitives_traits::Block>::Body>>,
-        >,
+        response: oneshot::Sender<RequestResult<BlockBodies<<C::Block as Block>::Body>>>,
     ) {
         self.metrics.eth_bodies_requests_received_total.increment(1);
         let mut bodies = Vec::new();

--- a/crates/net/p2p/src/test_utils/bodies.rs
+++ b/crates/net/p2p/src/test_utils/bodies.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloy_primitives::B256;
 use futures::FutureExt;
+use reth_network_peers::PeerId;
 use reth_primitives::BlockBody;
 use std::fmt::{Debug, Formatter};
 use tokio::sync::oneshot;
@@ -23,7 +24,7 @@ impl<F> Debug for TestBodiesClient<F> {
 }
 
 impl<F: Sync + Send> DownloadClient for TestBodiesClient<F> {
-    fn report_bad_message(&self, _peer_id: reth_network_peers::PeerId) {
+    fn report_bad_message(&self, _peer_id: PeerId) {
         // noop
     }
 

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -12,9 +12,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
     type EVM: ConfigureEvmFor<<Node::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
-    type Executor: BlockExecutorProvider<
-        Primitives = <Node::Types as reth_node_api::NodeTypes>::Primitives,
-    >;
+    type Executor: BlockExecutorProvider<Primitives = <Node::Types as NodeTypes>::Primitives>;
 
     /// Creates the EVM config.
     fn build_evm(
@@ -27,8 +25,7 @@ impl<Node, F, Fut, EVM, Executor> ExecutorBuilder<Node> for F
 where
     Node: FullNodeTypes,
     EVM: ConfigureEvmFor<<Node::Types as NodeTypes>::Primitives>,
-    Executor:
-        BlockExecutorProvider<Primitives = <Node::Types as reth_node_api::NodeTypes>::Primitives>,
+    Executor: BlockExecutorProvider<Primitives = <Node::Types as NodeTypes>::Primitives>,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<(EVM, Executor)>> + Send,
 {

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -204,13 +204,13 @@ pub fn validate_withdrawals_presence(
 
 #[cfg(test)]
 mod test {
+    use super::*;
 
     use crate::engine;
     use alloy_primitives::{b64, Address, B256, B64};
     use alloy_rpc_types_engine::PayloadAttributes;
+    use reth_node_builder::EngineValidator;
     use reth_optimism_chainspec::BASE_SEPOLIA;
-
-    use super::*;
 
     fn get_chainspec() -> Arc<OpChainSpec> {
         let hardforks = OpHardfork::base_sepolia();
@@ -251,7 +251,7 @@ mod test {
         let validator = OpEngineValidator::new(get_chainspec());
         let attributes = get_attributes(None, 1732633199);
 
-        let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
+        let result = <engine::OpEngineValidator as EngineValidator<
             OpEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes
@@ -264,7 +264,7 @@ mod test {
         let validator = OpEngineValidator::new(get_chainspec());
         let attributes = get_attributes(None, 1732633200);
 
-        let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
+        let result = <engine::OpEngineValidator as EngineValidator<
             OpEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes
@@ -277,7 +277,7 @@ mod test {
         let validator = OpEngineValidator::new(get_chainspec());
         let attributes = get_attributes(Some(b64!("0000000000000008")), 1732633200);
 
-        let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
+        let result = <engine::OpEngineValidator as EngineValidator<
             OpEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes
@@ -290,7 +290,7 @@ mod test {
         let validator = OpEngineValidator::new(get_chainspec());
         let attributes = get_attributes(Some(b64!("0000000800000008")), 1732633200);
 
-        let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
+        let result = <engine::OpEngineValidator as EngineValidator<
             OpEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes
@@ -303,7 +303,7 @@ mod test {
         let validator = OpEngineValidator::new(get_chainspec());
         let attributes = get_attributes(Some(b64!("0000000000000000")), 1732633200);
 
-        let result = <engine::OpEngineValidator as reth_node_builder::EngineValidator<
+        let result = <engine::OpEngineValidator as EngineValidator<
             OpEngineTypes,
         >>::ensure_well_formed_attributes(
             &validator, EngineApiMessageVersion::V3, &attributes

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -2,6 +2,7 @@ use crate::primitives::alloy_primitives::{BlockNumber, StorageKey, StorageValue}
 use alloy_primitives::{Address, B256, U256};
 use core::ops::{Deref, DerefMut};
 use reth_primitives::Account;
+use reth_storage_api::{AccountReader, BlockHashReader, StateProvider};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use revm::{
     db::DatabaseRef,
@@ -37,20 +38,20 @@ pub trait EvmStateProvider: Send + Sync {
 }
 
 // Blanket implementation of EvmStateProvider for any type that implements StateProvider.
-impl<T: reth_storage_api::StateProvider> EvmStateProvider for T {
+impl<T: StateProvider> EvmStateProvider for T {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
-        <T as reth_storage_api::AccountReader>::basic_account(self, address)
+        <T as AccountReader>::basic_account(self, address)
     }
 
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
-        <T as reth_storage_api::BlockHashReader>::block_hash(self, number)
+        <T as BlockHashReader>::block_hash(self, number)
     }
 
     fn bytecode_by_hash(
         &self,
         code_hash: &B256,
     ) -> ProviderResult<Option<reth_primitives::Bytecode>> {
-        <T as reth_storage_api::StateProvider>::bytecode_by_hash(self, code_hash)
+        <T as StateProvider>::bytecode_by_hash(self, code_hash)
     }
 
     fn storage(
@@ -58,7 +59,7 @@ impl<T: reth_storage_api::StateProvider> EvmStateProvider for T {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
-        <T as reth_storage_api::StateProvider>::storage(self, account, storage_key)
+        <T as StateProvider>::storage(self, account, storage_key)
     }
 }
 

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -3,6 +3,7 @@ use reth_db_api::models::StoredBlockBodyIndices;
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_node_types::NodePrimitives;
 use reth_primitives::RecoveredBlock;
+use reth_primitives_traits::Block;
 use reth_storage_api::{NodePrimitivesProvider, StorageLocation};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{updates::TrieUpdates, HashedPostStateSorted};
@@ -71,7 +72,7 @@ pub trait StateReader: Send + Sync {
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait BlockWriter: Send + Sync {
     /// The body this writer can write.
-    type Block: reth_primitives_traits::Block;
+    type Block: Block;
     /// The receipt type for [`ExecutionOutcome`].
     type Receipt: Send + Sync;
 
@@ -96,7 +97,7 @@ pub trait BlockWriter: Send + Sync {
     /// Bodies are passed as [`Option`]s, if body is `None` the corresponding block is empty.
     fn append_block_bodies(
         &self,
-        bodies: Vec<(BlockNumber, Option<<Self::Block as reth_primitives_traits::Block>::Body>)>,
+        bodies: Vec<(BlockNumber, Option<<Self::Block as Block>::Body>)>,
         write_to: StorageLocation,
     ) -> ProviderResult<()>;
 


### PR DESCRIPTION
These direct imports were either not required or could be included as an import at the top of the file