### PR TITLE
fix: do not record trie root metrics for ParallelProof

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -27,10 +27,10 @@ use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
 use std::{sync::Arc, time::Instant};
 use tracing::{debug, trace};
 
-#[cfg(feature = "metrics")]
-use crate::metrics::ParallelStateRootMetrics;
-
-/// TODO:
+/// Parallel proof calculator.
+///
+/// This can collect proof for many targets in parallel, spawning a task for each hashed address
+/// that has proof targets.
 #[derive(Debug)]
 pub struct ParallelProof<Factory> {
     /// Consistent view of the database.
@@ -48,14 +48,11 @@ pub struct ParallelProof<Factory> {
     collect_branch_node_masks: bool,
     /// Thread pool for local tasks
     thread_pool: Arc<rayon::ThreadPool>,
-    /// Parallel state root metrics.
-    #[cfg(feature = "metrics")]
-    metrics: ParallelStateRootMetrics,
 }
 
 impl<Factory> ParallelProof<Factory> {
     /// Create new state proof generator.
-    pub fn new(
+    pub const fn new(
         view: ConsistentDbView<Factory>,
         nodes_sorted: Arc<TrieUpdatesSorted>,
         state_sorted: Arc<HashedPostStateSorted>,
@@ -69,8 +66,6 @@ impl<Factory> ParallelProof<Factory> {
             prefix_sets,
             collect_branch_node_masks: false,
             thread_pool,
-            #[cfg(feature = "metrics")]
-            metrics: ParallelStateRootMetrics::default(),
         }
     }
 
@@ -119,7 +114,7 @@ where
         let storage_root_targets_len = storage_root_targets.len();
 
         debug!(
-            target: "trie::parallel_state_root",
+            target: "trie::parallel_proof",
             total_targets = storage_root_targets_len,
             "Starting parallel proof generation"
         );
@@ -143,7 +138,7 @@ where
 
             self.thread_pool.spawn_fifo(move || {
                 debug!(
-                    target: "trie::parallel",
+                    target: "trie::parallel_proof",
                     ?hashed_address,
                     "Starting proof calculation"
                 );
@@ -153,7 +148,7 @@ where
                     let provider_start = Instant::now();
                     let provider_ro = view.provider_ro()?;
                     trace!(
-                        target: "trie::parallel",
+                        target: "trie::parallel_proof",
                         ?hashed_address,
                         provider_time = ?provider_start.elapsed(),
                         "Got provider"
@@ -169,7 +164,7 @@ where
                         &hashed_state_sorted,
                     );
                     trace!(
-                        target: "trie::parallel",
+                        target: "trie::parallel_proof",
                         ?hashed_address,
                         cursor_time = ?cursor_start.elapsed(),
                         "Created cursors"
@@ -187,7 +182,7 @@ where
                     .map_err(|e| ParallelStateRootError::Other(e.to_string()));
 
                     trace!(
-                        target: "trie::parallel",
+                        target: "trie::parallel_proof",
                         ?hashed_address,
                         proof_time = ?proof_start.elapsed(),
                         "Completed proof calculation"
@@ -201,7 +196,7 @@ where
                 // `account_node_iter` below.
                 if let Err(e) = tx.send(result) {
                     debug!(
-                        target: "trie::parallel",
+                        target: "trie::parallel_proof",
                         ?hashed_address,
                         error = ?e,
                         task_time = ?task_start.elapsed(),
@@ -296,9 +291,6 @@ where
             }
         }
         let _ = hash_builder.root();
-
-        #[cfg(feature = "metrics")]
-        self.metrics.record_state_trie(tracker.finish());
 
         let account_subtree = hash_builder.take_proof_nodes();
         let (branch_node_hash_masks, branch_node_tree_masks) = if self.collect_branch_node_masks {


### PR DESCRIPTION
This removes trie metrics recording from `ParallelProof`. This was causing metrics issues, showing in the grafana that the state root was taking 6ms, for example, because that metric was being updated:
<img width="792" alt="Screenshot 2025-01-23 at 11 36 29 PM" src="https://github.com/user-attachments/assets/f4730d9b-8b40-41c2-a3bb-37864bca2d52" />

This deletes these metrics, because they are really meant for the parallel state root calculator. Log targets are also made consistent, using `trie::parallel_proof`, and docs are added to `ParallelProof`.