### PR TITLE
fix(mev_simBundle): Return fuller log objects.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,8 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -133,17 +132,17 @@ dependencies = [
  "arbitrary",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "rand 0.8.5",
  "serde",
  "serde_with",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -156,8 +155,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6180fb232becdea70fad57c63b6967f01f74ab9595671b870f504116dd29de"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -238,8 +236,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -250,7 +247,7 @@ dependencies = [
  "arbitrary",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "once_cell",
@@ -272,8 +269,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -297,8 +293,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -311,8 +306,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -336,8 +330,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -349,8 +342,7 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a3906afb50446392eb798dae4b918ba4ffcca47542efda7215776ddc8b5037"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-genesis",
  "alloy-network",
@@ -411,8 +403,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -453,8 +444,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3a68996f193f542f9e29c88dfa8ed1369d6ee04fa764c1bf23dc11b2f9e4a2"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -494,8 +484,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -520,8 +509,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -533,8 +521,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e30339fff15d53a3a258a7add476c7d24b61d6f4a71476cc39c8b567666772"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -545,8 +532,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d06300df4a87d960add35909240fc72da355dd2ac926fa6999f9efafbdc5a7"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -557,8 +543,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -568,8 +553,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799103aa44270c7bea076ec5d3d7b6c6d29557ab5485c91a74d3068327adb485"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -584,8 +568,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834b7012054cb2f90ee9893b7cc97702edca340ec1ef386c30c42e55e6cd691"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -594,29 +577,27 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83dde9fcf1ccb9b815cc0c89bba26bbbbaae5150a53ae624ed0fc63cb3676c1"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonrpsee-types",
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
- "strum 0.26.3",
+ "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -627,7 +608,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "jsonrpsee-types",
  "serde",
  "serde_json",
@@ -637,8 +618,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418eb6584edd695dfe496dda85a19102c1ae4838f142efce11e2463ed2288d71"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -651,8 +631,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd951155515fa452a2ca4b5434d4b3ab742bcd3d1d1b9a91704bcef5b8d2604"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -665,8 +644,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8dd5bd94993eda3d56a8c4c0d693548183a35462523ffc4385c0b020d3b0c"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -677,8 +655,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -689,8 +666,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -704,8 +680,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -792,8 +767,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -811,8 +785,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -826,8 +799,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e88304aa8b796204e5e2500dfe235933ed692745e3effd94c3733643db6d218"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -846,8 +818,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9653ea9aa06d0e02fcbe2f04f1c47f35a85c378ccefa98e54ae85210bc8bbfa"
+source = "git+https://github.com/ryanschneider/alloy?rev=c7dadbd#c7dadbd79a60c3a6717a4dc81a871ba461145d2d"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -693,34 +693,34 @@ revm-optimism = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "8900c2b" }
 
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+alloy-consensus = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-contract = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-eips = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-genesis = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-json-rpc = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-network = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-network-primitives = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-node-bindings = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-provider = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-pubsub = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-client = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-admin = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-anvil = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-beacon = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-debug = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-engine = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-eth = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-mev = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-trace = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-rpc-types-txpool = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-serde = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-signer = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-signer-local = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-transport = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-transport-http = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-transport-ipc = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
+alloy-transport-ws = { git = "https://github.com/ryanschneider/alloy", rev = "c7dadbd" }
 #
 # op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "ad607c1" }
 # op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "ad607c1" }

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -11,6 +11,7 @@ use alloy_rpc_types_mev::{
 use jsonrpsee::core::RpcResult;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv, Evm};
 use reth_primitives::Recovered;
+use reth_primitives_traits::SignedTransaction;
 use reth_provider::ProviderTx;
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};
 use reth_rpc_api::MevSimApiServer;
@@ -262,8 +263,9 @@ where
                 let mut body_logs: Vec<SimBundleLogs> = Vec::new();
 
                 let mut evm = eth_api.evm_config().evm_with_env(db, evm_env);
+                let mut log_index = 0;
 
-                for item in &flattened_bundle {
+                for (tx_index, item) in flattened_bundle.iter().enumerate() {
                     // Check inclusion constraints
                     let block_number = item.inclusion.block_number();
                     let max_block_number =
@@ -312,7 +314,24 @@ where
                     // TODO: since we are looping over iteratively, we are not collecting bundle
                     // logs. We should collect bundle logs when we are processing the bundle items.
                     if logs {
-                        let tx_logs = result.logs().to_vec();
+                        let tx_logs = result
+                            .logs()
+                            .iter()
+                            .map(|log| {
+                                let full_log = alloy_rpc_types_eth::Log {
+                                    inner: log.clone(),
+                                    block_hash: None,
+                                    block_number: None,
+                                    block_timestamp: None,
+                                    transaction_hash: Some(*item.tx.tx_hash()),
+                                    transaction_index: Some(tx_index as u64),
+                                    log_index: Some(log_index),
+                                    removed: false,
+                                };
+                                log_index += 1;
+                                full_log
+                            })
+                            .collect();
                         let sim_bundle_logs =
                             SimBundleLogs { tx_logs: Some(tx_logs), bundle_logs: None };
                         body_logs.push(sim_bundle_logs);


### PR DESCRIPTION
DRAFT since it uses an unpublished alloy fork in 65a46fef2720d9abf8a93cd036714a386bc217f0 since it needs https://github.com/alloy-rs/alloy/pull/2061.

This gets a closer to being a drop-in replacement for mev-geth, but is still missing `blockHash` and `blockNumber` values in the `txLogs` objects.

I think the cleanest way to get those would actually be to reuse some of the helpers from the `eth_simulateV1` `simulate` namespace, namely `simulate::build_simulated_block(...)` but maybe a couple more.