### PR TITLE
Avoiding infinite recursion in trait implementation

### DIFF
--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -51,7 +51,7 @@ pub trait RethNetworkConfig {
 
 impl<N: NetworkPrimitives> RethNetworkConfig for reth_network::NetworkManager<N> {
     fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol) {
-        reth_network::NetworkManager::add_rlpx_sub_protocol(self, protocol);
+        Self::add_rlpx_sub_protocol(self, protocol);
     }
 
     fn secret_key(&self) -> secp256k1::SecretKey {

--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -55,7 +55,7 @@ impl<N: NetworkPrimitives> RethNetworkConfig for reth_network::NetworkManager<N>
     }
 
     fn secret_key(&self) -> secp256k1::SecretKey {
-        reth_network::NetworkManager::secret_key(self)
+        Self::secret_key(self)
     }
 }
 

--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -51,11 +51,11 @@ pub trait RethNetworkConfig {
 
 impl<N: NetworkPrimitives> RethNetworkConfig for reth_network::NetworkManager<N> {
     fn add_rlpx_sub_protocol(&mut self, protocol: impl IntoRlpxSubProtocol) {
-        Self::add_rlpx_sub_protocol(self, protocol);
+        reth_network::NetworkManager::add_rlpx_sub_protocol(self, protocol);
     }
 
     fn secret_key(&self) -> secp256k1::SecretKey {
-        self.secret_key()
+        reth_network::NetworkManager::secret_key(self)
     }
 }
 


### PR DESCRIPTION
/*
Changes:
- Replaced:
   Self::add_rlpx_sub_protocol(self, protocol)
  with:
   reth_network::NetworkManager::add_rlpx_sub_protocol(self, protocol)

- Replaced:
   self.secret_key()
  with:
   reth_network::NetworkManager::secret_key(self)

Reason:
These changes avoid infinite recursion by explicitly calling NetworkManager’s methods instead of the trait’s own implementation.
*/
