### PR TITLE
fix: correctly set txtype for `eth_call`

### DIFF
--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,5 +1,6 @@
 use super::OpNodeCore;
 use crate::{OpEthApi, OpEthApiError};
+use alloy_consensus::TxType;
 use alloy_primitives::{Bytes, TxKind, U256};
 use alloy_rpc_types_eth::transaction::TransactionRequest;
 use reth_evm::{ConfigureEvm, EvmEnv, SpecFor};
@@ -60,7 +61,17 @@ where
             return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into_eth_err())
         }
 
-        let tx_type = request.preferred_type() as u8;
+        let tx_type = if request.authorization_list.is_some() {
+            TxType::Eip7702
+        } else if request.sidecar.is_some() || request.max_fee_per_blob_gas.is_some() {
+            TxType::Eip4844
+        } else if request.max_fee_per_gas.is_some() || request.max_priority_fee_per_gas.is_some() {
+            TxType::Eip1559
+        } else if request.access_list.is_some() {
+            TxType::Eip2930
+        } else {
+            TxType::Legacy
+        } as u8;
 
         let TransactionRequest {
             from,


### PR DESCRIPTION
Prefers setting `TxType::Legacy` when configuring `TxEnv` for RPC