### PR TITLE
feat: type erase concrete engine server trait

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -16,8 +16,19 @@ use alloy_rpc_types_eth::{
     EIP1186AccountProofResponse, Filter, Log, SyncStatus,
 };
 use alloy_serde::JsonStorageKey;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
 use reth_engine_primitives::EngineTypes;
+
+/// Helper trait for the engine api server.
+///
+/// This type-erases the concrete [`jsonrpsee`] server implementation and only returns the
+/// [`RpcModule`] that contains all the endpoints of the server.
+pub trait IntoEngineApiRpcModule {
+    /// Consumes the type and returns all the methods and subscriptions defined in the trait and
+    /// returns them as a single [`RpcModule`]
+    fn into_rpc_module(self) -> RpcModule<()>;
+}
+
 // NOTE: We can't use associated types in the `EngineApi` trait because of jsonrpsee, so we use a
 // generic here. It would be nice if the rpc macro would understand which types need to have serde.
 // By default, if the trait has a generic, the rpc macro will add e.g. `Engine: DeserializeOwned` to

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -39,7 +39,7 @@ pub mod servers {
     pub use crate::{
         admin::AdminApiServer,
         debug::{DebugApiServer, DebugExecutionWitnessApiServer},
-        engine::{EngineApiServer, EngineEthApiServer},
+        engine::{EngineApiServer, EngineEthApiServer, IntoEngineApiRpcModule},
         mev::{MevFullApiServer, MevSimApiServer},
         miner::MinerApiServer,
         net::NetApiServer,

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_engine::{
     PraguePayloadFields, TransitionConfiguration,
 };
 use async_trait::async_trait;
-use jsonrpsee_core::RpcResult;
+use jsonrpsee_core::{server::RpcModule, RpcResult};
 use parking_lot::Mutex;
 use reth_chainspec::{EthereumHardfork, EthereumHardforks};
 use reth_engine_primitives::{
@@ -27,7 +27,7 @@ use reth_payload_primitives::{
     PayloadOrAttributes,
 };
 use reth_primitives_traits::{Block, BlockBody};
-use reth_rpc_api::EngineApiServer;
+use reth_rpc_api::{EngineApiServer, IntoEngineApiRpcModule};
 use reth_storage_api::{BlockReader, HeaderProvider, StateProviderFactory};
 use reth_tasks::TaskSpawner;
 use reth_transaction_pool::TransactionPool;
@@ -1017,6 +1017,17 @@ where
             .tx_pool
             .get_blobs_for_versioned_hashes(&versioned_hashes)
             .map_err(|err| EngineApiError::Internal(Box::new(err)))?)
+    }
+}
+
+impl<Provider, EngineT, Pool, Validator, ChainSpec> IntoEngineApiRpcModule
+    for EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
+where
+    EngineT: EngineTypes,
+    Self: EngineApiServer<EngineT>,
+{
+    fn into_rpc_module(self) -> RpcModule<()> {
+        self.into_rpc().remove_context()
     }
 }
 


### PR DESCRIPTION
prep for

https://github.com/paradigmxyz/reth/issues/13831

we need to introduce an op specific engine API server trait, hence we can no longer hardcode this in the builder.

this introduces a helper trait that does the into_rpc conversion.

which is required because jsonrpsee can't auto impl an `Into<RpcModule>` impl due to unconstrained traits.
this also allows us to selectively mark something as the engineserver