### PR TITLE
chore: make stages types no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,7 +404,7 @@ reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-types-compat = { path = "crates/rpc/rpc-types-compat" }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
-reth-stages-types = { path = "crates/stages/types" }
+reth-stages-types = { path = "crates/stages/types", default-features = false }
 reth-static-file = { path = "crates/static-file/static-file" }
 reth-static-file-types = { path = "crates/static-file/types" }
 reth-storage-api = { path = "crates/storage/storage-api" }

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -53,6 +53,7 @@ test-utils = [
     "reth-trie-common/test-utils",
 ]
 arbitrary = [
+    "std",
     "alloy-primitives/arbitrary",
     "reth-codecs?/arbitrary",
     "reth-trie-common/arbitrary",

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -36,10 +36,10 @@ bytes.workspace = true
 [features]
 default = ["std"]
 std = [
-	"alloy-primitives/std",
-	"bytes?/std",
-	"reth-trie-common/std",
-	"serde?/std"
+    "alloy-primitives/std",
+    "bytes?/std",
+    "reth-trie-common/std",
+    "serde?/std",
 ]
 reth-codec = [
     "dep:reth-codecs",

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -34,6 +34,13 @@ rand.workspace = true
 bytes.workspace = true
 
 [features]
+default = ["std"]
+std = [
+	"alloy-primitives/std",
+	"bytes?/std",
+	"reth-trie-common/std",
+	"serde?/std"
+]
 reth-codec = [
     "dep:reth-codecs",
     "dep:bytes",

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -48,12 +48,13 @@ reth-codec = [
     "reth-trie-common/reth-codec",
 ]
 test-utils = [
-    "dep:arbitrary",
+    "arbitrary",
     "reth-codecs?/test-utils",
     "reth-trie-common/test-utils",
 ]
 arbitrary = [
     "std",
+    "dep:arbitrary",
     "alloy-primitives/arbitrary",
     "reth-codecs?/arbitrary",
     "reth-trie-common/arbitrary",

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -1,5 +1,5 @@
 use super::StageId;
-use alloc::vec::Vec;
+use alloc::{format, string::String, vec::Vec};
 use alloy_primitives::{Address, BlockNumber, B256};
 use core::ops::RangeInclusive;
 use reth_trie_common::{hash_builder::HashBuilderState, StoredSubNode};
@@ -170,6 +170,11 @@ impl EntitiesCheckpoint {
         let percentage = 100.0 * self.processed as f64 / self.total as f64;
 
         // Truncate to 2 decimal places, rounding down so that 99.999% becomes 99.99% and not 100%.
+        #[cfg(not(feature = "std"))]
+        {
+            Some(format!("{:.2}%", (percentage * 100.0) / 100.0))
+        }
+        #[cfg(feature = "std")]
         Some(format!("{:.2}%", (percentage * 100.0).floor() / 100.0))
     }
 }

--- a/crates/stages/types/src/id.rs
+++ b/crates/stages/types/src/id.rs
@@ -97,8 +97,8 @@ impl StageId {
     }
 }
 
-impl std::fmt::Display for StageId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for StageId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }

--- a/crates/stages/types/src/lib.rs
+++ b/crates/stages/types/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 
@@ -68,7 +69,7 @@ impl From<BlockHash> for PipelineTarget {
 }
 
 impl core::fmt::Display for PipelineTarget {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Sync(block) => {
                 write!(f, "Sync({block})")

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -46,4 +46,5 @@ std = [
     "reth-primitives/std",
     "reth-primitives-traits/std",
     "revm/std",
+    "reth-stages-types/std",
 ]


### PR DESCRIPTION
towards #13041 

primitively features gates f64::floor call, don't expect this to be useful in no-std anyway