### PR TITLE
feat: abstract `OpPooledTransaction` and `OpPool` over consensus tx

### DIFF
--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -231,7 +231,7 @@ where
         _sidecar: &BlobTransactionSidecar,
         _settings: &KzgSettings,
     ) -> Result<(), BlobTransactionValidationError> {
-        Err(BlobTransactionValidationError::NotBlobTransaction(self.inner.transaction.ty()))
+        Err(BlobTransactionValidationError::NotBlobTransaction(self.ty()))
     }
 }
 

--- a/crates/optimism/node/src/txpool.rs
+++ b/crates/optimism/node/src/txpool.rs
@@ -28,9 +28,9 @@ use std::{
 };
 
 /// Type alias for default optimism transaction pool
-pub type OpTransactionPool<Client, S> = Pool<
-    TransactionValidationTaskExecutor<OpTransactionValidator<Client, OpPooledTransaction>>,
-    CoinbaseTipOrdering<OpPooledTransaction>,
+pub type OpTransactionPool<Client, S, T = OpPooledTransaction> = Pool<
+    TransactionValidationTaskExecutor<OpTransactionValidator<Client, T>>,
+    CoinbaseTipOrdering<T>,
     S,
 >;
 
@@ -288,7 +288,7 @@ impl<Client, Tx> OpTransactionValidator<Client, Tx> {
 impl<Client, Tx> OpTransactionValidator<Client, Tx>
 where
     Client: ChainSpecProvider<ChainSpec: OpHardforks> + StateProviderFactory + BlockReaderIdExt,
-    Tx: EthPoolTransaction<Consensus = OpTransactionSigned>,
+    Tx: EthPoolTransaction,
 {
     /// Create a new [`OpTransactionValidator`].
     pub fn new(inner: EthTransactionValidator<Client, Tx>) -> Self {
@@ -424,7 +424,7 @@ where
 impl<Client, Tx> TransactionValidator for OpTransactionValidator<Client, Tx>
 where
     Client: ChainSpecProvider<ChainSpec: OpHardforks> + StateProviderFactory + BlockReaderIdExt,
-    Tx: EthPoolTransaction<Consensus = OpTransactionSigned>,
+    Tx: EthPoolTransaction,
 {
     type Transaction = Tx;
 

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -35,6 +35,7 @@ use reth_payload_util::{
 use reth_primitives::Recovered;
 use reth_provider::providers::BlockchainProvider;
 use reth_tasks::TaskManager;
+use reth_transaction_pool::PoolTransaction;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -68,13 +68,12 @@ impl OpPayloadTransactions<OpPooledTransaction> for CustomTxPriority {
             ..Default::default()
         };
         let signature = sender.sign_transaction_sync(&mut end_of_block_tx).unwrap();
-        let end_of_block_tx = Recovered::new_unchecked(
+        let end_of_block_tx = OpPooledTransaction::from_pooled(Recovered::new_unchecked(
             op_alloy_consensus::OpPooledTransaction::Eip1559(
                 end_of_block_tx.into_signed(signature),
             ),
             sender.address(),
-        )
-        .into();
+        ));
 
         PayloadTransactionsChain::new(
             BestPayloadTransactions::new(pool.best_transactions_with_attributes(attr)),

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -162,7 +162,7 @@ where
                 while let Some(tx) = transactions.next() {
                     let signer = tx.signer();
                     let tx = {
-                        let mut tx: <Eth::Pool as TransactionPool>::Transaction = tx.into();
+                        let mut tx = <Eth::Pool as TransactionPool>::Transaction::from_pooled(tx);
 
                         if let EthBlobTransactionSidecar::Present(sidecar) = tx.take_blob() {
                             tx.validate_blob(&sidecar, EnvKzgSettings::Default.get()).map_err(

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -694,7 +694,7 @@ mod tests {
         let tx_bytes = hex!("02f87201830655c2808505ef61f08482565f94388c818ca8b9251b393131c08a736a67ccb192978801049e39c4b5b1f580c001a01764ace353514e8abdfb92446de356b260e3c1225b73fc4c8876a6258d12a129a04f02294aa61ca7676061cd99f29275491218b4754b46a0248e5e42bc5091f507");
         let tx = PooledTransaction::decode_2718(&mut &tx_bytes[..]).unwrap();
         let provider = MockEthProvider::default();
-        let transaction: EthPooledTransaction = tx.try_into_recovered().unwrap().into();
+        let transaction = EthPooledTransaction::from_pooled(tx.try_into_recovered().unwrap());
         let tx_to_cmp = transaction.clone();
         let sender = hex!("1f9090aaE28b8a3dCeaDf281B0F12828e676c326").into();
         provider.add_account(sender, ExtendedAccount::new(42, U256::MAX));

--- a/crates/transaction-pool/src/test_utils/gen.rs
+++ b/crates/transaction-pool/src/test_utils/gen.rs
@@ -1,4 +1,4 @@
-use crate::EthPooledTransaction;
+use crate::{EthPooledTransaction, PoolTransaction};
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEip4844, TxLegacy};
 use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, eip2930::AccessList};
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
@@ -101,7 +101,8 @@ impl<R: Rng> TransactionGenerator<R> {
 
     /// Generates and returns a pooled EIP-1559 transaction with a random signer.
     pub fn gen_eip1559_pooled(&mut self) -> EthPooledTransaction {
-        self.gen_eip1559().try_into_recovered().unwrap().try_into().unwrap()
+        EthPooledTransaction::try_from_consensus(self.gen_eip1559().try_into_recovered().unwrap())
+            .unwrap()
     }
 
     /// Generates and returns a pooled EIP-4844 transaction with a random signer.

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -687,15 +687,6 @@ impl PoolTransaction for MockTransaction {
         pooled.into()
     }
 
-    fn try_consensus_into_pooled(
-        tx: Recovered<Self::Consensus>,
-    ) -> Result<Recovered<Self::Pooled>, Self::TryFromConsensusError> {
-        let (tx, signer) = tx.into_parts();
-        Self::Pooled::try_from(tx)
-            .map(|tx| tx.with_signer(signer))
-            .map_err(|_| TryFromRecoveredTransactionError::BlobSidecarMissing)
-    }
-
     fn hash(&self) -> &TxHash {
         self.get_hash()
     }

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -29,7 +29,10 @@ use rand::{
     prelude::Distribution,
 };
 use reth_primitives::{
-    transaction::{SignedTransactionIntoRecoveredExt, TryFromRecoveredTransactionError},
+    transaction::{
+        SignedTransactionIntoRecoveredExt, TransactionConversionError,
+        TryFromRecoveredTransactionError,
+    },
     PooledTransaction, Recovered, Transaction, TransactionSigned, TxType,
 };
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
@@ -667,17 +670,11 @@ impl MockTransaction {
 }
 
 impl PoolTransaction for MockTransaction {
-    type TryFromConsensusError = TryFromRecoveredTransactionError;
+    type TryFromConsensusError = TransactionConversionError;
 
     type Consensus = TransactionSigned;
 
     type Pooled = PooledTransaction;
-
-    fn try_from_consensus(
-        tx: Recovered<Self::Consensus>,
-    ) -> Result<Self, Self::TryFromConsensusError> {
-        tx.try_into()
-    }
 
     fn into_consensus(self) -> Recovered<Self::Consensus> {
         self.into()

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -928,7 +928,7 @@ mod tests {
         let data = hex::decode(raw).unwrap();
         let tx = PooledTransaction::decode_2718(&mut data.as_ref()).unwrap();
 
-        tx.try_into_recovered().unwrap().into()
+        EthPooledTransaction::from_pooled(tx.try_into_recovered().unwrap())
     }
 
     // <https://github.com/paradigmxyz/reth/issues/5178>


### PR DESCRIPTION
Changes in this PR:
1. `PoolTransaction` trait is simplified to not have any conversion traits as supertraits. Core conversions are now defined as `Self::from_pooled`, `Self::into_consensus` and `Pooled: TryFrom<Consensus>` where the latter is responsible for stripping all tx variants that can't be pooled.
2. `OpPooledTransaction` is made generic over both consensus and pooled tx. This is a bit ugly but it seems that we can't do much better unfortunately. Ideally `PoolTransaction::Pooled` should not exist, and the conversion into `Pooled` variant should be done somewhere closer to networking (which is the only consumer of the conversion)
3. `OpPool` and `OpPoolBuilder` are made generic over pool transaction, allowing them to no longer lock tx to `OpPooledTransaction`