### PR TITLE
chore(docs): add book/cli to workspace exclusions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ members = [
     "testing/testing-utils",
 ]
 default-members = ["bin/reth"]
-exclude = ["book/sources"]
+exclude = ["book/sources", "book/cli"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html


### PR DESCRIPTION
Fixes `book/cli/update.sh` error:
```
Running: $ ./book/cli/help.rs --root-dir ./book/ --root-indentation 2 --root-summary --out-dir ./book/cli/ target/debug/reth
error: current package believes it's in a workspace when it's not:
current:   /home/runner/work/reth/reth/book/cli/help.rs
workspace: /home/runner/work/reth/reth/Cargo.toml

this may be fixable by adding `book/cli` to the `workspace.members` array of the manifest located at: /home/runner/work/reth/reth/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```
like in this ci run https://github.com/paradigmxyz/reth/actions/runs/13357770985/job/37303297198?pr=14525. Probably caused by a nightly update https://github.com/paradigmxyz/reth/pull/14522#issuecomment-2661492478