### PR TITLE
Fix: Correct functionality of `get_queued_transactions_by_sender` and `get_pending_transactions_by_sender` 

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -807,7 +807,7 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         let sender_id = self.get_sender_id(sender);
-        self.get_pool_data().pending_txs_by_sender(sender_id)
+        self.get_pool_data().queued_txs_by_sender(sender_id)
     }
 
     /// Returns all pending transactions filtered by predicate
@@ -824,7 +824,7 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         let sender_id = self.get_sender_id(sender);
-        self.get_pool_data().queued_txs_by_sender(sender_id)
+        self.get_pool_data().pending_txs_by_sender(sender_id)
     }
 
     /// Returns the highest transaction of the address


### PR DESCRIPTION
Simple functionality fix: `pending` was reading from the `queued` pool, and vice versa.