### PR TITLE
chore: simplify `PayloadBuilder` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6510,7 +6510,6 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-tasks",
- "reth-transaction-pool",
  "revm",
  "tokio",
  "tracing",

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -216,8 +216,6 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         );
 
         let args = BuildArguments::new(
-            blockchain_db.clone(),
-            transaction_pool,
             CachedReads::default(),
             payload_config,
             CancelOnDrop::default(),
@@ -225,6 +223,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         );
 
         let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
+            blockchain_db.clone(),
+            transaction_pool,
             EthEvmConfig::new(provider_factory.chain_spec()),
             EthereumBuilderConfig::new(Default::default()),
         );

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -45,6 +45,8 @@ impl EthereumPayloadBuilder {
     {
         let conf = ctx.payload_builder_config();
         let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
+            ctx.provider().clone(),
+            pool,
             evm_config,
             EthereumBuilderConfig::new(conf.extra_data_bytes()).with_gas_limit(conf.gas_limit()),
         );
@@ -56,7 +58,6 @@ impl EthereumPayloadBuilder {
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
-            pool,
             ctx.task_executor().clone(),
             payload_job_config,
             payload_builder,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -210,6 +210,8 @@ where
         let Self { rpc_add_ons, da_config } = self;
 
         let builder = reth_optimism_payload_builder::OpPayloadBuilder::new(
+            ctx.node.pool().clone(),
+            ctx.node.provider().clone(),
             ctx.node.evm_config().clone(),
             BasicOpReceiptBuilder::default(),
         );
@@ -507,6 +509,8 @@ where
         Txs: OpPayloadTransactions<TxTy<Node::Types>>,
     {
         let payload_builder = reth_optimism_payload_builder::OpPayloadBuilder::with_builder_config(
+            pool,
+            ctx.provider().clone(),
             evm_config,
             BasicOpReceiptBuilder::default(),
             OpBuilderConfig { da_config: self.da_config },
@@ -522,7 +526,6 @@ where
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
-            pool,
             ctx.task_executor().clone(),
             payload_job_config,
             payload_builder,

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
-reth-transaction-pool.workspace = true
 reth-provider.workspace = true
 reth-payload-builder.workspace = true
 reth-payload-builder-primitives.workspace = true

--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -177,54 +177,45 @@ where
     }
 }
 
-impl<L, R, Pool, Client> PayloadBuilder<Pool, Client> for PayloadBuilderStack<L, R>
+impl<L, R> PayloadBuilder for PayloadBuilderStack<L, R>
 where
-    L: PayloadBuilder<Pool, Client> + Unpin + 'static,
-    R: PayloadBuilder<Pool, Client> + Unpin + 'static,
-    Client: Clone,
-    Pool: Clone,
+    L: PayloadBuilder + Unpin + 'static,
+    R: PayloadBuilder + Unpin + 'static,
     L::Attributes: Unpin + Clone,
     R::Attributes: Unpin + Clone,
     L::BuiltPayload: Unpin + Clone,
     R::BuiltPayload:
         BuiltPayload<Primitives = <L::BuiltPayload as BuiltPayload>::Primitives> + Unpin + Clone,
-    <<L as PayloadBuilder<Pool, Client>>::Attributes as PayloadBuilderAttributes>::Error: 'static,
-    <<R as PayloadBuilder<Pool, Client>>::Attributes as PayloadBuilderAttributes>::Error: 'static,
 {
     type Attributes = Either<L::Attributes, R::Attributes>;
     type BuiltPayload = Either<L::BuiltPayload, R::BuiltPayload>;
 
     fn try_build(
         &self,
-        args: BuildArguments<Pool, Client, Self::Attributes, Self::BuiltPayload>,
+        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         match args.config.attributes {
             Either::Left(ref left_attr) => {
-                let left_args: BuildArguments<Pool, Client, L::Attributes, L::BuiltPayload> =
-                    BuildArguments {
-                        client: args.client.clone(),
-                        pool: args.pool.clone(),
-                        cached_reads: args.cached_reads.clone(),
-                        config: PayloadConfig {
-                            parent_header: args.config.parent_header.clone(),
-                            attributes: left_attr.clone(),
-                        },
-                        cancel: args.cancel.clone(),
-                        best_payload: args.best_payload.clone().and_then(|payload| {
-                            if let Either::Left(p) = payload {
-                                Some(p)
-                            } else {
-                                None
-                            }
-                        }),
-                    };
+                let left_args: BuildArguments<L::Attributes, L::BuiltPayload> = BuildArguments {
+                    cached_reads: args.cached_reads.clone(),
+                    config: PayloadConfig {
+                        parent_header: args.config.parent_header.clone(),
+                        attributes: left_attr.clone(),
+                    },
+                    cancel: args.cancel.clone(),
+                    best_payload: args.best_payload.clone().and_then(|payload| {
+                        if let Either::Left(p) = payload {
+                            Some(p)
+                        } else {
+                            None
+                        }
+                    }),
+                };
 
                 self.left.try_build(left_args).map(|out| out.map_payload(Either::Left))
             }
             Either::Right(ref right_attr) => {
                 let right_args = BuildArguments {
-                    client: args.client.clone(),
-                    pool: args.pool.clone(),
                     cached_reads: args.cached_reads.clone(),
                     config: PayloadConfig {
                         parent_header: args.config.parent_header.clone(),
@@ -247,7 +238,6 @@ where
 
     fn build_empty_payload(
         &self,
-        client: &Client,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         match config.attributes {
@@ -256,14 +246,14 @@ where
                     parent_header: config.parent_header.clone(),
                     attributes: left_attr,
                 };
-                self.left.build_empty_payload(client, left_config).map(Either::Left)
+                self.left.build_empty_payload(left_config).map(Either::Left)
             }
             Either::Right(right_attr) => {
                 let right_config = PayloadConfig {
                     parent_header: config.parent_header.clone(),
                     attributes: right_attr,
                 };
-                self.right.build_empty_payload(client, right_config).map(Either::Right)
+                self.right.build_empty_payload(right_config).map(Either::Right)
             }
         }
     }

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -372,7 +372,14 @@ where
         ctx: &BuilderContext<Node>,
         pool: Pool,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>> {
-        let payload_builder = CustomPayloadBuilder::default();
+        let payload_builder = CustomPayloadBuilder {
+            inner: reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
+                ctx.provider().clone(),
+                pool,
+                EthEvmConfig::new(ctx.provider().chain_spec().clone()),
+                EthereumBuilderConfig::new(default_extra_data_bytes()),
+            ),
+        };
         let conf = ctx.payload_builder_config();
 
         let payload_job_config = BasicPayloadJobGeneratorConfig::default()
@@ -382,7 +389,6 @@ where
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
-            pool,
             ctx.task_executor().clone(),
             payload_job_config,
             payload_builder,
@@ -397,13 +403,15 @@ where
 }
 
 /// The type responsible for building custom payloads
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct CustomPayloadBuilder;
+pub struct CustomPayloadBuilder<Pool, Client> {
+    inner: reth_ethereum_payload_builder::EthereumPayloadBuilder<Pool, Client>,
+}
 
-impl<Pool, Client> PayloadBuilder<Pool, Client> for CustomPayloadBuilder
+impl<Pool, Client> PayloadBuilder for CustomPayloadBuilder<Pool, Client>
 where
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
     type Attributes = CustomPayloadBuilderAttributes;
@@ -411,22 +419,14 @@ where
 
     fn try_build(
         &self,
-        args: BuildArguments<Pool, Client, Self::Attributes, Self::BuiltPayload>,
+        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
-        let BuildArguments { client, pool, cached_reads, config, cancel, best_payload } = args;
+        let BuildArguments { cached_reads, config, cancel, best_payload } = args;
         let PayloadConfig { parent_header, attributes } = config;
-
-        let chain_spec = client.chain_spec();
 
         // This reuses the default EthereumPayloadBuilder to build the payload
         // but any custom logic can be implemented here
-        reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
-            EthEvmConfig::new(chain_spec.clone()),
-            EthereumBuilderConfig::new(default_extra_data_bytes()),
-        )
-        .try_build(BuildArguments {
-            client,
-            pool,
+        self.inner.try_build(BuildArguments {
             cached_reads,
             config: PayloadConfig { parent_header, attributes: attributes.0 },
             cancel,
@@ -436,19 +436,10 @@ where
 
     fn build_empty_payload(
         &self,
-        client: &Client,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         let PayloadConfig { parent_header, attributes } = config;
-        let chain_spec = client.chain_spec();
-        <reth_ethereum_payload_builder::EthereumPayloadBuilder as PayloadBuilder<Pool, Client>>::build_empty_payload(
-            &reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
-                EthEvmConfig::new(chain_spec.clone()),
-                EthereumBuilderConfig::new(default_extra_data_bytes())
-            ),
-            client,
-            PayloadConfig { parent_header, attributes: attributes.0}
-        )
+        self.inner.build_empty_payload(PayloadConfig { parent_header, attributes: attributes.0 })
     }
 }
 

--- a/examples/custom-payload-builder/src/generator.rs
+++ b/examples/custom-payload-builder/src/generator.rs
@@ -4,7 +4,6 @@ use reth::{
     api::Block,
     providers::{BlockReaderIdExt, BlockSource, StateProviderFactory},
     tasks::TaskSpawner,
-    transaction_pool::TransactionPool,
 };
 use reth_basic_payload_builder::{BasicPayloadJobGeneratorConfig, PayloadBuilder, PayloadConfig};
 use reth_node_api::PayloadBuilderAttributes;
@@ -14,11 +13,9 @@ use std::sync::Arc;
 
 /// The generator type that creates new jobs that builds empty blocks.
 #[derive(Debug)]
-pub struct EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
+pub struct EmptyBlockPayloadJobGenerator<Client, Tasks, Builder> {
     /// The client that can interact with the chain.
     client: Client,
-    /// txpool
-    pool: Pool,
     /// How to spawn building tasks
     executor: Tasks,
     /// The configuration for the job generator.
@@ -31,41 +28,39 @@ pub struct EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
 
 // === impl EmptyBlockPayloadJobGenerator ===
 
-impl<Client, Pool, Tasks, Builder> EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
+impl<Client, Tasks, Builder> EmptyBlockPayloadJobGenerator<Client, Tasks, Builder> {
     /// Creates a new [EmptyBlockPayloadJobGenerator] with the given config and custom
     /// [PayloadBuilder]
     pub fn with_builder(
         client: Client,
-        pool: Pool,
         executor: Tasks,
         config: BasicPayloadJobGeneratorConfig,
         builder: Builder,
     ) -> Self {
-        Self { client, pool, executor, _config: config, builder }
+        Self { client, executor, _config: config, builder }
     }
 }
 
-impl<Client, Pool, Tasks, Builder> PayloadJobGenerator
-    for EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder>
+impl<Client, Tasks, Builder> PayloadJobGenerator
+    for EmptyBlockPayloadJobGenerator<Client, Tasks, Builder>
 where
     Client: StateProviderFactory
         + BlockReaderIdExt<Block = reth_primitives::Block>
         + Clone
         + Unpin
         + 'static,
-    Pool: TransactionPool + Unpin + 'static,
     Tasks: TaskSpawner + Clone + Unpin + 'static,
-    Builder: PayloadBuilder<Pool, Client> + Unpin + 'static,
-    <Builder as PayloadBuilder<Pool, Client>>::Attributes: Unpin + Clone,
-    <Builder as PayloadBuilder<Pool, Client>>::BuiltPayload: Unpin + Clone,
+    Builder: PayloadBuilder + Unpin + 'static,
+    Builder::Attributes: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone,
 {
-    type Job = EmptyBlockPayloadJob<Client, Pool, Tasks, Builder>;
+    type Job = EmptyBlockPayloadJob<Tasks, Builder>;
 
     /// This is invoked when the node receives payload attributes from the beacon node via
     /// `engine_forkchoiceUpdatedV1`
     fn new_payload_job(
         &self,
-        attributes: <Builder as PayloadBuilder<Pool, Client>>::Attributes,
+        attributes: Builder::Attributes,
     ) -> Result<Self::Job, PayloadBuilderError> {
         let parent_block = if attributes.parent().is_zero() {
             // use latest block if parent is zero: genesis block
@@ -87,8 +82,6 @@ where
 
         let config = PayloadConfig::new(Arc::new(header), attributes);
         Ok(EmptyBlockPayloadJob {
-            client: self.client.clone(),
-            _pool: self.pool.clone(),
             _executor: self.executor.clone(),
             builder: self.builder.clone(),
             config,

--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -1,7 +1,5 @@
 use futures_util::Future;
-use reth::{
-    providers::StateProviderFactory, tasks::TaskSpawner, transaction_pool::TransactionPool,
-};
+use reth::tasks::TaskSpawner;
 use reth_basic_payload_builder::{PayloadBuilder, PayloadConfig};
 use reth_node_api::PayloadKind;
 use reth_payload_builder::{KeepPayloadJobAlive, PayloadBuilderError, PayloadJob};
@@ -12,16 +10,12 @@ use std::{
 };
 
 /// A [PayloadJob] that builds empty blocks.
-pub struct EmptyBlockPayloadJob<Client, Pool, Tasks, Builder>
+pub struct EmptyBlockPayloadJob<Tasks, Builder>
 where
-    Builder: PayloadBuilder<Pool, Client>,
+    Builder: PayloadBuilder,
 {
     /// The configuration for how the payload will be created.
     pub(crate) config: PayloadConfig<Builder::Attributes>,
-    /// The client that can interact with the chain.
-    pub(crate) client: Client,
-    /// The transaction pool.
-    pub(crate) _pool: Pool,
     /// How to spawn building tasks
     pub(crate) _executor: Tasks,
     /// The type responsible for building payloads.
@@ -30,14 +24,12 @@ where
     pub(crate) builder: Builder,
 }
 
-impl<Client, Pool, Tasks, Builder> PayloadJob for EmptyBlockPayloadJob<Client, Pool, Tasks, Builder>
+impl<Tasks, Builder> PayloadJob for EmptyBlockPayloadJob<Tasks, Builder>
 where
-    Client: StateProviderFactory + Clone + Unpin + 'static,
-    Pool: TransactionPool + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    Builder: PayloadBuilder<Pool, Client> + Unpin + 'static,
-    <Builder as PayloadBuilder<Pool, Client>>::Attributes: Unpin + Clone,
-    <Builder as PayloadBuilder<Pool, Client>>::BuiltPayload: Unpin + Clone,
+    Builder: PayloadBuilder + Unpin + 'static,
+    Builder::Attributes: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone,
 {
     type PayloadAttributes = Builder::Attributes;
     type ResolvePayloadFuture =
@@ -45,7 +37,7 @@ where
     type BuiltPayload = Builder::BuiltPayload;
 
     fn best_payload(&self) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        let payload = self.builder.build_empty_payload(&self.client, self.config.clone())?;
+        let payload = self.builder.build_empty_payload(self.config.clone())?;
         Ok(payload)
     }
 
@@ -63,14 +55,12 @@ where
 }
 
 /// A [PayloadJob] is a a future that's being polled by the `PayloadBuilderService`
-impl<Client, Pool, Tasks, Builder> Future for EmptyBlockPayloadJob<Client, Pool, Tasks, Builder>
+impl<Tasks, Builder> Future for EmptyBlockPayloadJob<Tasks, Builder>
 where
-    Client: StateProviderFactory + Clone + Unpin + 'static,
-    Pool: TransactionPool + Unpin + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    Builder: PayloadBuilder<Pool, Client> + Unpin + 'static,
-    <Builder as PayloadBuilder<Pool, Client>>::Attributes: Unpin + Clone,
-    <Builder as PayloadBuilder<Pool, Client>>::BuiltPayload: Unpin + Clone,
+    Builder: PayloadBuilder + Unpin + 'static,
+    Builder::Attributes: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone,
 {
     type Output = Result<(), PayloadBuilderError>;
 

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -62,10 +62,11 @@ where
 
         let payload_generator = EmptyBlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
-            pool,
             ctx.task_executor().clone(),
             payload_job_config,
             reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
+                ctx.provider().clone(),
+                pool,
                 EthEvmConfig::new(ctx.chain_spec()),
                 EthereumBuilderConfig::new(conf.extra_data_bytes()),
             ),


### PR DESCRIPTION
If we're planning to make `PayloadTransactions` yield pool transactions we'd need to make `OpPayloadBuilder` aware of the pool transaction type because we might not always know it, as e.g here: https://github.com/paradigmxyz/reth/blob/8f59efb96a67240f5fe76956cfadf2209393f725/crates/optimism/payload/src/builder.rs#L248-L249

This PR requires `PayloadBuilder` implementations to hold provider and pool, thus simplifying `PayloadBuilder` trait and making it easier to consume

