### PR TITLE
fix: validate block against header on `reth import`

### DIFF
--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -254,9 +254,7 @@ impl<B: FullBlock<Header: reth_primitives_traits::BlockHeader>> FromReader
                     Err(err) => return Err(err),
                 };
 
-                let block  = SealedBlock::seal_slow(
-                    block,
-                );
+                let block = SealedBlock::seal_slow(block);
 
                 // Validate standalone header
                 self.consensus.validate_header(block.sealed_header())?;


### PR DESCRIPTION
Validates the block against the header coming from `reth import`.

Fixes a bunch of `eest` tests on https://github.com/paradigmxyz/reth/pull/14009


