### PR TITLE
fix: dead link txn_manager.rs

### DIFF
--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -232,7 +232,7 @@ mod read_transactions {
                                 // important because we store the pointer in the `active` list
                                 // and assume that it is unique.
                                 //
-                                // See https://erthink.github.io/libmdbx/group__c__transactions.html#gae9f34737fe60b0ba538d5a09b6a25c8d for more info.
+                                // See https://libmdbx.dqdkfa.ru/group__c__transactions.html#gae9f34737fe60b0ba538d5a09b6a25c8d for more info.
                                 let result = mdbx_result(unsafe { ffi::mdbx_txn_reset(txn_ptr) });
                                 if result.is_ok() {
                                     tx.set_timed_out();


### PR DESCRIPTION
Hey! I noticed that there’s a broken link in the txn_manager.rs file pointing to the libmdbx documentation. The link was https://erthink.github.io/libmdbx/group__c__transactions.html#gae9f34737fe60b0ba538d5a09b6a25c8d, but it’s no longer working. I’ve replaced it with the correct one: https://libmdbx.dqdkfa.ru/group__c__transactions.html#gae9f34737fe60b0ba538d5a09b6a25c8d