### PR TITLE
chore: fix typo in comment

### DIFF
--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -6,7 +6,7 @@
 //! cargo run -p rpc-db
 //! ```
 //!
-//! This installs an additional RPC method `myrpcExt_customMethod` that can queried via [cast](https://github.com/foundry-rs/foundry)
+//! This installs an additional RPC method `myrpcExt_customMethod` that can be queried via [cast](https://github.com/foundry-rs/foundry)
 //!
 //! ```sh
 //! cast rpc myrpcExt_customMethod


### PR DESCRIPTION
I noticed a typo in the comment related to the RPC method, where "can queried" should be "can **be** queried."