### PR TITLE
chore(ci): unpin clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@clippy
         with:
-          toolchain: nightly-2025-01-16
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -54,7 +53,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2025-01-16
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -2201,7 +2201,7 @@ mod tests {
         match a {
             Ok(_) => panic!(),
             Err(err) => match err {
-                InboundConnectionError::IpBanned {} => {
+                InboundConnectionError::IpBanned => {
                     assert_eq!(peer_manager.connection_info.num_pending_in, 0)
                 }
                 _ => unreachable!(),


### PR DESCRIPTION
After #14147 we no longer need to pin clippy on CI. Includes fix for:
```
warning: struct pattern is not needed for a unit variant
    --> crates/net/network/src/peers.rs:2204:49
     |
2204 |                 InboundConnectionError::IpBanned {} => {
     |                                                 ^^^ help: remove the struct pattern
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
     = note: `#[warn(clippy::unneeded_struct_pattern)]` on by default
```