### PR TITLE
chore: rm redundant Send,Sync bounds on ParallelProof

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -78,12 +78,8 @@ impl<Factory> ParallelProof<Factory> {
 
 impl<Factory> ParallelProof<Factory>
 where
-    Factory: DatabaseProviderFactory<Provider: BlockReader>
-        + StateCommitmentProvider
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    Factory:
+        DatabaseProviderFactory<Provider: BlockReader> + StateCommitmentProvider + Clone + 'static,
 {
     /// Generate a state multiproof according to specified targets.
     pub fn multiproof(


### PR DESCRIPTION
This is also redundant due to `StateCommitment` / `DatabaseProviderFactory`