### PR TITLE
Fix Grammar & Typo Issues in Documentation

### DIFF
--- a/book/developers/exex/how-it-works.md
+++ b/book/developers/exex/how-it-works.md
@@ -11,7 +11,7 @@ Reth manages the lifecycle of all ExExes, including:
 - Sending [notifications](https://reth.rs/docs/reth_exex/enum.ExExNotification.html) about new chain, reverts,
   and reorgs from historical and live sync
 - Processing [events](https://reth.rs/docs/reth_exex/enum.ExExEvent.html) emitted by ExExes
-- Pruning (in case of a full or pruned node) only the data that have been processed by all ExExes
+- Pruning (in case of a full or pruned node) only the data that has been processed by all ExExes
 - Shutting ExExes down when the node is shut down
 
 ## Pruning

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -176,7 +176,7 @@ pub struct TaskManager {
 // === impl TaskManager ===
 
 impl TaskManager {
-    /// Returns a a [`TaskManager`] over the currently running Runtime.
+    /// Returns a [`TaskManager`] over the currently running Runtime.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
 Fix Subject-Verb Agreement in "Pruning" Sentence
File: (Specify the file name where this change was made)
Before:
"Pruning (in case of a full or pruned node) only the data that have been processed by all ExExes."
After:
"Pruning (in case of a full or pruned node) only the data that has been processed by all ExExes."
Reason:
The word "data" is an uncountable noun and, in formal English, is typically treated as singular. Therefore, "has" is the correct verb to use instead of "have."
2. Fix Typographical Error in TaskManager Documentation
File: (Specify the file name where this change was made)
Before:
"Returns a a [TaskManager] over the currently running Runtime."
After:
"Returns a [TaskManager] over the currently running Runtime."
Reason:
The phrase contained a duplicated "a", which was removed to correct the typo and improve readability.