### PR TITLE
Draft: Status struct to Status enum

### DIFF
--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod status;
-pub use status::{Status, StatusBuilder};
+pub use status::{Status, Status66_68, StatusBuilder};
 
 pub mod version;
 pub use version::{EthVersion, ProtocolVersion};

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -1,11 +1,146 @@
 use crate::EthVersion;
 use alloy_chains::{Chain, NamedChain};
 use alloy_primitives::{hex, B256, U256};
-use alloy_rlp::{RlpDecodable, RlpEncodable};
+use alloy_rlp::{
+    BufMut, Decodable, Encodable, Error as RlpError, Header, RlpDecodable, RlpEncodable,
+};
 use core::fmt::{Debug, Display};
 use reth_chainspec::{EthChainSpec, Hardforks, MAINNET};
 use reth_codecs_derive::add_arbitrary_tests;
 use reth_ethereum_forks::{EthereumHardfork, ForkId, Head};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
+pub enum Status {
+    Eth66_68(Status66_68),
+}
+
+impl Status {
+    /// Helper for returning a builder for the status message.
+    pub fn builder() -> StatusBuilder {
+        Default::default()
+    }
+
+    /// Sets the [`EthVersion`] for the status.
+    pub const fn set_eth_version(&mut self, version: EthVersion) {
+        use EthVersion::*;
+        match (self, version) {
+            (Status::Eth66_68(status), Eth66 | Eth67 | Eth68) => status.version = version,
+            _ => {}
+        }
+    }
+
+    /// Create a [`StatusBuilder`] from the given [`EthChainSpec`] and head block.
+    ///
+    /// Sets the `chain` and `genesis`, `blockhash`, and `forkid` fields based on the
+    /// [`EthChainSpec`] and head.
+    pub fn spec_builder<Spec>(spec: Spec, head: &Head) -> StatusBuilder
+    where
+        Spec: EthChainSpec + Hardforks,
+    {
+        Self::builder()
+            .chain(spec.chain())
+            .genesis(spec.genesis_hash())
+            .blockhash(head.hash)
+            .total_difficulty(head.total_difficulty)
+            .forkid(spec.fork_id(head))
+    }
+
+    pub fn version(&self) -> EthVersion {
+        match self {
+            Self::Eth66_68(status) => status.version,
+        }
+    }
+
+    pub fn chain(&self) -> &Chain {
+        match self {
+            Self::Eth66_68(status) => &status.chain,
+        }
+    }
+
+    pub fn total_difficulty(&self) -> Option<&U256> {
+        match self {
+            Self::Eth66_68(status) => Some(&status.total_difficulty),
+        }
+    }
+
+    pub fn total_difficulty_mut(&mut self) -> Option<&mut U256> {
+        match self {
+            Self::Eth66_68(status) => Some(&mut status.total_difficulty),
+        }
+    }
+
+    pub fn blockhash(&self) -> &B256 {
+        match self {
+            Self::Eth66_68(status) => &status.blockhash,
+        }
+    }
+
+    pub fn blockhash_mut(&mut self) -> &mut B256 {
+        match self {
+            Self::Eth66_68(status) => &mut status.blockhash,
+        }
+    }
+
+    pub fn genesis(&self) -> &B256 {
+        match self {
+            Self::Eth66_68(status) => &status.genesis,
+        }
+    }
+
+    pub fn forkid(&self) -> &ForkId {
+        match self {
+            Self::Eth66_68(status) => &status.forkid,
+        }
+    }
+
+    pub fn forkid_mut(&mut self) -> &mut ForkId {
+        match self {
+            Self::Eth66_68(status) => &mut status.forkid,
+        }
+    }
+}
+
+// <https://etherscan.io/block/0>
+impl Default for Status {
+    fn default() -> Self {
+        Self::Eth66_68(Status66_68::default())
+    }
+}
+
+impl Display for Status {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Status::Eth66_68(status) => Display::fmt(&status, f),
+        }
+    }
+}
+
+impl Encodable for Status {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Eth66_68(status) => status.encode(out),
+        }
+    }
+}
+
+impl Decodable for Status {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let b = &mut &**buf;
+        let rlp_head = Header::decode(b)?;
+        if !rlp_head.list {
+            return Err(RlpError::UnexpectedString);
+        }
+        let version = EthVersion::decode(b)?;
+
+        use EthVersion::*;
+        match version {
+            Eth66 | Eth67 | Eth68 | Eth69 => Ok(Status::Eth66_68(Status66_68::decode(buf)?)),
+        }
+    }
+}
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same
 /// network and are following the same fork.
