### PR TITLE
perf(mdbx): do not always collect the backtrace of a locked transaction

### DIFF
--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -586,8 +586,9 @@ impl TransactionPtr {
             tracing::debug!(
                 target: "libmdbx",
                 txn = %self.txn as usize,
-                backtrace = %std::backtrace::Backtrace::force_capture(),
-                "Transaction lock is already acquired, blocking..."
+                backtrace = %std::backtrace::Backtrace::capture(),
+                "Transaction lock is already acquired, blocking...
+                To display the full backtrace, run with `RUST_BACKTRACE=full` env variable."
             );
             self.lock.lock()
         }


### PR DESCRIPTION
This can greatly affect the performance, so instead we should only collect the backtrace if `RUST_BACKTRACE=1` env variable is set.