### PR TITLE
 Fix Typographical Error in zepter.yaml

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -18,7 +18,7 @@ workflows:
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
 
         "--left-side-outside-workspace=ignore",
-        # Auxilary flags:
+        # Auxiliary flags:
         "--offline",
         "--locked",
         "--show-path",


### PR DESCRIPTION
The word "Auxilary" was misspelled; the correct spelling is "Auxiliary"