### PR TITLE
feat: don't include hashes of preimages in execution witness

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -944,7 +944,7 @@ mod tests {
     use super::*;
     use crate::test_utils::TestBlockBuilder;
     use alloy_eips::eip7685::Requests;
-    use alloy_primitives::{map::B256Map, Address, BlockNumber, Bytes, StorageKey, StorageValue};
+    use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue};
     use rand::Rng;
     use reth_errors::ProviderResult;
     use reth_primitives::{Account, Bytecode, EthPrimitives, Receipt};
@@ -1104,8 +1104,8 @@ mod tests {
             &self,
             _input: TrieInput,
             _target: HashedPostState,
-        ) -> ProviderResult<B256Map<Bytes>> {
-            Ok(HashMap::default())
+        ) -> ProviderResult<Vec<Bytes>> {
+            Ok(Vec::default())
         }
     }
 

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -1,7 +1,7 @@
 use super::ExecutedBlockWithTrieUpdates;
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{
-    keccak256, map::B256Map, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256,
+    keccak256, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256,
 };
 use reth_errors::ProviderResult;
 use reth_primitives::{Account, Bytecode, NodePrimitives};
@@ -203,7 +203,7 @@ impl<N: NodePrimitives> StateProofProvider for MemoryOverlayStateProviderRef<'_,
         &self,
         mut input: TrieInput,
         target: HashedPostState,
-    ) -> ProviderResult<B256Map<Bytes>> {
+    ) -> ProviderResult<Vec<Bytes>> {
         let MemoryOverlayTrieState { nodes, state } = self.trie_state().clone();
         input.prepend_cached(nodes, state);
         self.historical.witness(input, target)

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -12,7 +12,7 @@ use reth_rpc_api::DebugApiClient;
 use reth_tracing::tracing::warn;
 use reth_trie::{updates::TrieUpdates, HashedStorage};
 use serde::Serialize;
-use std::{collections::HashMap, fmt::Debug, fs::File, io::Write, path::PathBuf};
+use std::{fmt::Debug, fs::File, io::Write, path::PathBuf};
 
 /// Generates a witness for the given block and saves it to a file.
 #[derive(Debug)]
@@ -73,7 +73,7 @@ where
         let mut bundle_state = db.take_bundle();
 
         // Initialize a map of preimages.
-        let mut state_preimages = HashMap::default();
+        let mut state_preimages = Vec::default();
 
         // Grab all account proofs for the data accessed during block execution.
         //
@@ -92,14 +92,14 @@ where
                 .or_insert_with(|| HashedStorage::new(account.status.was_destroyed()));
 
             if let Some(account) = account.account {
-                state_preimages.insert(hashed_address, alloy_rlp::encode(address).into());
+                state_preimages.push(alloy_rlp::encode(address).into());
 
                 for (slot, value) in account.storage {
                     let slot = B256::from(slot);
                     let hashed_slot = keccak256(slot);
                     storage.storage.insert(hashed_slot, value);
 
-                    state_preimages.insert(hashed_slot, alloy_rlp::encode(slot).into());
+                    state_preimages.push(alloy_rlp::encode(slot).into());
                 }
             }
         }
@@ -111,7 +111,7 @@ where
 
         // Write the witness to the output directory.
         let response = ExecutionWitness {
-            state: HashMap::from_iter(state),
+            state: state,
             codes: Default::default(),
             keys: state_preimages,
         };

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -1,5 +1,5 @@
 //! Implements a state provider that has a shared cache in front of it.
-use alloy_primitives::{map::B256Map, Address, StorageKey, StorageValue, B256};
+use alloy_primitives::{Address, StorageKey, StorageValue, B256};
 use metrics::Gauge;
 use mini_moka::sync::CacheBuilder;
 use reth_errors::ProviderResult;
@@ -273,7 +273,7 @@ impl<S: StateProofProvider> StateProofProvider for CachedStateProvider<S> {
         &self,
         input: TrieInput,
         target: HashedPostState,
-    ) -> ProviderResult<B256Map<alloy_primitives::Bytes>> {
+    ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
         self.state_provider.witness(input, target)
     }
 }

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_primitives::{
     keccak256,
-    map::{B256Map, HashMap},
+    map::{HashMap},
     Address, BlockNumber, Bytes, StorageKey, B256, U256,
 };
 use reth_primitives_traits::{Account, Bytecode};
