### PR TITLE
chore(trie): groups renamed to state_masks in hash builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,8 +842,7 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
+source = "git+https://github.com/alloy-rs/trie?rev=1825c77#1825c775c9d99d94a1b1c4b6903b01cd9f68533c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -1999,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2891,7 +2890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4464,7 +4463,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4807,7 +4806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6238,7 +6237,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10085,7 +10084,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10958,7 +10957,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11521,7 +11520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -11969,7 +11968,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -611,7 +611,7 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 # See: https://github.com/eira-fransham/crunchy/issues/13
 crunchy = "=0.2.2"
 
-# [patch.crates-io]
+[patch.crates-io]
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
@@ -647,3 +647,5 @@ crunchy = "=0.2.2"
 # op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "ad607c1" }
 #
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1207e33" }
+
+alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "1825c77" }

--- a/crates/trie/common/src/hash_builder/state.rs
+++ b/crates/trie/common/src/hash_builder/state.rs
@@ -21,7 +21,7 @@ pub struct HashBuilderState {
     pub stack: Vec<RlpNode>,
 
     /// Group masks.
-    pub groups: Vec<TrieMask>,
+    pub state_masks: Vec<TrieMask>,
     /// Tree masks.
     pub tree_masks: Vec<TrieMask>,
     /// Hash masks.
@@ -37,7 +37,7 @@ impl From<HashBuilderState> for HashBuilder {
             key: Nibbles::from_nibbles_unchecked(state.key),
             stack: state.stack,
             value: state.value,
-            groups: state.groups,
+            state_masks: state.state_masks,
             tree_masks: state.tree_masks,
             hash_masks: state.hash_masks,
             stored_in_database: state.stored_in_database,
@@ -54,7 +54,7 @@ impl From<HashBuilder> for HashBuilderState {
             key: state.key.into(),
             stack: state.stack,
             value: state.value,
-            groups: state.groups,
+            state_masks: state.state_masks,
             tree_masks: state.tree_masks,
             hash_masks: state.hash_masks,
             stored_in_database: state.stored_in_database,
@@ -82,9 +82,9 @@ impl reth_codecs::Compact for HashBuilderState {
 
         len += self.value.to_compact(buf);
 
-        buf.put_u16(self.groups.len() as u16);
+        buf.put_u16(self.state_masks.len() as u16);
         len += 2;
-        for item in &self.groups {
+        for item in &self.state_masks {
             len += (*item).to_compact(buf);
         }
 
@@ -120,11 +120,11 @@ impl reth_codecs::Compact for HashBuilderState {
 
         let (value, mut buf) = HashBuilderValue::from_compact(buf, 0);
 
-        let groups_len = buf.get_u16() as usize;
-        let mut groups = Vec::with_capacity(groups_len);
-        for _ in 0..groups_len {
+        let state_masks_len = buf.get_u16() as usize;
+        let mut state_masks = Vec::with_capacity(state_masks_len);
+        for _ in 0..state_masks_len {
             let (item, rest) = TrieMask::from_compact(buf, 0);
-            groups.push(item);
+            state_masks.push(item);
             buf = rest;
         }
 
@@ -145,7 +145,7 @@ impl reth_codecs::Compact for HashBuilderState {
         }
 
         let stored_in_database = buf.get_u8() != 0;
-        (Self { key, stack, value, groups, tree_masks, hash_masks, stored_in_database }, buf)
+        (Self { key, stack, value, state_masks, tree_masks, hash_masks, stored_in_database }, buf)
     }
 }
 


### PR DESCRIPTION
Blocked on https://github.com/alloy-rs/trie release