### PR TITLE
chore: update profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,6 +253,14 @@ significant_drop_in_scrutinee = "allow"
 significant_drop_tightening = "allow"
 too_long_first_doc_paragraph = "allow"
 
+# Speed up compilation time for dev builds by reducing emitted debug info.
+# NOTE: Debuggers may provide less useful information with this setting.
+# Uncomment this section if you're using a debugger.
+[profile.dev]
+# https://davidlattimore.github.io/posts/2024/02/04/speeding-up-the-rust-edit-build-run-cycle.html
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
 # Speed up tests.
 [profile.dev.package]
 proptest.opt-level = 3
@@ -263,32 +271,32 @@ unarray.opt-level = 3
 # Meant for testing - all optimizations, but with debug assertions and overflow checks.
 [profile.hivetests]
 inherits = "test"
-lto = "thin"
 opt-level = 3
+lto = "thin"
 
 [profile.release]
-codegen-units = 16
-debug = "line-tables-only"
-lto = "thin"
 opt-level = 3
+lto = "thin"
+debug = "none"
+strip = "symbols"
 panic = "unwind"
-strip = true
+codegen-units = 16
 
 # Use the `--profile profiling` flag to show symbols in release mode.
 # e.g. `cargo build --profile profiling`
 [profile.profiling]
-debug = 2
 inherits = "release"
-strip = false
+debug = "full"
+strip = "none"
 
-# Make sure debug symbols are in the bench profile
+# Include debug info in benchmarks too.
 [profile.bench]
 inherits = "profiling"
 
 [profile.maxperf]
-codegen-units = 1
 inherits = "release"
 lto = "fat"
+codegen-units = 1
 
 [workspace.dependencies]
 # reth
@@ -465,11 +473,11 @@ alloy-transport-ws = { version = "0.9.2", default-features = false }
 
 # op
 op-alloy-rpc-types = { version = "0.9.6", default-features = false }
-op-alloy-rpc-types-engine = { version =  "0.9.6", default-features = false }
-op-alloy-network = { version =  "0.9.6", default-features = false }
-op-alloy-consensus = { version =  "0.9.6", default-features = false }
-op-alloy-flz = { version =  "0.9.6", default-features = false }
-op-alloy-rpc-jsonrpsee = { version =  "0.9.6", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.9.6", default-features = false }
+op-alloy-network = { version = "0.9.6", default-features = false }
+op-alloy-consensus = { version = "0.9.6", default-features = false }
+op-alloy-flz = { version = "0.9.6", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.9.6", default-features = false }
 
 # misc
 aquamarine = "0.6"
@@ -510,7 +518,7 @@ rayon = "1.7"
 rustc-hash = { version = "2.0", default-features = false }
 schnellru = "0.2"
 serde = { version = "1.0", default-features = false }
-serde_json = { version = "1.0.94", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 sha2 = { version = "0.10", default-features = false }
 shellexpand = "3.0.0"


### PR DESCRIPTION
- `debug = false` -> `debug = "none"`
- Disable `debug` in release since it does nothing
- Reduce debug info in dev profile for faster and smaller builds