### PR TITLE
refactor: do not operate on `HaltReason` manually

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -436,8 +436,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         tx_env.set_access_list(access_list.clone());
         match result.result {
             ExecutionResult::Halt { reason, gas_used } => {
-                let error =
-                    Some(RpcInvalidTransactionError::halt(reason, tx_env.gas_limit()).to_string());
+                let error = Some(RpcInvalidTransactionError::halt(reason).to_string());
                 return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
             }
             ExecutionResult::Revert { output, gas_used } => {
@@ -448,11 +447,10 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         };
 
         // transact again to get the exact gas used
-        let (result, (_, tx_env)) = self.transact(&mut db, evm_env, tx_env)?;
+        let (result, _) = self.transact(&mut db, evm_env, tx_env)?;
         let res = match result.result {
             ExecutionResult::Halt { reason, gas_used } => {
-                let error =
-                    Some(RpcInvalidTransactionError::halt(reason, tx_env.gas_limit()).to_string());
+                let error = Some(RpcInvalidTransactionError::halt(reason).to_string());
                 AccessListResult { access_list, gas_used: U256::from(gas_used), error }
             }
             ExecutionResult::Revert { output, gas_used } => {

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -1,6 +1,6 @@
 //! Utilities for serving `eth_simulateV1`
 
-use alloy_consensus::{BlockHeader, Transaction as _, TxType};
+use alloy_consensus::{BlockHeader, TxType};
 use alloy_rpc_types_eth::{
     simulate::{SimCallResult, SimulateError, SimulatedBlock},
     transaction::TransactionRequest,
@@ -127,7 +127,7 @@ where
     for (index, (result, tx)) in results.iter().zip(block.body().transactions()).enumerate() {
         let call = match result {
             ExecutionResult::Halt { reason, gas_used } => {
-                let error = RpcInvalidTransactionError::halt(*reason, tx.gas_limit());
+                let error = RpcInvalidTransactionError::halt(*reason);
                 SimCallResult {
                     return_data: Bytes::new(),
                     error: Some(SimulateError {


### PR DESCRIPTION
Most of the time `HaltReason` can be treated as unknown internal EVM error. This PR removes usage of this type from RPC code
