### PR TITLE
feat(engine): Implement EIP-7685 requests and EIP-2935 syscall in create_reorg_head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7493,6 +7493,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-forks",
  "reth-evm",
+ "reth-evm-ethereum",
  "reth-fs-util",
  "reth-payload-primitives",
  "reth-payload-validator",

--- a/crates/engine/util/Cargo.toml
+++ b/crates/engine/util/Cargo.toml
@@ -21,6 +21,7 @@ reth-fs-util.workspace = true
 reth-engine-primitives.workspace = true
 reth-payload-validator.workspace = true
 reth-evm.workspace = true
+reth-evm-ethereum.workspace = true
 reth-revm.workspace = true
 reth-provider.workspace = true
 reth-ethereum-forks.workspace = true

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -33,7 +33,7 @@ use reth_revm::{
     DatabaseCommit,
 };
 use std::{
-    collections::VecDeque, future::Future, hash::Hash, pin::Pin, task::{ready, Context, Poll}
+    collections::VecDeque, future::Future, pin::Pin, task::{ready, Context, Poll}
 };
 use tokio::sync::oneshot;
 use tracing::*;
@@ -417,7 +417,7 @@ where
             blob_gas_used,
             excess_blob_gas,
             state_root: state_provider.state_root(hashed_state)?,
-            requests_hash: requests_hash,
+            requests_hash,
         },
         body: BlockBody {
             transactions,

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -14,7 +14,8 @@ use reth_engine_primitives::{
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResult};
 use reth_ethereum_forks::EthereumHardforks;
 use reth_evm::{
-    execute::BlockExecutionStrategy, state_change::post_block_withdrawals_balance_increments, ConfigureEvm
+    execute::BlockExecutionStrategy, state_change::post_block_withdrawals_balance_increments,
+    ConfigureEvm,
 };
 use reth_evm_ethereum::execute::{EthBlockExecutionInput, EthExecutionStrategy};
 use reth_payload_primitives::EngineApiMessageVersion;
@@ -331,15 +332,18 @@ where
         let gas_used = match strategy.execute_transaction(tx_recovered.as_recovered_ref()) {
             Ok(result) => result,
             Err(err) => match err {
-                BlockExecutionError::Validation(BlockValidationError::InvalidTx { hash, error }) => {
+                BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                    hash,
+                    error,
+                }) => {
                     trace!(target: "engine::stream::reorg", hash = %hash, ?error, "Error executing transaction from next block");
                     continue
-                },
+                }
                 _ => {
                     // Treat error as fatal
                     return Err(RethError::Execution(BlockExecutionError::other(err)));
                 }
-            }
+            },
         };
 
         cumulative_gas_used += gas_used;


### PR DESCRIPTION
There were some `TODO`s and missing code regarding changes for the Prague upgrade. This PR adds the following:

- Changes the call to `apply_beacon_root_contract_call` to `apply_pre_execution_changes`, so that both the beacon root and the parent hash syscalls are processed
- Processes EIP-7685 requests, as well as upgrades the returned `ExecutionPayloadSidecar`