### PR TITLE
fix: use alloc::vec::Vec

### DIFF
--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -12,7 +12,7 @@
 
 extern crate alloc;
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::{Address, U256};
 use core::fmt::Debug;


### PR DESCRIPTION
Just noticed a build error on these 2 lines:

https://github.com/paradigmxyz/reth/blob/974b197d3037795abfe0eab5cdc9f0a9c85201ea/crates/optimism/evm/src/lib.rs#L92

https://github.com/paradigmxyz/reth/blob/974b197d3037795abfe0eab5cdc9f0a9c85201ea/crates/optimism/evm/src/lib.rs#L94