### PR TITLE
fix(trie): reveal blinded sparse trie when calculating root

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -74,6 +74,11 @@ pub struct SparseTrieUpdate {
 }
 
 impl SparseTrieUpdate {
+    /// Returns true if the update is empty.
+    pub fn is_empty(&self) -> bool {
+        self.state.is_empty() && self.multiproof.is_empty()
+    }
+
     /// Construct update from multiproof.
     pub fn from_multiproof(multiproof: MultiProof) -> Self {
         Self { multiproof, ..Default::default() }
@@ -673,15 +678,15 @@ where
     ) -> Option<SparseTrieUpdate> {
         let ready_proofs = self.proof_sequencer.add_proof(sequence_number, update);
 
-        if ready_proofs.is_empty() {
-            None
-        } else {
+        ready_proofs
+            .into_iter()
             // Merge all ready proofs and state updates
-            ready_proofs.into_iter().reduce(|mut acc_update, update| {
+            .reduce(|mut acc_update, update| {
                 acc_update.extend(update);
                 acc_update
             })
-        }
+            // Return None if the resulting proof is empty
+            .filter(|proof| !proof.is_empty())
     }
 
     /// Starts the main loop that handles all incoming messages, fetches proofs, applies them to the
@@ -1017,8 +1022,9 @@ where
     debug!(target: "engine::root", num_iterations, "All proofs processed, ending calculation");
 
     let start = Instant::now();
-    let (state_root, trie_updates) =
-        trie.root_with_updates().expect("sparse trie should be revealed");
+    let (state_root, trie_updates) = trie.root_with_updates().map_err(|e| {
+        ParallelStateRootError::Other(format!("could not calculate state root: {e:?}"))
+    })?;
     let elapsed = start.elapsed();
     metrics.sparse_trie_final_update_duration_histogram.record(elapsed);
 
@@ -1147,7 +1153,7 @@ where
         trie.update_account(address, account.unwrap_or_default())?;
     }
 
-    trie.calculate_below_level(SPARSE_TRIE_INCREMENTAL_LEVEL);
+    trie.calculate_below_level(SPARSE_TRIE_INCREMENTAL_LEVEL)?;
     let elapsed = started_at.elapsed();
 
     Ok(elapsed)

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -1153,7 +1153,7 @@ where
         trie.update_account(address, account.unwrap_or_default())?;
     }
 
-    trie.calculate_below_level(SPARSE_TRIE_INCREMENTAL_LEVEL)?;
+    trie.calculate_below_level(SPARSE_TRIE_INCREMENTAL_LEVEL);
     let elapsed = started_at.elapsed();
 
     Ok(elapsed)

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -36,6 +36,14 @@ pub struct MultiProof {
 }
 
 impl MultiProof {
+    /// Returns true if the multiproof is empty.
+    pub fn is_empty(&self) -> bool {
+        self.account_subtree.is_empty() &&
+            self.branch_node_hash_masks.is_empty() &&
+            self.branch_node_tree_masks.is_empty() &&
+            self.storages.is_empty()
+    }
+
     /// Return the account proof nodes for the given account path.
     pub fn account_proof_nodes(&self, path: &Nibbles) -> Vec<(Nibbles, Bytes)> {
         self.account_subtree.matching_nodes_sorted(path)

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -468,9 +468,12 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     }
 
     /// Calculates the hashes of the nodes below the provided level.
-    pub fn calculate_below_level(&mut self, level: usize) -> SparseStateTrieResult<()> {
-        self.revealed_trie_mut()?.update_rlp_node_level(level);
-        Ok(())
+    ///
+    /// If the trie has not been revealed, this function does nothing.
+    pub fn calculate_below_level(&mut self, level: usize) {
+        if let SparseTrie::Revealed(trie) = &mut self.state {
+            trie.update_rlp_node_level(level);
+        }
     }
 
     /// Returns storage sparse trie root if the trie has been revealed.
@@ -507,7 +510,9 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         }
     }
 
-    /// Returns sparse trie root if the trie has been revealed.
+    /// Returns sparse trie root.
+    ///
+    /// If the trie has not been revealed, this function reveals the root node and returns its hash.
     pub fn root(&mut self) -> SparseStateTrieResult<B256> {
         Ok(self.revealed_trie_mut()?.root())
     }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -139,11 +139,6 @@ impl<P> SparseTrie<P> {
         let revealed = self.as_revealed_mut()?;
         Some((revealed.root(), revealed.take_updates()))
     }
-
-    /// Calculates the hashes of the nodes below the provided level.
-    pub fn calculate_below_level(&mut self, level: usize) {
-        self.as_revealed_mut().unwrap().update_rlp_node_level(level);
-    }
 }
 
 impl<P: BlindedProvider> SparseTrie<P> {


### PR DESCRIPTION
If all state updates that came to the `StateRootTask` were empty, we will not have any multiproofs revealed in the Sparse Trie, so it will be blinded. It means that on the call to `root()`, we will panic.

This PR reveals the blinded sparse trie on the call to `root()` using the blinded node provider.

Additionally, this PR makes it impossible to send empty `SparseTrieUpdate` to the sparse trie task by filtering out empty updates.