### PR TITLE
fix(trie): update prefix set on the call to `RevealedSparseTrie::update_rlp_node_level`

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2542,44 +2542,52 @@ mod tests {
 
         assert_eq!(
             sparse.get_changed_nodes_at_depth(&mut PrefixSet::default(), 0),
-            (PrefixSetMut::default(), vec![Nibbles::default()])
+            (vec![Nibbles::default()], PrefixSetMut::default())
         );
         assert_eq!(
             sparse.get_changed_nodes_at_depth(&mut PrefixSet::default(), 1),
-            ([Nibbles::default()].into(), vec![Nibbles::from_nibbles_unchecked([0x5])])
+            (vec![Nibbles::from_nibbles_unchecked([0x5])], [Nibbles::default()].into())
         );
         assert_eq!(
             sparse.get_changed_nodes_at_depth(&mut PrefixSet::default(), 2),
             (
-                [Nibbles::default(), Nibbles::from_nibbles_unchecked([0x5])].into(),
                 vec![
                     Nibbles::from_nibbles_unchecked([0x5, 0x0]),
                     Nibbles::from_nibbles_unchecked([0x5, 0x2]),
                     Nibbles::from_nibbles_unchecked([0x5, 0x3])
-                ]
+                ],
+                [Nibbles::default(), Nibbles::from_nibbles_unchecked([0x5])].into()
             )
         );
         assert_eq!(
             sparse.get_changed_nodes_at_depth(&mut PrefixSet::default(), 3),
             (
+                vec![
+                    Nibbles::from_nibbles_unchecked([0x5, 0x0, 0x2, 0x3]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x2]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x1]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x3])
+                ],
                 [
                     Nibbles::default(),
                     Nibbles::from_nibbles_unchecked([0x5]),
                     Nibbles::from_nibbles_unchecked([0x5, 0x0]),
                     Nibbles::from_nibbles_unchecked([0x5, 0x3])
                 ]
-                .into(),
-                vec![
-                    Nibbles::from_nibbles_unchecked([0x5, 0x0, 0x2, 0x3]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x2]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x1]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x3])
-                ]
+                .into()
             )
         );
         assert_eq!(
             sparse.get_changed_nodes_at_depth(&mut PrefixSet::default(), 4),
             (
+                vec![
+                    Nibbles::from_nibbles_unchecked([0x5, 0x0, 0x2, 0x3, 0x1]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x0, 0x2, 0x3, 0x3]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x2]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x1]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x3, 0x0]),
+                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x3, 0x2])
+                ],
                 [
                     Nibbles::default(),
                     Nibbles::from_nibbles_unchecked([0x5]),
@@ -2588,15 +2596,7 @@ mod tests {
                     Nibbles::from_nibbles_unchecked([0x5, 0x3]),
                     Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x3])
                 ]
