### PR TITLE
[wip] feat: `HeaderBuilder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6620,6 +6620,7 @@ dependencies = [
  "metrics",
  "reth-chainspec",
  "reth-evm",
+ "reth-execution-types",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,5 +1,7 @@
 use alloc::vec::Vec;
 use alloy_eips::eip7685::Requests;
+use alloy_primitives::{logs_bloom, Bloom};
+use reth_primitives_traits::Receipt;
 use revm::db::BundleState;
 
 /// The result of executing a block.
@@ -11,6 +13,13 @@ pub struct BlockExecutionResult<T> {
     pub requests: Requests,
     /// The total gas used by the block.
     pub gas_used: u64,
+}
+
+impl<T: Receipt> BlockExecutionResult<T> {
+    /// Calculates the logs bloom.
+    pub fn logs_bloom(&self) -> Bloom {
+        logs_bloom(self.receipts.iter().flat_map(|r| r.logs()))
+    }
 }
 
 /// [`BlockExecutionResult`] combined with state.

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-execution-types.workspace = true
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/payload/basic/src/header.rs
+++ b/crates/payload/basic/src/header.rs
@@ -1,0 +1,33 @@
+use alloy_primitives::B256;
+use reth_execution_types::BlockExecutionResult;
+use reth_primitives::SealedHeader;
+use reth_primitives_traits::NodePrimitives;
+
+/// Input for building a block header.
+pub struct BuildHeaderInput<'a, N: NodePrimitives, Attributes> {
+    /// Header of the parent block.
+    pub parent_header: &'a SealedHeader<N::BlockHeader>,
+    /// Body of the current block the header should correspond to.
+    pub body: &'a N::BlockBody,
+    /// Result of block execution.
+    pub execution_result: &'a BlockExecutionResult<N::Receipt>,
+    /// Payload attributes.
+    pub payload_attributes: &'a Attributes,
+    /// Computed state root.
+    pub state_root: B256,
+}
+
+/// A type that knows how to build a block header.
+pub trait HeaderBuilder<Attributes> {
+    /// Primitive types of the node.
+    type Primitives: NodePrimitives;
+
+    /// Errors that may occur during header building.
+    type Error;
+
+    /// Builds a block header.
+    fn build_header(
+        &self,
+        input: BuildHeaderInput<'_, Self::Primitives, Attributes>,
+    ) -> Result<<Self::Primitives as NodePrimitives>::BlockHeader, Self::Error>;
+}

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -40,6 +40,8 @@ use tokio::{
 };
 use tracing::{debug, trace, warn};
 
+mod header;
+pub use header::{BuildHeaderInput, HeaderBuilder};
 mod metrics;
 mod stack;
 
@@ -811,11 +813,11 @@ impl<Attributes, Payload: BuiltPayload> BuildArguments<Attributes, Payload> {
 ///
 /// Generic parameters `Pool` and `Client` represent the transaction pool and
 /// Ethereum client types.
-pub trait PayloadBuilder: Send + Sync + Clone {
+pub trait PayloadBuilder: HeaderBuilder<Self::Attributes> + Send + Sync + Clone {
     /// The payload attributes type to accept for building.
     type Attributes: PayloadBuilderAttributes;
     /// The type of the built payload.
-    type BuiltPayload: BuiltPayload;
+    type BuiltPayload: BuiltPayload<Primitives = Self::Primitives>;
 
     /// Tries to build a transaction payload using provided arguments.
     ///


### PR DESCRIPTION
RIght now the only type which knows how to construct a header is `PayloadBuilder`. This is unconvinient because we have peripheral usecases requiring constructing a block which ideally should not be embedded into PayloadBuilder logic. Examples of such usecases are complex RPC functionality (`eth_simulateV1`, pending block building), `debug.reorg` flags.

This PR experiments with a simpler trait providing access to header building logic. The idea is that caller can construct payload attributes and block body, delegate the execution to block executor, and then simply invoke `HeaderBuilder` to finish block building.

