### PR TITLE
feat: impl serde for OpPrimitives

### DIFF
--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -32,7 +32,7 @@ pub type OpBlock = alloy_consensus::Block<OpTransactionSigned>;
 pub type OpBlockBody = <OpBlock as reth_primitives_traits::Block>::Body;
 
 /// Primitive types for Optimism Node.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct OpPrimitives;
 
 #[cfg(feature = "optimism")]

--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -32,7 +32,8 @@ pub type OpBlock = alloy_consensus::Block<OpTransactionSigned>;
 pub type OpBlockBody = <OpBlock as reth_primitives_traits::Block>::Body;
 
 /// Primitive types for Optimism Node.
-#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpPrimitives;
 
 #[cfg(feature = "optimism")]


### PR DESCRIPTION
For using Reth in RSP I need `OpPrimitives` to be serializable and deserializable.

All good for `EthPrimitives`:

https://github.com/paradigmxyz/reth/blob/974b197d3037795abfe0eab5cdc9f0a9c85201ea/crates/ethereum/primitives/src/lib.rs#L30-L32