### PR TITLE
feat(grafana): add prewarm duration metrics

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -1,19 +1,19 @@
 {
   "__inputs": [
     {
-      "name": "DS_EXPRESSION",
-      "label": "Expression",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "__expr__"
-    },
-    {
       "name": "DS_PROMETHEUS",
       "label": "Prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_EXPRESSION",
+      "label": "Expression",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "__expr__"
     }
   ],
   "__elements": {},
@@ -3616,9 +3616,164 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "description": "The time it takes for operations that are part of block validation, but not execution or state root, to complete.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 125
+      },
+      "id": 252,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_prewarm_spawn_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Prewarm task spawn duration",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_cache_saving_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Cache saving duration",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_state_root_config_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "State root config creation duration",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "reth_sync_block_validation_trie_input_duration{instance=\"$instance\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Trie input creation duration",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "Block validation overhead",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Histograms for the amount of time spent in execution, and in the prewarm thread in total, respectively.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3679,9 +3834,9 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 125
+        "y": 136
       },
-      "id": 252,
+      "id": 256,
       "options": {
         "legend": {
           "calcs": [],
@@ -3698,16 +3853,16 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "reth_sync_block_validation_prewarm_spawn_duration{instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "reth_sync_prewarm_execution_duration{instance=\"$instance\",quantile=~\"(0|0.5|0.95|1)\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Prewarm task spawn duration",
+          "legendFormat": "Prewarm execution duration p{{quantile}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -3715,56 +3870,22 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "reth_sync_block_validation_cache_saving_duration{instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "reth_sync_prewarm_total_runtime{instance=\"$instance\",quantile=~\"(0|0.5|0.95|1)\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Cache saving duration",
+          "legendFormat": "Prewarm thread total duration p{{quantile}}",
           "range": true,
           "refId": "B",
           "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "reth_sync_block_validation_state_root_config_duration{instance=\"$instance\"}",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "State root config creation duration",
-          "range": true,
-          "refId": "C",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "reth_sync_block_validation_trie_input_duration{instance=\"$instance\"}",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "Trie input creation duration",
-          "range": true,
-          "refId": "D",
-          "useBackend": false
         }
       ],
-      "title": "Block validation overhead",
+      "title": "Prewarm execution duration",
       "type": "timeseries"
     },
     {
@@ -3773,7 +3894,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 136
+        "y": 147
       },
       "id": 24,
       "panels": [],
@@ -3870,7 +3991,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 137
+        "y": 148
       },
       "id": 26,
       "options": {
@@ -4004,7 +4125,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 137
+        "y": 148
       },
       "id": 33,
       "options": {
@@ -4124,7 +4245,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 145
+        "y": 156
       },
       "id": 36,
       "options": {
@@ -4173,7 +4294,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 153
+        "y": 164
       },
       "id": 32,
       "panels": [],
@@ -4280,7 +4401,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 154
+        "y": 165
       },
       "id": 30,
       "options": {
@@ -4446,7 +4567,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 154
+        "y": 165
       },
       "id": 28,
       "options": {
@@ -4566,7 +4687,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 162
+        "y": 173
       },
       "id": 35,
       "options": {
@@ -4692,7 +4813,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 162
+        "y": 173
       },
       "id": 73,
       "options": {
@@ -4819,7 +4940,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 170
+        "y": 181
       },
       "id": 102,
       "options": {
@@ -4882,7 +5003,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 178
+        "y": 189
       },
       "id": 79,
       "panels": [],
@@ -4955,7 +5076,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 179
+        "y": 190
       },
       "id": 74,
       "options": {
@@ -5052,7 +5173,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 179
+        "y": 190
       },
       "id": 80,
       "options": {
@@ -5149,7 +5270,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 187
+        "y": 198
       },
       "id": 81,
       "options": {
@@ -5246,7 +5367,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 187
+        "y": 198
       },
       "id": 114,
       "options": {
@@ -5343,7 +5464,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 195
+        "y": 206
       },
       "id": 190,
       "options": {
@@ -5381,7 +5502,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 203
+        "y": 214
       },
       "id": 87,
       "panels": [],
