### PR TITLE
fix: `no_std` for `reth-evm-ethereum`

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -19,6 +19,7 @@ crates_to_check=(
     reth-evm
 
     ## ethereum
+    reth-evm-ethereum
     reth-ethereum-forks
     reth-ethereum-primitives
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7782,8 +7782,8 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives",
  "reth-primitives-traits",
- "reth-revm",
  "reth-testing-utils",
+ "revm",
  "secp256k1 0.30.0",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-eip2124 = { version = "0.1.0", default-features = false }
 alloy-evm = { version = "0.1", default-features = false }
 alloy-primitives = { version = "0.8.20", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
-alloy-sol-types = "0.8.20"
+alloy-sol-types = { version = "0.8.20", default-features = false }
 alloy-trie = { version = "0.7", default-features = false }
 
 alloy-consensus = { version = "0.11.1", default-features = false }

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 reth-execution-types.workspace = true
 reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
-reth-revm.workspace = true
+revm.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
 
@@ -29,7 +29,6 @@ alloy-consensus.workspace = true
 [dev-dependencies]
 reth-testing-utils.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
-reth-revm = { workspace = true, features = ["test-utils"] }
 reth-primitives = { workspace = true, features = ["secp256k1"] }
 reth-primitives-traits.workspace = true
 reth-execution-types.workspace = true
@@ -41,7 +40,6 @@ alloy-genesis.workspace = true
 default = ["std"]
 std = [
     "reth-primitives/std",
-    "reth-revm/std",
     "alloy-consensus/std",
     "alloy-eips/std",
     "alloy-genesis/std",
@@ -54,4 +52,6 @@ std = [
     "reth-execution-types/std",
     "reth-evm/std",
     "reth-primitives-traits/std",
+    "alloy-sol-types/std",
+    "revm/std",
 ]

--- a/crates/ethereum/evm/src/config.rs
+++ b/crates/ethereum/evm/src/config.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::Header;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_ethereum_forks::EthereumHardfork;
-use reth_revm::specification::hardfork::SpecId;
+use revm::specification::hardfork::SpecId;
 
 /// Map the latest active hardfork at the given header to a revm [`SpecId`].
 pub fn revm_spec(chain_spec: &ChainSpec, header: &Header) -> SpecId {

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -28,7 +28,7 @@ use reth_evm::{
     ConfigureEvm, ConfigureEvmEnv, EvmEnv, EvmFactory, NextBlockEnvAttributes, TransactionEnv,
 };
 use reth_primitives::TransactionSigned;
-use reth_revm::{
+use revm::{
     context::{BlockEnv, CfgEnv},
     context_interface::block::BlobExcessGasAndPrice,
     specification::hardfork::SpecId,
@@ -204,10 +204,10 @@ mod tests {
     use alloy_genesis::Genesis;
     use reth_chainspec::{Chain, ChainSpec};
     use reth_evm::{execute::ProviderError, EvmEnv};
-    use reth_revm::{
+    use revm::{
         context::{BlockEnv, CfgEnv},
+        database::CacheDB,
         database_interface::EmptyDBTyped,
-        db::CacheDB,
         inspector::NoOpInspector,
     };
 


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/14730

Fixes `no-std` support for `reth-evm-ethereum`. This required disabling default features for `alloy-sol-types` and removing `reth-revm` dependency in favor of using `revm` directly