### PR TITLE
chore(ci): remove batcher extra param from kurtosis op network config

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -8,10 +8,8 @@ optimism_package:
   chains:
     - participants:
       - el_type: op-geth
+        el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.8"
         cl_type: op-node
       - el_type: op-reth
         el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
         cl_type: op-node
-      batcher_params:
-        extra_params:
-          - "--throttle-interval=0"


### PR DESCRIPTION
fixes errors like https://github.com/paradigmxyz/reth/actions/runs/13488342189

removes the additional params we were setting to op-batcher (now deprecated) and fixes geth service port retrieval. also pins op-geth image to prevent errors like:
```
[op-el-1-op-geth-op-node-op-kurtosis] INFO [02-24|13:55:41.615] HTTP server started                      endpoint=[::]:8551 auth=true  prefix= cors=localhost vhosts=*
[op-el-1-op-geth-op-node-op-kurtosis] INFO [02-24|13:55:41.658] Generated state snapshot                 accounts=2366 slots=2084 storage=394.01KiB dangling=0 elapsed=54.253ms
[op-el-1-op-geth-op-node-op-kurtosis] WARN [02-24|13:55:43.752] Served eth_getBlockByNumber              conn=172.16.0.22:57756 reqid=3 duration="33.032µs" err="finalized block not found"
[op-el-1-op-geth-op-node-op-kurtosis] WARN [02-24|13:55:43.753] Served eth_getBlockByNumber              conn=172.16.0.22:57756 reqid=4 duration="22.963µs" err="safe block not found"
[op-el-1-op-geth-op-node-op-kurtosis] INFO [02-24|13:55:45.758] Starting work on payload                 id=0x034f0ef9b786379f
[op-el-1-op-geth-op-node-op-kurtosis] INFO [02-24|13:55:45.758] Stopping work on payload                 id=0x034f0ef9b786379f reason=delivery elapsed="188.785µs"
[op-el-1-op-geth-op-node-op-kurtosis] panic: runtime error: invalid memory address or nil pointer dereference
[op-el-1-op-geth-op-node-op-kurtosis] [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x885e60]
[op-el-1-op-geth-op-node-op-kurtosis] 
[op-el-1-op-geth-op-node-op-kurtosis] goroutine 4709 [running]:
[op-el-1-op-geth-op-node-op-kurtosis] github.com/ethereum/go-ethereum/consensus/misc/eip4844.CalcBlobFee(0xc00011a640, 0xc003a88008)
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/consensus/misc/eip4844/eip4844.go:89 +0x40
[op-el-1-op-geth-op-node-op-kurtosis] github.com/ethereum/go-ethereum/core.NewEVMBlockContext(0xc003a88008, {0x27e3070, 0xc00043a808}, 0xc00355b920?, 0xc00011a640, {0x27d70a0, 0xc003822d80})
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/core/evm.go:64 +0x306
[op-el-1-op-geth-op-node-op-kurtosis] github.com/ethereum/go-ethereum/miner.(*Miner).makeEnv(0xc0002c4c80, 0xc0000ed688, 0xc003a88008, {0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...)
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/miner/worker.go:358 +0x1c6
[op-el-1-op-geth-op-node-op-kurtosis] github.com/ethereum/go-ethereum/miner.(*Miner).prepareWork(0xc0002c4c80, 0xc003b340e0, 0x0)
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/miner/worker.go:309 +0xb25
[op-el-1-op-geth-op-node-op-kurtosis] github.com/ethereum/go-ethereum/miner.(*Miner).generateWork(0xc0002c4c80, 0xc003b340e0, 0x90?)
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/miner/worker.go:129 +0x32
[op-el-1-op-geth-op-node-op-kurtosis] github.com/ethereum/go-ethereum/miner.(*Miner).buildPayload.func1.2()
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/miner/payload_building.go:382 +0x68
[op-el-1-op-geth-op-node-op-kurtosis] github.com/ethereum/go-ethereum/miner.(*Miner).buildPayload.func1()
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/miner/payload_building.go:413 +0x365
[op-el-1-op-geth-op-node-op-kurtosis] created by github.com/ethereum/go-ethereum/miner.(*Miner).buildPayload in goroutine 4708
[op-el-1-op-geth-op-node-op-kurtosis] 	github.com/ethereum/go-ethereum/miner/payload_building.go:357 +0x545
```

successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/13500317864