### PR TITLE
feat: pending block support in `BlockExecutionStrategyFactory`

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -19,6 +19,7 @@ crates_to_check=(
     reth-evm
 
     ## ethereum
+    reth-evm-ethereum
     reth-ethereum-forks
     reth-ethereum-primitives
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7782,8 +7782,8 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives",
  "reth-primitives-traits",
- "reth-revm",
  "reth-testing-utils",
+ "revm",
  "secp256k1 0.30.0",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,7 +7776,6 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-sol-types",
- "derive_more 2.0.1",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,6 +7776,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-sol-types",
+ "derive_more 2.0.1",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-eip2124 = { version = "0.1.0", default-features = false }
 alloy-evm = { version = "0.1", default-features = false }
 alloy-primitives = { version = "0.8.20", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
-alloy-sol-types = "0.8.20"
+alloy-sol-types = { version = "0.8.20", default-features = false }
 alloy-trie = { version = "0.7", default-features = false }
 
 alloy-consensus = { version = "0.11.1", default-features = false }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -303,7 +303,7 @@ where
         .with_bundle_update()
         .build();
 
-    let mut strategy = evm_config.create_strategy(&mut state, &reorg_target);
+    let mut strategy = evm_config.strategy_for_block(&mut state, &reorg_target);
 
     strategy.apply_pre_execution_changes()?;
 

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 reth-execution-types.workspace = true
 reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
-reth-revm.workspace = true
+revm.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
 
@@ -29,7 +29,6 @@ alloy-consensus.workspace = true
 [dev-dependencies]
 reth-testing-utils.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
-reth-revm = { workspace = true, features = ["test-utils"] }
 reth-primitives = { workspace = true, features = ["secp256k1"] }
 reth-primitives-traits.workspace = true
 reth-execution-types.workspace = true
@@ -41,7 +40,6 @@ alloy-genesis.workspace = true
 default = ["std"]
 std = [
     "reth-primitives/std",
-    "reth-revm/std",
     "alloy-consensus/std",
     "alloy-eips/std",
     "alloy-genesis/std",
@@ -54,4 +52,6 @@ std = [
     "reth-execution-types/std",
     "reth-evm/std",
     "reth-primitives-traits/std",
+    "alloy-sol-types/std",
+    "revm/std",
 ]

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -19,9 +19,6 @@ reth-revm.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
 
-# Ethereum
-reth-primitives-traits.workspace = true
-
 # Alloy
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
@@ -29,13 +26,12 @@ alloy-evm.workspace = true
 alloy-sol-types.workspace = true
 alloy-consensus.workspace = true
 
-derive_more.workspace = true
-
 [dev-dependencies]
 reth-testing-utils.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
 reth-revm = { workspace = true, features = ["test-utils"] }
 reth-primitives = { workspace = true, features = ["secp256k1"] }
+reth-primitives-traits.workspace = true
 reth-execution-types.workspace = true
 secp256k1.workspace = true
 serde_json.workspace = true
@@ -53,7 +49,6 @@ std = [
     "secp256k1/std",
     "reth-ethereum-forks/std",
     "serde_json/std",
-    "reth-primitives-traits/std",
     "reth-chainspec/std",
     "alloy-evm/std",
     "reth-execution-types/std",

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -29,6 +29,8 @@ alloy-evm.workspace = true
 alloy-sol-types.workspace = true
 alloy-consensus.workspace = true
 
+derive_more.workspace = true
+
 [dev-dependencies]
 reth-testing-utils.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -53,4 +53,5 @@ std = [
     "alloy-evm/std",
     "reth-execution-types/std",
     "reth-evm/std",
+    "reth-primitives-traits/std",
 ]

--- a/crates/ethereum/evm/src/config.rs
+++ b/crates/ethereum/evm/src/config.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::Header;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_ethereum_forks::EthereumHardfork;
-use reth_revm::specification::hardfork::SpecId;
+use revm::specification::hardfork::SpecId;
 
 /// Map the latest active hardfork at the given header to a revm [`SpecId`].
 pub fn revm_spec(chain_spec: &ChainSpec, header: &Header) -> SpecId {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -78,7 +78,7 @@ where
     }
 }
 
-/// Input for block execution.
+/// Context for Ethereum block execution.
 #[derive(Debug, Clone, Copy)]
 pub struct EthBlockExecutionCtx<'a> {
     /// Parent block hash.
@@ -97,7 +97,7 @@ pub struct EthExecutionStrategy<'a, Evm> {
     /// Reference to the [`ChainSpec`].
     chain_spec: &'a ChainSpec,
 
-    /// Input for block execution.
+    /// Context for block execution.
     ctx: EthBlockExecutionCtx<'a>,
     /// The EVM used by strategy.
     evm: Evm,

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -1,7 +1,5 @@
 //! Ethereum block execution strategy.
 
-use core::ops::Deref;
-
 use crate::{
     dao_fork::{DAO_HARDFORK_ACCOUNTS, DAO_HARDFORK_BENEFICIARY},
     EthEvmConfig,
@@ -19,20 +17,16 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, StateChangePostBlockSource, StateChangeSource, SystemCaller},
-    ConfigureEvm, ConfigureEvmEnv, Database, Evm, EvmEnv, EvmFactory, EvmFor, InspectorFor,
-    NextBlockEnvAttributes, TransactionEnv,
+    Database, Evm, EvmEnv, EvmFactory, EvmFor, InspectorFor, NextBlockEnvAttributes,
+    TransactionEnv,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives::{
     EthPrimitives, Receipt, Recovered, SealedBlock, SealedHeader, TransactionSigned,
 };
 use reth_revm::{
-    context::{result::ExecutionResult, BlockEnv},
-    context_interface::result::ResultAndState,
-    db::State,
-    inspector::NoOpInspector,
-    specification::hardfork::SpecId,
-    DatabaseCommit,
+    context::result::ExecutionResult, context_interface::result::ResultAndState, db::State,
+    specification::hardfork::SpecId, DatabaseCommit,
 };
 
 impl<EvmF> BlockExecutionStrategyFactory for EthEvmConfig<EvmF>

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -123,7 +123,7 @@ where
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: NextBlockEnvAttributes,
+        attributes: NextBlockEnvAttributes<'_>,
     ) -> Result<EvmEnv, Self::Error> {
         // ensure we're not missing any timestamp based hardforks
         let spec_id = revm_spec_by_timestamp_and_block_number(

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -28,7 +28,7 @@ use reth_evm::{
     ConfigureEvm, ConfigureEvmEnv, EvmEnv, EvmFactory, NextBlockEnvAttributes, TransactionEnv,
 };
 use reth_primitives::TransactionSigned;
-use reth_revm::{
+use revm::{
     context::{BlockEnv, CfgEnv},
     context_interface::block::BlobExcessGasAndPrice,
     specification::hardfork::SpecId,
@@ -204,10 +204,10 @@ mod tests {
     use alloy_genesis::Genesis;
     use reth_chainspec::{Chain, ChainSpec};
     use reth_evm::{execute::ProviderError, EvmEnv};
-    use reth_revm::{
+    use revm::{
         context::{BlockEnv, CfgEnv},
+        database::CacheDB,
         database_interface::EmptyDBTyped,
-        db::CacheDB,
         inspector::NoOpInspector,
     };
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -17,12 +17,12 @@ use reth_basic_payload_builder::{
 };
 use reth_chainspec::{ChainSpec, ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError};
-use reth_ethereum_primitives::{Block, BlockBody, TransactionSigned};
-use reth_evm::{execute::BlockExecutionStrategy, ConfigureEvm, NextBlockEnvAttributes};
-use reth_evm_ethereum::{
-    execute::{EthBlockExecutionInput, EthExecutionStrategy},
-    EthEvmConfig,
+use reth_ethereum_primitives::{Block, BlockBody, EthPrimitives, TransactionSigned};
+use reth_evm::{
+    execute::{BlockExecutionStrategy, BlockExecutionStrategyFactory},
+    Evm, NextBlockEnvAttributes,
 };
+use reth_evm_ethereum::EthEvmConfig;
 use reth_execution_types::{BlockExecutionResult, ExecutionOutcome};
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_payload_builder_primitives::PayloadBuilderError;
@@ -81,7 +81,7 @@ impl<Pool, Client, EvmConfig> EthereumPayloadBuilder<Pool, Client, EvmConfig> {
 // Default implementation of [PayloadBuilder] for unit type
 impl<Pool, Client, EvmConfig> PayloadBuilder for EthereumPayloadBuilder<Pool, Client, EvmConfig>
 where
-    EvmConfig: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
+    EvmConfig: BlockExecutionStrategyFactory<Primitives = EthPrimitives>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
@@ -136,7 +136,7 @@ pub fn default_ethereum_payload<EvmConfig, Client, Pool, F>(
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
-    EvmConfig: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
+    EvmConfig: BlockExecutionStrategyFactory<Primitives = EthPrimitives>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
@@ -154,43 +154,31 @@ where
         suggested_fee_recipient: attributes.suggested_fee_recipient(),
         prev_randao: attributes.prev_randao(),
         gas_limit: builder_config.gas_limit(parent_header.gas_limit),
+        parent_beacon_block_root: attributes.parent_beacon_block_root(),
+        withdrawals: Some(attributes.withdrawals()),
     };
-    let evm_env = evm_config
-        .next_evm_env(&parent_header, next_attributes)
+
+    let mut strategy = evm_config
+        .strategy_for_pending_block(&mut db, &parent_header, next_attributes)
         .map_err(PayloadBuilderError::other)?;
 
     let chain_spec = client.chain_spec();
 
     debug!(target: "payload_builder", id=%attributes.id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
     let mut cumulative_gas_used = 0;
-    let block_gas_limit: u64 = evm_env.block_env.gas_limit;
-    let base_fee = evm_env.block_env.basefee;
+    let block_gas_limit: u64 = strategy.evm_mut().block().gas_limit;
+    let base_fee = strategy.evm_mut().block().basefee;
 
     let mut executed_txs = Vec::new();
 
     let mut best_txs = best_txs(BestTransactionsAttributes::new(
         base_fee,
-        evm_env.block_env.blob_gasprice().map(|gasprice| gasprice as u64),
+        strategy.evm_mut().block().blob_gasprice().map(|gasprice| gasprice as u64),
     ));
     let mut total_fees = U256::ZERO;
 
-    let block_number = evm_env.block_env.number;
-    let beneficiary = evm_env.block_env.beneficiary;
-
-    let mut strategy = EthExecutionStrategy::new(
-        evm_config.evm_with_env(&mut db, evm_env),
-        EthBlockExecutionInput {
-            number: parent_header.number + 1,
-            timestamp: attributes.timestamp(),
-            parent_hash: parent_header.hash(),
-            gas_limit: next_attributes.gas_limit,
-            parent_beacon_block_root: attributes.parent_beacon_block_root,
-            beneficiary,
-            ommers: &[],
-            withdrawals: Some(&attributes.withdrawals),
-        },
-        &chain_spec,
-    );
+    let block_number = strategy.evm_mut().block().number;
+    let beneficiary = strategy.evm_mut().block().beneficiary;
 
     strategy.apply_pre_execution_changes().map_err(|err| {
         warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -159,7 +159,7 @@ where
     };
 
     let mut strategy = evm_config
-        .strategy_for_pending_block(&mut db, &parent_header, next_attributes)
+        .strategy_for_next_block(&mut db, &parent_header, next_attributes)
         .map_err(PayloadBuilderError::other)?;
 
     let chain_spec = client.chain_spec();

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -4,7 +4,7 @@ use alloy_consensus::BlockHeader;
 use alloy_evm::Evm;
 // Re-export execution types
 use crate::{
-    system_calls::OnStateHook, ConfigureEvmFor, Database, EvmEnvFor, EvmFor, InspectorFor,
+    system_calls::OnStateHook, ConfigureEvmFor, Database, EvmFor, InspectorFor,
     NextBlockEnvAttributes,
 };
 use alloc::{boxed::Box, vec::Vec};

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -228,13 +228,13 @@ pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> + 'st
         Evm = EvmFor<Self, &'a mut State<DB>, I>,
     >;
 
-    /// Context required for execution a block.
+    /// Context required for block execution.
     ///
     /// This is similar to [`alloy_evm::EvmEnv`], but only contains context unrelated to EVM and
     /// required for execution of an entire block.
     type ExecutionCtx<'a>;
 
-    /// Returns the configured [`BlockExecutionStrategyFactory::ExecutionCtx`] for block execution.
+    /// Returns the configured [`BlockExecutionStrategyFactory::ExecutionCtx`] for a given block.
     fn context_for_block<'a>(
         &self,
         block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -17,7 +17,7 @@
 
 extern crate alloc;
 
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip4895::Withdrawals};
 pub use alloy_evm::evm::EvmFactory;
 use alloy_evm::{FromRecoveredTx, IntoTxEnv};
 use alloy_primitives::{Address, B256};
@@ -177,7 +177,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: NextBlockEnvAttributes,
+        attributes: NextBlockEnvAttributes<'_>,
     ) -> Result<EvmEnv<Self::Spec>, Self::Error>;
 }
 
@@ -186,7 +186,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
 /// [`ConfigureEvmEnv::next_evm_env`] and contains fields that can't be derived from the
 /// parent header alone (attributes that are determined by the CL.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NextBlockEnvAttributes {
+pub struct NextBlockEnvAttributes<'a> {
     /// The timestamp of the next block.
     pub timestamp: u64,
     /// The suggested fee recipient for the next block.
@@ -195,6 +195,10 @@ pub struct NextBlockEnvAttributes {
     pub prev_randao: B256,
     /// Block gas limit.
     pub gas_limit: u64,
+    /// The parent beacon block root.
+    pub parent_beacon_block_root: Option<B256>,
+    /// Withdrawals
+    pub withdrawals: Option<&'a Withdrawals>,
 }
 
 /// Abstraction over transaction environment.

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -6,7 +6,7 @@ use reth_basic_payload_builder::PayloadBuilder;
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
 use reth_engine_primitives::{BeaconConsensusEngineEvent, BeaconConsensusEngineHandle};
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmFor};
+use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
 use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine, TxTy};
@@ -68,7 +68,7 @@ pub trait FullNodeComponents: FullNodeTypes + Clone + 'static {
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvmFor<<Self::Types as NodeTypes>::Primitives>;
+    type Evm: BlockExecutionStrategyFactory<Primitives = <Self::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <Self::Types as NodeTypes>::Primitives>;

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -72,7 +72,7 @@ where
     }
 }
 
-/// Input for block execution.
+/// Context for OP block execution.
 #[derive(Debug, Clone, Copy)]
 pub struct OpBlockExecutionCtx {
     /// Parent block hash.
@@ -89,7 +89,7 @@ pub struct OpExecutionStrategy<'a, E: Evm, N: NodePrimitives, ChainSpec> {
     /// Receipt builder.
     receipt_builder: &'a dyn OpReceiptBuilder<N::SignedTx, E::HaltReason, Receipt = N::Receipt>,
 
-    /// Input for block execution.
+    /// Context for block execution.
     ctx: OpBlockExecutionCtx,
     /// The EVM used by strategy.
     evm: E,

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -18,67 +18,67 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, StateChangePostBlockSource, StateChangeSource, SystemCaller},
-    ConfigureEvm, Database, Evm,
+    Database, Evm, EvmFor, InspectorFor, NextBlockEnvAttributes,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{transaction::signed::OpTransaction, DepositReceipt};
-use reth_primitives_traits::{Block, NodePrimitives, SealedBlock, SignedTransaction};
+use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader, SignedTransaction};
 use revm::{context::TxEnv, context_interface::result::ResultAndState, DatabaseCommit};
 use revm_database::State;
-use revm_primitives::{Address, B256};
+use revm_primitives::B256;
 use tracing::trace;
 
 impl<ChainSpec, N> BlockExecutionStrategyFactory for OpEvmConfig<ChainSpec, N>
 where
-    ChainSpec: EthChainSpec + OpHardforks,
+    ChainSpec: EthChainSpec + OpHardforks + 'static,
     N: NodePrimitives<SignedTx: OpTransaction, Receipt: DepositReceipt>,
     revm_optimism::OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx>,
 {
     type Primitives = N;
+    type Strategy<'a, DB: Database + 'a, I: InspectorFor<&'a mut State<DB>, Self> + 'a> =
+        OpExecutionStrategy<'a, EvmFor<Self, &'a mut State<DB>, I>, N, &'a ChainSpec>;
+    type ExecutionCtx<'a> = OpBlockExecutionCtx;
 
-    fn create_strategy<'a, DB>(
+    fn context_for_block<'a>(&self, block: &'a SealedBlock<N::Block>) -> Self::ExecutionCtx<'a> {
+        OpBlockExecutionCtx {
+            parent_hash: block.header().parent_hash(),
+            parent_beacon_block_root: block.header().parent_beacon_block_root(),
+        }
+    }
+
+    fn context_for_next_block<'a>(
+        &self,
+        parent: &SealedHeader<N::BlockHeader>,
+        attributes: NextBlockEnvAttributes<'a>,
+    ) -> Self::ExecutionCtx<'a> {
+        OpBlockExecutionCtx {
+            parent_hash: parent.hash(),
+            parent_beacon_block_root: attributes.parent_beacon_block_root,
+        }
+    }
+
+    fn create_strategy<'a, DB, I>(
         &'a self,
-        db: &'a mut State<DB>,
-        block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
-    ) -> impl BlockExecutionStrategy<Primitives = Self::Primitives, Error = BlockExecutionError> + 'a
+        evm: EvmFor<Self, &'a mut State<DB>, I>,
+        ctx: Self::ExecutionCtx<'a>,
+    ) -> Self::Strategy<'a, DB, I>
     where
         DB: Database,
