### PR TITLE
test(db): complete DatabaseProviderFactory impl for MockEthProvider

### DIFF
--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1,9 +1,9 @@
 use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
-    ChainSpecProvider, ChangeSetReader, DatabaseProvider, EthStorage, HeaderProvider,
-    ReceiptProviderIdExt, StateProvider, StateProviderBox, StateProviderFactory, StateReader,
-    StateRootProvider, TransactionVariant, TransactionsProvider, WithdrawalsProvider,
+    ChainSpecProvider, ChangeSetReader, EthStorage, HeaderProvider, ReceiptProviderIdExt,
+    StateProvider, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
+    TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
 use alloy_consensus::{
     constants::EMPTY_ROOT_HASH, transaction::TransactionMeta, Header, Transaction,
@@ -23,16 +23,18 @@ use reth_db_api::{
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::NodeTypes;
 use reth_primitives::{
-    Account, Block, Bytecode, EthPrimitives, GotExpected, Receipt, RecoveredBlock, SealedBlock,
-    SealedHeader, TransactionSigned,
+    Account, Block, Bytecode, EthPrimitives, Receipt, RecoveredBlock, SealedBlock, SealedHeader,
+    TransactionSigned,
 };
 use reth_primitives_traits::SignedTransaction;
+use reth_prune_types::PruneModes;
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
-    BlockBodyIndicesProvider, DatabaseProviderFactory, HashedPostStateProvider, OmmersProvider,
-    StageCheckpointReader, StateCommitmentProvider, StateProofProvider, StorageRootProvider,
+    BlockBodyIndicesProvider, DBProvider, DatabaseProviderFactory, HashedPostStateProvider,
+    OmmersProvider, StageCheckpointReader, StateCommitmentProvider, StateProofProvider,
+    StorageRootProvider,
 };
-use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
@@ -57,6 +59,8 @@ pub struct MockEthProvider<T = TransactionSigned, ChainSpec = reth_chainspec::Ch
     pub chain_spec: Arc<ChainSpec>,
     /// Local state roots
     pub state_roots: Arc<Mutex<Vec<B256>>>,
+    tx: TxMock,
+    prune_modes: Arc<PruneModes>,
 }
 
 impl<T, ChainSpec> Clone for MockEthProvider<T, ChainSpec> {
@@ -67,6 +71,8 @@ impl<T, ChainSpec> Clone for MockEthProvider<T, ChainSpec> {
             accounts: self.accounts.clone(),
             chain_spec: self.chain_spec.clone(),
             state_roots: self.state_roots.clone(),
+            tx: self.tx.clone(),
+            prune_modes: self.prune_modes.clone(),
         }
     }
 }
@@ -80,6 +86,8 @@ impl<T> MockEthProvider<T> {
             accounts: Default::default(),
             chain_spec: Arc::new(reth_chainspec::ChainSpecBuilder::mainnet().build()),
             state_roots: Default::default(),
+            tx: Default::default(),
+            prune_modes: Default::default(),
         }
     }
 }
@@ -136,6 +144,8 @@ impl<T, ChainSpec> MockEthProvider<T, ChainSpec> {
             accounts: self.accounts,
             chain_spec: Arc::new(chain_spec),
             state_roots: self.state_roots,
+            tx: self.tx,
+            prune_modes: self.prune_modes,
         }
     }
 }
@@ -200,19 +210,41 @@ impl<T: Transaction, ChainSpec: EthChainSpec> StateCommitmentProvider
     type StateCommitment = <MockNode as NodeTypes>::StateCommitment;
 }
 
-impl<T: Transaction, ChainSpec: EthChainSpec> DatabaseProviderFactory
+impl<T: Transaction, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProviderFactory
     for MockEthProvider<T, ChainSpec>
 {
     type DB = DatabaseMock;
-    type Provider = DatabaseProvider<TxMock, MockNode>;
-    type ProviderRW = DatabaseProvider<TxMock, MockNode>;
+    type Provider = Self;
+    type ProviderRW = Self;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
-        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+        Ok(self.clone())
     }
 
     fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
-        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+        Ok(self.clone())
+    }
+}
+
+impl<T: Transaction, ChainSpec: EthChainSpec + 'static> DBProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    type Tx = TxMock;
+
+    fn tx_ref(&self) -> &Self::Tx {
+        &self.tx
+    }
+
+    fn tx_mut(&mut self) -> &mut Self::Tx {
+        &mut self.tx
+    }
+
+    fn into_tx(self) -> Self::Tx {
+        self.tx
+    }
+
+    fn prune_modes_ref(&self) -> &PruneModes {
+        &self.prune_modes
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -23,8 +23,8 @@ use reth_db_api::{
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::NodeTypes;
 use reth_primitives::{
-    Account, Block, Bytecode, EthPrimitives, Receipt, RecoveredBlock, SealedBlock, SealedHeader,
-    TransactionSigned,
+    Account, Block, Bytecode, EthPrimitives, GotExpected, Receipt, RecoveredBlock, SealedBlock,
+    SealedHeader, TransactionSigned,
 };
 use reth_primitives_traits::SignedTransaction;
 use reth_prune_types::PruneModes;
@@ -34,7 +34,7 @@ use reth_storage_api::{
     OmmersProvider, StageCheckpointReader, StateCommitmentProvider, StateProofProvider,
     StorageRootProvider,
 };
-use reth_storage_errors::provider::{ProviderError, ProviderResult};
+use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
 use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
@@ -218,11 +218,17 @@ impl<T: Transaction, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProvider
     type ProviderRW = Self;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
-        Ok(self.clone())
+        // TODO: return Ok(self.clone()) when engine tests stops relying on an
+        // Error returned here https://github.com/paradigmxyz/reth/pull/14482
+        //Ok(self.clone())
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
     }
 
     fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {
-        Ok(self.clone())
+        // TODO: return Ok(self.clone()) when engine tests stops relying on an
+        // Error returned here https://github.com/paradigmxyz/reth/pull/14482
+        //Ok(self.clone())
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
     }
 }
 


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/14376
Extracted from https://github.com/paradigmxyz/reth/pull/14482

`ConsistentDBView` uses `DatabaseProviderFactory::database_provider_ro` for the provider it uses to perform consistency checks on the current tip https://github.com/paradigmxyz/reth/blob/c5df8fbaaf8a7f6101980beff9d94e2d76b8bcee/crates/storage/provider/src/providers/consistent_view.rs#L71

In the current impl of that method for `MockEthProvider` we just return an error. These changes add a proper implementation to use the mock in scenarios where `ConsistentDbView` is at play (like engine unit tests). The `Provider` and `ProviderRW` associated types are set to `Self` so that we can leverage the existing methods to setup the mock state.