### PR TITLE
fix: typos in documentation comments

### DIFF
--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -54,7 +54,7 @@ where
     }
 }
 
-/// A [PayloadJob] is a a future that's being polled by the `PayloadBuilderService`
+/// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
 impl<Tasks, Builder> Future for EmptyBlockPayloadJob<Tasks, Builder>
 where
     Tasks: TaskSpawner + Clone + 'static,

--- a/examples/custom-rlpx-subprotocol/src/subprotocol/protocol/proto.rs
+++ b/examples/custom-rlpx-subprotocol/src/subprotocol/protocol/proto.rs
@@ -45,7 +45,7 @@ impl CustomRlpxProtoMessage {
             message: CustomRlpxProtoMessageKind::PingMessage(msg.into()),
         }
     }
-    /// Creates a ping message
+    /// Creates a pong message
     pub fn pong_message(msg: impl Into<String>) -> Self {
         Self {
             message_type: CustomRlpxProtoMessageId::PongMessage,


### PR DESCRIPTION
Hi! Fixed a couple of typos in documentation comments:

- In `job.rs`, there was a duplicated part of the comment about `PayloadJob`, which I removed.
- In `proto.rs`, the comment incorrectly described `pong_message` as a "ping message"—corrected that.