@@ -145,7 +145,7 @@ impl StateProofProvider for StateProviderTest {
         &self,
         _input: TrieInput,
         _target: HashedPostState,
-    ) -> ProviderResult<B256Map<Bytes>> {
+    ) -> ProviderResult<Vec<Bytes>> {
         unimplemented!("witness generation is not supported")
     }
 }

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_primitives::{
     keccak256,
-    map::{HashMap},
+    map::HashMap,
     Address, BlockNumber, Bytes, StorageKey, B256, U256,
 };
 use reth_primitives_traits::{Account, Bytecode};

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -101,7 +101,7 @@ impl reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'_> {
         &self,
         input: reth_trie::TrieInput,
         target: reth_trie::HashedPostState,
-    ) -> reth_errors::ProviderResult<alloy_primitives::map::B256Map<alloy_primitives::Bytes>> {
+    ) -> reth_errors::ProviderResult<Vec<alloy_primitives::Bytes>> {
         self.0.witness(input, target)
     }
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -649,7 +649,7 @@ where
                 let state = state_provider
                     .witness(Default::default(), hashed_state)
                     .map_err(EthApiError::from)?;
-                Ok(ExecutionWitness { state: state.clone(), codes, keys })
+                Ok(ExecutionWitness { state, codes, keys })
             })
             .await
     }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -649,7 +649,7 @@ where
                 let state = state_provider
                     .witness(Default::default(), hashed_state)
                     .map_err(EthApiError::from)?;
-                Ok(ExecutionWitness { state: state.into_iter().collect(), codes, keys })
+                Ok(ExecutionWitness { state: state.clone(), codes, keys })
             })
             .await
     }

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -1,7 +1,7 @@
 use crate::{
     AccountReader, BlockHashReader, ExecutionDataProvider, StateProvider, StateRootProvider,
 };
-use alloy_primitives::{map::B256Map, Address, BlockNumber, Bytes, B256};
+use alloy_primitives::{Address, BlockNumber, Bytes, B256};
 use reth_primitives::{Account, Bytecode};
 use reth_storage_api::{HashedPostStateProvider, StateProofProvider, StorageRootProvider};
 use reth_storage_errors::provider::ProviderResult;
@@ -177,7 +177,7 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProofProvider
         &self,
         mut input: TrieInput,
         target: HashedPostState,
-    ) -> ProviderResult<B256Map<Bytes>> {
+    ) -> ProviderResult<Vec<Bytes>> {
         let bundle_state = self.block_execution_data_provider.execution_outcome().state();
         input.prepend(self.hashed_post_state(bundle_state));
         self.state_provider.witness(input, target)

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -392,7 +392,7 @@ impl<Provider: DBProvider + BlockNumReader + StateCommitmentProvider> StateProof
         input.prepend(self.revert_state()?);
         TrieWitness::overlay_witness(self.tx(), input, target)
             .map_err(ProviderError::from)
-            .map(|hm| hm.values().cloned().collect())
+            .map(|hm| hm.into_values().collect())
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -3,7 +3,8 @@ use crate::{
     HashedPostStateProvider, ProviderError, StateProvider, StateRootProvider,
 };
 use alloy_eips::merge::EPOCH_SLOTS;
-use alloy_primitives::{map::B256Map, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use reth_db::{tables, BlockNumberList};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     models::{storage_sharded_key::StorageShardedKey, ShardedKey},
@@ -387,9 +388,11 @@ impl<Provider: DBProvider + BlockNumReader + StateCommitmentProvider> StateProof
         &self,
         mut input: TrieInput,
         target: HashedPostState,
-    ) -> ProviderResult<B256Map<Bytes>> {
+    ) -> ProviderResult<Vec<Bytes>> {
         input.prepend(self.revert_state()?);
-        TrieWitness::overlay_witness(self.tx(), input, target).map_err(ProviderError::from)
+        TrieWitness::overlay_witness(self.tx(), input, target)
+            .map_err(ProviderError::from)
+            .map(|hm| hm.values().cloned().collect())
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
-use reth_db::{tables, BlockNumberList};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     models::{storage_sharded_key::StorageShardedKey, ShardedKey},

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -145,7 +145,7 @@ impl<Provider: DBProvider + StateCommitmentProvider> StateProofProvider
 
     fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
         TrieWitness::overlay_witness(self.tx(), input, target)
-            .map_err(ProviderError::from)
+                    .map_err(ProviderError::from)
             .map(|hm| hm.values().cloned().collect())
     }
 }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -145,8 +145,8 @@ impl<Provider: DBProvider + StateCommitmentProvider> StateProofProvider
 
     fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
         TrieWitness::overlay_witness(self.tx(), input, target)
