### PR TITLE
docs: update broken link run-a-node.md

### DIFF
--- a/book/run/run-a-node.md
+++ b/book/run/run-a-node.md
@@ -12,4 +12,4 @@ In this chapter we'll go through a few different topics you'll encounter when ru
 1. [Ports](./ports.md)
 1. [Troubleshooting](./troubleshooting.md)
 
-In the future, we also intend to support the [OP Stack](https://stack.optimism.io/docs/understand/explainer/), which will allow you to run Reth as a Layer 2 client. More there soon!
+In the future, we also intend to support the [OP Stack](https://docs.optimism.io/get-started/superchain), which will allow you to run Reth as a Layer 2 client. More there soon!


### PR DESCRIPTION
Hi! This PR addresses an issue where the link to the OP Stack documentation in `run-a-node.md` was outdated. The link has been updated to point to the current and correct documentation.

**Why this change is important:**
- The previous link (`https://stack.optimism.io/docs/understand/explainer/`) no longer points to the correct resource.
![image](https://github.com/user-attachments/assets/9dec5987-928d-47e6-afb4-8df3b6009ec1)

- The new link (`https://docs.optimism.io/get-started/superchain`) directs users to the official and up-to-date documentation for the OP Stack.
![image](https://github.com/user-attachments/assets/f50b5974-6194-471a-97d8-750264e625d2)
