### PR TITLE
refactor: remove `Events` generic from RPC types

### DIFF
--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -20,7 +20,6 @@ pub type EthApiBuilderCtx<N> = reth_rpc_eth_types::EthApiBuilderCtx<
     <N as RpcNodeCore>::Evm,
     <N as RpcNodeCore>::Network,
     TaskExecutor,
-    <N as RpcNodeCore>::Provider,
 >;
 
 /// A general purpose trait that launches a new node of any kind.

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -197,7 +197,6 @@ pub struct RpcRegistry<Node: FullNodeComponents, EthApi: EthApiTypes> {
         Node::Pool,
         Node::Network,
         TaskExecutor,
-        Node::Provider,
         EthApi,
         Node::Executor,
         Node::Consensus,
@@ -214,7 +213,6 @@ where
         Node::Pool,
         Node::Network,
         TaskExecutor,
-        Node::Provider,
         EthApi,
         Node::Executor,
         Node::Consensus,
@@ -453,7 +451,6 @@ where
             .with_provider(node.provider().clone())
             .with_pool(node.pool().clone())
             .with_network(node.network().clone())
-            .with_events(node.provider().clone())
             .with_executor(node.task_executor().clone())
             .with_evm_config(node.evm_config().clone())
             .with_block_executor(node.block_executor().clone())

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -31,11 +31,10 @@
 //! use reth_transaction_pool::{PoolTransaction, TransactionPool};
 //! use std::sync::Arc;
 //!
-//! pub async fn launch<Provider, Pool, Network, Events, BlockExecutor, Consensus, Validator>(
+//! pub async fn launch<Provider, Pool, Network, BlockExecutor, Consensus, Validator>(
 //!     provider: Provider,
 //!     pool: Pool,
 //!     network: Network,
-//!     events: Events,
 //!     evm_config: EthEvmConfig,
 //!     block_executor: BlockExecutor,
 //!     consensus: Consensus,
@@ -47,7 +46,7 @@
 //!             Receipt = reth_primitives::Receipt,
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
-//!         + ChangeSetReader,
+//!         + ChangeSetReader + CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives>,
 //!     Pool: TransactionPool<
 //!             Transaction: PoolTransaction<
 //!                 Consensus = TransactionSigned,
@@ -56,9 +55,7 @@
 //!         > + Unpin
 //!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
-//!     Events:
-//!         CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives> + Clone + 'static,
-//!     BlockExecutor: BlockExecutorProvider<Primitives = Events::Primitives>,
+//!     BlockExecutor: BlockExecutorProvider<Primitives = Provider::Primitives>,
 //!     Consensus: FullConsensus<Error = ConsensusError> + Clone + 'static,
 //!     Validator: PayloadValidator<Block = reth_primitives::Block>,
 //! {
@@ -74,7 +71,6 @@
 //!         pool,
 //!         network,
 //!         TokioTaskExecutor::default(),
-//!         events,
 //!         evm_config,
 //!         block_executor,
 //!         consensus,
@@ -114,7 +110,6 @@
 //!     Provider,
 //!     Pool,
 //!     Network,
-//!     Events,
 //!     EngineApi,
 //!     EngineT,
 //!     BlockExecutor,
@@ -124,7 +119,6 @@
 //!     provider: Provider,
 //!     pool: Pool,
 //!     network: Network,
-//!     events: Events,
 //!     engine_api: EngineApi,
 //!     evm_config: EthEvmConfig,
 //!     block_executor: BlockExecutor,
@@ -137,7 +131,8 @@
 //!             Receipt = reth_primitives::Receipt,
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
-//!         + ChangeSetReader,
+//!         + ChangeSetReader
+//!         + CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives>,
 //!     Pool: TransactionPool<
 //!             Transaction: PoolTransaction<
 //!                 Consensus = TransactionSigned,
@@ -146,11 +141,9 @@
 //!         > + Unpin
 //!         + 'static,
 //!     Network: NetworkInfo + Peers + Clone + 'static,
-//!     Events:
-//!         CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives> + Clone + 'static,
 //!     EngineApi: EngineApiServer<EngineT>,
 //!     EngineT: EngineTypes,
-//!     BlockExecutor: BlockExecutorProvider<Primitives = Events::Primitives>,
+//!     BlockExecutor: BlockExecutorProvider<Primitives = Provider::Primitives>,
 //!     Consensus: FullConsensus<Error = ConsensusError> + Clone + 'static,
 //!     Validator: PayloadValidator<Block = reth_primitives::Block>,
 //! {
@@ -166,7 +159,6 @@
 //!         pool,
 //!         network,
 //!         TokioTaskExecutor::default(),
-//!         events,
 //!         evm_config,
 //!         block_executor,
 //!         consensus,
@@ -279,16 +271,15 @@ pub mod rate_limiter;
 
 /// Convenience function for starting a server in one step.
 #[allow(clippy::too_many_arguments)]
-pub async fn launch<Provider, Pool, Network, Tasks, Events, EvmConfig, EthApi, BlockExecutor>(
+pub async fn launch<Provider, Pool, Network, Tasks, EvmConfig, EthApi, BlockExecutor>(
     provider: Provider,
     pool: Pool,
     network: Network,
     module_config: impl Into<TransportRpcModuleConfig>,
     server_config: impl Into<RpcServerConfig>,
     executor: Tasks,
-    events: Events,
     evm_config: EvmConfig,
-    eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, EthApi>,
+    eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
     block_executor: BlockExecutor,
     consensus: Arc<dyn FullConsensus<BlockExecutor::Primitives, Error = ConsensusError>>,
     payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
@@ -298,12 +289,12 @@ where
             Block = ProviderBlock<EthApi::Provider>,
             Receipt = ProviderReceipt<EthApi::Provider>,
             Header = ProviderHeader<EthApi::Provider>,
-        > + AccountReader
+        > + CanonStateSubscriptions<Primitives = BlockExecutor::Primitives>
+        + AccountReader
         + ChangeSetReader,
     Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction> + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    Events: CanonStateSubscriptions<Primitives = BlockExecutor::Primitives> + Clone + 'static,
     EvmConfig: ConfigureEvm<
         Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         Transaction = <BlockExecutor::Primitives as NodePrimitives>::SignedTx,
@@ -313,7 +304,7 @@ where
             Block = <BlockExecutor::Primitives as NodePrimitives>::Block,
             Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
-        >,
+        > + CanonStateSubscriptions<Primitives = BlockExecutor::Primitives>,
     >,
     BlockExecutor: BlockExecutorProvider,
 {
@@ -326,7 +317,6 @@ where
                 pool,
                 network,
                 executor,
-                events,
                 evm_config,
                 block_executor,
                 consensus,
@@ -340,16 +330,7 @@ where
 ///
 /// This is the main entrypoint and the easiest way to configure an RPC server.
 #[derive(Debug, Clone)]
-pub struct RpcModuleBuilder<
-    Provider,
-    Pool,
-    Network,
-    Tasks,
-    Events,
-    EvmConfig,
-    BlockExecutor,
-    Consensus,
-> {
+pub struct RpcModuleBuilder<Provider, Pool, Network, Tasks, EvmConfig, BlockExecutor, Consensus> {
     /// The Provider type to when creating all rpc handlers
     provider: Provider,
     /// The Pool type to when creating all rpc handlers
@@ -358,8 +339,6 @@ pub struct RpcModuleBuilder<
     network: Network,
     /// How additional tasks are spawned, for example in the eth pubsub namespace
     executor: Tasks,
-    /// Provides access to chain events, such as new blocks, required by pubsub.
-    events: Events,
     /// Defines how the EVM should be configured before execution.
     evm_config: EvmConfig,
     /// The provider for getting a block executor that executes blocks
@@ -370,8 +349,8 @@ pub struct RpcModuleBuilder<
 
 // === impl RpcBuilder ===
 
-impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus>
-    RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, Tasks, EvmConfig, BlockExecutor, Consensus>
+    RpcModuleBuilder<Provider, Pool, Network, Tasks, EvmConfig, BlockExecutor, Consensus>
 {
     /// Create a new instance of the builder
     #[allow(clippy::too_many_arguments)]
@@ -380,30 +359,27 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
         pool: Pool,
         network: Network,
         executor: Tasks,
-        events: Events,
         evm_config: EvmConfig,
         block_executor: BlockExecutor,
         consensus: Consensus,
     ) -> Self {
-        Self { provider, pool, network, executor, events, evm_config, block_executor, consensus }
+        Self { provider, pool, network, executor, evm_config, block_executor, consensus }
     }
 
     /// Configure the provider instance.
     pub fn with_provider<P>(
         self,
         provider: P,
-    ) -> RpcModuleBuilder<P, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus>
+    ) -> RpcModuleBuilder<P, Pool, Network, Tasks, EvmConfig, BlockExecutor, Consensus>
     where
         P: BlockReader + StateProviderFactory + 'static,
     {
-        let Self { pool, network, executor, events, evm_config, block_executor, consensus, .. } =
-            self;
+        let Self { pool, network, executor, evm_config, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
             executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -414,19 +390,16 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     pub fn with_pool<P>(
         self,
         pool: P,
-    ) -> RpcModuleBuilder<Provider, P, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus>
+    ) -> RpcModuleBuilder<Provider, P, Network, Tasks, EvmConfig, BlockExecutor, Consensus>
     where
         P: TransactionPool + 'static,
     {
-        let Self {
-            provider, network, executor, events, evm_config, block_executor, consensus, ..
-        } = self;
+        let Self { provider, network, executor, evm_config, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
             executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -445,18 +418,14 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
         NoopTransactionPool,
         Network,
         Tasks,
-        Events,
         EvmConfig,
         BlockExecutor,
         Consensus,
     > {
-        let Self {
-            provider, executor, events, network, evm_config, block_executor, consensus, ..
-        } = self;
+        let Self { provider, executor, network, evm_config, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             executor,
-            events,
             network,
             evm_config,
             block_executor,
@@ -469,19 +438,16 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     pub fn with_network<N>(
         self,
         network: N,
-    ) -> RpcModuleBuilder<Provider, Pool, N, Tasks, Events, EvmConfig, BlockExecutor, Consensus>
+    ) -> RpcModuleBuilder<Provider, Pool, N, Tasks, EvmConfig, BlockExecutor, Consensus>
     where
         N: NetworkInfo + Peers + 'static,
     {
-        let Self {
-            provider, pool, executor, events, evm_config, block_executor, consensus, ..
-        } = self;
+        let Self { provider, pool, executor, evm_config, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
             executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -495,24 +461,13 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     /// [`EthApi`](reth_rpc::eth::EthApi) which requires a [`NetworkInfo`] implementation.
     pub fn with_noop_network(
         self,
-    ) -> RpcModuleBuilder<
-        Provider,
-        Pool,
-        NoopNetwork,
-        Tasks,
-        Events,
-        EvmConfig,
-        BlockExecutor,
-        Consensus,
-    > {
-        let Self {
-            provider, pool, executor, events, evm_config, block_executor, consensus, ..
-        } = self;
+    ) -> RpcModuleBuilder<Provider, Pool, NoopNetwork, Tasks, EvmConfig, BlockExecutor, Consensus>
+    {
+        let Self { provider, pool, executor, evm_config, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             pool,
             executor,
-            events,
             network: NoopNetwork::default(),
             evm_config,
             block_executor,
@@ -524,18 +479,16 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     pub fn with_executor<T>(
         self,
         executor: T,
-    ) -> RpcModuleBuilder<Provider, Pool, Network, T, Events, EvmConfig, BlockExecutor, Consensus>
+    ) -> RpcModuleBuilder<Provider, Pool, Network, T, EvmConfig, BlockExecutor, Consensus>
     where
         T: TaskSpawner + 'static,
     {
-        let Self { pool, network, provider, events, evm_config, block_executor, consensus, .. } =
-            self;
+        let Self { pool, network, provider, evm_config, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
             executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -553,42 +506,16 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
         Pool,
         Network,
         TokioTaskExecutor,
-        Events,
         EvmConfig,
         BlockExecutor,
         Consensus,
     > {
-        let Self { pool, network, provider, events, evm_config, block_executor, consensus, .. } =
-            self;
+        let Self { pool, network, provider, evm_config, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
-            events,
             executor: TokioTaskExecutor::default(),
-            evm_config,
-            block_executor,
-            consensus,
-        }
-    }
-
-    /// Configure the event subscriber instance
-    pub fn with_events<E>(
-        self,
-        events: E,
-    ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, E, EvmConfig, BlockExecutor, Consensus>
-    where
-        E: CanonStateSubscriptions + 'static,
-    {
-        let Self {
-            provider, pool, executor, network, evm_config, block_executor, consensus, ..
-        } = self;
-        RpcModuleBuilder {
-            provider,
-            network,
-            pool,
-            executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -599,18 +526,16 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     pub fn with_evm_config<E>(
         self,
         evm_config: E,
-    ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, E, BlockExecutor, Consensus>
+    ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, E, BlockExecutor, Consensus>
     where
         E: ConfigureEvm + 'static,
     {
-        let Self { provider, pool, executor, network, events, block_executor, consensus, .. } =
-            self;
+        let Self { provider, pool, executor, network, block_executor, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
             executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -621,17 +546,16 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     pub fn with_block_executor<BE>(
         self,
         block_executor: BE,
-    ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, EvmConfig, BE, Consensus>
+    ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, EvmConfig, BE, Consensus>
     where
         BE: BlockExecutorProvider,
     {
-        let Self { provider, network, pool, executor, events, evm_config, consensus, .. } = self;
+        let Self { provider, network, pool, executor, evm_config, consensus, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
             executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -642,15 +566,13 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     pub fn with_consensus<C>(
         self,
         consensus: C,
-    ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, C> {
-        let Self { provider, network, pool, executor, events, evm_config, block_executor, .. } =
-            self;
+    ) -> RpcModuleBuilder<Provider, Pool, Network, Tasks, EvmConfig, BlockExecutor, C> {
+        let Self { provider, network, pool, executor, evm_config, block_executor, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
             executor,
-            events,
             evm_config,
             block_executor,
             consensus,
@@ -658,19 +580,19 @@ impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus
     }
 }
 
-impl<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus>
-    RpcModuleBuilder<Provider, Pool, Network, Tasks, Events, EvmConfig, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, Tasks, EvmConfig, BlockExecutor, Consensus>
+    RpcModuleBuilder<Provider, Pool, Network, Tasks, EvmConfig, BlockExecutor, Consensus>
 where
     Provider: FullRpcProvider<
-            Block = <Events::Primitives as NodePrimitives>::Block,
-            Receipt = <Events::Primitives as NodePrimitives>::Receipt,
-            Header = <Events::Primitives as NodePrimitives>::BlockHeader,
-        > + AccountReader
+            Block = <BlockExecutor::Primitives as NodePrimitives>::Block,
+            Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
+            Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
+        > + CanonStateSubscriptions<Primitives = BlockExecutor::Primitives>
+        + AccountReader
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    Events: CanonStateSubscriptions<Primitives = BlockExecutor::Primitives> + Clone + 'static,
     EvmConfig: ConfigureEvm<
         Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
         Transaction = <BlockExecutor::Primitives as NodePrimitives>::SignedTx,
@@ -689,34 +611,26 @@ where
         self,
         module_config: TransportRpcModuleConfig,
         engine: EngineApi,
-        eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, EthApi>,
+        eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
         payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
     ) -> (
         TransportRpcModules,
         AuthRpcModule,
-        RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>,
+        RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>,
     )
     where
         EngineT: EngineTypes,
         EngineApi: EngineApiServer<EngineT>,
         EthApi: FullEthApiServer<
             Provider: BlockReader<
-                Block = <Events::Primitives as NodePrimitives>::Block,
-                Receipt = <Events::Primitives as NodePrimitives>::Receipt,
-                Header = <Events::Primitives as NodePrimitives>::BlockHeader,
-            >,
+                Block = <BlockExecutor::Primitives as NodePrimitives>::Block,
+                Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
+                Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
+            > + CanonStateSubscriptions<Primitives = BlockExecutor::Primitives>,
         >,
     {
-        let Self {
-            provider,
-            pool,
-            network,
-            executor,
-            events,
-            evm_config,
-            block_executor,
-            consensus,
-        } = self;
+        let Self { provider, pool, network, executor, evm_config, block_executor, consensus } =
+            self;
 
         let config = module_config.config.clone().unwrap_or_default();
 
@@ -725,7 +639,6 @@ where
             pool,
             network,
             executor,
-            events,
             consensus,
             config,
             evm_config,
@@ -772,7 +685,6 @@ where
     ///         .with_pool(NoopTransactionPool::default())
     ///         .with_network(NoopNetwork::default())
     ///         .with_executor(TokioTaskExecutor::default())
-    ///         .with_events(TestCanonStateSubscriptions::default())
     ///         .with_evm_config(evm)
     ///         .with_block_executor(EthExecutorProvider::mainnet())
     ///         .with_consensus(NoopConsensus::default())
@@ -784,28 +696,19 @@ where
     pub fn into_registry<EthApi>(
         self,
         config: RpcModuleConfig,
-        eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, EthApi>,
+        eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
         payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
-    ) -> RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
+    ) -> RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
     where
         EthApi: EthApiTypes + 'static,
     {
-        let Self {
-            provider,
-            pool,
-            network,
-            executor,
-            events,
-            evm_config,
-            block_executor,
-            consensus,
-        } = self;
+        let Self { provider, pool, network, executor, evm_config, block_executor, consensus } =
+            self;
         RpcRegistryInner::new(
             provider,
             pool,
             network,
             executor,
-            events,
             consensus,
             config,
             evm_config,
@@ -820,31 +723,23 @@ where
     pub fn build<EthApi>(
         self,
         module_config: TransportRpcModuleConfig,
-        eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, Events, EthApi>,
+        eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
         payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
     ) -> TransportRpcModules<()>
     where
         EthApi: FullEthApiServer<
             Provider: BlockReader<
-                Receipt = <Events::Primitives as NodePrimitives>::Receipt,
-                Block = <Events::Primitives as NodePrimitives>::Block,
-                Header = <Events::Primitives as NodePrimitives>::BlockHeader,
-            >,
+                Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
+                Block = <BlockExecutor::Primitives as NodePrimitives>::Block,
+                Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
+            > + CanonStateSubscriptions<Primitives = BlockExecutor::Primitives>,
         >,
         Pool: TransactionPool<Transaction = <EthApi::Pool as TransactionPool>::Transaction>,
     {
         let mut modules = TransportRpcModules::default();
 
-        let Self {
-            provider,
-            pool,
-            network,
-            executor,
-            events,
-            evm_config,
-            block_executor,
-            consensus,
-        } = self;
+        let Self { provider, pool, network, executor, evm_config, block_executor, consensus } =
+            self;
 
         if !module_config.is_empty() {
             let TransportRpcModuleConfig { http, ws, ipc, config } = module_config.clone();
@@ -854,7 +749,6 @@ where
                 pool,
                 network,
                 executor,
-                events,
                 consensus,
                 config.unwrap_or_default(),
                 evm_config,
@@ -873,9 +767,9 @@ where
     }
 }
 
-impl Default for RpcModuleBuilder<(), (), (), (), (), (), (), ()> {
+impl Default for RpcModuleBuilder<(), (), (), (), (), (), ()> {
     fn default() -> Self {
-        Self::new((), (), (), (), (), (), (), ())
+        Self::new((), (), (), (), (), (), ())
     }
 }
 
@@ -963,7 +857,6 @@ pub struct RpcRegistryInner<
     Pool,
     Network,
     Tasks,
-    Events,
     EthApi: EthApiTypes,
     BlockExecutor,
     Consensus,
@@ -972,14 +865,13 @@ pub struct RpcRegistryInner<
     pool: Pool,
     network: Network,
     executor: Tasks,
-    events: Events,
     block_executor: BlockExecutor,
     consensus: Consensus,
     payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
     /// Holds the configuration for the RPC modules
     config: RpcModuleConfig,
     /// Holds a all `eth_` namespace handlers
-    eth: EthHandlers<Provider, Events, EthApi>,
+    eth: EthHandlers<Provider, EthApi>,
     /// to put trace calls behind semaphore
     blocking_pool_guard: BlockingTaskGuard,
     /// Contains the [Methods] of a module
@@ -988,19 +880,18 @@ pub struct RpcRegistryInner<
 
 // === impl RpcRegistryInner ===
 
-impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
+impl<N, Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
 where
+    N: NodePrimitives,
     Provider: StateProviderFactory
-        + BlockReader<
-            Block = <Events::Primitives as NodePrimitives>::Block,
-            Receipt = <Events::Primitives as NodePrimitives>::Receipt,
-        > + Clone
+        + CanonStateSubscriptions<Primitives = N>
+        + BlockReader<Block = N::Block, Receipt = N::Receipt>
+        + Clone
         + Unpin
         + 'static,
     Pool: Send + Sync + Clone + 'static,
     Network: Clone + 'static,
-    Events: CanonStateSubscriptions + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
     EthApi: EthApiTypes + 'static,
     BlockExecutor: BlockExecutorProvider,
@@ -1012,19 +903,10 @@ where
         pool: Pool,
         network: Network,
         executor: Tasks,
-        events: Events,
         consensus: Consensus,
         config: RpcModuleConfig,
         evm_config: EvmConfig,
-        eth_api_builder: DynEthApiBuilder<
-            Provider,
-            Pool,
-            EvmConfig,
-            Network,
-            Tasks,
-            Events,
-            EthApi,
-        >,
+        eth_api_builder: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
         block_executor: BlockExecutor,
         payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
     ) -> Self
@@ -1040,7 +922,6 @@ where
             evm_config,
             config.eth,
             executor.clone(),
-            events.clone(),
             eth_api_builder,
         );
 
@@ -1054,15 +935,14 @@ where
             config,
             modules: Default::default(),
             blocking_pool_guard,
-            events,
             block_executor,
             payload_validator,
         }
     }
 }
 
-impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
 where
     Provider: BlockReader,
     EthApi: EthApiTypes,
@@ -1073,7 +953,7 @@ where
     }
 
     /// Returns a reference to the installed [`EthHandlers`].
-    pub const fn eth_handlers(&self) -> &EthHandlers<Provider, Events, EthApi> {
+    pub const fn eth_handlers(&self) -> &EthHandlers<Provider, EthApi> {
         &self.eth
     }
 
@@ -1088,11 +968,6 @@ where
     /// Returns a reference to the pool
     pub const fn pool(&self) -> &Pool {
         &self.pool
-    }
-
-    /// Returns a reference to the events type
-    pub const fn events(&self) -> &Events {
-        &self.events
     }
 
     /// Returns a reference to the tasks type
@@ -1120,8 +995,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
 where
     Network: NetworkInfo + Clone + 'static,
     EthApi: EthApiTypes,
@@ -1159,8 +1034,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
 where
     Provider: FullRpcProvider + AccountReader + ChangeSetReader,
     Network: NetworkInfo + Peers + Clone + 'static,
@@ -1267,8 +1142,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
 where
     Provider: FullRpcProvider + AccountReader + ChangeSetReader,
     Network: NetworkInfo + Peers + Clone + 'static,
@@ -1354,22 +1229,22 @@ where
     }
 }
 
-impl<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, Events, EthApi, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
 where
     Provider: FullRpcProvider<Block = <BlockExecutor::Primitives as NodePrimitives>::Block>
+        + CanonStateSubscriptions<Primitives = BlockExecutor::Primitives>
         + AccountReader
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    Events: CanonStateSubscriptions<Primitives = BlockExecutor::Primitives> + Clone + 'static,
     EthApi: FullEthApiServer<
         Provider: BlockReader<
             Block = <BlockExecutor::Primitives as NodePrimitives>::Block,
             Receipt = <BlockExecutor::Primitives as NodePrimitives>::Receipt,
             Header = <BlockExecutor::Primitives as NodePrimitives>::BlockHeader,
-        >,
+        > + CanonStateSubscriptions<Primitives = BlockExecutor::Primitives>,
     >,
     BlockExecutor: BlockExecutorProvider,
     Consensus: FullConsensus<BlockExecutor::Primitives, Error = ConsensusError> + Clone + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -46,7 +46,8 @@
 //!             Receipt = reth_primitives::Receipt,
 //!             Header = reth_primitives::Header,
 //!         > + AccountReader
-//!         + ChangeSetReader + CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives>,
+//!         + ChangeSetReader
+//!         + CanonStateSubscriptions<Primitives = reth_primitives::EthPrimitives>,
 //!     Pool: TransactionPool<
 //!             Transaction: PoolTransaction<
 //!                 Consensus = TransactionSigned,

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -12,7 +12,7 @@ use reth_evm::execute::BasicBlockExecutorProvider;
 use reth_evm_ethereum::{execute::EthExecutionStrategyFactory, EthEvmConfig};
 use reth_network_api::noop::NoopNetwork;
 use reth_payload_builder::test_utils::spawn_test_payload_service;
-use reth_provider::test_utils::{NoopProvider, TestCanonStateSubscriptions};
+use reth_provider::test_utils::NoopProvider;
 use reth_rpc::EthApi;
 use reth_rpc_builder::{
     auth::{AuthRpcModule, AuthServerConfig, AuthServerHandle},
@@ -134,7 +134,6 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
     TestPool,
     NoopNetwork,
     TokioTaskExecutor,
-    TestCanonStateSubscriptions,
     EthEvmConfig,
     BasicBlockExecutorProvider<EthExecutionStrategyFactory>,
     NoopConsensus,
@@ -144,7 +143,6 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
         .with_pool(TestPoolBuilder::default().into())
         .with_network(NoopNetwork::default())
         .with_executor(TokioTaskExecutor::default())
-        .with_events(TestCanonStateSubscriptions::default())
         .with_evm_config(EthEvmConfig::new(MAINNET.clone()))
         .with_block_executor(
             BasicBlockExecutorProvider::new(EthExecutionStrategyFactory::mainnet()),

--- a/crates/rpc/rpc-eth-types/src/builder/ctx.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/ctx.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// Context for building the `eth` namespace API.
 #[derive(Debug, Clone)]
-pub struct EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks, Events>
+pub struct EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks>
 where
     Provider: BlockReader,
 {
@@ -29,14 +29,12 @@ where
     pub config: EthConfig,
     /// Runtime handle.
     pub executor: Tasks,
-    /// Events handle.
-    pub events: Events,
     /// RPC cache handle.
     pub cache: EthStateCache<Provider::Block, Provider::Receipt>,
 }
 
-impl<Provider, Pool, EvmConfig, Network, Tasks, Events>
-    EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks, Events>
+impl<Provider, Pool, EvmConfig, Network, Tasks>
+    EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks>
 where
     Provider: BlockReaderIdExt + Clone,
 {
@@ -45,13 +43,14 @@ where
     where
         N: NodePrimitives,
         Tasks: TaskSpawner,
-        Events: CanonStateSubscriptions<Primitives = N>,
-        Provider:
-            BlockReaderIdExt<Block = N::Block, Receipt = N::Receipt> + ChainSpecProvider + 'static,
+        Provider: BlockReaderIdExt<Block = N::Block, Receipt = N::Receipt>
+            + CanonStateSubscriptions<Primitives = N>
+            + ChainSpecProvider
+            + 'static,
     {
         let fee_history_cache = FeeHistoryCache::new(self.config.fee_history_cache);
 
-        let new_canonical_blocks = self.events.canonical_state_stream();
+        let new_canonical_blocks = self.provider.canonical_state_stream();
         let fhc = fee_history_cache.clone();
         let provider = self.provider.clone();
         let cache = self.cache.clone();

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -99,25 +99,24 @@ where
     }
 }
 
-impl<Provider, Pool, EvmConfig, Network> EthApi<Provider, Pool, Network, EvmConfig>
+impl<N, Provider, Pool, EvmConfig, Network> EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Provider: ChainSpecProvider + BlockReaderIdExt + Clone + 'static,
+    N: NodePrimitives,
+    Provider: ChainSpecProvider
+        + BlockReaderIdExt<Block = N::Block, Receipt = N::Receipt>
+        + CanonStateSubscriptions<Primitives = N>
+        + Clone
+        + 'static,
     Pool: Clone,
     EvmConfig: Clone,
     Network: Clone,
 {
     /// Creates a new, shareable instance.
-    pub fn with_spawner<Tasks, Events>(
-        ctx: &EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks, Events>,
+    pub fn with_spawner<Tasks>(
+        ctx: &EthApiBuilderCtx<Provider, Pool, EvmConfig, Network, Tasks>,
     ) -> Self
     where
         Tasks: TaskSpawner + Clone + 'static,
-        Events: CanonStateSubscriptions<
-            Primitives: NodePrimitives<
-                Block = ProviderBlock<Provider>,
-                Receipt = ProviderReceipt<Provider>,
-            >,
-        >,
     {
         let blocking_task_pool =
             BlockingTaskPool::build().expect("failed to build blocking task pool");

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -37,7 +37,7 @@ use reth::tasks::TokioTaskExecutor;
 use reth_node_ethereum::{
     node::EthereumEngineValidator, EthEvmConfig, EthExecutorProvider, EthereumNode,
 };
-use reth_provider::{test_utils::TestCanonStateSubscriptions, ChainSpecProvider};
+use reth_provider::ChainSpecProvider;
 
 // Custom rpc extension
 pub mod myrpc_ext;
@@ -70,7 +70,6 @@ async fn main() -> eyre::Result<()> {
         .with_noop_network()
         .with_executor(TokioTaskExecutor::default())
         .with_evm_config(EthEvmConfig::new(spec.clone()))
-        .with_events(TestCanonStateSubscriptions::default())
         .with_block_executor(EthExecutorProvider::ethereum(provider.chain_spec()))
         .with_consensus(EthBeaconConsensus::new(spec.clone()));
 


### PR DESCRIPTION
`Provider` implements the `CanonStateSubscriptions` and always used in place of `Events` generic.

This PR removes it and just relies on `Provider` instead