@@ -5438,8 +5559,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5454,7 +5574,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 204
+        "y": 215
       },
       "id": 83,
       "options": {
@@ -5534,8 +5654,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5550,7 +5669,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 204
+        "y": 215
       },
       "id": 84,
       "options": {
@@ -5642,8 +5761,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5659,7 +5777,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 212
+        "y": 223
       },
       "id": 213,
       "options": {
@@ -5739,8 +5857,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5756,7 +5873,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 212
+        "y": 223
       },
       "id": 210,
       "options": {
@@ -6064,8 +6181,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6080,7 +6196,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 220
+        "y": 231
       },
       "id": 85,
       "options": {
@@ -6160,8 +6276,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6177,7 +6292,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 220
+        "y": 231
       },
       "id": 212,
       "options": {
@@ -6406,8 +6521,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6423,7 +6537,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 228
+        "y": 239
       },
       "id": 211,
       "options": {
@@ -6731,8 +6845,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6748,7 +6861,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 236
+        "y": 247
       },
       "id": 249,
       "options": {
@@ -6792,7 +6905,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 244
+        "y": 255
       },
       "id": 214,
       "panels": [],
@@ -6847,8 +6960,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6864,7 +6976,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 245
+        "y": 256
       },
       "id": 215,
       "options": {
@@ -6944,15 +7056,15 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -6960,9 +7072,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 245
+        "y": 256
       },
-      "id": 216,
+      "id": 253,
       "options": {
         "legend": {
           "calcs": [],
@@ -6986,7 +7098,7 @@
           "instant": false,
           "legendFormat": "{{type}} branch nodes p{{quantile}}",
           "range": true,
-          "refId": "Branch Nodes"
+          "refId": "Trie Root Duration"
         },
         {
           "datasource": {
@@ -6999,10 +7111,309 @@
           "instant": false,
           "legendFormat": "{{type}} leaves added p{{quantile}}",
           "range": true,
-          "refId": "Leaf Nodes"
+          "refId": "A"
         }
       ],
       "title": "Trie Nodes Added",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 264
+      },
+      "id": 216,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "reth_tree_root_proof_calculation_storage_targets_histogram{instance=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "instant": false,
+          "legendFormat": "{{type}} storage proof targets p{{quantile}}",
+          "range": true,
+          "refId": "Branch Nodes"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "reth_tree_root_proof_calculation_account_targets_histogram{instance=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{type}} account proof targets p{{quantile}}",
+          "range": true,
+          "refId": "Leaf Nodes"
+        }
+      ],
+      "title": "Proof Targets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 264
+      },
+      "id": 255,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "reth_tree_root_proofs_processed_histogram{instance=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "instant": false,
+          "legendFormat": "{{type}} proofs processed p{{quantile}}",
+          "range": true,
+          "refId": "Branch Nodes"
+        }
+      ],
+      "title": "Proofs Processed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 272
+      },
+      "id": 254,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "reth_tree_root_proof_calculation_duration_histogram{instance=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "instant": false,
+          "legendFormat": "{{type}} Proof calculation duration p{{quantile}}",
+          "range": true,
+          "refId": "Branch Nodes"
+        }
+      ],
+      "title": "Proof calculation duration",
       "type": "timeseries"
     },
     {
@@ -7011,7 +7422,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 253
+        "y": 280
       },
       "id": 68,
       "panels": [],
@@ -7068,8 +7479,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7084,7 +7494,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 254
+        "y": 281
       },
       "id": 60,
       "options": {
@@ -7164,8 +7574,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7180,7 +7589,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 254
+        "y": 281
       },
       "id": 62,
       "options": {
@@ -7260,8 +7669,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7276,7 +7684,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 262
+        "y": 289
       },
       "id": 64,
       "options": {
@@ -7313,7 +7721,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 270
+        "y": 297
       },
       "id": 97,
       "panels": [],
