### PR TITLE
feat(grafana): add block validation overhead graph

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -1,19 +1,19 @@
 {
   "__inputs": [
     {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
+    },
+    {
       "name": "DS_PROMETHEUS",
       "label": "Prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
-    },
-    {
-      "name": "DS_EXPRESSION",
-      "label": "Expression",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "__expr__"
     }
   ],
   "__elements": {},
@@ -39,7 +39,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.4.0"
+      "version": "11.2.0"
     },
     {
       "type": "panel",
@@ -170,7 +170,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -240,7 +240,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -310,7 +310,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -380,7 +380,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -450,7 +450,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -520,7 +520,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -599,7 +599,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -675,7 +675,7 @@
         "sizing": "auto",
         "valueMode": "color"
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -777,7 +777,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -1438,7 +1438,7 @@
           "unit": "percentunit"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -2556,7 +2556,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -2792,7 +2792,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -2942,7 +2942,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -3614,12 +3614,166 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The time it takes for operations that are part of block validation, but not execution or state root, to complete.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 125
+      },
+      "id": 252,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_prewarm_spawn_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Prewarm task spawn duration",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_cache_saving_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Cache saving duration",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_state_root_config_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "State root config creation duration",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_trie_input_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Trie input creation duration",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "Block validation overhead",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 125
+        "y": 136
       },
       "id": 24,
       "panels": [],
@@ -3716,7 +3870,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 126
+        "y": 137
       },
       "id": 26,
       "options": {
@@ -3850,7 +4004,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 126
+        "y": 137
       },
       "id": 33,
       "options": {
@@ -3970,7 +4124,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 134
+        "y": 145
       },
       "id": 36,
       "options": {
@@ -4019,7 +4173,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 142
+        "y": 153
       },
       "id": 32,
       "panels": [],
@@ -4126,7 +4280,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 143
+        "y": 154
       },
       "id": 30,
       "options": {
@@ -4292,7 +4446,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 143
+        "y": 154
       },
       "id": 28,
       "options": {
@@ -4412,7 +4566,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 151
+        "y": 162
       },
       "id": 35,
       "options": {
@@ -4538,7 +4692,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 151
+        "y": 162
       },
       "id": 73,
       "options": {
@@ -4665,7 +4819,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 159
+        "y": 170
       },
       "id": 102,
       "options": {
@@ -4728,7 +4882,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 167
+        "y": 178
       },
       "id": 79,
       "panels": [],
@@ -4801,7 +4955,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 168
+        "y": 179
       },
       "id": 74,
       "options": {
@@ -4898,7 +5052,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 168
+        "y": 179
       },
       "id": 80,
       "options": {
@@ -4995,7 +5149,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 176
+        "y": 187
       },
       "id": 81,
       "options": {
@@ -5092,7 +5246,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 176
+        "y": 187
       },
       "id": 114,
       "options": {
@@ -5189,7 +5343,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 184
+        "y": 195
       },
       "id": 190,
       "options": {
@@ -5227,7 +5381,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 192
+        "y": 203
       },
       "id": 87,
       "panels": [],
@@ -5300,7 +5454,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 193
+        "y": 204
       },
       "id": 83,
       "options": {
@@ -5396,7 +5550,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 193
+        "y": 204
       },
       "id": 84,
       "options": {
@@ -5505,7 +5659,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 201
+        "y": 212
       },
       "id": 213,
       "options": {
@@ -5602,7 +5756,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 201
+        "y": 212
       },
       "id": 210,
       "options": {
@@ -5926,7 +6080,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 209
+        "y": 220
       },
       "id": 85,
       "options": {
@@ -6023,7 +6177,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 209
+        "y": 220
       },
       "id": 212,
       "options": {
@@ -6269,7 +6423,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 217
+        "y": 228
       },
       "id": 211,
       "options": {
@@ -6594,7 +6748,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 225
+        "y": 236
       },
       "id": 249,
       "options": {
@@ -6638,7 +6792,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 233
+        "y": 244
       },
       "id": 214,
       "panels": [],
@@ -6710,7 +6864,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 234
+        "y": 245
       },
       "id": 215,
       "options": {
@@ -6806,7 +6960,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 234
+        "y": 245
       },
       "id": 216,
       "options": {
@@ -6857,7 +7011,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 242
+        "y": 253
       },
       "id": 68,
       "panels": [],
