### PR TITLE
feat: add rlp support for snap message types

### DIFF
--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -8,6 +8,7 @@
 use alloc::vec::Vec;
 use alloy_primitives::{Bytes, B256};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
+use reth_codecs_derive::add_arbitrary_tests;
 
 /// Message IDs for the snap sync protocol
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,6 +35,8 @@ pub enum SnapMessageId {
 /// Request for a range of accounts from the state trie.
 // https://github.com/ethereum/devp2p/blob/master/caps/snap.md#getaccountrange-0x00
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetAccountRangeMessage {
     /// Request ID to match up responses with
     pub request_id: u64,
@@ -49,6 +52,8 @@ pub struct GetAccountRangeMessage {
 
 /// Account data in the response.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct AccountData {
     /// Hash of the account address (trie path)
     pub hash: B256,
@@ -59,6 +64,8 @@ pub struct AccountData {
 /// Response containing a number of consecutive accounts and the Merkle proofs for the entire range.
 // http://github.com/ethereum/devp2p/blob/master/caps/snap.md#accountrange-0x01
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct AccountRangeMessage {
     /// ID of the request this is a response for
     pub request_id: u64,
@@ -71,6 +78,8 @@ pub struct AccountRangeMessage {
 /// Request for the storage slots of multiple accounts' storage tries.
 // https://github.com/ethereum/devp2p/blob/master/caps/snap.md#getstorageranges-0x02
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetStorageRangesMessage {
     /// Request ID to match up responses with
     pub request_id: u64,
@@ -88,6 +97,8 @@ pub struct GetStorageRangesMessage {
 
 /// Storage slot data in the response.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct StorageData {
     /// Hash of the storage slot key (trie path)
     pub hash: B256,
@@ -100,6 +111,8 @@ pub struct StorageData {
 /// covers the storage trie.
 // https://github.com/ethereum/devp2p/blob/master/caps/snap.md#storageranges-0x03
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct StorageRangesMessage {
     /// ID of the request this is a response for
     pub request_id: u64,
@@ -112,6 +125,8 @@ pub struct StorageRangesMessage {
 /// Request to get a number of requested contract codes.
 // https://github.com/ethereum/devp2p/blob/master/caps/snap.md#getbytecodes-0x04
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetByteCodesMessage {
     /// Request ID to match up responses with
     pub request_id: u64,
@@ -124,6 +139,8 @@ pub struct GetByteCodesMessage {
 /// Response containing a number of requested contract codes.
 // https://github.com/ethereum/devp2p/blob/master/caps/snap.md#bytecodes-0x05
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct ByteCodesMessage {
     /// ID of the request this is a response for
     pub request_id: u64,
@@ -133,6 +150,8 @@ pub struct ByteCodesMessage {
 
 /// Path in the trie for an account and its storage
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct TriePath {
     /// Path in the account trie
     pub account_path: Bytes,
@@ -143,6 +162,8 @@ pub struct TriePath {
 /// Request a number of state (either account or storage) Merkle trie nodes by path
 // https://github.com/ethereum/devp2p/blob/master/caps/snap.md#gettrienodes-0x06
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct GetTrieNodesMessage {
     /// Request ID to match up responses with
     pub request_id: u64,
@@ -157,6 +178,8 @@ pub struct GetTrieNodesMessage {
 /// Response containing a number of requested state trie nodes
 // https://github.com/ethereum/devp2p/blob/master/caps/snap.md#trienodes-0x07
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
 pub struct TrieNodesMessage {
     /// ID of the request this is a response for
     pub request_id: u64,
@@ -200,46 +223,5 @@ impl SnapProtocolMessage {
             Self::GetTrieNodes(_) => SnapMessageId::GetTrieNodes,
             Self::TrieNodes(_) => SnapMessageId::TrieNodes,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_primitives::{hex, B256};
-    use alloy_rlp::{Decodable, Encodable};
-
-    #[test]
-    fn test_get_account_range_roundtrip() {
-        let original_msg = GetAccountRangeMessage {
-            request_id: 12345,
-            root_hash: B256::from_slice(&hex!(
-                "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-            )),
-            starting_hash: B256::from_slice(&hex!(
-                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-            )),
-            limit_hash: B256::from_slice(&hex!(
-                "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba"
-            )),
-            response_bytes: 1024,
-        };
-
-        let mut encoded = Vec::new();
-        original_msg.encode(&mut encoded);
-        let decoded = GetAccountRangeMessage::decode(&mut &encoded[..]).expect("Failed to decode");
-
-        assert_eq!(original_msg, decoded);
-    }
-
-    #[test]
-    fn test_get_account_range_invalid_format() {
-        // non-list RLP encoding
-        let invalid_rlp = [0x80];
-
-        // Attempt to decode it as a GetAccountRangeMessage
-        let result = GetAccountRangeMessage::decode(&mut &invalid_rlp[..]);
-
-        assert!(result.is_err());
     }
 }

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -292,7 +292,7 @@ mod tests {
         // non-list RLP encoding
         let invalid_rlp = [0x80];
 
-        // Attempt decode it as a GetAccountRangeMessage
+        // Attempt to decode it as a GetAccountRangeMessage
         let result = GetAccountRangeMessage::decode(&mut &invalid_rlp[..]);
 
         assert!(result.is_err());

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -272,10 +272,10 @@ mod tests {
                 "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
             )),
             starting_hash: B256::from_slice(&hex!(
-                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+                "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
             )),
             limit_hash: B256::from_slice(&hex!(
-                "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedc"
+                "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba"
             )),
             response_bytes: 1024,
         };


### PR DESCRIPTION
Following https://github.com/paradigmxyz/reth/pull/14119#pullrequestreview-2586451045. 

Add RLP support for snap message types.