### PR TITLE
feat(trie): parallel proof metrics

### DIFF
--- a/crates/trie/parallel/src/metrics.rs
+++ b/crates/trie/parallel/src/metrics.rs
@@ -18,7 +18,7 @@ impl Default for ParallelStateRootMetrics {
     fn default() -> Self {
         Self {
             state_trie: TrieRootMetrics::new(TrieType::State),
-            parallel: ParallelTrieMetrics::default(),
+            parallel: ParallelTrieMetrics::new_with_labels(&[("type", "root")]),
             storage_trie: TrieRootMetrics::new(TrieType::Storage),
         }
     }
@@ -28,8 +28,7 @@ impl ParallelStateRootMetrics {
     /// Record state trie metrics
     pub fn record_state_trie(&self, stats: ParallelTrieStats) {
         self.state_trie.record(stats.trie_stats());
-        self.parallel.precomputed_storage_roots.record(stats.precomputed_storage_roots() as f64);
-        self.parallel.missed_leaves.record(stats.missed_leaves() as f64);
+        self.parallel.record(stats);
     }
 }
 
@@ -41,4 +40,12 @@ pub struct ParallelTrieMetrics {
     pub precomputed_storage_roots: Histogram,
     /// The number of leaves for which we did not pre-compute the storage roots.
     pub missed_leaves: Histogram,
+}
+
+impl ParallelTrieMetrics {
+    /// Record parallel trie metrics.
+    pub fn record(&self, stats: ParallelTrieStats) {
+        self.precomputed_storage_roots.record(stats.precomputed_storage_roots() as f64);
+        self.missed_leaves.record(stats.missed_leaves() as f64);
+    }
 }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -1,4 +1,7 @@
-use crate::{root::ParallelStateRootError, stats::ParallelTrieTracker, StorageRootTargets};
+use crate::{
+    metrics::ParallelTrieMetrics, root::ParallelStateRootError, stats::ParallelTrieTracker,
+    StorageRootTargets,
+};
 use alloy_primitives::{
     map::{B256Map, HashMap},
     B256,
@@ -48,11 +51,12 @@ pub struct ParallelProof<Factory> {
     collect_branch_node_masks: bool,
     /// Thread pool for local tasks
     thread_pool: Arc<rayon::ThreadPool>,
+    metrics: ParallelTrieMetrics,
 }
 
 impl<Factory> ParallelProof<Factory> {
     /// Create new state proof generator.
-    pub const fn new(
+    pub fn new(
         view: ConsistentDbView<Factory>,
         nodes_sorted: Arc<TrieUpdatesSorted>,
         state_sorted: Arc<HashedPostStateSorted>,
@@ -66,6 +70,7 @@ impl<Factory> ParallelProof<Factory> {
             prefix_sets,
             collect_branch_node_masks: false,
             thread_pool,
+            metrics: ParallelTrieMetrics::new_with_labels(&[("type", "proof")]),
         }
     }
 
@@ -291,6 +296,10 @@ where
         }
         let _ = hash_builder.root();
 
+        let stats = tracker.finish();
+        #[cfg(feature = "metrics")]
+        self.metrics.record(stats);
+
         let account_subtree = hash_builder.take_proof_nodes();
         let (branch_node_hash_masks, branch_node_tree_masks) = if self.collect_branch_node_masks {
             let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
@@ -307,6 +316,17 @@ where
         } else {
             (HashMap::default(), HashMap::default())
         };
+
+        debug!(
+            target: "trie::parallel_proof",
+            total_targets = storage_root_targets_len,
+            duration = ?stats.duration(),
+            branches_added = stats.branches_added(),
+            leaves_added = stats.leaves_added(),
+            missed_leaves = stats.missed_leaves(),
+            precomputed_storage_roots = stats.precomputed_storage_roots(),
+            "Calculated proof"
+        );
 
         Ok(MultiProof { account_subtree, branch_node_hash_masks, branch_node_tree_masks, storages })
     }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -51,6 +51,7 @@ pub struct ParallelProof<Factory> {
     collect_branch_node_masks: bool,
     /// Thread pool for local tasks
     thread_pool: Arc<rayon::ThreadPool>,
+    #[cfg(feature = "metrics")]
     metrics: ParallelTrieMetrics,
 }
 
@@ -70,6 +71,7 @@ impl<Factory> ParallelProof<Factory> {
             prefix_sets,
             collect_branch_node_masks: false,
             thread_pool,
+            #[cfg(feature = "metrics")]
             metrics: ParallelTrieMetrics::new_with_labels(&[("type", "proof")]),
         }
     }

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -217,7 +217,7 @@ where
             leaves_added = stats.leaves_added(),
             missed_leaves = stats.missed_leaves(),
             precomputed_storage_roots = stats.precomputed_storage_roots(),
-            "calculated state root"
+            "Calculated state root"
         );
 
         Ok((root, trie_updates))


### PR DESCRIPTION
`ParallelTrieTracker` in `ParallelProof` wasn't used. This PR adds reporting metrics that it collected, and logging them when the proof calculation is completed.