### PR TITLE
fix(tree): state root task duration

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -36,10 +36,10 @@ use std::{
 };
 
 pub(crate) mod executor;
+pub(crate) mod sparse_trie;
 
 mod multiproof;
 mod prewarm;
-mod sparse_trie;
 
 /// Entrypoint for executing the payload.
 pub(super) struct PayloadProcessor<N, Evm> {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, trace};
 /// A trie update that can be applied to sparse trie alongside the proofs for touched parts of the
 /// state.
 #[derive(Default, Debug)]
-pub(super) struct SparseTrieUpdate {
+pub(crate) struct SparseTrieUpdate {
     /// The state update that was used to calculate the proof
     pub(crate) state: HashedPostState,
     /// The calculated multiproof

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -401,6 +401,8 @@ pub(crate) struct MultiProofTaskMetrics {
     pub sparse_trie_update_duration_histogram: Histogram,
     /// Histogram of sparse trie final update durations.
     pub sparse_trie_final_update_duration_histogram: Histogram,
+    /// Histogram of sparse trie total durations.
+    pub sparse_trie_total_duration_histogram: Histogram,
 
     /// Histogram of state updates received.
     pub state_updates_received_histogram: Histogram,

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -99,22 +99,18 @@ where
         })?;
 
         self.metrics.sparse_trie_final_update_duration_histogram.record(start.elapsed());
+        self.metrics.sparse_trie_total_duration_histogram.record(now.elapsed());
 
-        Ok(StateRootComputeOutcome {
-            state_root: (state_root, trie_updates),
-            total_time: now.elapsed(),
-        })
+        Ok(StateRootComputeOutcome { state_root, trie_updates })
     }
 }
 
 /// Outcome of the state root computation, including the state root itself with
-/// the trie updates and the total time spent.
+/// the trie updates.
 #[derive(Debug)]
 pub(crate) struct StateRootComputeOutcome {
-    /// The computed state root and trie updates
-    pub state_root: (B256, TrieUpdates),
-    /// The total time spent calculating the state root
-    pub total_time: Duration,
+    pub state_root: B256,
+    pub trie_updates: TrieUpdates,
 }
 
 /// Aliased for now to not introduce too many changes at once.


### PR DESCRIPTION
After https://github.com/paradigmxyz/reth/pull/14589, we started calculating the state root duration as the time spent in the sparse trie task. This PR returns the behaviour to the original "time since the end of EVM execution until state root task completion".