### PR TITLE
chore: move `Transaction lock acquired` mdbx log to trace

### DIFF
--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -579,11 +579,13 @@ impl TransactionPtr {
         self.timed_out.store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
+    /// Acquires the inner transaction lock to guarantee exclusive access to the transaction
+    /// pointer.
     fn lock(&self) -> MutexGuard<'_, ()> {
         if let Some(lock) = self.lock.try_lock() {
             lock
         } else {
-            tracing::debug!(
+            tracing::trace!(
                 target: "libmdbx",
                 txn = %self.txn as usize,
                 backtrace = %std::backtrace::Backtrace::capture(),


### PR DESCRIPTION
This is very spammy now with the parallelism in the root task, we can probably identify spending lots of time locking in the future through flamegraphs / profiling anyways