### PR TITLE
fix: only run windows check on windows runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,9 +9,13 @@ on:
     branches: [main]
   merge_group:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check-reth:
-    runs-on: ubuntu-20.04
+    runs-on: windows-latest
     timeout-minutes: 60
 
     steps:
@@ -24,13 +28,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: mingw-w64
-        run: sudo apt-get install -y mingw-w64
       - name: Check Reth
-        run: cargo check --target x86_64-pc-windows-gnu
+        run: |
+          cargo check --target x86_64-pc-windows-gnu
 
   check-op-reth:
-    runs-on: ubuntu-20.04
+    runs-on: windows-latest
     timeout-minutes: 60
 
     steps:
@@ -43,7 +46,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: mingw-w64
-        run: sudo apt-get install -y mingw-w64
       - name: Check OP-Reth
-        run: cargo check -p op-reth --features optimism --target x86_64-pc-windows-gnu
+        run: |
+          cargo check -p op-reth --features optimism --target x86_64-pc-windows-gnu


### PR DESCRIPTION
This only runs the windows check on windows runners, because `crunchy 0.2.3` (transitive dep from `tiny-keccak` now relies on the host path separator being the same as the target path separator.