### PR TITLE
chore: remove `BatchExecutor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7691,7 +7691,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
- "reth-consensus",
  "reth-storage-errors",
  "thiserror 2.0.11",
 ]

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -150,9 +150,6 @@ impl InsertBlockErrorKind {
                     BlockExecutionError::Validation(err) => {
                         Ok(InsertBlockValidationError::Validation(err))
                     }
-                    BlockExecutionError::Consensus(err) => {
-                        Ok(InsertBlockValidationError::Consensus(err))
-                    }
                     // these are internal errors, not caused by an invalid block
                     BlockExecutionError::Internal(error) => {
                         Err(InsertBlockFatalError::BlockExecutionError(error))

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [dependencies]
 # reth
-reth-consensus.workspace = true
 reth-storage-errors.workspace = true
 
 alloy-primitives.workspace = true
@@ -25,7 +24,6 @@ thiserror.workspace = true
 [features]
 default = ["std"]
 std = [
-    "reth-consensus/std",
     "alloy-eips/std",
     "alloy-primitives/std",
     "alloy-rlp/std",

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -17,7 +17,6 @@ use alloc::{
 };
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
-use reth_consensus::ConsensusError;
 use reth_storage_errors::provider::ProviderError;
 use thiserror::Error;
 
@@ -109,9 +108,6 @@ pub enum BlockExecutionError {
     /// Validation error, transparently wrapping [`BlockValidationError`]
     #[error(transparent)]
     Validation(#[from] BlockValidationError),
-    /// Consensus error, transparently wrapping [`ConsensusError`]
-    #[error(transparent)]
-    Consensus(#[from] ConsensusError),
     /// Internal, i.e. non consensus or validation related Block Executor Errors
     #[error(transparent)]
     Internal(#[from] InternalBlockExecutionError),

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -1,7 +1,7 @@
 //! Helper type that represents one of two possible executor types
 
 use crate::{
-    execute::{BatchExecutor, BlockExecutorProvider, Executor},
+    execute::{BlockExecutorProvider, Executor},
     system_calls::OnStateHook,
     Database,
 };
@@ -20,8 +20,6 @@ where
 
     type Executor<DB: Database> = Either<A::Executor<DB>, B::Executor<DB>>;
 
-    type BatchExecutor<DB: Database> = Either<A::BatchExecutor<DB>, B::BatchExecutor<DB>>;
-
     fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
     where
         DB: Database,
@@ -29,16 +27,6 @@ where
         match self {
             Self::Left(a) => Either::Left(a.executor(db)),
             Self::Right(b) => Either::Right(b.executor(db)),
-        }
-    }
-
-    fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
-    where
-        DB: Database,
-    {
-        match self {
-            Self::Left(a) => Either::Left(a.batch_executor(db)),
-            Self::Right(b) => Either::Right(b.batch_executor(db)),
         }
     }
 }
@@ -110,38 +98,6 @@ where
     }
 
     fn size_hint(&self) -> usize {
-        match self {
-            Self::Left(a) => a.size_hint(),
-            Self::Right(b) => b.size_hint(),
-        }
-    }
-}
-
-impl<A, B, DB> BatchExecutor<DB> for Either<A, B>
-where
-    A: BatchExecutor<DB>,
-    B: for<'a> BatchExecutor<DB, Input<'a> = A::Input<'a>, Output = A::Output, Error = A::Error>,
-    DB: Database,
-{
-    type Input<'a> = A::Input<'a>;
-    type Output = A::Output;
-    type Error = A::Error;
-
-    fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
-        match self {
-            Self::Left(a) => a.execute_and_verify_one(input),
-            Self::Right(b) => b.execute_and_verify_one(input),
-        }
-    }
-
-    fn finalize(self) -> Self::Output {
-        match self {
-            Self::Left(a) => a.finalize(),
-            Self::Right(b) => b.finalize(),
-        }
-    }
-
-    fn size_hint(&self) -> Option<usize> {
         match self {
             Self::Left(a) => a.size_hint(),
             Self::Right(b) => b.size_hint(),

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -1,11 +1,11 @@
 //! A no operation block executor implementation.
 
 use reth_execution_errors::BlockExecutionError;
-use reth_execution_types::{BlockExecutionResult, ExecutionOutcome};
+use reth_execution_types::BlockExecutionResult;
 use reth_primitives::{NodePrimitives, RecoveredBlock};
 
 use crate::{
-    execute::{BatchExecutor, BlockExecutorProvider, Executor},
+    execute::{BlockExecutorProvider, Executor},
     system_calls::OnStateHook,
     Database,
 };
@@ -22,16 +22,7 @@ impl<P: NodePrimitives> BlockExecutorProvider for NoopBlockExecutorProvider<P> {
 
     type Executor<DB: Database> = Self;
 
-    type BatchExecutor<DB: Database> = Self;
-
     fn executor<DB>(&self, _: DB) -> Self::Executor<DB>
-    where
-        DB: Database,
-    {
-        Self::default()
-    }
-
-    fn batch_executor<DB>(&self, _: DB) -> Self::BatchExecutor<DB>
     where
         DB: Database,
     {
@@ -68,23 +59,5 @@ impl<DB: Database, P: NodePrimitives> Executor<DB> for NoopBlockExecutorProvider
 
     fn size_hint(&self) -> usize {
         0
-    }
-}
-
-impl<DB, P: NodePrimitives> BatchExecutor<DB> for NoopBlockExecutorProvider<P> {
-    type Input<'a> = &'a RecoveredBlock<P::Block>;
-    type Output = ExecutionOutcome<P::Receipt>;
-    type Error = BlockExecutionError;
-
-    fn execute_and_verify_one(&mut self, _: Self::Input<'_>) -> Result<(), Self::Error> {
-        Err(BlockExecutionError::msg(UNAVAILABLE_FOR_NOOP))
-    }
-
-    fn finalize(self) -> Self::Output {
-        unreachable!()
-    }
-
-    fn size_hint(&self) -> Option<usize> {
-        None
     }
 }


### PR DESCRIPTION
This is unused now and fully replaced by basic `Executor`