### PR TITLE
feat(engine): use Hash Builder as a fallback to the Sparse Trie on newPayload

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -1,8 +1,7 @@
 ethereum_package:
   participants:
     - el_type: reth
-      el_extra_params:
-        - "--rpc.eth-proof-window 100"
+      el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
       cl_type: lighthouse
 optimism_package:
   chains:

--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -1,7 +1,8 @@
 ethereum_package:
   participants:
     - el_type: reth
-      el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
+      el_extra_params:
+        - "--rpc.eth-proof-window 100"
       cl_type: lighthouse
 optimism_package:
   chains:

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2887,20 +2887,17 @@ where
                         state_provider.state_root_with_updates(hashed_state.clone())?;
 
                     if regular_root == sealed_block.header().state_root() {
-                        if self.config.always_compare_trie_updates() {
-                            let provider_ro =
-                                state_root_task_config.consistent_view.provider_ro()?;
-                            let in_memory_trie_cursor = InMemoryTrieCursorFactory::new(
-                                DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-                                &state_root_task_config.nodes_sorted,
-                            );
-                            compare_trie_updates(
-                                in_memory_trie_cursor,
-                                task_trie_updates.clone(),
-                                regular_updates.clone(),
-                            )
-                            .map_err(ProviderError::from)?;
-                        }
+                        let provider_ro = state_root_task_config.consistent_view.provider_ro()?;
+                        let in_memory_trie_cursor = InMemoryTrieCursorFactory::new(
+                            DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
+                            &state_root_task_config.nodes_sorted,
+                        );
+                        compare_trie_updates(
+                            in_memory_trie_cursor,
+                            task_trie_updates.clone(),
+                            regular_updates.clone(),
+                        )
+                        .map_err(ProviderError::from)?;
                         if task_state_root != sealed_block.header().state_root() {
                             return Ok((regular_root, regular_updates, time_from_last_update));
                         }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2894,13 +2894,13 @@ where
                         );
                         compare_trie_updates(
                             in_memory_trie_cursor,
-                            task_trie_updates.clone(),
-                            regular_updates,
+                            task_trie_updates,
+                            regular_updates.clone(),
                         )
                         .map_err(ProviderError::from)?;
-                    } else {
-                        debug!(target: "engine::tree", "Regular state root does not match block state root");
+                        return Ok((regular_root, regular_updates, time_from_last_update))
                     }
+                    debug!(target: "engine::tree", "Regular state root does not match block state root");
                 }
 
                 Ok((task_state_root, task_trie_updates, time_from_last_update))

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2896,14 +2896,17 @@ where
                             );
                             compare_trie_updates(
                                 in_memory_trie_cursor,
-                                task_trie_updates,
+                                task_trie_updates.clone(),
                                 regular_updates.clone(),
                             )
                             .map_err(ProviderError::from)?;
                         }
-                        return Ok((regular_root, regular_updates, time_from_last_update))
+                        if task_state_root != sealed_block.header().state_root() {
+                            return Ok((regular_root, regular_updates, time_from_last_update));
+                        }
+                    } else {
+                        debug!(target: "engine::tree", "Regular state root does not match block state root");
                     }
-                    debug!(target: "engine::tree", "Regular state root does not match block state root");
                 }
 
                 Ok((task_state_root, task_trie_updates, time_from_last_update))

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2887,17 +2887,20 @@ where
                         state_provider.state_root_with_updates(hashed_state.clone())?;
 
                     if regular_root == sealed_block.header().state_root() {
-                        let provider_ro = state_root_task_config.consistent_view.provider_ro()?;
-                        let in_memory_trie_cursor = InMemoryTrieCursorFactory::new(
-                            DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
-                            &state_root_task_config.nodes_sorted,
-                        );
-                        compare_trie_updates(
-                            in_memory_trie_cursor,
-                            task_trie_updates,
-                            regular_updates.clone(),
-                        )
-                        .map_err(ProviderError::from)?;
+                        if self.config.always_compare_trie_updates() {
+                            let provider_ro =
+                                state_root_task_config.consistent_view.provider_ro()?;
+                            let in_memory_trie_cursor = InMemoryTrieCursorFactory::new(
+                                DatabaseTrieCursorFactory::new(provider_ro.tx_ref()),
+                                &state_root_task_config.nodes_sorted,
+                            );
+                            compare_trie_updates(
+                                in_memory_trie_cursor,
+                                task_trie_updates,
+                                regular_updates.clone(),
+                            )
+                            .map_err(ProviderError::from)?;
+                        }
                         return Ok((regular_root, regular_updates, time_from_last_update))
                     }
                     debug!(target: "engine::tree", "Regular state root does not match block state root");


### PR DESCRIPTION
Closes: #14166 

We are already calling `state_provider.state_root_with_updates` on `EngineApiTreeHandler::handle_state_root_result` on state root mismatch to diagnose the error comparing trie updates.

With these changes, we return the `state_provider.state_root_with_updates` result as the `EngineApiTreeHandler::handle_state_root_result` output.