### PR TITLE
feat: add reth-op crate

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,optimism,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,serde-bincode-compat,serde,test-utils,arbitrary,bench",
+        "--features=std,optimism,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,serde-bincode-compat,serde,test-utils,arbitrary,bench",
         # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8329,6 +8329,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-op"
+version = "1.1.5"
+dependencies = [
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-db",
+ "reth-evm",
+ "reth-network",
+ "reth-node-api",
+ "reth-optimism-chainspec",
+ "reth-optimism-consensus",
+ "reth-optimism-evm",
+ "reth-optimism-node",
+ "reth-optimism-primitives",
+ "reth-optimism-rpc",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-eth-types",
+ "reth-storage-api",
+]
+
+[[package]]
 name = "reth-optimism-chainspec"
 version = "1.1.5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ members = [
     "crates/optimism/node/",
     "crates/optimism/payload/",
     "crates/optimism/primitives/",
+    "crates/optimism/reth/",
     "crates/optimism/rpc/",
     "crates/optimism/storage",
     "crates/optimism/txpool/",
@@ -374,6 +375,7 @@ reth-node-events = { path = "crates/node/events" }
 reth-node-metrics = { path = "crates/node/metrics" }
 reth-optimism-node = { path = "crates/optimism/node" }
 reth-node-types = { path = "crates/node/types" }
+reth-op = { path = "crates/optimism/reth" }
 reth-optimism-chainspec = { path = "crates/optimism/chainspec" }
 reth-optimism-cli = { path = "crates/optimism/cli" }
 reth-optimism-consensus = { path = "crates/optimism/consensus" }

--- a/crates/engine/local/Cargo.toml
+++ b/crates/engine/local/Cargo.toml
@@ -49,4 +49,5 @@ workspace = true
 op = [
     "dep:op-alloy-rpc-types-engine",
     "dep:reth-optimism-chainspec",
+    "reth-payload-primitives/op",
 ]

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -1,0 +1,85 @@
+[package]
+name = "reth-op"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-primitives-traits = { workspace = true, features = ["op"] }
+reth-chainspec.workspace = true
+reth-network = { workspace = true, optional = true }
+reth-provider = { workspace = true, optional = true }
+reth-db = { workspace = true, optional = true, features = ["mdbx", "op"] }
+reth-storage-api = { workspace = true, optional = true }
+reth-node-api = { workspace = true, optional = true }
+reth-consensus = { workspace = true, optional = true }
+reth-consensus-common = { workspace = true, optional = true }
+reth-evm = { workspace = true, optional = true }
+reth-rpc = { workspace = true, optional = true }
+reth-rpc-api = { workspace = true, optional = true }
+reth-rpc-eth-types = { workspace = true, optional = true }
+reth-rpc-builder = { workspace = true, optional = true }
+
+# reth-op
+reth-optimism-primitives.workspace = true
+reth-optimism-chainspec.workspace = true
+reth-optimism-consensus = { workspace = true, optional = true }
+reth-optimism-evm = { workspace = true, optional = true }
+reth-optimism-node = { workspace = true, optional = true }
+reth-optimism-rpc = { workspace = true, optional = true }
+
+[features]
+default = ["std"]
+std = [
+    "reth-chainspec/std",
+    "reth-optimism-primitives/std",
+    "reth-primitives-traits/std",
+    "reth-consensus?/std",
+    "reth-consensus-common?/std",
+]
+arbitrary = [
+    "std",
+    "reth-chainspec/arbitrary",
+    "reth-optimism-primitives/arbitrary",
+    "reth-primitives-traits/arbitrary",
+    "reth-db?/arbitrary",
+]
+
+test-utils = [
+    "reth-chainspec/test-utils",
+    "reth-consensus?/test-utils",
+    "reth-db?/test-utils",
+    "reth-evm?/test-utils",
+    "reth-network?/test-utils",
+    "reth-optimism-node?/test-utils",
+    "reth-primitives-traits/test-utils",
+    "reth-provider?/test-utils",
+]
+
+full = ["consensus", "evm", "node", "provider", "rpc"]
+
+alloy-compat = []
+consensus = ["dep:reth-consensus", "dep:reth-consensus-common", "dep:reth-optimism-consensus"]
+evm = ["dep:reth-evm", "dep:reth-optimism-evm"]
+node-api = ["dep:reth-node-api"]
+node = ["provider", "consensus", "evm", "node-api", "dep:reth-optimism-node", "rpc"]
+rpc = ["dep:reth-rpc", "dep:reth-rpc-builder", "dep:reth-rpc-api", "dep:reth-rpc-eth-types", "dep:reth-optimism-rpc"]
+js-tracer = ["rpc", "reth-rpc/js-tracer"]
+network = ["dep:reth-network"]
+provider = ["storage-api", "dep:reth-provider", "dep:reth-db"]
+storage-api = ["dep:reth-storage-api"]
+optimism = [
+    "reth-db?/optimism",
+    "reth-optimism-consensus?/optimism",
+    "reth-optimism-evm?/optimism",
+    "reth-optimism-node?/optimism",
+    "reth-optimism-primitives/optimism",
+    "reth-optimism-rpc?/optimism",
+]

