### PR TITLE
fix: fix redundant Ok wrapping in install_exex closure

### DIFF
--- a/book/sources/exex/hello-world/src/bin/2.rs
+++ b/book/sources/exex/hello-world/src/bin/2.rs
@@ -11,7 +11,7 @@ fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(|builder, _| async move {
         let handle = builder
             .node(EthereumNode::default())
-            .install_exex("my-exex", |ctx| async move { Ok(my_exex(ctx)) })
+            .install_exex("my-exex", |ctx| my_exex(ctx))
             .launch()
             .await?;
 


### PR DESCRIPTION
Removed the unnecessary `Ok` wrapping around `my_exex(ctx)` since `my_exex(ctx)` already returns an `eyre::Result<()>`.  

This is important because `install_exex` expects a closure that returns `eyre::Result<()>`. Wrapping the result in `Ok` changes the type to `Result<eyre::Result<()>, _>`, which would cause a compilation error or a logical issue.  