### PR TITLE
feat(reth-bench): substract block fetch waiting time from benchmark duration

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 use csv::Writer;
 use reth_cli_runner::CliContext;
 use reth_node_core::args::BenchmarkArgs;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::{debug, info};
 
 /// `reth benchmark new-payload-only` command


### PR DESCRIPTION
Currently we are including the potential time spent waiting for blocks in the total benchmark duration, with these changes we record any waiting time and subtract it when we store the current benchmark duration for each block. 