### PR TITLE
chore(sdk): clean up op engine caps

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use crate::{BeaconConsensusEngineEvent, BeaconConsensusEngineHandle, EthApiBuilderCtx};
-use alloy_primitives::map::HashSet;
 use alloy_rpc_types::engine::ClientVersionV1;
 use alloy_rpc_types_engine::ExecutionData;
 use futures::TryFutureExt;
@@ -663,20 +662,9 @@ pub trait EngineApiBuilder<Node: FullNodeComponents>: Send + Sync {
 }
 
 /// Builder for basic [`EngineApi`] implementation.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct BasicEngineApiBuilder<EV> {
     engine_validator_builder: EV,
-    capabilities: Option<EngineCapabilities>,
-}
-
-impl<EV> BasicEngineApiBuilder<EV> {
-    /// Sets list of capabilities supported by engine API. Takes list of method names.
-    pub fn capabilities(mut self, caps: &[&str]) -> Self {
-        self.capabilities = Some(EngineCapabilities::new(
-            caps.iter().map(|cap| cap.to_string()).collect::<HashSet<_>>(),
-        ));
-        self
-    }
 }
 
 impl<N, EV> EngineApiBuilder<N> for BasicEngineApiBuilder<EV>
@@ -698,7 +686,7 @@ where
     >;
 
     async fn build_engine_api(self, ctx: &AddOnsContext<'_, N>) -> eyre::Result<Self::EngineApi> {
-        let Self { engine_validator_builder, capabilities } = self;
+        let Self { engine_validator_builder } = self;
 
         let engine_validator = engine_validator_builder.build(ctx).await?;
         let client = ClientVersionV1 {
@@ -715,7 +703,7 @@ where
             ctx.node.pool().clone(),
             Box::new(ctx.node.task_executor().clone()),
             client,
-            capabilities.unwrap_or_default(),
+            EngineCapabilities::default(),
             engine_validator,
         ))
     }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -662,7 +662,7 @@ pub trait EngineApiBuilder<Node: FullNodeComponents>: Send + Sync {
 }
 
 /// Builder for basic [`EngineApi`] implementation.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BasicEngineApiBuilder<EV> {
     engine_validator_builder: EV,
 }

--- a/crates/optimism/node/src/rpc.rs
+++ b/crates/optimism/node/src/rpc.rs
@@ -11,7 +11,7 @@ use reth_node_api::{
 };
 use reth_node_builder::rpc::{EngineApiBuilder, EngineValidatorBuilder};
 use reth_node_core::version::{CARGO_PKG_VERSION, CLIENT_CODE, VERGEN_GIT_SHA};
-use reth_optimism_rpc::engine::op_capabilities;
+use reth_optimism_rpc::engine::OP_ENGINE_CAPABILITIES;
 use reth_payload_builder::PayloadStore;
 use reth_rpc_engine_api::{EngineApi, EngineCapabilities};
 
@@ -19,7 +19,6 @@ use reth_rpc_engine_api::{EngineApi, EngineCapabilities};
 #[derive(Debug, Default)]
 pub struct OpEngineApiBuilder<EV> {
     engine_validator_builder: EV,
-    capabilities: Option<EngineCapabilities>,
 }
 
 impl<N, EV> EngineApiBuilder<N> for OpEngineApiBuilder<EV>
@@ -41,7 +40,7 @@ where
     >;
 
     async fn build_engine_api(self, ctx: &AddOnsContext<'_, N>) -> eyre::Result<Self::EngineApi> {
-        let Self { engine_validator_builder, capabilities } = self;
+        let Self { engine_validator_builder } = self;
 
         let engine_validator = engine_validator_builder.build(ctx).await?;
         let client = ClientVersionV1 {
@@ -58,7 +57,7 @@ where
             ctx.node.pool().clone(),
             Box::new(ctx.node.task_executor().clone()),
             client,
-            capabilities.unwrap_or_else(op_capabilities),
+            EngineCapabilities::new(OP_ENGINE_CAPABILITIES.iter().copied()),
             engine_validator,
         );
 

--- a/crates/optimism/rpc/src/engine.rs
+++ b/crates/optimism/rpc/src/engine.rs
@@ -36,13 +36,6 @@ pub const OP_ENGINE_CAPABILITIES: &[&str] = &[
     "engine_getPayloadBodiesByRangeV1",
 ];
 
-/// Returns [`EngineCapabilities`] supported by OP stack.
-pub fn op_capabilities() -> EngineCapabilities {
-    EngineCapabilities::new(
-        OP_CAPABILITIES.iter().map(|cap| cap.to_string()).collect::<HashSet<_>>(),
-    )
-}
-
 /// Extension trait that gives access to Optimism engine API RPC methods.
 ///
 /// Note:

--- a/crates/optimism/rpc/src/engine.rs
+++ b/crates/optimism/rpc/src/engine.rs
@@ -14,15 +14,14 @@ use reth_chainspec::EthereumHardforks;
 use reth_node_api::{EngineTypes, EngineValidator};
 use reth_provider::{BlockReader, HeaderProvider, StateProviderFactory};
 use reth_rpc_api::IntoEngineApiRpcModule;
-use reth_rpc_engine_api::{EngineApi, EngineCapabilities};
+use reth_rpc_engine_api::EngineApi;
 use reth_transaction_pool::TransactionPool;
-use std::collections::HashSet;
 use tracing::trace;
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
 ///
 /// Spec: <https://specs.optimism.io/protocol/exec-engine.html>
-pub const OP_CAPABILITIES: &[&str] = &[
+pub const OP_ENGINE_CAPABILITIES: &[&str] = &[
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",
     "engine_exchangeTransitionConfigurationV1",

--- a/crates/optimism/rpc/src/lib.rs
+++ b/crates/optimism/rpc/src/lib.rs
@@ -17,7 +17,7 @@ pub mod witness;
 
 #[cfg(feature = "client")]
 pub use engine::OpEngineApiClient;
-pub use engine::{op_capabilities, OpEngineApi, OpEngineApiServer, OP_CAPABILITIES};
+pub use engine::{OpEngineApi, OpEngineApiServer, OP_ENGINE_CAPABILITIES};
 pub use error::{OpEthApiError, OpInvalidTransactionError, SequencerClientError};
 pub use eth::{OpEthApi, OpReceiptBuilder};
 pub use sequencer::SequencerClient;

--- a/crates/rpc/rpc-engine-api/src/capabilities.rs
+++ b/crates/rpc/rpc-engine-api/src/capabilities.rs
@@ -30,7 +30,7 @@ pub struct EngineCapabilities {
 
 impl EngineCapabilities {
     /// Creates a new `EngineCapabilities` instance with the given capabilities.
-    pub fn new(capabilities: impl IntoIterator<Item = impl Into<String>>) -> Self {
+    pub fn new(capabilities: impl IntoIterator<Item: Into<String>>) -> Self {
         Self { inner: capabilities.into_iter().map(Into::into).collect() }
     }
 


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/pull/14207#discussion_r1975217810

- Removes redundant function for instantiating `EngineCapabilites` with OP capabilities.
- Removes redundant capabilities field from `BasicEngineApiBuilder`, isn't needed since `OpEngineBuilder` isn't a wrapper around this type anymore