### PR TITLE
feat: add `Spec` generic for `EvmEnv`

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -241,8 +241,7 @@ impl ConfigureEvm for EthEvmConfig {
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)] // side-effect of optimism fields
-            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+            handler_cfg: HandlerCfg::new(evm_env.spec),
         };
         EthEvm(
             EvmBuilder::default()
@@ -265,8 +264,7 @@ impl ConfigureEvm for EthEvmConfig {
     {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)] // side-effect of optimism fields
-            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+            handler_cfg: HandlerCfg::new(evm_env.spec),
         };
         EthEvm(
             EvmBuilder::default()

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -28,7 +28,7 @@ use reth_primitives_traits::transaction::execute::FillTxEnv;
 use reth_revm::{inspector_handle_register, Database, EvmBuilder};
 use revm_primitives::{
     AnalysisKind, BlobExcessGasAndPrice, BlockEnv, Bytes, CfgEnv, CfgEnvWithHandlerCfg, EVMError,
-    Env, HandlerCfg, ResultAndState, SpecId, TxEnv, TxKind,
+    HandlerCfg, ResultAndState, SpecId, TxEnv, TxKind,
 };
 
 mod config;
@@ -56,17 +56,6 @@ impl<EXT, DB: Database> Evm for EthEvm<'_, EXT, DB> {
 
     fn block(&self) -> &BlockEnv {
         self.0.block()
-    }
-
-    fn into_env(self) -> EvmEnv {
-        let Env { cfg, block, tx: _ } = *self.0.context.evm.inner.env;
-        EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: cfg,
-                handler_cfg: self.0.handler.cfg,
-            },
-            block_env: block,
-        }
     }
 
     fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
@@ -151,6 +140,7 @@ impl ConfigureEvmEnv for EthEvmConfig {
     type Transaction = TransactionSigned;
     type Error = Infallible;
     type TxEnv = TxEnv;
+    type Spec = revm_primitives::SpecId;
 
     fn tx_env(&self, transaction: &TransactionSigned, sender: Address) -> Self::TxEnv {
         let mut tx_env = TxEnv::default();
@@ -159,33 +149,27 @@ impl ConfigureEvmEnv for EthEvmConfig {
     }
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv {
-        let spec_id = config::revm_spec(self.chain_spec(), header);
+        let spec = config::revm_spec(self.chain_spec(), header);
 
         let mut cfg_env = CfgEnv::default();
         cfg_env.chain_id = self.chain_spec.chain().id();
         cfg_env.perf_analyse_created_bytecodes = AnalysisKind::default();
 
-        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
-            cfg_env,
-            #[allow(clippy::needless_update)] // side-effect of optimism fields
-            handler_cfg: HandlerCfg { spec_id, ..Default::default() },
-        };
-
         let block_env = BlockEnv {
             number: U256::from(header.number()),
             coinbase: header.beneficiary(),
             timestamp: U256::from(header.timestamp()),
-            difficulty: if spec_id >= SpecId::MERGE { U256::ZERO } else { header.difficulty() },
-            prevrandao: if spec_id >= SpecId::MERGE { header.mix_hash() } else { None },
+            difficulty: if spec >= SpecId::MERGE { U256::ZERO } else { header.difficulty() },
+            prevrandao: if spec >= SpecId::MERGE { header.mix_hash() } else { None },
             gas_limit: U256::from(header.gas_limit()),
             basefee: U256::from(header.base_fee_per_gas().unwrap_or_default()),
             // EIP-4844 excess blob gas of this block, introduced in Cancun
             blob_excess_gas_and_price: header.excess_blob_gas.map(|excess_blob_gas| {
-                BlobExcessGasAndPrice::new(excess_blob_gas, spec_id >= SpecId::PRAGUE)
+                BlobExcessGasAndPrice::new(excess_blob_gas, spec >= SpecId::PRAGUE)
             }),
         };
 
-        EvmEnv { cfg_env_with_handler_cfg, block_env }
+        EvmEnv { cfg_env, spec, block_env }
     }
 
     fn next_evm_env(
@@ -255,10 +239,15 @@ impl ConfigureEvm for EthEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
 
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)] // side-effect of optimism fields
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+        };
         EthEvm(
             EvmBuilder::default()
                 .with_db(db)
-                .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+                .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
                 .with_block_env(evm_env.block_env)
                 .build(),
         )