@@ -16,7 +151,7 @@ use reth_ethereum_forks::{EthereumHardfork, ForkId, Head};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[add_arbitrary_tests(rlp)]
-pub struct Status {
+pub struct Status66_68 {
     /// The current protocol version. For example, peers running `eth/66` would have a version of
     /// 66.
     pub version: EthVersion,
@@ -42,35 +177,24 @@ pub struct Status {
     pub forkid: ForkId,
 }
 
-impl Status {
-    /// Helper for returning a builder for the status message.
-    pub fn builder() -> StatusBuilder {
-        Default::default()
-    }
-
-    /// Sets the [`EthVersion`] for the status.
-    pub fn set_eth_version(&mut self, version: EthVersion) {
-        self.version = version;
-    }
-
-    /// Create a [`StatusBuilder`] from the given [`EthChainSpec`] and head block.
-    ///
-    /// Sets the `chain` and `genesis`, `blockhash`, and `forkid` fields based on the
-    /// [`EthChainSpec`] and head.
-    pub fn spec_builder<Spec>(spec: Spec, head: &Head) -> StatusBuilder
-    where
-        Spec: EthChainSpec + Hardforks,
-    {
-        Self::builder()
-            .chain(spec.chain())
-            .genesis(spec.genesis_hash())
-            .blockhash(head.hash)
-            .total_difficulty(head.total_difficulty)
-            .forkid(spec.fork_id(head))
+// <https://etherscan.io/block/0>
+impl Default for Status66_68 {
+    fn default() -> Self {
+        let mainnet_genesis = MAINNET.genesis_hash();
+        Self {
+            version: EthVersion::Eth68,
+            chain: Chain::from_named(NamedChain::Mainnet),
+            total_difficulty: U256::from(17_179_869_184u64),
+            blockhash: mainnet_genesis,
+            genesis: mainnet_genesis,
+            forkid: MAINNET
+                .hardfork_fork_id(EthereumHardfork::Frontier)
+                .expect("The Frontier hardfork should always exist"),
+        }
     }
 }
 
-impl Display for Status {
+impl Display for Status66_68 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let hexed_blockhash = hex::encode(self.blockhash);
         let hexed_genesis = hex::encode(self.genesis);
@@ -87,7 +211,7 @@ impl Display for Status {
     }
 }
 
-impl Debug for Status {
+impl Debug for Status66_68 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let hexed_blockhash = hex::encode(self.blockhash);
         let hexed_genesis = hex::encode(self.genesis);
@@ -117,20 +241,9 @@ impl Debug for Status {
     }
 }
 
-// <https://etherscan.io/block/0>
-impl Default for Status {
-    fn default() -> Self {
-        let mainnet_genesis = MAINNET.genesis_hash();
-        Self {
-            version: EthVersion::Eth68,
-            chain: Chain::from_named(NamedChain::Mainnet),
-            total_difficulty: U256::from(17_179_869_184u64),
-            blockhash: mainnet_genesis,
-            genesis: mainnet_genesis,
-            forkid: MAINNET
-                .hardfork_fork_id(EthereumHardfork::Frontier)
-                .expect("The Frontier hardfork should always exist"),
-        }
+impl Into<Status> for Status66_68 {
+    fn into(self) -> Status {
+        Status::Eth66_68(self)
     }
 }
 
@@ -141,7 +254,7 @@ impl Default for Status {
 /// use alloy_consensus::constants::MAINNET_GENESIS_HASH;
 /// use alloy_primitives::{B256, U256};
 /// use reth_chainspec::{Chain, EthereumHardfork, MAINNET};
-/// use reth_eth_wire_types::{EthVersion, Status};
+/// use reth_eth_wire_types::{EthVersion, Status, Status66_68};
 ///
 /// // this is just an example status message!
 /// let status = Status::builder()
@@ -155,14 +268,14 @@ impl Default for Status {
 ///
 /// assert_eq!(
 ///     status,
-///     Status {
+///     Status66_68 {
 ///         version: EthVersion::Eth66,
 ///         chain: Chain::mainnet(),
 ///         total_difficulty: U256::from(100),
 ///         blockhash: B256::from(MAINNET_GENESIS_HASH),
 ///         genesis: B256::from(MAINNET_GENESIS_HASH),
 ///         forkid: MAINNET.hardfork_fork_id(EthereumHardfork::Paris).unwrap(),
-///     }
+///     }.into()
 /// );
 /// ```
 #[derive(Debug, Default)]
@@ -178,44 +291,56 @@ impl StatusBuilder {
 
     /// Sets the protocol version.
     pub const fn version(mut self, version: EthVersion) -> Self {
-        self.status.version = version;
+        self.status.set_eth_version(version);
         self
     }
 
     /// Sets the chain id.
     pub const fn chain(mut self, chain: Chain) -> Self {
-        self.status.chain = chain;
+        match self.status {
+            Status::Eth66_68(ref mut status) => {
+                status.chain = chain;
+            }
+        }
         self
     }
 
     /// Sets the total difficulty.
     pub const fn total_difficulty(mut self, total_difficulty: U256) -> Self {
-        self.status.total_difficulty = total_difficulty;
+        match self.status {
+            Status::Eth66_68(ref mut status) => status.total_difficulty = total_difficulty,
+        }
         self
     }
 
     /// Sets the block hash.
     pub const fn blockhash(mut self, blockhash: B256) -> Self {
-        self.status.blockhash = blockhash;
+        match self.status {
+            Status::Eth66_68(ref mut status) => status.blockhash = blockhash,
+        }
         self
     }
 
     /// Sets the genesis hash.
     pub const fn genesis(mut self, genesis: B256) -> Self {
-        self.status.genesis = genesis;
+        match self.status {
+            Status::Eth66_68(ref mut status) => status.genesis = genesis,
+        }
         self
     }
 
     /// Sets the fork id.
     pub const fn forkid(mut self, forkid: ForkId) -> Self {
-        self.status.forkid = forkid;
+        match self.status {
+            Status::Eth66_68(ref mut status) => status.forkid = forkid,
+        }
         self
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{EthVersion, Status};
+    use crate::{status::Status66_68, EthVersion, Status};
     use alloy_consensus::constants::MAINNET_GENESIS_HASH;
     use alloy_genesis::Genesis;
     use alloy_primitives::{hex, B256, U256};
@@ -228,7 +353,7 @@ mod tests {
     #[test]
     fn encode_eth_status_message() {
         let expected = hex!("f85643018a07aac59dabcdd74bc567a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
-        let status = Status {
+        let status: Status = Status66_68 {
             version: EthVersion::Eth67,
             chain: Chain::from_named(NamedChain::Mainnet),
             total_difficulty: U256::from(36206751599115524359527u128),
@@ -238,7 +363,8 @@ mod tests {
             .unwrap(),
             genesis: MAINNET_GENESIS_HASH,
             forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
-        };
+        }
+        .into();
 
         let mut rlp_status = vec![];
         status.encode(&mut rlp_status);
@@ -248,7 +374,7 @@ mod tests {
     #[test]
     fn decode_eth_status_message() {
         let data = hex!("f85643018a07aac59dabcdd74bc567a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
-        let expected = Status {
+        let expected = Status66_68 {
             version: EthVersion::Eth67,
             chain: Chain::from_named(NamedChain::Mainnet),
             total_difficulty: U256::from(36206751599115524359527u128),
@@ -258,7 +384,8 @@ mod tests {
             .unwrap(),
             genesis: MAINNET_GENESIS_HASH,
             forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
-        };
+        }
+        .into();
         let status = Status::decode(&mut &data[..]).unwrap();
         assert_eq!(status, expected);
     }
@@ -266,7 +393,7 @@ mod tests {
     #[test]
     fn encode_network_status_message() {
         let expected = hex!("f850423884024190faa0f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27ba00d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5bc6845d43d2fd80");
-        let status = Status {
+        let status: Status = Status66_68 {
             version: EthVersion::Eth66,
             chain: Chain::from_named(NamedChain::BinanceSmartChain),
             total_difficulty: U256::from(37851386u64),
@@ -279,7 +406,8 @@ mod tests {
             )
             .unwrap(),
             forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
-        };
+        }
+        .into();
 
         let mut rlp_status = vec![];
         status.encode(&mut rlp_status);
@@ -289,7 +417,7 @@ mod tests {
     #[test]
     fn decode_network_status_message() {
         let data = hex!("f850423884024190faa0f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27ba00d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5bc6845d43d2fd80");
-        let expected = Status {
+        let expected = Status66_68 {
             version: EthVersion::Eth66,
             chain: Chain::from_named(NamedChain::BinanceSmartChain),
             total_difficulty: U256::from(37851386u64),
@@ -302,7 +430,8 @@ mod tests {
             )
             .unwrap(),
             forkid: ForkId { hash: ForkHash([0x5d, 0x43, 0xd2, 0xfd]), next: 0 },
-        };
+        }
+        .into();
         let status = Status::decode(&mut &data[..]).unwrap();
         assert_eq!(status, expected);
     }
@@ -310,7 +439,7 @@ mod tests {
     #[test]
     fn decode_another_network_status_message() {
         let data = hex!("f86142820834936d68fcffffffffffffffffffffffffdeab81b8a0523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0ca06499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bdc6841a67ccd880");
-        let expected = Status {
+        let expected = Status66_68 {
             version: EthVersion::Eth66,
             chain: Chain::from_id(2100),
             total_difficulty: U256::from_str(
@@ -326,7 +455,8 @@ mod tests {
             )
             .unwrap(),
             forkid: ForkId { hash: ForkHash([0x1a, 0x67, 0xcc, 0xd8]), next: 0 },
-        };
+        }
+        .into();
         let status = Status::decode(&mut &data[..]).unwrap();
         assert_eq!(status, expected);
     }
@@ -381,10 +511,10 @@ mod tests {
 
         let status = Status::spec_builder(&spec, &head).build();
 
-        assert_eq!(status.chain, Chain::from_id(1337));
-        assert_eq!(status.forkid, forkid);
-        assert_eq!(status.total_difficulty, total_difficulty);
-        assert_eq!(status.blockhash, head_hash);
-        assert_eq!(status.genesis, genesis_hash);
+        assert_eq!(status.chain(), &Chain::from_id(1337));
+        assert_eq!(status.forkid(), &forkid);
+        assert_eq!(status.total_difficulty(), Some(&total_difficulty));
+        assert_eq!(status.blockhash(), &head_hash);
+        assert_eq!(status.genesis(), &genesis_hash);
     }
 }

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -30,9 +30,9 @@ impl Status {
     }
 
     /// Sets the [`EthVersion`] for the status.
-    pub const fn set_eth_version(&mut self, version: EthVersion) {
+    pub fn set_eth_version(&mut self, version: EthVersion) {
         use EthVersion::{Eth66, Eth67, Eth68};
-        if let (Self::Eth66_68(status), Eth66 | Eth67 | Eth68) = (self, version) {
+        if let (Self::Eth66_68(ref mut status), Eth66 | Eth67 | Eth68) = (self, version) {
             status.version = version
         }
     }
@@ -150,7 +150,7 @@ impl Decodable for Status {
         }
         let version = EthVersion::decode(b)?;
 
-        use EthVersion::*;
+        use EthVersion::{Eth66, Eth67, Eth68, Eth69};
         match version {
             Eth66 | Eth67 | Eth68 | Eth69 => Ok(Self::Eth66_68(Status66_68::decode(buf)?)),
         }
@@ -286,7 +286,8 @@ impl Debug for Status66_68 {
 ///         blockhash: B256::from(MAINNET_GENESIS_HASH),
 ///         genesis: B256::from(MAINNET_GENESIS_HASH),
 ///         forkid: MAINNET.hardfork_fork_id(EthereumHardfork::Paris).unwrap(),
-///     }.into()
+///     }
+///     .into()
 /// );
 /// ```
 #[derive(Debug, Default)]
@@ -302,49 +303,69 @@ impl StatusBuilder {
 
     /// Sets the protocol version.
     pub const fn version(mut self, version: EthVersion) -> Self {
-        self.status.set_eth_version(version);
+        use EthVersion::{Eth66, Eth67, Eth68};
+        self.status =
+            if let (Status::Eth66_68(mut status), Eth66 | Eth67 | Eth68) = (self.status, version) {
+                status.version = version;
+                Status::Eth66_68(status)
+            } else {
+                self.status
+            };
         self
     }
 
     /// Sets the chain id.
     pub const fn chain(mut self, chain: Chain) -> Self {
-        match self.status {
-            Status::Eth66_68(ref mut status) => {
+        self.status = match self.status {
+            Status::Eth66_68(mut status) => {
                 status.chain = chain;
+                Status::Eth66_68(status)
             }
-        }
+        };
         self
     }
 
     /// Sets the total difficulty.
     pub const fn total_difficulty(mut self, total_difficulty: U256) -> Self {
-        match self.status {
-            Status::Eth66_68(ref mut status) => status.total_difficulty = total_difficulty,
-        }
+        self.status = match self.status {
+            Status::Eth66_68(mut status) => {
+                status.total_difficulty = total_difficulty;
+                Status::Eth66_68(status)
+            }
+        };
         self
     }
 
     /// Sets the block hash.
     pub const fn blockhash(mut self, blockhash: B256) -> Self {
-        match self.status {
-            Status::Eth66_68(ref mut status) => status.blockhash = blockhash,
-        }
+        self.status = match self.status {
+            Status::Eth66_68(mut status) => {
+                status.blockhash = blockhash;
+                Status::Eth66_68(status)
+            }
+        };
         self
     }
 
     /// Sets the genesis hash.
     pub const fn genesis(mut self, genesis: B256) -> Self {
-        match self.status {
-            Status::Eth66_68(ref mut status) => status.genesis = genesis,
-        }
+        self.status = match self.status {
+            Status::Eth66_68(mut status) => {
+                status.genesis = genesis;
+                Status::Eth66_68(status)
+            }
+        };
         self
     }
 
     /// Sets the fork id.
     pub const fn forkid(mut self, forkid: ForkId) -> Self {
-        match self.status {
-            Status::Eth66_68(ref mut status) => status.forkid = forkid,
-        }
+        self.status = match self.status {
+            Status::Eth66_68(mut status) => {
+                status.forkid = forkid;
+                Status::Eth66_68(status)
+            }
+        };
         self
     }
 }

--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -36,15 +36,15 @@ pub fn eth_handshake() -> (Status, ForkFilter) {
     let genesis = B256::random();
     let fork_filter = ForkFilter::new(Head::default(), genesis, 0, Vec::new());
 
-    let status = Status {
-        version: EthVersion::Eth67,
-        chain: Chain::mainnet(),
-        total_difficulty: U256::ZERO,
-        blockhash: B256::random(),
-        genesis,
+    let status = Status::builder()
+        .version(EthVersion::Eth67)
+        .chain(Chain::mainnet())
+        .total_difficulty(U256::ZERO)
+        .blockhash(B256::random())
+        .genesis(genesis)
         // Pass the current fork id.
-        forkid: fork_filter.current(),
-    };
+        .forkid(fork_filter.current())
+        .build();
     (status, fork_filter)
 }
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -703,13 +703,13 @@ mod tests {
         let fork_filter = config.fork_filter;
 
         // assert that there are no other forks
-        assert_eq!(status.forkid.next, 0);
+        assert_eq!(status.forkid().next, 0);
 
         // assert the same thing for the fork_filter
         assert_eq!(fork_filter.current().next, 0);
 
         // check status and fork_filter forkhash
-        assert_eq!(status.forkid.hash, genesis_fork_hash);
+        assert_eq!(status.forkid().hash, genesis_fork_hash);
         assert_eq!(fork_filter.current().hash, genesis_fork_hash);
     }
 }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -267,7 +267,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
         if let Some(disc_config) = discovery_v4_config.as_mut() {
             // merge configured boot nodes
             disc_config.bootstrap_nodes.extend(resolved_boot_nodes.clone());
-            disc_config.add_eip868_pair("eth", status.forkid);
+            disc_config.add_eip868_pair("eth", status.forkid());
         }
 
         if let Some(discv5) = discovery_v5_config.as_mut() {
@@ -447,9 +447,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             protocol_version: hello_message.protocol_version as u64,
             eth_protocol_info: EthProtocolInfo {
                 difficulty: None,
-                head: status.blockhash,
-                network: status.chain.id(),
-                genesis: status.genesis,
+                head: *status.blockhash(),
+                network: status.chain().id(),
+                genesis: *status.genesis(),
                 config: Default::default(),
             },
         }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -215,10 +215,12 @@ impl<N: NetworkPrimitives> SessionManager<N> {
     /// If the updated activated another fork, this will return a [`ForkTransition`] and updates the
     /// active [`ForkId`]. See also [`ForkFilter::set_head`].
     pub(crate) fn on_status_update(&mut self, head: Head) -> Option<ForkTransition> {
-        self.status.blockhash = head.hash;
-        self.status.total_difficulty = head.total_difficulty;
+        *self.status.blockhash_mut() = head.hash;
+        if let Some(total_difficulty) = self.status.total_difficulty_mut() {
+            *total_difficulty = head.total_difficulty;
+        }
         let transition = self.fork_filter.set_head(head);
-        self.status.forkid = self.fork_filter.current();
+        *self.status.forkid_mut() = self.fork_filter.current();
         transition
     }
 

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -154,13 +154,13 @@ impl<N: NetworkPrimitives> NetworkState<N> {
 
         // find the corresponding block number
         let block_number =
-            self.client.block_number(status.blockhash).ok().flatten().unwrap_or_default();
-        self.state_fetcher.new_active_peer(peer, status.blockhash, block_number, timeout);
+            self.client.block_number(*status.blockhash()).ok().flatten().unwrap_or_default();
+        self.state_fetcher.new_active_peer(peer, *status.blockhash(), block_number, timeout);
 
         self.active_peers.insert(
             peer,
             ActivePeer {
-                best_hash: status.blockhash,
+                best_hash: *status.blockhash(),
                 capabilities,
                 request_tx,
                 pending_response: None,

--- a/crates/net/network/tests/it/session.rs
+++ b/crates/net/network/tests/it/session.rs
@@ -37,7 +37,7 @@ async fn test_session_established_with_highest_version() {
             NetworkEvent::ActivePeerSession { info, .. } => {
                 let SessionInfo { peer_id, status, .. } = info;
                 assert_eq!(handle1.peer_id(), &peer_id);
-                assert_eq!(status.version, EthVersion::Eth68);
+                assert_eq!(status.version(), EthVersion::Eth68);
             }
             ev => {
                 panic!("unexpected event {ev:?}")
@@ -76,7 +76,7 @@ async fn test_session_established_with_different_capability() {
             NetworkEvent::ActivePeerSession { info, .. } => {
                 let SessionInfo { peer_id, status, .. } = info;
                 assert_eq!(handle1.peer_id(), &peer_id);
-                assert_eq!(status.version, EthVersion::Eth66);
+                assert_eq!(status.version(), EthVersion::Eth66);
             }
             ev => {
                 panic!("unexpected event: {ev:?}")

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -92,7 +92,7 @@ where
                     },
                     protocols: PeerProtocolInfo {
                         eth: Some(EthPeerInfo::Info(EthInfo {
-                            version: peer.status.version as u64,
+                            version: peer.status.version() as u64,
                         })),
                         snap: None,
                         other: Default::default(),

--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
         match evt {
             NetworkEvent::ActivePeerSession { info, .. } => {
                 let SessionInfo { status, client_version, peer_id, .. } = info;
-                info!(peers=%net_handle.num_connected_peers() , %peer_id, chain = %status.chain, ?client_version, "Session established with a new peer.");
+                info!(peers=%net_handle.num_connected_peers() , %peer_id, chain = %status.chain(), ?client_version, "Session established with a new peer.");
             }
             NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, reason }) => {
                 info!(peers=%net_handle.num_connected_peers() , %peer_id, ?reason, "Session closed.");

--- a/examples/manual-p2p/src/main.rs
+++ b/examples/manual-p2p/src/main.rs
@@ -68,7 +68,10 @@ async fn main() -> eyre::Result<()> {
 
                 println!(
                     "Successfully connected to a peer at {}:{} ({}) using eth-wire version eth/{}",
-                    peer.address, peer.tcp_port, their_hello.client_version, their_status.version
+                    peer.address,
+                    peer.tcp_port,
+                    their_hello.client_version,
+                    their_status.version()
                 );
 
                 snoop(peer, eth_stream).await;
@@ -100,14 +103,13 @@ async fn handshake_eth(p2p_stream: AuthedP2PStream) -> eyre::Result<(AuthedEthSt
         ..Default::default()
     });
 
-    let status = Status::builder()
+    let mut status = Status::builder()
         .chain(Chain::mainnet())
         .genesis(MAINNET_GENESIS_HASH)
         .forkid(MAINNET.hardfork_fork_id(EthereumHardfork::Shanghai).unwrap())
         .build();
 
-    let status =
-        Status { version: p2p_stream.shared_capabilities().eth()?.version().try_into()?, ..status };
+    status.set_eth_version(p2p_stream.shared_capabilities().eth()?.version().try_into()?);
     let eth_unauthed = UnauthedEthStream::new(p2p_stream);
     Ok(eth_unauthed.handshake(status, fork_filter).await?)
 }

--- a/examples/polygon-p2p/src/main.rs
+++ b/examples/polygon-p2p/src/main.rs
@@ -73,7 +73,7 @@ async fn main() {
         // with the chain specific details
         if let NetworkEvent::ActivePeerSession { info, .. } = evt {
             let SessionInfo { status, client_version, .. } = info;
-            let chain = status.chain;
+            let chain = status.chain();
             info!(?chain, ?client_version, "Session established with a new peer.");
         }
         // More events here


### PR DESCRIPTION
Towards issue 12194

This is a draft proposition to make `Status` an enum, in a followup commit we could then add a `Status69` struct, and extend `Status` with a new `Eth69(Status69)` variant.