### PR TITLE
fix spelling erros 

### DIFF
--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -14,7 +14,7 @@ pub struct ExecutionWitnessRecord {
     pub codes: B256Map<Bytes>,
     /// Map of all hashed account and storage keys (addresses and slots) to their preimages
     /// (unhashed account addresses and storage slots, respectively) that were required during
-    /// the execution of the block. during the execution of the block.
+    /// during the execution of the block.
     ///
     /// `keccak(address|slot) => address|slot`
     pub keys: B256Map<Bytes>,

--- a/crates/rpc/ipc/src/client/mod.rs
+++ b/crates/rpc/ipc/src/client/mod.rs
@@ -84,7 +84,7 @@ impl IpcTransportClientBuilder {
 pub struct IpcClientBuilder;
 
 impl IpcClientBuilder {
-    /// Connects to a IPC socket
+    /// Connects to an IPC socket
     ///
     /// ```
     /// use jsonrpsee::{core::client::ClientT, rpc_params};

--- a/crates/rpc/ipc/src/server/connection.rs
+++ b/crates/rpc/ipc/src/server/connection.rs
@@ -1,4 +1,4 @@
-//! A IPC connection.
+//! An IPC connection.
 
 use crate::stream_codec::StreamCodec;
 use futures::{stream::FuturesUnordered, FutureExt, Sink, Stream};

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -111,7 +111,7 @@ pub trait EthBlocks: LoadBlock {
     where
         Self: LoadReceipt;
 
-    /// Helper method that loads a bock and all its receipts.
+    /// Helper method that loads a block and all its receipts.
     #[allow(clippy::type_complexity)]
     fn load_block_and_receipts(
         &self,

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -33,7 +33,7 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         self.tracing_task_guard().clone().acquire_owned()
     }
 
-    /// See also  [`Semaphore::acquire_many_owned`](`tokio::sync::Semaphore::acquire_many_owned`).
+    /// See also [`Semaphore::acquire_many_owned`](`tokio::sync::Semaphore::acquire_many_owned`).
     fn acquire_many_owned(
         &self,
         n: u32,


### PR DESCRIPTION
crates/revm/src/witness.rs
the execution of the block. during the execution of the block. - during the execution of the block. `deleted duplicate comment`

crates/rpc/ipc/src/client/mod.rs
crates/rpc/ipc/src/server/connection.rs
a IPC - an IPC `fix article x2`

crates/rpc/rpc-eth-api/src/helpers/block.rs
bock - block `fix typo`

crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
also  ['Semaphore - also ['Semaphore `deleted missing space `