@@ -274,11 +263,16 @@ impl ConfigureEvm for EthEvmConfig {
         DB: Database,
         I: reth_revm::GetInspector<DB>,
     {
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)] // side-effect of optimism fields
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+        };
         EthEvm(
             EvmBuilder::default()
                 .with_db(db)
                 .with_external_context(inspector)
-                .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+                .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
                 .with_block_env(evm_env.block_env)
                 .append_handler_register(inspector_handle_register)
                 .build(),
@@ -318,12 +312,12 @@ mod tests {
 
         // Use the `EthEvmConfig` to fill the `cfg_env` and `block_env` based on the ChainSpec,
         // Header, and total difficulty
-        let EvmEnv { cfg_env_with_handler_cfg, .. } =
+        let EvmEnv { cfg_env, .. } =
             EthEvmConfig::new(Arc::new(chain_spec.clone())).evm_env(&header);
 
         // Assert that the chain ID in the `cfg_env` is correctly set to the chain ID of the
         // ChainSpec
-        assert_eq!(cfg_env_with_handler_cfg.chain_id, chain_spec.chain().id());
+        assert_eq!(cfg_env.chain_id, chain_spec.chain().id());
     }
 
     #[test]
@@ -339,7 +333,7 @@ mod tests {
 
         // Check that the EVM environment
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
-        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env);
 
         // Default spec ID
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -358,13 +352,7 @@ mod tests {
         // Create a custom configuration environment with a chain ID of 111
         let cfg = CfgEnv::default().with_chain_id(111);
 
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: cfg.clone(),
-                handler_cfg: Default::default(),
-            },
-            ..Default::default()
-        };
+        let evm_env = EvmEnv { cfg_env: cfg.clone(), ..Default::default() };
 
         let evm = evm_config.evm_with_env(db, evm_env);
 
@@ -393,13 +381,7 @@ mod tests {
             ..Default::default()
         };
 
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: CfgEnv::default(),
-                handler_cfg: Default::default(),
-            },
-            block_env: block,
-        };
+        let evm_env = EvmEnv { block_env: block, ..Default::default() };
 
         let evm = evm_config.evm_with_env(db, evm_env.clone());
 
@@ -420,15 +402,7 @@ mod tests {
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let handler_cfg = HandlerCfg { spec_id: SpecId::CONSTANTINOPLE, ..Default::default() };
-
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: Default::default(),
-                handler_cfg,
-            },
-            ..Default::default()
-        };
+        let evm_env = EvmEnv { spec: SpecId::CONSTANTINOPLE, ..Default::default() };
 
         let evm = evm_config.evm_with_env(db, evm_env);
 
@@ -454,7 +428,7 @@ mod tests {
 
         // Check that the EVM environment is set to default values
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
-        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env);
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
 
@@ -470,13 +444,8 @@ mod tests {
 
         let cfg_env = CfgEnv::default().with_chain_id(111);
         let block = BlockEnv::default();
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: cfg_env.clone(),
-                handler_cfg: Default::default(),
-            },
-            block_env: block,
-        };
+        let evm_env =
+            EvmEnv { cfg_env: cfg_env.clone(), block_env: block, spec: Default::default() };
 
         let evm = evm_config.evm_with_env_and_inspector(db, evm_env, NoOpInspector);
 
