### PR TITLE
Export chainspec's HardforkBlobParams struct publicly

### DIFF
--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -31,7 +31,7 @@ pub use info::ChainInfo;
 pub use spec::test_fork_ids;
 pub use spec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, ChainSpecProvider,
-    DepositContract, ForkBaseFeeParams, DEV, HOLESKY, MAINNET, SEPOLIA,
+    DepositContract, ForkBaseFeeParams, HardforkBlobParams, DEV, HOLESKY, MAINNET, SEPOLIA,
 };
 
 use reth_primitives_traits::sync::OnceLock;


### PR DESCRIPTION
Exporting the `spec` module's `HardforkBlobParams` struct to make custom chainspecs. This is similar to how the other structs such as `BaseFeeParams, BaseFeeParamsKind, ... DepositContract, ForkBaseFeeParams` are exported.