### PR TITLE
feat(tree): more logs for proofs prefetching

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2707,6 +2707,14 @@ where
                 targets.insert(keccak256(addr), storage_set);
             }
 
+            debug!(
+                target: "engine::tree",
+                tx_hash = ?tx.tx_hash(),
+                targets = targets.len(),
+                storage_targets = targets.values().map(|slots| slots.len()).sum::<usize>(),
+                "Prefetching proofs for a transaction"
+            );
+
             let _ = state_root_sender.send(StateRootMessage::PrefetchProofs(targets));
         });
 

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -676,7 +676,8 @@ where
                         prefetch_proofs_received += 1;
                         debug!(
                             target: "engine::root",
-                            len = targets.len(),
+                            targets = targets.len(),
+                            storage_targets = targets.values().map(|slots| slots.len()).sum::<usize>(),
                             total_prefetches = prefetch_proofs_received,
                             "Prefetching proofs"
                         );


### PR DESCRIPTION
Helps to understand which transactions generate a lot of proof targets.