### PR TITLE
feat(eth-wire): improve Capability arbitrary implementation

### DIFF
--- a/crates/net/eth-wire-types/src/capability.rs
+++ b/crates/net/eth-wire-types/src/capability.rs
@@ -91,7 +91,7 @@ impl From<EthVersion> for Capability {
 impl<'a> arbitrary::Arbitrary<'a> for Capability {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let version = u.int_in_range(66..=69)?; // Valid eth protocol versions are 66-69
-        // Only generate valid eth protocol name for now since it's the only supported protocol
+                                                // Only generate valid eth protocol name for now since it's the only supported protocol
         Ok(Self::new_static("eth", version))
     }
 }

--- a/crates/net/eth-wire-types/src/capability.rs
+++ b/crates/net/eth-wire-types/src/capability.rs
@@ -90,9 +90,9 @@ impl From<EthVersion> for Capability {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for Capability {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let version = u.int_in_range(0..=32)?; // TODO: What's the max?
-        let name = String::arbitrary(u)?; // TODO: what possible values?
-        Ok(Self::new(name, version))
+        let version = u.int_in_range(66..=69)?; // Valid eth protocol versions are 66-69
+        // Only generate valid eth protocol name for now since it's the only supported protocol
+        Ok(Self::new_static("eth", version))
     }
 }
 


### PR DESCRIPTION
- Update version range to match supported eth protocol versions (66-69)
- Use static "eth" protocol name as it's currently the only supported protocol
- Remove TODOs as they are now resolved