### PR TITLE
chore: fix spelling issues

### DIFF
--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -25,7 +25,7 @@ use std::{
 /// If the response arrived with insufficient number of bodies, the future
 /// will issue another request until all bodies are collected.
 ///
-/// It then proceeds to verify the downloaded bodies. In case of an validation error,
+/// It then proceeds to verify the downloaded bodies. In case of a validation error,
 /// the future will start over.
 ///
 /// The future will filter out any empty headers (see [`alloy_consensus::Header::is_empty`]) from

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -175,7 +175,7 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
     }
 }
 
-/// Commands delegated tot the spawned [`HeaderDownloader`]
+/// Commands delegated to the spawned [`HeaderDownloader`]
 enum DownloaderUpdates<H> {
     UpdateSyncGap(SealedHeader<H>, SyncTarget),
     UpdateLocalHead(SealedHeader<H>),

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -30,7 +30,7 @@ pub struct BodyDownloaderMetrics {
     pub buffered_responses: Gauge,
     /// The number of blocks the internal buffer of the
     /// downloader.
-    /// These are bodies that have been received, but not cannot be committed yet because they're
+    /// These are bodies that have been received, but cannot be committed yet because they're
     /// not contiguous
     pub buffered_blocks: Gauge,
     /// Total amount of memory used by the buffered blocks in bytes
@@ -101,7 +101,7 @@ pub struct HeaderDownloaderMetrics {
     pub buffered_responses: Gauge,
     /// The number of blocks the internal buffer of the
     /// downloader.
-    /// These are bodies that have been received, but not cannot be committed yet because they're
+    /// These are bodies that have been received, but cannot be committed yet because they're
     /// not contiguous
     pub buffered_blocks: Gauge,
     /// Total amount of memory used by the buffered blocks in bytes

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -1,4 +1,4 @@
-//! A Protocol defines a P2P subprotocol in a `RLPx` connection
+//! A Protocol defines a P2P subprotocol in an `RLPx` connection
 
 use crate::{Capability, EthMessageID, EthVersion};
 

--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 use tokio::net::TcpStream;
 use tokio_util::codec::{Decoder, Framed, LengthDelimitedCodec};
 
-pub type P2pPassthroughTcpStream = P2PStream<Framzzed<TcpStream, LengthDelimitedCodec>>;
+pub type P2pPassthroughTcpStream = P2PStream<Framed<TcpStream, LengthDelimitedCodec>>;
 
 /// Returns a new testing `HelloMessage` and new secretkey
 pub fn eth_hello() -> (HelloMessageWithProtocols, SecretKey) {

--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 use tokio::net::TcpStream;
 use tokio_util::codec::{Decoder, Framed, LengthDelimitedCodec};
 
-pub type P2pPassthroughTcpStream = P2PStream<Framed<TcpStream, LengthDelimitedCodec>>;
+pub type P2pPassthroughTcpStream = P2PStream<Framzzed<TcpStream, LengthDelimitedCodec>>;
 
 /// Returns a new testing `HelloMessage` and new secretkey
 pub fn eth_hello() -> (HelloMessageWithProtocols, SecretKey) {
@@ -60,7 +60,7 @@ pub async fn connect_passthrough(
     p2p_stream
 }
 
-/// A Rplx subprotocol for testing
+/// An Rplx subprotocol for testing
 pub mod proto {
     use super::*;
     use crate::{protocol::Protocol, Capability};

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -48,7 +48,7 @@ impl PendingSessionHandle {
 
 /// An established session with a remote peer.
 ///
-/// Within an active session that supports the `Ethereum Wire Protocol `, three high-level tasks can
+/// Within an active session that supports the `Ethereum Wire Protocol`, three high-level tasks can
 /// be performed: chain synchronization, block propagation and transaction exchange.
 #[derive(Debug)]
 pub struct ActiveSessionHandle<N: NetworkPrimitives> {


### PR DESCRIPTION
`an validation ` - `a validation`

`tot the` - `to the`

`but not cannot` - `but cannot` x2

`a RLPx` - `an RLPx` 

`A Rplx` - `An Rplx` 

`Ethereum Wire Protocol ` - `Ethereum Wire Protocol`  - deleted space



When pronounced out loud, “RPLx” starts with the vowel sound [ɑr], similar to "ar-P-L-x." According to the rule that we use "an" before vowel sounds, the correct phrase is "an RPLx," not "a RPLx."

I tried my best , and I hope it was helpful to you ! Thanks 