-                    .map_err(ProviderError::from)
-            .map(|hm| hm.values().cloned().collect())
+            .map_err(ProviderError::from)
+            .map(|hm| hm.into_values().collect())
     }
 }
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -2,7 +2,7 @@ use crate::{
     providers::state::macros::delegate_provider_impls, AccountReader, BlockHashReader,
     HashedPostStateProvider, StateProvider, StateRootProvider,
 };
-use alloy_primitives::{map::B256Map, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
 use reth_primitives::{Account, Bytecode};
 use reth_storage_api::{
@@ -143,8 +143,10 @@ impl<Provider: DBProvider + StateCommitmentProvider> StateProofProvider
         Proof::overlay_multiproof(self.tx(), input, targets).map_err(ProviderError::from)
     }
 
-    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<B256Map<Bytes>> {
-        TrieWitness::overlay_witness(self.tx(), input, target).map_err(ProviderError::from)
+    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+        TrieWitness::overlay_witness(self.tx(), input, target)
+            .map_err(ProviderError::from)
+            .map(|hm| hm.values().cloned().collect())
     }
 }
 

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -55,7 +55,7 @@ macro_rules! delegate_provider_impls {
             StateProofProvider $(where [$($generics)*])? {
                 fn proof(&self, input: reth_trie::TrieInput, address: alloy_primitives::Address, slots: &[alloy_primitives::B256]) -> reth_storage_errors::provider::ProviderResult<reth_trie::AccountProof>;
                 fn multiproof(&self, input: reth_trie::TrieInput, targets: reth_trie::MultiProofTargets) -> reth_storage_errors::provider::ProviderResult<reth_trie::MultiProof>;
-                fn witness(&self, input: reth_trie::TrieInput, target: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<alloy_primitives::map::B256Map<alloy_primitives::Bytes>>;
+                fn witness(&self, input: reth_trie::TrieInput, target: reth_trie::HashedPostState) -> reth_storage_errors::provider::ProviderResult<Vec<alloy_primitives::Bytes>>;
             }
             HashedPostStateProvider $(where [$($generics)*])? {
                 fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> reth_trie::HashedPostState;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -11,7 +11,7 @@ use alloy_consensus::{
 use alloy_eips::{eip4895::Withdrawals, BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{
     keccak256,
-    map::{B256Map, HashMap},
+    map::HashMap,
     Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, B256, U256,
 };
 use parking_lot::Mutex;
@@ -764,8 +764,8 @@ impl<T: Transaction, ChainSpec: EthChainSpec> StateProofProvider for MockEthProv
         &self,
         _input: TrieInput,
         _target: HashedPostState,
-    ) -> ProviderResult<B256Map<Bytes>> {
-        Ok(HashMap::default())
+    ) -> ProviderResult<Vec<Bytes>> {
+        Ok(Vec::default())
     }
 }
 

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -12,7 +12,6 @@ use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{eip4895::Withdrawals, BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{
-    map::{B256Map, HashMap},
     Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, B256, U256,
 };
 use core::{
@@ -441,8 +440,8 @@ impl<C: Send + Sync, N: NodePrimitives> StateProofProvider for NoopProvider<C, N
         &self,
         _input: TrieInput,
         _target: HashedPostState,
-    ) -> ProviderResult<B256Map<Bytes>> {
-        Ok(HashMap::default())
+    ) -> ProviderResult<Vec<Bytes>> {
+        Ok(Vec::default())
     }
 }
 

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -85,7 +85,7 @@ pub trait StateProofProvider: Send + Sync {
     ) -> ProviderResult<MultiProof>;
 
     /// Get trie witness for provided state.
-    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<B256Map<Bytes>>;
+    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
 }
 
 /// Trie Writer


### PR DESCRIPTION
Switch execution witness to return vectors instead of hashes. There's no reason to include the hash of the preimage in the response, potentially allowing callers to trust the EL client unnecessarily. No other clients implement this RPC and the only usage currently is in optimism and kona. I'll update these usages once this is merged.

Request from geth team here: https://github.com/ethereum/go-ethereum/pull/30613#issuecomment-2531732780

Once this is complete, I can start implementing `debug_executePayload` method in geth and execution-apis.

Edit: this is blocked by https://github.com/paradigmxyz/reth/pull/14503