### PR TITLE
chore: Fix missing word in the comment

### DIFF
--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -1,4 +1,4 @@
-//! Example for how hook into the bsc p2p network
+//! Example for how to hook into the bsc p2p network
 //!
 //! Run with
 //!


### PR DESCRIPTION
Noticed a typo in the comment—missing "to".
Fixed it.