### PR TITLE
Introduce StatusEth69 for `eth/69` status messages

### DIFF
--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod status;
-pub use status::{Status, StatusBuilder, StatusEth69, StatusEth69Builder};
+pub use status::{Status, StatusBuilder, StatusEth69};
 
 pub mod version;
 pub use version::{EthVersion, ProtocolVersion};

--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod status;
-pub use status::{Status, StatusBuilder};
+pub use status::{Status, StatusBuilder, StatusEth69, StatusEth69Builder};
 
 pub mod version;
 pub use version::{EthVersion, ProtocolVersion};

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -213,9 +213,181 @@ impl StatusBuilder {
     }
 }
 
+/// Similar to [`Status`], but for `eth/69` version, which does not contain
+/// the `total_difficulty` field.
+#[derive(Copy, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
+pub struct StatusEth69 {
+    /// The current protocol version.
+    /// Here, version is `eth/69`.
+    pub version: EthVersion,
+
+    /// The chain id, as introduced in
+    /// [EIP155](https://eips.ethereum.org/EIPS/eip-155#list-of-chain-ids).
+    pub chain: Chain,
+
+    /// The highest difficulty block hash the peer has seen
+    pub blockhash: B256,
+
+    /// The genesis hash of the peer's chain.
+    pub genesis: B256,
+
+    /// The fork identifier, a [CRC32
+    /// checksum](https://en.wikipedia.org/wiki/Cyclic_redundancy_check#CRC-32_algorithm) for
+    /// identifying the peer's fork as defined by
+    /// [EIP-2124](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2124.md).
+    /// This was added in [`eth/64`](https://eips.ethereum.org/EIPS/eip-2364)
+    pub forkid: ForkId,
+}
+
+impl StatusEth69 {
+    /// Helper for returning a builder for the status message.
+    pub fn builder() -> StatusEth69Builder {
+        Default::default()
+    }
+
+    /// Create a [`StatusEth69Builder`] from the given [`EthChainSpec`] and head block.
+    ///
+    /// Sets the `chain` and `genesis`, `blockhash`, and `forkid` fields based on the
+    /// [`EthChainSpec`] and head.
+    pub fn spec_builder<Spec>(spec: Spec, head: &Head) -> StatusEth69Builder
+    where
+        Spec: EthChainSpec + Hardforks,
+    {
+        Self::builder()
+            .chain(spec.chain())
+            .genesis(spec.genesis_hash())
+            .blockhash(head.hash)
+            .forkid(spec.fork_id(head))
+    }
+}
+
+impl Display for StatusEth69 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let hexed_blockhash = hex::encode(self.blockhash);
+        let hexed_genesis = hex::encode(self.genesis);
+        write!(
+            f,
+            "Status {{ version: {}, chain: {}, blockhash: {}, genesis: {}, forkid: {:X?} }}",
+            self.version, self.chain, hexed_blockhash, hexed_genesis, self.forkid
+        )
+    }
+}
+
+impl Debug for StatusEth69 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let hexed_blockhash = hex::encode(self.blockhash);
+        let hexed_genesis = hex::encode(self.genesis);
+        if f.alternate() {
+            write!(
+                f,
+                "Status {{\n\tversion: {:?},\n\tchain: {:?},\n\tblockhash: {},\n\tgenesis: {},\n\tforkid: {:X?}\n}}",
+                self.version,
+                self.chain,
+                hexed_blockhash,
+                hexed_genesis,
+                self.forkid
+            )
+        } else {
+            write!(
+                f,
+                "Status {{ version: {:?}, chain: {:?}, blockhash: {}, genesis: {}, forkid: {:X?} }}",
+                self.version,
+                self.chain,
+                hexed_blockhash,
+                hexed_genesis,
+                self.forkid
+            )
+        }
+    }
+}
+
+// <https://etherscan.io/block/0>
+impl Default for StatusEth69 {
+    fn default() -> Self {
+        let mainnet_genesis = MAINNET.genesis_hash();
+        Self {
+            version: EthVersion::Eth69,
+            chain: Chain::from_named(NamedChain::Mainnet),
+            blockhash: mainnet_genesis,
+            genesis: mainnet_genesis,
+            forkid: MAINNET
+                .hardfork_fork_id(EthereumHardfork::Frontier)
+                .expect("The Frontier hardfork should always exist"),
+        }
+    }
+}
+
+/// Builder for [`StatusEth69`] messages.
+///
+/// # Example
+/// ```
+/// use alloy_consensus::constants::MAINNET_GENESIS_HASH;
+/// use alloy_primitives::{B256, U256};
+/// use reth_chainspec::{Chain, EthereumHardfork, MAINNET};
+/// use reth_eth_wire_types::{EthVersion, StatusEth69};
+///
+/// // this is just an example status message!
+/// let status = StatusEth69::builder()
+///     .chain(Chain::mainnet())
+///     .blockhash(B256::from(MAINNET_GENESIS_HASH))
+///     .genesis(B256::from(MAINNET_GENESIS_HASH))
+///     .forkid(MAINNET.hardfork_fork_id(EthereumHardfork::Paris).unwrap())
+///     .build();
+///
+/// assert_eq!(
+///     status,
+///     StatusEth69 {
+///         version: EthVersion::Eth69,
+///         chain: Chain::mainnet(),
+///         blockhash: B256::from(MAINNET_GENESIS_HASH),
+///         genesis: B256::from(MAINNET_GENESIS_HASH),
+///         forkid: MAINNET.hardfork_fork_id(EthereumHardfork::Paris).unwrap(),
+///     }
+/// );
+/// ```
+#[derive(Debug, Default)]
+pub struct StatusEth69Builder {
+    status: StatusEth69,
+}
+
+impl StatusEth69Builder {
+    /// Consumes the type and creates the actual [`StatusEth69`] message.
+    pub const fn build(mut self) -> StatusEth69 {
+        self.status.version = EthVersion::Eth69;
+        self.status
+    }
+
+    /// Sets the chain id.
+    pub const fn chain(mut self, chain: Chain) -> Self {
+        self.status.chain = chain;
+        self
+    }
+
+    /// Sets the block hash.
+    pub const fn blockhash(mut self, blockhash: B256) -> Self {
+        self.status.blockhash = blockhash;
+        self
+    }
+
+    /// Sets the genesis hash.
+    pub const fn genesis(mut self, genesis: B256) -> Self {
+        self.status.genesis = genesis;
+        self
+    }
+
+    /// Sets the fork id.
+    pub const fn forkid(mut self, forkid: ForkId) -> Self {
+        self.status.forkid = forkid;
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{EthVersion, Status};
+    use crate::{EthVersion, Status, StatusEth69};
     use alloy_consensus::constants::MAINNET_GENESIS_HASH;
     use alloy_genesis::Genesis;
     use alloy_primitives::{hex, B256, U256};
@@ -260,6 +432,55 @@ mod tests {
             forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
         };
         let status = Status::decode(&mut &data[..]).unwrap();
+        assert_eq!(status, expected);
+    }
+
+    #[test]
+    fn encode_eth69_status_message() {
+        let expected = hex!("f84b4501a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
+        let status = StatusEth69 {
+            version: EthVersion::Eth69,
+            chain: Chain::from_named(NamedChain::Mainnet),
+            blockhash: B256::from_str(
+                "feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d",
+            )
+            .unwrap(),
+            genesis: MAINNET_GENESIS_HASH,
+            forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
+        };
+
+        let mut rlp_status = vec![];
+        status.encode(&mut rlp_status);
+        assert_eq!(rlp_status, expected);
+
+        let status = StatusEth69::builder()
+            .chain(Chain::from_named(NamedChain::Mainnet))
+            .blockhash(
+                B256::from_str("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d")
+                    .unwrap(),
+            )
+            .genesis(MAINNET_GENESIS_HASH)
+            .forkid(ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 })
+            .build();
+        let mut rlp_status = vec![];
+        status.encode(&mut rlp_status);
+        assert_eq!(rlp_status, expected);
+    }
+
+    #[test]
+    fn decode_eth69_status_message() {
+        let data = hex!("0xf84b4501a0feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13da0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3c684b715077d80");
+        let expected = StatusEth69 {
+            version: EthVersion::Eth69,
+            chain: Chain::from_named(NamedChain::Mainnet),
+            blockhash: B256::from_str(
+                "feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d",
+            )
+            .unwrap(),
+            genesis: MAINNET_GENESIS_HASH,
+            forkid: ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 },
+        };
+        let status = StatusEth69::decode(&mut &data[..]).unwrap();
         assert_eq!(status, expected);
     }
 


### PR DESCRIPTION
(potentially) Closes https://github.com/paradigmxyz/reth/issues/12194

<del>Continued with the option approach, but implemented a custom `PartialEq` in which:
- <del>If version is eth69, ignore the total_difficulty field
- <del>If version is eth66_68, treat a `total_difficulty=None` and `total_difficulty=0` as equal, avoiding this comparison issue: (https://github.com/paradigmxyz/reth/issues/12194#issuecomment-2639392058)

---

Introducing `StatusEth69` struct for `eth/69` status messages, in which the `total_difficulty` field was dropped.