### PR TITLE
chore: allow new advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,7 +11,7 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0388 used by ssz, will be removed https://github.com/sigp/ethereum_ssz/pull/34
     "RUSTSEC-2024-0388",
     # https://rustsec.org/advisories/RUSTSEC-2025-0007 *ring* is unmaintained, used by jsonwebtoken
-    "RUSTSEC-2025-0007"
+    "RUSTSEC-2025-0007",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,8 @@ ignore = [
     "RUSTSEC-2024-0384",
     # https://rustsec.org/advisories/RUSTSEC-2024-0388 used by ssz, will be removed https://github.com/sigp/ethereum_ssz/pull/34
     "RUSTSEC-2024-0388",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0007 *ring* is unmaintained, used by jsonwebtoken
+    "RUSTSEC-2025-0007"
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
ignore unmaintained advisory