### PR TITLE
fix typos and remove redundant code

### DIFF
--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -62,7 +62,7 @@ where
     }
 }
 
-/// A [PayloadJob] is a a future that's being polled by the `PayloadBuilderService`
+/// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
 impl<Client, Pool, Tasks, Builder> Future for EmptyBlockPayloadJob<Client, Pool, Tasks, Builder>
 where
     Client: StateProviderFactory + Clone + Unpin + 'static,

--- a/examples/custom-rlpx-subprotocol/src/subprotocol/protocol/proto.rs
+++ b/examples/custom-rlpx-subprotocol/src/subprotocol/protocol/proto.rs
@@ -45,7 +45,7 @@ impl CustomRlpxProtoMessage {
             message: CustomRlpxProtoMessageKind::PingMessage(msg.into()),
         }
     }
-    /// Creates a ping message
+    /// Creates a pong message
     pub fn pong_message(msg: impl Into<String>) -> Self {
         Self {
             message_type: CustomRlpxProtoMessageId::PongMessage,

--- a/examples/network-proxy/src/main.rs
+++ b/examples/network-proxy/src/main.rs
@@ -54,8 +54,6 @@ async fn main() -> eyre::Result<()> {
         }
     });
 
-    let handle = network.handle().clone();
-
     // spawn the network
     tokio::task::spawn(network);
 

--- a/examples/polygon-p2p/src/chain_cfg.rs
+++ b/examples/polygon-p2p/src/chain_cfg.rs
@@ -8,7 +8,7 @@ use reth_primitives::Head;
 
 use std::sync::Arc;
 
-const SHANGAI_BLOCK: u64 = 50523000;
+const SHANGHAI_BLOCK: u64 = 50523000;
 
 pub(crate) fn polygon_chain_spec() -> Arc<ChainSpec> {
     const GENESIS: B256 = b256!("a9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b");
@@ -26,7 +26,7 @@ pub(crate) fn polygon_chain_spec() -> Arc<ChainSpec> {
             (EthereumHardfork::MuirGlacier.boxed(), ForkCondition::Block(3395000)),
             (EthereumHardfork::Berlin.boxed(), ForkCondition::Block(14750000)),
             (EthereumHardfork::London.boxed(), ForkCondition::Block(23850000)),
-            (EthereumHardfork::Shanghai.boxed(), ForkCondition::Block(SHANGAI_BLOCK)),
+            (EthereumHardfork::Shanghai.boxed(), ForkCondition::Block(SHANGHAI_BLOCK)),
         ]),
         deposit_contract: None,
         base_fee_params: reth_chainspec::BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
@@ -45,7 +45,7 @@ static BOOTNODES : [&str; 4] = [
 ];
 
 pub(crate) fn head() -> Head {
-    Head { number: SHANGAI_BLOCK, ..Default::default() }
+    Head { number: SHANGHAI_BLOCK, ..Default::default() }
 }
 
 pub(crate) fn boot_nodes() -> Vec<NodeRecord> {


### PR DESCRIPTION
Hey! Fixed a few typos and removed some redundant code:

- **chain_cfg.rs** – fixed typo `SHANGAI_BLOCK` → `SHANGHAI_BLOCK`, now it's correct.
- **proto.rs** – fixed a comment, `pong_message` was incorrectly described as creating a "ping".
- **job.rs** – removed a duplicate comment, it was annoying.
- **main.rs** – removed `network.handle().clone()`, it was unnecessary.

Code is a bit cleaner now, no functional changes.
