### PR TITLE
fix: use custom generator in custom builder example

### DIFF
--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -346,8 +346,8 @@ where
         let network = network_builder.build_network(context, pool.clone()).await?;
         let payload_builder =
             payload_builder_builder.build_payload_builder(context, pool.clone()).await?;
-        let payload_builder_handle =
-            payload_builder_builder.spawn_payload_builder_service(context, payload_builder.clone());
+        let payload_builder_handle = payload_builder_builder
+            .spawn_payload_builder_service(context, payload_builder.clone())?;
         let consensus = consensus_builder.build_consensus(context).await?;
 
         Ok(Components {

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -30,7 +30,7 @@ pub trait PayloadServiceBuilder<Node: FullNodeTypes, Pool: TransactionPool>: Sen
         self,
         ctx: &BuilderContext<Node>,
         payload_builder: Self::PayloadBuilder,
-    ) -> PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine> {
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>> {
         let conf = ctx.config().builder.clone();
 
         let payload_job_config = BasicPayloadJobGeneratorConfig::default()
@@ -49,7 +49,7 @@ pub trait PayloadServiceBuilder<Node: FullNodeTypes, Pool: TransactionPool>: Sen
 
         ctx.task_executor().spawn_critical("payload builder service", Box::pin(payload_service));
 
-        payload_service_handle
+        Ok(payload_service_handle)
     }
 }
 


### PR DESCRIPTION
After #14276 this wasn't migrated into new `spawn_` method