### PR TITLE
chore(ci): unpin op-geth for kurtosis-op

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -8,7 +8,6 @@ optimism_package:
   chains:
     - participants:
       - el_type: op-geth
-        el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.8"
         cl_type: op-node
       - el_type: op-reth
         el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"


### PR DESCRIPTION
The error described in https://github.com/paradigmxyz/reth/pull/14679 no longer happens with the latest op-geth, successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/13604665984