+        I: reth_evm::InspectorFor<&'a mut State<DB>, Self> + 'a,
     {
-        let evm = self.evm_for_block(db, block.header());
-        OpExecutionStrategy::new(evm, block, &self.chain_spec, self.receipt_builder.as_ref())
+        OpExecutionStrategy::new(evm, ctx, self.chain_spec.as_ref(), self.receipt_builder.as_ref())
     }
 }
 
 /// Input for block execution.
 #[derive(Debug, Clone, Copy)]
-pub struct OpBlockExecutionInput {
-    /// Block number.
-    pub number: u64,
-    /// Block timestamp.
-    pub timestamp: u64,
+pub struct OpBlockExecutionCtx {
     /// Parent block hash.
     pub parent_hash: B256,
-    /// Block gas limit.
-    pub gas_limit: u64,
     /// Parent beacon block root.
     pub parent_beacon_block_root: Option<B256>,
-    /// Block beneficiary.
-    pub beneficiary: Address,
-}
-
-impl<'a, B: Block> From<&'a SealedBlock<B>> for OpBlockExecutionInput {
-    fn from(block: &'a SealedBlock<B>) -> Self {
-        Self {
-            number: block.header().number(),
-            timestamp: block.header().timestamp(),
-            parent_hash: block.header().parent_hash(),
-            gas_limit: block.header().gas_limit(),
-            parent_beacon_block_root: block.header().parent_beacon_block_root(),
-            beneficiary: block.header().beneficiary(),
-        }
-    }
 }
 
 /// Block execution strategy for Optimism.
@@ -90,7 +90,7 @@ pub struct OpExecutionStrategy<'a, E: Evm, N: NodePrimitives, ChainSpec> {
     receipt_builder: &'a dyn OpReceiptBuilder<N::SignedTx, E::HaltReason, Receipt = N::Receipt>,
 
     /// Input for block execution.
-    input: OpBlockExecutionInput,
+    ctx: OpBlockExecutionCtx,
     /// The EVM used by strategy.
     evm: E,
     /// Receipts of executed transactions.
@@ -112,20 +112,19 @@ where
     /// Creates a new [`OpExecutionStrategy`]
     pub fn new(
         evm: E,
-        input: impl Into<OpBlockExecutionInput>,
+        ctx: OpBlockExecutionCtx,
         chain_spec: ChainSpec,
         receipt_builder: &'a dyn OpReceiptBuilder<N::SignedTx, E::HaltReason, Receipt = N::Receipt>,
     ) -> Self {
-        let input = input.into();
         Self {
-            is_regolith: chain_spec.is_regolith_active_at_timestamp(input.timestamp),
+            is_regolith: chain_spec.is_regolith_active_at_timestamp(evm.block().timestamp),
             evm,
             system_caller: SystemCaller::new(chain_spec.clone()),
             chain_spec,
             receipt_builder,
             receipts: Vec::new(),
             gas_used: 0,
-            input,
+            ctx,
         }
     }
 }
