### PR TITLE
Fix duplicate words in documentation

### DIFF
--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -176,7 +176,7 @@ pub struct TaskManager {
 // === impl TaskManager ===
 
 impl TaskManager {
-    /// Returns a a [`TaskManager`] over the currently running Runtime.
+    /// Returns a [`TaskManager`] over the currently running Runtime.
     ///
     /// # Panics
     ///

--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -62,7 +62,7 @@ where
     }
 }
 
-/// A [PayloadJob] is a a future that's being polled by the `PayloadBuilderService`
+/// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
 impl<Client, Pool, Tasks, Builder> Future for EmptyBlockPayloadJob<Client, Pool, Tasks, Builder>
 where
     Client: StateProviderFactory + Clone + Unpin + 'static,


### PR DESCRIPTION

## Changes

1. crates/tasks/src/lib.rs:
- /// Returns a a [`TaskManager`]
+ /// Returns a [`TaskManager`]

2. examples/custom-payload-builder/src/job.rs:  
- /// A [PayloadJob] is a a future
+ /// A [PayloadJob] is a future

## Description
Fixed duplicate word "a" in documentation comments to improve readability and maintain documentation quality. No functional changes.

Files changed:
- crates/tasks/src/lib.rs
- examples/custom-payload-builder/src/job.rs