### PR TITLE
chore: move EthPrimitives to reth-ethereum-primitives

### DIFF
--- a/crates/ethereum/primitives/src/lib.rs
+++ b/crates/ethereum/primitives/src/lib.rs
@@ -25,3 +25,17 @@ pub type Block = alloy_consensus::Block<TransactionSigned>;
 
 /// Type alias for the ethereum blockbody
 pub type BlockBody = alloy_consensus::BlockBody<TransactionSigned>;
+
+/// Helper struct that specifies the ethereum
+/// [`NodePrimitives`](reth_primitives_traits::NodePrimitives) types.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub struct EthPrimitives;
+
+impl reth_primitives_traits::NodePrimitives for EthPrimitives {
+    type Block = crate::Block;
+    type BlockHeader = alloy_consensus::Header;
+    type BlockBody = crate::BlockBody;
+    type SignedTx = crate::TransactionSigned;
+    type Receipt = crate::Receipt;
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -75,15 +75,5 @@ pub mod serde_bincode_compat {
     pub use reth_primitives_traits::serde_bincode_compat::*;
 }
 
-/// Temp helper struct for integrating [`NodePrimitives`].
-#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[non_exhaustive]
-pub struct EthPrimitives;
-
-impl reth_primitives_traits::NodePrimitives for EthPrimitives {
-    type Block = crate::Block;
-    type BlockHeader = alloy_consensus::Header;
-    type BlockBody = crate::BlockBody;
-    type SignedTx = crate::TransactionSigned;
-    type Receipt = crate::Receipt;
-}
+// Re-export of `EthPrimitives`
+pub use reth_ethereum_primitives::EthPrimitives;


### PR DESCRIPTION
This can now be brought directly into `reth_ethereum_primitives` because all of the other types have been moved