### PR TITLE
chore: allow missing total difficulty when loading node head

### DIFF
--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -323,7 +323,9 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
 
         let total_difficulty = provider
             .header_td_by_number(head)?
-            .expect("the total difficulty for the latest block is missing, database is corrupt");
+            // total difficulty is effectively deprecated, but still required in some places, e.g.
+            // p2p
+            .unwrap_or_default();
 
         let hash = provider
             .block_hash(head)?


### PR DESCRIPTION
we shouldn't Hit this expect because we store the paris ttd in the chainspec but we can relax this and think about not storing ttd at all