### PR TITLE
Fixed grammatical errors, typos, and spelling mistakes

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -13,12 +13,12 @@ workflows:
         "propagate-feature",
         # These are the features to check:
         "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat",
-        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        # Do not try to add a new section to `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
 
         "--left-side-outside-workspace=ignore",
-        # Auxilary flags:
+        # Auxiliary flags:
         "--offline",
         "--locked",
         "--show-path",

--- a/crates/rpc/ipc/src/client/mod.rs
+++ b/crates/rpc/ipc/src/client/mod.rs
@@ -84,7 +84,7 @@ impl IpcTransportClientBuilder {
 pub struct IpcClientBuilder;
 
 impl IpcClientBuilder {
-    /// Connects to a IPC socket
+    /// Connects to an IPC socket
     ///
     /// ```
     /// use jsonrpsee::{core::client::ClientT, rpc_params};

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -111,7 +111,7 @@ pub trait EthBlocks: LoadBlock {
     where
         Self: LoadReceipt;
 
-    /// Helper method that loads a bock and all its receipts.
+    /// Helper method that loads a block and all its receipts.
     #[allow(clippy::type_complexity)]
     fn load_block_and_receipts(
         &self,


### PR DESCRIPTION
File: .config/zepter.yaml

Old: into '[features]' of 'A' only because 'B' expose
New: to '[features]' of 'A' only because 'B' exposes
Reason: Corrected grammar for clarity.
File: crates/rpc/src/client/mod.rs

Old: /// Connects to a IPC socket
New: /// Connects to an IPC socket
Reason: Corrected article use ("a" to "an").
File: crates/rpc-eth-api/src/helpers/block.rs

Old: /// Helper method that loads a bock
New: /// Helper method that loads a block
Reason: Fixed typo ("bock" to "block").
File: .config/zepter.yaml

Old: # Auxilary flags:
New: # Auxiliary flags:
Reason: Corrected the spelling of "Auxilary" to "Auxiliary."