### PR TITLE
test(engine): enable state root task in engine unit tests

### DIFF
--- a/crates/engine/local/src/service.rs
+++ b/crates/engine/local/src/service.rs
@@ -27,7 +27,7 @@ use reth_engine_tree::{
         RequestHandlerEvent,
     },
     persistence::PersistenceHandle,
-    tree::{EngineApiTreeHandler, InvalidBlockHook, TreeConfig},
+    tree::{root::BasicStateRootTaskFactory, EngineApiTreeHandler, InvalidBlockHook, TreeConfig},
 };
 use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_node_types::{BlockTy, HeaderTy, TxTy};
@@ -95,8 +95,10 @@ where
             PersistenceHandle::<N::Primitives>::spawn_service(provider, pruner, sync_metrics_tx);
         let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();
 
+        let state_root_task_factory = BasicStateRootTaskFactory::new();
+
         let (to_tree_tx, from_tree) =
-            EngineApiTreeHandler::<N::Primitives, _, _, _, _, _>::spawn_new(
+            EngineApiTreeHandler::<N::Primitives, _, _, _, _, _, _>::spawn_new(
                 blockchain_db.clone(),
                 executor_factory,
                 consensus,
@@ -108,6 +110,7 @@ where
                 invalid_block_hook,
                 engine_kind,
                 evm_config,
+                state_root_task_factory,
             );
 
         let handler = EngineApiRequestHandler::new(to_tree_tx, from_tree);

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -8,7 +8,7 @@ use reth_engine_tree::{
     download::BasicBlockDownloader,
     engine::{EngineApiKind, EngineApiRequest, EngineApiRequestHandler, EngineHandler},
     persistence::PersistenceHandle,
-    tree::{EngineApiTreeHandler, InvalidBlockHook, TreeConfig},
+    tree::{root::BasicStateRootTaskFactory, EngineApiTreeHandler, InvalidBlockHook, TreeConfig},
 };
 pub use reth_engine_tree::{
     chain::{ChainEvent, ChainOrchestrator},
@@ -105,8 +105,10 @@ where
 
         let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();
 
+        let state_root_task_factory = BasicStateRootTaskFactory::new();
+
         let (to_tree_tx, from_tree) =
-            EngineApiTreeHandler::<N::Primitives, _, _, _, _, _>::spawn_new(
+            EngineApiTreeHandler::<N::Primitives, _, _, _, _, _, _>::spawn_new(
                 blockchain_db,
                 executor_factory,
                 consensus,
@@ -118,6 +120,7 @@ where
                 invalid_block_hook,
                 engine_kind,
                 evm_config,
+                state_root_task_factory,
             );
 
         let engine_handler = EngineApiRequestHandler::new(to_tree_tx, from_tree);

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -23,8 +23,8 @@ use reth_db_api::{
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::NodeTypes;
 use reth_primitives::{
-    Account, Block, Bytecode, EthPrimitives, GotExpected, Receipt, RecoveredBlock, SealedBlock,
-    SealedHeader, TransactionSigned,
+    Account, Block, Bytecode, EthPrimitives, Receipt, RecoveredBlock, SealedBlock, SealedHeader,
+    TransactionSigned,
 };
 use reth_primitives_traits::SignedTransaction;
 use reth_prune_types::PruneModes;
@@ -34,7 +34,7 @@ use reth_storage_api::{
     OmmersProvider, StageCheckpointReader, StateCommitmentProvider, StateProofProvider,
     StorageRootProvider,
 };
-use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
@@ -218,17 +218,11 @@ impl<T: Transaction, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProvider
     type ProviderRW = Self;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
-        // TODO: return Ok(self.clone()) when engine tests stops relying on an
-        // Error returned here https://github.com/paradigmxyz/reth/pull/14482
-        //Ok(self.clone())
-        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+        Ok(self.clone())
     }
 
     fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
-        // TODO: return Ok(self.clone()) when engine tests stops relying on an
-        // Error returned here https://github.com/paradigmxyz/reth/pull/14482
-        //Ok(self.clone())
-        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+        Ok(self.clone())
     }
 }
 


### PR DESCRIPTION
* Introduces traits `StateRootTaskFactory`, `StateRootTaskRunner` and `StateRootComputeHandle`
* Changes `EngineApiTreeHandler` to accept and use a `StateRootTaskFactory`, `StateRootTask` is created from it
* Adds implementations to these traits for prod and test code. In tests, the impl allows to set the expected state root