### PR TITLE
feat: add sealed_block method to ExecutedBlock

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -810,22 +810,32 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         Self { recovered_block, execution_output, hashed_state, trie }
     }
 
+    /// Returns a reference to an inner [`SealedBlock`]
+    #[inline]
+    pub fn sealed_block(&self) -> &SealedBlock<N::Block> {
+        self.recovered_block.sealed_block()
+    }
+
     /// Returns a reference to [`RecoveredBlock`]
+    #[inline]
     pub fn recovered_block(&self) -> &RecoveredBlock<N::Block> {
         &self.recovered_block
     }
 
     /// Returns a reference to the block's execution outcome
+    #[inline]
     pub fn execution_outcome(&self) -> &ExecutionOutcome<N::Receipt> {
         &self.execution_output
     }
 
     /// Returns a reference to the hashed state result of the execution outcome
+    #[inline]
     pub fn hashed_state(&self) -> &HashedPostState {
         &self.hashed_state
     }
 
     /// Returns a reference to the trie updates for the block
+    #[inline]
     pub fn trie_updates(&self) -> &TrieUpdates {
         &self.trie
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1260,7 +1260,7 @@ where
                     EngineApiRequest::InsertExecutedBlock(block) => {
                         debug!(target: "engine::tree", block=?block.recovered_block().num_hash(), "inserting already executed block");
                         let now = Instant::now();
-                        let sealed_block = Arc::new(block.recovered_block().sealed_block().clone());
+                        let sealed_block = Arc::new(block.sealed_block().clone());
                         self.state.tree_state.insert_executed(block);
                         self.metrics.engine.inserted_already_executed_blocks.increment(1);
 


### PR DESCRIPTION
Adds a `sealed_block` helper method for getting a reference to the sealed block, on `ExecutedBlock`