@@ -139,30 +138,39 @@ where
 {
     type Primitives = N;
     type Error = BlockExecutionError;
+    type Evm = E;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), Self::Error> {
         // Set state clear flag if the block is after the Spurious Dragon hardfork.
         let state_clear_flag =
-            self.chain_spec.is_spurious_dragon_active_at_block(self.input.number);
+            self.chain_spec.is_spurious_dragon_active_at_block(self.evm.block().number);
         self.evm.db_mut().set_state_clear_flag(state_clear_flag);
 
         self.system_caller
-            .apply_beacon_root_contract_call(self.input.parent_beacon_block_root, &mut self.evm)?;
+            .apply_beacon_root_contract_call(self.ctx.parent_beacon_block_root, &mut self.evm)?;
 
         // Ensure that the create2deployer is force-deployed at the canyon transition. Optimism
         // blocks will always have at least a single transaction in them (the L1 info transaction),
         // so we can safely assume that this will always be triggered upon the transition and that
         // the above check for empty blocks will never be hit on OP chains.
-        ensure_create2_deployer(self.chain_spec.clone(), self.input.timestamp, self.evm.db_mut())
-            .map_err(|_| OpBlockExecutionError::ForceCreate2DeployerFail)?;
+        ensure_create2_deployer(
+            self.chain_spec.clone(),
+            self.evm.block().timestamp,
+            self.evm.db_mut(),
+        )
+        .map_err(|_| OpBlockExecutionError::ForceCreate2DeployerFail)?;
 
         Ok(())
     }
 
