### PR TITLE
feat: validate empty execution requests for OP

### DIFF
--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -112,7 +112,7 @@ where
         // according to op spec, execution requests must be empty
         if !requests.is_empty() {
             return Err(EngineObjectValidationError::InvalidParams(
-                "non-empty execution requests".to_string().into(),
+                "NonEmptyExecutionRequests".to_string().into(),
             ))
         }
         Ok(())

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -115,7 +115,7 @@ where
                 "non-empty execution requests".to_string().into(),
             ))
         }
-        Ok(()) 
+        Ok(())
     }
 
     fn validate_version_specific_fields(

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -105,6 +105,19 @@ impl<Types> EngineValidator<Types> for OpEngineValidator
 where
     Types: EngineTypes<PayloadAttributes = OpPayloadAttributes>,
 {
+    fn validate_execution_requests(
+        &self,
+        requests: &alloy_eips::eip7685::Requests,
+    ) -> Result<(), EngineObjectValidationError> {
+        // according to op spec, execution requests must be empty
+        if !requests.is_empty() {
+            return Err(EngineObjectValidationError::InvalidParams(
+                "non-empty execution requests".to_string().into(),
+            ))
+        }
+        Ok(()) 
+    }
+
     fn validate_version_specific_fields(
         &self,
         version: EngineApiMessageVersion,


### PR DESCRIPTION
Ensures that execution requests array is empty for Optimism. Fixes https://github.com/paradigmxyz/reth/issues/13908