### PR TITLE
chore: do not clone already recovered block

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2375,10 +2375,7 @@ where
         debug!(target: "engine::tree", ?root_elapsed, block=?sealed_block.num_hash(), "Calculated state root");
 
         let executed: ExecutedBlock<N> = ExecutedBlock {
-            recovered_block: Arc::new(RecoveredBlock::new_sealed(
-                sealed_block.as_ref().clone(),
-                block.senders().to_vec(),
-            )),
+            recovered_block: Arc::new(block),
             execution_output: Arc::new(ExecutionOutcome::from((output, block_number))),
             hashed_state: Arc::new(hashed_state),
             trie: Arc::new(trie_output),


### PR DESCRIPTION
We already have the recovered block, so we can just `Arc` it instead of cloning the senders and the sealed block