### PR TITLE
perf(tree): adjust cross-block cache config

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -388,9 +388,9 @@ pub(crate) struct ProviderCacheBuilder {
 impl ProviderCacheBuilder {
     /// Build a [`ProviderCaches`] struct, so that provider caches can be easily cloned.
     pub(crate) fn build_caches(self) -> ProviderCaches {
-        const STORAGE_MAX_WEIGHT: u64 = 6 * 1024 * 1024 * 1024; // 6Gb
-        const ACCOUNT_MAX_WEIGHT: u64 = 1024 * 1024 * 1024; // 1Gb
-        const CODE_MAX_WEIGHT: u64 = 1024 * 1024 * 1024; // 1Gb
+        const STORAGE_MAX_WEIGHT: u64 = 8 * 1024 * 1024 * 1024; // 8Gb
+        const ACCOUNT_MAX_WEIGHT: u64 = 512 * 1024 * 1024; // 512Mb
+        const CODE_MAX_WEIGHT: u64 = 512 * 1024 * 1024; // 512Mb
 
         const EXPIRY_TIME: Duration = Duration::from_secs(7200); // 2 hours
         const TIME_TO_IDLE: Duration = Duration::from_secs(3600); // 1 hour
@@ -458,12 +458,12 @@ impl Default for ProviderCacheBuilder {
         // the maximum number of entries that can be stored, not the actual
         // memory usage which is controlled by max_capacity.
         //
-        // Code cache: up to 1M entries but limited to 1GB
-        // Storage cache: up to 1M accounts but limited to 6GB
-        // Account cache: up to 10M accounts but limited to 1GB
+        // Code cache: up to 10M entries but limited to 0.5GB
+        // Storage cache: up to 10M accounts but limited to 8GB
+        // Account cache: up to 10M accounts but limited to 0.5GB
         Self {
-            code_cache_size: 1_000_000,
-            storage_cache_size: 1_000_000,
+            code_cache_size: 10_000_000,
+            storage_cache_size: 10_000_000,
             account_cache_size: 10_000_000,
         }
     }
@@ -528,10 +528,10 @@ impl AccountStorageCache {
 
 impl Default for AccountStorageCache {
     fn default() -> Self {
-        // With weigher and max_capacity in place, this numbers represent
+        // With weigher and max_capacity in place, this number represents
         // the maximum number of entries that can be stored, not the actual
         // memory usage which is controlled by storage cache's max_capacity.
-        Self::new(10000)
+        Self::new(1_000_000)
     }
 }
 

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -418,15 +418,18 @@ impl Default for ProviderCacheBuilder {
         //   * Per Cache instance: 192 bytes base overhead
         //
         //   Theoretical maximum memory usage:
-        //   Base data (8.9 GB):
-        //   * First level: 150k accounts * 20B = 0.003 GB
-        //   * Second level: 150k accounts * 1000 slots * 64B = 8.941 GB
+        //   Base data (5.4 GB):
+        //   * First level: 90k accounts * 20B = 0.002 GB
+        //   * Second level: 90k accounts * 1000 slots * 64B = 5.364 GB
         //
-        //   Overhead (6.7 GB):
-        //   * First level: 150k accounts * 48B = 0.007 GB
-        //   * Second level: 150k accounts * (192B + 1000 slots * 48B) = 6.732 GB
+        //   Overhead (4.0 GB):
+        //   * First level: 90k accounts * 48B = 0.004 GB
+        //   * Second level: 90k accounts * (192B + 1000 slots * 48B) = 4.039 GB
         //
-        //   Total maximum: 15.7 GB
+        //   Total maximum: 9.4 GB
+        //
+        //   This maximum represents the worst case scenario, not all cached
+        //   addresses will be using 1000 slots.
         //
         // Code cache can be much much larger - this needs to be space instead of element bound.
         // Accounts can be element bound but memory calculation TODO
@@ -434,7 +437,7 @@ impl Default for ProviderCacheBuilder {
         // See: https://github.com/moka-rs/moka/wiki#admission-and-eviction-policies
         Self {
             code_cache_size: 1_000_000,
-            storage_cache_size: 150_000,
+            storage_cache_size: 90_000,
             account_cache_size: 10_000_000,
         }
     }

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -398,8 +398,8 @@ impl ProviderCacheBuilder {
         let storage_cache = CacheBuilder::new(self.storage_cache_size)
             .weigher(|_key: &Address, value: &AccountStorageCache| -> u32 {
                 // values based on results from measure_storage_cache_overhead test
-                let base_weight = 40_000;
-                let slots_weight = value.len() * 320;
+                let base_weight = 39_000;
+                let slots_weight = value.len() * 218;
                 (base_weight + slots_weight) as u32
             })
             .max_capacity(STORAGE_MAX_WEIGHT)
@@ -419,7 +419,7 @@ impl ProviderCacheBuilder {
                             weight += 32;
                         }
                         if account.bytecode_hash.is_some() {
-                            weight += 40; // size of Option<B256>
+                            weight += 33; // size of Option<B256>
                         } else {
                             weight += 8; // size of None variant
                         }
@@ -618,18 +618,20 @@ mod tests {
         });
         println!("First slot insertion overhead: {} bytes", first_slot);
 
-        let (hundred_slots, _) = measure_allocation(|| {
-            for _ in 0..100 {
+        const TOTAL_SLOTS: usize = 10_000;
+        let (test_slots, _) = measure_allocation(|| {
+            for _ in 0..TOTAL_SLOTS {
                 let key = StorageKey::random();
                 let value = StorageValue::from(rng.gen::<u128>());
                 cache.insert_storage(key, Some(value));
             }
         });
-        println!("Average overhead over 100 slots: {} bytes", hundred_slots / 100);
+        println!("Average overhead over {} slots: {} bytes", TOTAL_SLOTS, test_slots / TOTAL_SLOTS);
 
         println!("\nTheoretical sizes:");
         println!("StorageKey size: {} bytes", size_of::<StorageKey>());
         println!("StorageValue size: {} bytes", size_of::<StorageValue>());
         println!("Option<StorageValue> size: {} bytes", size_of::<Option<StorageValue>>());
+        println!("Option<B256> size: {} bytes", size_of::<Option<B256>>());
     }
 }


### PR DESCRIPTION
Based on top of #13769

* Switched to size-aware eviction to have deterministic maximum cache sizes, done for all the cross-block caches. 

* Added a test to estimate the sizes of the different elements of the hierarchical structure of the storage cache, applied the result values to the cache's `weigher` closure.

* Added `time_to_live` and `time_to_idle` to all cross-block caches to keep in memory only the most relevant data.

With these values we get similar performance compared with the previous ones, during an execution of `reth-bench` for a range of 1000 blocks:

* Execution gas/s:

![Screenshot_2025-02-03_12-20-49](https://github.com/user-attachments/assets/12b810b9-9784-4827-9273-0cb618803957)

* Storage cache hit rate:

![Screenshot_2025-02-03_12-21-04](https://github.com/user-attachments/assets/1d30a552-f2d7-4c94-8613-ace6b6ee0772)

* Storage cache miss rate:

![Screenshot_2025-02-03_12-21-23](https://github.com/user-attachments/assets/ce632ad0-482e-44fe-8bf9-6cb22f43b0f4)

* Storage cache size:

![Screenshot_2025-02-03_12-21-42](https://github.com/user-attachments/assets/9247c6d8-847d-4dc8-ac39-88d44b5803be)