--- a/crates/optimism/reth/src/lib.rs
+++ b/crates/optimism/reth/src/lib.rs
@@ -26,7 +26,9 @@ pub mod primitives {
 pub mod consensus {
     #[doc(inline)]
     pub use reth_consensus::*;
+    #[doc(inline)]
     pub use reth_consensus_common::*;
+    #[doc(inline)]
     pub use reth_optimism_consensus::*;
 }
 

--- a/crates/optimism/reth/src/lib.rs
+++ b/crates/optimism/reth/src/lib.rs
@@ -8,9 +8,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(unused_crate_dependencies)]
 // The `optimism` feature must be enabled to use this crate.
 #![cfg(feature = "optimism")]
-#![allow(unused_crate_dependencies)]
 
 /// Re-exported ethereum types
 #[doc(inline)]

--- a/crates/optimism/reth/src/lib.rs
+++ b/crates/optimism/reth/src/lib.rs
@@ -1,0 +1,98 @@
+//! Optimism meta crate that provides access to commonly used reth dependencies.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+// The `optimism` feature must be enabled to use this crate.
+#![cfg(feature = "optimism")]
+
+/// Re-exported ethereum types
+#[doc(inline)]
+pub use reth_optimism_primitives::*;
+
+/// Re-exported reth primitives
+pub mod primitives {
+    #[doc(inline)]
+    pub use reth_primitives_traits::*;
+}
+
+/// Re-exported consensus types
+#[cfg(feature = "consensus")]
+pub mod consensus {
+    #[doc(inline)]
+    pub use reth_consensus::*;
+    pub use reth_consensus_common::*;
+    pub use reth_optimism_consensus::*;
+}
+
+/// Re-exported from `reth_chainspec`
+pub mod chainspec {
+    #[doc(inline)]
+    pub use reth_chainspec::*;
+    #[doc(inline)]
+    pub use reth_optimism_chainspec::*;
+}
+
+/// Re-exported evm types
+#[cfg(feature = "evm")]
+pub mod evm {
+    #[doc(inline)]
+    pub use reth_optimism_evm::*;
+
+    #[doc(inline)]
+    pub use reth_evm as primitives;
+}
+
+/// Re-exported reth network types
+#[cfg(feature = "network")]
+pub mod network {
+    #[doc(inline)]
+    pub use reth_network::*;
+}
+
+/// Re-exported reth provider types
+#[cfg(feature = "provider")]
+pub mod provider {
+    #[doc(inline)]
+    pub use reth_provider::*;
+
+    #[doc(inline)]
+    pub use reth_db as db;
+}
+
+/// Re-exported reth storage api types
+#[cfg(feature = "storage-api")]
+pub mod storage {
+    #[doc(inline)]
+    pub use reth_storage_api::*;
+}
+
+/// Re-exported ethereum node
+#[cfg(feature = "node-api")]
+pub mod node {
+    #[doc(inline)]
+    pub use reth_node_api as api;
+    #[cfg(feature = "node")]
+    pub use reth_optimism_node::*;
+}
+
+/// Re-exported rpc types
+#[cfg(feature = "rpc")]
+pub mod rpc {
+    #[doc(inline)]
+    pub use reth_optimism_rpc::*;
+    #[doc(inline)]
+    pub use reth_rpc::*;
+
+    #[doc(inline)]
+    pub use reth_rpc_api as api;
+    #[doc(inline)]
+    pub use reth_rpc_builder as builder;
+    #[doc(inline)]
+    pub use reth_rpc_eth_types as eth;
+}

--- a/crates/optimism/reth/src/lib.rs
+++ b/crates/optimism/reth/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // The `optimism` feature must be enabled to use this crate.
 #![cfg(feature = "optimism")]
-#[allow(unused_crate_dependencies)]
+#![allow(unused_crate_dependencies)]
 
 /// Re-exported ethereum types
 #[doc(inline)]

--- a/crates/optimism/reth/src/lib.rs
+++ b/crates/optimism/reth/src/lib.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // The `optimism` feature must be enabled to use this crate.
 #![cfg(feature = "optimism")]
+#[allow(unused_crate_dependencies)]
 
 /// Re-exported ethereum types
 #[doc(inline)]

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -142,6 +142,7 @@ reth-codec = [
 ]
 op = [
     "dep:op-alloy-consensus",
+    "reth-codecs?/op",
 ]
 rayon = [
     "dep:rayon",

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -91,4 +91,8 @@ optimism = [
     "reth-optimism-primitives?/optimism",
     "op",
 ]
-op = ["dep:reth-optimism-primitives", "reth-codecs/op"]
+op = [
+    "dep:reth-optimism-primitives",
+    "reth-codecs/op",
+    "reth-primitives-traits/op",
+]

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -104,7 +104,10 @@ arbitrary = [
     "alloy-consensus/arbitrary",
 ]
 optimism = ["reth-db-api/optimism"]
-op = ["reth-db-api/op"]
+op = [
+    "reth-db-api/op",
+    "reth-primitives-traits/op",
+]
 disable-lock = []
 
 [[bench]]


### PR DESCRIPTION
closes #14361 

mirrors reth-ethereum crate and re-exports

still requires mandatory optimism feature due to workspace constraints