### PR TITLE
fix(hive): overflow when timestamp is `u64::max`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -111,7 +111,7 @@ pub trait LoadPendingBlock:
             .next_evm_env(
                 &latest,
                 NextBlockEnvAttributes {
-                    timestamp: latest.timestamp() + 12,
+                    timestamp: latest.timestamp().saturating_add(12),
                     suggested_fee_recipient: latest.beneficiary(),
                     prev_randao: B256::random(),
                     gas_limit: latest.gas_limit(),

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -116,11 +116,11 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
             last_seen_block_number: latest.number(),
             pending_basefee: latest
                 .next_block_base_fee(
-                    chain_spec.base_fee_params_at_timestamp(latest.timestamp() + 12),
+                    chain_spec.base_fee_params_at_timestamp(latest.timestamp().saturating_add(12)),
                 )
                 .unwrap_or_default(),
             pending_blob_fee: latest.maybe_next_block_blob_fee(
-                chain_spec.blob_params_at_timestamp(latest.timestamp() + 12),
+                chain_spec.blob_params_at_timestamp(latest.timestamp().saturating_add(12)),
             ),
         };
         pool.set_block_info(info);
@@ -276,11 +276,12 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
                 let pending_block_base_fee = new_tip
                     .header()
                     .next_block_base_fee(
-                        chain_spec.base_fee_params_at_timestamp(new_tip.timestamp() + 12),
+                        chain_spec
+                            .base_fee_params_at_timestamp(new_tip.timestamp().saturating_add(12)),
                     )
                     .unwrap_or_default();
                 let pending_block_blob_fee = new_tip.header().maybe_next_block_blob_fee(
-                    chain_spec.blob_params_at_timestamp(new_tip.timestamp() + 12),
+                    chain_spec.blob_params_at_timestamp(new_tip.timestamp().saturating_add(12)),
                 );
 
                 // we know all changed account in the new chain
@@ -382,11 +383,11 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
                 let pending_block_base_fee = tip
                     .header()
                     .next_block_base_fee(
-                        chain_spec.base_fee_params_at_timestamp(tip.timestamp() + 12),
+                        chain_spec.base_fee_params_at_timestamp(tip.timestamp().saturating_add(12)),
                     )
                     .unwrap_or_default();
                 let pending_block_blob_fee = tip.header().maybe_next_block_blob_fee(
-                    chain_spec.blob_params_at_timestamp(tip.timestamp() + 12),
+                    chain_spec.blob_params_at_timestamp(tip.timestamp().saturating_add(12)),
                 );
 
                 let first_block = blocks.first();


### PR DESCRIPTION
Some tests have a `u64::max` timestamp, and we'd overflow there 