@@ -521,21 +490,14 @@ mod tests {
         let evm_config = EthEvmConfig::new(MAINNET.clone());
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let handler_cfg = HandlerCfg { spec_id: SpecId::CONSTANTINOPLE, ..Default::default() };
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                handler_cfg,
-                cfg_env: Default::default(),
-            },
-            ..Default::default()
-        };
+        let evm_env = EvmEnv { spec: SpecId::CONSTANTINOPLE, ..Default::default() };
 
         let evm = evm_config.evm_with_env_and_inspector(db, evm_env.clone(), NoOpInspector);
 
         // Check that the spec ID is set properly
         assert_eq!(evm.handler.spec_id(), SpecId::PETERSBURG);
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
-        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env);
         assert_eq!(evm.context.evm.env.tx, Default::default());
         assert_eq!(evm.context.external, NoOpInspector);
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -81,11 +81,11 @@ where
 {
     /// Returns the configured [`EvmEnv`] for the targeted payload
     /// (that has the `parent` as its parent).
-    fn cfg_and_block_env(
+    fn evm_env(
         &self,
         config: &PayloadConfig<EthPayloadBuilderAttributes>,
         parent: &Header,
-    ) -> Result<EvmEnv, EvmConfig::Error> {
+    ) -> Result<EvmEnv<EvmConfig::Spec>, EvmConfig::Error> {
         let next_attributes = NextBlockEnvAttributes {
             timestamp: config.attributes.timestamp(),
             suggested_fee_recipient: config.attributes.suggested_fee_recipient(),
@@ -111,7 +111,7 @@ where
         args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
     ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError> {
         let evm_env = self
-            .cfg_and_block_env(&args.config, &args.config.parent_header)
+            .evm_env(&args.config, &args.config.parent_header)
             .map_err(PayloadBuilderError::other)?;
 
         let pool = args.pool.clone();
@@ -140,7 +140,7 @@ where
         );
 
         let evm_env = self
-            .cfg_and_block_env(&args.config, &args.config.parent_header)
+            .evm_env(&args.config, &args.config.parent_header)
             .map_err(PayloadBuilderError::other)?;
 
         let pool = args.pool.clone();
@@ -167,7 +167,7 @@ pub fn default_ethereum_payload<EvmConfig, Pool, Client, F>(
     evm_config: EvmConfig,
     builder_config: EthereumBuilderConfig,
     args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
-    evm_env: EvmEnv,
+    evm_env: EvmEnv<EvmConfig::Spec>,
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -8,7 +8,8 @@ pub struct EvmEnv<Spec = SpecId> {
     pub cfg_env: CfgEnv,
     /// The block environment containing block-specific data
     pub block_env: BlockEnv,
-    /// The spec id of the chain
+    /// The spec id of the chain. Specifies which hardfork is currently active, `Spec` type will
+    /// most likely be an enum over hardforks.
     pub spec: Spec,
 }
 
@@ -19,7 +20,7 @@ impl<Spec> EvmEnv<Spec> {
     ///
     /// * `cfg_env_with_handler_cfg` - The configuration environment with handler settings
     /// * `block` - The block environment containing block-specific data
-    pub const fn new(cfg_env: CfgEnv, spec: Spec, block_env: BlockEnv) -> Self {
+    pub const fn new(cfg_env: CfgEnv, block_env: BlockEnv, spec: Spec) -> Self {
         Self { cfg_env, spec, block_env }
     }
 

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -1,36 +1,26 @@
 use revm::primitives::{BlockEnv, CfgEnvWithHandlerCfg};
+use revm_primitives::{CfgEnv, SpecId};
 
 /// Container type that holds both the configuration and block environment for EVM execution.
-#[derive(Debug, Clone)]
-pub struct EvmEnv {
+#[derive(Debug, Clone, Default)]
+pub struct EvmEnv<Spec = SpecId> {
     /// The configuration environment with handler settings
-    pub cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg,
+    pub cfg_env: CfgEnv,
     /// The block environment containing block-specific data
     pub block_env: BlockEnv,
+    /// The spec id of the chain
+    pub spec: Spec,
 }
 
-impl Default for EvmEnv {
-    fn default() -> Self {
-        Self {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: Default::default(),
-                // Will set `is_optimism` if `revm/optimism-default-handler` is enabled.
-                handler_cfg: Default::default(),
-            },
-            block_env: BlockEnv::default(),
-        }
-    }
-}
-
-impl EvmEnv {
+impl<Spec> EvmEnv<Spec> {
     /// Create a new `EvmEnv` from its components.
     ///
     /// # Arguments
     ///
     /// * `cfg_env_with_handler_cfg` - The configuration environment with handler settings
     /// * `block` - The block environment containing block-specific data
-    pub const fn new(cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg, block_env: BlockEnv) -> Self {
-        Self { cfg_env_with_handler_cfg, block_env }
+    pub const fn new(cfg_env: CfgEnv, spec: Spec, block_env: BlockEnv) -> Self {
+        Self { cfg_env, spec, block_env }
     }
 
     /// Returns a reference to the block environment.
@@ -39,19 +29,19 @@ impl EvmEnv {
     }
 
     /// Returns a reference to the configuration environment.
-    pub const fn cfg_env_with_handler_cfg(&self) -> &CfgEnvWithHandlerCfg {
-        &self.cfg_env_with_handler_cfg
+    pub const fn cfg_env(&self) -> &CfgEnv {
+        &self.cfg_env
+    }
+
+    /// Returns the spec id of the chain
+    pub const fn spec_id(&self) -> &Spec {
+        &self.spec
     }
 }
 
 impl From<(CfgEnvWithHandlerCfg, BlockEnv)> for EvmEnv {
     fn from((cfg_env_with_handler_cfg, block_env): (CfgEnvWithHandlerCfg, BlockEnv)) -> Self {
-        Self { cfg_env_with_handler_cfg, block_env }
-    }
-}
-
-impl From<EvmEnv> for (CfgEnvWithHandlerCfg, BlockEnv) {
-    fn from(env: EvmEnv) -> Self {
-        (env.cfg_env_with_handler_cfg, env.block_env)
+        let CfgEnvWithHandlerCfg { cfg_env, handler_cfg } = cfg_env_with_handler_cfg;
+        Self { cfg_env, spec: handler_cfg.spec_id, block_env }
     }
 }

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -123,7 +123,7 @@ where
     pub fn pre_block_blockhashes_contract_call<DB>(
         &mut self,
         db: &mut DB,
-        evm_env: &EvmEnv,
+        evm_env: &EvmEnv<EvmConfig::Spec>,
         parent_block_hash: B256,
     ) -> Result<(), BlockExecutionError>
     where
@@ -173,7 +173,7 @@ where
     pub fn pre_block_beacon_root_contract_call<DB>(
         &mut self,
         db: &mut DB,
-        evm_env: &EvmEnv,
+        evm_env: &EvmEnv<EvmConfig::Spec>,
         parent_beacon_block_root: Option<B256>,
     ) -> Result<(), BlockExecutionError>
     where
@@ -223,7 +223,7 @@ where
     pub fn post_block_withdrawal_requests_contract_call<DB>(
         &mut self,
         db: &mut DB,
-        evm_env: &EvmEnv,
+        evm_env: &EvmEnv<EvmConfig::Spec>,
     ) -> Result<Bytes, BlockExecutionError>
     where
         DB: Database + DatabaseCommit,
@@ -256,7 +256,7 @@ where
     pub fn post_block_consolidation_requests_contract_call<DB>(
         &mut self,
         db: &mut DB,
-        evm_env: &EvmEnv,
+        evm_env: &EvmEnv<EvmConfig::Spec>,
     ) -> Result<Bytes, BlockExecutionError>
     where
         DB: Database + DatabaseCommit,

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -228,7 +228,6 @@ impl ConfigureEvm for OpEvmConfig {
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)]
             handler_cfg: HandlerCfg { spec_id: evm_env.spec, is_optimism: true },
         };
 
@@ -252,7 +251,6 @@ impl ConfigureEvm for OpEvmConfig {
     {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)]
             handler_cfg: HandlerCfg { spec_id: evm_env.spec, is_optimism: true },
         };
 

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -40,7 +40,7 @@ pub use receipts::*;
 mod error;
 pub use error::OpBlockExecutionError;
 use revm_primitives::{
-    BlobExcessGasAndPrice, BlockEnv, Bytes, CfgEnv, EVMError, Env, HandlerCfg, OptimismFields,
+    BlobExcessGasAndPrice, BlockEnv, Bytes, CfgEnv, EVMError, HandlerCfg, OptimismFields,
     ResultAndState, SpecId, TxKind,
 };
 
@@ -56,17 +56,6 @@ impl<EXT, DB: Database> Evm for OpEvm<'_, EXT, DB> {
 
     fn block(&self) -> &BlockEnv {
         self.0.block()
-    }
-
-    fn into_env(self) -> EvmEnv {
-        let Env { cfg, block, tx: _ } = *self.0.context.evm.inner.env;
-        EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: cfg,
-                handler_cfg: self.0.handler.cfg,
-            },
-            block_env: block,
-        }
     }
 
     fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
@@ -158,6 +147,7 @@ impl ConfigureEvmEnv for OpEvmConfig {
     type Transaction = OpTransactionSigned;
     type Error = EIP1559ParamError;
     type TxEnv = TxEnv;
+    type Spec = SpecId;
 
     fn tx_env(&self, transaction: &Self::Transaction, signer: Address) -> Self::TxEnv {
         let mut tx_env = TxEnv::default();
@@ -166,32 +156,27 @@ impl ConfigureEvmEnv for OpEvmConfig {
     }
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv {
-        let spec_id = config::revm_spec(self.chain_spec(), header);
+        let spec = config::revm_spec(self.chain_spec(), header);
 
         let mut cfg_env = CfgEnv::default();
         cfg_env.chain_id = self.chain_spec.chain().id();
         cfg_env.perf_analyse_created_bytecodes = AnalysisKind::default();
 
-        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
-            cfg_env,
-            handler_cfg: HandlerCfg { spec_id, is_optimism: true },
-        };
-
         let block_env = BlockEnv {
             number: U256::from(header.number()),
             coinbase: header.beneficiary(),
             timestamp: U256::from(header.timestamp()),
-            difficulty: if spec_id >= SpecId::MERGE { U256::ZERO } else { header.difficulty() },
-            prevrandao: if spec_id >= SpecId::MERGE { header.mix_hash() } else { None },
+            difficulty: if spec >= SpecId::MERGE { U256::ZERO } else { header.difficulty() },
+            prevrandao: if spec >= SpecId::MERGE { header.mix_hash() } else { None },
             gas_limit: U256::from(header.gas_limit()),
             basefee: U256::from(header.base_fee_per_gas().unwrap_or_default()),
             // EIP-4844 excess blob gas of this block, introduced in Cancun
             blob_excess_gas_and_price: header.excess_blob_gas().map(|excess_blob_gas| {
-                BlobExcessGasAndPrice::new(excess_blob_gas, spec_id >= SpecId::PRAGUE)
+                BlobExcessGasAndPrice::new(excess_blob_gas, spec >= SpecId::PRAGUE)
             }),
         };
 
-        EvmEnv { cfg_env_with_handler_cfg, block_env }
+        EvmEnv { cfg_env, block_env, spec }
     }
 
     fn next_evm_env(
@@ -240,12 +225,16 @@ impl ConfigureEvmEnv for OpEvmConfig {
 impl ConfigureEvm for OpEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = OpEvm<'a, I, DB>;
 
-    fn evm_with_env<DB: Database>(&self, db: DB, mut evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
-        evm_env.cfg_env_with_handler_cfg.handler_cfg.is_optimism = true;
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)]
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, is_optimism: true },
+        };
 
         EvmBuilder::default()
             .with_db(db)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+            .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
             .build()
             .into()
@@ -254,19 +243,23 @@ impl ConfigureEvm for OpEvmConfig {
     fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
-        mut evm_env: EvmEnv,
+        evm_env: EvmEnv,
         inspector: I,
     ) -> Self::Evm<'_, DB, I>
     where
         DB: Database,
         I: GetInspector<DB>,
     {
-        evm_env.cfg_env_with_handler_cfg.handler_cfg.is_optimism = true;
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)]
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, is_optimism: true },
+        };
 
         EvmBuilder::default()
             .with_db(db)
             .with_external_context(inspector)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+            .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
             .append_handler_register(inspector_handle_register)
             .build()
@@ -318,12 +311,12 @@ mod tests {
 
         // Use the `OpEvmConfig` to create the `cfg_env` and `block_env` based on the ChainSpec,
         // Header, and total difficulty
-        let EvmEnv { cfg_env_with_handler_cfg, .. } =
+        let EvmEnv { cfg_env, .. } =
             OpEvmConfig::new(Arc::new(OpChainSpec { inner: chain_spec.clone() })).evm_env(&header);
 
         // Assert that the chain ID in the `cfg_env` is correctly set to the chain ID of the
         // ChainSpec
-        assert_eq!(cfg_env_with_handler_cfg.chain_id, chain_spec.chain().id());
+        assert_eq!(cfg_env.chain_id, chain_spec.chain().id());
     }
 
     #[test]
@@ -337,7 +330,7 @@ mod tests {
         let evm = evm_config.evm_with_env(db, evm_env.clone());
 
         // Check that the EVM environment
-        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env);
 
         // Default spec ID
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -355,13 +348,7 @@ mod tests {
         // Create a custom configuration environment with a chain ID of 111
         let cfg = CfgEnv::default().with_chain_id(111);
 
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: cfg.clone(),
-                handler_cfg: Default::default(),
-            },
-            ..Default::default()
-        };
+        let evm_env = EvmEnv { cfg_env: cfg.clone(), ..Default::default() };
 
         let evm = evm_config.evm_with_env(db, evm_env);
 
@@ -409,15 +396,7 @@ mod tests {
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let handler_cfg = HandlerCfg { spec_id: SpecId::ECOTONE, ..Default::default() };
-
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                handler_cfg,
-                cfg_env: Default::default(),
-            },
-            ..Default::default()
-        };
+        let evm_env = EvmEnv { spec: SpecId::ECOTONE, ..Default::default() };
 
         let evm = evm_config.evm_with_env(db, evm_env);
 