-                .into(),
-                vec![
-                    Nibbles::from_nibbles_unchecked([0x5, 0x0, 0x2, 0x3, 0x1]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x0, 0x2, 0x3, 0x3]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x2]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x1]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x3, 0x0]),
-                    Nibbles::from_nibbles_unchecked([0x5, 0x3, 0x3, 0x2])
-                ]
+                .into()
             )
         );
     }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -570,7 +570,7 @@ impl<P> RevealedSparseTrie<P> {
     /// Return the root of the sparse trie.
     /// Updates all remaining dirty nodes before calculating the root.
     pub fn root(&mut self) -> B256 {
-        // take the current prefix set.
+        // Take the current prefix set
         let mut prefix_set = std::mem::take(&mut self.prefix_set).freeze();
         let rlp_node = self.rlp_node_allocate(Nibbles::default(), &mut prefix_set);
         if let Some(root_hash) = rlp_node.as_hash() {
@@ -583,12 +583,14 @@ impl<P> RevealedSparseTrie<P> {
     /// Update hashes of the nodes that are located at a level deeper than or equal to the provided
     /// depth. Root node has a level of 0.
     pub fn update_rlp_node_level(&mut self, depth: usize) {
+        // Take the current prefix set
         let mut prefix_set = std::mem::take(&mut self.prefix_set).freeze();
         let mut buffers = RlpNodeBuffers::default();
 
-        let (targets, unchanged_prefix_set) =
-            self.get_changed_nodes_at_depth(&mut prefix_set, depth);
-        self.prefix_set = unchanged_prefix_set;
+        // Get the nodes that have changed at the given depth.
+        let (targets, new_prefix_set) = self.get_changed_nodes_at_depth(&mut prefix_set, depth);
+        // Update the prefix set to the prefix set of the nodes that stil need to be updated.
+        self.prefix_set = new_prefix_set;
 
         trace!(target: "trie::sparse", ?depth, ?targets, "Updating nodes at depth");
         for target in targets {
@@ -1405,7 +1407,8 @@ struct RemovedSparseNode {
 /// Collection of reusable buffers for [`RevealedSparseTrie::rlp_node`].
 #[derive(Debug, Default)]
 pub struct RlpNodeBuffers {
-    /// Stack of paths we need rlp nodes for and whether the path is in the prefix set.
+    /// Stack of levels of depth starting from the node where the calculation began, paths we need
+    /// rlp nodes for, whether the path is in the prefix set.
     path_stack: Vec<(usize, Nibbles, Option<bool>)>,
     /// Stack of rlp nodes
     rlp_node_stack: Vec<(Nibbles, RlpNode, SparseNodeType)>,

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -668,13 +668,15 @@ impl<P> RevealedSparseTrie<P> {
         let starting_path = buffers.path_stack.last().map(|(_, path, _)| path).cloned();
 
         'main: while let Some((level, path, mut is_in_prefix_set)) = buffers.path_stack.pop() {
+            let node = self.nodes.get_mut(&path).unwrap();
             trace!(
                 target: "trie::sparse",
                 ?starting_path,
                 ?level,
                 ?path,
                 ?is_in_prefix_set,
-                "Popped path from stack"
+                ?node,
+                "Popped node from path stack"
             );
 
             // Check if the path is in the prefix set.
@@ -683,7 +685,7 @@ impl<P> RevealedSparseTrie<P> {
             let mut prefix_set_contains =
                 |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path));
 
-            let (rlp_node, node_type) = match self.nodes.get_mut(&path).unwrap() {
+            let (rlp_node, node_type) = match node {
                 SparseNode::Empty => (RlpNode::word_rlp(&EMPTY_ROOT_HASH), SparseNodeType::Empty),
                 SparseNode::Hash(hash) => (RlpNode::word_rlp(hash), SparseNodeType::Hash),
                 SparseNode::Leaf { key, hash } => {
@@ -913,9 +915,10 @@ impl<P> RevealedSparseTrie<P> {
                 ?starting_path,
                 ?level,
                 ?path,
+                ?node,
                 ?node_type,
                 ?is_in_prefix_set,
-                "Adding node to rlp node stack"
+                "Added node to rlp node stack"
             );
 
             buffers.rlp_node_stack.push((path, rlp_node, node_type));

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -668,6 +668,15 @@ impl<P> RevealedSparseTrie<P> {
         let starting_path = buffers.path_stack.last().map(|(_, path, _)| path).cloned();
 
         'main: while let Some((level, path, mut is_in_prefix_set)) = buffers.path_stack.pop() {
+            trace!(
+                target: "trie::sparse",
+                ?starting_path,
+                ?level,
+                ?path,
+                ?is_in_prefix_set,
+                "Popped path from stack"
+            );
+
             // Check if the path is in the prefix set.
             // First, check the cached value. If it's `None`, then check the prefix set, and update
             // the cached value.
@@ -906,7 +915,7 @@ impl<P> RevealedSparseTrie<P> {
                 ?path,
                 ?node_type,
                 ?is_in_prefix_set,
-                "Popped path from stack"
+                "Adding node to rlp node stack"
             );
 
             buffers.rlp_node_stack.push((path, rlp_node, node_type));

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -904,6 +904,7 @@ impl<P> RevealedSparseTrie<P> {
                 ?starting_path,
                 ?level,
                 ?path,
+                ?node_type,
                 ?is_in_prefix_set,
                 "Popped path from stack"
             );

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -583,7 +583,7 @@ impl<P> RevealedSparseTrie<P> {
     /// Update hashes of the nodes that are located at a level deeper than or equal to the provided
     /// depth. Root node has a level of 0.
     pub fn update_rlp_node_level(&mut self, depth: usize) {
-        let mut prefix_set = self.prefix_set.clone().freeze();
+        let mut prefix_set = std::mem::take(&mut self.prefix_set).freeze();
         let mut buffers = RlpNodeBuffers::default();
 
         let targets = self.get_changed_nodes_at_depth(&mut prefix_set, depth);

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -587,6 +587,7 @@ impl<P> RevealedSparseTrie<P> {
         let mut buffers = RlpNodeBuffers::default();
 
         let targets = self.get_changed_nodes_at_depth(&mut prefix_set, depth);
+        trace!(target: "trie::sparse", ?depth, ?targets, "Updating nodes at depth");
         for target in targets {
             buffers.path_stack.push((0, target, Some(true)));
             self.rlp_node(&mut prefix_set, &mut buffers);


### PR DESCRIPTION
Previously, we were doing the `std::mem::take` for the whole prefix set on each call to `RevealedSparseTrie::root`, but not on `RevealedSparseTrie::update_rlp_node_level`.

Effectively, this made `update_rlp_node_level` have no effect on the subsequent `root` call, because it was still re-calculating the whole trie.

---

This PR makes the `RevealedSparseTrie::update_rlp_node_level` update the prefix set, so that it includes only those paths that are above the specified level. Just doing the `take` is not correct there, because the nodes above the specified level still need re-calculation.

On the screenshot, before 14:40 is `main`, after is this branch.

<img width="738" alt="image" src="https://github.com/user-attachments/assets/a70ace54-2b02-4406-876d-f91a4a4ab29a" />
