### PR TITLE
feat: use `SealedHeader` in `ChainSpec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,7 @@ dependencies = [
 name = "example-bsc-p2p"
 version = "0.0.0"
 dependencies = [
+ "alloy-genesis",
  "alloy-primitives",
  "reth-chainspec",
  "reth-discv4",
@@ -3224,6 +3225,7 @@ dependencies = [
 name = "example-polygon-p2p"
 version = "0.0.0"
 dependencies = [
+ "alloy-genesis",
  "alloy-primitives",
  "reth-chainspec",
  "reth-discv4",

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -30,8 +30,9 @@ pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;
 pub use spec::{
-    BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, ChainSpecProvider,
-    DepositContract, ForkBaseFeeParams, HardforkBlobParams, DEV, HOLESKY, MAINNET, SEPOLIA,
+    make_genesis_header, BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder,
+    ChainSpecProvider, DepositContract, ForkBaseFeeParams, HardforkBlobParams, DEV, HOLESKY,
+    MAINNET, SEPOLIA,
 };
 
 use reth_primitives_traits::sync::OnceLock;

--- a/crates/ethereum/cli/src/lib.rs
+++ b/crates/ethereum/cli/src/lib.rs
@@ -23,7 +23,7 @@ mod test {
         let cmd: NodeCommand = NodeCommand::parse_from(["reth", "--dev"]);
         let chain = DEV.clone();
         assert_eq!(cmd.chain.chain, chain.chain);
-        assert_eq!(cmd.chain.genesis_hash, chain.genesis_hash);
+        assert_eq!(cmd.chain.genesis_hash(), chain.genesis_hash());
         assert_eq!(
             cmd.chain.paris_block_and_final_difficulty,
             chain.paris_block_and_final_difficulty

--- a/crates/optimism/chainspec/src/base.rs
+++ b/crates/optimism/chainspec/src/base.rs
@@ -4,24 +4,28 @@ use alloc::{sync::Arc, vec};
 
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{make_genesis_header, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, Hardfork};
 use reth_optimism_forks::OpHardfork;
+use reth_primitives_traits::SealedHeader;
 
 use crate::{LazyLock, OpChainSpec};
 
 /// The Base mainnet spec
 pub static BASE_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    let genesis = serde_json::from_str(include_str!("../res/genesis/base.json"))
+        .expect("Can't deserialize Base genesis json");
+    let hardforks = OpHardfork::base_mainnet();
     OpChainSpec {
         inner: ChainSpec {
             chain: Chain::base_mainnet(),
-            genesis: serde_json::from_str(include_str!("../res/genesis/base.json"))
-                .expect("Can't deserialize Base genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
-            )),
+            genesis_header: SealedHeader::new(
+                make_genesis_header(&genesis, &hardforks),
+                b256!("f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"),
+            ),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::base_mainnet(),
+            hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(
                 vec![
                     (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),

--- a/crates/optimism/chainspec/src/base_sepolia.rs
+++ b/crates/optimism/chainspec/src/base_sepolia.rs
@@ -4,24 +4,28 @@ use alloc::{sync::Arc, vec};
 
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
+use reth_chainspec::{make_genesis_header, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_optimism_forks::OpHardfork;
+use reth_primitives_traits::SealedHeader;
 
 use crate::{LazyLock, OpChainSpec};
 
 /// The Base Sepolia spec
 pub static BASE_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    let genesis = serde_json::from_str(include_str!("../res/genesis/sepolia_base.json"))
+        .expect("Can't deserialize Base Sepolia genesis json");
+    let hardforks = OpHardfork::base_sepolia();
     OpChainSpec {
         inner: ChainSpec {
             chain: Chain::base_sepolia(),
-            genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_base.json"))
-                .expect("Can't deserialize Base Sepolia genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
-            )),
+            genesis_header: SealedHeader::new(
+                make_genesis_header(&genesis, &hardforks),
+                b256!("0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"),
+            ),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::base_sepolia(),
+            hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(
                 vec![
                     (EthereumHardfork::London.boxed(), BaseFeeParams::base_sepolia()),

--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -5,8 +5,9 @@ use alloc::sync::Arc;
 use alloy_chains::Chain;
 use alloy_consensus::constants::DEV_GENESIS_HASH;
 use alloy_primitives::U256;
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
+use reth_chainspec::{make_genesis_header, BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_optimism_forks::DEV_HARDFORKS;
+use reth_primitives_traits::SealedHeader;
 
 use crate::{LazyLock, OpChainSpec};
 
@@ -15,14 +16,19 @@ use crate::{LazyLock, OpChainSpec};
 /// Includes 20 prefunded accounts with `10_000` ETH each derived from mnemonic "test test test test
 /// test test test test test test test junk".
 pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    let genesis = serde_json::from_str(include_str!("../res/genesis/dev.json"))
+        .expect("Can't deserialize Dev testnet genesis json");
+    let hardforks = DEV_HARDFORKS.clone();
     OpChainSpec {
         inner: ChainSpec {
             chain: Chain::dev(),
-            genesis: serde_json::from_str(include_str!("../res/genesis/dev.json"))
-                .expect("Can't deserialize Dev testnet genesis json"),
-            genesis_hash: once_cell_set(DEV_GENESIS_HASH),
+            genesis_header: SealedHeader::new(
+                make_genesis_header(&genesis, &hardforks),
+                DEV_GENESIS_HASH,
+            ),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: DEV_HARDFORKS.clone(),
+            hardforks,
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
             deposit_contract: None, // TODO: do we even have?
             ..Default::default()

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -443,8 +443,8 @@ mod tests {
 
     #[test]
     fn base_mainnet_forkids() {
-        let base_mainnet = OpChainSpecBuilder::base_mainnet().build();
-        let _ = base_mainnet.genesis_hash.set(BASE_MAINNET.genesis_hash.get().copied().unwrap());
+        let mut base_mainnet = OpChainSpecBuilder::base_mainnet().build();
+        base_mainnet.inner.genesis_header.set_hash(BASE_MAINNET.genesis_hash());
         test_fork_ids(
             &BASE_MAINNET,
             &[
@@ -539,10 +539,10 @@ mod tests {
 
     #[test]
     fn op_mainnet_forkids() {
-        let op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
+        let mut op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
         // for OP mainnet we have to do this because the genesis header can't be properly computed
         // from the genesis.json file
-        let _ = op_mainnet.genesis_hash.set(OP_MAINNET.genesis_hash());
+        op_mainnet.inner.genesis_header.set_hash(OP_MAINNET.genesis_hash());
         test_fork_ids(
             &op_mainnet,
             &[

--- a/crates/optimism/chainspec/src/op.rs
+++ b/crates/optimism/chainspec/src/op.rs
@@ -4,24 +4,28 @@ use crate::{LazyLock, OpChainSpec};
 use alloc::{sync::Arc, vec};
 use alloy_chains::Chain;
 use alloy_primitives::{b256, U256};
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
+use reth_chainspec::{make_genesis_header, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_optimism_forks::OpHardfork;
+use reth_primitives_traits::SealedHeader;
 
 /// The Optimism Mainnet spec
 pub static OP_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    // genesis contains empty alloc field because state at first bedrock block is imported
+    // manually from trusted source
+    let genesis = serde_json::from_str(include_str!("../res/genesis/optimism.json"))
+        .expect("Can't deserialize Optimism Mainnet genesis json");
+    let hardforks = OpHardfork::op_mainnet();
     OpChainSpec {
         inner: ChainSpec {
             chain: Chain::optimism_mainnet(),
-            // genesis contains empty alloc field because state at first bedrock block is imported
-            // manually from trusted source
-            genesis: serde_json::from_str(include_str!("../res/genesis/optimism.json"))
-                .expect("Can't deserialize Optimism Mainnet genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"
-            )),
+            genesis_header: SealedHeader::new(
+                make_genesis_header(&genesis, &hardforks),
+                b256!("7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"),
+            ),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::op_mainnet(),
+            hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(
                 vec![
                     (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),

--- a/crates/optimism/chainspec/src/op_sepolia.rs
+++ b/crates/optimism/chainspec/src/op_sepolia.rs
@@ -4,22 +4,26 @@ use crate::{LazyLock, OpChainSpec};
 use alloc::{sync::Arc, vec};
 use alloy_chains::{Chain, NamedChain};
 use alloy_primitives::{b256, U256};
-use reth_chainspec::{once_cell_set, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
+use reth_chainspec::{make_genesis_header, BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_optimism_forks::OpHardfork;
+use reth_primitives_traits::SealedHeader;
 
 /// The OP Sepolia spec
 pub static OP_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    let genesis = serde_json::from_str(include_str!("../res/genesis/sepolia_op.json"))
+        .expect("Can't deserialize OP Sepolia genesis json");
+    let hardforks = OpHardfork::op_sepolia();
     OpChainSpec {
         inner: ChainSpec {
             chain: Chain::from_named(NamedChain::OptimismSepolia),
-            genesis: serde_json::from_str(include_str!("../res/genesis/sepolia_op.json"))
-                .expect("Can't deserialize OP Sepolia genesis json"),
-            genesis_hash: once_cell_set(b256!(
-                "102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
-            )),
+            genesis_header: SealedHeader::new(
+                make_genesis_header(&genesis, &hardforks),
+                b256!("102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"),
+            ),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
-            hardforks: OpHardfork::op_sepolia(),
+            hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(
                 vec![
                     (EthereumHardfork::London.boxed(), BaseFeeParams::optimism_sepolia()),

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -209,7 +209,7 @@ mod test {
         let cmd = NodeCommand::<OpChainSpecParser, NoArgs>::parse_from(["op-reth", "--dev"]);
         let chain = OP_DEV.clone();
         assert_eq!(cmd.chain.chain, chain.chain);
-        assert_eq!(cmd.chain.genesis_hash, chain.genesis_hash);
+        assert_eq!(cmd.chain.genesis_hash(), chain.genesis_hash());
         assert_eq!(
             cmd.chain.paris_block_and_final_difficulty,
             chain.paris_block_and_final_difficulty

--- a/crates/optimism/consensus/src/validation/mod.rs
+++ b/crates/optimism/consensus/src/validation/mod.rs
@@ -160,7 +160,7 @@ mod tests {
             inner: ChainSpec {
                 chain: BASE_SEPOLIA.inner.chain,
                 genesis: BASE_SEPOLIA.inner.genesis.clone(),
-                genesis_hash: BASE_SEPOLIA.inner.genesis_hash.clone(),
+                genesis_header: BASE_SEPOLIA.inner.genesis_header.clone(),
                 paris_block_and_final_difficulty: Some((0, U256::from(0))),
                 hardforks,
                 base_fee_params: BASE_SEPOLIA.inner.base_fee_params.clone(),

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -232,7 +232,7 @@ mod test {
             inner: ChainSpec {
                 chain: BASE_SEPOLIA.inner.chain,
                 genesis: BASE_SEPOLIA.inner.genesis.clone(),
-                genesis_hash: BASE_SEPOLIA.inner.genesis_hash.clone(),
+                genesis_header: BASE_SEPOLIA.inner.genesis_header.clone(),
                 paris_block_and_final_difficulty: BASE_SEPOLIA
                     .inner
                     .paris_block_and_final_difficulty,

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -724,7 +724,6 @@ mod tests {
                 ..Default::default()
             },
             hardforks: Default::default(),
-            genesis_hash: Default::default(),
             paris_block_and_final_difficulty: None,
             deposit_contract: None,
             ..Default::default()

--- a/examples/bsc-p2p/Cargo.toml
+++ b/examples/bsc-p2p/Cargo.toml
@@ -23,4 +23,5 @@ tokio-stream.workspace = true
 
 serde_json.workspace = true
 
+alloy-genesis.workspace = true
 alloy-primitives.workspace = true

--- a/examples/bsc-p2p/src/chainspec.rs
+++ b/examples/bsc-p2p/src/chainspec.rs
@@ -1,33 +1,14 @@
-use alloy_primitives::{b256, B256};
-use reth_chainspec::{
-    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork,
-    ForkCondition, Hardfork,
-};
+use alloy_genesis::Genesis;
+use reth_chainspec::ChainSpec;
 use reth_network_peers::NodeRecord;
-
 use std::sync::Arc;
 
 pub const SHANGHAI_TIME: u64 = 1705996800;
 
 pub(crate) fn bsc_chain_spec() -> Arc<ChainSpec> {
-    const GENESIS: B256 = b256!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b");
-
-    ChainSpec {
-        chain: Chain::from_id(56),
-        genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
-        genesis_hash: once_cell_set(GENESIS),
-        genesis_header: Default::default(),
-        paris_block_and_final_difficulty: None,
-        hardforks: ChainHardforks::new(vec![(
-            EthereumHardfork::Shanghai.boxed(),
-            ForkCondition::Timestamp(SHANGHAI_TIME),
-        )]),
-        deposit_contract: None,
-        base_fee_params: reth_chainspec::BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
-        prune_delete_limit: 0,
-        blob_params: Default::default(),
-    }
-    .into()
+    let genesis: Genesis =
+        serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis");
+    Arc::new(genesis.into())
 }
 
 /// BSC mainnet bootnodes <https://github.com/bnb-chain/bsc/blob/master/params/bootnodes.go#L23>

--- a/examples/polygon-p2p/Cargo.toml
+++ b/examples/polygon-p2p/Cargo.toml
@@ -19,3 +19,4 @@ reth-tracing.workspace = true
 tokio-stream.workspace = true
 reth-discv4 = { workspace = true, features = ["test-utils"] }
 alloy-primitives.workspace = true
+alloy-genesis.workspace = true

--- a/examples/polygon-p2p/src/chain_cfg.rs
+++ b/examples/polygon-p2p/src/chain_cfg.rs
@@ -1,8 +1,5 @@
-use alloy_primitives::{b256, B256};
-use reth_chainspec::{
-    once_cell_set, BaseFeeParams, Chain, ChainHardforks, ChainSpec, EthereumHardfork,
-    ForkCondition, Hardfork,
-};
+use alloy_genesis::Genesis;
+use reth_chainspec::ChainSpec;
 use reth_discv4::NodeRecord;
 use reth_primitives::Head;
 
@@ -11,29 +8,9 @@ use std::sync::Arc;
 const SHANGHAI_BLOCK: u64 = 50523000;
 
 pub(crate) fn polygon_chain_spec() -> Arc<ChainSpec> {
-    const GENESIS: B256 = b256!("a9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b");
-
-    ChainSpec {
-        chain: Chain::from_id(137),
-        // <https://github.com/maticnetwork/bor/blob/d521b8e266b97efe9c8fdce8167e9dd77b04637d/builder/files/genesis-mainnet-v1.json>
-        genesis: serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis"),
-        genesis_hash: once_cell_set(GENESIS),
-        genesis_header: Default::default(),
-        paris_block_and_final_difficulty: None,
-        hardforks: ChainHardforks::new(vec![
-            (EthereumHardfork::Petersburg.boxed(), ForkCondition::Block(0)),
-            (EthereumHardfork::Istanbul.boxed(), ForkCondition::Block(3395000)),
-            (EthereumHardfork::MuirGlacier.boxed(), ForkCondition::Block(3395000)),
-            (EthereumHardfork::Berlin.boxed(), ForkCondition::Block(14750000)),
-            (EthereumHardfork::London.boxed(), ForkCondition::Block(23850000)),
-            (EthereumHardfork::Shanghai.boxed(), ForkCondition::Block(SHANGHAI_BLOCK)),
-        ]),
-        deposit_contract: None,
-        base_fee_params: reth_chainspec::BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
-        prune_delete_limit: 0,
-        blob_params: Default::default(),
-    }
-    .into()
+    let genesis: Genesis =
+        serde_json::from_str(include_str!("./genesis.json")).expect("deserialize genesis");
+    Arc::new(genesis.into())
 }
 
 /// Polygon mainnet boot nodes <https://github.com/maticnetwork/bor/blob/master/params/bootnodes.go#L79>


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/14469
Closes https://github.com/paradigmxyz/reth/issues/14355
Supersedes https://github.com/paradigmxyz/reth/pull/14441

Requires header to always be provided when setting up a chainspec.

This unblocks custom chain-dependant logic for `Genesis` -> `Header` conversion required for e.g Isthmus, and allows to make chainspec generic over header.

We still need `make_genesis_header` as it's useful for basic conversion, not sure if it makes more sense to put it somewhere else vs just a free function?