### PR TITLE
chore: relax bounds on RPC types

### DIFF
--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -2,7 +2,6 @@
 
 use alloy_consensus::{transaction::TransactionMeta, BlockHeader};
 use alloy_rpc_types_eth::BlockId;
-use op_alloy_network::Network;
 use op_alloy_rpc_types::OpTransactionReceipt;
 use reth_chainspec::ChainSpecProvider;
 use reth_node_api::BlockBody;
@@ -12,6 +11,7 @@ use reth_primitives_traits::SignedTransaction;
 use reth_provider::{BlockReader, HeaderProvider};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
+    types::RpcTypes,
     RpcReceipt,
 };
 
@@ -21,7 +21,7 @@ impl<N> EthBlocks for OpEthApi<N>
 where
     Self: LoadBlock<
         Error = OpEthApiError,
-        NetworkTypes: Network<ReceiptResponse = OpTransactionReceipt>,
+        NetworkTypes: RpcTypes<Receipt = OpTransactionReceipt>,
         Provider: BlockReader<Receipt = OpReceipt, Transaction = OpTransactionSigned>,
     >,
     N: OpNodeCore<Provider: ChainSpecProvider<ChainSpec = OpChainSpec> + HeaderProvider>,

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -8,7 +8,6 @@ use alloy_consensus::{
 use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE, BlockNumberOrTag};
 use alloy_primitives::{B256, U256};
 use op_alloy_consensus::{OpDepositReceipt, OpTxType};
-use op_alloy_network::Network;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;
@@ -21,6 +20,7 @@ use reth_provider::{
 };
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
+    types::RpcTypes,
     EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock};
@@ -31,8 +31,8 @@ impl<N> LoadPendingBlock for OpEthApi<N>
 where
     Self: SpawnBlocking
         + EthApiTypes<
-            NetworkTypes: Network<
-                HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+            NetworkTypes: RpcTypes<
+                Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
             >,
             Error: FromEvmError<Self::Evm>,
         >,

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -2,10 +2,9 @@
 //! RPC methods.
 
 use super::SpawnBlocking;
-use crate::{EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore};
+use crate::{types::RpcTypes, EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore};
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK;
-use alloy_network::Network;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use futures::Future;
@@ -41,8 +40,8 @@ use tracing::debug;
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` blocks RPC methods.
 pub trait LoadPendingBlock:
     EthApiTypes<
-        NetworkTypes: Network<
-            HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+        NetworkTypes: RpcTypes<
+            Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
         >,
         Error: FromEvmError<Self::Evm>,
     > + RpcNodeCore<

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -28,9 +28,9 @@ impl<T> RpcTypes for T
 where
     T: Network,
 {
-    type Header = <T as Network>::HeaderResponse;
-    type Receipt = <T as Network>::ReceiptResponse;
-    type Transaction = <T as Network>::TransactionResponse;
+    type Header = T::HeaderResponse;
+    type Receipt = T::ReceiptResponse;
+    type Transaction = T::TransactionResponse;
 }
 
 /// Network specific `eth` API types.

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -1,7 +1,8 @@
 //! Trait for specifying `eth` network dependent API types.
 
 use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
-use alloy_network::Network;
+use alloy_json_rpc::RpcObject;
+use alloy_network::{Network, ReceiptResponse, TransactionResponse};
 use alloy_rpc_types_eth::Block;
 use reth_provider::{ProviderTx, ReceiptProvider, TransactionsProvider};
 use reth_rpc_types_compat::TransactionCompat;
@@ -10,6 +11,27 @@ use std::{
     error::Error,
     fmt::{self},
 };
+
+/// RPC types used by the `eth_` RPC API.
+///
+/// This is a subset of [`alloy_network::Network`] trait with only RPC response types kept.
+pub trait RpcTypes {
+    /// Header response type.
+    type Header: RpcObject;
+    /// Receipt response type.
+    type Receipt: RpcObject + ReceiptResponse;
+    /// Transaction response type.
+    type Transaction: RpcObject + TransactionResponse;
+}
+
+impl<T> RpcTypes for T
+where
+    T: Network,
+{
+    type Header = <T as Network>::HeaderResponse;
+    type Receipt = <T as Network>::ReceiptResponse;
+    type Transaction = <T as Network>::TransactionResponse;
+}
 
 /// Network specific `eth` API types.
 ///
@@ -28,7 +50,7 @@ pub trait EthApiTypes: Send + Sync + Clone {
         + Send
         + Sync;
     /// Blockchain primitive types, specific to network, e.g. block and transaction.
-    type NetworkTypes: Network;
+    type NetworkTypes: RpcTypes;
     /// Conversion methods for transaction RPC type.
     type TransactionCompat: Send + Sync + Clone + fmt::Debug;
 
@@ -37,16 +59,16 @@ pub trait EthApiTypes: Send + Sync + Clone {
 }
 
 /// Adapter for network specific transaction type.
-pub type RpcTransaction<T> = <T as Network>::TransactionResponse;
+pub type RpcTransaction<T> = <T as RpcTypes>::Transaction;
 
 /// Adapter for network specific block type.
-pub type RpcBlock<T> = Block<RpcTransaction<T>, <T as Network>::HeaderResponse>;
+pub type RpcBlock<T> = Block<RpcTransaction<T>, RpcHeader<T>>;
 
 /// Adapter for network specific receipt type.
-pub type RpcReceipt<T> = <T as Network>::ReceiptResponse;
+pub type RpcReceipt<T> = <T as RpcTypes>::Receipt;
 
 /// Adapter for network specific header type.
-pub type RpcHeader<T> = <T as Network>::HeaderResponse;
+pub type RpcHeader<T> = <T as RpcTypes>::Header;
 
 /// Adapter for network specific error type.
 pub type RpcError<T> = <T as EthApiTypes>::Error;

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -7,6 +7,7 @@ use reth_primitives_traits::{BlockBody, SignedTransaction};
 use reth_provider::{BlockReader, ChainSpecProvider};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
+    types::RpcTypes,
     RpcNodeCoreExt, RpcReceipt,
 };
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
@@ -17,7 +18,7 @@ impl<Provider, Pool, Network, EvmConfig> EthBlocks for EthApi<Provider, Pool, Ne
 where
     Self: LoadBlock<
         Error = EthApiError,
-        NetworkTypes: alloy_network::Network<ReceiptResponse = TransactionReceipt>,
+        NetworkTypes: RpcTypes<Receipt = TransactionReceipt>,
         Provider: BlockReader<
             Transaction = reth_primitives::TransactionSigned,
             Receipt = reth_primitives::Receipt,

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -13,6 +13,7 @@ use reth_provider::{
 };
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
+    types::RpcTypes,
     FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::PendingBlock;
@@ -25,7 +26,7 @@ impl<Provider, Pool, Network, EvmConfig> LoadPendingBlock
     for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: SpawnBlocking<
-            NetworkTypes: alloy_network::Network<HeaderResponse = alloy_rpc_types_eth::Header>,
+            NetworkTypes: RpcTypes<Header = alloy_rpc_types_eth::Header>,
             Error: FromEvmError<Self::Evm>,
         > + RpcNodeCore<
             Provider: BlockReaderIdExt<


### PR DESCRIPTION
Right now any eth API implementation is required to provide an `alloy_network::Network` implementation to configure RPC types which is too restrictive as it also requires a bunch of consensus types which might be different from the ones in the node itself.

This PR introduces a separate `RpcTypes` trait which only contains the respones types and still has blanket impl for any `alloy_network::Network` type