### PR TITLE
fix: no-std for op crates

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -26,7 +26,9 @@ crates_to_check=(
     ## optimism
     reth-optimism-chainspec
     reth-optimism-forks
+    reth-optimism-consensus
     reth-optimism-primitives
+    reth-optimism-evm
 )
 
 # Array to hold the results

--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -44,8 +44,6 @@ exclude_crates=(
   reth-optimism-payload-builder
   reth-optimism-rpc
   reth-optimism-chain-registry
-  reth-optimism-consensus
-  reth-optimism-evm
   reth-rpc
   reth-rpc-api
   reth-rpc-api-testing-util

--- a/crates/optimism/consensus/Cargo.toml
+++ b/crates/optimism/consensus/Cargo.toml
@@ -18,7 +18,7 @@ reth-chainspec.workspace = true
 reth-consensus-common.workspace = true
 reth-consensus.workspace = true
 reth-primitives-traits.workspace = true
-reth-storage-api.workspace = true
+reth-storage-api = { workspace = true, optional = true }
 reth-storage-errors.workspace = true
 reth-trie-common.workspace = true
 
@@ -26,8 +26,8 @@ reth-trie-common.workspace = true
 reth-optimism-forks.workspace = true
 reth-optimism-chainspec.workspace = true
 # remove this after feature cleanup
-reth-optimism-primitives = { workspace = true, features = ["serde", "reth-codec"] }
-reth-optimism-storage.workspace = true
+reth-optimism-primitives = { workspace = true, features = ["serde"] }
+reth-optimism-storage = { workspace = true, optional = true }
 
 # ethereum
 alloy-eips.workspace = true
@@ -56,6 +56,9 @@ op-alloy-consensus.workspace = true
 [features]
 default = ["std"]
 std = [
+    "dep:reth-optimism-storage",
+    "dep:reth-storage-api",
+    "reth-optimism-primitives/reth-codec",
     "reth-chainspec/std",
     "reth-consensus/std",
     "reth-consensus-common/std",

--- a/crates/optimism/consensus/src/validation/isthmus.rs
+++ b/crates/optimism/consensus/src/validation/isthmus.rs
@@ -49,7 +49,7 @@ where
 /// `L2ToL1MessagePasser.sol` predeploy post block execution.
 ///
 /// Takes pre-hashed storage updates of `L2ToL1MessagePasser.sol` predeploy, resulting from
-/// execution of block, if any. Otherwise takes empty [`HashedStorage::default`].
+/// execution of block, if any. Otherwise takes empty [`reth_trie_common::HashedStorage::default`].
 ///
 /// See <https://specs.optimism.io/protocol/isthmus/exec-engine.html#l2tol1messagepasser-storage-root-in-header>.
 #[cfg(feature = "std")]

--- a/crates/optimism/consensus/src/validation/isthmus.rs
+++ b/crates/optimism/consensus/src/validation/isthmus.rs
@@ -2,11 +2,6 @@
 
 use crate::OpConsensusError;
 use alloy_consensus::BlockHeader;
-use core::fmt;
-use reth_optimism_storage::predeploys::{withdrawals_root, withdrawals_root_prehashed};
-use reth_storage_api::StorageRootProvider;
-use reth_trie_common::HashedStorage;
-use revm::database::BundleState;
 
 /// Verifies that `withdrawals_root` (i.e. `l2tol1-msg-passer` storage root since Isthmus) field is
 /// set in block header.
@@ -24,19 +19,20 @@ pub fn ensure_withdrawals_storage_root_is_some<H: BlockHeader>(
 /// Takes state updates resulting from execution of block.
 ///
 /// See <https://specs.optimism.io/protocol/isthmus/exec-engine.html#l2tol1messagepasser-storage-root-in-header>.
+#[cfg(feature = "std")]
 pub fn verify_withdrawals_root<DB, H>(
-    state_updates: &BundleState,
+    state_updates: &revm::database::BundleState,
     state: DB,
     header: H,
 ) -> Result<(), OpConsensusError>
 where
-    DB: StorageRootProvider,
-    H: BlockHeader + fmt::Debug,
+    DB: reth_storage_api::StorageRootProvider,
+    H: BlockHeader + core::fmt::Debug,
 {
     let header_storage_root =
         header.withdrawals_root().ok_or(OpConsensusError::L2WithdrawalsRootMissing)?;
 
-    let storage_root = withdrawals_root(state_updates, state)
+    let storage_root = reth_optimism_storage::predeploys::withdrawals_root(state_updates, state)
         .map_err(OpConsensusError::L2WithdrawalsRootCalculationFail)?;
 
     if header_storage_root != storage_root {
@@ -56,20 +52,24 @@ where
 /// execution of block, if any. Otherwise takes empty [`HashedStorage::default`].
 ///
 /// See <https://specs.optimism.io/protocol/isthmus/exec-engine.html#l2tol1messagepasser-storage-root-in-header>.
+#[cfg(feature = "std")]
 pub fn verify_withdrawals_root_prehashed<DB, H>(
-    hashed_storage_updates: HashedStorage,
+    hashed_storage_updates: reth_trie_common::HashedStorage,
     state: DB,
     header: H,
 ) -> Result<(), OpConsensusError>
 where
-    DB: StorageRootProvider,
-    H: BlockHeader + fmt::Debug,
+    DB: reth_storage_api::StorageRootProvider,
+    H: BlockHeader + core::fmt::Debug,
 {
     let header_storage_root =
         header.withdrawals_root().ok_or(OpConsensusError::L2WithdrawalsRootMissing)?;
 
-    let storage_root = withdrawals_root_prehashed(hashed_storage_updates, state)
-        .map_err(OpConsensusError::L2WithdrawalsRootCalculationFail)?;
+    let storage_root = reth_optimism_storage::predeploys::withdrawals_root_prehashed(
+        hashed_storage_updates,
+        state,
+    )
+    .map_err(OpConsensusError::L2WithdrawalsRootCalculationFail)?;
 
     if header_storage_root != storage_root {
         return Err(OpConsensusError::L2WithdrawalsRootMismatch {
@@ -97,6 +97,7 @@ mod test {
         providers::BlockchainProvider, test_utils::create_test_provider_factory_with_node_types,
         StateWriter,
     };
+    use reth_revm::db::BundleState;
     use reth_storage_api::StateProviderFactory;
     use reth_trie::{test_utils::storage_root_prehashed, HashedStorage};
     use reth_trie_common::HashedPostState;

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -42,7 +42,7 @@ reth-optimism-evm.workspace = true
 reth-optimism-rpc.workspace = true
 reth-optimism-txpool.workspace = true
 reth-optimism-chainspec.workspace = true
-reth-optimism-consensus.workspace = true
+reth-optimism-consensus = { workspace = true, features = ["std"] }
 reth-optimism-forks.workspace = true
 reth-optimism-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"] }
 

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -33,7 +33,7 @@ reth-payload-validator.workspace = true
 reth-optimism-consensus.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-forks.workspace = true
-reth-optimism-primitives.workspace = true
+reth-optimism-primitives = { workspace = true, features = ["reth-codec"] }
 reth-optimism-storage.workspace = true
 
 # ethereum


### PR DESCRIPTION
fixes no-std for optimism-consensus and optimism-evm crates

required feature-gating isthmus storage root logic behind `feature = "std"` as it depends on storage-api