### PR TITLE
refactor: use Recovered<Tx> when setting up TxEnv

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -8,7 +8,6 @@ use reth_evm::{
     state_change::post_block_balance_increments, system_calls::SystemCaller, ConfigureEvmFor, Evm,
 };
 use reth_primitives::{NodePrimitives, RecoveredBlock, SealedHeader};
-use reth_primitives_traits::{BlockBody, SignedTransaction};
 use reth_provider::{BlockExecutionOutput, ChainSpecProvider, StateProviderFactory};
 use reth_revm::{
     database::StateProviderDatabase,
@@ -85,10 +84,8 @@ where
 
         // Re-execute all of the transactions in the block to load all touched accounts into
         // the cache DB.
-        for tx in block.body().transactions() {
-            let signer =
-                tx.recover_signer().map_err(|_| eyre::eyre!("failed to recover sender"))?;
-            evm.transact_commit(self.evm_config.tx_env(tx, signer))?;
+        for tx in block.transactions_recovered() {
+            evm.transact_commit(self.evm_config.tx_env(tx))?;
         }
 
         drop(evm);

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2775,7 +2775,7 @@ where
             let mut evm = evm_config.evm_with_env(state_provider, evm_env);
 
             // create the tx env and reset nonce
-            let tx_env = evm_config.tx_env(&tx, tx.signer());
+            let tx_env = evm_config.tx_env(&tx);
 
             // exit early if execution is done
             if cancel_execution.is_cancelled() {

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -312,7 +312,7 @@ where
         // Configure the environment for the block.
         let tx_recovered =
             tx.try_clone_into_recovered().map_err(|_| ProviderError::SenderRecoveryError)?;
-        let tx_env = evm_config.tx_env(&tx_recovered, tx_recovered.signer());
+        let tx_env = evm_config.tx_env(tx_recovered);
         let exec_result = match evm.transact(tx_env) {
             Ok(result) => result,
             Err(err) if err.is_invalid_tx_err() => {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -149,7 +149,7 @@ where
                 .into())
             }
 
-            let tx_env = self.evm_config.tx_env(tx.tx(), tx.signer());
+            let tx_env = self.evm_config.tx_env(tx.clone());
             let hash = tx.hash();
 
             // Execute transaction.

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -279,7 +279,7 @@ where
         }
 
         // Configure the environment for the tx.
-        let tx_env = evm_config.tx_env(tx.tx(), tx.signer());
+        let tx_env = evm_config.tx_env(&tx);
 
         let ResultAndState { result, state } = match evm.transact(tx_env) {
             Ok(res) => res,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -17,6 +17,7 @@
 
 extern crate alloc;
 
+use alloc::borrow::Borrow;
 use alloy_consensus::transaction::Recovered;
 use alloy_eips::eip2930::AccessList;
 pub use alloy_evm::evm::EvmFactory;
@@ -182,13 +183,10 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone + 'static {
     type Spec: Debug + Copy + Send + Sync + 'static;
 
     /// Returns a [`TxEnv`] from a transaction and [`Address`].
-    fn tx_env(&self, transaction: &Self::Transaction, signer: Address) -> Self::TxEnv;
-
-    /// Returns a [`TxEnv`] from a [`Recovered`] transaction.
-    fn tx_env_from_recovered(&self, tx: Recovered<&Self::Transaction>) -> Self::TxEnv {
-        let (tx, address) = tx.into_parts();
-        self.tx_env(tx, address)
-    }
+    fn tx_env<T: Borrow<Self::Transaction>>(
+        &self,
+        transaction: impl Borrow<Recovered<T>>,
+    ) -> Self::TxEnv;
 
     /// Creates a new [`EvmEnv`] for the given header.
     fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec>;

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -199,7 +199,7 @@ where
                 .transpose()
                 .map_err(|_| OpBlockExecutionError::AccountLoadFailed(tx.signer()))?;
 
-            let tx_env = self.evm_config.tx_env(tx.tx(), tx.signer());
+            let tx_env = self.evm_config.tx_env(&tx);
             let hash = tx.tx_hash();
 
             // Execute transaction.

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -929,7 +929,7 @@ where
                     ))
                 })?;
 
-            let tx_env = self.evm_config.tx_env(sequencer_tx.tx(), sequencer_tx.signer());
+            let tx_env = self.evm_config.tx_env(&sequencer_tx);
 
             let ResultAndState { result, state: _ } = match evm.transact_commit(tx_env) {
                 Ok(res) => res,
@@ -1006,7 +1006,7 @@ where
             }
 
             // Configure the environment for the tx.
