### PR TITLE
chore: fix examples lint not running in ci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,7 +3088,6 @@ dependencies = [
 name = "example-custom-beacon-withdrawals"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus",
  "alloy-eips",
  "alloy-sol-macro",
  "alloy-sol-types",
@@ -3312,7 +3311,6 @@ name = "example-polygon-p2p"
 version = "0.0.0"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives",
  "reth-chainspec",
  "reth-discv4",
  "reth-network",

--- a/examples/beacon-api-sidecar-fetcher/src/main.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/main.rs
@@ -1,6 +1,6 @@
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p beacon-api-beacon-sidecar-fetcher --node --full
 //! ```
 //!
@@ -11,7 +11,7 @@
 //!
 //! See beacon Node API: <https://ethereum.github.io/beacon-APIs/>
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use std::{
     collections::VecDeque,

--- a/examples/beacon-api-sse/src/main.rs
+++ b/examples/beacon-api-sse/src/main.rs
@@ -4,7 +4,7 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p beacon-api-sse -- node
 //! ```
 //!
@@ -15,7 +15,7 @@
 //!
 //! See lighthouse beacon Node API: <https://lighthouse-book.sigmaprime.io/api-bn.html#beacon-node-api>
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use clap::Parser;

--- a/examples/bsc-p2p/Cargo.toml
+++ b/examples/bsc-p2p/Cargo.toml
@@ -5,8 +5,6 @@ publish = false
 edition.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 reth-chainspec.workspace = true
 reth-discv4 = { workspace = true, features = ["test-utils"] }

--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -2,15 +2,15 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p bsc-p2p
 //! ```
 //!
-//! This launch the regular reth node overriding the engine api payload builder with our custom.
+//! This launches a regular reth node overriding the engine api payload builder with our custom.
 //!
 //! Credits to: <https://blog.merkle.io/blog/fastest-transaction-network-eth-polygon-bsc>
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use chainspec::{boot_nodes, bsc_chain_spec};
 use reth_discv4::Discv4ConfigBuilder;

--- a/examples/custom-beacon-withdrawals/Cargo.toml
+++ b/examples/custom-beacon-withdrawals/Cargo.toml
@@ -16,6 +16,5 @@ reth-primitives.workspace = true
 alloy-sol-macro.workspace = true
 alloy-sol-types.workspace = true
 alloy-eips.workspace = true
-alloy-consensus.workspace = true
 
 eyre.workspace = true

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -1,7 +1,7 @@
 //! Example for how to modify a block post-execution step. It credits beacon withdrawals with a
 //! custom mechanism instead of minting native tokens
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use alloy_eips::eip4895::{Withdrawal, Withdrawals};
 use alloy_sol_macro::sol;

--- a/examples/custom-dev-node/src/main.rs
+++ b/examples/custom-dev-node/src/main.rs
@@ -1,7 +1,7 @@
 //! This example shows how to run a custom dev node programmatically and submit a transaction
 //! through rpc.
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use std::sync::Arc;
 

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -15,7 +15,7 @@
 //! Once traits are implemented and custom types are defined, the [EngineTypes] trait can be
 //! implemented:
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use alloy_eips::eip4895::Withdrawals;
 use alloy_genesis::Genesis;

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -1,6 +1,6 @@
 //! This example shows how to implement a node with a custom EVM
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use alloy_evm::{eth::EthEvmContext, EvmFactory};
 use alloy_genesis::Genesis;

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -2,13 +2,13 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run --release -p custom-inspector -- node --http --ws --recipients 0x....,0x....
 //! ```
 //!
 //! If no recipients are specified, all transactions will be inspected.
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_evm::Evm;

--- a/examples/custom-node-components/src/main.rs
+++ b/examples/custom-node-components/src/main.rs
@@ -1,6 +1,6 @@
 //! This example shows how to configure custom components for a reth node.
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use reth::{
     api::NodeTypes,

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -3,13 +3,13 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p custom-payload-builder -- node
 //! ```
 //!
-//! This launch the regular reth node overriding the engine api payload builder with our custom.
+//! This launches a regular reth node overriding the engine api payload builder with our custom.
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use crate::generator::EmptyBlockPayloadJobGenerator;
 use reth::{

--- a/examples/custom-rlpx-subprotocol/src/main.rs
+++ b/examples/custom-rlpx-subprotocol/src/main.rs
@@ -2,11 +2,13 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p example-custom-rlpx-subprotocol -- node
 //! ```
 //!
-//! This launch a regular reth node with a custom rlpx subprotocol.
+//! This launches a regular reth node with a custom rlpx subprotocol.
+
+#![warn(unused_crate_dependencies)]
 
 mod subprotocol;
 

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(unused_crate_dependencies)]
+
 use alloy_primitives::{Address, B256};
 use reth_ethereum::{
     chainspec::ChainSpecBuilder,

--- a/examples/manual-p2p/src/main.rs
+++ b/examples/manual-p2p/src/main.rs
@@ -2,9 +2,11 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p manual-p2p
 //! ```
+
+#![warn(unused_crate_dependencies)]
 
 use std::time::Duration;
 

--- a/examples/network-proxy/src/main.rs
+++ b/examples/network-proxy/src/main.rs
@@ -6,9 +6,11 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run --release -p example-network-proxy
 //! ```
+
+#![warn(unused_crate_dependencies)]
 
 use futures::StreamExt;
 use reth_chainspec::DEV;

--- a/examples/network-txpool/src/main.rs
+++ b/examples/network-txpool/src/main.rs
@@ -3,9 +3,11 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run --release -p network-txpool -- node
 //! ```
+
+#![warn(unused_crate_dependencies)]
 
 use alloy_consensus::Transaction;
 use reth_network::{config::rng_secret_key, EthNetworkPrimitives, NetworkConfig, NetworkManager};

--- a/examples/network/src/main.rs
+++ b/examples/network/src/main.rs
@@ -2,9 +2,11 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run --release -p network
 //! ```
+
+#![warn(unused_crate_dependencies)]
 
 use futures::StreamExt;
 use reth_network::{

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p node-custom-rpc -- node --http --ws --enable-ext
 //! ```
 //!
@@ -11,6 +11,8 @@
 //! ```sh
 //! cast rpc txpoolExt_transactionCount
 //! ```
+
+#![warn(unused_crate_dependencies)]
 
 use clap::Parser;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};

--- a/examples/node-event-hooks/src/main.rs
+++ b/examples/node-event-hooks/src/main.rs
@@ -3,13 +3,15 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p node-event-hooks -- node
 //! ```
 //!
-//! This launch the regular reth node and also print:
+//! This launches a regular reth node and also print:
 //! > "All components initialized" – once all components have been initialized
 //! > "Node started" – once the node has been started.
+
+#![warn(unused_crate_dependencies)]
 
 use reth::cli::Cli;
 use reth_node_ethereum::EthereumNode;

--- a/examples/polygon-p2p/Cargo.toml
+++ b/examples/polygon-p2p/Cargo.toml
@@ -16,5 +16,4 @@ serde_json.workspace = true
 reth-tracing.workspace = true
 tokio-stream.workspace = true
 reth-discv4 = { workspace = true, features = ["test-utils"] }
-alloy-primitives.workspace = true
 alloy-genesis.workspace = true

--- a/examples/polygon-p2p/Cargo.toml
+++ b/examples/polygon-p2p/Cargo.toml
@@ -5,8 +5,6 @@ publish = false
 edition.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 secp256k1 = { workspace = true, features = ["global-context", "std", "recovery"] }
 tokio.workspace = true

--- a/examples/polygon-p2p/src/main.rs
+++ b/examples/polygon-p2p/src/main.rs
@@ -2,13 +2,16 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p polygon-p2p
 //! ```
 //!
-//! This launch the regular reth node overriding the engine api payload builder with our custom.
+//! This launches a regular reth node overriding the engine api payload builder with our custom.
 //!
 //! Credits to: <https://blog.merkle.io/blog/fastest-transaction-network-eth-polygon-bsc>
+
+#![warn(unused_crate_dependencies)]
+
 use chain_cfg::{boot_nodes, head, polygon_chain_spec};
 use reth_discv4::Discv4ConfigBuilder;
 use reth_network::{

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run -p rpc-db
 //! ```
 //!
@@ -11,6 +11,8 @@
 //! ```sh
 //! cast rpc myrpcExt_customMethod
 //! ```
+
+#![warn(unused_crate_dependencies)]
 
 use std::{path::Path, sync::Arc};
 

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -1,6 +1,6 @@
 //! This example shows how to implement a node with a custom EVM that uses a stateful precompile
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use alloy_evm::{eth::EthEvmContext, EvmFactory};
 use alloy_genesis::Genesis;

--- a/examples/txpool-tracing/src/main.rs
+++ b/examples/txpool-tracing/src/main.rs
@@ -2,13 +2,13 @@
 //!
 //! Run with
 //!
-//! ```not_rust
+//! ```sh
 //! cargo run --release -p txpool-tracing -- node --http --ws --recipients 0x....,0x....
 //! ```
 //!
 //! If no recipients are specified, all transactions will be traced.
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(unused_crate_dependencies)]
 
 use alloy_primitives::Address;
 use alloy_rpc_types_trace::{parity::TraceType, tracerequest::TraceCallRequest};


### PR DESCRIPTION
Every once in a while I get warnings in my editor on the examples because the unused crate lint does not run in CI due to clippy running with cfg(test)