### PR TITLE
chore: pre alloc on send raw

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -257,7 +257,7 @@ where
 
     /// Sends a raw capability message directly over the stream
     pub fn start_send_raw(&mut self, msg: RawCapabilityMessage) -> Result<(), EthStreamError> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(msg.payload.len() + 1);
         msg.id.encode(&mut bytes);
         bytes.extend_from_slice(&msg.payload);
 


### PR DESCRIPTION
we know how large the buffer must be