### PR TITLE
feat: `EngineApiBuilder`

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -352,6 +352,7 @@ impl OpAddOnsBuilder {
             rpc_add_ons: RpcAddOns::new(
                 move |ctx| OpEthApi::<N>::builder().with_sequencer(sequencer_client).build(ctx),
                 Default::default(),
+                Default::default(),
             ),
             da_config: da_config.unwrap_or_default(),
         }


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/13831

Add `EngineApiBuilder` to `RpcAddOns` which uses default `EngineApi` impl by default but already can be customized to use any implementation.

Technically this is all we need for #13831 but I think we can keep it open until we have at least one usecase for custom engine API implemented (either OP or custom header example)