### PR TITLE
fix(provider): fix pending block retrieval in `find_block_by_hash`

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -797,22 +797,21 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
         source: BlockSource,
     ) -> ProviderResult<Option<Self::Block>> {
         if matches!(source, BlockSource::Canonical | BlockSource::Any) {
-            return self.get_in_memory_or_storage_by_block(
+            if let Some(block) = self.get_in_memory_or_storage_by_block(
                 hash.into(),
                 |db_provider| db_provider.find_block_by_hash(hash, BlockSource::Canonical),
                 |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_block())),
-            )
+            ) {
+                return Ok(Some(block))
+            }
         }
 
         if matches!(source, BlockSource::Pending | BlockSource::Any) {
-            if let Some(block) = self
+            return Ok(self
                 .canonical_in_memory_state
                 .pending_block()
                 .filter(|b| b.hash() == hash)
-                .map(|b| b.into_block())
-            {
-                return Ok(Some(block))
-            }
+                .map(|b| b.into_block()))
         }
 
         Ok(None)

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -801,7 +801,7 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
                 hash.into(),
                 |db_provider| db_provider.find_block_by_hash(hash, BlockSource::Canonical),
                 |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_block())),
-            ) {
+            )? {
                 return Ok(Some(block))
             }
         }


### PR DESCRIPTION
## Description

If the block that's seeked is currently pending, it will not be returned by this fn. Fix the behavior.