### PR TITLE
fix: update --rpc-cache.headers name

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -381,7 +381,7 @@ RPC State Cache:
 
           [default: 2000]
 
-      --rpc-cache.max-envs <MAX_HEADERS>
+      --rpc-cache.max-headers <MAX_HEADERS>
           Max number of headers in cache
 
           [default: 1000]

--- a/crates/node/core/src/args/rpc_state_cache.rs
+++ b/crates/node/core/src/args/rpc_state_cache.rs
@@ -24,7 +24,8 @@ pub struct RpcStateCacheArgs {
 
     /// Max number of headers in cache.
     #[arg(
-        long = "rpc-cache.max-envs",
+        long = "rpc-cache.max-headers",
+        alias = "rpc-cache.max-envs",
         default_value_t = DEFAULT_HEADER_CACHE_MAX_LEN,
     )]
     pub max_headers: u32,


### PR DESCRIPTION
this should be headers.

kept -env as alias for backwards compat