### PR TITLE
fix(ci): changes in kurtosis-op network config latest optimism package

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -2,20 +2,16 @@ ethereum_package:
   participants:
     - el_type: reth
       el_extra_params:
-        - "--rpc.eth-proof-window 100"
-      cl_type: lighthouse
+        - "--rpc.eth-proof-window=100"
+      cl_type: teku
 optimism_package:
   chains:
     - participants:
       - el_type: op-geth
         cl_type: op-node
-        # https://github.com/ethpandaops/optimism-package/issues/157
-        cl_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:a79e8cc06aa354511983fafcb6d71ab04cdfadbc"
       - el_type: op-reth
         el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
         cl_type: op-node
-        # https://github.com/ethpandaops/optimism-package/issues/157
-        cl_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:a79e8cc06aa354511983fafcb6d71ab04cdfadbc"
       batcher_params:
         extra_params:
           - "--throttle-interval=0"


### PR DESCRIPTION
we have failures like https://github.com/paradigmxyz/reth/actions/runs/13253156460/job/36995691042, kurtosis `optimism-package` has updated the `ethereum-package` it uses https://github.com/ethpandaops/optimism-package/pull/160, changes to make it work for us:
* switch to teku for L1 CL (lighthouse doesn't work with minimal preset)
* update EL extra args, single string without whitespaces
* unpin op-node in L2

successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/13261191654