### PR TITLE
feat: abstract over `Evm::Error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7511,7 +7511,6 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
  "nybbles",
  "reth-consensus",
  "reth-prune-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7511,11 +7511,11 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "derive_more",
  "nybbles",
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
- "revm-primitives",
  "thiserror 2.0.11",
 ]
 
@@ -8321,6 +8321,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
+ "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-rpc-types-compat",
  "reth-tasks",
@@ -8503,7 +8504,6 @@ dependencies = [
  "reth-chainspec",
  "reth-errors",
  "reth-primitives",
- "revm-primitives",
  "serde",
  "thiserror 2.0.11",
  "tokio",

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -327,7 +327,7 @@ where
         let tx_env = evm_config.tx_env(&tx_recovered, tx_recovered.signer());
         let exec_result = match evm.transact(tx_env) {
             Ok(result) => result,
-            Err(err) if err.as_invalid_tx_err().is_some() => {
+            Err(err) if err.is_invalid_tx_err() => {
                 trace!(target: "engine::stream::reorg", hash = %tx.tx_hash(), ?err, "Error executing transaction from next block");
                 continue
             }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -14,7 +14,7 @@ use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResu
 use reth_ethereum_forks::EthereumHardforks;
 use reth_evm::{
     state_change::post_block_withdrawals_balance_increments, system_calls::SystemCaller,
-    ConfigureEvm, Evm,
+    ConfigureEvm, Evm, EvmError,
 };
 use reth_payload_primitives::EngineApiMessageVersion;
 use reth_payload_validator::ExecutionPayloadValidator;
@@ -29,7 +29,6 @@ use reth_revm::{
     DatabaseCommit,
 };
 use reth_rpc_types_compat::engine::payload::block_to_payload;
-use revm_primitives::EVMError;
 use std::{
     collections::VecDeque,
     future::Future,
@@ -328,8 +327,8 @@ where
         let tx_env = evm_config.tx_env(&tx_recovered, tx_recovered.signer());
         let exec_result = match evm.transact(tx_env) {
             Ok(result) => result,
-            error @ Err(EVMError::Transaction(_) | EVMError::Header(_)) => {
-                trace!(target: "engine::stream::reorg", hash = %tx.tx_hash(), ?error, "Error executing transaction from next block");
+            Err(err) if err.as_invalid_tx_err().is_some() => {
+                trace!(target: "engine::stream::reorg", hash = %tx.tx_hash(), ?err, "Error executing transaction from next block");
                 continue
             }
             // Treat error as fatal

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -22,10 +22,10 @@ use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::{Address, U256};
 use core::{convert::Infallible, fmt::Debug};
 use reth_chainspec::ChainSpec;
-use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Evm, NextBlockEnvAttributes};
+use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Database, Evm, NextBlockEnvAttributes};
 use reth_primitives::TransactionSigned;
 use reth_primitives_traits::transaction::execute::FillTxEnv;
-use reth_revm::{inspector_handle_register, Database, EvmBuilder};
+use reth_revm::{inspector_handle_register, EvmBuilder};
 use revm_primitives::{
     AnalysisKind, BlobExcessGasAndPrice, BlockEnv, Bytes, CfgEnv, CfgEnvWithHandlerCfg, EVMError,
     HandlerCfg, ResultAndState, SpecId, TxEnv, TxKind,
@@ -237,6 +237,7 @@ impl ConfigureEvmEnv for EthEvmConfig {
 
 impl ConfigureEvm for EthEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
+    type EvmError<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
 
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -27,10 +27,10 @@ derive_more.workspace = true
 [features]
 default = ["std"]
 std = [
-	"reth-consensus/std",
-	"alloy-eips/std",
-	"alloy-primitives/std",
-	"alloy-rlp/std",
-	"thiserror/std",
-	"nybbles/std"
+    "reth-consensus/std",
+    "alloy-eips/std",
+    "alloy-primitives/std",
+    "alloy-rlp/std",
+    "thiserror/std",
+    "nybbles/std",
 ]

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -22,7 +22,6 @@ alloy-eips.workspace = true
 nybbles.workspace = true
 
 thiserror.workspace = true
-derive_more.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -19,19 +19,18 @@ reth-prune-types.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
-revm-primitives.workspace = true
 nybbles.workspace = true
 
 thiserror.workspace = true
+derive_more.workspace = true
 
 [features]
 default = ["std"]
 std = [
-    "reth-consensus/std",
-    "alloy-eips/std",
-    "alloy-primitives/std",
-    "revm-primitives/std",
-    "alloy-rlp/std",
-    "thiserror/std",
-    "nybbles/std",
+	"reth-consensus/std",
+	"alloy-eips/std",
+	"alloy-primitives/std",
+	"alloy-rlp/std",
+	"thiserror/std",
+	"nybbles/std"
 ]

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -11,6 +11,8 @@
 
 extern crate alloc;
 
+use core::fmt::Display;
+
 use alloc::{
     boxed::Box,
     string::{String, ToString},
@@ -20,22 +22,22 @@ use alloy_primitives::B256;
 use reth_consensus::ConsensusError;
 use reth_prune_types::PruneSegmentError;
 use reth_storage_errors::provider::ProviderError;
-use revm_primitives::EVMError;
 use thiserror::Error;
 
 pub mod trie;
 pub use trie::*;
 
 /// Transaction validation errors
-#[derive(Error, Clone, Debug)]
+#[derive(Error, derive_more::Debug)]
 pub enum BlockValidationError {
     /// EVM error with transaction hash and message
     #[error("EVM reported invalid transaction ({hash}): {error}")]
+    #[debug("{error}")]
     EVM {
         /// The hash of the transaction
         hash: B256,
         /// The EVM error.
-        error: Box<EVMError<ProviderError>>,
+        error: Box<dyn Display + Send + Sync>,
     },
     /// Error when recovering the sender for a transaction
     #[error("failed to recover sender for transaction")]

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -28,16 +28,15 @@ pub mod trie;
 pub use trie::*;
 
 /// Transaction validation errors
-#[derive(Error, derive_more::Debug)]
+#[derive(Error, Debug)]
 pub enum BlockValidationError {
     /// EVM error with transaction hash and message
     #[error("EVM reported invalid transaction ({hash}): {error}")]
-    #[debug("{error}")]
     EVM {
         /// The hash of the transaction
         hash: B256,
         /// The EVM error.
-        error: Box<dyn Display + Send + Sync>,
+        error: Box<dyn core::error::Error + Send + Sync>,
     },
     /// Error when recovering the sender for a transaction
     #[error("failed to recover sender for transaction")]

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -11,8 +11,6 @@
 
 extern crate alloc;
 
-use core::fmt::Display;
-
 use alloc::{
     boxed::Box,
     string::{String, ToString},

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -1,13 +1,10 @@
 //! Helper type that represents one of two possible executor types
 
-use core::fmt::Display;
-
 use crate::{
     execute::{BatchExecutor, BlockExecutorProvider, Executor},
     system_calls::OnStateHook,
+    Database,
 };
-use reth_storage_errors::provider::ProviderError;
-use revm_primitives::db::Database;
 
 // re-export Either
 pub use futures_util::future::Either;
@@ -20,15 +17,13 @@ where
 {
     type Primitives = A::Primitives;
 
-    type Executor<DB: Database<Error: Into<ProviderError> + Display>> =
-        Either<A::Executor<DB>, B::Executor<DB>>;
+    type Executor<DB: Database> = Either<A::Executor<DB>, B::Executor<DB>>;
 
-    type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> =
-        Either<A::BatchExecutor<DB>, B::BatchExecutor<DB>>;
+    type BatchExecutor<DB: Database> = Either<A::BatchExecutor<DB>, B::BatchExecutor<DB>>;
 
     fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         match self {
             Self::Left(a) => Either::Left(a.executor(db)),
@@ -38,7 +33,7 @@ where
 
     fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         match self {
             Self::Left(a) => Either::Left(a.batch_executor(db)),
@@ -51,7 +46,7 @@ impl<A, B, DB> Executor<DB> for Either<A, B>
 where
     A: Executor<DB>,
     B: for<'a> Executor<DB, Input<'a> = A::Input<'a>, Output = A::Output, Error = A::Error>,
-    DB: Database<Error: Into<ProviderError> + Display>,
+    DB: Database,
 {
     type Input<'a> = A::Input<'a>;
     type Output = A::Output;
@@ -97,7 +92,7 @@ impl<A, B, DB> BatchExecutor<DB> for Either<A, B>
 where
     A: BatchExecutor<DB>,
     B: for<'a> BatchExecutor<DB, Input<'a> = A::Input<'a>, Output = A::Output, Error = A::Error>,
-    DB: Database<Error: Into<ProviderError> + Display>,
+    DB: Database,
 {
     type Input<'a> = A::Input<'a>;
     type Output = A::Output;

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -1,0 +1,49 @@
+use revm_primitives::{EVMError, InvalidTransaction};
+
+/// Abstraction over transaction validation error.
+pub trait InvalidTxError: core::error::Error + Send + Sync + 'static {
+    /// Returns whether the error cause by transaction having a nonce lower than expected.
+    fn is_nonce_too_low(&self) -> bool;
+}
+
+impl InvalidTxError for InvalidTransaction {
+    fn is_nonce_too_low(&self) -> bool {
+        matches!(self, Self::NonceTooLow { .. })
+    }
+}
+
+/// Abstraction over errors that can occur during EVM execution.
+///
+/// It's assumed that errors can occur either because of an invalid transaction, meaning that other
+/// transaction might still result in successful execution, or because of a general EVM
+/// misconfiguration.
+///
+/// If caller occurs a error different from [`EvmError::InvalidTransaction`], it should most likely
+/// be treated as fatal error flagging some EVM misconfiguration.
+pub trait EvmError: core::error::Error + Send + Sync + 'static {
+    /// Errors which might occur as a result of an invalid transaction. i.e unrelated to general EVM
+    /// configuration.
+    type InvalidTransaction: InvalidTxError;
+
+    /// Returns the [`EvmError::InvalidTransaction`] if the error is an invalid transaction error.
+    fn as_invalid_tx_err(&self) -> Option<&Self::InvalidTransaction>;
+
+    /// Returns `true` if the error is an invalid transaction error.
+    fn is_invalid_tx_err(&self) -> bool {
+        self.as_invalid_tx_err().is_some()
+    }
+}
+
+impl<DBError> EvmError for EVMError<DBError>
+where
+    DBError: core::error::Error + Send + Sync + 'static,
+{
+    type InvalidTransaction = InvalidTransaction;
+
+    fn as_invalid_tx_err(&self) -> Option<&Self::InvalidTransaction> {
+        match self {
+            Self::Transaction(err) => Some(err),
+            _ => None,
+        }
+    }
+}

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -108,7 +108,7 @@ pub trait EvmError: core::error::Error + Send + Sync + 'static {
     /// configuration.
     type InvalidTransaction: InvalidTxError;
 
-    /// Returns the [`InvalidTransactionError`] if the error is an invalid transaction error.
+    /// Returns the [`EvmError::InvalidTransaction`] if the error is an invalid transaction error.
     fn as_invalid_tx_err(&self) -> Option<&Self::InvalidTransaction>;
 }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -97,7 +97,7 @@ impl InvalidTxError for InvalidTransaction {
 
 /// Abstraction over errors that can occur during EVM execution.
 ///
-/// Assumed that errors can occur either because of an invalid transaction, meaning that other
+/// It's assumed that errors can occur either because of an invalid transaction, meaning that other
 /// transaction might still result in successful execution, or because of a general EVM
 /// misconfiguration.
 ///

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -1,16 +1,14 @@
 //! A no operation block executor implementation.
 
-use core::fmt::Display;
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
 use reth_primitives::{NodePrimitives, RecoveredBlock};
-use reth_storage_errors::provider::ProviderError;
 use revm::State;
-use revm_primitives::db::Database;
 
 use crate::{
     execute::{BatchExecutor, BlockExecutorProvider, Executor},
     system_calls::OnStateHook,
+    Database,
 };
 
 const UNAVAILABLE_FOR_NOOP: &str = "execution unavailable for noop";
@@ -23,20 +21,20 @@ pub struct NoopBlockExecutorProvider<P>(core::marker::PhantomData<P>);
 impl<P: NodePrimitives> BlockExecutorProvider for NoopBlockExecutorProvider<P> {
     type Primitives = P;
 
-    type Executor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
+    type Executor<DB: Database> = Self;
 
-    type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
+    type BatchExecutor<DB: Database> = Self;
 
     fn executor<DB>(&self, _: DB) -> Self::Executor<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         Self::default()
     }
 
     fn batch_executor<DB>(&self, _: DB) -> Self::BatchExecutor<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         Self::default()
     }

--- a/crates/evm/src/system_calls/mod.rs
+++ b/crates/evm/src/system_calls/mod.rs
@@ -1,6 +1,6 @@
 //! System contract call functions.
 
-use crate::{ConfigureEvm, Evm, EvmEnv};
+use crate::{ConfigureEvm, Database, Evm, EvmEnv};
 use alloc::{boxed::Box, sync::Arc};
 use alloy_consensus::BlockHeader;
 use alloy_eips::{
@@ -10,7 +10,7 @@ use alloy_primitives::Bytes;
 use core::fmt::Display;
 use reth_chainspec::EthereumHardforks;
 use reth_execution_errors::BlockExecutionError;
-use revm::{Database, DatabaseCommit};
+use revm::DatabaseCommit;
 use revm_primitives::{EvmState, B256};
 
 mod eip2935;
@@ -260,7 +260,6 @@ where
     ) -> Result<Bytes, BlockExecutionError>
     where
         DB: Database + DatabaseCommit,
-        DB::Error: Display,
     {
         let evm_config = self.evm_config.clone();
         let mut evm = evm_config.evm_with_env(db, evm_env.clone());

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -6,16 +6,15 @@ use crate::{
         BlockExecutionStrategy, BlockExecutorProvider, Executor,
     },
     system_calls::OnStateHook,
+    Database,
 };
 use alloy_eips::eip7685::Requests;
 use parking_lot::Mutex;
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{EthPrimitives, NodePrimitives, Receipt, Receipts, RecoveredBlock};
-use reth_storage_errors::provider::ProviderError;
 use revm::State;
-use revm_primitives::db::Database;
-use std::{fmt::Display, sync::Arc};
+use std::sync::Arc;
 
 /// A [`BlockExecutorProvider`] that returns mocked execution results.
 #[derive(Clone, Debug, Default)]
@@ -33,20 +32,20 @@ impl MockExecutorProvider {
 impl BlockExecutorProvider for MockExecutorProvider {
     type Primitives = EthPrimitives;
 
-    type Executor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
+    type Executor<DB: Database> = Self;
 
-    type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
+    type BatchExecutor<DB: Database> = Self;
 
     fn executor<DB>(&self, _: DB) -> Self::Executor<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         self.clone()
     }
 
     fn batch_executor<DB>(&self, _: DB) -> Self::BatchExecutor<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         self.clone()
     }

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -7,7 +7,6 @@ use crate::{
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Eip658Value, Receipt, Transaction as _};
 use alloy_eips::eip7685::Requests;
-use core::fmt::Display;
 use op_alloy_consensus::OpDepositReceipt;
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::ConsensusError;
@@ -15,11 +14,10 @@ use reth_evm::{
     execute::{
         balance_increment_state, BasicBlockExecutorProvider, BlockExecutionError,
         BlockExecutionStrategy, BlockExecutionStrategyFactory, BlockValidationError, ExecuteOutput,
-        ProviderError,
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, SystemCaller},
-    ConfigureEvmFor, Evm,
+    ConfigureEvmFor, Database, Evm,
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::validate_block_post_execution;
@@ -29,7 +27,7 @@ use reth_optimism_primitives::{
 };
 use reth_primitives::{NodePrimitives, RecoveredBlock};
 use reth_primitives_traits::{BlockBody, SignedTransaction};
-use reth_revm::{Database, State};
+use reth_revm::State;
 use revm_primitives::{db::DatabaseCommit, ResultAndState};
 use tracing::trace;
 
@@ -76,12 +74,11 @@ where
     EvmConfig: ConfigureEvmFor<N> + Clone + Unpin + Sync + Send + 'static,
 {
     type Primitives = N;
-    type Strategy<DB: Database<Error: Into<ProviderError> + Display>> =
-        OpExecutionStrategy<DB, N, EvmConfig>;
+    type Strategy<DB: Database> = OpExecutionStrategy<DB, N, EvmConfig>;
 
     fn create_strategy<DB>(&self, db: DB) -> Self::Strategy<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         let state =
             State::builder().with_database(db).with_bundle_update().without_state_clear().build();
@@ -131,7 +128,7 @@ where
 
 impl<DB, N, EvmConfig> BlockExecutionStrategy for OpExecutionStrategy<DB, N, EvmConfig>
 where
-    DB: Database<Error: Into<ProviderError> + Display>,
+    DB: Database,
     N: NodePrimitives<
         BlockHeader = alloy_consensus::Header,
         SignedTx: OpTransaction,
@@ -214,11 +211,10 @@ where
 
             // Execute transaction.
             let result_and_state = evm.transact(tx_env).map_err(move |err| {
-                let new_err = err.map_db_err(|e| e.into());
                 // Ensure hash is calculated for error log, if not already done
                 BlockValidationError::EVM {
                     hash: transaction.recalculate_hash(),
-                    error: Box::new(new_err),
+                    error: Box::new(err),
                 }
             })?;
 

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -18,14 +18,14 @@ use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, U256};
 use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
-use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Evm, NextBlockEnvAttributes};
+use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Database, Evm, NextBlockEnvAttributes};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_primitives_traits::FillTxEnv;
 use reth_revm::{
     inspector_handle_register,
     primitives::{AnalysisKind, CfgEnvWithHandlerCfg, TxEnv},
-    Database, EvmBuilder, GetInspector,
+    EvmBuilder, GetInspector,
 };
 
 mod config;
@@ -224,6 +224,7 @@ impl ConfigureEvmEnv for OpEvmConfig {
 
 impl ConfigureEvm for OpEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = OpEvm<'a, I, DB>;
+    type EvmError<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
 
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -33,6 +33,7 @@ reth-revm = { workspace = true, features = ["std"] }
 reth-trie-db.workspace = true
 reth-rpc-server-types.workspace = true
 reth-rpc-types-compat.workspace = true
+reth-rpc-eth-types.workspace = true
 reth-tasks = { workspace = true, optional = true }
 
 # op-reth

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -9,7 +9,9 @@ use crate::{
 use op_alloy_consensus::OpPooledTransaction;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_chainspec::{EthChainSpec, Hardforks};
-use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvmEnv, ConfigureEvmFor};
+use reth_evm::{
+    execute::BasicBlockExecutorProvider, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmFor,
+};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{AddOnsContext, FullNodeComponents, NodeAddOns, PrimitivesTy, TxTy};
 use reth_node_builder::{
@@ -32,10 +34,11 @@ use reth_optimism_primitives::{OpPrimitives, OpReceipt, OpTransactionSigned};
 use reth_optimism_rpc::{
     miner::{MinerApiExtServer, OpMinerExtApi},
     witness::{DebugExecutionWitnessApiServer, OpDebugWitnessApi},
-    OpEthApi, SequencerClient,
+    OpEthApi, OpEthApiError, SequencerClient,
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::{CanonStateSubscriptions, EthStorage};
+use reth_rpc_eth_types::error::FromEvmError;
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
@@ -193,6 +196,7 @@ where
         >,
         Evm: ConfigureEvmEnv<TxEnv = TxEnv>,
     >,
+    OpEthApiError: FromEvmError<N::Evm>,
 {
     type Handle = RpcHandle<N, OpEthApi<N>>;
 
@@ -241,8 +245,9 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Evm: ConfigureEvmEnv<TxEnv = TxEnv>,
+        Evm: ConfigureEvm<TxEnv = TxEnv>,
     >,
+    OpEthApiError: FromEvmError<N::Evm>,
 {
     type EthApi = OpEthApi<N>;
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -818,17 +818,12 @@ where
             let ResultAndState { result, state } = match evm.transact(tx_env) {
                 Ok(res) => res,
                 Err(err) => {
-                    match err {
-                        err => {
-                            if err.as_invalid_tx_err().is_some() {
-                                trace!(target: "payload_builder", %err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
-                                continue
-                            } else {
-                                // this is an error that we should treat as fatal for this attempt
-                                return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)))
-                            }
-                        }
+                    if err.as_invalid_tx_err().is_some() {
+                        trace!(target: "payload_builder", %err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
+                        continue
                     }
+                    // this is an error that we should treat as fatal for this attempt
+                    return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)))
                 }
             };
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -923,10 +923,9 @@ where
                         }
 
                         continue
-                    } else {
-                        // this is an error that we should treat as fatal for this attempt
-                        return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)))
                     }
+                    // this is an error that we should treat as fatal for this attempt
+                    return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)))
                 }
             };
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -17,8 +17,8 @@ use reth_basic_payload_builder::*;
 use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_evm::{
-    env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, Evm,
-    NextBlockEnvAttributes,
+    env::EvmEnv, system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, Database, Evm,
+    EvmError, InvalidTxError, NextBlockEnvAttributes,
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_optimism_chainspec::OpChainSpec;
@@ -42,8 +42,8 @@ use reth_transaction_pool::{
 };
 use revm::{
     db::{states::bundle_state::BundleRetention, State},
-    primitives::{EVMError, InvalidTransaction, ResultAndState},
-    Database, DatabaseCommit,
+    primitives::ResultAndState,
+    DatabaseCommit,
 };
 use std::{fmt::Display, sync::Arc};
 use tracing::{debug, trace, warn};
@@ -819,13 +819,14 @@ where
                 Ok(res) => res,
                 Err(err) => {
                     match err {
-                        EVMError::Transaction(err) => {
-                            trace!(target: "payload_builder", %err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
-                            continue
-                        }
                         err => {
-                            // this is an error that we should treat as fatal for this attempt
-                            return Err(PayloadBuilderError::EvmExecutionError(err))
+                            if err.as_invalid_tx_err().is_some() {
+                                trace!(target: "payload_builder", %err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
+                                continue
+                            } else {
+                                // this is an error that we should treat as fatal for this attempt
+                                return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)))
+                            }
                         }
                     }
                 }
@@ -915,24 +916,21 @@ where
             let ResultAndState { result, state } = match evm.transact(tx_env) {
                 Ok(res) => res,
                 Err(err) => {
-                    match err {
-                        EVMError::Transaction(err) => {
-                            if matches!(err, InvalidTransaction::NonceTooLow { .. }) {
-                                // if the nonce is too low, we can skip this transaction
-                                trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
-                            } else {
-                                // if the transaction is invalid, we can skip it and all of its
-                                // descendants
-                                trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
-                                best_txs.mark_invalid(tx.signer(), tx.nonce());
-                            }
+                    if let Some(err) = err.as_invalid_tx_err() {
+                        if err.is_nonce_too_low() {
+                            // if the nonce is too low, we can skip this transaction
+                            trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
+                        } else {
+                            // if the transaction is invalid, we can skip it and all of its
+                            // descendants
+                            trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
+                            best_txs.mark_invalid(tx.signer(), tx.nonce());
+                        }
 
-                            continue
-                        }
-                        err => {
-                            // this is an error that we should treat as fatal for this attempt
-                            return Err(PayloadBuilderError::EvmExecutionError(err))
-                        }
+                        continue
+                    } else {
+                        // this is an error that we should treat as fatal for this attempt
+                        return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)))
                     }
                 }
             };

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -818,7 +818,7 @@ where
             let ResultAndState { result, state } = match evm.transact(tx_env) {
                 Ok(res) => res,
                 Err(err) => {
-                    if err.as_invalid_tx_err().is_some() {
+                    if err.is_invalid_tx_err() {
                         trace!(target: "payload_builder", %err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
                         continue
                     }

--- a/crates/optimism/rpc/src/error.rs
+++ b/crates/optimism/rpc/src/error.rs
@@ -6,7 +6,7 @@ use reth_optimism_evm::OpBlockExecutionError;
 use reth_rpc_eth_api::AsEthApiError;
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_server_types::result::{internal_rpc_err, rpc_err};
-use revm::primitives::{InvalidTransaction, OptimismInvalidTransaction};
+use revm::primitives::{EVMError, InvalidTransaction, OptimismInvalidTransaction};
 
 /// Optimism specific errors, that extend [`EthApiError`].
 #[derive(Debug, thiserror::Error)]
@@ -116,6 +116,15 @@ impl From<SequencerClientError> for jsonrpsee_types::error::ErrorObject<'static>
 
 impl From<BlockError> for OpEthApiError {
     fn from(error: BlockError) -> Self {
+        Self::Eth(error.into())
+    }
+}
+
+impl<DB> From<EVMError<DB>> for OpEthApiError
+where
+    EthApiError: From<EVMError<DB>>,
+{
+    fn from(error: EVMError<DB>) -> Self {
         Self::Eth(error.into())
     }
 }

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -40,8 +40,7 @@ where
             let excess_blob_gas = block.excess_blob_gas();
             let timestamp = block.timestamp();
 
-            let mut l1_block_info =
-                reth_optimism_evm::extract_l1_info(block.body()).map_err(OpEthApiError::from)?;
+            let mut l1_block_info = reth_optimism_evm::extract_l1_info(block.body())?;
 
             return block
                 .body()

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -6,7 +6,7 @@ use reth_evm::ConfigureEvm;
 use reth_provider::ProviderHeader;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadBlock, LoadState, SpawnBlocking},
-    FromEthApiError, FullEthApiTypes, IntoEthApiError,
+    FromEthApiError, FromEvmError, FullEthApiTypes, IntoEthApiError,
 };
 use reth_rpc_eth_types::{revm_utils::CallFees, RpcInvalidTransactionError};
 use revm::primitives::{BlockEnv, OptimismFields, TxEnv};
@@ -28,8 +28,10 @@ where
 
 impl<N> Call for OpEthApi<N>
 where
-    Self: LoadState<Evm: ConfigureEvm<Header = ProviderHeader<Self::Provider>, TxEnv = TxEnv>>
-        + SpawnBlocking,
+    Self: LoadState<
+            Evm: ConfigureEvm<Header = ProviderHeader<Self::Provider>, TxEnv = TxEnv>,
+            Error: FromEvmError<Self::Evm>,
+        > + SpawnBlocking,
     Self::Error: From<OpEthApiError>,
     N: OpNodeCore,
 {

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -30,7 +30,7 @@ use reth_rpc_eth_api::{
         AddDevSigners, EthApiSpec, EthFees, EthSigner, EthState, LoadBlock, LoadFee, LoadState,
         SpawnBlocking, Trace,
     },
-    EthApiTypes, RpcNodeCore, RpcNodeCoreExt,
+    EthApiTypes, FromEvmError, RpcNodeCore, RpcNodeCoreExt,
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
 use reth_tasks::{
@@ -252,6 +252,7 @@ where
                 Header = ProviderHeader<Self::Provider>,
                 Transaction = ProviderTx<Self::Provider>,
             >,
+            Error: FromEvmError<Self::Evm>,
         >,
     N: OpNodeCore,
 {

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -21,7 +21,7 @@ use reth_provider::{
 };
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
-    EthApiTypes, FromEthApiError, RpcNodeCore,
+    EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -34,6 +34,7 @@ where
             NetworkTypes: Network<
                 HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
             >,
+            Error: FromEvmError<Self::Evm>,
         >,
     N: RpcNodeCore<
         Provider: BlockReaderIdExt<

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -18,8 +18,6 @@ reth-errors.workspace = true
 reth-primitives.workspace = true
 reth-chain-state.workspace = true
 
-revm-primitives.workspace = true
-
 # alloy
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
@@ -39,7 +37,6 @@ default = ["std"]
 std = [
     "reth-chainspec/std",
     "reth-primitives/std",
-    "revm-primitives/std",
     "alloy-eips/std",
     "alloy-primitives/std",
     "alloy-rpc-types-engine/std",

--- a/crates/payload/primitives/src/error.rs
+++ b/crates/payload/primitives/src/error.rs
@@ -4,7 +4,6 @@ use alloc::boxed::Box;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ForkchoiceUpdateError;
 use reth_errors::{ProviderError, RethError};
-use revm_primitives::EVMError;
 use tokio::sync::oneshot;
 
 /// Possible error variants during payload building.
@@ -27,13 +26,21 @@ pub enum PayloadBuilderError {
     Internal(#[from] RethError),
     /// Unrecoverable error during evm execution.
     #[error("evm execution error: {0}")]
-    EvmExecutionError(EVMError<ProviderError>),
+    EvmExecutionError(Box<dyn core::error::Error + Send + Sync>),
     /// Any other payload building errors.
     #[error(transparent)]
     Other(Box<dyn core::error::Error + Send + Sync>),
 }
 
 impl PayloadBuilderError {
+    /// Create a new EVM error from a boxed error.
+    pub fn evm<E>(error: E) -> Self
+    where
+        E: core::error::Error + Send + Sync + 'static,
+    {
+        Self::EvmExecutionError(Box::new(error))
+    }
+
     /// Create a new error from a boxed error.
     pub fn other<E>(error: E) -> Self
     where

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -17,7 +17,8 @@ use alloy_rpc_types_eth::{
 };
 use futures::Future;
 use reth_chainspec::EthChainSpec;
-use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Evm, TransactionEnv};
+use reth_errors::ProviderError;
+use reth_evm::{env::EvmEnv, ConfigureEvm, ConfigureEvmEnv, Database, Evm, TransactionEnv};
 use reth_node_api::BlockBody;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::{BlockIdReader, ChainSpecProvider, ProviderHeader};
@@ -36,7 +37,7 @@ use reth_rpc_eth_types::{
     simulate::{self, EthSimulateError},
     EthApiError, RevertError, RpcInvalidTransactionError, StateCacheDb,
 };
-use revm::{Database, DatabaseCommit, GetInspector};
+use revm::{DatabaseCommit, GetInspector};
 use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use tracing::trace;
 
@@ -473,7 +474,10 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
 /// Executes code on state.
 pub trait Call:
-    LoadState<Evm: ConfigureEvm<Header = ProviderHeader<Self::Provider>>> + SpawnBlocking
+    LoadState<
+        Evm: ConfigureEvm<Header = ProviderHeader<Self::Provider>>,
+        Error: FromEvmError<Self::Evm>,
+    > + SpawnBlocking
 {
     /// Returns default gas limit to use for `eth_call` and tracing RPC methods.
     ///
@@ -508,8 +512,7 @@ pub trait Call:
         Self::Error,
     >
     where
-        DB: Database,
-        EthApiError: From<DB::Error>,
+        DB: Database<Error = ProviderError>,
     {
         let mut evm = self.evm_config().evm_with_env(db, evm_env.clone());
         let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
@@ -534,8 +537,7 @@ pub trait Call:
         Self::Error,
     >
     where
-        DB: Database,
-        EthApiError: From<DB::Error>,
+        DB: Database<Error = ProviderError>,
     {
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env.clone(), inspector);
         let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
@@ -704,8 +706,7 @@ pub trait Call:
         target_tx_hash: B256,
     ) -> Result<usize, Self::Error>
     where
-        DB: Database + DatabaseCommit,
-        EthApiError: From<DB::Error>,
+        DB: Database<Error = ProviderError> + DatabaseCommit,
         I: IntoIterator<Item = (&'a Address, &'a <Self::Evm as ConfigureEvmEnv>::Transaction)>,
         <Self::Evm as ConfigureEvmEnv>::Transaction: SignedTransaction,
     {

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -6,7 +6,8 @@ use alloy_primitives::U256;
 use alloy_rpc_types_eth::{state::StateOverride, transaction::TransactionRequest, BlockId};
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
-use reth_evm::{env::EvmEnv, ConfigureEvmEnv, TransactionEnv};
+use reth_errors::ProviderError;
+use reth_evm::{env::EvmEnv, ConfigureEvmEnv, Database, TransactionEnv};
 use reth_provider::StateProvider;
 use reth_revm::{
     database::StateProviderDatabase,
@@ -18,7 +19,7 @@ use reth_rpc_eth_types::{
     EthApiError, RevertError, RpcInvalidTransactionError,
 };
 use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO};
-use revm_primitives::{db::Database, TxKind};
+use revm_primitives::TxKind;
 use tracing::trace;
 
 /// Gas execution estimates
@@ -286,7 +287,7 @@ pub trait EstimateCall: Call {
         db: &mut DB,
     ) -> Self::Error
     where
-        DB: Database,
+        DB: Database<Error = ProviderError>,
         EthApiError: From<DB::Error>,
     {
         let req_gas_limit = tx_env.gas_limit();

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -11,7 +11,7 @@ use reth_provider::{ProviderTx, ReceiptProvider, TransactionsProvider};
 use reth_rpc_types_compat::TransactionCompat;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
-use crate::{AsEthApiError, FromEthApiError, FromEvmError, RpcNodeCore};
+use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
 
 /// Network specific `eth` API types.
 pub trait EthApiTypes: Send + Sync + Clone {
@@ -19,7 +19,6 @@ pub trait EthApiTypes: Send + Sync + Clone {
     type Error: Into<jsonrpsee_types::error::ErrorObject<'static>>
         + FromEthApiError
         + AsEthApiError
-        + FromEvmError
         + Error
         + Send
         + Sync;

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -1,7 +1,8 @@
 //! Helper traits to wrap generic l1 errors, in network specific error type configured in
 //! `reth_rpc_eth_api::EthApiTypes`.
 
-use revm_primitives::EVMError;
+use reth_errors::ProviderError;
+use reth_evm::ConfigureEvm;
 
 use crate::EthApiError;
 
@@ -79,21 +80,16 @@ impl AsEthApiError for EthApiError {
 }
 
 /// Helper trait to convert from revm errors.
-pub trait FromEvmError: From<EthApiError> {
-    /// Converts from a revm error.
-    fn from_evm_err<E>(err: EVMError<E>) -> Self
-    where
-        EthApiError: From<E>;
+pub trait FromEvmError<Evm: ConfigureEvm>: From<Evm::EvmError<ProviderError>> {
+    /// Converts from EVM error to this type.
+    fn from_evm_err(err: Evm::EvmError<ProviderError>) -> Self {
+        err.into()
+    }
 }
 
-impl<T> FromEvmError for T
+impl<T, Evm> FromEvmError<Evm> for T
 where
-    T: From<EthApiError>,
+    T: From<Evm::EvmError<ProviderError>>,
+    Evm: ConfigureEvm,
 {
-    fn from_evm_err<E>(err: EVMError<E>) -> Self
-    where
-        EthApiError: From<E>,
-    {
-        err.into_eth_err()
-    }
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -651,8 +651,9 @@ where
 
                 let ExecutionWitnessRecord { hashed_state, codes, keys } = witness_record;
 
-                let state =
-                    state_provider.witness(Default::default(), hashed_state).map_err(Into::into)?;
+                let state = state_provider
+                    .witness(Default::default(), hashed_state)
+                    .map_err(EthApiError::from)?;
                 Ok(ExecutionWitness { state: state.into_iter().collect(), codes, keys })
             })
             .await

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -7,7 +7,7 @@ use reth_evm::ConfigureEvm;
 use reth_provider::{BlockReader, ProviderHeader};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
-    FromEthApiError, FullEthApiTypes, IntoEthApiError,
+    FromEthApiError, FromEvmError, FullEthApiTypes, IntoEthApiError,
 };
 use reth_rpc_eth_types::{revm_utils::CallFees, RpcInvalidTransactionError};
 use revm_primitives::{BlockEnv, TxEnv, TxKind, U256};
@@ -21,8 +21,10 @@ where
 
 impl<Provider, Pool, Network, EvmConfig> Call for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: LoadState<Evm: ConfigureEvm<TxEnv = TxEnv, Header = ProviderHeader<Self::Provider>>>
-        + SpawnBlocking,
+    Self: LoadState<
+            Evm: ConfigureEvm<TxEnv = TxEnv, Header = ProviderHeader<Self::Provider>>,
+            Error: FromEvmError<Self::Evm>,
+        > + SpawnBlocking,
     EvmConfig: ConfigureEvm<Header = Header>,
     Provider: BlockReader,
 {

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -13,7 +13,7 @@ use reth_provider::{
 };
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
-    RpcNodeCore,
+    FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::PendingBlock;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -26,6 +26,7 @@ impl<Provider, Pool, Network, EvmConfig> LoadPendingBlock
 where
     Self: SpawnBlocking<
             NetworkTypes: alloy_network::Network<HeaderResponse = alloy_rpc_types_eth::Header>,
+            Error: FromEvmError<Self::Evm>,
         > + RpcNodeCore<
             Provider: BlockReaderIdExt<
                 Transaction = reth_primitives::TransactionSigned,

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -2,7 +2,10 @@
 
 use reth_evm::ConfigureEvm;
 use reth_provider::{BlockReader, ProviderHeader, ProviderTx};
-use reth_rpc_eth_api::helpers::{LoadState, Trace};
+use reth_rpc_eth_api::{
+    helpers::{LoadState, Trace},
+    FromEvmError,
+};
 
 use crate::EthApi;
 
@@ -14,6 +17,7 @@ where
             Header = ProviderHeader<Self::Provider>,
             Transaction = ProviderTx<Self::Provider>,
         >,
+        Error: FromEvmError<Self::Evm>,
     >,
     Provider: BlockReader,
 {

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -14,7 +14,7 @@ use reth_revm::database::StateProviderDatabase;
 use reth_rpc_api::MevSimApiServer;
 use reth_rpc_eth_api::{
     helpers::{Call, EthTransactions, LoadPendingBlock},
-    FromEthApiError,
+    FromEthApiError, FromEvmError,
 };
 use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError};
 use reth_tasks::pool::BlockingTaskGuard;
@@ -307,7 +307,7 @@ where
 
                     let ResultAndState { result, state } = evm
                         .transact(eth_api.evm_config().tx_env(&item.tx, item.signer))
-                        .map_err(EthApiError::from_eth_err)?;
+                        .map_err(Eth::Error::from_evm_err)?;
 
                     if !result.is_success() && !item.can_revert {
                         return Err(EthApiError::InvalidParams(

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -11,10 +11,9 @@ use reth::{
     api::{ConfigureEvm, NodeTypesWithEngine},
     builder::{components::ExecutorBuilder, BuilderContext, FullNodeTypes},
     cli::Cli,
-    providers::ProviderError,
     revm::{
         primitives::{address, Address},
-        Database, DatabaseCommit, State,
+        DatabaseCommit, State,
     },
 };
 use reth_chainspec::{ChainSpec, EthereumHardforks};
@@ -23,7 +22,7 @@ use reth_evm::{
         BlockExecutionError, BlockExecutionStrategy, BlockExecutionStrategyFactory, ExecuteOutput,
         InternalBlockExecutionError,
     },
-    Evm,
+    Database, Evm,
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_ethereum::{node::EthereumAddOns, BasicBlockExecutorProvider, EthereumNode};
@@ -90,11 +89,11 @@ pub struct CustomExecutorStrategyFactory {
 
 impl BlockExecutionStrategyFactory for CustomExecutorStrategyFactory {
     type Primitives = EthPrimitives;
-    type Strategy<DB: Database<Error: Into<ProviderError> + Display>> = CustomExecutorStrategy<DB>;
+    type Strategy<DB: Database> = CustomExecutorStrategy<DB>;
 
     fn create_strategy<DB>(&self, db: DB) -> Self::Strategy<DB>
     where
-        DB: Database<Error: Into<ProviderError> + Display>,
+        DB: Database,
     {
         let state =
             State::builder().with_database(db).with_bundle_update().without_state_clear().build();
@@ -108,7 +107,7 @@ impl BlockExecutionStrategyFactory for CustomExecutorStrategyFactory {
 
 pub struct CustomExecutorStrategy<DB>
 where
-    DB: Database<Error: Into<ProviderError> + Display>,
+    DB: Database,
 {
     /// The chainspec
     chain_spec: Arc<ChainSpec>,
@@ -120,7 +119,7 @@ where
 
 impl<DB> BlockExecutionStrategy for CustomExecutorStrategy<DB>
 where
-    DB: Database<Error: Into<ProviderError> + Display>,
+    DB: Database,
 {
     type DB = DB;
     type Primitives = EthPrimitives;

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -15,15 +15,17 @@ use reth::{
         handler::register::EvmHandler,
         inspector_handle_register,
         precompile::{Precompile, PrecompileOutput, PrecompileSpecId},
-        primitives::{CfgEnvWithHandlerCfg, Env, HandlerCfg, PrecompileResult, SpecId, TxEnv},
-        ContextPrecompiles, Database, EvmBuilder, GetInspector,
+        primitives::{
+            CfgEnvWithHandlerCfg, EVMError, Env, HandlerCfg, PrecompileResult, SpecId, TxEnv,
+        },
+        ContextPrecompiles, EvmBuilder, GetInspector,
     },
     rpc::types::engine::PayloadAttributes,
     tasks::TaskManager,
     transaction_pool::{PoolTransaction, TransactionPool},
 };
 use reth_chainspec::{Chain, ChainSpec};
-use reth_evm::env::EvmEnv;
+use reth_evm::{env::EvmEnv, Database};
 use reth_evm_ethereum::{EthEvm, EthEvmConfig};
 use reth_node_api::{
     ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NextBlockEnvAttributes, NodeTypes,
@@ -109,6 +111,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
 
 impl ConfigureEvm for MyEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
+    type EvmError<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
 
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -14,15 +14,15 @@ use reth::{
         inspector_handle_register,
         precompile::{Precompile, PrecompileSpecId},
         primitives::{
-            CfgEnvWithHandlerCfg, Env, HandlerCfg, PrecompileResult, SpecId, StatefulPrecompileMut,
-            TxEnv,
+            CfgEnvWithHandlerCfg, EVMError, Env, HandlerCfg, PrecompileResult, SpecId,
+            StatefulPrecompileMut, TxEnv,
         },
-        ContextPrecompile, ContextPrecompiles, Database, EvmBuilder, GetInspector,
+        ContextPrecompile, ContextPrecompiles, EvmBuilder, GetInspector,
     },
     tasks::TaskManager,
 };
 use reth_chainspec::{Chain, ChainSpec};
-use reth_evm::env::EvmEnv;
+use reth_evm::{env::EvmEnv, Database};
 use reth_node_api::{ConfigureEvm, ConfigureEvmEnv, FullNodeTypes, NodeTypes};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::{
@@ -173,6 +173,7 @@ impl ConfigureEvmEnv for MyEvmConfig {
 
 impl ConfigureEvm for MyEvmConfig {
     type Evm<'a, DB: Database + 'a, I: 'a> = EthEvm<'a, I, DB>;
+    type EvmError<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
 
     fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv) -> Self::Evm<'_, DB, ()> {
         let cfg_env_with_handler_cfg = CfgEnvWithHandlerCfg {


### PR DESCRIPTION
Changes in this PR:
- `Evm::Error` is no longer bounded to a concrete type (was `EVMError<DB::Error>` before). Instead, `EvmError` trait is introduced: https://github.com/paradigmxyz/reth/blob/b1dfab93b45a6c9a983b8d0c8118287cfb7d25d6/crates/evm/src/lib.rs#L98-L113
- Current revm does not yet have `core::error::Error` bound on `Database::Error`, so I've introduced a helper `Database` trait which is now used everywhere: https://github.com/paradigmxyz/reth/blob/b1dfab93b45a6c9a983b8d0c8118287cfb7d25d6/crates/evm/src/lib.rs#L129-L131
  This is not great and won't get solved with new revm because it doesn't have `Send + Sync + 'static` bounds. What we could do is just bound `Error = ProviderError` everywhere but this would also be a bit redundant.
- On RPC side, `EthApi::Error` is now required to implement `From<EthApi::Evm::EvmError<ProviderError>>` which basically means that it should be able to convert any Evm error as long as underlying database has `ProviderError` error type which always holds for RPC.
https://github.com/paradigmxyz/reth/blob/3b6d97e490281b522d9615e41a8e5d301594efa5/crates/rpc/rpc-eth-types/src/error/api.rs#L82-L89