-    fn execute_transaction(&mut self, tx: Recovered<&N::SignedTx>) -> Result<u64, Self::Error> {
+    fn execute_transaction_with_result_closure(
+        &mut self,
+        tx: Recovered<&<Self::Primitives as NodePrimitives>::SignedTx>,
+        f: impl FnOnce(&revm::context::result::ExecutionResult<<Self::Evm as Evm>::HaltReason>),
+    ) -> Result<u64, Self::Error> {
         // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
         // must be no greater than the block’s gasLimit.
-        let block_available_gas = self.input.gas_limit - self.gas_used;
+        let block_available_gas = self.evm.block().gas_limit - self.gas_used;
         if tx.gas_limit() > block_available_gas && (self.is_regolith || !tx.is_deposit()) {
             return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
                 transaction_gas_limit: tx.gas_limit(),
@@ -202,6 +210,8 @@ where
         let ResultAndState { result, state } = result_and_state;
         self.evm.db_mut().commit(state);
 
+        f(&result);
+
         let gas_used = result.gas_used();
 
         // append gas used
@@ -232,7 +242,8 @@ where
                         // this is only set for post-Canyon deposit
                         // transactions.
                         deposit_receipt_version: (tx.is_deposit() &&
-                            self.chain_spec.is_canyon_active_at_timestamp(self.input.timestamp))
+                            self.chain_spec
+                                .is_canyon_active_at_timestamp(self.evm.block().timestamp))
                         .then_some(1),
                     })
                 }
