### PR TITLE
fix: minor typo in `trie.rs` comments

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -589,7 +589,7 @@ impl<P> RevealedSparseTrie<P> {
 
         // Get the nodes that have changed at the given depth.
         let (targets, new_prefix_set) = self.get_changed_nodes_at_depth(&mut prefix_set, depth);
-        // Update the prefix set to the prefix set of the nodes that stil need to be updated.
+        // Update the prefix set to the prefix set of the nodes that still need to be updated.
         self.prefix_set = new_prefix_set;
 
         trace!(target: "trie::sparse", ?depth, ?targets, "Updating nodes at depth");


### PR DESCRIPTION
Hey! Just a small typo fix in `trie.rs`. Changed "stil" to "still" in a comment to improve clarity.