### PR TITLE
refactor: simplify `SystemCaller` API

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -78,8 +78,7 @@ where
         // Setup EVM
         let mut evm = self.evm_config.evm_for_block(&mut db, block.header());
 
-        let mut system_caller =
-            SystemCaller::new(self.evm_config.clone(), self.provider.chain_spec());
+        let mut system_caller = SystemCaller::new(self.provider.chain_spec());
 
         // Apply pre-block system contract calls.
         system_caller.apply_pre_execution_changes(block.header(), &mut evm)?;

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -293,14 +293,10 @@ where
     let mut evm = evm_config.evm_for_block(&mut state, &reorg_target.header);
 
     // apply eip-4788 pre block contract call
-    let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
+    let mut system_caller = SystemCaller::new(chain_spec.clone());
 
-    system_caller.apply_beacon_root_contract_call(
-        reorg_target.timestamp,
-        reorg_target.number,
-        reorg_target.parent_beacon_block_root,
-        &mut evm,
-    )?;
+    system_caller
+        .apply_beacon_root_contract_call(reorg_target.parent_beacon_block_root, &mut evm)?;
 
     let mut cumulative_gas_used = 0;
     let mut sum_blob_gas_used = 0;

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -90,7 +90,7 @@ where
     /// Current state for block execution.
     state: State<DB>,
     /// Utility to call system smart contracts.
-    system_caller: SystemCaller<EvmConfig, ChainSpec>,
+    system_caller: SystemCaller<Arc<ChainSpec>>,
 }
 
 impl<DB, EvmConfig> EthExecutionStrategy<DB, EvmConfig>
@@ -99,7 +99,7 @@ where
 {
     /// Creates a new [`EthExecutionStrategy`]
     pub fn new(state: State<DB>, chain_spec: Arc<ChainSpec>, evm_config: EvmConfig) -> Self {
-        let system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
+        let system_caller = SystemCaller::new(chain_spec.clone());
         Self { state, chain_spec, evm_config, system_caller }
     }
 }

--- a/crates/evm/src/system_calls/eip2935.rs
+++ b/crates/evm/src/system_calls/eip2935.rs
@@ -23,18 +23,16 @@ use revm::context_interface::result::ResultAndState;
 #[inline]
 pub(crate) fn transact_blockhashes_contract_call<Halt>(
     chain_spec: impl EthereumHardforks,
-    block_timestamp: u64,
-    block_number: u64,
     parent_block_hash: B256,
     evm: &mut impl Evm<HaltReason = Halt>,
 ) -> Result<Option<ResultAndState<Halt>>, BlockExecutionError> {
-    if !chain_spec.is_prague_active_at_timestamp(block_timestamp) {
+    if !chain_spec.is_prague_active_at_timestamp(evm.block().timestamp) {
         return Ok(None)
     }
 
     // if the block number is zero (genesis block) then no system transaction may occur as per
     // EIP-2935
-    if block_number == 0 {
+    if evm.block().number == 0 {
         return Ok(None)
     }
 

--- a/crates/evm/src/system_calls/eip4788.rs
+++ b/crates/evm/src/system_calls/eip4788.rs
@@ -20,12 +20,10 @@ use revm::context_interface::result::ResultAndState;
 #[inline]
 pub(crate) fn transact_beacon_root_contract_call<Halt>(
     chain_spec: impl EthereumHardforks,
-    block_timestamp: u64,
-    block_number: u64,
     parent_beacon_block_root: Option<B256>,
     evm: &mut impl Evm<Error: Display, HaltReason = Halt>,
 ) -> Result<Option<ResultAndState<Halt>>, BlockExecutionError> {
-    if !chain_spec.is_cancun_active_at_timestamp(block_timestamp) {
+    if !chain_spec.is_cancun_active_at_timestamp(evm.block().timestamp) {
         return Ok(None)
     }
 
@@ -34,7 +32,7 @@ pub(crate) fn transact_beacon_root_contract_call<Halt>(
 
     // if the block number is zero (genesis block) then the parent beacon block root must
     // be 0x0 and no system transaction may occur as per EIP-4788
-    if block_number == 0 {
+    if evm.block().number == 0 {
         if !parent_beacon_block_root.is_zero() {
             return Err(BlockValidationError::CancunGenesisParentBeaconBlockRootNotZero {
                 parent_beacon_block_root,


### PR DESCRIPTION
Extracted from https://github.com/paradigmxyz/reth/pull/14480

Changes `SystemCaller` to always take `Evm` as input