### PR TITLE
chore: update links `crates/ethereum-forks/src/hardfork/ethereum.rs`

### DIFF
--- a/crates/ethereum-forks/src/hardfork/ethereum.rs
+++ b/crates/ethereum-forks/src/hardfork/ethereum.rs
@@ -45,9 +45,9 @@ hardfork!(
         Paris,
         /// Shanghai: <https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md>.
         Shanghai,
-        /// Cancun.
+        /// Cancun: <https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md>
         Cancun,
-        /// Prague: <https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/prague.md>
+        /// Prague.
         Prague,
         /// Osaka: <https://eips.ethereum.org/EIPS/eip-7607>
         Osaka,


### PR DESCRIPTION
Hi! This pull request updates the Ethereum hardfork links in the `ethereum.rs` file. Here's a summary of the changes:

- Removed the Prague link as it no longer exists in the source repository.
- Added link for Cancun to ensure the documentation stays accurate and up-to-date.
