### PR TITLE
feat(rpc/validation): Expose metric for validation disallow list size.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8748,6 +8748,7 @@ dependencies = [
  "reth-errors",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-metrics",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -20,6 +20,7 @@ reth-rpc-api.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-engine-primitives.workspace = true
 reth-errors.workspace = true
+reth-metrics.workspace = true
 reth-provider.workspace = true
 reth-transaction-pool.workspace = true
 reth-network-api.workspace = true

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -54,7 +54,6 @@ where
     ) -> Self {
         let ValidationApiConfig { disallow, validation_window } = config;
 
-        let disallow_size = disallow.len();
         let inner = Arc::new(ValidationApiInner {
             provider,
             consensus,
@@ -67,7 +66,7 @@ where
             metrics: Default::default(),
         });
 
-        inner.metrics.disallow_size.set(disallow_size as f64);
+        inner.metrics.disallow_size.set(inner.disallow.len() as f64);
         Self { inner }
     }
 
@@ -544,9 +543,10 @@ pub enum ValidationApiError {
     Payload(#[from] PayloadError),
 }
 
+/// Metrics for the validation endpoint.
 #[derive(Metrics)]
 #[metrics(scope = "builder.validation")]
 pub(crate) struct ValidationMetrics {
-    /// The number of entries configured in the builder validation disallow list
+    /// The number of entries configured in the builder validation disallow list.
     pub(crate) disallow_size: Gauge,
 }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -546,7 +546,7 @@ pub enum ValidationApiError {
 
 #[derive(Metrics)]
 #[metrics(scope = "builder.validation")]
-pub(crate) struct ValidationMetrics{
+pub(crate) struct ValidationMetrics {
     /// The number of entries configured in the builder validation disallow list
     pub(crate) disallow_size: Gauge,
 }


### PR DESCRIPTION
For compliance reasons it's desirable to have a metric for the validation API's disallow list size (for example an infra provider can setup an alert on this metric if it's `0` or lower than expected as it might indicate the disallow list is misconfigured).

Example metric output:

```
# HELP reth_builder_validation_disallow_size The number of entries configured in the builder validation disallow list
# TYPE reth_builder_validation_disallow_size gauge
reth_builder_validation_disallow_size 1
```