### PR TITLE
feat(reth-bench): send-payload CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6672,6 +6672,7 @@ dependencies = [
  "reqwest",
  "reth-cli-runner",
  "reth-cli-util",
+ "reth-fs-util",
  "reth-node-api",
  "reth-node-core",
  "reth-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,6 +2511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6638,12 +6649,14 @@ dependencies = [
 name = "reth-bench"
 version = "1.2.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "alloy-transport",
  "alloy-transport-http",
@@ -6652,8 +6665,10 @@ dependencies = [
  "async-trait",
  "clap",
  "csv",
+ "delegate",
  "eyre",
  "futures",
+ "op-alloy-rpc-types",
  "reqwest",
  "reth-cli-runner",
  "reth-cli-util",
@@ -6663,6 +6678,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-tracing",
  "serde",
+ "serde_json",
  "thiserror 2.0.11",
  "tokio",
  "tower 0.4.13",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -16,24 +16,27 @@ workspace = true
 # reth
 reth-cli-runner.workspace = true
 reth-cli-util.workspace = true
-reth-node-core.workspace = true
 reth-node-api.workspace = true
+reth-node-core.workspace = true
 reth-primitives = { workspace = true, features = ["alloy-compat"] }
 reth-primitives-traits.workspace = true
 reth-tracing.workspace = true
 
 # alloy
-alloy-provider = { workspace = true, features = ["engine-api", "reqwest-rustls-tls"], default-features = false }
-alloy-rpc-types-engine.workspace = true
-alloy-transport.workspace = true
-alloy-transport-http.workspace = true
-alloy-transport-ws.workspace = true
-alloy-transport-ipc.workspace = true
-alloy-pubsub.workspace = true
-alloy-json-rpc.workspace = true
-alloy-rpc-client.workspace = true
+alloy-consensus = { workspace = true }
 alloy-eips.workspace = true
+alloy-json-rpc.workspace = true
 alloy-primitives.workspace = true
+alloy-provider = { workspace = true, features = ["engine-api", "reqwest-rustls-tls"], default-features = false }
+alloy-pubsub.workspace = true
+alloy-rpc-client.workspace = true
+alloy-rpc-types = { workspace = true }
+alloy-rpc-types-engine = { workspace = true }
+alloy-transport-http.workspace = true
+alloy-transport-ipc.workspace = true
+alloy-transport-ws.workspace = true
+alloy-transport.workspace = true
+op-alloy-rpc-types.workspace = true
 
 # reqwest
 reqwest = { workspace = true, default-features = false, features = ["rustls-tls-native-roots"] }
@@ -44,18 +47,20 @@ tower.workspace = true
 # tracing
 tracing.workspace = true
 
-# io
+# serde
 serde.workspace = true
+serde_json.workspace = true
 
 # async
-tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
-futures.workspace = true
 async-trait.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
 
 # misc
+clap = { workspace = true, features = ["derive", "env"] }
+delegate = "0.13"
 eyre.workspace = true
 thiserror.workspace = true
-clap = { workspace = true, features = ["derive", "env"] }
 
 # for writing data
 csv = "1.3.0"

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 # reth
 reth-cli-runner.workspace = true
 reth-cli-util.workspace = true
+reth-fs-util.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true
 reth-primitives = { workspace = true, features = ["alloy-compat"] }

--- a/bin/reth-bench/src/bench/generate_payload.rs
+++ b/bin/reth-bench/src/bench/generate_payload.rs
@@ -1,0 +1,175 @@
+use alloy_consensus::{
+    Block as PrimitiveBlock, BlockBody, Header as PrimitiveHeader,
+    Transaction as PrimitiveTransaction,
+};
+use alloy_eips::{eip7702::SignedAuthorization, Encodable2718, Typed2718};
+use alloy_primitives::{bytes::BufMut, Bytes, ChainId, TxKind, B256, U256};
+use alloy_rpc_types::{
+    AccessList, Block as RpcBlock, BlockTransactions, Transaction as EthRpcTransaction,
+};
+use alloy_rpc_types_engine::ExecutionPayload;
+use clap::Parser;
+use delegate::delegate;
+use eyre::Result;
+use op_alloy_rpc_types::Transaction as OpRpcTransaction;
+use reth_cli_runner::CliContext;
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+
+/// Command for generating an `engine_newPayload` request data from an RPC block.
+///
+/// This command takes a JSON block input (either from a file or stdin) and generates
+/// an execution payload that can be used with the `engine_newPayloadV*` API.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Path to the json file to parse. If not specified, stdin will be used.
+    #[arg(short, long)]
+    path: Option<String>,
+
+    /// The engine RPC url to use.
+    #[arg(short, long, conflicts_with = "raw")]
+    rpc_url: Option<String>,
+
+    /// The JWT secret to use.
+    #[arg(short, long, conflicts_with = "raw")]
+    jwt_secret: Option<String>,
+
+    /// Output the raw JSON payload, instead of `cast` command. When used with stdin this
+    /// can be very powerful, for example:
+    ///
+    /// `cast block latest -r https://reth-ethereum.ithaca.xyz/rpc --full -j | reth-bench generate-payload --raw | cast rpc --jwt-secret <JWT_SECRET> engine_newPayloadV3 --raw`
+    #[arg(long)]
+    raw: bool,
+
+    #[arg(long, default_value_t = 3)]
+    new_payload_version: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum RpcTransaction {
+    Ethereum(EthRpcTransaction),
+    Optimism(OpRpcTransaction),
+}
+
+impl Typed2718 for RpcTransaction {
+    delegate! {
+        to match self {
+            Self::Ethereum(tx) => tx,
+            Self::Optimism(tx) => tx,
+        } {
+            fn ty(&self) -> u8;
+        }
+    }
+}
+
+impl PrimitiveTransaction for RpcTransaction {
+    delegate! {
+        to match self {
+            Self::Ethereum(tx) => tx,
+            Self::Optimism(tx) => tx,
+        } {
+            fn chain_id(&self) -> Option<ChainId>;
+            fn nonce(&self) -> u64;
+            fn gas_limit(&self) -> u64;
+            fn gas_price(&self) -> Option<u128>;
+            fn max_fee_per_gas(&self) -> u128;
+            fn max_priority_fee_per_gas(&self) -> Option<u128>;
+            fn max_fee_per_blob_gas(&self) -> Option<u128>;
+            fn priority_fee_or_price(&self) -> u128;
+            fn effective_gas_price(&self, base_fee: Option<u64>) -> u128;
+            fn is_dynamic_fee(&self) -> bool;
+            fn kind(&self) -> TxKind;
+            fn is_create(&self) -> bool;
+            fn value(&self) -> U256;
+            fn input(&self) -> &Bytes;
+            fn access_list(&self) -> Option<&AccessList>;
+            fn blob_versioned_hashes(&self) -> Option<&[B256]>;
+            fn authorization_list(&self) -> Option<&[SignedAuthorization]>;
+        }
+    }
+}
+
+impl Encodable2718 for RpcTransaction {
+    delegate! {
+        to match self {
+            Self::Ethereum(tx) => tx.inner,
+            Self::Optimism(tx) => tx.inner.inner,
+        } {
+            fn encode_2718_len(&self) -> usize;
+            fn encode_2718(&self, out: &mut dyn BufMut);
+        }
+    }
+}
+
+impl Command {
+    /// Execute the generate payload command
+    pub async fn execute(self, _ctx: CliContext) -> Result<()> {
+        // Read from file or stdin
+        let block_json = if let Some(path) = &self.path {
+            std::fs::read_to_string(path)?
+        } else {
+            let mut buffer = String::new();
+            std::io::stdin().read_to_string(&mut buffer)?;
+            buffer
+        };
+
+        // Parse the block
+        let block: RpcBlock<RpcTransaction> = serde_json::from_str(&block_json)?;
+
+        // Extract parent beacon block root
+        let parent_beacon_block_root = block.header.parent_beacon_block_root;
+
+        // Extract transactions
+        let transactions = match block.transactions {
+            BlockTransactions::Hashes(_) => {
+                return Err(eyre::eyre!("Block must include full transaction data. Send the eth_getBlockByHash request with full: `true`"));
+            }
+            BlockTransactions::Full(txs) => txs,
+            BlockTransactions::Uncle => {
+                return Err(eyre::eyre!("Cannot process uncle blocks"));
+            }
+        };
+
+        // Extract blob versioned hashes
+        let blob_versioned_hashes = transactions
+            .iter()
+            .filter_map(|tx| tx.blob_versioned_hashes().map(|v| v.to_vec()))
+            .collect::<Vec<_>>();
+
+        // Convert to execution payload
+        let execution_payload = ExecutionPayload::from_block_slow(&PrimitiveBlock::new(
+            PrimitiveHeader::from(block.header),
+            BlockBody { transactions, ommers: vec![], withdrawals: block.withdrawals },
+        ))
+        .0;
+
+        // Create JSON request data
+        let json_request = serde_json::to_string(&(
+            execution_payload,
+            blob_versioned_hashes,
+            parent_beacon_block_root,
+        ))?;
+
+        // Print output
+        if self.raw {
+            println!("{json_request}");
+        } else {
+            let mut cmd = format!(
+                "cast rpc engine_newPayloadV{} --raw {}",
+                self.new_payload_version, json_request
+            );
+
+            if let Some(rpc_url) = self.rpc_url {
+                cmd += &format!(" --rpc-url {}", rpc_url);
+            }
+            if let Some(secret) = self.jwt_secret {
+                cmd += &format!(" --jwt-secret {}", secret);
+            }
+
+            println!("{cmd}");
+        }
+
+        Ok(())
+    }
+}

--- a/bin/reth-bench/src/bench/generate_payload.rs
+++ b/bin/reth-bench/src/bench/generate_payload.rs
@@ -156,7 +156,7 @@ impl Command {
             println!("{json_request}");
         } else {
             let mut cmd = format!(
-                "cast rpc engine_newPayloadV{} --raw {}",
+                "cast rpc engine_newPayloadV{} --raw '{}'",
                 self.new_payload_version, json_request
             );
 

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -30,7 +30,17 @@ pub enum Subcommands {
     /// Benchmark which only calls subsequent `newPayload` calls.
     NewPayloadOnly(new_payload_only::Command),
 
-    /// Generate a `newPayload` message for the given RPC block.
+    /// Command for generating and sending an `engine_newPayload` request constructed from an RPC
+    /// block.
+    ///
+    /// This command takes a JSON block input (either from a file or stdin) and generates
+    /// an execution payload that can be used with the `engine_newPayloadV*` API.
+    ///
+    /// One powerful use case is pairing this command with the `cast block` command, for example:
+    ///
+    /// `cast block latest -r https://reth-ethereum.ithaca.xyz/rpc --full --json |
+    /// reth-bench send-payload --rpc-url localhost:5000 --jwt-secret $(cat
+    /// ~/.local/share/reth/mainnet/jwt.hex)`
     SendPayload(send_payload::Command),
 }
 

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -30,7 +30,7 @@ pub enum Subcommands {
     /// Benchmark which only calls subsequent `newPayload` calls.
     NewPayloadOnly(new_payload_only::Command),
 
-    /// Generate a `newPayload` message for the given block.
+    /// Generate a `newPayload` message for the given RPC block.
     GeneratePayload(generate_payload::Command),
 }
 

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -6,10 +6,10 @@ use reth_node_core::args::LogArgs;
 use reth_tracing::FileWorkerGuard;
 
 mod context;
-mod generate_payload;
 mod new_payload_fcu;
 mod new_payload_only;
 mod output;
+mod send_payload;
 
 /// `reth bench` command
 #[derive(Debug, Parser)]
@@ -31,7 +31,7 @@ pub enum Subcommands {
     NewPayloadOnly(new_payload_only::Command),
 
     /// Generate a `newPayload` message for the given RPC block.
-    GeneratePayload(generate_payload::Command),
+    SendPayload(send_payload::Command),
 }
 
 impl BenchmarkCommand {
@@ -43,7 +43,7 @@ impl BenchmarkCommand {
         match self.command {
             Subcommands::NewPayloadFcu(command) => command.execute(ctx).await,
             Subcommands::NewPayloadOnly(command) => command.execute(ctx).await,
-            Subcommands::GeneratePayload(command) => command.execute(ctx).await,
+            Subcommands::SendPayload(command) => command.execute(ctx).await,
         }
     }
 

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -38,9 +38,8 @@ pub enum Subcommands {
     ///
     /// One powerful use case is pairing this command with the `cast block` command, for example:
     ///
-    /// `cast block latest -r https://reth-ethereum.ithaca.xyz/rpc --full --json |
-    /// reth-bench send-payload --rpc-url localhost:5000 --jwt-secret $(cat
-    /// ~/.local/share/reth/mainnet/jwt.hex)`
+    /// `cast block latest--full --json | reth-bench send-payload --rpc-url localhost:5000
+    /// --jwt-secret $(cat ~/.local/share/reth/mainnet/jwt.hex)`
     SendPayload(send_payload::Command),
 }
 

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -6,6 +6,7 @@ use reth_node_core::args::LogArgs;
 use reth_tracing::FileWorkerGuard;
 
 mod context;
+mod generate_payload;
 mod new_payload_fcu;
 mod new_payload_only;
 mod output;
@@ -28,6 +29,9 @@ pub enum Subcommands {
 
     /// Benchmark which only calls subsequent `newPayload` calls.
     NewPayloadOnly(new_payload_only::Command),
+
+    /// Generate a `newPayload` message for the given block.
+    GeneratePayload(generate_payload::Command),
 }
 
 impl BenchmarkCommand {
@@ -39,6 +43,7 @@ impl BenchmarkCommand {
         match self.command {
             Subcommands::NewPayloadFcu(command) => command.execute(ctx).await,
             Subcommands::NewPayloadOnly(command) => command.execute(ctx).await,
+            Subcommands::GeneratePayload(command) => command.execute(ctx).await,
         }
     }
 

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -27,7 +27,7 @@ pub struct Command {
     path: Option<String>,
 
     /// The engine RPC url to use.
-    #[arg(short, long)]
+    #[arg(short, long, required_if_eq_any([("mode", "execute"), ("mode", "cast")]), required_unless_present("mode"))]
     rpc_url: Option<String>,
 
     /// The JWT secret to use.
@@ -42,18 +42,15 @@ pub struct Command {
     mode: Mode,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[derive(Debug, Clone, clap::ValueEnum)]
 enum Mode {
-    /// Execute the `cast` command
-    ///
-    /// This works with blocks of any size, because it saves a temporary file with the
-    /// payload, and deletes it afterwards.
+    /// Execute the `cast` command. This works with blocks of any size, because it pipes the
+    /// payload into the `cast` command.
     Execute,
-    /// Print the `cast` command
-    ///
-    /// Caution: this may not work with large blocks because of the command length limit.
+    /// Print the `cast` command. Caution: this may not work with large blocks because of the
+    /// command length limit.
     Cast,
-    /// Print the JSON payload
+    /// Print the JSON payload. Can be piped into `cast` command if the block is small enough.
     Json,
 }
 
@@ -163,7 +160,7 @@ impl Command {
             parent_beacon_block_root,
         ))?;
 
-        // Print output
+        // Print output or execute command
         match self.mode {
             Mode::Execute => {
                 let mut command = std::process::Command::new("cast");

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -27,7 +27,14 @@ pub struct Command {
     path: Option<String>,
 
     /// The engine RPC url to use.
-    #[arg(short, long, required_if_eq_any([("mode", "execute"), ("mode", "cast")]), required_unless_present("mode"))]
+    #[arg(
+        short,
+        long,
+        // Required if `mode` is `execute` or `cast`.
+        required_if_eq_any([("mode", "execute"), ("mode", "cast")]),
+        // If `mode` is not specified, then `execute` is used, so we need to require it.
+        required_unless_present("mode")
+    )]
     rpc_url: Option<String>,
 
     /// The JWT secret to use.

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -190,6 +190,7 @@ impl Command {
         // Print output or execute command
         match self.mode {
             Mode::Execute => {
+                // Create cast command
                 let mut command = std::process::Command::new("cast");
                 command.arg("rpc").arg("engine_newPayloadV3").arg("--raw");
                 if let Some(rpc_url) = self.rpc_url {
@@ -199,12 +200,15 @@ impl Command {
                     command.arg("--jwt-secret").arg(secret);
                 }
 
+                // Start cast process
                 let mut process = command.stdin(std::process::Stdio::piped()).spawn()?;
 
+                // Write to cast's stdin
                 let mut stdin = process.stdin.take().ok_or_eyre("stdin not available")?;
                 stdin.write_all(json_request.as_bytes())?;
                 drop(stdin);
 
+                // Wait for cast to finish
                 process.wait()?;
             }
             Mode::Cast => {

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -164,7 +164,7 @@ impl Command {
         match self.mode {
             Mode::Execute => {
                 let mut command = std::process::Command::new("cast");
-                command.arg("rpc").arg("engine_newPayloadV3");
+                command.arg("rpc").arg("engine_newPayloadV3").arg("--raw");
                 if let Some(rpc_url) = self.rpc_url {
                     command.arg("--rpc-url").arg(rpc_url);
                 }

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -16,10 +16,8 @@ use reth_cli_runner::CliContext;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 
-/// Command for generating and sending an `engine_newPayload` request constructed from an RPC block.
-///
-/// This command takes a JSON block input (either from a file or stdin) and generates
-/// an execution payload that can be used with the `engine_newPayloadV*` API.
+/// Command for generating and sending an `engine_newPayload` request constructed from an RPC
+/// block.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// Path to the json file to parse. If not specified, stdin will be used.

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -144,6 +144,7 @@ impl Command {
         let blob_versioned_hashes = transactions
             .iter()
             .filter_map(|tx| tx.blob_versioned_hashes().map(|v| v.to_vec()))
+            .flatten()
             .collect::<Vec<_>>();
 
         // Convert to execution payload

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -121,7 +121,7 @@ impl Command {
     /// Read input from either a file or stdin
     fn read_input(&self) -> Result<String> {
         Ok(match &self.path {
-            Some(path) => std::fs::read_to_string(path)?,
+            Some(path) => reth_fs_util::read_to_string(path)?,
             None => String::from_utf8(std::io::stdin().bytes().collect::<Result<Vec<_>, _>>()?)?,
         })
     }
@@ -204,9 +204,11 @@ impl Command {
                 let mut process = command.stdin(std::process::Stdio::piped()).spawn()?;
 
                 // Write to cast's stdin
-                let mut stdin = process.stdin.take().ok_or_eyre("stdin not available")?;
-                stdin.write_all(json_request.as_bytes())?;
-                drop(stdin);
+                process
+                    .stdin
+                    .take()
+                    .ok_or_eyre("stdin not available")?
+                    .write_all(json_request.as_bytes())?;
 
                 // Wait for cast to finish
                 process.wait()?;


### PR DESCRIPTION
Pulled out of https://github.com/Rjected/execution-payload-builder, migrated to Alloy, and cleaned up.

Still not perfect Alloy migration-wise (had to create a wrapper enum with delegated methods), but https://github.com/alloy-rs/op-alloy/pull/427 and other improvements should fix that in the future.

```console
$ cast block 21837989 -r https://reth-ethereum.ithaca.xyz/rpc --full --json | reth-bench send-payload --rpc-url localhost:5000 --jwt-secret /mnt/nvme/reth/mainnet/jwt.hex
{"status":"VALID","latestValidHash":"0x6ab2f864c1fedab183e1ea3470e97c0f5b0ef6d4fe82f501fba337a0ecb66f5d","validationError":null}
```