### PR TITLE
feat: add MaybeSerdeBincodeCompat to SignedTx

### DIFF
--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -15,7 +15,7 @@ pub trait NodePrimitives:
     /// Block body primitive.
     type BlockBody: FullBlockBody<Transaction = Self::SignedTx, OmmerHeader = Self::BlockHeader>;
     /// Signed version of the transaction type.
-    type SignedTx: FullSignedTx + MaybeSerdeBincodeCompat;
+    type SignedTx: FullSignedTx;
     /// A receipt.
     type Receipt: Receipt;
 }

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -15,7 +15,7 @@ pub trait NodePrimitives:
     /// Block body primitive.
     type BlockBody: FullBlockBody<Transaction = Self::SignedTx, OmmerHeader = Self::BlockHeader>;
     /// Signed version of the transaction type.
-    type SignedTx: FullSignedTx;
+    type SignedTx: FullSignedTx + MaybeSerdeBincodeCompat;
     /// A receipt.
     type Receipt: Receipt;
 }

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     crypto::secp256k1::{recover_signer, recover_signer_unchecked},
-    FillTxEnv, InMemorySize, MaybeCompact, MaybeSerde,
+    FillTxEnv, InMemorySize, MaybeCompact, MaybeSerde, MaybeSerdeBincodeCompat,
 };
 use alloc::{fmt, vec::Vec};
 use alloy_consensus::{
@@ -14,9 +14,15 @@ use alloy_primitives::{keccak256, Address, PrimitiveSignature as Signature, TxHa
 use core::hash::Hash;
 
 /// Helper trait that unifies all behaviour required by block to support full node operations.
-pub trait FullSignedTx: SignedTransaction + FillTxEnv + MaybeCompact {}
+pub trait FullSignedTx:
+    SignedTransaction + FillTxEnv + MaybeCompact + MaybeSerdeBincodeCompat
+{
+}
 
-impl<T> FullSignedTx for T where T: SignedTransaction + FillTxEnv + MaybeCompact {}
+impl<T> FullSignedTx for T where
+    T: SignedTransaction + FillTxEnv + MaybeCompact + MaybeSerdeBincodeCompat
+{
+}
 
 /// A signed transaction.
 #[auto_impl::auto_impl(&, Arc)]


### PR DESCRIPTION
In order to be able to do that: 

https://github.com/paradigmxyz/reth/blob/ea40f78e5911220b89d245f87a31f0f1be2cbdcb/crates/primitives-traits/src/serde_bincode_compat.rs#L53-L56

with `NodePrimitives`, I need `SignedTx` to be `MaybeSerdeBincodeCompat`.