### PR TITLE
refactor: remove `BatchExecutor` usage

### DIFF
--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -1,4 +1,4 @@
-use crate::BlockExecutionOutput;
+use crate::{BlockExecutionOutput, BlockExecutionResult};
 use alloc::{vec, vec::Vec};
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::{logs_bloom, map::HashMap, Address, BlockNumber, Bloom, Log, B256, U256};
@@ -126,6 +126,30 @@ impl<T> ExecutionOutcome<T> {
         );
 
         Self { bundle, receipts, first_block, requests }
+    }
+
+    /// Creates a new `ExecutionOutcome` from a single block execution result.
+    pub fn single(block_number: u64, result: BlockExecutionOutput<T>) -> Self {
+        Self {
+            bundle: result.state,
+            receipts: vec![result.receipts],
+            first_block: block_number,
+            requests: vec![result.requests],
+        }
+    }
+
+    /// Creates a new `ExecutionOutcome` from multiple [`BlockExecutionResult`]s.
+    pub fn from_blocks(
+        first_block: u64,
+        bundle: BundleState,
+        results: Vec<BlockExecutionResult<T>>,
+    ) -> Self {
+        let mut value = Self { bundle, first_block, receipts: Vec::new(), requests: Vec::new() };
+        for result in results {
+            value.receipts.push(result.receipts);
+            value.requests.push(result.requests);
+        }
+        value
     }
 
     /// Return revm bundle state.

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -7,13 +7,14 @@ use std::{
 use alloy_consensus::BlockHeader;
 use alloy_primitives::BlockNumber;
 use reth_evm::execute::{
-    BatchExecutor, BlockExecutionError, BlockExecutionOutput, BlockExecutorProvider, Executor,
+    BlockExecutionError, BlockExecutionOutput, BlockExecutorProvider, Executor,
 };
 use reth_node_api::{Block as _, BlockBody as _, NodePrimitives};
 use reth_primitives::{Receipt, RecoveredBlock};
 use reth_primitives_traits::{format_gas_throughput, SignedTransaction};
 use reth_provider::{
-    BlockReader, Chain, HeaderProvider, ProviderError, StateProviderFactory, TransactionVariant,
+    BlockReader, Chain, ExecutionOutcome, HeaderProvider, ProviderError, StateProviderFactory,
+    TransactionVariant,
 };
 use reth_prune_types::PruneModes;
 use reth_revm::database::StateProviderDatabase;
@@ -75,7 +76,7 @@ where
             "Executing block range"
         );
 
-        let mut executor = self.executor.batch_executor(StateProviderDatabase::new(
+        let mut executor = self.executor.executor(StateProviderDatabase::new(
             self.provider.history_by_block_number(self.range.start().saturating_sub(1))?,
         ));
 
@@ -85,6 +86,7 @@ where
         let batch_start = Instant::now();
 
         let mut blocks = Vec::new();
+        let mut results = Vec::new();
         for block_number in self.range.clone() {
             // Fetch the block
             let fetch_block_start = Instant::now();
@@ -110,19 +112,17 @@ where
             let (header, body) = block.split_sealed_header_body();
             let block = P::Block::new_sealed(header, body).with_senders(senders);
 
-            executor.execute_and_verify_one(&block)?;
+            results.push(executor.execute_one(&block)?);
             execution_duration += execute_start.elapsed();
 
             // TODO(alexey): report gas metrics using `block.header.gas_used`
 
             // Seal the block back and save it
             blocks.push(block);
-
             // Check if we should commit now
-            let bundle_size_hint = executor.size_hint().unwrap_or_default() as u64;
             if self.thresholds.is_end_of_batch(
                 block_number - *self.range.start(),
-                bundle_size_hint,
+                executor.size_hint() as u64,
                 cumulative_gas,
                 batch_start.elapsed(),
             ) {
@@ -141,7 +141,12 @@ where
         );
         self.range = last_block_number + 1..=*self.range.end();
 
-        let chain = Chain::new(blocks, executor.finalize(), None);
+        let outcome = ExecutionOutcome::from_blocks(
+            *self.range.start(),
+            executor.into_state().take_bundle(),
+            results,
+        );
+        let chain = Chain::new(blocks, outcome, None);
         Ok(chain)
     }
 }

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -130,6 +130,7 @@ where
             }
         }
 
+        let first_block_number = blocks.first().expect("blocks should not be empty").number();
         let last_block_number = blocks.last().expect("blocks should not be empty").number();
         debug!(
             target: "exex::backfill",
@@ -142,7 +143,7 @@ where
         self.range = last_block_number + 1..=*self.range.end();
 
         let outcome = ExecutionOutcome::from_blocks(
-            *self.range.start(),
+            first_block_number,
             executor.into_state().take_bundle(),
             results,
         );

--- a/crates/exex/exex/src/backfill/test_utils.rs
+++ b/crates/exex/exex/src/backfill/test_utils.rs
@@ -4,7 +4,7 @@ use alloy_consensus::{constants::ETH_TO_WEI, BlockHeader, Header, TxEip2930};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{b256, Address, TxKind, U256};
 use reth_chainspec::{ChainSpec, ChainSpecBuilder, EthereumHardfork, MAINNET, MIN_TRANSACTION_GAS};
-use reth_evm::execute::{BatchExecutor, BlockExecutionOutput, BlockExecutorProvider, Executor};
+use reth_evm::execute::{BlockExecutionOutput, BlockExecutorProvider, Executor};
 use reth_evm_ethereum::execute::EthExecutorProvider;
 use reth_node_api::FullNodePrimitives;
 use reth_primitives::{Block, BlockBody, Receipt, RecoveredBlock, Transaction};
@@ -195,9 +195,9 @@ where
     let provider = provider_factory.provider()?;
 
     let executor = EthExecutorProvider::ethereum(chain_spec)
-        .batch_executor(StateProviderDatabase::new(LatestStateProviderRef::new(&provider)));
+        .executor(StateProviderDatabase::new(LatestStateProviderRef::new(&provider)));
 
-    let mut execution_outcome = executor.execute_and_verify_batch(vec![&block1, &block2])?;
+    let mut execution_outcome = executor.execute_batch(vec![&block1, &block2])?;
     execution_outcome.state_mut().reverts.sort();
 
     // Commit the block's execution outcome to the database


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/14447

Replaces all usage of `BatchExecutor` with `Executor`.

For `ExecutionStage` validation is still performed by using the stored consensus instance. For exex backfill validation is no longer performed as it always operates on already validated blocks