### PR TITLE
feat: expose pool transaction in `PayloadTransactions`

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -64,6 +64,7 @@ exclude_crates=(
   reth-stages-api # reth-provider, reth-prune
   reth-static-file # tokio
   reth-transaction-pool # c-kzg
+  reth-payload-util # reth-transaction-pool
   reth-trie-parallel # tokio
   reth-testing-utils
 )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8547,7 +8547,6 @@ version = "1.1.5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
- "reth-primitives",
  "reth-transaction-pool",
 ]
 
@@ -9330,7 +9329,6 @@ dependencies = [
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
- "reth-payload-util",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8548,6 +8548,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "reth-primitives",
+ "reth-transaction-pool",
 ]
 
 [[package]]

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -473,16 +473,10 @@ impl OpPayloadBuilder {
     }
 }
 
-impl<Txs> OpPayloadBuilder<Txs>
-where
-    Txs: OpPayloadTransactions,
-{
+impl<Txs> OpPayloadBuilder<Txs> {
     /// Configures the type responsible for yielding the transactions that should be included in the
     /// payload.
-    pub fn with_transactions<T: OpPayloadTransactions>(
-        self,
-        best_transactions: T,
-    ) -> OpPayloadBuilder<T> {
+    pub fn with_transactions<T>(self, best_transactions: T) -> OpPayloadBuilder<T> {
         let Self { compute_pending_block, da_config, .. } = self;
         OpPayloadBuilder { compute_pending_block, best_transactions, da_config }
     }
@@ -506,7 +500,7 @@ where
             + Unpin
             + 'static,
         Evm: ConfigureEvmFor<PrimitivesTy<Node::Types>>,
-        Txs: OpPayloadTransactions<TxTy<Node::Types>>,
+        Txs: OpPayloadTransactions<Pool::Transaction>,
     {
         let payload_builder = reth_optimism_payload_builder::OpPayloadBuilder::with_builder_config(
             pool,
@@ -551,7 +545,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    Txs: OpPayloadTransactions<TxTy<Node::Types>>,
+    Txs: OpPayloadTransactions<Pool::Transaction>,
 {
     async fn spawn_payload_service(
         self,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -543,9 +543,7 @@ impl<Txs> OpBuilder<'_, Txs> {
 }
 
 /// A type that returns a the [`PayloadTransactions`] that should be included in the pool.
-pub trait OpPayloadTransactions<Transaction: PoolTransaction>:
-    Clone + Send + Sync + Unpin + 'static
-{
+pub trait OpPayloadTransactions<Transaction>: Clone + Send + Sync + Unpin + 'static {
     /// Returns an iterator that yields the transaction in the order they should get included in the
     /// new payload.
     fn best_transactions<Pool: TransactionPool<Transaction = Transaction>>(

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -6,6 +6,7 @@ use jsonrpsee_core::{async_trait, RpcResult};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::ChainSpecProvider;
 use reth_evm::ConfigureEvmFor;
+use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_payload_builder::{OpPayloadBuilder, OpPayloadPrimitives};
 use reth_primitives::SealedHeader;
@@ -15,6 +16,7 @@ use reth_provider::{
 pub use reth_rpc_api::DebugExecutionWitnessApiServer;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_tasks::TaskSpawner;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::{oneshot, Semaphore};
 
@@ -55,7 +57,11 @@ where
 impl<Pool, Provider, EvmConfig> DebugExecutionWitnessApiServer<OpPayloadAttributes>
     for OpDebugWitnessApi<Pool, Provider, EvmConfig>
 where
-    Pool: Send + Sync + 'static,
+    Pool: TransactionPool<
+            Transaction: PoolTransaction<
+                Consensus = <Provider::Primitives as NodePrimitives>::SignedTx,
+            >,
+        > + 'static,
     Provider: BlockReaderIdExt<Header = reth_primitives::Header>
         + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>
         + StateProviderFactory

--- a/crates/payload/util/Cargo.toml
+++ b/crates/payload/util/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives.workspace = true
 reth-transaction-pool.workspace = true
 
 # alloy

--- a/crates/payload/util/Cargo.toml
+++ b/crates/payload/util/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives.workspace = true
+reth-transaction-pool.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/payload/util/src/lib.rs
+++ b/crates/payload/util/src/lib.rs
@@ -11,5 +11,5 @@
 mod traits;
 mod transaction;
 
-pub use traits::{NoopPayloadTransactions, PayloadTransactions};
+pub use traits::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
 pub use transaction::{PayloadTransactionsChain, PayloadTransactionsFixed};

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -88,3 +88,95 @@ where
         self.invalid.insert(sender);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_primitives::{map::HashSet, Address};
+    use reth_transaction_pool::{
+        pool::{BestTransactionsWithPrioritizedSenders, PendingPool},
+        test_utils::{MockOrdering, MockTransaction},
+    };
+
+    use crate::{BestPayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
+
+    #[test]
+    fn test_best_transactions_chained_iterators() {
+        let mut priority_pool = PendingPool::new(MockOrdering::default());
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        // Block composition
+        // ===
+        // (1) up to 100 gas: custom top-of-block transaction
+        // (2) up to 100 gas: transactions from the priority pool
+        // (3) up to 200 gas: only transactions from address A
+        // (4) up to 200 gas: only transactions from address B
+        // (5) until block gas limit: all transactions from the main pool
+
+        // Notes:
+        // - If prioritized addresses overlap, a single transaction will be prioritized twice and
+        //   therefore use the per-segment gas limit twice.
+        // - Priority pool and main pool must synchronize between each other to make sure there are
+        //   no conflicts for the same nonce. For example, in this scenario, pools can't reject
+        //   transactions with seemingly incorrect nonces, because previous transactions might be in
+        //   the other pool.
+
+        let address_top_of_block = Address::random();
+        let address_in_priority_pool = Address::random();
+        let address_a = Address::random();
+        let address_b = Address::random();
+        let address_regular = Address::random();
+
+        // Add transactions to the main pool
+        {
+            let prioritized_tx_a =
+                MockTransaction::eip1559().with_gas_price(5).with_sender(address_a);
+            // without our custom logic, B would be prioritized over A due to gas price:
+            let prioritized_tx_b =
+                MockTransaction::eip1559().with_gas_price(10).with_sender(address_b);
+            let regular_tx =
+                MockTransaction::eip1559().with_gas_price(15).with_sender(address_regular);
+            pool.add_transaction(Arc::new(f.validated(prioritized_tx_a)), 0);
+            pool.add_transaction(Arc::new(f.validated(prioritized_tx_b)), 0);
+            pool.add_transaction(Arc::new(f.validated(regular_tx)), 0);
+        }
+
+        // Add transactions to the priority pool
+        {
+            let prioritized_tx =
+                MockTransaction::eip1559().with_gas_price(0).with_sender(address_in_priority_pool);
+            let valid_prioritized_tx = f.validated(prioritized_tx);
+            priority_pool.add_transaction(Arc::new(valid_prioritized_tx), 0);
+        }
+
+        let mut block = PayloadTransactionsChain::new(
+            PayloadTransactionsFixed::single(
+                MockTransaction::eip1559().with_sender(address_top_of_block).into(),
+            ),
+            Some(100),
+            PayloadTransactionsChain::new(
+                BestPayloadTransactions::new(priority_pool.best()),
+                Some(100),
+                BestPayloadTransactions::new(BestTransactionsWithPrioritizedSenders::new(
+                    HashSet::from([address_a]),
+                    200,
+                    BestTransactionsWithPrioritizedSenders::new(
+                        HashSet::from([address_b]),
+                        200,
+                        pool.best(),
+                    ),
+                )),
+                None,
+            ),
+            None,
+        );
+
+        assert_eq!(block.next(()).unwrap().signer(), address_top_of_block);
+        assert_eq!(block.next(()).unwrap().signer(), address_in_priority_pool);
+        assert_eq!(block.next(()).unwrap().signer(), address_a);
+        assert_eq!(block.next(()).unwrap().signer(), address_b);
+        assert_eq!(block.next(()).unwrap().signer(), address_regular);
+    }
+}

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -93,13 +93,16 @@ where
 mod tests {
     use std::sync::Arc;
 
+    use crate::{
+        BestPayloadTransactions, PayloadTransactions, PayloadTransactionsChain,
+        PayloadTransactionsFixed,
+    };
     use alloy_primitives::{map::HashSet, Address};
     use reth_transaction_pool::{
         pool::{BestTransactionsWithPrioritizedSenders, PendingPool},
-        test_utils::{MockOrdering, MockTransaction},
+        test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},
+        PoolTransaction,
     };
-
-    use crate::{BestPayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed};
 
     #[test]
     fn test_best_transactions_chained_iterators() {
@@ -153,7 +156,7 @@ mod tests {
 
         let mut block = PayloadTransactionsChain::new(
             PayloadTransactionsFixed::single(
-                MockTransaction::eip1559().with_sender(address_top_of_block).into(),
+                MockTransaction::eip1559().with_sender(address_top_of_block),
             ),
             Some(100),
             PayloadTransactionsChain::new(
@@ -173,10 +176,10 @@ mod tests {
             None,
         );
 
-        assert_eq!(block.next(()).unwrap().signer(), address_top_of_block);
-        assert_eq!(block.next(()).unwrap().signer(), address_in_priority_pool);
-        assert_eq!(block.next(()).unwrap().signer(), address_a);
-        assert_eq!(block.next(()).unwrap().signer(), address_b);
-        assert_eq!(block.next(()).unwrap().signer(), address_regular);
+        assert_eq!(block.next(()).unwrap().sender(), address_top_of_block);
+        assert_eq!(block.next(()).unwrap().sender(), address_in_priority_pool);
+        assert_eq!(block.next(()).unwrap().sender(), address_a);
+        assert_eq!(block.next(()).unwrap().sender(), address_b);
+        assert_eq!(block.next(()).unwrap().sender(), address_regular);
     }
 }

--- a/crates/payload/util/src/transaction.rs
+++ b/crates/payload/util/src/transaction.rs
@@ -1,7 +1,7 @@
 use crate::PayloadTransactions;
 use alloy_consensus::Transaction;
 use alloy_primitives::Address;
-use reth_primitives::Recovered;
+use reth_transaction_pool::PoolTransaction;
 
 /// An implementation of [`crate::traits::PayloadTransactions`] that yields
 /// a pre-defined set of transactions.
@@ -26,10 +26,10 @@ impl<T> PayloadTransactionsFixed<T> {
     }
 }
 
-impl<T: Clone> PayloadTransactions for PayloadTransactionsFixed<Recovered<T>> {
+impl<T: Clone> PayloadTransactions for PayloadTransactionsFixed<T> {
     type Transaction = T;
 
-    fn next(&mut self, _ctx: ()) -> Option<Recovered<T>> {
+    fn next(&mut self, _ctx: ()) -> Option<T> {
         (self.index < self.transactions.len()).then(|| {
             let tx = self.transactions[self.index].clone();
             self.index += 1;
@@ -91,20 +91,20 @@ impl<B: PayloadTransactions, A: PayloadTransactions> PayloadTransactionsChain<B,
 
 impl<A, B> PayloadTransactions for PayloadTransactionsChain<A, B>
 where
-    A: PayloadTransactions<Transaction: Transaction>,
+    A: PayloadTransactions<Transaction: PoolTransaction>,
     B: PayloadTransactions<Transaction = A::Transaction>,
 {
     type Transaction = A::Transaction;
 
-    fn next(&mut self, ctx: ()) -> Option<Recovered<Self::Transaction>> {
+    fn next(&mut self, ctx: ()) -> Option<Self::Transaction> {
         while let Some(tx) = self.before.next(ctx) {
             if let Some(before_max_gas) = self.before_max_gas {
-                if self.before_gas + tx.tx().gas_limit() <= before_max_gas {
-                    self.before_gas += tx.tx().gas_limit();
+                if self.before_gas + tx.gas_limit() <= before_max_gas {
+                    self.before_gas += tx.gas_limit();
                     return Some(tx);
                 }
-                self.before.mark_invalid(tx.signer(), tx.tx().nonce());
-                self.after.mark_invalid(tx.signer(), tx.tx().nonce());
+                self.before.mark_invalid(tx.sender(), tx.nonce());
+                self.after.mark_invalid(tx.sender(), tx.nonce());
             } else {
                 return Some(tx);
             }
@@ -112,11 +112,11 @@ where
 
         while let Some(tx) = self.after.next(ctx) {
             if let Some(after_max_gas) = self.after_max_gas {
-                if self.after_gas + tx.tx().gas_limit() <= after_max_gas {
-                    self.after_gas += tx.tx().gas_limit();
+                if self.after_gas + tx.gas_limit() <= after_max_gas {
+                    self.after_gas += tx.gas_limit();
                     return Some(tx);
                 }
-                self.after.mark_invalid(tx.signer(), tx.tx().nonce());
+                self.after.mark_invalid(tx.sender(), tx.nonce());
             } else {
                 return Some(tx);
             }

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -71,7 +71,6 @@ pprof = { workspace = true, features = ["criterion", "flamegraph"] }
 assert_matches.workspace = true
 tempfile.workspace = true
 serde_json.workspace = true
-reth-payload-util.workspace = true
 
 [features]
 default = ["serde"]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -18,7 +18,6 @@ reth-chainspec.workspace = true
 reth-eth-wire-types.workspace = true
 reth-primitives = { workspace = true, features = ["c-kzg", "secp256k1"] }
 reth-primitives-traits.workspace = true
-reth-payload-util.workspace = true
 reth-execution-types.workspace = true
 reth-fs-util.workspace = true
 reth-storage-api.workspace = true
@@ -72,6 +71,7 @@ pprof = { workspace = true, features = ["criterion", "flamegraph"] }
 assert_matches.workspace = true
 tempfile.workspace = true
 serde_json.workspace = true
+reth-payload-util.workspace = true
 
 [features]
 default = ["serde"]

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -379,7 +379,6 @@ mod tests {
         BestTransactions, Priority,
     };
     use alloy_primitives::U256;
-    use reth_payload_util::{PayloadTransactionsChain, PayloadTransactionsFixed};
 
     #[test]
     fn test_best_iter() {
@@ -798,85 +797,6 @@ mod tests {
         }
 
         // TODO: Test that gas limits for prioritized transactions are respected
-    }
-
-    #[test]
-    fn test_best_transactions_chained_iterators() {
-        let mut priority_pool = PendingPool::new(MockOrdering::default());
-        let mut pool = PendingPool::new(MockOrdering::default());
-        let mut f = MockTransactionFactory::default();
-
-        // Block composition
-        // ===
-        // (1) up to 100 gas: custom top-of-block transaction
-        // (2) up to 100 gas: transactions from the priority pool
-        // (3) up to 200 gas: only transactions from address A
-        // (4) up to 200 gas: only transactions from address B
-        // (5) until block gas limit: all transactions from the main pool
-
-        // Notes:
-        // - If prioritized addresses overlap, a single transaction will be prioritized twice and
-        //   therefore use the per-segment gas limit twice.
-        // - Priority pool and main pool must synchronize between each other to make sure there are
-        //   no conflicts for the same nonce. For example, in this scenario, pools can't reject
-        //   transactions with seemingly incorrect nonces, because previous transactions might be in
-        //   the other pool.
-
-        let address_top_of_block = Address::random();
-        let address_in_priority_pool = Address::random();
-        let address_a = Address::random();
-        let address_b = Address::random();
-        let address_regular = Address::random();
-
-        // Add transactions to the main pool
-        {
-            let prioritized_tx_a =
-                MockTransaction::eip1559().with_gas_price(5).with_sender(address_a);
-            // without our custom logic, B would be prioritized over A due to gas price:
-            let prioritized_tx_b =
-                MockTransaction::eip1559().with_gas_price(10).with_sender(address_b);
-            let regular_tx =
-                MockTransaction::eip1559().with_gas_price(15).with_sender(address_regular);
-            pool.add_transaction(Arc::new(f.validated(prioritized_tx_a)), 0);
-            pool.add_transaction(Arc::new(f.validated(prioritized_tx_b)), 0);
-            pool.add_transaction(Arc::new(f.validated(regular_tx)), 0);
-        }
-
-        // Add transactions to the priority pool
-        {
-            let prioritized_tx =
-                MockTransaction::eip1559().with_gas_price(0).with_sender(address_in_priority_pool);
-            let valid_prioritized_tx = f.validated(prioritized_tx);
-            priority_pool.add_transaction(Arc::new(valid_prioritized_tx), 0);
-        }
-
-        let mut block = PayloadTransactionsChain::new(
-            PayloadTransactionsFixed::single(
-                MockTransaction::eip1559().with_sender(address_top_of_block).into(),
-            ),
-            Some(100),
-            PayloadTransactionsChain::new(
-                BestPayloadTransactions::new(priority_pool.best()),
-                Some(100),
-                BestPayloadTransactions::new(BestTransactionsWithPrioritizedSenders::new(
-                    HashSet::from([address_a]),
-                    200,
-                    BestTransactionsWithPrioritizedSenders::new(
-                        HashSet::from([address_b]),
-                        200,
-                        pool.best(),
-                    ),
-                )),
-                None,
-            ),
-            None,
-        );
-
-        assert_eq!(block.next(()).unwrap().signer(), address_top_of_block);
-        assert_eq!(block.next(()).unwrap().signer(), address_in_priority_pool);
-        assert_eq!(block.next(()).unwrap().signer(), address_a);
-        assert_eq!(block.next(()).unwrap().signer(), address_b);
-        assert_eq!(block.next(()).unwrap().signer(), address_regular);
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -101,9 +101,7 @@ use crate::{
     traits::{GetPooledTransactionLimit, NewBlobSidecar, TransactionListenerKind},
     validate::ValidTransaction,
 };
-pub use best::{
-    BestPayloadTransactions, BestTransactionFilter, BestTransactionsWithPrioritizedSenders,
-};
+pub use best::{BestTransactionFilter, BestTransactionsWithPrioritizedSenders};
 pub use blob::{blob_tx_priority, fee_delta};
 pub use events::{FullTransactionEvent, TransactionEvent};
 pub use listener::{AllTransactionsEvents, TransactionEvents};

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -98,7 +98,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
     /// provides a way to mark transactions that the consumer of this iterator considers invalid. In
     /// which case the transaction's subgraph is also automatically marked invalid, See (1.).
     /// Invalid transactions are skipped.
-    pub(crate) fn best(&self) -> BestTransactions<T> {
+    pub fn best(&self) -> BestTransactions<T> {
         BestTransactions {
             all: self.by_id.clone(),
             independent: self.independent_transactions.values().cloned().collect(),


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/14246
Closes https://github.com/paradigmxyz/reth/issues/13901

Changes PayloadTransactions to return `Pool::Transaction` directly. OpPayloadBuilder still bounds transaction to `PoolTransaction<Consensus = N::SignedTx>`, next step would be to use a customized `OpPooledTx` trait directly which would provide access to tx conditionals and cached tx size