### PR TITLE
fix(trie): do not reveal same node twice in sparse trie

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -258,6 +258,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
 
             // Reveal the remaining proof nodes.
             for (path, bytes) in account_nodes {
+                // If the node is already revealed, skip it.
                 if self.revealed_account_nodes.contains(&path) {
                     continue
                 }
@@ -273,6 +274,8 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
 
                 trace!(target: "trie::sparse", ?path, ?node, ?hash_mask, ?tree_mask, "Revealing account node");
                 trie.reveal_node(path.clone(), node, tree_mask, hash_mask)?;
+
+                // Track the revealed node.
                 self.revealed_account_nodes.insert(path);
             }
         }
@@ -294,6 +297,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
 
                 // Reveal the remaining proof nodes.
                 for (path, bytes) in nodes {
+                    // If the node is already revealed, skip it.
                     if revealed_nodes.contains(&path) {
                         continue
                     }
@@ -309,6 +313,8 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
 
                     trace!(target: "trie::sparse", ?account, ?path, ?node, ?hash_mask, ?tree_mask, "Revealing storage node");
                     trie.reveal_node(path.clone(), node, tree_mask, hash_mask)?;
+
+                    // Track the revealed node.
                     revealed_nodes.insert(path);
                 }
             }

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -119,7 +119,7 @@ where
         );
         let mut sparse_trie =
             SparseStateTrie::new(WitnessBlindedProviderFactory::new(proof_provider_factory, tx));
-        sparse_trie.reveal_multiproof(proof_targets.clone(), multiproof)?;
+        sparse_trie.reveal_multiproof(multiproof)?;
 
         // Attempt to update state trie to gather additional information for the witness.
         for (hashed_address, hashed_slots) in


### PR DESCRIPTION
## Problem

The issue is that it's possible to reveal the same leaf twice if we request two proofs with two leaves that have the same prefix.

For example, in DB we have a leaf at path `0x0d07`. First, we request a proof for leaf `0xd7b6990105719101dabeb77144f2a3385c8033acd3af97e9423a695e81ad1eb5`. Then, we request another proof for leaf `0xd7999c7eedf8fe42767a51577f99fda631d84616191df1557bdaf61266d16a0f`.

In both cases, the multiproof will have a leaf at path `0xd07`, and we will try to reveal it. Current prevention for not revealing it second time is this check https://github.com/paradigmxyz/reth/blob/a7f895e72a44d1939bdf4dd83875919ce5ef4296/crates/trie/sparse/src/trie.rs#L314-L317, but it will not pass if the first leaf `0xd7b6990105719101dabeb77144f2a3385c8033acd3af97e9423a695e81ad1eb5` was deleted after it was revealed, so we will reveal the leaf node agian.

It's problematic because we could have already deleted a leaf node, and we should not insert it again on proof revealing.

## Solution

Maintain a list of revealed paths per account trie and each of storage tries.