### PR TITLE
[wip] feat: Evm::inspect

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -45,8 +45,8 @@ pub trait Trace:
         EthApiError: From<DB::Error>,
         I: GetInspector<DB>,
     {
-        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
-        let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
+        let mut evm = self.evm_config().evm_with_env(db, evm_env);
+        let res = evm.inspect(tx_env.clone(), inspector).map_err(Self::Error::from_evm_err)?;
         let evm_env = evm.into_env();
         Ok((res, (evm_env, tx_env)))
     }


### PR DESCRIPTION
This PR removes `evm_with_env_and_inspector` in favor of `Evm::inspect` which delegates all of the logic for execution with inspectors to `Evm` implementation.

This seems nicer because we're no longer required to know whether we're going to use evm for tracing or standard execution before creating it, thus Evm AT can have less generics. However, this might have performance impact because with this change we need to create a new `Evm` on every `transact` call. This should be fine for new revm because `Handler` there is pretty much stateless, however in new revm this might be more impactful