### PR TITLE
feat(optimism): disable state root task by default

### DIFF
--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -23,6 +23,10 @@ pub struct EngineArgs {
     #[arg(long = "engine.legacy-state-root", default_value = "false")]
     pub legacy_state_root_task_enabled: bool,
 
+    /// Enable state root task
+    #[arg(long = "engine.state-root-task", default_value = "false", hide = true)]
+    pub state_root_task_enabled: bool,
+
     /// Enable cross-block caching and parallel prewarming
     #[arg(long = "engine.caching-and-prewarming")]
     pub caching_and_prewarming_enabled: bool,
@@ -43,6 +47,7 @@ impl Default for EngineArgs {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             legacy_state_root_task_enabled: false,
+            state_root_task_enabled: false,
             state_root_task_compare_updates: false,
             caching_and_prewarming_enabled: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB,

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -147,7 +147,11 @@ where
 
         let runner = CliRunner::default();
         match self.command {
-            Commands::Node(command) => {
+            Commands::Node(mut command) => {
+                // TODO: remove when we're ready to roll out State Root Task on OP-Reth
+                if !command.engine.state_root_task_enabled {
+                    command.engine.legacy_state_root_task_enabled = true;
+                }
                 runner.run_command_until_exit(|ctx| command.execute(ctx, launcher))
             }
             Commands::Init(command) => {


### PR DESCRIPTION
We're not ready to roll out State Root Task to OP-Reth by default yet, see https://github.com/paradigmxyz/reth/issues/14417.

Tested on both Ethereum Mainnet and Base Mainnet.