@@ -269,6 +280,10 @@ where
 
     fn with_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
         self.system_caller.with_state_hook(hook);
+    }
+
+    fn evm_mut(&mut self) -> &mut Self::Evm {
+        &mut self.evm
     }
 }
 

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -132,7 +132,7 @@ where
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: NextBlockEnvAttributes,
+        attributes: NextBlockEnvAttributes<'_>,
     ) -> Result<EvmEnv<Self::Spec>, Self::Error> {
         // ensure we're not missing any timestamp based hardforks
         let spec_id = revm_spec_by_timestamp_after_bedrock(&self.chain_spec, attributes.timestamp);

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee_core::{async_trait, RpcResult};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::ChainSpecProvider;
-use reth_evm::{ConfigureEvm, ConfigureEvmFor};
+use reth_evm::{execute::BlockExecutionStrategyFactory, ConfigureEvm};
 use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_payload_builder::{OpPayloadBuilder, OpPayloadPrimitives};
@@ -69,7 +69,7 @@ where
         + ChainSpecProvider<ChainSpec = OpChainSpec>
         + Clone
         + 'static,
-    EvmConfig: ConfigureEvmFor<Provider::Primitives> + 'static,
+    EvmConfig: BlockExecutionStrategyFactory<Primitives = Provider::Primitives> + 'static,
 {
     async fn execute_payload(
         &self,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -104,8 +104,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let mut gas_used = 0;
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
-                let mut block_state_calls = block_state_calls.into_iter().peekable();
-                while let Some(block) = block_state_calls.next() {
+                for block in block_state_calls {
                     let mut evm_env = this
                         .evm_config()
                         .next_evm_env(&parent, this.next_env_attributes(&parent)?)

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -1,8 +1,6 @@
 //! Loads a pending block from database. Helper trait for `eth_` transaction, call and trace RPC
 //! methods.
 
-use std::borrow::BorrowMut;
-
 use super::{LoadBlock, LoadPendingBlock, LoadState, LoadTransaction, SpawnBlocking, Trace};
 use crate::{
     helpers::estimate::EstimateCall, FromEvmError, FullEthApiTypes, RpcBlock, RpcNodeCore,
@@ -167,8 +165,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         // prepare inspector to capture transfer inside the evm so they are recorded
                         // and included in logs
                         let inspector = TransferInspector::new(false).with_logs(true);
-                        let evm =
-                            this.evm_config().evm_with_env_and_inspector(&mut db, evm_env, inspector);
+                        let evm = this
+                            .evm_config()
+                            .evm_with_env_and_inspector(&mut db, evm_env, inspector);
                         let strategy = this.evm_config().create_strategy(evm, ctx);
                         simulate::execute_transactions(
                             strategy,

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -67,7 +67,7 @@ pub trait LoadPendingBlock:
         &self,
     ) -> &Mutex<Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>>;
 
-    /// Configures the [`EvmEnv`] for the pending block
+    /// Configures the [`PendingBlockEnv`] for the pending block
     ///
     /// If no pending block is available, this will derive it from the `latest` block
     #[expect(clippy::type_complexity)]

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -9,17 +9,18 @@ use alloy_primitives::B256;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use futures::Future;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_errors::RethError;
+use reth_errors::{BlockExecutionError, BlockValidationError, RethError};
 use reth_evm::{
-    state_change::post_block_withdrawals_balance_increments, system_calls::SystemCaller,
-    ConfigureEvm, ConfigureEvmEnv, Evm, EvmEnv, EvmError, HaltReasonFor, InvalidTxError,
-    NextBlockEnvAttributes,
+    execute::{BlockExecutionStrategy, BlockExecutionStrategyFactory},
+    ConfigureEvmEnv, Evm, NextBlockEnvAttributes,
 };
-use reth_primitives::{InvalidTransactionError, RecoveredBlock};
+use reth_node_api::NodePrimitives;
+use reth_primitives::{InvalidTransactionError, RecoveredBlock, SealedHeader};
 use reth_primitives_traits::Receipt;
 use reth_provider::{
-    BlockReader, BlockReaderIdExt, ChainSpecProvider, ProviderBlock, ProviderError, ProviderHeader,
-    ProviderReceipt, ProviderTx, ReceiptProvider, StateProviderFactory,
+    BlockExecutionResult, BlockReader, BlockReaderIdExt, ChainSpecProvider, ProviderBlock,
+    ProviderError, ProviderHeader, ProviderReceipt, ProviderTx, ReceiptProvider,
+    StateProviderFactory,
 };
 use reth_revm::{
     database::StateProviderDatabase,
@@ -30,13 +31,7 @@ use reth_transaction_pool::{
     error::InvalidPoolTransactionError, BestTransactionsAttributes, PoolTransaction,
     TransactionPool,
 };
-use revm::{
-    context::BlockEnv,
-    context_interface::{
-        result::{ExecutionResult, ResultAndState},
-        Block,
-    },
-};
+use revm::{context::BlockEnv, context_interface::Block};
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tracing::debug;
@@ -55,9 +50,12 @@ pub trait LoadPendingBlock:
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
-        Evm: ConfigureEvm<
-            Header = ProviderHeader<Self::Provider>,
-            Transaction = ProviderTx<Self::Provider>,
+        Evm: BlockExecutionStrategyFactory<
+            Primitives: NodePrimitives<
+                BlockHeader = ProviderHeader<Self::Provider>,
+                SignedTx = ProviderTx<Self::Provider>,
+                Receipt = ProviderReceipt<Self::Provider>,
+            >,
         >,
     >
 {
@@ -113,19 +111,26 @@ pub trait LoadPendingBlock:
 
         let evm_env = self
             .evm_config()
-            .next_evm_env(
-                &latest,
-                NextBlockEnvAttributes {
-                    timestamp: latest.timestamp().saturating_add(12),
-                    suggested_fee_recipient: latest.beneficiary(),
-                    prev_randao: B256::random(),
-                    gas_limit: latest.gas_limit(),
-                },
-            )
+            .next_evm_env(&latest, self.pending_next_env_attributes(&latest)?)
             .map_err(RethError::other)
             .map_err(Self::Error::from_eth_err)?;
 
-        Ok(PendingBlockEnv::new(evm_env, PendingBlockEnvOrigin::DerivedFromLatest(latest.hash())))
+        Ok(PendingBlockEnv::new(evm_env, PendingBlockEnvOrigin::DerivedFromLatest(latest)))
+    }
+
+    /// Returns [`NextBlockEnvAttributes`] for building a local pending block.
+    fn pending_next_env_attributes(
+        &self,
+        parent: &SealedHeader<ProviderHeader<Self::Provider>>,
+    ) -> Result<NextBlockEnvAttributes<'_>, Self::Error> {
+        Ok(NextBlockEnvAttributes {
+            timestamp: parent.timestamp().saturating_add(12),
+            suggested_fee_recipient: parent.beneficiary(),
+            prev_randao: B256::random(),
+            gas_limit: parent.gas_limit(),
+            parent_beacon_block_root: parent.parent_beacon_block_root(),
+            withdrawals: None,
+        })
     }
 
     /// Returns the locally built pending block
@@ -146,11 +151,11 @@ pub trait LoadPendingBlock:
     {
         async move {
             let pending = self.pending_block_env_and_cfg()?;
-            let parent_hash = match pending.origin {
+            let parent = match pending.origin {
                 PendingBlockEnvOrigin::ActualPending(block, receipts) => {
                     return Ok(Some((block, receipts)));
                 }
-                PendingBlockEnvOrigin::DerivedFromLatest(parent_hash) => parent_hash,
+                PendingBlockEnvOrigin::DerivedFromLatest(parent) => parent,
             };
 
             // we couldn't find the real pending block, so we need to build it ourselves
@@ -162,7 +167,7 @@ pub trait LoadPendingBlock:
             if let Some(pending_block) = lock.as_ref() {
                 // this is guaranteed to be the `latest` header
                 if pending.evm_env.block_env.number == pending_block.block.number() &&
-                    parent_hash == pending_block.block.parent_hash() &&
+                    parent.hash() == pending_block.block.parent_hash() &&
                     now <= pending_block.expires_at
                 {
                     return Ok(Some((pending_block.block.clone(), pending_block.receipts.clone())));
@@ -173,7 +178,7 @@ pub trait LoadPendingBlock:
             let (sealed_block, receipts) = match self
                 .spawn_blocking_io(move |this| {
                     // we rebuild the block
-                    this.build_block(pending.evm_env, parent_hash)
+                    this.build_block(&parent)
                 })
                 .await
             {
@@ -195,46 +200,15 @@ pub trait LoadPendingBlock:
         }
     }
 
-    /// Assembles a receipt for a transaction, based on its [`ExecutionResult`].
-    fn assemble_receipt(
-        &self,
-        tx: &ProviderTx<Self::Provider>,
-        result: ExecutionResult<HaltReasonFor<Self::Evm>>,
-        cumulative_gas_used: u64,
-    ) -> ProviderReceipt<Self::Provider>;
-
     /// Assembles a pending block.
     fn assemble_block(
         &self,
         block_env: &BlockEnv,
-        parent_hash: B256,
+        result: &BlockExecutionResult<ProviderReceipt<Self::Provider>>,
+        parent: &SealedHeader<ProviderHeader<Self::Provider>>,
         state_root: B256,
         transactions: Vec<Recovered<ProviderTx<Self::Provider>>>,
-        receipts: &[ProviderReceipt<Self::Provider>],
     ) -> ProviderBlock<Self::Provider>;
-
-    /// Helper to invoke both [`Self::assemble_block`] and [`Self::assemble_receipt`].
-    fn assemble_block_and_receipts(
-        &self,
-        block_env: &BlockEnv,
-        parent_hash: B256,
-        state_root: B256,
-        transactions: Vec<Recovered<ProviderTx<Self::Provider>>>,
-        results: Vec<ExecutionResult<HaltReasonFor<Self::Evm>>>,
-    ) -> (ProviderBlock<Self::Provider>, Vec<ProviderReceipt<Self::Provider>>) {
-        let mut cumulative_gas_used = 0;
-        let mut receipts = Vec::with_capacity(results.len());
-
-        for (tx, outcome) in transactions.iter().zip(results) {
-            cumulative_gas_used += outcome.gas_used();
-            receipts.push(self.assemble_receipt(tx, outcome, cumulative_gas_used));
-        }
-
-        let block =
-            self.assemble_block(block_env, parent_hash, state_root, transactions, &receipts);
-
-        (block, receipts)
-    }
 
     /// Builds a pending block using the configured provider and pool.
     ///
@@ -245,8 +219,7 @@ pub trait LoadPendingBlock:
     #[expect(clippy::type_complexity)]
     fn build_block(
         &self,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-        parent_hash: B256,
+        parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<
         (RecoveredBlock<ProviderBlock<Self::Provider>>, Vec<ProviderReceipt<Self::Provider>>),
         Self::Error,
@@ -256,33 +229,31 @@ pub trait LoadPendingBlock:
     {
         let state_provider = self
             .provider()
-            .history_by_block_hash(parent_hash)
+            .history_by_block_hash(parent.hash())
             .map_err(Self::Error::from_eth_err)?;
         let state = StateProviderDatabase::new(state_provider);
         let mut db = State::builder().with_database(state).with_bundle_update().build();
 
+        let mut strategy = self
+            .evm_config()
+            .strategy_for_pending_block(&mut db, parent, self.pending_next_env_attributes(parent)?)
+            .map_err(RethError::other)
+            .map_err(Self::Error::from_eth_err)?;
+
+        strategy.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
+
+        let block_env = strategy.evm_mut().block().clone();
+
         let mut cumulative_gas_used = 0;
         let mut sum_blob_gas_used = 0;
-        let block_gas_limit: u64 = evm_env.block_env.gas_limit;
-        let base_fee = evm_env.block_env.basefee;
+        let block_gas_limit: u64 = block_env.gas_limit;
 
         let mut executed_txs = Vec::new();
         let mut best_txs =
             self.pool().best_transactions_with_attributes(BestTransactionsAttributes::new(
-                base_fee,
-                evm_env.block_env.blob_gasprice().map(|gasprice| gasprice as u64),
+                block_env.basefee,
+                block_env.blob_gasprice().map(|gasprice| gasprice as u64),
             ));
-
-        let chain_spec = self.provider().chain_spec();
-
-        let mut system_caller = SystemCaller::new(chain_spec.clone());
-        let mut evm = self.evm_config().evm_with_env(&mut db, evm_env.clone());
-
-        system_caller
-            .apply_blockhashes_contract_call(parent_hash, &mut evm)
-            .map_err(|err| EthApiError::Internal(err.into()))?;
-
-        let mut results = Vec::new();
 
         while let Some(pool_tx) = best_txs.next() {
             // ensure we still have capacity for this transaction
@@ -335,29 +306,28 @@ pub trait LoadPendingBlock:
                 }
             }
 
-            let tx_env = self.evm_config().tx_env(&tx);
-
-            let ResultAndState { result, state: _ } = match evm.transact_commit(tx_env) {
-                Ok(res) => res,
-                Err(err) => {
-                    if let Some(err) = err.as_invalid_tx_err() {
-                        if err.is_nonce_too_low() {
-                            // if the nonce is too low, we can skip this transaction
-                        } else {
-                            // if the transaction is invalid, we can skip it and all of its
-                            // descendants
-                            best_txs.mark_invalid(
-                                &pool_tx,
-                                InvalidPoolTransactionError::Consensus(
-                                    InvalidTransactionError::TxTypeNotSupported,
-                                ),
-                            );
-                        }
-                        continue
+            let gas_used = match strategy.execute_transaction(tx.as_recovered_ref()) {
+                Ok(gas_used) => gas_used,
+                Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                    error,
+                    ..
+                })) => {
+                    if error.is_nonce_too_low() {
+                        // if the nonce is too low, we can skip this transaction
+                    } else {
+                        // if the transaction is invalid, we can skip it and all of its
+                        // descendants
+                        best_txs.mark_invalid(
+                            &pool_tx,
+                            InvalidPoolTransactionError::Consensus(
+                                InvalidTransactionError::TxTypeNotSupported,
+                            ),
+                        );
                     }
-                    // this is an error that we should treat as fatal for this attempt
-                    return Err(Self::Error::from_evm_err(err));
+                    continue
                 }
+                // this is an error that we should treat as fatal for this attempt
+                Err(err) => return Err(Self::Error::from_eth_err(err)),
             };
 
             // add to the total blob gas used if the transaction successfully executed
@@ -370,28 +340,14 @@ pub trait LoadPendingBlock:
                 }
             }
 
-            let gas_used = result.gas_used();
-
             // add gas used by the transaction to cumulative gas used, before creating the receipt
             cumulative_gas_used += gas_used;
 
             // append transaction to the list of executed transactions
             executed_txs.push(tx);
-            results.push(result);
         }
 
-        // executes the withdrawals and commits them to the Database and BundleState.
-        let balance_increments = post_block_withdrawals_balance_increments(
-            chain_spec.as_ref(),
-            evm_env.block_env.timestamp,
-            &[],
-        );
-
-        // release db
-        drop(evm);
-
-        // increment account balances for withdrawals
-        db.increment_balances(balance_increments).map_err(Self::Error::from_eth_err)?;
+        let result = strategy.apply_post_execution_changes().map_err(Self::Error::from_eth_err)?;
 
         // merge all transitions into bundle state.
         db.merge_transitions(BundleRetention::PlainState);
@@ -404,14 +360,8 @@ pub trait LoadPendingBlock:
 
         let senders = executed_txs.iter().map(|tx| tx.signer()).collect();
 
-        let (block, receipts) = self.assemble_block_and_receipts(
-            &evm_env.block_env,
-            parent_hash,
-            state_root,
-            executed_txs,
-            results,
-        );
+        let block = self.assemble_block(&block_env, &result, parent, state_root, executed_txs);
 
-        Ok((RecoveredBlock::new_unhashed(block, senders), receipts))
+        Ok((RecoveredBlock::new_unhashed(block, senders), result.receipts))
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -111,7 +111,7 @@ pub trait LoadPendingBlock:
 
         let evm_env = self
             .evm_config()
-            .next_evm_env(&latest, self.pending_next_env_attributes(&latest)?)
+            .next_evm_env(&latest, self.next_env_attributes(&latest)?)
             .map_err(RethError::other)
             .map_err(Self::Error::from_eth_err)?;
 
@@ -119,7 +119,7 @@ pub trait LoadPendingBlock:
     }
 
     /// Returns [`NextBlockEnvAttributes`] for building a local pending block.
-    fn pending_next_env_attributes(
+    fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<NextBlockEnvAttributes<'_>, Self::Error> {
@@ -236,7 +236,7 @@ pub trait LoadPendingBlock:
 
         let mut strategy = self
             .evm_config()
-            .strategy_for_pending_block(&mut db, parent, self.pending_next_env_attributes(parent)?)
+            .strategy_for_next_block(&mut db, parent, self.next_env_attributes(parent)?)
             .map_err(RethError::other)
             .map_err(Self::Error::from_eth_err)?;
 

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_eth::{error::EthRpcErrorCode, request::TransactionInputError
 use alloy_sol_types::{ContractError, RevertReason};
 pub use api::{AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError};
 use core::time::Duration;
-use reth_errors::RethError;
+use reth_errors::{BlockExecutionError, RethError};
 use reth_primitives_traits::transaction::signed::RecoveryError;
 use reth_rpc_server_types::result::{
     block_id_to_str, internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code,
@@ -252,6 +252,12 @@ impl From<RethError> for EthApiError {
             RethError::Provider(err) => err.into(),
             err => Self::Internal(err),
         }
+    }
+}
+
+impl From<BlockExecutionError> for EthApiError {
+    fn from(error: BlockExecutionError) -> Self {
+        Self::Internal(error.into())
     }
 }
 

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -9,7 +9,7 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::B256;
 use derive_more::Constructor;
 use reth_evm::EvmEnv;
-use reth_primitives::{Receipt, RecoveredBlock};
+use reth_primitives::{Receipt, RecoveredBlock, SealedHeader};
 use reth_primitives_traits::Block;
 
 /// Configured [`EvmEnv`] for a pending block.
@@ -32,7 +32,7 @@ pub enum PendingBlockEnvOrigin<B: Block = reth_primitives::Block, R = Receipt> {
     ///  - the timestamp
     ///  - the block number
     ///  - fees
-    DerivedFromLatest(B256),
+    DerivedFromLatest(SealedHeader<B::Header>),
 }
 
 impl<B: Block, R> PendingBlockEnvOrigin<B, R> {
@@ -56,7 +56,7 @@ impl<B: Block, R> PendingBlockEnvOrigin<B, R> {
     pub fn state_block_id(&self) -> BlockId {
         match self {
             Self::ActualPending(_, _) => BlockNumberOrTag::Pending.into(),
-            Self::DerivedFromLatest(hash) => BlockId::Hash((*hash).into()),
+            Self::DerivedFromLatest(latest) => BlockId::Hash(latest.hash().into()),
         }
     }
 
@@ -68,7 +68,7 @@ impl<B: Block, R> PendingBlockEnvOrigin<B, R> {
     pub fn build_target_hash(&self) -> B256 {
         match self {
             Self::ActualPending(block, _) => block.header().parent_hash(),
-            Self::DerivedFromLatest(hash) => *hash,
+            Self::DerivedFromLatest(latest) => latest.hash(),
         }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -7,7 +7,9 @@ use alloy_rpc_types_eth::{
     Block, BlockTransactionsKind, Header,
 };
 use jsonrpsee_types::ErrorObject;
-use reth_primitives::{Recovered, RecoveredBlock};
+use reth_evm::{execute::BlockExecutionStrategy, Evm};
+use reth_execution_types::BlockExecutionResult;
+use reth_primitives::{NodePrimitives, Recovered, RecoveredBlock};
 use reth_primitives_traits::{block::BlockTx, BlockBody as _, SignedTransaction};
 use reth_rpc_server_types::result::rpc_err;
 use reth_rpc_types_compat::{block::from_block, TransactionCompat};
@@ -46,6 +48,59 @@ impl ToRpcError for EthSimulateError {
     fn to_rpc_error(&self) -> ErrorObject<'static> {
         rpc_err(self.error_code(), self.to_string(), None)
     }
+}
+
+/// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the
+/// given [`BlockExecutionStrategy`].
+///
+/// Returns all executed transactions and the result of the execution.
+pub fn execute_transactions<N, S, T>(
+    mut strategy: S,
+    calls: Vec<TransactionRequest>,
+    validation: bool,
+    default_gas_limit: u64,
+    chain_id: u64,
+    tx_resp_builder: &T,
+) -> Result<
+    (
+        Vec<Recovered<N::SignedTx>>,
+        BlockExecutionResult<N::Receipt>,
+        Vec<ExecutionResult<<S::Evm as Evm>::HaltReason>>,
+    ),
+    EthApiError,
+>
+where
+    N: NodePrimitives,
+    S: BlockExecutionStrategy<Primitives = N>,
+    EthApiError: From<S::Error> + From<<<S::Evm as Evm>::DB as Database>::Error>,
+    S::Evm: Evm<DB: Database<Error: Into<EthApiError>>>,
+    T: TransactionCompat<N::SignedTx>,
+{
+    strategy.apply_pre_execution_changes()?;
+
+    let mut transactions = Vec::with_capacity(calls.len());
+    let mut results = Vec::with_capacity(calls.len());
+    for call in calls {
+        // Resolve transaction, populate missing fields and enforce calls
+        // correctness.
+        let tx = resolve_transaction(
+            call,
+            validation,
+            default_gas_limit,
+            chain_id,
+            strategy.evm_mut().db_mut(),
+            tx_resp_builder,
+        )?;
+
+        strategy.execute_transaction_with_result_closure(tx.as_recovered_ref(), |result| {
+            results.push(result.clone())
+        })?;
+        transactions.push(tx);
+    }
+
+    let result = strategy.apply_post_execution_changes()?;
+
+    Ok((transactions, result, results))
 }
 
 /// Goes over the list of [`TransactionRequest`]s and populates missing fields trying to resolve

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -54,6 +54,7 @@ impl ToRpcError for EthSimulateError {
 /// given [`BlockExecutionStrategy`].
 ///
 /// Returns all executed transactions and the result of the execution.
+#[expect(clippy::type_complexity)]
 pub fn execute_transactions<N, S, T>(
     mut strategy: S,
     calls: Vec<TransactionRequest>,


### PR DESCRIPTION
This PR extends `BlockExecutionStrategyFactory` API allowing it to be used for execution of new blocks. Changes include:
- `NextBlockEnvAttributes` is extended to contain `parent_beacon_block_root` and `withdrawals` thus fully encapsulating context required for block building in them. This type can later be an abstraction point allowing to expose any engine API inputs to EVM
-  `BlockExecutionStrategyFactory` API is refactored to take EVM + new `ExecutionCtx` AT as input. `ExecutionCtx` encapsulates context required for block execution that is missing from EVM, for Ethereum this includes `ommers`, `withdrawals`, `parent_hash` and `parent_beacon_block_root` https://github.com/paradigmxyz/reth/blob/7272f5653d55be5f6b54e9fae5c0e78056ff18de/crates/evm/src/execute.rs#L251-L259
- `Evm` is exposed on `BlockExecutionStrategy`, providing access to database and `BlockEnv` during execution.

This allowed to integrate `BlockExecutionStrategy` into RPC for pending block building and `eth_simulateV1` endpoint, thus no longer requiring RPC to provide logic for constructing receipts and correctly applying system calls