@@ -6930,7 +7084,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 243
+        "y": 254
       },
       "id": 60,
       "options": {
@@ -7026,7 +7180,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 243
+        "y": 254
       },
       "id": 62,
       "options": {
@@ -7122,7 +7276,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 251
+        "y": 262
       },
       "id": 64,
       "options": {
@@ -7159,7 +7313,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 259
+        "y": 270
       },
       "id": 97,
       "panels": [],
@@ -7244,7 +7398,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 260
+        "y": 271
       },
       "id": 98,
       "options": {
@@ -7407,7 +7561,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 260
+        "y": 271
       },
       "id": 101,
       "options": {
@@ -7505,7 +7659,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 268
+        "y": 279
       },
       "id": 99,
       "options": {
@@ -7603,7 +7757,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 268
+        "y": 279
       },
       "id": 100,
       "options": {
@@ -7641,7 +7795,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 276
+        "y": 287
       },
       "id": 105,
       "panels": [],
@@ -7714,7 +7868,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 277
+        "y": 288
       },
       "id": 106,
       "options": {
@@ -7812,7 +7966,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 277
+        "y": 288
       },
       "id": 107,
       "options": {
@@ -7909,7 +8063,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 285
+        "y": 296
       },
       "id": 217,
       "options": {
@@ -7947,7 +8101,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 293
+        "y": 304
       },
       "id": 108,
       "panels": [],
@@ -8045,7 +8199,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 294
+        "y": 305
       },
       "id": 109,
       "options": {
@@ -8107,7 +8261,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 294
+        "y": 305
       },
       "id": 111,
       "maxDataPoints": 25,
@@ -8152,7 +8306,7 @@
           "unit": "percentunit"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -8237,7 +8391,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 302
+        "y": 313
       },
       "id": 120,
       "options": {
@@ -8295,7 +8449,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 302
+        "y": 313
       },
       "id": 112,
       "maxDataPoints": 25,
@@ -8340,7 +8494,7 @@
           "unit": "percentunit"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -8461,7 +8615,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 310
+        "y": 321
       },
       "id": 198,
       "options": {
@@ -8681,7 +8835,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 310
+        "y": 321
       },
       "id": 246,
       "options": {
@@ -8720,7 +8874,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 318
+        "y": 329
       },
       "id": 236,
       "panels": [],
@@ -8792,7 +8946,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 319
+        "y": 330
       },
       "id": 237,
       "options": {
@@ -8889,7 +9043,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 319
+        "y": 330
       },
       "id": 238,
       "options": {
@@ -8986,7 +9140,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 327
+        "y": 338
       },
       "id": 239,
       "options": {
@@ -9095,7 +9249,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 327
+        "y": 338
       },
       "id": 219,
       "options": {
@@ -9143,7 +9297,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -9159,7 +9314,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 335
+        "y": 346
       },
       "id": 220,
       "options": {
@@ -9179,7 +9334,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -9203,7 +9358,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 343
+        "y": 354
       },
       "id": 241,
       "panels": [],
@@ -9260,7 +9415,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -9275,7 +9431,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 344
+        "y": 355
       },
       "id": 243,
       "options": {
@@ -9371,7 +9527,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -9386,7 +9543,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 344
+        "y": 355
       },
       "id": 244,
       "options": {
@@ -9482,7 +9639,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -9498,7 +9656,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 352
+        "y": 363
       },
       "id": 245,
       "options": {
@@ -9537,7 +9695,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 360
+        "y": 371
       },
       "id": 226,
       "panels": [],
@@ -9593,7 +9751,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -9634,7 +9793,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 361
+        "y": 372
       },
       "id": 225,
       "options": {
@@ -9721,7 +9880,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -9762,7 +9922,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 361
+        "y": 372
       },
       "id": 227,
       "options": {
@@ -9849,7 +10009,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -9890,7 +10051,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 369
+        "y": 380
       },
       "id": 235,
       "options": {
@@ -9977,7 +10138,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -10018,7 +10180,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 369
+        "y": 380
       },
       "id": 234,
       "options": {
@@ -10102,7 +10264,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
Adds a graph that measures overhead of various operations that are part of block validation, but are not execution or state root.

<img width="1191" alt="Screenshot 2025-02-11 at 9 34 01 PM" src="https://github.com/user-attachments/assets/65a7e9f3-2d14-4e5b-bd02-c38f457c5d78" />
