### PR TITLE
chore(trie-db): remove reth-primitives dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9393,7 +9393,7 @@ dependencies = [
  "reth-db-api",
  "reth-execution-errors",
  "reth-metrics",
- "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-execution-errors.workspace = true
 reth-db.workspace = true
 reth-db-api.workspace = true
@@ -45,7 +45,7 @@ serde = { workspace = true, optional = true }
 [dev-dependencies]
 # reth
 reth-chainspec.workspace = true
-reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
+reth-primitives-traits = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-storage-errors.workspace = true
@@ -74,13 +74,14 @@ serde = [
     "reth-trie/serde",
     "reth-trie-common/serde",
     "reth-provider/serde",
+    "reth-primitives-traits/serde",
 ]
 test-utils = [
     "triehash",
     "revm/test-utils",
     "reth-trie-common/test-utils",
+    "reth-primitives-traits/test-utils",
     "reth-chainspec/test-utils",
-    "reth-primitives/test-utils",
     "reth-db/test-utils",
     "reth-db-api/test-utils",
     "reth-provider/test-utils",

--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -4,7 +4,7 @@ use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     transaction::DbTx,
 };
-use reth_primitives::Account;
+use reth_primitives_traits::Account;
 use reth_trie::hashed_cursor::{HashedCursor, HashedCursorFactory, HashedStorageCursor};
 
 /// A struct wrapping database transaction that implements [`HashedCursorFactory`].

--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -11,7 +11,7 @@ use reth_db_api::{
     transaction::DbTx,
     DatabaseError,
 };
-use reth_primitives::StorageEntry;
+use reth_primitives_traits::StorageEntry;
 use reth_trie::{
     prefix_set::{PrefixSetMut, TriePrefixSets},
     KeyHasher, Nibbles,

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -80,7 +80,7 @@ pub trait DatabaseStateRoot<'a, TX>: Sized {
     /// use alloy_primitives::U256;
     /// use reth_db::test_utils::create_test_rw_db;
     /// use reth_db_api::database::Database;
-    /// use reth_primitives::Account;
+    /// use reth_primitives_traits::Account;
     /// use reth_trie::{updates::TrieUpdates, HashedPostState, StateRoot};
     /// use reth_trie_db::DatabaseStateRoot;
     ///

--- a/crates/trie/db/tests/fuzz_in_memory_nodes.rs
+++ b/crates/trie/db/tests/fuzz_in_memory_nodes.rs
@@ -7,7 +7,7 @@ use reth_db::{
     tables,
     transaction::DbTxMut,
 };
-use reth_primitives::{Account, StorageEntry};
+use reth_primitives_traits::{Account, StorageEntry};
 use reth_provider::test_utils::create_test_provider_factory;
 use reth_trie::{
     test_utils::{state_root_prehashed, storage_root_prehashed},

--- a/crates/trie/db/tests/post_state.rs
+++ b/crates/trie/db/tests/post_state.rs
@@ -5,7 +5,7 @@ use proptest::prelude::*;
 use proptest_arbitrary_interop::arb;
 use reth_db::{tables, test_utils::create_test_rw_db};
 use reth_db_api::{database::Database, transaction::DbTxMut};
-use reth_primitives::{Account, StorageEntry};
+use reth_primitives_traits::{Account, StorageEntry};
 use reth_trie::{
     hashed_cursor::{
         HashedCursor, HashedCursorFactory, HashedPostStateCursorFactory, HashedStorageCursor,

--- a/crates/trie/db/tests/proof.rs
+++ b/crates/trie/db/tests/proof.rs
@@ -4,7 +4,7 @@ use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_rlp::EMPTY_STRING_CODE;
 use reth_chainspec::{Chain, ChainSpec, HOLESKY, MAINNET};
-use reth_primitives::Account;
+use reth_primitives_traits::Account;
 use reth_provider::test_utils::{create_test_provider_factory, insert_genesis};
 use reth_trie::{proof::Proof, AccountProof, Nibbles, StorageProof};
 use reth_trie_db::DatabaseProof;

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -10,7 +10,7 @@ use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     transaction::{DbTx, DbTxMut},
 };
-use reth_primitives::{Account, StorageEntry};
+use reth_primitives_traits::{Account, StorageEntry};
 use reth_provider::{
     providers::ProviderNodeTypes, test_utils::create_test_provider_factory, DatabaseProviderRW,
     StorageTrieWriter, TrieWriter,

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{
 use alloy_rlp::EMPTY_STRING_CODE;
 use reth_db::{cursor::DbCursorRW, tables};
 use reth_db_api::transaction::DbTxMut;
-use reth_primitives::{Account, StorageEntry};
+use reth_primitives_traits::{Account, StorageEntry};
 use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
 use reth_trie::{proof::Proof, witness::TrieWitness, HashedPostState, HashedStorage, StateRoot};
 use reth_trie_db::{DatabaseProof, DatabaseStateRoot, DatabaseTrieWitness};


### PR DESCRIPTION
We can use `reth-primitives-traits` for these imports now