### PR TITLE
Feat: add a `discv4` test to verify the bootnode event behaviour

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -3030,10 +3030,7 @@ mod tests {
             Some(update) = updates.next() => Some(update),
             _ = &mut timeout => None,
         } {
-            match update {
-                DiscoveryUpdate::Added(_) => panic!("Bootnode should not emit DiscoveryUpdate::Added"),
-                _ => {}
-            }
+            if let DiscoveryUpdate::Added(_) = update { panic!("Bootnode should not emit DiscoveryUpdate::Added") }
         }
     }
 }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -3012,4 +3012,14 @@ mod tests {
             }
         }
     }
+
+    #[tokio::test]
+    async fn test_update_event_emission_on_bootnode() {
+        reth_tracing::init_test_tracing();
+
+        let (bootnode, mut service1) = create_discv4().await;
+        let (discv4_instance, mut service2) = create_discv4().await;
+
+
+    }
 }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -3015,14 +3015,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_bootnode_not_in_update_stream() {
+        reth_tracing::init_test_tracing();
         let (_, service_1) = create_discv4().await;
+        let peerid_1 = *service_1.local_peer_id();
 
         let config = Discv4Config::builder().add_boot_node(service_1.local_node_record).build();
+        service_1.spawn();
+
         let (_, mut service_2) = create_discv4_with_config(config).await;
 
         let mut updates = service_2.update_stream();
 
-        service_2.bootstrap();
+        service_2.spawn();
 
         // Poll for events for a reasonable time
         let mut bootnode_appeared = false;
@@ -3033,7 +3037,7 @@ mod tests {
             tokio::select! {
                 Some(update) = updates.next() => {
                     if let DiscoveryUpdate::Added(record) = update {
-                        if record.id == *service_1.local_peer_id() {
+                        if record.id == peerid_1 {
                             bootnode_appeared = true;
                             break;
                         }
@@ -3044,6 +3048,6 @@ mod tests {
         }
 
         // Assert bootnode did not appear in update stream
-        assert!(!bootnode_appeared, "Bootnode should not appear in update stream");
+        assert!(bootnode_appeared, "Bootnode should appear in update stream");
     }
 }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -3017,8 +3017,8 @@ mod tests {
     async fn test_update_event_emission_on_bootnode() {
         reth_tracing::init_test_tracing();
 
-        let (bootnode, mut service1) = create_discv4().await;
-        let (discv4_instance, mut service2) = create_discv4().await;
+        let (_, bootnode_service) = create_discv4().await;
+        let (_discv4_instance, _discv4_service) = create_discv4_with_config(Discv4Config::builder().add_boot_node(bootnode_service.local_node_record).build()).await;
 
 
     }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -3012,4 +3012,38 @@ mod tests {
             }
         }
     }
+
+    #[tokio::test]
+    async fn test_bootnode_not_in_update_stream() {
+        let (_, service_1) = create_discv4().await;
+
+        let config = Discv4Config::builder().add_boot_node(service_1.local_node_record).build();
+        let (_, mut service_2) = create_discv4_with_config(config).await;
+
+        let mut updates = service_2.update_stream();
+
+        service_2.bootstrap();
+
+        // Poll for events for a reasonable time
+        let mut bootnode_appeared = false;
+        let timeout = tokio::time::sleep(Duration::from_secs(1));
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                Some(update) = updates.next() => {
+                    if let DiscoveryUpdate::Added(record) = update {
+                        if record.id == *service_1.local_peer_id() {
+                            bootnode_appeared = true;
+                            break;
+                        }
+                    }
+                }
+                _ = &mut timeout => break,
+            }
+        }
+
+        // Assert bootnode did not appear in update stream
+        assert!(!bootnode_appeared, "Bootnode should not appear in update stream");
+    }
 }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -3018,7 +3018,9 @@ mod tests {
         reth_tracing::init_test_tracing();
 
         let (_, mut bootnode_service) = create_discv4().await;
-        let (_discv4_instance, _discv4_service) = create_discv4_with_config(Discv4Config::builder().add_boot_node(bootnode_service.local_node_record).build()).await;
+        let (_discv4_instance, _discv4_service) = create_discv4_with_config(
+            Discv4Config::builder().add_boot_node(bootnode_service.local_node_record).build(),
+        ).await;
 
         let mut updates = bootnode_service.update_stream();
 
@@ -3030,7 +3032,9 @@ mod tests {
             Some(update) = updates.next() => Some(update),
             _ = &mut timeout => None,
         } {
-            if let DiscoveryUpdate::Added(_) = update { panic!("Bootnode should not emit DiscoveryUpdate::Added") }
+            if let DiscoveryUpdate::Added(_) = update {
+                panic!("Bootnode should not emit DiscoveryUpdate::Added")
+            }
         }
     }
 }


### PR DESCRIPTION
Closes: #14643 

This PR adds `test_bootnode_not_in_update_stream` test case that validates that there is bootnode doesn't appears in the update stream as suggested by the [`bootstrap()`](https://github.com/paradigmxyz/reth/blob/fa22b2657bb811f445038183dc9bfe83aa3122db/crates/net/discv4/src/lib.rs#L667-L680) docs.