@@ -433,19 +412,13 @@ mod tests {
         let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: Default::default(),
-                handler_cfg: HandlerCfg { is_optimism: true, ..Default::default() },
-            },
-            ..Default::default()
-        };
+        let evm_env = EvmEnv { cfg_env: Default::default(), ..Default::default() };
 
         let evm = evm_config.evm_with_env_and_inspector(db, evm_env.clone(), NoOpInspector);
 
         // Check that the EVM environment is set to default values
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
-        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env);
         assert_eq!(evm.context.evm.env.tx, Default::default());
         assert_eq!(evm.context.external, NoOpInspector);
         assert_eq!(evm.handler.spec_id(), SpecId::LATEST);
@@ -461,13 +434,7 @@ mod tests {
 
         let cfg = CfgEnv::default().with_chain_id(111);
         let block = BlockEnv::default();
-        let evm_env = EvmEnv {
-            block_env: block,
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: cfg.clone(),
-                handler_cfg: Default::default(),
-            },
-        };
+        let evm_env = EvmEnv { block_env: block, cfg_env: cfg.clone(), ..Default::default() };
 
         let evm = evm_config.evm_with_env_and_inspector(db, evm_env.clone(), NoOpInspector);
 
@@ -511,20 +478,13 @@ mod tests {
         let evm_config = test_evm_config();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
-        let handler_cfg = HandlerCfg { spec_id: SpecId::ECOTONE, ..Default::default() };
-        let evm_env = EvmEnv {
-            cfg_env_with_handler_cfg: CfgEnvWithHandlerCfg {
-                cfg_env: Default::default(),
-                handler_cfg,
-            },
-            ..Default::default()
-        };
+        let evm_env = EvmEnv { spec: SpecId::ECOTONE, ..Default::default() };
 
         let evm = evm_config.evm_with_env_and_inspector(db, evm_env.clone(), NoOpInspector);
 
         // Check that the spec ID is set properly
         assert_eq!(evm.handler.spec_id(), SpecId::ECOTONE);
-        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env_with_handler_cfg.cfg_env);
+        assert_eq!(evm.context.evm.env.cfg, evm_env.cfg_env);
         assert_eq!(evm.context.evm.env.block, evm_env.block_env);
         assert_eq!(evm.context.external, NoOpInspector);
 

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -36,7 +36,7 @@ pub trait EstimateCall: Call {
     ///  - `nonce` is set to `None`
     fn estimate_gas_with<S>(
         &self,
-        mut evm_env: EvmEnv,
+        mut evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
         mut request: TransactionRequest,
         state: S,
         state_override: Option<StateOverride>,
@@ -46,12 +46,12 @@ pub trait EstimateCall: Call {
     {
         // Disabled because eth_estimateGas is sometimes used with eoa senders
         // See <https://github.com/paradigmxyz/reth/issues/1959>
-        evm_env.cfg_env_with_handler_cfg.disable_eip3607 = true;
+        evm_env.cfg_env.disable_eip3607 = true;
 
         // The basefee should be ignored for eth_estimateGas and similar
         // See:
         // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
-        evm_env.cfg_env_with_handler_cfg.disable_base_fee = true;
+        evm_env.cfg_env.disable_base_fee = true;
 
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.nonce = None;
@@ -281,7 +281,7 @@ pub trait EstimateCall: Call {
     fn map_out_of_gas_err<DB>(
         &self,
         env_gas_limit: U256,
-        evm_env: EvmEnv,
+        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
         mut tx_env: <Self::Evm as ConfigureEvmEnv>::TxEnv,
         db: &mut DB,
     ) -> Self::Error

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -69,7 +69,11 @@ pub trait LoadPendingBlock:
     fn pending_block_env_and_cfg(
         &self,
     ) -> Result<
-        PendingBlockEnv<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>,
+        PendingBlockEnv<
+            ProviderBlock<Self::Provider>,
+            ProviderReceipt<Self::Provider>,
+            <Self::Evm as ConfigureEvmEnv>::Spec,
+        >,
         Self::Error,
     > {
         if let Some(block) =
@@ -234,7 +238,7 @@ pub trait LoadPendingBlock:
     #[expect(clippy::type_complexity)]
     fn build_block(
         &self,
-        evm_env: EvmEnv,
+        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
         parent_hash: B256,
     ) -> Result<
         (RecoveredBlock<ProviderBlock<Self::Provider>>, Vec<ProviderReceipt<Self::Provider>>),

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -210,10 +210,13 @@ pub trait LoadState:
     /// for.
     /// If the [`BlockId`] is pending, this will return the "Pending" tag, otherwise this returns
     /// the hash of the exact block.
+    #[expect(clippy::type_complexity)]
     fn evm_env_at(
         &self,
         at: BlockId,
-    ) -> impl Future<Output = Result<(EvmEnv, BlockId), Self::Error>> + Send
+    ) -> impl Future<
+        Output = Result<(EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>, BlockId), Self::Error>,
+    > + Send
     where
         Self: LoadPendingBlock + SpawnBlocking,
     {

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -14,9 +14,9 @@ use reth_primitives_traits::Block;
 
 /// Configured [`EvmEnv`] for a pending block.
 #[derive(Debug, Clone, Constructor)]
-pub struct PendingBlockEnv<B: Block = reth_primitives::Block, R = Receipt> {
+pub struct PendingBlockEnv<B: Block, R, Spec> {
     /// Configured [`EvmEnv`] for the pending block.
-    pub evm_env: EvmEnv,
+    pub evm_env: EvmEnv<Spec>,
     /// Origin block for the config
     pub origin: PendingBlockEnvOrigin<B, R>,
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -95,7 +95,7 @@ where
     async fn trace_block(
         &self,
         block: Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>,
-        evm_env: EvmEnv,
+        evm_env: EvmEnv<<Eth::Evm as ConfigureEvmEnv>::Spec>,
         opts: GethDebugTracingOptions,
     ) -> Result<Vec<TraceResult>, Eth::Error> {
         // replay all transactions of the block
@@ -446,7 +446,7 @@ where
                                 &mut inspector,
                             )?;
                             let env = revm_primitives::Env::boxed(
-                                evm_env.cfg_env_with_handler_cfg.cfg_env,
+                                evm_env.cfg_env,
                                 evm_env.block_env,
                                 tx_env.into(),
                             );
@@ -650,7 +650,7 @@ where
     fn trace_transaction(
         &self,
         opts: &GethDebugTracingOptions,
-        evm_env: EvmEnv,
+        evm_env: EvmEnv<<Eth::Evm as ConfigureEvmEnv>::Spec>,
         tx_env: <Eth::Evm as ConfigureEvmEnv>::TxEnv,
         db: &mut StateCacheDb<'_>,
         transaction_context: Option<TransactionContext>,
@@ -781,7 +781,7 @@ where
 
                     let state = res.state.clone();
                     let env = revm_primitives::Env::boxed(
-                        evm_env.cfg_env_with_handler_cfg.cfg_env,
+                        evm_env.cfg_env,
                         evm_env.block_env,
                         tx_env.into(),
                     );

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -1,18 +1,16 @@
 //! `Eth` bundle implementation and helpers.
 
-use alloy_consensus::{BlockHeader, EnvKzgSettings, Transaction as _};
+use alloy_consensus::{EnvKzgSettings, Transaction as _};
 use alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK;
 use alloy_primitives::{Keccak256, U256};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv, Evm};
 use reth_primitives_traits::SignedTransaction;
-use reth_provider::{ChainSpecProvider, HeaderProvider};
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_eth_api::{
     helpers::{Call, EthTransactions, LoadPendingBlock},
-    EthCallBundleApiServer, FromEthApiError, FromEvmError, RpcNodeCore,
+    EthCallBundleApiServer, FromEthApiError, FromEvmError,
 };
 use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError, RpcInvalidTransactionError};
 use reth_tasks::pool::BlockingTaskGuard;
@@ -23,7 +21,6 @@ use revm::{
     db::{CacheDB, DatabaseCommit, DatabaseRef},
     primitives::ResultAndState,
 };
-use revm_primitives::SpecId;
 use std::sync::Arc;
 
 /// `Eth` bundle implementation.
@@ -132,21 +129,6 @@ where
 
         if let Some(base_fee) = base_fee {
             evm_env.block_env.basefee = U256::from(base_fee);
-        } else if evm_env.cfg_env_with_handler_cfg.handler_cfg.spec_id.is_enabled_in(SpecId::LONDON)
-        {
-            let parent_block = evm_env.block_env.number.saturating_to::<u64>();
-            // here we need to fetch the _next_ block's basefee based on the parent block <https://github.com/flashbots/mev-geth/blob/fddf97beec5877483f879a77b7dea2e58a58d653/internal/ethapi/api.go#L2130>
-            let parent = RpcNodeCore::provider(self.eth_api())
-                .header_by_number(parent_block)
-                .map_err(Eth::Error::from_eth_err)?
-                .ok_or(EthApiError::HeaderNotFound(parent_block.into()))?;
-            if let Some(base_fee) = parent.next_block_base_fee(
-                RpcNodeCore::provider(self.eth_api())
-                    .chain_spec()
-                    .base_fee_params_at_block(parent_block),
-            ) {
-                evm_env.block_env.basefee = U256::from(base_fee);
-            }
         }
 
         let state_block_number = evm_env.block_env.number;

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -1,6 +1,5 @@
 //! `Eth` Sim bundle implementation and helpers.
 
-use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::BlockId;
@@ -9,21 +8,20 @@ use alloy_rpc_types_mev::{
     SimBundleOverrides, SimBundleResponse, Validity,
 };
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv, Evm};
-use reth_provider::{ChainSpecProvider, HeaderProvider, ProviderTx};
+use reth_provider::ProviderTx;
 use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::MevSimApiServer;
 use reth_rpc_eth_api::{
     helpers::{Call, EthTransactions, LoadPendingBlock},
-    FromEthApiError, RpcNodeCore,
+    FromEthApiError,
 };
 use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError};
 use reth_tasks::pool::BlockingTaskGuard;
 use reth_transaction_pool::{PoolConsensusTx, PoolPooledTx, PoolTransaction, TransactionPool};
 use revm::{
     db::CacheDB,
-    primitives::{Address, ResultAndState, SpecId},
+    primitives::{Address, ResultAndState},
     DatabaseCommit, DatabaseRef,
 };
 use std::{sync::Arc, time::Duration};
@@ -246,15 +244,6 @@ where
         let block_id = parent_block.unwrap_or(BlockId::Number(BlockNumberOrTag::Pending));
         let (mut evm_env, current_block) = self.eth_api().evm_env_at(block_id).await?;
 
-        let parent_header = RpcNodeCore::provider(&self.inner.eth_api)
-            .header_by_number(evm_env.block_env.number.saturating_to::<u64>())
-            .map_err(EthApiError::from_eth_err)? // Explicitly map the error
-            .ok_or_else(|| {
-                EthApiError::HeaderNotFound(
-                    (evm_env.block_env.number.saturating_to::<u64>()).into(),
-                )
-            })?;
-
         // apply overrides
         if let Some(block_number) = block_number {
             evm_env.block_env.number = U256::from(block_number);
@@ -274,15 +263,6 @@ where
 
         if let Some(base_fee) = base_fee {
             evm_env.block_env.basefee = U256::from(base_fee);
-        } else if evm_env.cfg_env_with_handler_cfg.handler_cfg.spec_id.is_enabled_in(SpecId::LONDON)
-        {
-            if let Some(base_fee) = parent_header.next_block_base_fee(
-                RpcNodeCore::provider(&self.inner.eth_api)
-                    .chain_spec()
-                    .base_fee_params_at_block(evm_env.block_env.number.saturating_to::<u64>()),
-            ) {
-                evm_env.block_env.basefee = U256::from(base_fee);
-            }
         }
 
         let eth_api = self.inner.eth_api.clone();

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -113,8 +113,7 @@ impl ConfigureEvm for MyEvmConfig {
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)]
-            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+            handler_cfg: HandlerCfg::new(evm_env.spec),
         };
         EvmBuilder::default()
             .with_db(db)
@@ -138,8 +137,7 @@ impl ConfigureEvm for MyEvmConfig {
     {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)]
-            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+            handler_cfg: HandlerCfg::new(evm_env.spec),
         };
 
         EvmBuilder::default()

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -15,7 +15,7 @@ use reth::{
         handler::register::EvmHandler,
         inspector_handle_register,
         precompile::{Precompile, PrecompileOutput, PrecompileSpecId},
-        primitives::{Env, PrecompileResult, TxEnv},
+        primitives::{CfgEnvWithHandlerCfg, Env, HandlerCfg, PrecompileResult, SpecId, TxEnv},
         ContextPrecompiles, Database, EvmBuilder, GetInspector,
     },
     rpc::types::engine::PayloadAttributes,
@@ -88,6 +88,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
     type Transaction = TransactionSigned;
     type Error = Infallible;
     type TxEnv = TxEnv;
+    type Spec = SpecId;
 
     fn tx_env(&self, transaction: &Self::Transaction, signer: Address) -> Self::TxEnv {
         self.inner.tx_env(transaction, signer)
@@ -110,9 +111,14 @@ impl ConfigureEvm for MyEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
 
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)]
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+        };
         EvmBuilder::default()
             .with_db(db)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+            .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
             // add additional precompiles
             .append_handler_register(MyEvmConfig::set_precompiles)
@@ -130,10 +136,16 @@ impl ConfigureEvm for MyEvmConfig {
         DB: Database,
         I: GetInspector<DB>,
     {
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)]
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+        };
+
         EvmBuilder::default()
             .with_db(db)
             .with_external_context(inspector)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+            .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
             // add additional precompiles
             .append_handler_register(MyEvmConfig::set_precompiles)

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -30,7 +30,7 @@ use reth::{
 };
 use reth_evm::EvmEnv;
 use reth_node_ethereum::node::EthereumNode;
