### PR TITLE
feat: add `ExecutionData` AT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7157,6 +7157,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "auto_impl",
  "futures",
  "reth-errors",
  "reth-execution-types",

--- a/crates/engine/primitives/Cargo.toml
+++ b/crates/engine/primitives/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true, features = ["sync"] }
 futures.workspace = true
 
 # misc
+auto_impl.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::BeaconForkChoiceUpdateError, BeaconOnNewPayloadError, EngineApiMessageVersion,
-    EngineTypes, ExecutionData, ForkchoiceStatus,
+    EngineTypes, ExecutionPayload, ForkchoiceStatus,
 };
 use alloy_rpc_types_engine::{
     ForkChoiceUpdateResult, ForkchoiceState, ForkchoiceUpdateError, ForkchoiceUpdated, PayloadId,
@@ -145,7 +145,7 @@ pub enum BeaconEngineMessage<Engine: EngineTypes> {
     /// Message with new payload.
     NewPayload {
         /// The execution payload received by Engine API.
-        payload: ExecutionData,
+        payload: Engine::ExecutionData,
         /// The sender for returning payload status result.
         tx: oneshot::Sender<Result<PayloadStatus, BeaconOnNewPayloadError>>,
     },
@@ -217,7 +217,7 @@ where
     /// See also <https://github.com/ethereum/execution-apis/blob/3d627c95a4d3510a8187dd02e0250ecb4331d27e/src/engine/shanghai.md#engine_newpayloadv2>
     pub async fn new_payload(
         &self,
-        payload: ExecutionData,
+        payload: Engine::ExecutionData,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
         let (tx, rx) = oneshot::channel();
         let _ = self.to_engine.send(BeaconEngineMessage::NewPayload { payload, tx });

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -790,7 +790,7 @@ where
 
     /// When the Consensus layer receives a new block via the consensus gossip protocol,
     /// the transactions in the block are sent to the execution layer in the form of a
-    /// [`ExecutionData`]. The Execution layer executes the transactions and validates the
+    /// [`EngineTypes::ExecutionData`]. The Execution layer executes the transactions and validates the
     /// state in the block header, then passes validation data back to Consensus layer, that
     /// adds the block to the head of its own blockchain and attests to it. The block is then
     /// broadcast over the consensus p2p network in the form of a "Beacon block".

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -790,8 +790,8 @@ where
 
     /// When the Consensus layer receives a new block via the consensus gossip protocol,
     /// the transactions in the block are sent to the execution layer in the form of a
-    /// [`EngineTypes::ExecutionData`]. The Execution layer executes the transactions and validates the
-    /// state in the block header, then passes validation data back to Consensus layer, that
+    /// [`EngineTypes::ExecutionData`]. The Execution layer executes the transactions and validates
+    /// the state in the block header, then passes validation data back to Consensus layer, that
     /// adds the block to the head of its own blockchain and attests to it. The block is then
     /// broadcast over the consensus p2p network in the form of a "Beacon block".
     ///

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -28,7 +28,7 @@ use reth_consensus::{Consensus, FullConsensus, PostExecutionInput};
 pub use reth_engine_primitives::InvalidBlockHook;
 use reth_engine_primitives::{
     BeaconConsensusEngineEvent, BeaconEngineMessage, BeaconOnNewPayloadError, EngineTypes,
-    EngineValidator, ExecutionData, ForkchoiceStateTracker, OnForkChoiceUpdated,
+    EngineValidator, ExecutionPayload, ForkchoiceStateTracker, OnForkChoiceUpdated,
 };
 use reth_errors::{ConsensusError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
@@ -803,7 +803,7 @@ where
     #[instrument(level = "trace", skip_all, fields(block_hash = %payload.block_hash(), block_num = %payload.block_number(),), target = "engine::tree")]
     fn on_new_payload(
         &mut self,
-        payload: ExecutionData,
+        payload: T::ExecutionData,
     ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> {
         trace!(target: "engine::tree", "invoked new payload");
         self.metrics.engine.new_payload_messages.increment(1);
@@ -2925,7 +2925,7 @@ mod tests {
     use assert_matches::assert_matches;
     use reth_chain_state::{test_utils::TestBlockBuilder, BlockState};
     use reth_chainspec::{ChainSpec, HOLESKY, MAINNET};
-    use reth_engine_primitives::ForkchoiceStatus;
+    use reth_engine_primitives::{ExecutionData, ForkchoiceStatus};
     use reth_ethereum_consensus::EthBeaconConsensus;
     use reth_ethereum_engine_primitives::{EthEngineTypes, EthereumEngineValidator};
     use reth_ethereum_primitives::{Block, EthPrimitives};

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -27,7 +27,7 @@ pub enum StoredEngineApiMessage<EngineT: EngineTypes> {
     },
     /// The on-disk representation of an `engine_newPayload` method call.
     NewPayload {
-        /// The [`ExecutionData`] sent in the persisted call.
+        /// The [`EngineTypes::ExecutionData`] sent in the persisted call.
         #[serde(flatten)]
         payload: EngineT::ExecutionData,
     },

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -2,7 +2,7 @@
 
 use alloy_rpc_types_engine::ForkchoiceState;
 use futures::{Stream, StreamExt};
-use reth_engine_primitives::{BeaconEngineMessage, EngineTypes, ExecutionData};
+use reth_engine_primitives::{BeaconEngineMessage, EngineTypes, ExecutionPayload};
 use reth_fs_util as fs;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -17,19 +17,19 @@ use tracing::*;
 /// A message from the engine API that has been stored to disk.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum StoredEngineApiMessage<Attributes> {
+pub enum StoredEngineApiMessage<EngineT: EngineTypes> {
     /// The on-disk representation of an `engine_forkchoiceUpdated` method call.
     ForkchoiceUpdated {
         /// The [`ForkchoiceState`] sent in the persisted call.
         state: ForkchoiceState,
         /// The payload attributes sent in the persisted call, if any.
-        payload_attrs: Option<Attributes>,
+        payload_attrs: Option<EngineT::PayloadAttributes>,
     },
     /// The on-disk representation of an `engine_newPayload` method call.
     NewPayload {
         /// The [`ExecutionData`] sent in the persisted call.
         #[serde(flatten)]
-        payload: ExecutionData,
+        payload: EngineT::ExecutionData,
     },
 }
 
@@ -70,7 +70,7 @@ impl EngineMessageStore {
                 let filename = format!("{}-fcu-{}.json", timestamp, state.head_block_hash);
                 fs::write(
                     self.path.join(filename),
-                    serde_json::to_vec(&StoredEngineApiMessage::ForkchoiceUpdated {
+                    serde_json::to_vec(&StoredEngineApiMessage::<Engine>::ForkchoiceUpdated {
                         state: *state,
                         payload_attrs: payload_attrs.clone(),
                     })?,
@@ -80,11 +80,9 @@ impl EngineMessageStore {
                 let filename = format!("{}-new_payload-{}.json", timestamp, payload.block_hash());
                 fs::write(
                     self.path.join(filename),
-                    serde_json::to_vec(
-                        &StoredEngineApiMessage::<Engine::PayloadAttributes>::NewPayload {
-                            payload: payload.clone(),
-                        },
-                    )?,
+                    serde_json::to_vec(&StoredEngineApiMessage::<Engine>::NewPayload {
+                        payload: payload.clone(),
+                    })?,
                 )?;
             }
             // noop

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -8,7 +8,8 @@ use futures::{stream::FuturesUnordered, Stream, StreamExt, TryFutureExt};
 use itertools::Either;
 use reth_chainspec::EthChainSpec;
 use reth_engine_primitives::{
-    BeaconEngineMessage, BeaconOnNewPayloadError, EngineTypes, ExecutionData, OnForkChoiceUpdated,
+    BeaconEngineMessage, BeaconOnNewPayloadError, EngineTypes, ExecutionData,
+    ExecutionPayload as _, OnForkChoiceUpdated,
 };
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResult};
 use reth_ethereum_forks::EthereumHardforks;
@@ -104,7 +105,7 @@ impl<S, Engine: EngineTypes, Provider, Evm, Spec> EngineReorg<S, Engine, Provide
 impl<S, Engine, Provider, Evm, Spec> Stream for EngineReorg<S, Engine, Provider, Evm, Spec>
 where
     S: Stream<Item = BeaconEngineMessage<Engine>>,
-    Engine: EngineTypes,
+    Engine: EngineTypes<ExecutionData = ExecutionData>,
     Provider: BlockReader<Block = reth_primitives::Block> + StateProviderFactory,
     Evm: ConfigureEvm<Header = Header, Transaction = reth_primitives::TransactionSigned>,
     Spec: EthChainSpec + EthereumHardforks,

--- a/crates/engine/util/src/skip_new_payload.rs
+++ b/crates/engine/util/src/skip_new_payload.rs
@@ -2,7 +2,7 @@
 
 use alloy_rpc_types_engine::{PayloadStatus, PayloadStatusEnum};
 use futures::{Stream, StreamExt};
-use reth_engine_primitives::{BeaconEngineMessage, EngineTypes};
+use reth_engine_primitives::{BeaconEngineMessage, EngineTypes, ExecutionPayload};
 use std::{
     pin::Pin,
     task::{ready, Context, Poll},

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -50,6 +50,7 @@ where
         + TryInto<ExecutionPayloadEnvelopeV3>
         + TryInto<ExecutionPayloadEnvelopeV4>,
 {
+    type ExecutionData = ExecutionData;
     type ExecutionPayloadEnvelopeV1 = ExecutionPayloadV1;
     type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadEnvelopeV3 = ExecutionPayloadEnvelopeV3;
@@ -98,6 +99,7 @@ impl EthereumEngineValidator {
 
 impl PayloadValidator for EthereumEngineValidator {
     type Block = Block;
+    type ExecutionData = ExecutionData;
 
     fn ensure_well_formed_payload(
         &self,
@@ -109,7 +111,7 @@ impl PayloadValidator for EthereumEngineValidator {
 
 impl<Types> EngineValidator<Types> for EthereumEngineValidator
 where
-    Types: EngineTypes<PayloadAttributes = EthPayloadAttributes>,
+    Types: EngineTypes<PayloadAttributes = EthPayloadAttributes, ExecutionData = ExecutionData>,
 {
     fn validate_version_specific_fields(
         &self,

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -10,8 +10,8 @@ use std::{
 use alloy_rpc_types::engine::ClientVersionV1;
 use futures::TryFutureExt;
 use reth_node_api::{
-    AddOnsContext, BlockTy, EngineValidator, FullNodeComponents, NodeAddOns, NodeTypes,
-    NodeTypesWithEngine,
+    AddOnsContext, BlockTy, EngineTypes, EngineValidator, ExecutionData, FullNodeComponents,
+    NodeAddOns, NodeTypes, NodeTypesWithEngine,
 };
 use reth_node_core::{
     node_config::NodeConfig,
@@ -401,7 +401,9 @@ where
 
 impl<N, EthApi, EV> RpcAddOns<N, EthApi, EV>
 where
-    N: FullNodeComponents,
+    N: FullNodeComponents<
+        Types: NodeTypesWithEngine<Engine: EngineTypes<ExecutionData = ExecutionData>>,
+    >,
     EthApi: EthApiTypes
         + FullEthApiServer<Provider = N::Provider, Pool = N::Pool, Network = N::Network>
         + AddDevSigners
@@ -528,7 +530,9 @@ where
 
 impl<N, EthApi, EV> NodeAddOns<N> for RpcAddOns<N, EthApi, EV>
 where
-    N: FullNodeComponents,
+    N: FullNodeComponents<
+        Types: NodeTypesWithEngine<Engine: EngineTypes<ExecutionData = ExecutionData>>,
+    >,
     EthApi: EthApiTypes
         + FullEthApiServer<Provider = N::Provider, Pool = N::Pool, Network = N::Network>
         + AddDevSigners

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -47,6 +47,7 @@ where
     type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadEnvelopeV3 = OpExecutionPayloadEnvelopeV3;
     type ExecutionPayloadEnvelopeV4 = OpExecutionPayloadEnvelopeV4;
+    type ExecutionData = ExecutionData;
 
     fn block_to_payload(
         block: SealedBlock<
@@ -91,6 +92,7 @@ impl OpEngineValidator {
 
 impl PayloadValidator for OpEngineValidator {
     type Block = OpBlock;
+    type ExecutionData = ExecutionData;
 
     fn ensure_well_formed_payload(
         &self,
@@ -102,7 +104,7 @@ impl PayloadValidator for OpEngineValidator {
 
 impl<Types> EngineValidator<Types> for OpEngineValidator
 where
-    Types: EngineTypes<PayloadAttributes = OpPayloadAttributes>,
+    Types: EngineTypes<PayloadAttributes = OpPayloadAttributes, ExecutionData = ExecutionData>,
 {
     fn validate_execution_requests(
         &self,

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -115,9 +115,9 @@ impl<ChainSpec: EthereumHardforks> ExecutionPayloadValidator<ChainSpec> {
         &self,
         payload: ExecutionData,
     ) -> Result<SealedBlock<reth_primitives::Block<T>>, PayloadError> {
-        let expected_hash = payload.block_hash();
-
         let ExecutionData { payload, sidecar } = payload;
+
+        let expected_hash = payload.block_hash();
 
         // First parse the block
         let sealed_block = payload.try_into_block_with_sidecar(&sidecar)?.seal_slow();

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -213,7 +213,7 @@ use jsonrpsee::{
 };
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_engine_primitives::{EngineTypes, PayloadValidator};
+use reth_engine_primitives::{EngineTypes, ExecutionData, PayloadValidator};
 use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives::NodePrimitives;
@@ -284,7 +284,9 @@ pub async fn launch<Provider, Pool, Network, Tasks, EvmConfig, EthApi, BlockExec
     eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
     block_executor: BlockExecutor,
     consensus: Arc<dyn FullConsensus<BlockExecutor::Primitives, Error = ConsensusError>>,
-    payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
+    payload_validator: Arc<
+        dyn PayloadValidator<Block = Provider::Block, ExecutionData = ExecutionData>,
+    >,
 ) -> Result<RpcServerHandle, RpcError>
 where
     Provider: FullRpcProvider<
@@ -614,7 +616,9 @@ where
         module_config: TransportRpcModuleConfig,
         engine: EngineApi,
         eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
-        payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
+        payload_validator: Arc<
+            dyn PayloadValidator<Block = Provider::Block, ExecutionData = ExecutionData>,
+        >,
     ) -> (
         TransportRpcModules,
         AuthRpcModule,
@@ -699,7 +703,9 @@ where
         self,
         config: RpcModuleConfig,
         eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
-        payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
+        payload_validator: Arc<
+            dyn PayloadValidator<Block = Provider::Block, ExecutionData = ExecutionData>,
+        >,
     ) -> RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
     where
         EthApi: EthApiTypes + 'static,
@@ -726,7 +732,9 @@ where
         self,
         module_config: TransportRpcModuleConfig,
         eth: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
-        payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
+        payload_validator: Arc<
+            dyn PayloadValidator<Block = Provider::Block, ExecutionData = ExecutionData>,
+        >,
     ) -> TransportRpcModules<()>
     where
         EthApi: FullEthApiServer<
@@ -869,7 +877,8 @@ pub struct RpcRegistryInner<
     executor: Tasks,
     block_executor: BlockExecutor,
     consensus: Consensus,
-    payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
+    payload_validator:
+        Arc<dyn PayloadValidator<Block = Provider::Block, ExecutionData = ExecutionData>>,
     /// Holds the configuration for the RPC modules
     config: RpcModuleConfig,
     /// Holds a all `eth_` namespace handlers
@@ -910,7 +919,9 @@ where
         evm_config: EvmConfig,
         eth_api_builder: DynEthApiBuilder<Provider, Pool, EvmConfig, Network, Tasks, EthApi>,
         block_executor: BlockExecutor,
-        payload_validator: Arc<dyn PayloadValidator<Block = Provider::Block>>,
+        payload_validator: Arc<
+            dyn PayloadValidator<Block = Provider::Block, ExecutionData = ExecutionData>,
+        >,
     ) -> Self
     where
         EvmConfig: ConfigureEvm<Header = Provider::Header>,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ```
 //! use reth_consensus::{ConsensusError, FullConsensus};
-//! use reth_engine_primitives::PayloadValidator;
+//! use reth_engine_primitives::{ExecutionData, PayloadValidator};
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_evm_ethereum::EthEvmConfig;
 //! use reth_network_api::{NetworkInfo, Peers};
@@ -58,7 +58,7 @@
 //!     Network: NetworkInfo + Peers + Clone + 'static,
 //!     BlockExecutor: BlockExecutorProvider<Primitives = Provider::Primitives>,
 //!     Consensus: FullConsensus<Provider::Primitives, Error = ConsensusError> + Clone + 'static,
-//!     Validator: PayloadValidator<Block = reth_primitives::Block>,
+//!     Validator: PayloadValidator<Block = reth_primitives::Block, ExecutionData = ExecutionData>,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -89,7 +89,7 @@
 //!
 //! ```
 //! use reth_consensus::{ConsensusError, FullConsensus};
-//! use reth_engine_primitives::{EngineTypes, PayloadValidator};
+//! use reth_engine_primitives::{EngineTypes, ExecutionData, PayloadValidator};
 //! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_evm_ethereum::EthEvmConfig;
 //! use reth_network_api::{NetworkInfo, Peers};
@@ -146,7 +146,7 @@
 //!     EngineT: EngineTypes,
 //!     BlockExecutor: BlockExecutorProvider<Primitives = Provider::Primitives>,
 //!     Consensus: FullConsensus<Provider::Primitives, Error = ConsensusError> + Clone + 'static,
-//!     Validator: PayloadValidator<Block = reth_primitives::Block>,
+//!     Validator: PayloadValidator<Block = reth_primitives::Block, ExecutionData = ExecutionData>,
 //! {
 //!     // configure the rpc module per transport
 //!     let transports = TransportRpcModuleConfig::default().with_http(vec![
@@ -669,7 +669,7 @@ where
     ///
     /// ```no_run
     /// use reth_consensus::noop::NoopConsensus;
-    /// use reth_engine_primitives::PayloadValidator;
+    /// use reth_engine_primitives::{ExecutionData, PayloadValidator};
     /// use reth_evm::ConfigureEvm;
     /// use reth_evm_ethereum::execute::EthExecutorProvider;
     /// use reth_network_api::noop::NoopNetwork;
@@ -684,7 +684,8 @@ where
     /// fn init<Evm, Validator>(evm: Evm, validator: Validator)
     /// where
     ///     Evm: ConfigureEvm<Header = Header, Transaction = TransactionSigned> + 'static,
-    ///     Validator: PayloadValidator<Block = reth_primitives::Block> + 'static,
+    ///     Validator: PayloadValidator<Block = reth_primitives::Block, ExecutionData = ExecutionData>
+    ///         + 'static,
     /// {
     ///     let mut registry = RpcModuleBuilder::default()
     ///         .with_provider(NoopProvider::default())

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -78,7 +78,7 @@ impl<Provider, EngineT, Pool, Validator, ChainSpec>
     EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
-    EngineT: EngineTypes,
+    EngineT: EngineTypes<ExecutionData = ExecutionData>,
     Pool: TransactionPool + 'static,
     Validator: EngineValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,
@@ -739,7 +739,7 @@ impl<Provider, EngineT, Pool, Validator, ChainSpec> EngineApiServer<EngineT>
     for EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
-    EngineT: EngineTypes,
+    EngineT: EngineTypes<ExecutionData = ExecutionData>,
     Pool: TransactionPool + 'static,
     Validator: EngineValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -51,7 +51,10 @@ where
         config: ValidationApiConfig,
         task_spawner: Box<dyn TaskSpawner>,
         payload_validator: Arc<
-            dyn PayloadValidator<Block = <E::Primitives as NodePrimitives>::Block>,
+            dyn PayloadValidator<
+                Block = <E::Primitives as NodePrimitives>::Block,
+                ExecutionData = ExecutionData,
+            >,
         >,
     ) -> Self {
         let ValidationApiConfig { disallow, validation_window } = config;
@@ -468,7 +471,12 @@ pub struct ValidationApiInner<Provider, E: BlockExecutorProvider> {
     /// Consensus implementation.
     consensus: Arc<dyn FullConsensus<E::Primitives, Error = ConsensusError>>,
     /// Execution payload validator.
-    payload_validator: Arc<dyn PayloadValidator<Block = <E::Primitives as NodePrimitives>::Block>>,
+    payload_validator: Arc<
+        dyn PayloadValidator<
+            Block = <E::Primitives as NodePrimitives>::Block,
+            ExecutionData = ExecutionData,
+        >,
+    >,
     /// Block executor factory.
     executor_provider: E,
     /// Set of disallowed addresses

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -174,6 +174,7 @@ impl EngineTypes for CustomEngineTypes {
     type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadEnvelopeV3 = ExecutionPayloadEnvelopeV3;
     type ExecutionPayloadEnvelopeV4 = ExecutionPayloadEnvelopeV4;
+    type ExecutionData = ExecutionData;
 
     fn block_to_payload(
         block: SealedBlock<
@@ -207,6 +208,7 @@ impl CustomEngineValidator {
 
 impl PayloadValidator for CustomEngineValidator {
     type Block = Block;
+    type ExecutionData = ExecutionData;
 
     fn ensure_well_formed_payload(
         &self,
@@ -218,7 +220,7 @@ impl PayloadValidator for CustomEngineValidator {
 
 impl<T> EngineValidator<T> for CustomEngineValidator
 where
-    T: EngineTypes<PayloadAttributes = CustomPayloadAttributes>,
+    T: EngineTypes<PayloadAttributes = CustomPayloadAttributes, ExecutionData = ExecutionData>,
 {
     fn validate_version_specific_fields(
         &self,


### PR DESCRIPTION
Adds `ExecutionData` AT to `EngineTypes` and `PayloadValidator`, propagating it to all types requiring this.

For now it's locked to default `ExecutionData` type in RPC