### PR TITLE
feat: use `PROMETHEUS_URL` env var for Grafana in Docker Compose

### DIFF
--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     ports:
       - 3000:3000
     environment:
-      PROMETHEUS_URL: http://prometheus:9090
+      PROMETHEUS_URL: ${PROMETHEUS_URL:-http://prometheus:9090}
     volumes:
       - grafanadata:/var/lib/grafana
       - ./grafana/datasources:/etc/grafana/provisioning/datasources


### PR DESCRIPTION
Useful when you port-forwarded Prometheus from a remote machine, and locally want to access that Prometheus from the Grafana running in Docker

```console
PROMETHEUS_URL=http://host.docker.internal:9090 docker compose -f etc/docker-compose.yml up --no-deps -d grafana
```