### PR TITLE
feat: add granular prewarm metrics

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -16,6 +16,8 @@ pub(crate) struct EngineApiMetrics {
     pub(crate) block_validation: BlockValidationMetrics,
     /// A copy of legacy blockchain tree metrics, to be replaced when we replace the old tree
     pub(crate) tree: TreeMetrics,
+    /// Metrics for transaction prewarming threads
+    pub(crate) prewarm: PrewarmThreadMetrics,
 }
 
 /// Metrics for the entire blockchain tree
@@ -69,8 +71,6 @@ pub(crate) struct BlockValidationMetrics {
     pub(crate) state_root_duration: Gauge,
     /// Trie input computation duration
     pub(crate) trie_input_duration: Gauge,
-    /// Prewarm spawn duration
-    pub(crate) prewarm_spawn_duration: Gauge,
     /// Cache saving duration
     #[allow(dead_code)]
     pub(crate) cache_saving_duration: Gauge,
@@ -86,6 +86,26 @@ impl BlockValidationMetrics {
         self.state_root_duration.set(elapsed_as_secs);
         self.state_root_histogram.record(elapsed_as_secs);
     }
+}
+
+/// Metrics for prewarming threads
+#[derive(Metrics, Clone)]
+#[metrics(scope = "sync.prewarm")]
+pub(crate) struct PrewarmThreadMetrics {
+    /// Prewarm thread spawn duration
+    pub(crate) spawn_duration: Gauge,
+    /// A histogram of the prewarm thread spawn duration
+    pub(crate) spawn_duration_histogram: Histogram,
+    /// The number of transactions in the block
+    pub(crate) transactions: Gauge,
+    /// A histogram of the number of transactions in the block
+    pub(crate) transactions_histogram: Histogram,
+    /// A histogram of total runtime durations for prewarm threads
+    pub(crate) total_runtime: Histogram,
+    /// A histogram of execution durations for prewarm threads
+    pub(crate) execution_duration: Histogram,
+    /// A histogram for total prefetch targets in prewarm threads
+    pub(crate) prefetch_storage_targets: Histogram,
 }
 
 /// Metrics for the blockchain tree block buffer

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -21,6 +21,7 @@ use alloy_rpc_types_engine::{
 use block_buffer::BlockBuffer;
 use cached_state::{ProviderCaches, SavedCache};
 use error::{InsertBlockError, InsertBlockErrorKind, InsertBlockFatalError};
+use metrics::PrewarmThreadMetrics;
 use persistence_state::CurrentPersistenceAction;
 use reth_chain_state::{
     CanonicalInMemoryState, ExecutedBlock, ExecutedBlockWithTrieUpdates,
@@ -2455,6 +2456,7 @@ where
         if self.config.use_caching_and_prewarming() {
             debug!(target: "engine::tree", "Spawning prewarm threads");
             let prewarm_start = Instant::now();
+            let prewarm_metrics = self.metrics.prewarm.clone();
 
             // Prewarm transactions
             for (tx_idx, tx) in block.transactions_recovered().enumerate() {
@@ -2469,16 +2471,21 @@ where
                     state_root_sender,
                     cancel_execution.clone(),
                     prewarm_task_lock.clone(),
+                    prewarm_metrics.clone(),
                 )?;
                 let elapsed = start.elapsed();
                 debug!(target: "engine::tree", ?tx_idx, elapsed = ?elapsed, "Spawned transaction prewarm");
             }
 
+            prewarm_metrics.transactions.set(block.transaction_count() as f64);
+            prewarm_metrics.transactions_histogram.record(block.transaction_count() as f64);
+
             drop(state_root_sender);
             let elapsed = prewarm_start.elapsed();
             debug!(target: "engine::tree", ?elapsed, "Done spawning prewarm threads");
 
-            self.metrics.block_validation.prewarm_spawn_duration.set(elapsed.as_secs_f64());
+            self.metrics.prewarm.spawn_duration.set(elapsed);
+            self.metrics.prewarm.spawn_duration_histogram.record(elapsed);
         }
         trace!(target: "engine::tree", block=?block_num_hash, "Executing block");
 
@@ -2676,6 +2683,7 @@ where
         state_root_sender: Option<Sender<StateRootMessage>>,
         cancel_execution: ManualCancel,
         task_finished: Arc<RwLock<()>>,
+        metrics: PrewarmThreadMetrics,
     ) -> Result<(), InsertBlockErrorKind> {
         let Some(state_provider) = self.state_provider(block.parent_hash())? else {
             trace!(target: "engine::tree", parent=%block.parent_hash(), "Could not get state provider for prewarm");
@@ -2691,6 +2699,7 @@ where
 
         // spawn task executing the individual tx
         self.thread_pool.spawn(move || {
+            let thread_start = Instant::now();
             let in_progress = task_finished.read().unwrap();
             let state_provider = StateProviderDatabase::new(&state_provider);
 
@@ -2706,6 +2715,7 @@ where
                 return
             }
 
+            let execution_start = Instant::now();
             let ResultAndState { state, .. } = match evm.transact(tx_env) {
                 Ok(res) => res,
                 Err(err) => {
@@ -2713,6 +2723,7 @@ where
                     return
                 }
             };
+            metrics.execution_duration.record(execution_start.elapsed());
 
             // execution no longer in progress, so we can drop the lock
             drop(in_progress);
@@ -2746,15 +2757,20 @@ where
                 targets.insert(keccak256(addr), storage_set);
             }
 
+            let storage_targets = targets.values().map(|slots| slots.len()).sum::<usize>();
             debug!(
                 target: "engine::tree",
                 tx_hash = ?tx.tx_hash(),
                 targets = targets.len(),
-                storage_targets = targets.values().map(|slots| slots.len()).sum::<usize>(),
+                storage_targets,
                 "Prefetching proofs for a transaction"
             );
+            metrics.prefetch_storage_targets.record(storage_targets as f64);
 
             let _ = state_root_sender.send(StateRootMessage::PrefetchProofs(targets));
+
+            // record final metrics
+            metrics.total_runtime.record(thread_start.elapsed());
         });
 
         Ok(())


### PR DESCRIPTION
This adds a bunch of prewarm specific metrics, mostly histograms because we have many different threads and a `Gauge` won't be useful if we are recording many different values. The prewarm spawn duration is also moved to this dedicated metrics struct.