### PR TITLE
fix: return correct `prune_target_block` when syncing

### DIFF
--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -113,7 +113,8 @@ mod tests {
                 PruneMode::Before(tip - MINIMUM_PRUNING_DISTANCE - 1),
                 Ok(Some(tip - MINIMUM_PRUNING_DISTANCE - 2)),
             ),
-            (PruneMode::Before(tip - 1), Err(PruneSegmentError::Configuration(segment))),
+            // Nothing to prune
+            (PruneMode::Before(tip - 1), Ok(None)),
         ];
 
         for (index, (mode, expected_result)) in tests.into_iter().enumerate() {

--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -48,8 +48,8 @@ impl PruneMode {
             }
             Self::Before(n) if *n == tip + 1 && purpose.is_static_file() => Some((tip, *self)),
             Self::Before(n) if *n > tip => None, // Nothing to prune yet
-            Self::Before(n) if tip - n >= segment.min_blocks(purpose) => {
-                Some(((*n).saturating_sub(1), *self))
+            Self::Before(n) => {
+                (tip - n >= segment.min_blocks(purpose)).then(|| ((*n).saturating_sub(1), *self))
             }
             _ => return Err(PruneSegmentError::Configuration(segment)),
         };


### PR DESCRIPTION
Right now we are likely to fail here when starting e.g Holesky full node and trying to insert genesis block:
https://github.com/paradigmxyz/reth/blob/f17dc01be35c3cd8c1e4fc69eaa8c0eb0ee8d801/crates/storage/provider/src/providers/database/provider.rs#L1832

Reason is that this match would return Err for `Self::Before(0)`, `tip == 0`

https://github.com/paradigmxyz/reth/blob/f17dc01be35c3cd8c1e4fc69eaa8c0eb0ee8d801/crates/prune/types/src/mode.rs#L49-L54

Instead, we should return `None` if `tip - n < segment.min_blocks(purpose)` because this might become false once node syncs to a higher `tip`