-use revm_primitives::CfgEnvWithHandlerCfg;
+use revm_primitives::HandlerCfg;
 
 fn main() {
     Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
@@ -65,13 +65,13 @@ fn main() {
                                     BlockNumberOrTag::Latest.into(),
                                     EvmOverrides::default(),
                                     move |db, evm_env, tx_env| {
-                                        let EvmEnv {
-                                            cfg_env_with_handler_cfg:
-                                                CfgEnvWithHandlerCfg { handler_cfg, cfg_env },
-                                            block_env,
-                                        } = evm_env;
+                                        let EvmEnv { cfg_env, block_env, spec } = evm_env;
                                         let env = EnvWithHandlerCfg {
-                                            handler_cfg,
+                                            #[allow(clippy::needless_update)]
+                                            handler_cfg: HandlerCfg {
+                                                spec_id: spec,
+                                                ..Default::default()
+                                            },
                                             env: Env::boxed(cfg_env, block_env, tx_env),
                                         };
                                         let mut dummy_inspector = DummyInspector::default();

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -67,11 +67,7 @@ fn main() {
                                     move |db, evm_env, tx_env| {
                                         let EvmEnv { cfg_env, block_env, spec } = evm_env;
                                         let env = EnvWithHandlerCfg {
-                                            #[allow(clippy::needless_update)]
-                                            handler_cfg: HandlerCfg {
-                                                spec_id: spec,
-                                                ..Default::default()
-                                            },
+                                            handler_cfg: HandlerCfg::new(spec),
                                             env: Env::boxed(cfg_env, block_env, tx_env),
                                         };
                                         let mut dummy_inspector = DummyInspector::default();

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -13,7 +13,10 @@ use reth::{
         handler::register::EvmHandler,
         inspector_handle_register,
         precompile::{Precompile, PrecompileSpecId},
-        primitives::{Env, PrecompileResult, SpecId, StatefulPrecompileMut, TxEnv},
+        primitives::{
+            CfgEnvWithHandlerCfg, Env, HandlerCfg, PrecompileResult, SpecId, StatefulPrecompileMut,
+            TxEnv,
+        },
         ContextPrecompile, ContextPrecompiles, Database, EvmBuilder, GetInspector,
     },
     tasks::TaskManager,
@@ -149,6 +152,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
     type Transaction = TransactionSigned;
     type Error = Infallible;
     type TxEnv = TxEnv;
+    type Spec = SpecId;
 
     fn tx_env(&self, transaction: &Self::Transaction, signer: Address) -> Self::TxEnv {
         self.inner.tx_env(transaction, signer)
@@ -171,10 +175,16 @@ impl ConfigureEvm for MyEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
 
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)]
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+        };
+
         let new_cache = self.precompile_cache.clone();
         EvmBuilder::default()
             .with_db(db)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+            .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
             // add additional precompiles
             .append_handler_register_box(Box::new(move |handler| {
@@ -194,11 +204,16 @@ impl ConfigureEvm for MyEvmConfig {
         DB: Database,
         I: GetInspector<DB>,
     {
+        let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
+            cfg_env: evm_env.cfg_env,
+            #[allow(clippy::needless_update)]
+            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+        };
         let new_cache = self.precompile_cache.clone();
         EvmBuilder::default()
             .with_db(db)
             .with_external_context(inspector)
-            .with_cfg_env_with_handler_cfg(evm_env.cfg_env_with_handler_cfg)
+            .with_cfg_env_with_handler_cfg(cfg_env_with_handler_cfg)
             .with_block_env(evm_env.block_env)
             // add additional precompiles
             .append_handler_register_box(Box::new(move |handler| {

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -177,8 +177,7 @@ impl ConfigureEvm for MyEvmConfig {
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)]
-            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+            handler_cfg: HandlerCfg::new(evm_env.spec),
         };
 
         let new_cache = self.precompile_cache.clone();
@@ -206,8 +205,7 @@ impl ConfigureEvm for MyEvmConfig {
     {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {
             cfg_env: evm_env.cfg_env,
-            #[allow(clippy::needless_update)]
-            handler_cfg: HandlerCfg { spec_id: evm_env.spec, ..Default::default() },
+            handler_cfg: HandlerCfg::new(evm_env.spec),
         };
         let new_cache = self.precompile_cache.clone();
         EvmBuilder::default()


### PR DESCRIPTION
This makes `EvmEnv` generic over `Spec`.

Given that in current/new revm both op and eth operate on the same `BlockEnv` and `CfgEnv`, and we still need mutable access to those for various overrides, it seems reasonable to only abstract over `Spec` for now.
