### PR TITLE
feat: `BlockExecutionStrategy::execute_transaction` API

### DIFF
--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -133,9 +133,9 @@ where
         Ok(())
     }
 
-    fn execute_transactions<'a>(
+    fn execute_transaction(
         &mut self,
-        _transactions: impl IntoIterator<Item = Recovered<&'a TransactionSigned>>,
+        _tx: Recovered<&TransactionSigned>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }


### PR DESCRIPTION
Introduces API allowing to apply a single tx to internal strategy state vs requring all of the block transactions to be known beforehand

Easier to review with "Hide whitespace"