### PR TITLE
chore(trie): unify get_proof_targets methods

### DIFF
--- a/crates/trie/common/src/hashedstate.rs
+++ b/crates/trie/common/src/hashedstate.rs
@@ -176,6 +176,16 @@ impl HashedPostState {
         }
     }
 
+    /// Returns iterator over account hashed addresses
+    pub fn iter_accounts(&self) -> impl Iterator<Item = &B256> {
+        self.accounts.keys()
+    }
+
+    /// Returns iterator over accounts with storage keys
+    pub fn iter_storages(&self) -> impl Iterator<Item = (&B256, impl Iterator<Item = &B256>)> {
+        self.storages.iter().map(|(k, v)| (k, v.storage.keys()))
+    }
+
     fn extend_storages<'a>(
         &mut self,
         storages: impl IntoIterator<Item = (B256, Cow<'a, HashedStorage>)>,


### PR DESCRIPTION
WIP for https://github.com/paradigmxyz/reth/issues/14275

Currently just the prefetch sanity tests fail