### PR TITLE
chore(ci): update hive expected failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -15,7 +15,6 @@ rpc-compat:
 
   # https://github.com/paradigmxyz/reth/issues/13879
   - eth_createAccessList/create-al-contract-eip1559 (reth)
-  - eth_getBlockByNumber/get-genesis (reth)
 
 # https://github.com/paradigmxyz/reth/issues/8732
 engine-withdrawals:


### PR DESCRIPTION
`eth_getBlockByNumber/get-genesis (reth)` is now passing https://github.com/paradigmxyz/reth/actions/runs/13156954070