### PR TITLE
chore: enable no-std for execution types crate

### DIFF
--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -1,7 +1,7 @@
 //! Contains [Chain], a chain of blocks and their final state.
 
 use crate::ExecutionOutcome;
-use alloc::{borrow::Cow, collections::BTreeMap};
+use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap, vec::Vec};
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1898::ForkBlock, eip2718::Encodable2718, BlockNumHash};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash};
@@ -345,7 +345,7 @@ impl<N: NodePrimitives> Chain<N> {
         let split_at = block_number + 1;
         let higher_number_blocks = self.blocks.split_off(&split_at);
 
-        let execution_outcome = std::mem::take(&mut self.execution_outcome);
+        let execution_outcome = core::mem::take(&mut self.execution_outcome);
         let (canonical_block_exec_outcome, pending_block_exec_outcome) =
             execution_outcome.split_at(split_at);
 
@@ -463,7 +463,7 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
 
 impl<B: Block> IntoIterator for ChainBlocks<'_, B> {
     type Item = (BlockNumber, RecoveredBlock<B>);
-    type IntoIter = std::collections::btree_map::IntoIter<BlockNumber, RecoveredBlock<B>>;
+    type IntoIter = alloc::collections::btree_map::IntoIter<BlockNumber, RecoveredBlock<B>>;
 
     fn into_iter(self) -> Self::IntoIter {
         #[allow(clippy::unnecessary_to_owned)]

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use alloy_eips::eip7685::Requests;
 use revm::db::BundleState;
 

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -1,4 +1,5 @@
 use crate::BlockExecutionOutput;
+use alloc::{vec, vec::Vec};
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::{logs_bloom, map::HashMap, Address, BlockNumber, Bloom, Log, B256, U256};
 use reth_primitives::Receipts;
@@ -314,13 +315,13 @@ impl<T> ExecutionOutcome<T> {
     pub fn prepend_state(&mut self, mut other: BundleState) {
         let other_len = other.reverts.len();
         // take this bundle
-        let this_bundle = std::mem::take(&mut self.bundle);
+        let this_bundle = core::mem::take(&mut self.bundle);
         // extend other bundle with this
         other.extend(this_bundle);
         // discard other reverts
         other.take_n_reverts(other_len);
         // swap bundles
-        std::mem::swap(&mut self.bundle, &mut other)
+        core::mem::swap(&mut self.bundle, &mut other)
     }
 
     /// Create a new instance with updated receipts.

--- a/crates/evm/execution-types/src/lib.rs
+++ b/crates/evm/execution-types/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 


### PR DESCRIPTION
this crate already has a std feature but didn't actually use it