### PR TITLE
chore: rm unused error variants

### DIFF
--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -15,7 +15,6 @@ use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, Environ
 use reth_cli_runner::CliContext;
 use reth_cli_util::get_secret_key;
 use reth_config::Config;
-use reth_errors::BlockValidationError;
 use reth_evm::execute::{BlockExecutorProvider, Executor};
 use reth_execution_types::ExecutionOutcome;
 use reth_network::{BlockDownloaderProvider, NetworkHandle};
@@ -165,9 +164,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         let provider_rw = provider_factory.database_provider_rw()?;
 
         // Insert block, state and hashes
-        provider_rw.insert_historical_block(
-            block.clone().try_recover().map_err(|_| BlockValidationError::SenderRecoveryError)?,
-        )?;
+        provider_rw.insert_historical_block(block.clone().try_recover()?)?;
         provider_rw.write_state(
             &execution_outcome,
             OriginalValuesKnown::No,

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -189,10 +189,3 @@ pub enum InsertBlockValidationError {
     #[error(transparent)]
     Validation(#[from] BlockValidationError),
 }
-
-impl InsertBlockValidationError {
-    /// Returns true if this is a block pre merge error.
-    pub const fn is_block_pre_merge(&self) -> bool {
-        matches!(self, Self::Validation(BlockValidationError::BlockPreMerge { .. }))
-    }
-}

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2592,12 +2592,7 @@ where
         // invalid headers cache and `Ok` with [PayloadStatusEnum::Invalid] is
         // returned.
         warn!(target: "engine::tree", invalid_hash=?block.hash(), invalid_number=?block.number(), %validation_err, "Invalid block error on new payload");
-        let latest_valid_hash = if validation_err.is_block_pre_merge() {
-            // zero hash must be returned if block is pre-merge
-            Some(B256::ZERO)
-        } else {
-            self.latest_valid_hash_for_invalid_payload(block.parent_hash())?
-        };
+        let latest_valid_hash = self.latest_valid_hash_for_invalid_payload(block.parent_hash())?;
 
         // keep track of the invalid header
         self.state.invalid_headers.insert(block.block_with_parent());

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -313,9 +313,8 @@ where
         }
 
         // Configure the environment for the block.
-        let tx_recovered = tx.try_clone_into_recovered().map_err(|_| {
-            BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError)
-        })?;
+        let tx_recovered =
+            tx.try_clone_into_recovered().map_err(|_| ProviderError::SenderRecoveryError)?;
         let tx_env = evm_config.tx_env(&tx_recovered, tx_recovered.signer());
         let exec_result = match evm.transact(tx_env) {
             Ok(result) => result,

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -36,9 +36,6 @@ pub enum BlockValidationError {
         /// The EVM error.
         error: Box<dyn core::error::Error + Send + Sync>,
     },
-    /// Error when recovering the sender for a transaction
-    #[error("failed to recover sender for transaction")]
-    SenderRecoveryError,
     /// Error when incrementing balance in post execution
     #[error("incrementing balance in post execution failed")]
     IncrementBalanceFailed,
@@ -54,18 +51,6 @@ pub enum BlockValidationError {
         transaction_gas_limit: u64,
         /// The available block gas
         block_available_gas: u64,
-    },
-    /// Error for pre-merge block
-    #[error("block {hash} is pre merge")]
-    BlockPreMerge {
-        /// The hash of the block
-        hash: B256,
-    },
-    /// Error for missing total difficulty
-    #[error("missing total difficulty for block {hash}")]
-    MissingTotalDifficulty {
-        /// The hash of the block
-        hash: B256,
     },
     /// Error for EIP-4788 when parent beacon block root is missing
     #[error("EIP-4788 parent beacon block root missing for active Cancun block")]

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -651,7 +651,6 @@ mod tests {
     use reth_db_api::{models::AccountBeforeTx, transaction::DbTxMut};
     use reth_evm::execute::BasicBlockExecutorProvider;
     use reth_evm_ethereum::execute::EthExecutionStrategyFactory;
-    use reth_execution_errors::BlockValidationError;
     use reth_primitives::{Account, Bytecode, SealedBlock, StorageEntry};
     use reth_provider::{
         test_utils::create_test_provider_factory, AccountReader, DatabaseProviderFactory,
@@ -714,14 +713,7 @@ mod tests {
         let genesis = SealedBlock::<reth_primitives::Block>::decode(&mut genesis_rlp).unwrap();
         let mut block_rlp = hex!("f90262f901f9a075c371ba45999d87f4542326910a11af515897aebce5265d3f6acd1f1161f82fa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa098f2dcd87c8ae4083e7017a05456c14eea4b1db2032126e27b3b1563d57d7cc0a08151d548273f6683169524b66ca9fe338b9ce42bc3540046c828fd939ae23bcba03f4e5c2ec5b2170b711d97ee755c160457bb58d8daa338e835ec02ae6860bbabb901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000083020000018502540be40082a8798203e800a00000000000000000000000000000000000000000000000000000000000000000880000000000000000f863f861800a8405f5e10094100000000000000000000000000000000000000080801ba07e09e26678ed4fac08a249ebe8ed680bf9051a5e14ad223e4b2b9d26e0208f37a05f6e3f188e3e6eab7d7d3b6568f5eac7d687b08d307d3154ccd8c87b4630509bc0").as_slice();
         let block = SealedBlock::<reth_primitives::Block>::decode(&mut block_rlp).unwrap();
-        provider
-            .insert_historical_block(
-                genesis
-                    .try_recover()
-                    .map_err(|_| BlockValidationError::SenderRecoveryError)
-                    .unwrap(),
-            )
-            .unwrap();
+        provider.insert_historical_block(genesis.try_recover().unwrap()).unwrap();
         provider.insert_historical_block(block.clone().try_recover().unwrap()).unwrap();
         provider
             .static_file_provider()


### PR DESCRIPTION
none of those were used.

the only weird one is the pre-merge error check which I believe was legacy engine specific.
we can remove this