### PR TITLE
chore: make optypedtx fields private

### DIFF
--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -136,7 +136,7 @@ impl PoolTransaction for OpPooledTransaction {
     }
 
     fn max_fee_per_gas(&self) -> u128 {
-        self.inner.transaction.transaction.max_fee_per_gas()
+        self.inner.transaction.max_fee_per_gas()
     }
 
     fn access_list(&self) -> Option<&AccessList> {
@@ -144,7 +144,7 @@ impl PoolTransaction for OpPooledTransaction {
     }
 
     fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        self.inner.transaction.transaction.max_priority_fee_per_gas()
+        self.inner.transaction.max_priority_fee_per_gas()
     }
 
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
@@ -172,7 +172,7 @@ impl PoolTransaction for OpPooledTransaction {
     }
 
     fn size(&self) -> usize {
-        self.inner.transaction.transaction.input().len()
+        self.inner.transaction.input().len()
     }
 
     fn tx_type(&self) -> u8 {
@@ -220,7 +220,7 @@ impl EthPoolTransaction for OpPooledTransaction {
     }
 
     fn authorization_count(&self) -> usize {
-        match &self.inner.transaction.transaction {
+        match self.inner.transaction.transaction() {
             OpTypedTransaction::Eip7702(tx) => tx.authorization_list.len(),
             _ => 0,
         }

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -191,7 +191,7 @@ async fn test_custom_block_priority_config() {
 
     // Check that last transaction in the block looks like a transfer to a random address.
     let end_of_block_tx = block_payload.body().transactions.last().unwrap();
-    let OpTypedTransaction::Eip1559(end_of_block_tx) = &end_of_block_tx.transaction else {
+    let OpTypedTransaction::Eip1559(end_of_block_tx) = end_of_block_tx.transaction() else {
         panic!("expected EIP-1559 transaction");
     };
     assert_eq!(end_of_block_tx.nonce, 1);

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -37,13 +37,13 @@ use reth_primitives_traits::{
 pub struct OpTransactionSigned {
     /// Transaction hash
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub hash: OnceLock<TxHash>,
+    hash: OnceLock<TxHash>,
     /// The transaction signature values
-    pub signature: Signature,
+    signature: Signature,
     /// Raw transaction info
     #[deref]
     #[as_ref]
-    pub transaction: OpTypedTransaction,
+    transaction: OpTypedTransaction,
 }
 
 impl OpTransactionSigned {
@@ -55,6 +55,23 @@ impl OpTransactionSigned {
         }
 
         signed_tx
+    }
+
+    /// Consumes the type and returns the transaction.
+    #[inline]
+    pub fn into_transaction(self) -> OpTypedTransaction {
+        self.transaction
+    }
+
+    /// Returns the transaction.
+    #[inline]
+    pub const fn transaction(&self) -> &OpTypedTransaction {
+        &self.transaction
+    }
+
+    /// Splits the `OpTransactionSigned` into its transaction and signature.
+    pub fn split(self) -> (OpTypedTransaction, Signature) {
+        (self.transaction, self.signature)
     }
 
     /// Creates a new signed transaction from the given transaction and signature without the hash.
@@ -379,6 +396,18 @@ impl Transaction for OpTransactionSigned {
         self.deref().priority_fee_or_price()
     }
 
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.deref().effective_gas_price(base_fee)
+    }
+
+    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
+        self.deref().effective_tip_per_gas(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.deref().is_dynamic_fee()
+    }
+
     fn kind(&self) -> TxKind {
         self.deref().kind()
     }
@@ -405,18 +434,6 @@ impl Transaction for OpTransactionSigned {
 
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         self.deref().authorization_list()
-    }
-
-    fn is_dynamic_fee(&self) -> bool {
-        self.deref().is_dynamic_fee()
-    }
-
-    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        self.deref().effective_gas_price(base_fee)
-    }
-
-    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
-        self.deref().effective_tip_per_gas(base_fee)
     }
 }
 

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -89,7 +89,7 @@ where
     ) -> Result<Self::Transaction, Self::Error> {
         let from = tx.signer();
         let hash = *tx.tx_hash();
-        let OpTransactionSigned { transaction, signature, .. } = tx.into_tx();
+        let (transaction, signature) = tx.into_tx().split();
         let mut deposit_receipt_version = None;
         let mut deposit_nonce = None;
 


### PR DESCRIPTION
#13915

followup.

we should do proper access hygiene for these types, any potential refactor will be easier