### PR TITLE
chore: simplify `OpBuiltPayload`

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -847,6 +847,12 @@ impl<N: NodePrimitives> ExecutedBlockWithTrieUpdates<N> {
     pub fn trie_updates(&self) -> &TrieUpdates {
         &self.trie
     }
+
+    /// Converts the value into [`SealedBlock`].
+    pub fn into_sealed_block(self) -> SealedBlock<N::Block> {
+        let block = Arc::unwrap_or_clone(self.block.recovered_block);
+        block.into_sealed_block()
+    }
 }
 
 /// Non-empty chain of blocks.

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -449,14 +449,7 @@ where
 
         let no_tx_pool = ctx.attributes().no_tx_pool;
 
-        let payload = OpBuiltPayload::new(
-            ctx.payload_id(),
-            sealed_block,
-            info.total_fees,
-            ctx.chain_spec.clone(),
-            ctx.config.attributes,
-            Some(executed),
-        );
+        let payload = OpBuiltPayload::new(ctx.payload_id(), info.total_fees, executed);
 
         if no_tx_pool {
             // if `no_tx_pool` is set only transactions from the payload attributes will be included

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -6,8 +6,7 @@ use alloy_eips::{
 use alloy_primitives::{keccak256, Address, Bytes, B256, B64, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{
-    BlobsBundleV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadV1,
-    PayloadId,
+    BlobsBundleV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadV1, ExecutionPayloadV3, PayloadId
 };
 use op_alloy_consensus::{encode_holocene_extra_data, EIP1559ParamError};
 /// Re-export for use in downstream arguments.
@@ -18,7 +17,6 @@ use reth_optimism_primitives::{OpBlock, OpPrimitives, OpTransactionSigned};
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
 use reth_primitives::{transaction::WithEncoded, SealedBlock};
-use reth_rpc_types_compat::engine::payload::{block_to_payload_v1, block_to_payload_v3};
 
 /// Optimism Payload Builder Attributes
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -210,7 +208,7 @@ impl From<OpBuiltPayload> for ExecutionPayloadV1 {
     fn from(value: OpBuiltPayload) -> Self {
         Self::from_block_unchecked(
             value.block().hash(),
-            value.block.into_sealed_block().into_block(),
+            &value.block.into_sealed_block().into_block(),
         )
     }
 }
@@ -240,8 +238,8 @@ impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV3 {
 
         Self {
             execution_payload: ExecutionPayloadV3::from_block_unchecked(
-                value.block().hash(),
-                value.block.into_sealed_block().into_block(),
+                block.sealed_block().hash(),
+                &block.into_sealed_block().into_block(),
             ),
             block_value: fees,
             // From the engine API spec:
@@ -268,8 +266,8 @@ impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV4 {
 
         Self {
             execution_payload: ExecutionPayloadV3::from_block_unchecked(
-                value.block().hash(),
-                value.block.into_sealed_block().into_block(),
+                block.sealed_block().hash(),
+                &block.into_sealed_block().into_block(),
             ),
             block_value: fees,
             // From the engine API spec:

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -6,7 +6,8 @@ use alloy_eips::{
 use alloy_primitives::{keccak256, Address, Bytes, B256, B64, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{
-    BlobsBundleV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadV1, ExecutionPayloadV3, PayloadId
+    BlobsBundleV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadV1,
+    ExecutionPayloadV3, PayloadId,
 };
 use op_alloy_consensus::{encode_holocene_extra_data, EIP1559ParamError};
 /// Re-export for use in downstream arguments.

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -1,13 +1,12 @@
 //! Payload related types
 
 use alloy_eips::{
-    eip1559::BaseFeeParams, eip2718::Decodable2718, eip4844::BlobTransactionSidecar,
-    eip4895::Withdrawals, eip7685::Requests,
+    eip1559::BaseFeeParams, eip2718::Decodable2718, eip4895::Withdrawals, eip7685::Requests,
 };
 use alloy_primitives::{keccak256, Address, Bytes, B256, B64, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{
-    ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadV1, ExecutionPayloadV3,
+    BlobsBundleV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadV1,
     PayloadId,
 };
 use op_alloy_consensus::{encode_holocene_extra_data, EIP1559ParamError};
@@ -15,14 +14,11 @@ use op_alloy_consensus::{encode_holocene_extra_data, EIP1559ParamError};
 pub use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4};
 use reth_chain_state::ExecutedBlockWithTrieUpdates;
-use reth_chainspec::EthereumHardforks;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::{OpBlock, OpPrimitives, OpTransactionSigned};
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
 use reth_primitives::{transaction::WithEncoded, SealedBlock};
-
-use std::sync::Arc;
+use reth_rpc_types_compat::engine::payload::{block_to_payload_v1, block_to_payload_v3};
 
 /// Optimism Payload Builder Attributes
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -135,19 +131,10 @@ impl PayloadBuilderAttributes for OpPayloadBuilderAttributes {
 pub struct OpBuiltPayload {
     /// Identifier of the payload
     pub(crate) id: PayloadId,
-    /// The built block
-    pub(crate) block: Arc<SealedBlock<OpBlock>>,
     /// Block execution data for the payload, if any.
-    pub(crate) executed_block: Option<ExecutedBlockWithTrieUpdates<OpPrimitives>>,
+    pub(crate) block: ExecutedBlockWithTrieUpdates<OpPrimitives>,
     /// The fees of the block
     pub(crate) fees: U256,
-    /// The blobs, proofs, and commitments in the block. If the block is pre-cancun, this will be
-    /// empty.
-    pub(crate) sidecars: Vec<BlobTransactionSidecar>,
-    /// The rollup's chainspec.
-    pub(crate) chain_spec: Arc<OpChainSpec>,
-    /// The payload attributes.
-    pub(crate) attributes: OpPayloadBuilderAttributes,
 }
 
 // === impl BuiltPayload ===
@@ -156,13 +143,10 @@ impl OpBuiltPayload {
     /// Initializes the payload with the given initial block.
     pub const fn new(
         id: PayloadId,
-        block: Arc<SealedBlock<OpBlock>>,
         fees: U256,
-        chain_spec: Arc<OpChainSpec>,
-        attributes: OpPayloadBuilderAttributes,
-        executed_block: Option<ExecutedBlockWithTrieUpdates<OpPrimitives>>,
+        block: ExecutedBlockWithTrieUpdates<OpPrimitives>,
     ) -> Self {
-        Self { id, block, executed_block, fees, sidecars: Vec::new(), chain_spec, attributes }
+        Self { id, block, fees }
     }
 
     /// Returns the identifier of the payload.
@@ -172,17 +156,12 @@ impl OpBuiltPayload {
 
     /// Returns the built block(sealed)
     pub fn block(&self) -> &SealedBlock<OpBlock> {
-        &self.block
+        self.block.sealed_block()
     }
 
     /// Fees of the block
     pub const fn fees(&self) -> U256 {
         self.fees
-    }
-
-    /// Adds sidecars to the payload.
-    pub fn extend_sidecars(&mut self, sidecars: Vec<BlobTransactionSidecar>) {
-        self.sidecars.extend(sidecars)
     }
 }
 
@@ -190,7 +169,7 @@ impl BuiltPayload for OpBuiltPayload {
     type Primitives = OpPrimitives;
 
     fn block(&self) -> &SealedBlock<OpBlock> {
-        &self.block
+        self.block()
     }
 
     fn fees(&self) -> U256 {
@@ -198,7 +177,7 @@ impl BuiltPayload for OpBuiltPayload {
     }
 
     fn executed_block(&self) -> Option<ExecutedBlockWithTrieUpdates<OpPrimitives>> {
-        self.executed_block.clone()
+        Some(self.block.clone())
     }
 
     fn requests(&self) -> Option<Requests> {
@@ -218,7 +197,7 @@ impl BuiltPayload for &OpBuiltPayload {
     }
 
     fn executed_block(&self) -> Option<ExecutedBlockWithTrieUpdates<OpPrimitives>> {
-        self.executed_block.clone()
+        Some(self.block.clone())
     }
 
     fn requests(&self) -> Option<Requests> {
@@ -231,7 +210,7 @@ impl From<OpBuiltPayload> for ExecutionPayloadV1 {
     fn from(value: OpBuiltPayload) -> Self {
         Self::from_block_unchecked(
             value.block().hash(),
-            &Arc::unwrap_or_clone(value.block).into_block(),
+            value.block.into_sealed_block().into_block(),
         )
     }
 }
@@ -241,11 +220,12 @@ impl From<OpBuiltPayload> for ExecutionPayloadEnvelopeV2 {
     fn from(value: OpBuiltPayload) -> Self {
         let OpBuiltPayload { block, fees, .. } = value;
 
+        let block = block.into_sealed_block();
         Self {
             block_value: fees,
             execution_payload: ExecutionPayloadFieldV2::from_block_unchecked(
                 block.hash(),
-                &Arc::unwrap_or_clone(block).into_block(),
+                &block.into_block(),
             ),
         }
     }
@@ -253,18 +233,15 @@ impl From<OpBuiltPayload> for ExecutionPayloadEnvelopeV2 {
 
 impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV3 {
     fn from(value: OpBuiltPayload) -> Self {
-        let OpBuiltPayload { block, fees, sidecars, chain_spec, attributes, .. } = value;
+        let OpBuiltPayload { block, fees, .. } = value;
 
         let parent_beacon_block_root =
-            if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp()) {
-                attributes.parent_beacon_block_root().unwrap_or(B256::ZERO)
-            } else {
-                B256::ZERO
-            };
+            block.sealed_block().parent_beacon_block_root.unwrap_or_default();
+
         Self {
             execution_payload: ExecutionPayloadV3::from_block_unchecked(
-                block.hash(),
-                &Arc::unwrap_or_clone(block).into_block(),
+                value.block().hash(),
+                value.block.into_sealed_block().into_block(),
             ),
             block_value: fees,
             // From the engine API spec:
@@ -276,25 +253,23 @@ impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV3 {
             // Spec:
             // <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#specification-2>
             should_override_builder: false,
-            blobs_bundle: sidecars.into_iter().collect::<Vec<_>>().into(),
+            // No blobs for OP.
+            blobs_bundle: BlobsBundleV1 { blobs: vec![], commitments: vec![], proofs: vec![] },
             parent_beacon_block_root,
         }
     }
 }
 impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV4 {
     fn from(value: OpBuiltPayload) -> Self {
-        let OpBuiltPayload { block, fees, sidecars, chain_spec, attributes, .. } = value;
+        let OpBuiltPayload { block, fees, .. } = value;
 
         let parent_beacon_block_root =
-            if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp()) {
-                attributes.parent_beacon_block_root().unwrap_or(B256::ZERO)
-            } else {
-                B256::ZERO
-            };
+            block.sealed_block().parent_beacon_block_root.unwrap_or_default();
+
         Self {
             execution_payload: ExecutionPayloadV3::from_block_unchecked(
-                block.hash(),
-                &Arc::unwrap_or_clone(block).into_block(),
+                value.block().hash(),
+                value.block.into_sealed_block().into_block(),
             ),
             block_value: fees,
             // From the engine API spec:
@@ -306,7 +281,8 @@ impl From<OpBuiltPayload> for OpExecutionPayloadEnvelopeV4 {
             // Spec:
             // <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#specification-2>
             should_override_builder: false,
-            blobs_bundle: sidecars.into_iter().collect::<Vec<_>>().into(),
+            // No blobs for OP.
+            blobs_bundle: BlobsBundleV1 { blobs: vec![], commitments: vec![], proofs: vec![] },
             parent_beacon_block_root,
             execution_requests: vec![],
         }


### PR DESCRIPTION
There's no need to keep ChainSpec, attributes and blobs in OpBuiltPayload.

This should make it easier to reuse the type with custom blocks