### PR TITLE
feat: expose `InvalidTxError` in `BlockExecutionError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=1ac2157#1ac2157131212d10d4b06d76564f811248b7475a"
+source = "git+https://github.com/alloy-rs/evm?rev=3a57c0d#3a57c0db813d45ddf9b5dcbe4756ae2ce3fc2569"
 dependencies = [
  "alloy-primitives",
  "revm",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=1ac2157#1ac2157131212d10d4b06d76564f811248b7475a"
+source = "git+https://github.com/alloy-rs/evm?rev=3a57c0d#3a57c0db813d45ddf9b5dcbe4756ae2ce3fc2569"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,6 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=b77a39a#b77a39aa954a95b1c0385905b7d39c9d096b0a1b"
 dependencies = [
  "alloy-primitives",
  "revm",
@@ -368,7 +367,6 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=b77a39a#b77a39aa954a95b1c0385905b7d39c9d096b0a1b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7792,6 +7790,7 @@ name = "reth-execution-errors"
 version = "1.2.0"
 dependencies = [
  "alloy-eips",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=10c095b#10c095b4265abf9ccb2fb6402c9702d5aafd0287"
+source = "git+https://github.com/alloy-rs/evm?rev=1ac2157#1ac2157131212d10d4b06d76564f811248b7475a"
 dependencies = [
  "alloy-primitives",
  "revm",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=10c095b#10c095b4265abf9ccb2fb6402c9702d5aafd0287"
+source = "git+https://github.com/alloy-rs/evm?rev=1ac2157#1ac2157131212d10d4b06d76564f811248b7475a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/evm?rev=10c095b#10c095b4265abf9ccb2fb6402c9702d5aafd0287"
 dependencies = [
  "alloy-primitives",
  "revm",
@@ -367,6 +368,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/evm?rev=10c095b#10c095b4265abf9ccb2fb6402c9702d5aafd0287"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,8 +623,8 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 crunchy = "=0.2.2"
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "3a57c0d" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "3a57c0d" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,8 +623,8 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 crunchy = "=0.2.2"
 
 [patch.crates-io]
-alloy-evm = { path = "../evm/crates/evm" }
-alloy-op-evm = { path = "../evm/crates/op-evm" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,8 +623,8 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 crunchy = "=0.2.2"
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,8 +623,8 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 crunchy = "=0.2.2"
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "b77a39a" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "b77a39a" }
+alloy-evm = { path = "../evm/crates/evm" }
+alloy-op-evm = { path = "../evm/crates/op-evm" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,8 +13,8 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "3a57c0d" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "3a57c0d" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,8 +13,8 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "048248c" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "048248c" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,8 +13,8 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "10c095b" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "1ac2157" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -11,7 +11,7 @@ use reth_chainspec::EthChainSpec;
 use reth_engine_primitives::{
     BeaconEngineMessage, BeaconOnNewPayloadError, EngineTypes, OnForkChoiceUpdated,
 };
-use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResult};
+use reth_errors::{BlockExecutionError, RethError, RethResult};
 use reth_ethereum_forks::EthereumHardforks;
 use reth_evm::{
     state_change::post_block_withdrawals_balance_increments, system_calls::SystemCaller,
@@ -320,11 +320,7 @@ where
                 continue
             }
             // Treat error as fatal
-            Err(error) => {
-                return Err(RethError::Execution(BlockExecutionError::Validation(
-                    BlockValidationError::EVM { hash: *tx.tx_hash(), error: Box::new(error) },
-                )))
-            }
+            Err(error) => return Err(RethError::Execution(BlockExecutionError::other(error))),
         };
         evm.db_mut().commit(exec_result.state);
 

--- a/crates/errors/src/error.rs
+++ b/crates/errors/src/error.rs
@@ -67,8 +67,8 @@ mod size_asserts {
         };
     }
 
-    static_assert_size!(RethError, 56);
-    static_assert_size!(BlockExecutionError, 56);
+    static_assert_size!(RethError, 64);
+    static_assert_size!(BlockExecutionError, 64);
     static_assert_size!(ConsensusError, 48);
     static_assert_size!(DatabaseError, 32);
     static_assert_size!(ProviderError, 48);

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -15,7 +15,7 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, StateChangePostBlockSource, StateChangeSource, SystemCaller},
-    ConfigureEvm, ConfigureEvmEnv, Database, Evm, EvmError,
+    ConfigureEvm, ConfigureEvmEnv, Database, Evm,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives::{
@@ -155,12 +155,7 @@ where
 
         // Execute transaction.
         let result_and_state =
-            self.evm.transact(tx_env).map_err(move |err| match err.try_into_invalid_tx_err() {
-                Ok(err) => {
-                    BlockValidationError::InvalidTx { hash: *hash, error: Box::new(err) }.into()
-                }
-                Err(err) => BlockExecutionError::other(err),
-            })?;
+            self.evm.transact(tx_env).map_err(move |err| BlockExecutionError::evm(err, *hash))?;
         self.system_caller
             .on_state(StateChangeSource::Transaction(self.receipts.len()), &result_and_state.state);
         let ResultAndState { result, state } = result_and_state;

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -155,7 +155,7 @@ where
 
         // Execute transaction.
         let result_and_state =
-            self.evm.transact(tx_env).map_err(move |err| match err.into_invalid_tx_err() {
+            self.evm.transact(tx_env).map_err(move |err| match err.try_into_invalid_tx_err() {
                 Ok(err) => {
                     BlockValidationError::InvalidTx { hash: *hash, error: Box::new(err) }.into()
                 }

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -15,7 +15,7 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, StateChangePostBlockSource, StateChangeSource, SystemCaller},
-    ConfigureEvm, ConfigureEvmEnv, Database, Evm,
+    ConfigureEvm, ConfigureEvmEnv, Database, Evm, EvmError,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives::{
@@ -154,10 +154,13 @@ where
         let hash = tx.hash();
 
         // Execute transaction.
-        let result_and_state = self.evm.transact(tx_env).map_err(move |err| {
-            // Ensure hash is calculated for error log, if not already done
-            BlockValidationError::EVM { hash: *hash, error: Box::new(err) }
-        })?;
+        let result_and_state =
+            self.evm.transact(tx_env).map_err(move |err| match err.into_invalid_tx_err() {
+                Ok(err) => {
+                    BlockValidationError::InvalidTx { hash: *hash, error: Box::new(err) }.into()
+                }
+                Err(err) => BlockExecutionError::other(err),
+            })?;
         self.system_caller
             .on_state(StateChangeSource::Transaction(self.receipts.len()), &result_and_state.state);
         let ResultAndState { result, state } = result_and_state;

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # reth
 reth-storage-errors.workspace = true
 
+alloy-evm.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -34,4 +34,5 @@ std = [
     "nybbles/std",
     "revm-database-interface/std",
     "reth-storage-errors/std",
+    "alloy-evm/std",
 ]

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -16,7 +16,7 @@ use alloc::{
     string::{String, ToString},
 };
 use alloy_eips::BlockNumHash;
-use alloy_evm::InvalidTxError;
+use alloy_evm::{EvmError, InvalidTxError};
 use alloy_primitives::B256;
 use reth_storage_errors::provider::ProviderError;
 use thiserror::Error;
@@ -142,6 +142,21 @@ impl BlockExecutionError {
     pub const fn is_state_root_error(&self) -> bool {
         matches!(self, Self::Validation(BlockValidationError::StateRoot(_)))
     }
+
+    /// Handles an EVM error occured when executing a transaction.
+    ///
+    /// If an error matches [`EvmError::InvalidTransaction`], it will be wrapped into
+    /// [`BlockValidationError::InvalidTx`], otherwise into [`InternalBlockExecutionError::EVM`].
+    pub fn evm<E: EvmError>(error: E, hash: B256) -> Self {
+        match error.try_into_invalid_tx_err() {
+            Ok(err) => {
+                Self::Validation(BlockValidationError::InvalidTx { hash, error: Box::new(err) })
+            }
+            Err(err) => {
+                Self::Internal(InternalBlockExecutionError::EVM { hash, error: Box::new(err) })
+            }
+        }
+    }
 }
 
 impl From<ProviderError> for BlockExecutionError {
@@ -164,6 +179,16 @@ pub enum InternalBlockExecutionError {
         chain_tip: Box<BlockNumHash>,
         /// The fork on the other chain
         other_chain_fork: Box<BlockNumHash>,
+    },
+    /// EVM error occurred when executing transaction. This is different from
+    /// [`BlockValidationError::InvalidTx`] because it will only contain EVM errors which are not
+    /// transaction validation errors and are assumed to be fatal.
+    #[error("internal EVM error occurred when executing transaction {hash}: {error}")]
+    EVM {
+        /// The hash of the transaction
+        hash: B256,
+        /// The EVM error.
+        error: Box<dyn core::error::Error + Send + Sync>,
     },
     /// Error when fetching data from the db.
     #[error(transparent)]

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -16,6 +16,7 @@ use alloc::{
     string::{String, ToString},
 };
 use alloy_eips::BlockNumHash;
+use alloy_evm::InvalidTxError;
 use alloy_primitives::B256;
 use reth_storage_errors::provider::ProviderError;
 use thiserror::Error;
@@ -28,11 +29,11 @@ pub use trie::*;
 pub enum BlockValidationError {
     /// EVM error with transaction hash and message
     #[error("EVM reported invalid transaction ({hash}): {error}")]
-    EVM {
+    InvalidTx {
         /// The hash of the transaction
         hash: B256,
         /// The EVM error.
-        error: Box<dyn core::error::Error + Send + Sync>,
+        error: Box<dyn InvalidTxError>,
     },
     /// Error when incrementing balance in post execution
     #[error("incrementing balance in post execution failed")]

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -16,7 +16,7 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, StateChangePostBlockSource, StateChangeSource, SystemCaller},
-    ConfigureEvm, ConfigureEvmFor, Database, Evm, EvmError, HaltReasonFor,
+    ConfigureEvm, ConfigureEvmFor, Database, Evm, HaltReasonFor,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_optimism_chainspec::OpChainSpec;
@@ -203,12 +203,7 @@ where
 
         // Execute transaction.
         let result_and_state =
-            self.evm.transact(tx_env).map_err(move |err| match err.try_into_invalid_tx_err() {
-                Ok(err) => {
-                    BlockValidationError::InvalidTx { hash: *hash, error: Box::new(err) }.into()
-                }
-                Err(err) => BlockExecutionError::other(err),
-            })?;
+            self.evm.transact(tx_env).map_err(move |err| BlockExecutionError::evm(err, *hash))?;
 
         trace!(
             target: "evm",

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -203,7 +203,7 @@ where
 
         // Execute transaction.
         let result_and_state =
-            self.evm.transact(tx_env).map_err(move |err| match err.into_invalid_tx_err() {
+            self.evm.transact(tx_env).map_err(move |err| match err.try_into_invalid_tx_err() {
                 Ok(err) => {
                     BlockValidationError::InvalidTx { hash: *hash, error: Box::new(err) }.into()
                 }


### PR DESCRIPTION
Depends on https://github.com/alloy-rs/evm/pull/17

For reuse in payload building, we need to 
a) distinguish between tx validation errors and fatal evm errors (e.g comming from database)
b) have access to `InvalidTxError` to decide whether we should skip tx descendants https://github.com/paradigmxyz/reth/blob/626f3b566f01d13d9ff0aca897e21b6c6bfdebda/crates/ethereum/payload/src/lib.rs#L287-L303

With this PR `BlockValidationError::InvalidTx` would only contain boxed `invalidTxError`, and any other errors would be stored in `BlockExecutionError::Internal` variant