### PR TITLE
feat: `ConfigureEvm::NextBlockEnvCtx`

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -17,8 +17,7 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, StateChangePostBlockSource, StateChangeSource, SystemCaller},
-    Database, Evm, EvmEnv, EvmFactory, EvmFor, InspectorFor, NextBlockEnvAttributes,
-    TransactionEnv,
+    Database, Evm, EvmEnv, EvmFactory, EvmFor, InspectorFor, TransactionEnv,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives::{
@@ -55,7 +54,7 @@ where
     fn context_for_next_block<'a>(
         &self,
         parent: &SealedHeader,
-        attributes: NextBlockEnvAttributes<'a>,
+        attributes: Self::NextBlockEnvCtx<'a>,
     ) -> Self::ExecutionCtx<'a> {
         EthBlockExecutionCtx {
             parent_hash: parent.hash(),

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -4,7 +4,7 @@ use crate::{
     dao_fork::{DAO_HARDFORK_ACCOUNTS, DAO_HARDFORK_BENEFICIARY},
     EthEvmConfig,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Transaction};
 use alloy_eips::{eip4895::Withdrawals, eip6110, eip7685::Requests};
 use alloy_evm::FromRecoveredTx;
@@ -47,20 +47,20 @@ where
             parent_hash: block.header().parent_hash,
             parent_beacon_block_root: block.header().parent_beacon_block_root,
             ommers: &block.body().ommers,
-            withdrawals: block.body().withdrawals.as_ref(),
+            withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),
         }
     }
 
-    fn context_for_next_block<'a>(
+    fn context_for_next_block(
         &self,
         parent: &SealedHeader,
-        attributes: Self::NextBlockEnvCtx<'a>,
-    ) -> Self::ExecutionCtx<'a> {
+        attributes: Self::NextBlockEnvCtx,
+    ) -> Self::ExecutionCtx<'_> {
         EthBlockExecutionCtx {
             parent_hash: parent.hash(),
             parent_beacon_block_root: attributes.parent_beacon_block_root,
             ommers: &[],
-            withdrawals: attributes.withdrawals,
+            withdrawals: attributes.withdrawals.map(Cow::Owned),
         }
     }
 
@@ -78,7 +78,7 @@ where
 }
 
 /// Context for Ethereum block execution.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct EthBlockExecutionCtx<'a> {
     /// Parent block hash.
     pub parent_hash: B256,
@@ -87,7 +87,7 @@ pub struct EthBlockExecutionCtx<'a> {
     /// Block ommers
     pub ommers: &'a [Header],
     /// Block withdrawals.
-    pub withdrawals: Option<&'a Withdrawals>,
+    pub withdrawals: Option<Cow<'a, Withdrawals>>,
 }
 
 /// Block execution strategy for Ethereum.
@@ -215,7 +215,7 @@ where
             self.chain_spec,
             self.evm.block(),
             self.ctx.ommers,
-            self.ctx.withdrawals,
+            self.ctx.withdrawals.as_deref(),
         );
 
         // Irregular state change at Ethereum DAO hardfork

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -96,6 +96,7 @@ where
     type Error = Infallible;
     type TxEnv = EvmF::Tx;
     type Spec = SpecId;
