### PR TITLE
chore: use u64 for blobcount

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -267,8 +267,8 @@ where
                     &pool_tx,
                     InvalidPoolTransactionError::Eip4844(
                         Eip4844PoolTransactionError::TooManyEip4844Blobs {
-                            have: (block_blob_count + tx_blob_count) as usize,
-                            permitted: max_blob_count as usize,
+                            have: block_blob_count + tx_blob_count,
+                            permitted: max_blob_count,
                         },
                     ),
                 );

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -161,9 +161,9 @@ pub enum Eip4844PoolTransactionError {
     #[error("too many blobs in transaction: have {have}, permitted {permitted}")]
     TooManyEip4844Blobs {
         /// Number of blobs the transaction has
-        have: usize,
+        have: u64,
         /// Number of maximum blobs the transaction can have
-        permitted: usize,
+        permitted: u64,
     },
     /// Thrown if validating the blob sidecar for the transaction failed.
     #[error(transparent)]

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -328,7 +328,8 @@ where
                 )
             }
 
-            let blob_count = transaction.blob_versioned_hashes().map(|b| b.len()).unwrap_or(0);
+            let blob_count =
+                transaction.blob_versioned_hashes().map(|b| b.len() as u64).unwrap_or(0);
             if blob_count == 0 {
                 // no blobs
                 return TransactionValidationOutcome::Invalid(
@@ -339,7 +340,7 @@ where
                 )
             }
 
-            let max_blob_count = self.fork_tracker.max_blob_count() as usize;
+            let max_blob_count = self.fork_tracker.max_blob_count();
             if blob_count > max_blob_count {
                 return TransactionValidationOutcome::Invalid(
                     transaction,


### PR DESCRIPTION
we're using u64 for blob counts

changing this removes some casts