### PR TITLE
chore: use alloy traits for `PoolTransaction`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,6 +3122,7 @@ dependencies = [
 name = "example-network-txpool"
 version = "0.0.0"
 dependencies = [
+ "alloy-consensus",
  "eyre",
  "reth-network",
  "reth-provider",

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1710,7 +1710,7 @@ impl PooledTransactionsHashesBuilder {
             Self::Eth68(msg) => {
                 msg.hashes.push(*pooled_tx.hash());
                 msg.sizes.push(pooled_tx.encoded_length());
-                msg.types.push(pooled_tx.transaction.tx_type());
+                msg.types.push(pooled_tx.transaction.ty());
             }
         }
     }

--- a/crates/transaction-pool/benches/reorder.rs
+++ b/crates/transaction-pool/benches/reorder.rs
@@ -113,7 +113,7 @@ fn generate_test_data(
 
 mod implementations {
     use super::*;
-    use reth_transaction_pool::PoolTransaction;
+    use alloy_consensus::Transaction;
     use std::collections::BinaryHeap;
 
     /// This implementation appends the transactions and uses [`Vec::sort_by`] function for sorting.

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -4,6 +4,8 @@ use crate::{
     pool::pending::PendingTransaction,
     PoolTransaction, TransactionOrdering, ValidPoolTransaction,
 };
+use alloy_consensus::Transaction;
+use alloy_eips::Typed2718;
 use alloy_primitives::Address;
 use core::fmt;
 use reth_payload_util::PayloadTransactions;

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -29,7 +29,7 @@ pub(crate) struct BlobTransactions<T: PoolTransaction> {
     pending_fees: PendingFees,
     /// Keeps track of the size of this pool.
     ///
-    /// See also [`PoolTransaction::size`].
+    /// See also [`reth_primitives_traits::InMemorySize::size`].
     size_of: SizeTracker,
 }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -87,7 +87,7 @@ use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use reth_eth_wire_types::HandleMempoolData;
 use reth_execution_types::ChangedAccount;
 
-use alloy_eips::eip4844::BlobTransactionSidecar;
+use alloy_eips::{eip4844::BlobTransactionSidecar, Typed2718};
 use reth_primitives::Recovered;
 use rustc_hash::FxHashMap;
 use std::{collections::HashSet, fmt, sync::Arc, time::Instant};

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -43,7 +43,7 @@ pub struct ParkedPool<T: ParkedOrd> {
     sender_transaction_count: FxHashMap<SenderId, SenderTransactionCount>,
     /// Keeps track of the size of this pool.
     ///
-    /// See also [`PoolTransaction::size`].
+    /// See also [`reth_primitives_traits::InMemorySize::size`].
     size_of: SizeTracker,
 }
 

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -520,6 +520,7 @@ impl<T: PoolTransaction> Ord for QueuedOrd<T> {
 mod tests {
     use super::*;
     use crate::test_utils::{MockTransaction, MockTransactionFactory, MockTransactionSet};
+    use alloy_consensus::Transaction;
     use alloy_primitives::address;
     use reth_primitives::TxType;
     use std::collections::HashSet;

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -43,7 +43,7 @@ pub struct PendingPool<T: TransactionOrdering> {
     independent_transactions: FxHashMap<SenderId, PendingTransaction<T>>,
     /// Keeps track of the size of this pool.
     ///
-    /// See also [`PoolTransaction::size`](crate::traits::PoolTransaction::size).
+    /// See also [`reth_primitives_traits::InMemorySize::size`].
     size_of: SizeTracker,
     /// Used to broadcast new transactions that have been added to the `PendingPool` to existing
     /// `static_files` of this pool.

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -613,6 +613,7 @@ mod tests {
         test_utils::{MockOrdering, MockTransaction, MockTransactionFactory, MockTransactionSet},
         PoolTransaction,
     };
+    use alloy_consensus::Transaction;
     use alloy_primitives::address;
     use reth_primitives::TxType;
     use std::collections::HashSet;

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -25,6 +25,7 @@ use alloy_consensus::constants::{
 use alloy_eips::{
     eip1559::{ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE},
     eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+    Typed2718,
 };
 use alloy_primitives::{Address, TxHash, B256};
 use rustc_hash::FxHashMap;
@@ -571,7 +572,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         let mut eip7702_count = 0;
 
         for tx in self.all_transactions.transactions_iter() {
-            match tx.transaction.tx_type() {
+            match tx.transaction.ty() {
                 LEGACY_TX_TYPE_ID => legacy_count += 1,
                 EIP2930_TX_TYPE_ID => eip2930_count += 1,
                 EIP1559_TX_TYPE_ID => eip1559_count += 1,
@@ -1978,6 +1979,7 @@ mod tests {
         traits::TransactionOrigin,
         SubPoolLimit,
     };
+    use alloy_consensus::Transaction;
     use alloy_primitives::address;
     use reth_primitives::TxType;
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1077,7 +1077,7 @@ pub trait EthPoolTransaction: PoolTransaction {
     /// Tries to reattach the blob sidecar to the transaction.
     ///
     /// This returns an option, but callers should ensure that the transaction is an EIP-4844
-    /// transaction: [`PoolTransaction::is_eip4844`].
+    /// transaction: [`Typed2718::is_eip4844`].
     fn try_into_pooled_eip4844(
         self,
         sidecar: Arc<BlobTransactionSidecar>,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -7,12 +7,13 @@ use crate::{
 };
 use alloy_consensus::{
     constants::{EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID},
-    BlockHeader, Signed, Transaction as _, Typed2718,
+    BlockHeader, Signed, Typed2718,
 };
 use alloy_eips::{
     eip2718::Encodable2718,
     eip2930::AccessList,
     eip4844::{BlobAndProofV1, BlobTransactionSidecar, BlobTransactionValidationError},
+    eip7702::SignedAuthorization,
 };
 use alloy_primitives::{Address, TxHash, TxKind, B256, U256};
 use futures_util::{ready, Stream};
@@ -21,9 +22,9 @@ use reth_execution_types::ChangedAccount;
 use reth_primitives::{
     kzg::KzgSettings,
     transaction::{SignedTransactionIntoRecoveredExt, TryFromRecoveredTransactionError},
-    PooledTransaction, Recovered, SealedBlock, Transaction, TransactionSigned,
+    PooledTransaction, Recovered, SealedBlock, TransactionSigned,
 };
-use reth_primitives_traits::{Block, SignedTransaction};
+use reth_primitives_traits::{Block, InMemorySize, SignedTransaction};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -964,7 +965,9 @@ impl BestTransactionsAttributes {
 /// sidecar when they are gossiped around the network. It is expected that the `Consensus` format is
 /// a subset of the `Pooled` format.
 pub trait PoolTransaction:
-    fmt::Debug
+    alloy_consensus::Transaction
+    + InMemorySize
+    + fmt::Debug
     + Send
     + Sync
     + Clone
@@ -1029,9 +1032,6 @@ pub trait PoolTransaction:
     /// Reference to the Sender of the transaction.
     fn sender_ref(&self) -> &Address;
 
-    /// Returns the nonce for this transaction.
-    fn nonce(&self) -> u64;
-
     /// Returns the cost that this transaction is allowed to consume:
     ///
     /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
@@ -1040,86 +1040,10 @@ pub trait PoolTransaction:
     /// max_blob_fee_per_gas * blob_gas_used`.
     fn cost(&self) -> &U256;
 
-    /// Amount of gas that should be used in executing this transaction. This is paid up-front.
-    fn gas_limit(&self) -> u64;
-
-    /// Returns the EIP-1559 the maximum fee per gas the caller is willing to pay.
-    ///
-    /// For legacy transactions this is `gas_price`.
-    ///
-    /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
-    fn max_fee_per_gas(&self) -> u128;
-
-    /// Returns the `access_list` for the particular transaction type.
-    /// For Legacy transactions, returns default.
-    fn access_list(&self) -> Option<&AccessList>;
-
-    /// Returns the EIP-1559 Priority fee the caller is paying to the block author.
-    ///
-    /// This will return `None` for non-EIP1559 transactions
-    fn max_priority_fee_per_gas(&self) -> Option<u128>;
-
-    /// Returns the EIP-4844 max fee per data gas
-    ///
-    /// This will return `None` for non-EIP4844 transactions
-    fn max_fee_per_blob_gas(&self) -> Option<u128>;
-
-    /// Returns the effective tip for this transaction.
-    ///
-    /// For EIP-1559 transactions: `min(max_fee_per_gas - base_fee, max_priority_fee_per_gas)`.
-    /// For legacy transactions: `gas_price - base_fee`.
-    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128>;
-
-    /// Returns the max priority fee per gas if the transaction is an EIP-1559 transaction, and
-    /// otherwise returns the gas price.
-    fn priority_fee_or_price(&self) -> u128;
-
-    /// Returns the transaction's [`TxKind`], which is the address of the recipient or
-    /// [`TxKind::Create`] if the transaction is a contract creation.
-    fn kind(&self) -> TxKind;
-
-    /// Returns true if the transaction is a contract creation.
-    /// We don't provide a default implementation via `kind` as it copies the 21-byte
-    /// [`TxKind`] for this simple check. A proper implementation shouldn't allocate.
-    fn is_create(&self) -> bool;
-
-    /// Returns the recipient of the transaction if it is not a [`TxKind::Create`]
-    /// transaction.
-    fn to(&self) -> Option<Address> {
-        self.kind().to().copied()
-    }
-
-    /// Returns the input data of this transaction.
-    fn input(&self) -> &[u8];
-
-    /// Returns a measurement of the heap usage of this type and all its internals.
-    fn size(&self) -> usize;
-
-    /// Returns the transaction type
-    fn tx_type(&self) -> u8;
-
-    /// Returns true if the transaction is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.tx_type() == EIP1559_TX_TYPE_ID
-    }
-
-    /// Returns true if the transaction is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.tx_type() == EIP4844_TX_TYPE_ID
-    }
-
-    /// Returns true if the transaction is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.tx_type() == EIP7702_TX_TYPE_ID
-    }
-
     /// Returns the length of the rlp encoded transaction object
     ///
     /// Note: Implementations should cache this value.
     fn encoded_length(&self) -> usize;
-
-    /// Returns `chain_id`
-    fn chain_id(&self) -> Option<u64>;
 
     /// Ensures that the transaction's code size does not exceed the provided `max_init_code_size`.
     ///
@@ -1149,9 +1073,6 @@ pub trait EthPoolTransaction: PoolTransaction {
     /// Extracts the blob sidecar from the transaction.
     fn take_blob(&mut self) -> EthBlobTransactionSidecar;
 
-    /// Returns the number of blobs this transaction has.
-    fn blob_count(&self) -> usize;
-
     /// A specialization for the EIP-4844 transaction type.
     /// Tries to reattach the blob sidecar to the transaction.
     ///
@@ -1176,9 +1097,6 @@ pub trait EthPoolTransaction: PoolTransaction {
         blob: &BlobTransactionSidecar,
         settings: &KzgSettings,
     ) -> Result<(), BlobTransactionValidationError>;
-
-    /// Returns the number of authorizations this transaction has.
-    fn authorization_count(&self) -> usize;
 }
 
 /// The default [`PoolTransaction`] for the [Pool](crate::Pool) for Ethereum.
@@ -1300,11 +1218,6 @@ impl PoolTransaction for EthPooledTransaction {
         self.transaction.signer_ref()
     }
 
-    /// Returns the nonce for this transaction.
-    fn nonce(&self) -> u64 {
-        self.transaction.nonce()
-    }
-
     /// Returns the cost that this transaction is allowed to consume:
     ///
     /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
@@ -1315,82 +1228,91 @@ impl PoolTransaction for EthPooledTransaction {
         &self.cost
     }
 
-    /// Amount of gas that should be used in executing this transaction. This is paid up-front.
+    /// Returns the length of the rlp encoded object
+    fn encoded_length(&self) -> usize {
+        self.encoded_length
+    }
+}
+
+impl<T: Typed2718> Typed2718 for EthPooledTransaction<T> {
+    fn ty(&self) -> u8 {
+        self.transaction.ty()
+    }
+}
+
+impl<T: InMemorySize> InMemorySize for EthPooledTransaction<T> {
+    fn size(&self) -> usize {
+        self.transaction.size()
+    }
+}
+
+impl<T: alloy_consensus::Transaction> alloy_consensus::Transaction for EthPooledTransaction<T> {
+    fn chain_id(&self) -> Option<alloy_primitives::ChainId> {
+        self.transaction.chain_id()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.transaction.nonce()
+    }
+
     fn gas_limit(&self) -> u64 {
         self.transaction.gas_limit()
     }
 
-    /// Returns the EIP-1559 Max base fee the caller is willing to pay.
-    ///
-    /// For legacy transactions this is `gas_price`.
-    ///
-    /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
+    fn gas_price(&self) -> Option<u128> {
+        self.transaction.gas_price()
+    }
+
     fn max_fee_per_gas(&self) -> u128 {
-        self.transaction.transaction().max_fee_per_gas()
+        self.transaction.max_fee_per_gas()
     }
 
-    fn access_list(&self) -> Option<&AccessList> {
-        self.transaction.access_list()
-    }
-
-    /// Returns the EIP-1559 Priority fee the caller is paying to the block author.
-    ///
-    /// This will return `None` for non-EIP1559 transactions
     fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        self.transaction.transaction().max_priority_fee_per_gas()
+        self.transaction.max_priority_fee_per_gas()
     }
 
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         self.transaction.max_fee_per_blob_gas()
     }
 
-    /// Returns the effective tip for this transaction.
-    ///
-    /// For EIP-1559 transactions: `min(max_fee_per_gas - base_fee, max_priority_fee_per_gas)`.
-    /// For legacy transactions: `gas_price - base_fee`.
-    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
-        self.transaction.effective_tip_per_gas(base_fee)
-    }
-
-    /// Returns the max priority fee per gas if the transaction is an EIP-1559 transaction, and
-    /// otherwise returns the gas price.
     fn priority_fee_or_price(&self) -> u128 {
         self.transaction.priority_fee_or_price()
     }
 
-    /// Returns the transaction's [`TxKind`], which is the address of the recipient or
-    /// [`TxKind::Create`] if the transaction is a contract creation.
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.transaction.effective_gas_price(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.transaction.is_dynamic_fee()
+    }
+
     fn kind(&self) -> TxKind {
         self.transaction.kind()
     }
 
-    /// Returns true if the transaction is a contract creation.
     fn is_create(&self) -> bool {
         self.transaction.is_create()
     }
 
-    fn input(&self) -> &[u8] {
+    fn value(&self) -> U256 {
+        self.transaction.value()
+    }
+
+    fn input(&self) -> &revm_primitives::Bytes {
         self.transaction.input()
     }
 
-    /// Returns a measurement of the heap usage of this type and all its internals.
-    fn size(&self) -> usize {
-        self.transaction.transaction().input().len()
+    fn access_list(&self) -> Option<&AccessList> {
+        self.transaction.access_list()
     }
 
-    /// Returns the transaction type
-    fn tx_type(&self) -> u8 {
-        self.transaction.ty()
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        self.transaction.blob_versioned_hashes()
     }
 
-    /// Returns the length of the rlp encoded object
-    fn encoded_length(&self) -> usize {
-        self.encoded_length
-    }
-
-    /// Returns `chain_id`
-    fn chain_id(&self) -> Option<u64> {
-        self.transaction.chain_id()
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.transaction.authorization_list()
     }
 }
 
@@ -1400,13 +1322,6 @@ impl EthPoolTransaction for EthPooledTransaction {
             std::mem::replace(&mut self.blob_sidecar, EthBlobTransactionSidecar::Missing)
         } else {
             EthBlobTransactionSidecar::None
-        }
-    }
-
-    fn blob_count(&self) -> usize {
-        match self.transaction.transaction() {
-            Transaction::Eip4844(tx) => tx.blob_versioned_hashes.len(),
-            _ => 0,
         }
     }
 
@@ -1438,15 +1353,8 @@ impl EthPoolTransaction for EthPooledTransaction {
         settings: &KzgSettings,
     ) -> Result<(), BlobTransactionValidationError> {
         match self.transaction.transaction() {
-            Transaction::Eip4844(tx) => tx.validate_blob(sidecar, settings),
-            _ => Err(BlobTransactionValidationError::NotBlobTransaction(self.tx_type())),
-        }
-    }
-
-    fn authorization_count(&self) -> usize {
-        match self.transaction.transaction() {
-            Transaction::Eip7702(tx) => tx.authorization_list.len(),
-            _ => 0,
+            reth_primitives::Transaction::Eip4844(tx) => tx.validate_blob(sidecar, settings),
+            _ => Err(BlobTransactionValidationError::NotBlobTransaction(self.ty())),
         }
     }
 }
@@ -1640,7 +1548,7 @@ mod tests {
     use alloy_consensus::{TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
     use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
     use alloy_primitives::PrimitiveSignature as Signature;
-    use reth_primitives::TransactionSigned;
+    use reth_primitives::{Transaction, TransactionSigned};
 
     #[test]
     fn test_pool_size_invariants() {

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -282,7 +282,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
 
     /// Returns the type identifier of the transaction
     pub fn tx_type(&self) -> u8 {
-        self.transaction.tx_type()
+        self.transaction.ty()
     }
 
     /// Returns the address of the sender

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -1,5 +1,6 @@
 //! Transaction pool eviction tests.
 
+use alloy_consensus::Transaction;
 use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::{Address, B256};
 use rand::distributions::Uniform;
@@ -8,8 +9,7 @@ use reth_transaction_pool::{
     test_utils::{
         MockFeeRange, MockTransactionDistribution, MockTransactionRatio, TestPool, TestPoolBuilder,
     },
-    BlockInfo, PoolConfig, PoolTransaction, SubPoolLimit, TransactionOrigin, TransactionPool,
-    TransactionPoolExt,
+    BlockInfo, PoolConfig, SubPoolLimit, TransactionOrigin, TransactionPool, TransactionPoolExt,
 };
 
 #[tokio::test(flavor = "multi_thread")]

--- a/examples/network-txpool/Cargo.toml
+++ b/examples/network-txpool/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+alloy-consensus.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 eyre.workspace = true
 tokio.workspace = true

--- a/examples/network-txpool/src/main.rs
+++ b/examples/network-txpool/src/main.rs
@@ -7,6 +7,7 @@
 //! cargo run --release -p network-txpool -- node
 //! ```
 
+use alloy_consensus::Transaction;
 use reth_network::{config::rng_secret_key, EthNetworkPrimitives, NetworkConfig, NetworkManager};
 use reth_provider::test_utils::NoopProvider;
 use reth_transaction_pool::{


### PR DESCRIPTION
Most of the `PoolTransaction` methods are same as `alloy_consensus::Transaction`, so we can unify those