### PR TITLE
chore(trie): remove from_cache_state

### DIFF
--- a/crates/trie/common/src/key.rs
+++ b/crates/trie/common/src/key.rs
@@ -11,6 +11,7 @@ pub trait KeyHasher: Default + Clone + Send + Sync + 'static {
 pub struct KeccakKeyHasher;
 
 impl KeyHasher for KeccakKeyHasher {
+    #[inline]
     fn hash_key<T: AsRef<[u8]>>(bytes: T) -> B256 {
         keccak256(bytes)
     }

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use reth_primitives::Account;
 use reth_trie_common::KeyHasher;
-use revm::db::{states::CacheAccount, AccountStatus, BundleAccount};
+use revm::db::{AccountStatus, BundleAccount};
 use std::borrow::Cow;
 
 /// Representation of in-memory hashed state.
@@ -27,6 +27,7 @@ impl HashedPostState {
     /// Initialize [`HashedPostState`] from bundle state.
     /// Hashes all changed accounts and storage entries that are currently stored in the bundle
     /// state.
+    #[inline]
     pub fn from_bundle_state<'a, KH: KeyHasher>(
         state: impl IntoParallelIterator<Item = (&'a Address, &'a BundleAccount)>,
     ) -> Self {
@@ -38,33 +39,6 @@ impl HashedPostState {
                 let hashed_storage = HashedStorage::from_plain_storage(
                     account.status,
                     account.storage.iter().map(|(slot, value)| (slot, &value.present_value)),
-                );
-                (hashed_address, (hashed_account, hashed_storage))
-            })
-            .collect::<Vec<(B256, (Option<Account>, HashedStorage))>>();
-
-        let mut accounts = HashMap::with_capacity_and_hasher(hashed.len(), Default::default());
-        let mut storages = HashMap::with_capacity_and_hasher(hashed.len(), Default::default());
-        for (address, (account, storage)) in hashed {
-            accounts.insert(address, account);
-            storages.insert(address, storage);
-        }
-        Self { accounts, storages }
-    }
-
-    /// Initialize [`HashedPostState`] from cached state.
-    /// Hashes all changed accounts and storage entries that are currently stored in cache.
-    pub fn from_cache_state<'a, KH: KeyHasher>(
-        state: impl IntoParallelIterator<Item = (&'a Address, &'a CacheAccount)>,
-    ) -> Self {
-        let hashed = state
-            .into_par_iter()
-            .map(|(address, account)| {
-                let hashed_address = KH::hash_key(address);
-                let hashed_account = account.account.as_ref().map(|a| (&a.info).into());
-                let hashed_storage = HashedStorage::from_plain_storage(
-                    account.status,
-                    account.account.as_ref().map(|a| a.storage.iter()).into_iter().flatten(),
                 );
                 (hashed_address, (hashed_account, hashed_storage))
             })
@@ -357,10 +331,7 @@ mod tests {
     use alloy_primitives::Bytes;
     use reth_trie_common::KeccakKeyHasher;
     use revm::{
-        db::{
-            states::{plain_account::PlainStorage, StorageSlot},
-            PlainAccount, StorageWithOriginalValues,
-        },
+        db::{states::StorageSlot, StorageWithOriginalValues},
         primitives::{AccountInfo, Bytecode},
     };
 
@@ -470,45 +441,6 @@ mod tests {
 
         // Convert the bundle state into a hashed post state.
         let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(state);
-
-        // Validate the hashed post state.
-        assert_eq!(hashed_state.accounts.len(), 1);
-        assert_eq!(hashed_state.storages.len(), 1);
-
-        // Validate the account info.
-        assert_eq!(
-            *hashed_state.accounts.get(&keccak256(address)).unwrap(),
-            Some(account_info.into())
-        );
-    }
-
-    #[test]
-    fn test_hashed_post_state_from_cache_state() {
-        // Prepare a random Ethereum address.
-        let address = Address::random();
-
-        // Create mock account info.
-        let account_info = AccountInfo {
-            balance: U256::from(500),
-            nonce: 5,
-            code_hash: B256::random(),
-            code: None,
-        };
-
-        let mut storage = PlainStorage::default();
-        storage.insert(U256::from(1), U256::from(35636));
-
-        // Create a `CacheAccount` with the mock account info.
-        let account = CacheAccount {
-            account: Some(PlainAccount { info: account_info.clone(), storage }),
-            status: AccountStatus::Changed,
-        };
-
-        // Create a vector of tuples representing the cache state.
-        let state = vec![(&address, &account)];
-
-        // Convert the cache state into a hashed post state.
-        let hashed_state = HashedPostState::from_cache_state::<KeccakKeyHasher>(state);
 
         // Validate the hashed post state.
         assert_eq!(hashed_state.accounts.len(), 1);


### PR DESCRIPTION
Seems like this method was entirely unused, we always go from bundle state to hashed post state. Also adds some `#[inline]`s