@@ -7368,8 +7776,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7398,7 +7805,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 271
+        "y": 298
       },
       "id": 98,
       "options": {
@@ -7544,8 +7951,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7561,7 +7967,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 271
+        "y": 298
       },
       "id": 101,
       "options": {
@@ -7642,8 +8048,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7659,7 +8064,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 279
+        "y": 306
       },
       "id": 99,
       "options": {
@@ -7740,8 +8145,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7757,7 +8161,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 279
+        "y": 306
       },
       "id": 100,
       "options": {
@@ -7795,7 +8199,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 287
+        "y": 314
       },
       "id": 105,
       "panels": [],
@@ -7851,8 +8255,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7868,7 +8271,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 288
+        "y": 315
       },
       "id": 106,
       "options": {
@@ -7949,8 +8352,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7966,7 +8368,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 288
+        "y": 315
       },
       "id": 107,
       "options": {
@@ -8046,8 +8448,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8063,7 +8464,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 296
+        "y": 323
       },
       "id": 217,
       "options": {
@@ -8101,7 +8502,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 304
+        "y": 331
       },
       "id": 108,
       "panels": [],
@@ -8157,8 +8558,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8199,7 +8599,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 305
+        "y": 332
       },
       "id": 109,
       "options": {
@@ -8261,7 +8661,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 305
+        "y": 332
       },
       "id": 111,
       "maxDataPoints": 25,
@@ -8374,8 +8774,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8391,7 +8790,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 313
+        "y": 340
       },
       "id": 120,
       "options": {
@@ -8449,7 +8848,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 313
+        "y": 340
       },
       "id": 112,
       "maxDataPoints": 25,
@@ -8562,8 +8961,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8615,7 +9013,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 321
+        "y": 348
       },
       "id": 198,
       "options": {
@@ -8818,8 +9216,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8835,7 +9232,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 321
+        "y": 348
       },
       "id": 246,
       "options": {
@@ -8874,7 +9271,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 329
+        "y": 356
       },
       "id": 236,
       "panels": [],
@@ -8930,8 +9327,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8946,7 +9342,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 330
+        "y": 357
       },
       "id": 237,
       "options": {
@@ -9027,8 +9423,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9043,7 +9438,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 330
+        "y": 357
       },
       "id": 238,
       "options": {
@@ -9124,8 +9519,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9140,7 +9534,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 338
+        "y": 365
       },
       "id": 239,
       "options": {
@@ -9233,8 +9627,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9249,7 +9642,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 338
+        "y": 365
       },
       "id": 219,
       "options": {
@@ -9297,8 +9690,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9314,7 +9706,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 346
+        "y": 373
       },
       "id": 220,
       "options": {
@@ -9358,7 +9750,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 354
+        "y": 381
       },
       "id": 241,
       "panels": [],
@@ -9415,8 +9807,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9431,7 +9822,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 355
+        "y": 382
       },
       "id": 243,
       "options": {
@@ -9527,8 +9918,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9543,7 +9933,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 355
+        "y": 382
       },
       "id": 244,
       "options": {
@@ -9639,8 +10029,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9656,7 +10045,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 363
+        "y": 390
       },
       "id": 245,
       "options": {
@@ -9695,7 +10084,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 371
+        "y": 398
       },
       "id": 226,
       "panels": [],
@@ -9751,8 +10140,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9793,7 +10181,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 372
+        "y": 399
       },
       "id": 225,
       "options": {
@@ -9880,8 +10268,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -9922,7 +10309,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 372
+        "y": 399
       },
       "id": 227,
       "options": {
@@ -10009,8 +10396,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -10051,7 +10437,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 380
+        "y": 407
       },
       "id": 235,
       "options": {
@@ -10138,8 +10524,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -10180,7 +10565,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 380
+        "y": 407
       },
       "id": 234,
       "options": {
@@ -10264,7 +10649,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
This adds prewarm thread duration metrics, and turns the block validation overhead graph into a stacked graph


<img width="1198" alt="Screenshot 2025-02-13 at 10 38 35 PM" src="https://github.com/user-attachments/assets/5e6bcedc-a90b-4ae4-adf0-0fb8b88a1afa" />
<img width="1198" alt="Screenshot 2025-02-13 at 10 37 50 PM" src="https://github.com/user-attachments/assets/52a0b710-5c01-4e0c-a6cf-05fd809be6d7" />