### PR TITLE
chore(sdk): Complete adapters for `NodePrimitives` ATs

### DIFF
--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -138,7 +138,7 @@ pub use size::InMemorySize;
 
 /// Node traits
 pub mod node;
-pub use node::{BodyTy, FullNodePrimitives, HeaderTy, NodePrimitives, ReceiptTy};
+pub use node::{BlockTy, BodyTy, FullNodePrimitives, HeaderTy, NodePrimitives, ReceiptTy, TxTy};
 
 /// Helper trait that requires de-/serialize implementation since `serde` feature is enabled.
 #[cfg(feature = "serde")]

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -65,5 +65,11 @@ pub type HeaderTy<N> = <N as NodePrimitives>::BlockHeader;
 /// Helper adapter type for accessing [`NodePrimitives`] block body types.
 pub type BodyTy<N> = <N as NodePrimitives>::BlockBody;
 
+/// Helper adapter type for accessing [`NodePrimitives`] block types.
+pub type BlockTy<N> = <N as NodePrimitives>::Block;
+
 /// Helper adapter type for accessing [`NodePrimitives`] receipt types.
 pub type ReceiptTy<N> = <N as NodePrimitives>::Receipt;
+
+/// Helper adapter type for accessing [`NodePrimitives`] signed transaction types.
+pub type TxTy<N> = <N as NodePrimitives>::SignedTx;


### PR DESCRIPTION
Adds missing `BlockTy` and `TxTy` to `NodePrimitives` adapters