### PR TITLE
chore(hive): rename expected eest failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -52,6 +52,6 @@ sync: []
 
 # no fix: it’s too expensive to check whether the storage is empty on each creation
 eest/consume-engine:
-  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test_engine-zero_nonce]-blockchain_test_engine-reth
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test_engine-zero_nonce]-reth
 eest/consume-rlp:
-  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]-blockchain_test-reth
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]-reth


### PR DESCRIPTION
eest tests started failing like in https://github.com/paradigmxyz/reth/actions/runs/13402629846, the names of the expected failures have changed.

successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/13408304944