### PR TITLE
chore: fixed duplicate phrase issue in block description

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -77,7 +77,7 @@ pub struct Command<C: ChainSpecParser> {
 }
 
 impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
-    /// Fetches the best block block from the database.
+    /// Fetches the best block from the database.
     ///
     /// If the database is empty, returns the genesis block.
     fn lookup_best_block<N: ProviderNodeTypes<ChainSpec = C::ChainSpec>>(


### PR DESCRIPTION
<img width="531" alt="Снимок экрана 2025-02-25 в 13 52 14" src="https://github.com/user-attachments/assets/92e3a4e0-3cc0-43a2-a595-93d3fe4b2761" />

I’ve removed the repeated occurrence of the phrase "best block" in the block description. 