### PR TITLE
chore: use BlockNumHash in exex

### DIFF
--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -1,8 +1,8 @@
 use crate::{ExExContextDyn, ExExEvent, ExExNotifications, ExExNotificationsStream};
+use alloy_eips::BlockNumHash;
 use reth_exex_types::ExExHead;
 use reth_node_api::{FullNodeComponents, NodePrimitives, NodeTypes, PrimitivesTy};
 use reth_node_core::node_config::NodeConfig;
-use reth_primitives::Head;
 use reth_provider::BlockReader;
 use reth_tasks::TaskExecutor;
 use std::fmt::Debug;
@@ -11,7 +11,7 @@ use tokio::sync::mpsc::UnboundedSender;
 /// Captures the context that an `ExEx` has access to.
 pub struct ExExContext<Node: FullNodeComponents> {
     /// The current head of the blockchain at launch.
-    pub head: Head,
+    pub head: BlockNumHash,
     /// The config of the node
     pub config: NodeConfig<<Node::Types as NodeTypes>::ChainSpec>,
     /// The loaded node config

--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -1,13 +1,13 @@
 //! Mirrored version of [`ExExContext`](`crate::ExExContext`)
 //! without generic abstraction over [Node](`reth_node_api::FullNodeComponents`)
 
-use std::fmt::Debug;
-
-use reth_chainspec::{EthChainSpec, Head};
+use alloy_eips::BlockNumHash;
+use reth_chainspec::EthChainSpec;
 use reth_node_api::{FullNodeComponents, HeaderTy, NodePrimitives, NodeTypes, PrimitivesTy};
 use reth_node_core::node_config::NodeConfig;
 use reth_primitives::EthPrimitives;
 use reth_provider::BlockReader;
+use std::fmt::Debug;
 use tokio::sync::mpsc;
 
 use crate::{ExExContext, ExExEvent, ExExNotificationsStream};
@@ -16,7 +16,7 @@ use crate::{ExExContext, ExExEvent, ExExNotificationsStream};
 /// Captures the context that an `ExEx` has access to.
 pub struct ExExContextDyn<N: NodePrimitives = EthPrimitives> {
     /// The current head of the blockchain at launch.
-    pub head: Head,
+    pub head: BlockNumHash,
     /// The config of the node
     pub config: NodeConfig<Box<dyn EthChainSpec<Header = N::BlockHeader> + 'static>>,
     /// The loaded node config

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -7,7 +7,6 @@ use futures::StreamExt;
 use itertools::Itertools;
 use metrics::Gauge;
 use reth_chain_state::ForkChoiceStream;
-use reth_chainspec::Head;
 use reth_evm::execute::BlockExecutorProvider;
 use reth_metrics::{metrics::Counter, Metrics};
 use reth_node_api::NodePrimitives;
@@ -96,7 +95,7 @@ impl<N: NodePrimitives> ExExHandle<N> {
     /// [`mpsc::Receiver`] for [`ExExNotification`]s that should be given to the `ExEx`.
     pub fn new<P, E: BlockExecutorProvider<Primitives = N>>(
         id: String,
-        node_head: Head,
+        node_head: BlockNumHash,
         provider: P,
         executor: E,
         wal_handle: WalHandle<N>,
@@ -685,7 +684,7 @@ mod tests {
 
         let (mut exex_handle, event_tx, mut _notification_rx) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -705,7 +704,7 @@ mod tests {
 
         let (exex_handle_1, _, _) = ExExHandle::new(
             "test_exex_1".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -727,7 +726,7 @@ mod tests {
 
         let (exex_handle_1, _, _) = ExExHandle::new(
             "test_exex_1".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -755,7 +754,7 @@ mod tests {
 
         let (exex_handle, _, _) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -810,7 +809,7 @@ mod tests {
 
         let (exex_handle, _, _) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -861,7 +860,7 @@ mod tests {
 
         let (exex_handle, event_tx, mut _notification_rx) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -916,14 +915,14 @@ mod tests {
         // Create two `ExExHandle` instances
         let (exex_handle1, event_tx1, _) = ExExHandle::new(
             "test_exex1".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
         );
         let (exex_handle2, event_tx2, _) = ExExHandle::new(
             "test_exex2".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -973,14 +972,14 @@ mod tests {
         // Create two `ExExHandle` instances
         let (exex_handle1, event_tx1, _) = ExExHandle::new(
             "test_exex1".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
         );
         let (exex_handle2, event_tx2, _) = ExExHandle::new(
             "test_exex2".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -1036,7 +1035,7 @@ mod tests {
 
         let (exex_handle_1, _, _) = ExExHandle::new(
             "test_exex_1".to_string(),
-            Head::default(),
+            Default::default(),
             (),
             MockExecutorProvider::default(),
             wal.handle(),
@@ -1105,7 +1104,7 @@ mod tests {
 
         let (mut exex_handle, _, mut notifications) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             provider,
             EthExecutorProvider::mainnet(),
             wal.handle(),
@@ -1160,7 +1159,7 @@ mod tests {
 
         let (mut exex_handle, _, mut notifications) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             provider,
             EthExecutorProvider::mainnet(),
             wal.handle(),
@@ -1210,7 +1209,7 @@ mod tests {
 
         let (mut exex_handle, _, mut notifications) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             provider,
             EthExecutorProvider::mainnet(),
             wal.handle(),
@@ -1253,7 +1252,7 @@ mod tests {
 
         let (mut exex_handle, _, mut notifications) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             provider,
             EthExecutorProvider::mainnet(),
             wal.handle(),
@@ -1313,7 +1312,7 @@ mod tests {
 
         let (exex_handle, events_tx, mut notifications) = ExExHandle::new(
             "test_exex".to_string(),
-            Head::default(),
+            Default::default(),
             provider.clone(),
             EthExecutorProvider::mainnet(),
             wal.handle(),

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -45,7 +45,7 @@ use reth_node_ethereum::{
     EthEngineTypes, EthEvmConfig,
 };
 use reth_payload_builder::noop::NoopPayloadBuilderService;
-use reth_primitives::{EthPrimitives, Head, RecoveredBlock, TransactionSigned};
+use reth_primitives::{EthPrimitives, RecoveredBlock, TransactionSigned};
 use reth_primitives_traits::Block as _;
 use reth_provider::{
     providers::{BlockchainProvider, StaticFileProvider},
@@ -308,13 +308,7 @@ pub async fn test_exex_context_with_chain_spec(
         .seal_slow()
         .try_recover()?;
 
-    let head = Head {
-        number: genesis.number,
-        hash: genesis_hash,
-        difficulty: genesis.difficulty,
-        timestamp: genesis.timestamp,
-        total_difficulty: Default::default(),
-    };
+    let head = genesis.num_hash();
 
     let wal_directory = tempfile::tempdir()?;
     let wal = Wal::new(wal_directory.path())?;

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -1,7 +1,6 @@
 //! Support for launching execution extensions.
 
-use std::{fmt, fmt::Debug};
-
+use alloy_eips::BlockNumHash;
 use futures::future;
 use reth_chain_state::ForkChoiceSubscriptions;
 use reth_chainspec::EthChainSpec;
@@ -13,6 +12,7 @@ use reth_node_api::{FullNodeComponents, NodeTypes, PrimitivesTy};
 use reth_primitives::Head;
 use reth_provider::CanonStateSubscriptions;
 use reth_tracing::tracing::{debug, info};
+use std::{fmt, fmt::Debug};
 use tracing::Instrument;
 
 use crate::{common::WithConfigs, exex::BoxedLaunchExEx};
@@ -44,6 +44,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
         self,
     ) -> eyre::Result<Option<ExExManagerHandle<PrimitivesTy<Node::Types>>>> {
         let Self { head, extensions, components, config_container } = self;
+        let head = BlockNumHash::new(head.number, head.hash);
 
         if extensions.is_empty() {
             // nothing to launch


### PR DESCRIPTION
for exex we only need hash and number.

the head type includes more info that we don't need, including deprecated fields like total difficulty