### PR TITLE
perf(trie): deduplicate already fetched prefetch targets

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -611,7 +611,7 @@ where
         }
 
         if duplicates > 0 {
-            trace!(target: "engine::root", duplicates, "Removed duplicate proof targets");
+            trace!(target: "engine::root", duplicates, "Removed duplicate prefetch proof targets");
         }
 
         targets


### PR DESCRIPTION
This prevents fetching proofs that have already been fetched by state updates or other proof fetches. Previously we would only extend `self.fetched_proof_targets`, without checking it or modifying for prefetch calls.