### PR TITLE
remove needlessness async block and await op

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -53,7 +53,7 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
         self.io_task_spawner().spawn_blocking(Box::pin(async move {
-            let res = async move { f(this) }.await;
+            let res = f(this);
             let _ = tx.send(res);
         }));
 


### PR DESCRIPTION
Seems the inside async block is useless, and can be removed, and this also should not lead to performance issue