### PR TITLE
refactor: implement `BlockExecutionStrategyFactory` directly on `EvmConfig`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/evm?rev=6684403#6684403e31710658ddd4ca372c280fc466455ce7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -368,6 +369,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/evm?rev=6684403#6684403e31710658ddd4ca372c280fc466455ce7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=6684403#6684403e31710658ddd4ca372c280fc466455ce7"
+source = "git+https://github.com/alloy-rs/evm?rev=04fa394#04fa3947c5694c2d15956bb18a31834b95e0e975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=6684403#6684403e31710658ddd4ca372c280fc466455ce7"
+source = "git+https://github.com/alloy-rs/evm?rev=04fa394#04fa3947c5694c2d15956bb18a31834b95e0e975"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,6 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=beb6832#beb68324d7e05ae2eafad9f726a94cb0b63d15a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -369,7 +368,6 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=beb6832#beb68324d7e05ae2eafad9f726a94cb0b63d15a5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -3146,7 +3144,6 @@ dependencies = [
 name = "example-custom-evm"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -3345,7 +3342,6 @@ dependencies = [
 name = "example-stateful-precompile"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,8 +623,8 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 crunchy = "=0.2.2"
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "04fa394" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "04fa394" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,8 +623,8 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 crunchy = "=0.2.2"
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "beb6832" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "beb6832" }
+alloy-evm = { path = "../evm/crates/evm" }
+alloy-op-evm = { path = "../evm/crates/op-evm" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,8 +623,8 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 crunchy = "=0.2.2"
 
 [patch.crates-io]
-alloy-evm = { path = "../evm/crates/evm" }
-alloy-op-evm = { path = "../evm/crates/op-evm" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,8 +13,8 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-alloy-evm = { path = "../evm/crates/evm" }
-alloy-op-evm = { path = "../evm/crates/op-evm" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,8 +13,8 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "beb6832" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "beb6832" }
+alloy-evm = { path = "../evm/crates/evm" }
+alloy-op-evm = { path = "../evm/crates/op-evm" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,8 +13,8 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "6684403" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "04fa394" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "04fa394" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
 revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -20,14 +20,16 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
 pub use alloy_evm::EthEvm;
-use alloy_evm::EthEvmFactory;
+use alloy_evm::{EthEvmFactory, FromRecoveredTx};
 use alloy_primitives::U256;
 use core::{convert::Infallible, fmt::Debug};
 use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv, EvmEnv, NextBlockEnvAttributes};
+use reth_evm::{
+    ConfigureEvm, ConfigureEvmEnv, EvmEnv, EvmFactory, NextBlockEnvAttributes, TransactionEnv,
+};
 use reth_primitives::TransactionSigned;
 use reth_revm::{
-    context::{BlockEnv, CfgEnv, TxEnv},
+    context::{BlockEnv, CfgEnv},
     context_interface::block::BlobExcessGasAndPrice,
     specification::hardfork::SpecId,
 };
@@ -47,20 +49,32 @@ pub mod eip6110;
 
 /// Ethereum-related EVM configuration.
 #[derive(Debug, Clone)]
-pub struct EthEvmConfig {
+pub struct EthEvmConfig<EvmFactory = EthEvmFactory> {
     chain_spec: Arc<ChainSpec>,
-    evm_factory: EthEvmFactory,
+    evm_factory: EvmFactory,
 }
 
 impl EthEvmConfig {
     /// Creates a new Ethereum EVM configuration with the given chain spec.
     pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        Self { chain_spec, evm_factory: Default::default() }
+        Self::ethereum(chain_spec)
+    }
+
+    /// Creates a new Ethereum EVM configuration.
+    pub fn ethereum(chain_spec: Arc<ChainSpec>) -> Self {
+        Self::new_with_evm_factory(chain_spec, EthEvmFactory::default())
     }
 
     /// Creates a new Ethereum EVM configuration for the ethereum mainnet.
     pub fn mainnet() -> Self {
-        Self::new(MAINNET.clone())
+        Self::ethereum(MAINNET.clone())
+    }
+}
+
+impl<EvmFactory> EthEvmConfig<EvmFactory> {
+    /// Creates a new Ethereum EVM configuration with the given chain spec and EVM factory.
+    pub fn new_with_evm_factory(chain_spec: Arc<ChainSpec>, evm_factory: EvmFactory) -> Self {
+        Self { chain_spec, evm_factory }
     }
 
     /// Returns the chain spec associated with this configuration.
@@ -69,11 +83,18 @@ impl EthEvmConfig {
     }
 }
 
-impl ConfigureEvmEnv for EthEvmConfig {
+impl<EvmF> ConfigureEvmEnv for EthEvmConfig<EvmF>
+where
+    EvmF: EvmFactory<EvmEnv<SpecId>, Tx: TransactionEnv + FromRecoveredTx<TransactionSigned>>
+        + Send
+        + Sync
+        + Unpin
+        + Clone,
+{
     type Header = Header;
     type Transaction = TransactionSigned;
     type Error = Infallible;
-    type TxEnv = TxEnv;
+    type TxEnv = EvmF::Tx;
     type Spec = SpecId;
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv {
@@ -161,8 +182,15 @@ impl ConfigureEvmEnv for EthEvmConfig {
     }
 }
 
-impl ConfigureEvm for EthEvmConfig {
-    type EvmFactory = EthEvmFactory;
+impl<EvmF> ConfigureEvm for EthEvmConfig<EvmF>
+where
+    EvmF: EvmFactory<EvmEnv<SpecId>, Tx: TransactionEnv + FromRecoveredTx<TransactionSigned>>
+        + Send
+        + Sync
+        + Unpin
+        + Clone,
+{
+    type EvmFactory = EvmF;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory
@@ -174,7 +202,7 @@ mod tests {
     use super::*;
     use alloy_consensus::Header;
     use alloy_genesis::Genesis;
-    use reth_chainspec::{Chain, ChainSpec, MAINNET};
+    use reth_chainspec::{Chain, ChainSpec};
     use reth_evm::{execute::ProviderError, EvmEnv};
     use reth_revm::{
         context::{BlockEnv, CfgEnv},
@@ -210,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_default_spec() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -225,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_custom_cfg() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -242,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_custom_block_and_tx() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -263,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_spec_id() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
 
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
@@ -280,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_and_default_inspector() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let evm_env = EvmEnv::default();
@@ -294,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_inspector_and_custom_cfg() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let cfg_env = CfgEnv::default().with_chain_id(111);
@@ -310,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_inspector_and_custom_block_tx() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         // Create custom block and tx environment
@@ -327,7 +355,7 @@ mod tests {
 
     #[test]
     fn test_evm_with_env_inspector_and_spec_id() {
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let evm_env = EvmEnv {

--- a/crates/ethereum/node/src/evm.rs
+++ b/crates/ethereum/node/src/evm.rs
@@ -3,6 +3,6 @@
 #[doc(inline)]
 pub use reth_evm::execute::BasicBlockExecutorProvider;
 #[doc(inline)]
-pub use reth_evm_ethereum::execute::{EthExecutionStrategyFactory, EthExecutorProvider};
+pub use reth_evm_ethereum::execute::EthExecutorProvider;
 #[doc(inline)]
 pub use reth_evm_ethereum::{EthEvm, EthEvmConfig};

--- a/crates/ethereum/node/src/lib.rs
+++ b/crates/ethereum/node/src/lib.rs
@@ -17,9 +17,7 @@ use revm as _;
 pub use reth_ethereum_engine_primitives::EthEngineTypes;
 
 pub mod evm;
-pub use evm::{
-    BasicBlockExecutorProvider, EthEvmConfig, EthExecutionStrategyFactory, EthExecutorProvider,
-};
+pub use evm::{BasicBlockExecutorProvider, EthEvmConfig, EthExecutorProvider};
 
 pub use reth_ethereum_consensus as consensus;
 pub mod node;

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -11,7 +11,6 @@ use reth_ethereum_engine_primitives::{
 };
 use reth_ethereum_primitives::{EthPrimitives, PooledTransaction};
 use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
-use reth_evm_ethereum::execute::EthExecutionStrategyFactory;
 use reth_network::{EthNetworkPrimitives, NetworkHandle, PeersInfo};
 use reth_node_api::{AddOnsContext, FullNodeComponents, NodeAddOns, TxTy};
 use reth_node_builder::{
@@ -241,16 +240,14 @@ where
     Node: FullNodeTypes<Types = Types>,
 {
     type EVM = EthEvmConfig;
-    type Executor = BasicBlockExecutorProvider<EthExecutionStrategyFactory>;
+    type Executor = BasicBlockExecutorProvider<EthEvmConfig>;
 
     async fn build_evm(
         self,
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
-        let chain_spec = ctx.chain_spec();
         let evm_config = EthEvmConfig::new(ctx.chain_spec());
-        let strategy_factory = EthExecutionStrategyFactory::new(chain_spec, evm_config.clone());
-        let executor = BasicBlockExecutorProvider::new(strategy_factory);
+        let executor = BasicBlockExecutorProvider::new(evm_config.clone());
 
         Ok((evm_config, executor))
     }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -2,7 +2,7 @@
 
 use alloy_consensus::BlockHeader;
 // Re-export execution types
-use crate::{system_calls::OnStateHook, Database};
+use crate::{system_calls::OnStateHook, ConfigureEvmFor, Database};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{
     map::{DefaultHashBuilder, HashMap},
@@ -191,7 +191,7 @@ pub trait BlockExecutionStrategy {
 }
 
 /// A strategy factory that can create block execution strategies.
-pub trait BlockExecutionStrategyFactory: Send + Sync + Clone + Unpin + 'static {
+pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> {
     /// Primitive types used by the strategy.
     type Primitives: NodePrimitives;
 
@@ -229,7 +229,7 @@ impl<F> BasicBlockExecutorProvider<F> {
 
 impl<F> BlockExecutorProvider for BasicBlockExecutorProvider<F>
 where
-    F: BlockExecutionStrategyFactory,
+    F: BlockExecutionStrategyFactory + 'static,
 {
     type Primitives = F::Primitives;
 
@@ -359,10 +359,8 @@ where
 mod tests {
     use super::*;
     use alloy_consensus::constants::KECCAK_EMPTY;
-    use alloy_eips::eip7685::Requests;
-    use alloy_primitives::{address, bytes, U256};
+    use alloy_primitives::{address, U256};
     use core::marker::PhantomData;
-    use reth_ethereum_primitives::TransactionSigned;
     use reth_primitives::EthPrimitives;
     use revm::state::AccountInfo;
     use revm_database::{CacheDB, EmptyDBTyped};
@@ -416,80 +414,12 @@ mod tests {
         }
     }
 
-    struct TestExecutorStrategy {
-        result: BlockExecutionResult<Receipt>,
-    }
-
-    #[derive(Clone)]
-    struct TestExecutorStrategyFactory {
-        result: BlockExecutionResult<Receipt>,
-    }
-
-    impl BlockExecutionStrategyFactory for TestExecutorStrategyFactory {
-        type Primitives = EthPrimitives;
-
-        fn create_strategy<'a, DB>(
-            &'a mut self,
-            _db: &'a mut State<DB>,
-            _block: &'a RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
-        ) -> impl BlockExecutionStrategy<Primitives = Self::Primitives, Error = BlockExecutionError> + 'a
-        where
-            DB: Database,
-        {
-            TestExecutorStrategy { result: self.result.clone() }
-        }
-    }
-
-    impl BlockExecutionStrategy for TestExecutorStrategy {
-        type Primitives = EthPrimitives;
-        type Error = BlockExecutionError;
-
-        fn apply_pre_execution_changes(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        fn execute_transaction(
-            &mut self,
-            _tx: Recovered<&TransactionSigned>,
-        ) -> Result<u64, Self::Error> {
-            Ok(0)
-        }
-
-        fn apply_post_execution_changes(
-            self,
-        ) -> Result<BlockExecutionResult<<Self::Primitives as NodePrimitives>::Receipt>, Self::Error>
-        {
-            Ok(self.result)
-        }
-
-        fn with_state_hook(&mut self, _hook: Option<Box<dyn OnStateHook>>) {}
-    }
-
     #[test]
     fn test_provider() {
         let provider = TestExecutorProvider;
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
         let executor = provider.executor(db);
         let _ = executor.execute(&Default::default());
-    }
-
-    #[test]
-    fn test_strategy() {
-        let expected_result = BlockExecutionResult {
-            receipts: vec![Receipt::default()],
-            gas_used: 10,
-            requests: Requests::new(vec![bytes!("deadbeef")]),
-        };
-
-        let strategy_factory = TestExecutorStrategyFactory { result: expected_result.clone() };
-        let provider = BasicBlockExecutorProvider::new(strategy_factory);
-        let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
-        let executor = provider.executor(db);
-        let result = executor.execute(&Default::default());
-
-        assert!(result.is_ok());
-        let block_execution_output = result.unwrap();
-        assert_eq!(block_execution_output.result, expected_result);
     }
 
     fn setup_state_with_account(

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     BuilderContext, FullNodeTypes,
 };
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
+use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
 use reth_network::NetworkPrimitives;
 use reth_node_api::{BlockTy, BodyTy, HeaderTy, PrimitivesTy, TxTy};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -409,7 +409,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: ConfigureEvmFor<PrimitivesTy<Node::Types>> + 'static,
+    EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     Cons:
         FullConsensus<PrimitivesTy<Node::Types>, Error = ConsensusError> + Clone + Unpin + 'static,

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -1,6 +1,6 @@
 //! EVM component for the node builder.
 use crate::{BuilderContext, FullNodeTypes};
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
+use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
 use reth_node_api::PrimitivesTy;
 use std::future::Future;
 
@@ -9,7 +9,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
     /// The EVM config to use.
     ///
     /// This provides the node with the necessary configuration to configure an EVM.
-    type EVM: ConfigureEvmFor<PrimitivesTy<Node::Types>> + 'static;
+    type EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>;
@@ -24,7 +24,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
 impl<Node, F, Fut, EVM, Executor> ExecutorBuilder<Node> for F
 where
     Node: FullNodeTypes,
-    EVM: ConfigureEvmFor<PrimitivesTy<Node::Types>> + 'static,
+    EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<(EVM, Executor)>> + Send,

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -25,7 +25,7 @@ use reth_payload_builder::PayloadBuilderHandle;
 
 use crate::{ConfigureEvm, FullNodeTypes};
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
+use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
 use reth_network::{NetworkHandle, NetworkPrimitives};
 use reth_network_api::FullNetwork;
 use reth_node_api::{
@@ -44,7 +44,7 @@ pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'stati
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<T::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvmFor<<T::Types as NodeTypes>::Primitives>;
+    type Evm: BlockExecutionStrategyFactory<Primitives = <T::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <T::Types as NodeTypes>::Primitives>;
@@ -127,7 +127,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: ConfigureEvm<Header = HeaderTy<Node::Types>, Transaction = TxTy<Node::Types>> + 'static,
+    EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     Cons:
         FullConsensus<PrimitivesTy<Node::Types>, Error = ConsensusError> + Clone + Unpin + 'static,

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -1,10 +1,10 @@
-use alloy_consensus::Header;
+use alloy_consensus::BlockHeader;
 use reth_optimism_forks::OpHardforks;
 use revm_optimism::OpSpecId;
 
 /// Map the latest active hardfork at the given header to a revm [`OpSpecId`].
-pub fn revm_spec(chain_spec: impl OpHardforks, header: &Header) -> OpSpecId {
-    revm_spec_by_timestamp_after_bedrock(chain_spec, header.timestamp)
+pub fn revm_spec(chain_spec: impl OpHardforks, header: impl BlockHeader) -> OpSpecId {
+    revm_spec_by_timestamp_after_bedrock(chain_spec, header.timestamp())
 }
 
 /// Returns the revm [`OpSpecId`] at the given timestamp.
@@ -42,6 +42,7 @@ pub fn revm_spec_by_timestamp_after_bedrock(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::Header;
     use reth_chainspec::ChainSpecBuilder;
     use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 
@@ -98,35 +99,32 @@ mod tests {
             f(cs).build()
         }
         assert_eq!(
-            revm_spec(op_cs(|cs| cs.isthmus_activated()), &Default::default()),
+            revm_spec(op_cs(|cs| cs.isthmus_activated()), Header::default()),
             OpSpecId::ISTHMUS
         );
         assert_eq!(
-            revm_spec(op_cs(|cs| cs.holocene_activated()), &Default::default()),
+            revm_spec(op_cs(|cs| cs.holocene_activated()), Header::default()),
             OpSpecId::HOLOCENE
         );
         assert_eq!(
-            revm_spec(op_cs(|cs| cs.granite_activated()), &Default::default()),
+            revm_spec(op_cs(|cs| cs.granite_activated()), Header::default()),
             OpSpecId::GRANITE
         );
+        assert_eq!(revm_spec(op_cs(|cs| cs.fjord_activated()), Header::default()), OpSpecId::FJORD);
         assert_eq!(
-            revm_spec(op_cs(|cs| cs.fjord_activated()), &Default::default()),
-            OpSpecId::FJORD
-        );
-        assert_eq!(
-            revm_spec(op_cs(|cs| cs.ecotone_activated()), &Default::default()),
+            revm_spec(op_cs(|cs| cs.ecotone_activated()), Header::default()),
             OpSpecId::ECOTONE
         );
         assert_eq!(
-            revm_spec(op_cs(|cs| cs.canyon_activated()), &Default::default()),
+            revm_spec(op_cs(|cs| cs.canyon_activated()), Header::default()),
             OpSpecId::CANYON
         );
         assert_eq!(
-            revm_spec(op_cs(|cs| cs.bedrock_activated()), &Default::default()),
+            revm_spec(op_cs(|cs| cs.bedrock_activated()), Header::default()),
             OpSpecId::BEDROCK
         );
         assert_eq!(
-            revm_spec(op_cs(|cs| cs.regolith_activated()), &Default::default()),
+            revm_spec(op_cs(|cs| cs.regolith_activated()), Header::default()),
             OpSpecId::REGOLITH
         );
     }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -26,7 +26,7 @@ use reth_node_builder::{
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::OpBeaconConsensus;
-use reth_optimism_evm::{BasicOpReceiptBuilder, OpEvmConfig, OpExecutionStrategyFactory};
+use reth_optimism_evm::{BasicOpReceiptBuilder, OpEvmConfig};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{
     builder::OpPayloadTransactions,
@@ -414,15 +414,14 @@ where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives>>,
 {
     type EVM = OpEvmConfig;
-    type Executor = BasicBlockExecutorProvider<OpExecutionStrategyFactory<OpPrimitives>>;
+    type Executor = BasicBlockExecutorProvider<Self::EVM>;
 
     async fn build_evm(
         self,
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
-        let evm_config = OpEvmConfig::new(ctx.chain_spec());
-        let strategy_factory = OpExecutionStrategyFactory::optimism(ctx.chain_spec());
-        let executor = BasicBlockExecutorProvider::new(strategy_factory);
+        let evm_config = OpEvmConfig::optimism(ctx.chain_spec());
+        let executor = BasicBlockExecutorProvider::new(evm_config.clone());
 
         Ok((evm_config, executor))
     }
@@ -660,7 +659,7 @@ where
         ctx: &BuilderContext<Node>,
         pool: Pool,
     ) -> eyre::Result<Self::PayloadBuilder> {
-        self.build(OpEvmConfig::new(ctx.chain_spec()), ctx, pool)
+        self.build(OpEvmConfig::optimism(ctx.chain_spec()), ctx, pool)
     }
 }
 

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -62,9 +62,6 @@ impl<T> FullNodePrimitives for T where
 /// Helper adapter type for accessing [`NodePrimitives`] block header types.
 pub type HeaderTy<N> = <N as NodePrimitives>::BlockHeader;
 
-/// Helper adapter type for accessing [`NodePrimitives::SignedTx`].
-pub type TxTy<N> = <N as NodePrimitives>::SignedTx;
-
 /// Helper adapter type for accessing [`NodePrimitives`] block body types.
 pub type BodyTy<N> = <N as NodePrimitives>::BlockBody;
 

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -62,6 +62,9 @@ impl<T> FullNodePrimitives for T where
 /// Helper adapter type for accessing [`NodePrimitives`] block header types.
 pub type HeaderTy<N> = <N as NodePrimitives>::BlockHeader;
 
+/// Helper adapter type for accessing [`NodePrimitives::SignedTx`].
+pub type TxTy<N> = <N as NodePrimitives>::SignedTx;
+
 /// Helper adapter type for accessing [`NodePrimitives`] block body types.
 pub type BodyTy<N> = <N as NodePrimitives>::BlockBody;
 

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -6,7 +6,7 @@ use reth_consensus::noop::NoopConsensus;
 use reth_engine_primitives::BeaconConsensusEngineHandle;
 use reth_ethereum_engine_primitives::{EthEngineTypes, EthereumEngineValidator};
 use reth_evm::execute::BasicBlockExecutorProvider;
-use reth_evm_ethereum::{execute::EthExecutionStrategyFactory, EthEvmConfig};
+use reth_evm_ethereum::EthEvmConfig;
 use reth_network_api::noop::NoopNetwork;
 use reth_payload_builder::test_utils::spawn_test_payload_service;
 use reth_provider::test_utils::NoopProvider;
@@ -124,7 +124,7 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
     NoopNetwork,
     TokioTaskExecutor,
     EthEvmConfig,
-    BasicBlockExecutorProvider<EthExecutionStrategyFactory>,
+    BasicBlockExecutorProvider<EthEvmConfig>,
     NoopConsensus,
 > {
     RpcModuleBuilder::default()
@@ -132,9 +132,7 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
         .with_pool(TestPoolBuilder::default().into())
         .with_network(NoopNetwork::default())
         .with_executor(TokioTaskExecutor::default())
-        .with_evm_config(EthEvmConfig::new(MAINNET.clone()))
-        .with_block_executor(
-            BasicBlockExecutorProvider::new(EthExecutionStrategyFactory::mainnet()),
-        )
+        .with_evm_config(EthEvmConfig::mainnet())
+        .with_block_executor(BasicBlockExecutorProvider::new(EthEvmConfig::mainnet()))
         .with_consensus(NoopConsensus::default())
 }

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -38,7 +38,6 @@ mod tests {
     use super::*;
     use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use alloy_primitives::{Address, StorageKey, StorageValue, U256};
-    use reth_chainspec::MAINNET;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider, NoopProvider};
@@ -55,7 +54,7 @@ mod tests {
 
     fn noop_eth_api() -> EthApi<NoopProvider, TestPool, NoopNetwork, EthEvmConfig> {
         let pool = testing_pool();
-        let evm_config = EthEvmConfig::new(MAINNET.clone());
+        let evm_config = EthEvmConfig::mainnet();
 
         let cache = EthStateCache::spawn(NoopProvider::default(), Default::default());
         EthApi::new(

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -680,7 +680,7 @@ mod tests {
     };
     use reth_ethereum_consensus::EthBeaconConsensus;
     use reth_evm::execute::BasicBlockExecutorProvider;
-    use reth_evm_ethereum::execute::EthExecutionStrategyFactory;
+    use reth_evm_ethereum::EthEvmConfig;
     use reth_primitives::{Account, Bytecode, SealedBlock, StorageEntry};
     use reth_provider::{
         test_utils::create_test_provider_factory, AccountReader, DatabaseProviderFactory,
@@ -691,10 +691,9 @@ mod tests {
     use reth_stages_api::StageUnitCheckpoint;
     use std::collections::BTreeMap;
 
-    fn stage() -> ExecutionStage<BasicBlockExecutorProvider<EthExecutionStrategyFactory>> {
-        let strategy_factory = EthExecutionStrategyFactory::ethereum(Arc::new(
-            ChainSpecBuilder::mainnet().berlin_activated().build(),
-        ));
+    fn stage() -> ExecutionStage<BasicBlockExecutorProvider<EthEvmConfig>> {
+        let strategy_factory =
+            EthEvmConfig::new(Arc::new(ChainSpecBuilder::mainnet().berlin_activated().build()));
         let executor_provider = BasicBlockExecutorProvider::new(strategy_factory);
         let consensus = Arc::new(EthBeaconConsensus::new(Arc::new(
             ChainSpecBuilder::mainnet().berlin_activated().build(),

--- a/examples/custom-evm/Cargo.toml
+++ b/examples/custom-evm/Cargo.toml
@@ -19,7 +19,6 @@ reth-evm.workspace = true
 alloy-evm.workspace = true
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true
-alloy-consensus.workspace = true
 
 eyre.workspace = true
 tokio.workspace = true

--- a/examples/stateful-precompile/Cargo.toml
+++ b/examples/stateful-precompile/Cargo.toml
@@ -17,7 +17,6 @@ reth-evm.workspace = true
 alloy-evm.workspace = true
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true
-alloy-consensus.workspace = true
 
 eyre.workspace = true
 parking_lot.workspace = true


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/14571

Exposes `BlockExecutionStrategyFactory` implementation directly on `EvmConfig` thus fully encapsulating block and transaction execution semantics in it.

This allows all of the components holding `EvmConfig` to get access to pre/post execution changes and receipts construction implementation without additional generics