### PR TITLE
feat(tree): enter tracing span for each storage trie in state root task

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -36,7 +36,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tracing::{debug, error, span, trace, Level};
+use tracing::{debug, error, trace, trace_span};
 
 /// The level below which the sparse trie hashes are calculated in [`update_sparse_trie`].
 const SPARSE_TRIE_INCREMENTAL_LEVEL: usize = 2;
@@ -1098,7 +1098,7 @@ where
         .map(|(address, storage)| (address, storage, trie.take_storage_trie(&address)))
         .par_bridge()
         .map(|(address, storage, storage_trie)| {
-            let span = span!(Level::TRACE, "engine::root::sparse", ?address);
+            let span = trace_span!(target: "engine::root::sparse", "Storage trie", ?address);
             let _enter = span.enter();
             trace!(target: "engine::root::sparse", "Updating storage");
             let mut storage_trie = storage_trie.ok_or(SparseTrieErrorKind::Blind)?;

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -36,7 +36,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, error, span, trace, Level};
 
 /// The level below which the sparse trie hashes are calculated in [`update_sparse_trie`].
 const SPARSE_TRIE_INCREMENTAL_LEVEL: usize = 2;
@@ -1098,20 +1098,22 @@ where
         .map(|(address, storage)| (address, storage, trie.take_storage_trie(&address)))
         .par_bridge()
         .map(|(address, storage, storage_trie)| {
-            trace!(target: "engine::root::sparse", ?address, "Updating storage");
+            let span = span!(Level::TRACE, "engine::root::sparse", ?address);
+            let _enter = span.enter();
+            trace!(target: "engine::root::sparse", "Updating storage");
             let mut storage_trie = storage_trie.ok_or(SparseTrieErrorKind::Blind)?;
 
             if storage.wiped {
-                trace!(target: "engine::root::sparse", ?address, "Wiping storage");
+                trace!(target: "engine::root::sparse", "Wiping storage");
                 storage_trie.wipe()?;
             }
             for (slot, value) in storage.storage {
                 let slot_nibbles = Nibbles::unpack(slot);
                 if value.is_zero() {
-                    trace!(target: "engine::root::sparse", ?address, ?slot, "Removing storage slot");
+                    trace!(target: "engine::root::sparse", ?slot, "Removing storage slot");
                     storage_trie.remove_leaf(&slot_nibbles)?;
                 } else {
-                    trace!(target: "engine::root::sparse", ?address, ?slot, "Updating storage slot");
+                    trace!(target: "engine::root::sparse", ?slot, "Updating storage slot");
                     storage_trie
                         .update_leaf(slot_nibbles, alloy_rlp::encode_fixed_size(&value).to_vec())?;
                 }
@@ -1121,9 +1123,7 @@ where
 
             SparseStateTrieResult::Ok((address, storage_trie))
         })
-        .for_each_init(|| tx.clone(), |tx, result| {
-            tx.send(result).unwrap()
-        });
+        .for_each_init(|| tx.clone(), |tx, result| tx.send(result).unwrap());
     drop(tx);
     for result in rx {
         let (address, storage_trie) = result?;


### PR DESCRIPTION
Before
```console
2025-02-10T12:16:07.520526Z TRACE trie::sparse: Added node to rlp node stack starting_path=Some(Nibbles(0x)) level=1 path=Nibbles(0x0f) node=Hash(0xce2b756377b5f4e8330f5b61018845106a1afc05528b8162bdfcae501487072a) node_type=Hash is_in_prefix_set=None
```

After
```console
2025-02-10T12:16:07.520526Z TRACE Storage trie{address=0x526f8bf91558307e88903ba81376c191bd02a2c23d7f4554a83c7d8875cb9cdc}: trie::sparse: Added node to rlp node stack starting_path=Some(Nibbles(0x)) level=1 path=Nibbles(0x0f) node=Hash(0xce2b756377b5f4e8330f5b61018845106a1afc05528b8162bdfcae501487072a) node_type=Hash is_in_prefix_set=None
```