### PR TITLE
chore(storage): cleanup consistent view revert state checks

### DIFF
--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -56,9 +56,10 @@ where
             .block_number(block_hash)?
             .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
         let best_block_number = provider.best_block_number()?;
-        let last_block_number = provider.last_block_number()?;
 
-        if block_number == best_block_number && block_number == last_block_number {
+        // We do not check against the `last_block_number` here because
+        // `HashedPostState::from_reverts` only uses the database tables, and not static files.
+        if block_number == best_block_number {
             debug!(target: "providers::consistent_view", ?block_hash, block_number, "Returning empty revert state");
             Ok(HashedPostState::default())
         } else {
@@ -70,7 +71,6 @@ where
                 ?block_hash,
                 block_number,
                 best_block_number,
-                last_block_number,
                 accounts = revert_state.accounts.len(),
                 storages = revert_state.storages.len(),
                 "Returning non-empty revert state"


### PR DESCRIPTION
It's fine for `last_block_number` (which is the highest Header block number between database and static files) to be behind/ahead, because `HashedPostState::from_reverts` doesn't use static files when reconstructing the state.