### PR TITLE
chore: reexport eip types for convenience

### DIFF
--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -46,3 +46,7 @@ pub use capability::*;
 
 pub mod primitives;
 pub use primitives::*;
+
+/// re-export for convenience
+pub use alloy_eips::eip1898::{BlockHashOrNumber, HashOrNumber};
+pub use alloy_eips::eip2718::Encodable2718;


### PR DESCRIPTION
these are used internally and we should re-export them for convenience