### PR TITLE
Use `AsyncFnOnce` in consensus builder

### DIFF
--- a/crates/node/builder/src/lib.rs
+++ b/crates/node/builder/src/lib.rs
@@ -10,6 +10,8 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![feature(async_fn_traits)]
+#![feature(unboxed_closures)]
 
 /// Node event hooks.
 pub mod hooks;


### PR DESCRIPTION
I got it working @DaniPopes, re: https://github.com/paradigmxyz/reth/pull/14725#issuecomment-2688476235

before adding `#![feature(unboxed_closures)]` I got error
```
error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
  --> crates/node/builder/src/components/consensus.rs:29:13
   |
29 |    for <'a> <F as AsyncFnOnce<(&'a BuilderContext<Node>,)>>::CallOnceFuture: Send,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `AsyncFnOnce(&'a BuilderContext<Node>) -> ()`
   |
   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
   = note: this compiler was built on 2025-02-26; consider upgrading it if it is out of date
```
but then when I changed to the suggested parenthetical syntax I also got an error. but makes sense that the error message isn't correct since this is a feature in development.