### PR TITLE
fix(root): yield from sparse trie task

### DIFF
--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -43,14 +43,13 @@ use tracing::{debug, error, trace, trace_span};
 const SPARSE_TRIE_INCREMENTAL_LEVEL: usize = 2;
 
 /// Determines the size of the thread pool to be used in [`StateRootTask`].
-/// It should be at least three, one for multiproof calculations  plus two to be
-/// used internally in [`StateRootTask`].
+/// It should be at least two, one for spawning multiproof calculations plus one to be
+/// used by multiproof calculation internally.
 ///
 /// NOTE: this value can be greater than the available cores in the host, it
 /// represents the maximum number of threads that can be handled by the pool.
 pub(crate) fn thread_pool_size() -> usize {
-    // std::thread::available_parallelism().map_or(3, |num| (num.get() / 2).max(3))
-    2
+    std::thread::available_parallelism().map_or(2, |num| (num.get() / 2).max(2))
 }
 
 /// Determines if the host has enough parallelism to run the state root task.

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -1035,22 +1035,21 @@ where
 
     'main: loop {
         let mut update: Option<SparseTrieUpdate> = None;
-        num_iterations += 1;
 
         let mut num_updates = 0;
         'poll: loop {
             match update_rx.try_recv() {
                 Ok(next) => {
                     num_updates += 1;
-                    update.get_or_insert_default().extend(next);
+                    update.get_or_insert_with(SparseTrieUpdate::default).extend(next);
                 }
                 Err(TryRecvError::Empty) => break 'poll,
                 Err(TryRecvError::Disconnected) => {
                     if update.is_some() {
                         break 'poll
-                    } else {
-                        break 'main
                     }
+
+                    break 'main
                 }
             };
         }
@@ -1060,6 +1059,7 @@ where
             continue 'main;
         };
 
+        num_iterations += 1;
         debug!(
             target: "engine::root",
             num_updates,

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -369,7 +369,7 @@ where
 {
     /// Creates a new [`MultiproofManager`].
     fn new(thread_pool: Arc<rayon::ThreadPool>, thread_pool_size: usize) -> Self {
-        // we keep 2 threads to be used internally by [`StateRootTask`]
+        // we keep 1 thread to be used internally by [`StateRootTask`]
         let max_concurrent = thread_pool_size.saturating_sub(1);
         debug_assert!(max_concurrent != 0);
         Self {


### PR DESCRIPTION
## Description

Sparse trie task is a long running task on rayon thread pool. It blocks on each iteration attempting to receive sparse trie updates from the main task.

Yield from sparse trie task if there is no work to be done.