+    type NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>;
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv {
         let spec = config::revm_spec(self.chain_spec(), header);

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -96,7 +96,7 @@ where
     type Error = Infallible;
     type TxEnv = EvmF::Tx;
     type Spec = SpecId;
-    type NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>;
+    type NextBlockEnvCtx = NextBlockEnvAttributes;
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv {
         let spec = config::revm_spec(self.chain_spec(), header);
@@ -124,7 +124,7 @@ where
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: NextBlockEnvAttributes<'_>,
+        attributes: &NextBlockEnvAttributes,
     ) -> Result<EvmEnv, Self::Error> {
         // ensure we're not missing any timestamp based hardforks
         let spec_id = revm_spec_by_timestamp_and_block_number(

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -9,7 +9,7 @@ use reth_ethereum_engine_primitives::{
     EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
 };
 use reth_ethereum_primitives::{EthPrimitives, PooledTransaction};
-use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm};
+use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm, NextBlockEnvAttributes};
 use reth_network::{EthNetworkPrimitives, NetworkHandle, PeersInfo};
 use reth_node_api::{AddOnsContext, BlockTy, FullNodeComponents, NodeAddOns, ReceiptTy, TxTy};
 use reth_node_builder::{
@@ -178,7 +178,7 @@ where
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: ConfigureEvm<TxEnv = TxEnv>,
+        Evm: for<'a> ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>>,
     >,
     EthApiError: FromEvmError<N::Evm>,
 {
@@ -212,13 +212,13 @@ where
 
 impl<N> RethRpcAddOns<N> for EthereumAddOns<N>
 where
-    N: FullNodeComponents<
+    N: for<'a> FullNodeComponents<
         Types: NodeTypesWithEngine<
             ChainSpec = ChainSpec,
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: ConfigureEvm<TxEnv = TxEnv>,
+        Evm: ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>>,
     >,
     EthApiError: FromEvmError<N::Evm>,
 {

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -212,7 +212,7 @@ where
 
 impl<N> RethRpcAddOns<N> for EthereumAddOns<N>
 where
-    N: for<'a> FullNodeComponents<
+    N: FullNodeComponents<
         Types: NodeTypesWithEngine<
             ChainSpec = ChainSpec,
             Primitives = EthPrimitives,

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -178,7 +178,7 @@ where
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: for<'a> ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>>,
+        Evm: ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthApiError: FromEvmError<N::Evm>,
 {
@@ -218,7 +218,7 @@ where
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>>,
+        Evm: ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthApiError: FromEvmError<N::Evm>,
 {

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -84,7 +84,10 @@ impl<Pool, Client, EvmConfig> EthereumPayloadBuilder<Pool, Client, EvmConfig> {
 // Default implementation of [PayloadBuilder] for unit type
 impl<Pool, Client, EvmConfig> PayloadBuilder for EthereumPayloadBuilder<Pool, Client, EvmConfig>
 where
-    EvmConfig: BlockExecutionStrategyFactory<Primitives = EthPrimitives>,
+    EvmConfig: for<'a> BlockExecutionStrategyFactory<
+        Primitives = EthPrimitives,
+        NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+    >,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
@@ -139,7 +142,10 @@ pub fn default_ethereum_payload<EvmConfig, Client, Pool, F>(
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
-    EvmConfig: BlockExecutionStrategyFactory<Primitives = EthPrimitives>,
+    EvmConfig: for<'a> BlockExecutionStrategyFactory<
+        Primitives = EthPrimitives,
+        NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+    >,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -84,9 +84,9 @@ impl<Pool, Client, EvmConfig> EthereumPayloadBuilder<Pool, Client, EvmConfig> {
 // Default implementation of [PayloadBuilder] for unit type
 impl<Pool, Client, EvmConfig> PayloadBuilder for EthereumPayloadBuilder<Pool, Client, EvmConfig>
 where
-    EvmConfig: for<'a> BlockExecutionStrategyFactory<
+    EvmConfig: BlockExecutionStrategyFactory<
         Primitives = EthPrimitives,
-        NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        NextBlockEnvCtx = NextBlockEnvAttributes,
     >,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
@@ -142,9 +142,9 @@ pub fn default_ethereum_payload<EvmConfig, Client, Pool, F>(
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
-    EvmConfig: for<'a> BlockExecutionStrategyFactory<
+    EvmConfig: BlockExecutionStrategyFactory<
         Primitives = EthPrimitives,
-        NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        NextBlockEnvCtx = NextBlockEnvAttributes,
     >,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
@@ -164,7 +164,7 @@ where
         prev_randao: attributes.prev_randao(),
         gas_limit: builder_config.gas_limit(parent_header.gas_limit),
         parent_beacon_block_root: attributes.parent_beacon_block_root(),
-        withdrawals: Some(attributes.withdrawals()),
+        withdrawals: Some(attributes.withdrawals().clone()),
     };
 
     let mut strategy = evm_config

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -3,10 +3,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_evm::Evm;
 // Re-export execution types
-use crate::{
-    system_calls::OnStateHook, ConfigureEvmFor, Database, EvmFor, InspectorFor,
-    NextBlockEnvAttributes,
-};
+use crate::{system_calls::OnStateHook, ConfigureEvmFor, Database, EvmFor, InspectorFor};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{
     map::{DefaultHashBuilder, HashMap},
@@ -268,7 +265,7 @@ pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> + 'st
     fn context_for_next_block<'a>(
         &self,
         parent: &SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
-        attributes: NextBlockEnvAttributes<'a>,
+        attributes: Self::NextBlockEnvCtx<'a>,
     ) -> Self::ExecutionCtx<'a>;
 
     /// Creates a strategy with given EVM and execution context.
@@ -297,7 +294,7 @@ pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> + 'st
         &'a self,
         db: &'a mut State<DB>,
         parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
-        attributes: NextBlockEnvAttributes<'a>,
+        attributes: Self::NextBlockEnvCtx<'a>,
     ) -> Result<Self::Strategy<'a, DB, NoOpInspector>, Self::Error> {
         let evm_env = self.next_evm_env(parent, attributes)?;
         let evm = self.evm_with_env(db, evm_env);

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -262,11 +262,11 @@ pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> + 'st
 
     /// Returns the configured [`BlockExecutionStrategyFactory::ExecutionCtx`] for `parent + 1`
     /// block.
-    fn context_for_next_block<'a>(
+    fn context_for_next_block(
         &self,
         parent: &SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
-        attributes: Self::NextBlockEnvCtx<'a>,
-    ) -> Self::ExecutionCtx<'a>;
+        attributes: Self::NextBlockEnvCtx,
+    ) -> Self::ExecutionCtx<'_>;
 
     /// Creates a strategy with given EVM and execution context.
     fn create_strategy<'a, DB, I>(
@@ -294,9 +294,9 @@ pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> + 'st
         &'a self,
         db: &'a mut State<DB>,
         parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
-        attributes: Self::NextBlockEnvCtx<'a>,
+        attributes: Self::NextBlockEnvCtx,
     ) -> Result<Self::Strategy<'a, DB, NoOpInspector>, Self::Error> {
-        let evm_env = self.next_evm_env(parent, attributes)?;
+        let evm_env = self.next_evm_env(parent, &attributes)?;
         let evm = self.evm_with_env(db, evm_env);
         let ctx = self.context_for_next_block(parent, attributes);
         Ok(self.create_strategy(evm, ctx))

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -232,7 +232,7 @@ pub trait BlockExecutionStrategy {
 ///
 /// Strategy is required to provide a way to obtain [`ExecutionCtx`] from either a complete
 /// [`SealedBlock`] (in case of execution of an externally obtained block), or from a parent header
-/// along with [`NextBlockEnvAttributes`] (in the case of block building).
+/// along with [`crate::ConfigureEvmEnv::NextBlockEnvCtx`] (in the case of block building).
 ///
 /// For more context on the strategy design, see the documentation for [`BlockExecutionStrategy`].
 ///

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -164,7 +164,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
     /// Context required for configuring next block environment.
     ///
     /// Contains values that can't be derived from the parent block.
-    type NextBlockEnvCtx<'a>: Clone + Copy;
+    type NextBlockEnvCtx: Debug + Clone;
 
     /// Returns a [`TxEnv`] from a transaction and [`Address`].
     fn tx_env(&self, transaction: impl IntoTxEnv<Self::TxEnv>) -> Self::TxEnv {
@@ -182,7 +182,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: Self::NextBlockEnvCtx<'_>,
+        attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnv<Self::Spec>, Self::Error>;
 }
 
@@ -190,8 +190,8 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
 /// This is used to configure the next block's environment
 /// [`ConfigureEvmEnv::next_evm_env`] and contains fields that can't be derived from the
 /// parent header alone (attributes that are determined by the CL.)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NextBlockEnvAttributes<'a> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NextBlockEnvAttributes {
     /// The timestamp of the next block.
     pub timestamp: u64,
     /// The suggested fee recipient for the next block.
@@ -203,7 +203,7 @@ pub struct NextBlockEnvAttributes<'a> {
     /// The parent beacon block root.
     pub parent_beacon_block_root: Option<B256>,
     /// Withdrawals
-    pub withdrawals: Option<&'a Withdrawals>,
+    pub withdrawals: Option<Withdrawals>,
 }
 
 /// Abstraction over transaction environment.

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -161,6 +161,11 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
     /// Identifier of the EVM specification.
     type Spec: Debug + Copy + Send + Sync + 'static;
 
+    /// Context required for configuring next block environment.
+    ///
+    /// Contains values that can't be derived from the parent block.
+    type NextBlockEnvCtx<'a>: Clone + Copy;
+
     /// Returns a [`TxEnv`] from a transaction and [`Address`].
     fn tx_env(&self, transaction: impl IntoTxEnv<Self::TxEnv>) -> Self::TxEnv {
         transaction.into_tx_env()
@@ -177,7 +182,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: NextBlockEnvAttributes<'_>,
+        attributes: Self::NextBlockEnvCtx<'_>,
     ) -> Result<EvmEnv<Self::Spec>, Self::Error>;
 }
 

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -1,6 +1,24 @@
 use alloy_consensus::BlockHeader;
 use reth_optimism_forks::OpHardforks;
 use revm_optimism::OpSpecId;
+use revm_primitives::{Address, Bytes, B256};
+
+/// Context relevant for execution of a next block w.r.t OP.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpNextBlockEnvAttributes {
+    /// The timestamp of the next block.
+    pub timestamp: u64,
+    /// The suggested fee recipient for the next block.
+    pub suggested_fee_recipient: Address,
+    /// The randomness value for the next block.
+    pub prev_randao: B256,
+    /// Block gas limit.
+    pub gas_limit: u64,
+    /// The parent beacon block root.
+    pub parent_beacon_block_root: Option<B256>,
+    /// Encoded EIP-1559 parameters to include into block's `extra_data` field.
+    pub extra_data: Bytes,
+}
 
 /// Map the latest active hardfork at the given header to a revm [`OpSpecId`].
 pub fn revm_spec(chain_spec: impl OpHardforks, header: impl BlockHeader) -> OpSpecId {

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -48,11 +48,11 @@ where
         }
     }
 
-    fn context_for_next_block<'a>(
+    fn context_for_next_block(
         &self,
         parent: &SealedHeader<N::BlockHeader>,
-        attributes: Self::NextBlockEnvCtx<'a>,
-    ) -> Self::ExecutionCtx<'a> {
+        attributes: Self::NextBlockEnvCtx,
+    ) -> Self::ExecutionCtx<'_> {
         OpBlockExecutionCtx {
             parent_hash: parent.hash(),
             parent_beacon_block_root: attributes.parent_beacon_block_root,

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -18,7 +18,7 @@ use reth_evm::{
     },
     state_change::post_block_balance_increments,
     system_calls::{OnStateHook, StateChangePostBlockSource, StateChangeSource, SystemCaller},
-    Database, Evm, EvmFor, InspectorFor, NextBlockEnvAttributes,
+    Database, Evm, EvmFor, InspectorFor,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_optimism_chainspec::OpChainSpec;
@@ -51,7 +51,7 @@ where
     fn context_for_next_block<'a>(
         &self,
         parent: &SealedHeader<N::BlockHeader>,
-        attributes: NextBlockEnvAttributes<'a>,
+        attributes: Self::NextBlockEnvCtx<'a>,
     ) -> Self::ExecutionCtx<'a> {
         OpBlockExecutionCtx {
             parent_hash: parent.hash(),

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -18,7 +18,7 @@ use alloy_primitives::U256;
 use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
 use reth_chainspec::EthChainSpec;
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv, EvmEnv, NextBlockEnvAttributes};
+use reth_evm::{ConfigureEvm, ConfigureEvmEnv, EvmEnv};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::next_block_base_fee;
 use reth_optimism_forks::OpHardforks;
@@ -32,7 +32,7 @@ use revm::{
 use revm_optimism::{OpHaltReason, OpSpecId, OpTransaction};
 
 mod config;
-pub use config::{revm_spec, revm_spec_by_timestamp_after_bedrock};
+pub use config::{revm_spec, revm_spec_by_timestamp_after_bedrock, OpNextBlockEnvAttributes};
 mod execute;
 pub use execute::*;
 pub mod l1;
@@ -98,7 +98,7 @@ where
     type Error = EIP1559ParamError;
     type TxEnv = OpTransaction<TxEnv>;
     type Spec = OpSpecId;
-    type NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>;
+    type NextBlockEnvCtx = OpNextBlockEnvAttributes;
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec> {
         let spec = config::revm_spec(self.chain_spec(), header);
@@ -133,7 +133,7 @@ where
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: NextBlockEnvAttributes<'_>,
+        attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnv<Self::Spec>, Self::Error> {
         // ensure we're not missing any timestamp based hardforks
         let spec_id = revm_spec_by_timestamp_after_bedrock(&self.chain_spec, attributes.timestamp);

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -98,6 +98,7 @@ where
     type Error = EIP1559ParamError;
     type TxEnv = OpTransaction<TxEnv>;
     type Spec = OpSpecId;
+    type NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>;
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec> {
         let spec = config::revm_spec(self.chain_spec(), header);

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -10,6 +10,7 @@ use op_alloy_consensus::OpPooledTransaction;
 use reth_chainspec::{EthChainSpec, Hardforks};
 use reth_evm::{
     execute::BasicBlockExecutorProvider, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmFor,
+    NextBlockEnvAttributes,
 };
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{
@@ -272,14 +273,17 @@ where
 
 impl<N> NodeAddOns<N> for OpAddOns<N>
 where
-    N: FullNodeComponents<
+    N: for<'a> FullNodeComponents<
         Types: NodeTypesWithEngine<
             ChainSpec = OpChainSpec,
             Primitives = OpPrimitives,
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Evm: ConfigureEvmEnv<TxEnv = revm_optimism::OpTransaction<TxEnv>>,
+        Evm: ConfigureEvmEnv<
+            TxEnv = revm_optimism::OpTransaction<TxEnv>,
+            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        >,
     >,
     OpEthApiError: FromEvmError<N::Evm>,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: MaybeConditionalTransaction,
@@ -344,14 +348,17 @@ where
 
 impl<N> RethRpcAddOns<N> for OpAddOns<N>
 where
-    N: FullNodeComponents<
+    N: for<'a> FullNodeComponents<
         Types: NodeTypesWithEngine<
             ChainSpec = OpChainSpec,
             Primitives = OpPrimitives,
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Evm: ConfigureEvm<TxEnv = revm_optimism::OpTransaction<TxEnv>>,
+        Evm: ConfigureEvm<
+            TxEnv = revm_optimism::OpTransaction<TxEnv>,
+            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        >,
     >,
     OpEthApiError: FromEvmError<N::Evm>,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: MaybeConditionalTransaction,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -10,7 +10,6 @@ use op_alloy_consensus::OpPooledTransaction;
 use reth_chainspec::{EthChainSpec, Hardforks};
 use reth_evm::{
     execute::BasicBlockExecutorProvider, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmFor,
-    NextBlockEnvAttributes,
 };
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{
@@ -30,7 +29,7 @@ use reth_node_builder::{
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::OpBeaconConsensus;
-use reth_optimism_evm::{BasicOpReceiptBuilder, OpEvmConfig};
+use reth_optimism_evm::{BasicOpReceiptBuilder, OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{
     builder::OpPayloadTransactions,
@@ -282,7 +281,7 @@ where
         >,
         Evm: ConfigureEvmEnv<
             TxEnv = revm_optimism::OpTransaction<TxEnv>,
-            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+            NextBlockEnvCtx = OpNextBlockEnvAttributes,
         >,
     >,
     OpEthApiError: FromEvmError<N::Evm>,
@@ -357,7 +356,7 @@ where
         >,
         Evm: ConfigureEvm<
             TxEnv = revm_optimism::OpTransaction<TxEnv>,
-            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+            NextBlockEnvCtx = OpNextBlockEnvAttributes,
         >,
     >,
     OpEthApiError: FromEvmError<N::Evm>,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -272,7 +272,7 @@ where
 
 impl<N> NodeAddOns<N> for OpAddOns<N>
 where
-    N: for<'a> FullNodeComponents<
+    N: FullNodeComponents<
         Types: NodeTypesWithEngine<
             ChainSpec = OpChainSpec,
             Primitives = OpPrimitives,
@@ -347,7 +347,7 @@ where
 
 impl<N> RethRpcAddOns<N> for OpAddOns<N>
 where
-    N: for<'a> FullNodeComponents<
+    N: FullNodeComponents<
         Types: NodeTypesWithEngine<
             ChainSpec = OpChainSpec,
             Primitives = OpPrimitives,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -163,7 +163,10 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
     N: OpPayloadPrimitives,
-    EvmConfig: BlockExecutionStrategyFactory<Primitives = N>,
+    EvmConfig: for<'a> BlockExecutionStrategyFactory<
+        Primitives = N,
+        NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+    >,
 {
     /// Constructs an Optimism payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
@@ -248,7 +251,10 @@ where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
     N: OpPayloadPrimitives,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
-    EvmConfig: BlockExecutionStrategyFactory<Primitives = N>,
+    EvmConfig: for<'a> BlockExecutionStrategyFactory<
+        Primitives = N,
+        NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+    >,
     Txs: OpPayloadTransactions<Pool::Transaction>,
 {
     type Attributes = OpPayloadBuilderAttributes<N::SignedTx>;
@@ -327,7 +333,10 @@ impl<Txs> OpBuilder<'_, Txs> {
     where
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
-        EvmConfig: BlockExecutionStrategyFactory<Primitives = N>,
+        EvmConfig: for<'a> BlockExecutionStrategyFactory<
+            Primitives = N,
+            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        >,
         ChainSpec: EthChainSpec + OpHardforks,
         DB: Database<Error = ProviderError> + AsRef<P>,
         P: StorageRootProvider,
@@ -406,7 +415,10 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx: OpPayloadBuilderCtx<EvmConfig, ChainSpec, N>,
     ) -> Result<BuildOutcomeKind<OpBuiltPayload<N>>, PayloadBuilderError>
     where
-        EvmConfig: BlockExecutionStrategyFactory<Primitives = N>,
+        EvmConfig: for<'a> BlockExecutionStrategyFactory<
+            Primitives = N,
+            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        >,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
@@ -529,7 +541,10 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx: &OpPayloadBuilderCtx<EvmConfig, ChainSpec, N>,
     ) -> Result<ExecutionWitness, PayloadBuilderError>
     where
-        EvmConfig: BlockExecutionStrategyFactory<Primitives = N>,
+        for<'a> EvmConfig: BlockExecutionStrategyFactory<
+            Primitives = N,
+            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        >,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -537,7 +537,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx: &OpPayloadBuilderCtx<EvmConfig, ChainSpec, N>,
     ) -> Result<ExecutionWitness, PayloadBuilderError>
     where
-        for<'a> EvmConfig: BlockExecutionStrategyFactory<
+        EvmConfig: BlockExecutionStrategyFactory<
             Primitives = N,
             NextBlockEnvCtx = OpNextBlockEnvAttributes,
         >,

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -70,7 +70,7 @@ where
         + ChainSpecProvider<ChainSpec = OpChainSpec>
         + Clone
         + 'static,
-    for<'a> EvmConfig: BlockExecutionStrategyFactory<
+    EvmConfig: BlockExecutionStrategyFactory<
             Primitives = Provider::Primitives,
             NextBlockEnvCtx = OpNextBlockEnvAttributes,
         > + 'static,

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee_core::{async_trait, RpcResult};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::ChainSpecProvider;
-use reth_evm::{execute::BlockExecutionStrategyFactory, ConfigureEvm};
+use reth_evm::{execute::BlockExecutionStrategyFactory, ConfigureEvm, NextBlockEnvAttributes};
 use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_payload_builder::{OpPayloadBuilder, OpPayloadPrimitives};
@@ -69,7 +69,10 @@ where
         + ChainSpecProvider<ChainSpec = OpChainSpec>
         + Clone
         + 'static,
-    EvmConfig: BlockExecutionStrategyFactory<Primitives = Provider::Primitives> + 'static,
+    for<'a> EvmConfig: BlockExecutionStrategyFactory<
+            Primitives = Provider::Primitives,
+            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+        > + 'static,
 {
     async fn execute_payload(
         &self,

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -5,9 +5,10 @@ use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee_core::{async_trait, RpcResult};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::ChainSpecProvider;
-use reth_evm::{execute::BlockExecutionStrategyFactory, ConfigureEvm, NextBlockEnvAttributes};
+use reth_evm::{execute::BlockExecutionStrategyFactory, ConfigureEvm};
 use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_payload_builder::{OpPayloadBuilder, OpPayloadPrimitives};
 use reth_primitives::SealedHeader;
 use reth_provider::{
@@ -71,7 +72,7 @@ where
         + 'static,
     for<'a> EvmConfig: BlockExecutionStrategyFactory<
             Primitives = Provider::Primitives,
-            NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+            NextBlockEnvCtx = OpNextBlockEnvAttributes,
         > + 'static,
 {
     async fn execute_payload(

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -107,7 +107,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 for block in block_state_calls {
                     let mut evm_env = this
                         .evm_config()
-                        .next_evm_env(&parent, this.next_env_attributes(&parent)?)
+                        .next_evm_env(&parent, &this.next_env_attributes(&parent)?)
                         .map_err(RethError::other)
                         .map_err(Self::Error::from_eth_err)?;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -12,7 +12,7 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError};
 use reth_evm::{
     execute::{BlockExecutionStrategy, BlockExecutionStrategyFactory},
-    ConfigureEvmEnv, Evm, NextBlockEnvAttributes,
+    ConfigureEvmEnv, Evm,
 };
 use reth_node_api::NodePrimitives;
 use reth_primitives::{InvalidTransactionError, RecoveredBlock, SealedHeader};
@@ -122,16 +122,7 @@ pub trait LoadPendingBlock:
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
-    ) -> Result<NextBlockEnvAttributes<'_>, Self::Error> {
-        Ok(NextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12),
-            suggested_fee_recipient: parent.beneficiary(),
-            prev_randao: B256::random(),
-            gas_limit: parent.gas_limit(),
-            parent_beacon_block_root: parent.parent_beacon_block_root(),
-            withdrawals: None,
-        })
-    }
+    ) -> Result<<Self::Evm as ConfigureEvmEnv>::NextBlockEnvCtx<'_>, Self::Error>;
 
     /// Returns the locally built pending block
     #[expect(clippy::type_complexity)]

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -111,7 +111,7 @@ pub trait LoadPendingBlock:
 
         let evm_env = self
             .evm_config()
-            .next_evm_env(&latest, self.next_env_attributes(&latest)?)
+            .next_evm_env(&latest, &self.next_env_attributes(&latest)?)
             .map_err(RethError::other)
             .map_err(Self::Error::from_eth_err)?;
 
@@ -122,7 +122,7 @@ pub trait LoadPendingBlock:
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
-    ) -> Result<<Self::Evm as ConfigureEvmEnv>::NextBlockEnvCtx<'_>, Self::Error>;
+    ) -> Result<<Self::Evm as ConfigureEvmEnv>::NextBlockEnvCtx, Self::Error>;
 
     /// Returns the locally built pending block
     #[expect(clippy::type_complexity)]

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -118,7 +118,7 @@ pub trait LoadPendingBlock:
         Ok(PendingBlockEnv::new(evm_env, PendingBlockEnvOrigin::DerivedFromLatest(latest)))
     }
 
-    /// Returns [`ConfigureEvmEnv::NextBlockEnvAttributes`] for building a local pending block.
+    /// Returns [`ConfigureEvmEnv::NextBlockEnvCtx`] for building a local pending block.
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -118,7 +118,7 @@ pub trait LoadPendingBlock:
         Ok(PendingBlockEnv::new(evm_env, PendingBlockEnvOrigin::DerivedFromLatest(latest)))
     }
 
-    /// Returns [`NextBlockEnvAttributes`] for building a local pending block.
+    /// Returns [`ConfigureEvmEnv::NextBlockEnvAttributes`] for building a local pending block.
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -44,13 +44,13 @@ where
             Pool: TransactionPool<
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
-            Evm: for<'a> BlockExecutionStrategyFactory<
+            Evm: BlockExecutionStrategyFactory<
                 Primitives: NodePrimitives<
                     BlockHeader = Header,
                     SignedTx = ProviderTx<Self::Provider>,
                     Receipt = ProviderReceipt<Self::Provider>,
                 >,
-                NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
+                NextBlockEnvCtx = NextBlockEnvAttributes,
             >,
         >,
     Provider: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>,
@@ -67,7 +67,7 @@ where
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
-    ) -> Result<<Self::Evm as reth_evm::ConfigureEvmEnv>::NextBlockEnvCtx<'_>, Self::Error> {
+    ) -> Result<<Self::Evm as reth_evm::ConfigureEvmEnv>::NextBlockEnvCtx, Self::Error> {
         Ok(NextBlockEnvAttributes {
             timestamp: parent.timestamp().saturating_add(12),
             suggested_fee_recipient: parent.beneficiary(),

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -1,13 +1,13 @@
 //! Support for building a pending block with transactions from local view of mempool.
 
 use alloy_consensus::{
-    constants::EMPTY_WITHDRAWALS, transaction::Recovered, Header, Transaction,
+    constants::EMPTY_WITHDRAWALS, transaction::Recovered, BlockHeader, Header, Transaction,
     EMPTY_OMMER_ROOT_HASH,
 };
 use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_primitives::U256;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_evm::execute::BlockExecutionStrategyFactory;
+use reth_evm::{execute::BlockExecutionStrategyFactory, NextBlockEnvAttributes};
 use reth_node_api::NodePrimitives;
 use reth_primitives::{logs_bloom, BlockBody, Receipt, SealedHeader};
 use reth_primitives_traits::proofs::calculate_transaction_root;
@@ -44,12 +44,13 @@ where
             Pool: TransactionPool<
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
-            Evm: BlockExecutionStrategyFactory<
+            Evm: for<'a> BlockExecutionStrategyFactory<
                 Primitives: NodePrimitives<
                     BlockHeader = Header,
                     SignedTx = ProviderTx<Self::Provider>,
                     Receipt = ProviderReceipt<Self::Provider>,
                 >,
+                NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>,
             >,
         >,
     Provider: BlockReader<Block = reth_primitives::Block, Receipt = reth_primitives::Receipt>,
@@ -61,6 +62,20 @@ where
         Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>,
     > {
         self.inner.pending_block()
+    }
+
+    fn next_env_attributes(
+        &self,
+        parent: &SealedHeader<ProviderHeader<Self::Provider>>,
+    ) -> Result<<Self::Evm as reth_evm::ConfigureEvmEnv>::NextBlockEnvCtx<'_>, Self::Error> {
+        Ok(NextBlockEnvAttributes {
+            timestamp: parent.timestamp().saturating_add(12),
+            suggested_fee_recipient: parent.beneficiary(),
+            prev_randao: B256::random(),
+            gas_limit: parent.gas_limit(),
+            parent_beacon_block_root: parent.parent_beacon_block_root(),
+            withdrawals: None,
+        })
     }
 
     fn assemble_block(

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -91,6 +91,7 @@ impl ConfigureEvmEnv for CustomEvmConfig {
     type Spec = <EthEvmConfig as ConfigureEvmEnv>::Spec;
     type Transaction = <EthEvmConfig as ConfigureEvmEnv>::Transaction;
     type TxEnv = <EthEvmConfig as ConfigureEvmEnv>::TxEnv;
+    type NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>;
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec> {
         self.inner.evm_env(header)
@@ -130,7 +131,7 @@ impl BlockExecutionStrategyFactory for CustomEvmConfig {
     fn context_for_next_block<'a>(
         &self,
         _parent: &SealedHeader,
-        attributes: NextBlockEnvAttributes<'a>,
+        attributes: Self::NextBlockEnvCtx<'a>,
     ) -> Self::ExecutionCtx<'a> {
         CustomExecutionCtx { withdrawals: attributes.withdrawals }
     }

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -31,7 +31,7 @@ use reth_node_ethereum::{node::EthereumAddOns, BasicBlockExecutorProvider, Ether
 use reth_primitives::{
     EthPrimitives, Receipt, Recovered, SealedBlock, SealedHeader, TransactionSigned,
 };
-use std::fmt::Display;
+use std::{borrow::Cow, fmt::Display};
 
 pub const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
 pub const WITHDRAWALS_ADDRESS: Address = address!("4200000000000000000000000000000000000000");
@@ -91,7 +91,7 @@ impl ConfigureEvmEnv for CustomEvmConfig {
     type Spec = <EthEvmConfig as ConfigureEvmEnv>::Spec;
     type Transaction = <EthEvmConfig as ConfigureEvmEnv>::Transaction;
     type TxEnv = <EthEvmConfig as ConfigureEvmEnv>::TxEnv;
-    type NextBlockEnvCtx<'a> = NextBlockEnvAttributes<'a>;
+    type NextBlockEnvCtx = NextBlockEnvAttributes;
 
     fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec> {
         self.inner.evm_env(header)
@@ -100,7 +100,7 @@ impl ConfigureEvmEnv for CustomEvmConfig {
     fn next_evm_env(
         &self,
         parent: &Self::Header,
-        attributes: NextBlockEnvAttributes,
+        attributes: &NextBlockEnvAttributes,
     ) -> Result<EvmEnv<Self::Spec>, Self::Error> {
         self.inner.next_evm_env(parent, attributes)
     }
@@ -115,7 +115,7 @@ impl ConfigureEvm for CustomEvmConfig {
 }
 
 pub struct CustomExecutionCtx<'a> {
-    withdrawals: Option<&'a Withdrawals>,
+    withdrawals: Option<Cow<'a, Withdrawals>>,
 }
 
 impl BlockExecutionStrategyFactory for CustomEvmConfig {
@@ -125,15 +125,15 @@ impl BlockExecutionStrategyFactory for CustomEvmConfig {
         CustomExecutorStrategy<'a, EvmFor<Self, &'a mut State<DB>, I>>;
 
     fn context_for_block<'a>(&self, block: &'a SealedBlock) -> Self::ExecutionCtx<'a> {
-        CustomExecutionCtx { withdrawals: block.body().withdrawals.as_ref() }
+        CustomExecutionCtx { withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed) }
     }
 
-    fn context_for_next_block<'a>(
+    fn context_for_next_block(
         &self,
         _parent: &SealedHeader,
-        attributes: Self::NextBlockEnvCtx<'a>,
-    ) -> Self::ExecutionCtx<'a> {
-        CustomExecutionCtx { withdrawals: attributes.withdrawals }
+        attributes: Self::NextBlockEnvCtx,
+    ) -> Self::ExecutionCtx<'_> {
+        CustomExecutionCtx { withdrawals: attributes.withdrawals.map(Cow::Owned) }
     }
 
     fn create_strategy<'a, DB, I>(
@@ -159,7 +159,7 @@ pub struct CustomExecutorStrategy<'a, Evm> {
     /// EVM used for execution.
     evm: Evm,
     /// Block withdrawals.
-    withdrawals: Option<&'a Withdrawals>,
+    withdrawals: Option<Cow<'a, Withdrawals>>,
 }
 
 impl<'db, DB, E> BlockExecutionStrategy for CustomExecutorStrategy<'_, E>
@@ -192,7 +192,7 @@ where
         mut self,
     ) -> Result<BlockExecutionResult<Receipt>, Self::Error> {
         if let Some(withdrawals) = self.withdrawals {
-            apply_withdrawals_contract_call(withdrawals, &mut self.evm)?;
+            apply_withdrawals_contract_call(withdrawals.as_ref(), &mut self.evm)?;
         }
 
         Ok(Default::default())


### PR DESCRIPTION
Introduces abstraction over pending block context via an AT on `ConfigureEvm`. This AT encapsulates all context required to be provided in addition to parent block header to configure next block's EVM and block executor.

For simplicity of API this type is expected to own all of the data and it's assumed that it's relatively cheap to clone this context during block building.