### PR TITLE
feat: re-introduce `debug.reorg` logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7492,6 +7492,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-forks",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-fs-util",
  "reth-payload-primitives",

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -5,6 +5,7 @@ use reth_chainspec::EthChainSpec;
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_network_api::test_utils::PeersHandleProvider;
+use reth_node_api::NodePrimitives;
 use reth_node_builder::{
     components::NodeComponentsBuilder,
     rpc::{EngineValidatorAddOn, RethRpcAddOns},
@@ -52,6 +53,10 @@ pub async fn setup<N>(
 ) -> eyre::Result<(Vec<NodeHelperType<N>>, TaskManager, Wallet)>
 where
     N: Default + Node<TmpNodeAdapter<N>> + NodeTypesForProvider + NodeTypesWithEngine,
+    N::Primitives: NodePrimitives<
+        BlockHeader = alloy_consensus::Header,
+        BlockBody = alloy_consensus::BlockBody<<N::Primitives as NodePrimitives>::SignedTx>,
+    >,
     N::ComponentsBuilder: NodeComponentsBuilder<
         TmpNodeAdapter<N>,
         Components: NodeComponents<TmpNodeAdapter<N>, Network: PeersHandleProvider>,
@@ -123,6 +128,10 @@ where
         + Node<TmpNodeAdapter<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>>
         + NodeTypesWithEngine
         + NodeTypesForProvider,
+    N::Primitives: NodePrimitives<
+        BlockHeader = alloy_consensus::Header,
+        BlockBody = alloy_consensus::BlockBody<<N::Primitives as NodePrimitives>::SignedTx>,
+    >,
     N::ComponentsBuilder: NodeComponentsBuilder<
         TmpNodeAdapter<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>,
         Components: NodeComponents<

--- a/crates/engine/util/Cargo.toml
+++ b/crates/engine/util/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-ethereum-primitives.workspace = true
 reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-errors.workspace = true

--- a/crates/engine/util/src/lib.rs
+++ b/crates/engine/util/src/lib.rs
@@ -2,7 +2,6 @@
 
 use futures::Stream;
 use reth_engine_primitives::{BeaconEngineMessage, EngineTypes};
-use reth_payload_validator::ExecutionPayloadValidator;
 use std::path::PathBuf;
 use tokio_util::either::Either;
 
@@ -94,14 +93,14 @@ pub trait EngineMessageStreamExt<Engine: EngineTypes>:
     }
 
     /// Creates reorgs with specified frequency.
