### PR TITLE
chore(chainspec): remove `MAINNET` usage from `ChainSpec::default`

### DIFF
--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -4,6 +4,10 @@ use alloy_primitives::b256;
 
 /// Gas per transaction not creating a contract.
 pub const MIN_TRANSACTION_GAS: u64 = 21_000u64;
+
+/// Mainnet prune delete limit.
+pub const MAINNET_PRUNE_DELETE_LIMIT: usize = 20000;
+
 /// Deposit contract address: `0x00000000219ab540356cbb839cbe05303d7705fa`
 pub(crate) const MAINNET_DEPOSIT_CONTRACT: DepositContract = DepositContract::new(
     MAINNET_DEPOSIT_CONTRACT_ADDRESS,

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -12,8 +12,8 @@
 extern crate alloc;
 
 /// Chain specific constants
-pub(crate) mod constants;
-pub use constants::MIN_TRANSACTION_GAS;
+mod constants;
+pub use constants::*;
 
 mod api;
 /// The chain info module.

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1,6 +1,9 @@
 pub use alloy_eips::eip1559::BaseFeeParams;
 
-use crate::{constants::MAINNET_DEPOSIT_CONTRACT, EthChainSpec};
+use crate::{
+    constants::{MAINNET_DEPOSIT_CONTRACT, MAINNET_PRUNE_DELETE_LIMIT},
+    EthChainSpec,
+};
 use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::{
@@ -320,7 +323,7 @@ impl Default for ChainSpec {
             hardforks: Default::default(),
             deposit_contract: Default::default(),
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
-            prune_delete_limit: MAINNET.prune_delete_limit,
+            prune_delete_limit: MAINNET_PRUNE_DELETE_LIMIT,
             blob_params: Default::default(),
         }
     }

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::{segments::SegmentSet, Pruner};
 use alloy_eips::eip2718::Encodable2718;
-use reth_chainspec::MAINNET;
+use reth_chainspec::MAINNET_PRUNE_DELETE_LIMIT;
 use reth_config::PruneConfig;
 use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_exex_types::FinishedExExHeight;
@@ -129,7 +129,7 @@ impl Default for PrunerBuilder {
         Self {
             block_interval: 5,
             segments: PruneModes::none(),
-            delete_limit: MAINNET.prune_delete_limit,
+            delete_limit: MAINNET_PRUNE_DELETE_LIMIT,
             timeout: None,
             finished_exex_height: watch::channel(FinishedExExHeight::NoExExs).1,
         }

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -20,8 +20,9 @@ mod target;
 
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::{Address, BlockNumber};
-pub use checkpoint::PruneCheckpoint;
 use core::ops::Deref;
+
+pub use checkpoint::PruneCheckpoint;
 pub use event::PrunerEvent;
 pub use mode::PruneMode;
 pub use pruner::{


### PR DESCRIPTION
Avoids initializing the `MAINNET` `ChainSpec` unnecessarily, although it's probably used like this in other places.