### PR TITLE
chore(root): state root task and sparse trie task logs

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -556,7 +556,7 @@ where
         std::thread::Builder::new()
             .name("State Root Task".to_string())
             .spawn(move || {
-                debug!(target: "engine::tree", "Starting state root task");
+                debug!(target: "engine::tree", "State root task starting");
 
                 let result = self.run(sparse_trie_tx);
                 let _ = tx.send(result);
@@ -575,7 +575,7 @@ where
     ) -> Sender<SparseTrieUpdate> {
         let (tx, rx) = mpsc::channel();
         thread_pool.spawn(move || {
-            debug!(target: "engine::tree", "Starting sparse trie task");
+            debug!(target: "engine::tree", "Sparse trie task starting");
             // We clone the task sender here so that it can be used in case the sparse trie task
             // succeeds, without blocking due to any `Drop` implementation.
             //


### PR DESCRIPTION
Make the logs consistent with https://github.com/paradigmxyz/reth/blob/8c2bcf11dbed3e13ecb8ab72416c121a91c66491/crates/engine/tree/src/tree/mod.rs#L2885-L2891