### PR TITLE
fix: fix log key format for target_block_number argument

### DIFF
--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -112,7 +112,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         let executor_provider = EthExecutorProvider::ethereum(provider_factory.chain_spec());
 
         // Initialize the fetch client
-        info!(target: "reth::cli", target_block_number=self.to, "Downloading tip of block range");
+        info!(target: "reth::cli", target_block_number = self.to, "Downloading tip of block range");
         let fetch_client = network.fetch_client().await?;
 
         // fetch the header at `self.to`


### PR DESCRIPTION
### Description
i’ve corrected the format for the `target_block_number` argument,
it should now follow the `key = value` structure, ensuring proper functionality when processing logs.

this change ensures the argument is passed in the correct format with an equal sign.