-            let tx_env = self.evm_config.tx_env(tx.tx(), tx.signer());
+            let tx_env = self.evm_config.tx_env(&tx);
 
             let ResultAndState { result, state: _ } = match evm.transact_commit(tx_env) {
                 Ok(res) => res,

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -176,7 +176,7 @@ where
                     hasher.update(*tx.tx_hash());
                     let gas_price = tx.effective_gas_price(basefee);
                     let ResultAndState { result, state } = evm
-                        .transact(eth_api.evm_config().tx_env(&tx, signer))
+                        .transact(eth_api.evm_config().tx_env(&tx))
                         .map_err(Eth::Error::from_evm_err)?;
 
                     let gas_used = result.gas_used();

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -113,7 +113,7 @@ where
             .map_transaction(<Eth::Pool as TransactionPool>::Transaction::pooled_into_consensus);
 
         let (evm_env, at) = self.eth_api().evm_env_at(block_id.unwrap_or_default()).await?;
-        let tx_env = self.eth_api().evm_config().tx_env(tx.tx(), tx.signer());
+        let tx_env = self.eth_api().evm_config().tx_env(tx);
 
         let config = TracingInspectorConfig::from_parity_config(&trace_types);
 

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -41,9 +41,10 @@ use reth_node_ethereum::{
     node::{EthereumAddOns, EthereumPayloadBuilder},
     BasicBlockExecutorProvider, EthExecutionStrategyFactory, EthereumNode,
 };
-use reth_primitives::{EthPrimitives, TransactionSigned};
+use reth_primitives::{EthPrimitives, Recovered, TransactionSigned};
 use reth_tracing::{RethTracer, Tracer};
 use std::{
+    borrow::Borrow,
     convert::Infallible,
     sync::{Arc, OnceLock},
 };
@@ -105,8 +106,11 @@ impl ConfigureEvmEnv for MyEvmConfig {
     type TxEnv = TxEnv;
     type Spec = SpecId;
 
-    fn tx_env(&self, transaction: &Self::Transaction, signer: Address) -> Self::TxEnv {
-        self.inner.tx_env(transaction, signer)
+    fn tx_env<T: Borrow<Self::Transaction>>(
+        &self,
+        transaction: impl Borrow<Recovered<T>>,
+    ) -> Self::TxEnv {
+        self.inner.tx_env(transaction)
     }
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv {

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -33,10 +33,10 @@ use reth_node_ethereum::{
     evm::EthEvm, node::EthereumAddOns, BasicBlockExecutorProvider, EthEvmConfig,
     EthExecutionStrategyFactory, EthereumNode,
 };
-use reth_primitives::{EthPrimitives, TransactionSigned};
+use reth_primitives::{EthPrimitives, Recovered, TransactionSigned};
 use reth_tracing::{RethTracer, Tracer};
 use schnellru::{ByLength, LruMap};
-use std::{collections::HashMap, convert::Infallible, sync::Arc};
+use std::{borrow::Borrow, collections::HashMap, convert::Infallible, sync::Arc};
 
 /// Type alias for the LRU cache used within the [`PrecompileCache`].
 type PrecompileLRUCache = LruMap<(SpecId, Bytes, u64), Result<InterpreterResult, PrecompileErrors>>;
@@ -186,8 +186,11 @@ impl ConfigureEvmEnv for MyEvmConfig {
     type TxEnv = TxEnv;
     type Spec = SpecId;
 
-    fn tx_env(&self, transaction: &Self::Transaction, signer: Address) -> Self::TxEnv {
-        self.inner.tx_env(transaction, signer)
+    fn tx_env<T: Borrow<Self::Transaction>>(
+        &self,
+        transaction: impl Borrow<Recovered<T>>,
+    ) -> Self::TxEnv {
+        self.inner.tx_env(transaction)
     }
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv {


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/14480

Towards https://github.com/paradigmxyz/reth/issues/14551

Changes all `Tx -> TxEnv` conversions to operate on `Recovered<Tx>` instead of passing sender separately. This should be better for the API because we can now hide this behind a `FillTxEnv`/`IntoTxEnv` trait and have `fn transact(&self, tx: impl IntoTxEnv<Self::Tx>)` directly on Evm. This would not have been possible with `transact(tx, sender)` API

