### PR TITLE
fix(reth-bench): return error on invalid range

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -83,7 +83,7 @@ impl Command {
             let (payload, _) =
                 ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
 
-            debug!(?block_number, "Sending payload",);
+            debug!(target: "reth-bench", ?block_number, "Sending payload",);
 
             // construct fcu to call
             let forkchoice_state = ForkchoiceState {

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -70,6 +70,7 @@ impl Command {
             let block_number = payload.block_number();
 
             debug!(
+                target: "reth-bench",
                 number=?payload.block_number(),
                 "Sending payload to engine",
             );

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -119,6 +119,11 @@ where
                 );
                 panic!("Invalid newPayloadV3: {status:?}");
             }
+            if status.is_syncing() {
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "invalid range: no canonical state found for parent of requested block",
+                ))
+            }
             status = self
                 .new_payload_v3(payload.clone(), versioned_hashes.clone(), parent_beacon_block_root)
                 .await?;
@@ -144,6 +149,11 @@ where
                 );
                 panic!("Invalid forkchoiceUpdatedV1: {status:?}");
             }
+            if status.is_syncing() {
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "invalid range: no canonical state found for parent of requested block",
+                ))
+            }
             status =
                 self.fork_choice_updated_v1(fork_choice_state, payload_attributes.clone()).await?;
         }
@@ -168,6 +178,11 @@ where
                     "Invalid forkchoiceUpdatedV2 message",
                 );
                 panic!("Invalid forkchoiceUpdatedV2: {status:?}");
+            }
+            if status.is_syncing() {
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "invalid range: no canonical state found for parent of requested block",
+                ))
             }
             status =
                 self.fork_choice_updated_v2(fork_choice_state, payload_attributes.clone()).await?;


### PR DESCRIPTION
After unwinding to block N, if you start `reth-bench` with `--from N+1` it will enter a loop here 

https://github.com/paradigmxyz/reth/blob/5322877aed96804711671154658e79b08f9a1868/bin/reth-bench/src/valid_payload.rs#L111-L125 

and won't advance, from the command line only this is shown before getting stuck:
```
2025-02-04T10:02:09.095541Z  INFO reth_bench::bench::context: Running benchmark using data from RPC URL: https://<your-rcp-url>
2025-02-04T10:02:09.113755Z  INFO reth_bench::bench::context: Connecting to Engine RPC at http://localhost:9551/ for replay
2025-02-04T10:02:10.276392Z DEBUG reth-bench: Sending payload block_number=<N+1>
```
With these changes, it will exit the loop with an error if the node is syncing, if no canonical state is found for the parent of the requested block. 