-    fn reorg<Provider, Evm, Spec>(
+    fn reorg<Provider, Evm, Validator>(
         self,
         provider: Provider,
         evm_config: Evm,
-        payload_validator: ExecutionPayloadValidator<Spec>,
+        payload_validator: Validator,
         frequency: usize,
         depth: Option<usize>,
-    ) -> EngineReorg<Self, Engine, Provider, Evm, Spec>
+    ) -> EngineReorg<Self, Engine, Provider, Evm, Validator>
     where
         Self: Sized,
     {
@@ -117,14 +116,14 @@ pub trait EngineMessageStreamExt<Engine: EngineTypes>:
 
     /// If frequency is [Some], returns the stream that creates reorgs with
     /// specified frequency. Otherwise, returns `Self`.
-    fn maybe_reorg<Provider, Evm, Spec>(
+    fn maybe_reorg<Provider, Evm, Validator>(
         self,
         provider: Provider,
         evm_config: Evm,
-        payload_validator: ExecutionPayloadValidator<Spec>,
+        payload_validator: Validator,
         frequency: Option<usize>,
         depth: Option<usize>,
-    ) -> Either<EngineReorg<Self, Engine, Provider, Evm, Spec>, Self>
+    ) -> Either<EngineReorg<Self, Engine, Provider, Evm, Validator>, Self>
     where
         Self: Sized,
     {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -20,9 +20,7 @@ use reth_evm::{
     ConfigureEvm, Database, Evm, EvmEnv, EvmFactory, TransactionEnv,
 };
 use reth_execution_types::BlockExecutionResult;
-use reth_primitives::{
-    EthPrimitives, Receipt, Recovered, RecoveredBlock, SealedBlock, TransactionSigned,
-};
+use reth_primitives::{EthPrimitives, Receipt, Recovered, SealedBlock, TransactionSigned};
 use reth_primitives_traits::NodePrimitives;
 use reth_revm::{
     context_interface::result::ResultAndState, db::State, specification::hardfork::SpecId,
@@ -40,15 +38,15 @@ where
     type Primitives = EthPrimitives;
 
     fn create_strategy<'a, DB>(
-        &'a mut self,
+        &'a self,
         db: &'a mut State<DB>,
-        block: &'a RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
+        block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
     ) -> impl BlockExecutionStrategy<Primitives = Self::Primitives, Error = BlockExecutionError> + 'a
     where
         DB: Database,
     {
         let evm = self.evm_for_block(db, block.header());
-        EthExecutionStrategy::new(evm, block.sealed_block(), &self.chain_spec)
+        EthExecutionStrategy::new(evm, block, &self.chain_spec)
     }
 }
 
@@ -283,7 +281,7 @@ mod tests {
     use reth_chainspec::{ChainSpecBuilder, ForkCondition, MAINNET};
     use reth_evm::execute::{BasicBlockExecutorProvider, BlockExecutorProvider, Executor};
     use reth_execution_types::BlockExecutionResult;
-    use reth_primitives::{Account, Block, BlockBody, Transaction};
+    use reth_primitives::{Account, Block, BlockBody, RecoveredBlock, Transaction};
     use reth_primitives_traits::{crypto::secp256k1::public_key_to_address, Block as _};
     use reth_revm::{
         database::StateProviderDatabase,

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -13,7 +13,7 @@ pub use reth_execution_errors::{
 };
 use reth_execution_types::BlockExecutionResult;
 pub use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
-use reth_primitives::{NodePrimitives, Receipt, Recovered, RecoveredBlock};
+use reth_primitives::{NodePrimitives, Receipt, Recovered, RecoveredBlock, SealedBlock};
 pub use reth_storage_errors::provider::ProviderError;
 use revm::state::{Account, AccountStatus, EvmState};
 use revm_database::{states::bundle_state::BundleRetention, State};
@@ -197,9 +197,9 @@ pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> {
 
     /// Creates a strategy using the given database.
     fn create_strategy<'a, DB>(
-        &'a mut self,
+        &'a self,
         db: &'a mut State<DB>,
-        block: &'a RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
+        block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
     ) -> impl BlockExecutionStrategy<Primitives = Self::Primitives, Error = BlockExecutionError> + 'a
     where
         DB: Database;

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -24,9 +24,7 @@ use reth_execution_types::BlockExecutionResult;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{transaction::signed::OpTransaction, DepositReceipt};
-use reth_primitives_traits::{
-    Block, NodePrimitives, RecoveredBlock, SealedBlock, SignedTransaction,
-};
+use reth_primitives_traits::{Block, NodePrimitives, SealedBlock, SignedTransaction};
 use revm::{context::TxEnv, context_interface::result::ResultAndState, DatabaseCommit};
 use revm_database::State;
 use revm_primitives::{Address, B256};
@@ -41,20 +39,15 @@ where
     type Primitives = N;
 
     fn create_strategy<'a, DB>(
-        &'a mut self,
+        &'a self,
         db: &'a mut State<DB>,
-        block: &'a RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
+        block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
     ) -> impl BlockExecutionStrategy<Primitives = Self::Primitives, Error = BlockExecutionError> + 'a
     where
         DB: Database,
     {
         let evm = self.evm_for_block(db, block.header());
-        OpExecutionStrategy::new(
-            evm,
-            block.sealed_block(),
-            &self.chain_spec,
-            self.receipt_builder.as_ref(),
-        )
+        OpExecutionStrategy::new(evm, block, &self.chain_spec, self.receipt_builder.as_ref())
     }
 }
 
@@ -306,7 +299,7 @@ mod tests {
     use reth_evm::execute::{BasicBlockExecutorProvider, BlockExecutorProvider, Executor};
     use reth_optimism_chainspec::OpChainSpecBuilder;
     use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
-    use reth_primitives_traits::Account;
+    use reth_primitives_traits::{Account, RecoveredBlock};
     use reth_revm::{database::StateProviderDatabase, test_utils::StateProviderTest};
     use revm_optimism::constants::L1_BLOCK_CONTRACT;
     use std::{collections::HashMap, str::FromStr};

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -28,9 +28,7 @@ use reth_evm::{
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_ethereum::{node::EthereumAddOns, BasicBlockExecutorProvider, EthereumNode};
-use reth_primitives::{
-    Block, EthPrimitives, Receipt, Recovered, RecoveredBlock, SealedBlock, TransactionSigned,
-};
+use reth_primitives::{Block, EthPrimitives, Receipt, Recovered, SealedBlock, TransactionSigned};
 use std::fmt::Display;
 
 pub const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
@@ -117,9 +115,9 @@ impl BlockExecutionStrategyFactory for CustomEvmConfig {
     type Primitives = EthPrimitives;
 
     fn create_strategy<'a, DB>(
-        &'a mut self,
+        &'a self,
         db: &'a mut State<DB>,
-        block: &'a RecoveredBlock<Block>,
+        block: &'a SealedBlock<Block>,
     ) -> impl BlockExecutionStrategy<Primitives = Self::Primitives, Error = BlockExecutionError> + 'a
     where
         DB: Database,


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/14675

Reason for it being disabled was that building a reorg target required constructing receipts for all of the transactions which we didn't have an abstraction for.

With `BlockExecutionStrategy` receipt building is now available through its API thus allowing us to build blocks without knowing the underlying receipt type.

We don't yet have identical abstraction for building headers (ref https://github.com/paradigmxyz/reth/pull/14470), thus this logic for now requires us to lock header and body types to concrete `alloy_consensus` values. Also logic is not yet accounting for op-specific nuances when building headers but this shouldn't be a big issue for now
