### PR TITLE
chore(ci): pin op-node image for kurtosis-op

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -9,9 +9,13 @@ optimism_package:
     - participants:
       - el_type: op-geth
         cl_type: op-node
+        # https://github.com/ethpandaops/optimism-package/issues/157
+        cl_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:a79e8cc06aa354511983fafcb6d71ab04cdfadbc"
       - el_type: op-reth
         el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
         cl_type: op-node
+        # https://github.com/ethpandaops/optimism-package/issues/157
+        cl_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:a79e8cc06aa354511983fafcb6d71ab04cdfadbc"
       batcher_params:
         extra_params:
           - "--throttle-interval=0"


### PR DESCRIPTION
`kurtosis-op` started failing like https://github.com/paradigmxyz/reth/actions/runs/13215444996/job/36894362688 in `op-node` logs:
```
t=2025-02-08T12:21:45+0000 lvl=crit msg="Application failed" message="failed to setup: unable to create the rollup node: failed to init L2: failed to load or fetch chain config for id 2151908: fetching: the method debug_chainConfig does not exist/is not available"
```
Pinning `op-node` to an older image works, already opened upstream issue https://github.com/ethpandaops/optimism-package/issues/157 