### PR TITLE
feat: add exceeds allowance error message

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -139,6 +139,16 @@ pub trait EstimateCall: Call {
                         &mut db,
                     ))
                 }
+                Err(err) if err.is_gas_too_low() => {
+                    // This failed because the configured gas cost of the tx was lower than what
+                    // actually consumed by the tx This can happen if the
+                    // request provided fee values manually and the resulting gas cost exceeds the
+                    // sender's allowance, so we return the appropriate error here
+                    return Err(RpcInvalidTransactionError::GasRequiredExceedsAllowance {
+                        gas_limit: tx_env.gas_limit(),
+                    }
+                    .into_eth_err())
+                }
                 // Propagate other results (successful or other errors).
                 ethres => ethres?,
             };

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -338,6 +338,16 @@ pub enum RpcInvalidTransactionError {
         /// Current balance of transaction sender.
         balance: U256,
     },
+    /// This is similar to [`Self::InsufficientFunds`] but with a different error message and
+    /// exists for compatibility reasons.
+    ///
+    /// This error is used in `eth_estimateCall` when the highest available gas limit, capped with
+    /// the allowance of the caller is too low: [`Self::GasTooLow`].
+    #[error("gas required exceeds allowance ({gas_limit})")]
+    GasRequiredExceedsAllowance {
+        /// The gas limit the transaction was executed with.
+        gas_limit: u64,
+    },
     /// Thrown when calculating gas usage
     #[error("gas uint64 overflow")]
     GasUintOverflow,
@@ -448,9 +458,10 @@ impl RpcInvalidTransactionError {
     /// Returns the rpc error code for this error.
     pub const fn error_code(&self) -> i32 {
         match self {
-            Self::InvalidChainId | Self::GasTooLow | Self::GasTooHigh => {
-                EthRpcErrorCode::InvalidInput.code()
-            }
+            Self::InvalidChainId |
+            Self::GasTooLow |
+            Self::GasTooHigh |
+            Self::GasRequiredExceedsAllowance { .. } => EthRpcErrorCode::InvalidInput.code(),
             Self::Revert(_) => EthRpcErrorCode::ExecutionError.code(),
             _ => EthRpcErrorCode::TransactionRejected.code(),
         }


### PR DESCRIPTION
closes #14212

this represents this error handling in (op-)geth

https://github.com/ethereum-optimism/op-geth/blob/03e95dbb6093a324b162f96edf86398a20e2ee06/eth/gasestimator/gasestimator.go#L125-L136