### PR TITLE
fix: no-std for storage-api

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -17,6 +17,7 @@ crates_to_check=(
     reth-execution-types
     reth-db-models
     reth-evm
+    reth-storage-api
 
     ## ethereum
     reth-evm-ethereum

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9605,7 +9605,7 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
- "reth-trie",
+ "reth-trie-common",
  "reth-trie-db",
  "revm-database",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,7 +324,7 @@ reth-consensus-debug-client = { path = "crates/consensus/debug-client" }
 reth-db = { path = "crates/storage/db", default-features = false }
 reth-db-api = { path = "crates/storage/db-api" }
 reth-db-common = { path = "crates/storage/db-common" }
-reth-db-models = { path = "crates/storage/db-models" }
+reth-db-models = { path = "crates/storage/db-models", default-features = false }
 reth-discv4 = { path = "crates/net/discv4" }
 reth-discv5 = { path = "crates/net/discv5" }
 reth-dns-discovery = { path = "crates/net/dns" }

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -24,7 +24,7 @@ reth-trie.workspace = true
 
 # ethereum
 alloy-eips.workspace = true
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["std"] }
 alloy-consensus.workspace = true
 revm-database.workspace = true
 revm-state = { workspace = true, optional = true }

--- a/crates/optimism/txpool/Cargo.toml
+++ b/crates/optimism/txpool/Cargo.toml
@@ -33,7 +33,7 @@ op-alloy-consensus.workspace = true
 op-alloy-flz.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-forks.workspace = true
-reth-optimism-primitives = { workspace = true, features = ["reth-codec"] }
+reth-optimism-primitives.workspace = true
 
 # metrics
 reth-metrics.workspace = true

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -21,8 +21,8 @@ reth-primitives-traits.workspace = true
 reth-prune-types.workspace = true
 reth-stages-types.workspace = true
 reth-storage-errors.workspace = true
-reth-trie.workspace = true
-reth-trie-db.workspace = true
+reth-trie-common.workspace = true
+reth-trie-db = { workspace = true, optional = true }
 revm-database.workspace = true
 reth-ethereum-primitives.workspace = true
 
@@ -49,8 +49,11 @@ std = [
     "reth-execution-types/std",
     "reth-prune-types/std",
     "reth-storage-errors/std",
+    "reth-db-models/std",
+    "reth-trie-common/std",
 ]
 
 db-api = [
     "dep:reth-db-api",
+    "dep:reth-trie-db",
 ]

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -28,9 +28,9 @@ use reth_primitives_traits::{
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
-use reth_trie::{
+use reth_trie_common::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
-    MultiProofTargets, TrieInput,
+    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 
 /// Supports various api interfaces for testing purposes.
@@ -405,8 +405,8 @@ impl<C: Send + Sync, N: NodePrimitives> StorageRootProvider for NoopProvider<C, 
         _address: Address,
         slot: B256,
         _hashed_storage: HashedStorage,
-    ) -> ProviderResult<reth_trie::StorageProof> {
-        Ok(reth_trie::StorageProof::new(slot))
+    ) -> ProviderResult<StorageProof> {
+        Ok(StorageProof::new(slot))
     }
 
     fn storage_multiproof(
@@ -414,8 +414,8 @@ impl<C: Send + Sync, N: NodePrimitives> StorageRootProvider for NoopProvider<C, 
         _address: Address,
         _slots: &[B256],
         _hashed_storage: HashedStorage,
-    ) -> ProviderResult<reth_trie::StorageMultiProof> {
-        Ok(reth_trie::StorageMultiProof::empty())
+    ) -> ProviderResult<StorageMultiProof> {
+        Ok(StorageMultiProof::empty())
     }
 }
 

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -85,10 +85,12 @@ pub trait StateProvider:
     }
 }
 
-/// Trait implemented for database providers that can provide the [`StateCommitment`] type.
+/// Trait implemented for database providers that can provide the [`reth_trie_db::StateCommitment`]
+/// type.
 #[cfg(feature = "db-api")]
 pub trait StateCommitmentProvider: Send + Sync {
-    /// The [`StateCommitment`] type that can be used to perform state commitment operations.
+    /// The [`reth_trie_db::StateCommitment`] type that can be used to perform state commitment
+    /// operations.
     type StateCommitment: reth_trie_db::StateCommitment;
 }
 

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -9,8 +9,7 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue
 use auto_impl::auto_impl;
 use reth_primitives_traits::Bytecode;
 use reth_storage_errors::provider::ProviderResult;
-use reth_trie::HashedPostState;
-use reth_trie_db::StateCommitment;
+use reth_trie_common::HashedPostState;
 use revm_database::BundleState;
 
 /// Type alias of boxed [`StateProvider`].
@@ -87,9 +86,10 @@ pub trait StateProvider:
 }
 
 /// Trait implemented for database providers that can provide the [`StateCommitment`] type.
+#[cfg(feature = "db-api")]
 pub trait StateCommitmentProvider: Send + Sync {
     /// The [`StateCommitment`] type that can be used to perform state commitment operations.
-    type StateCommitment: StateCommitment;
+    type StateCommitment: reth_trie_db::StateCommitment;
 }
 
 /// Trait that provides the hashed state from various sources.

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{map::B256Map, Address, Bytes, B256};
 use reth_storage_errors::provider::ProviderResult;
-use reth_trie::{
+use reth_trie_common::{
     updates::{StorageTrieUpdates, TrieUpdates},
     AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
     StorageProof, TrieInput,

--- a/crates/trie/common/src/input.rs
+++ b/crates/trie/common/src/input.rs
@@ -34,16 +34,16 @@ impl TrieInput {
     /// Prepend state to the input and extend the prefix sets.
     pub fn prepend(&mut self, mut state: HashedPostState) {
         self.prefix_sets.extend(state.construct_prefix_sets());
-        std::mem::swap(&mut self.state, &mut state);
+        core::mem::swap(&mut self.state, &mut state);
         self.state.extend(state);
     }
 
     /// Prepend intermediate nodes and state to the input.
     /// Prefix sets for incoming state will be ignored.
     pub fn prepend_cached(&mut self, mut nodes: TrieUpdates, mut state: HashedPostState) {
-        std::mem::swap(&mut self.nodes, &mut nodes);
+        core::mem::swap(&mut self.nodes, &mut nodes);
         self.nodes.extend(nodes);
-        std::mem::swap(&mut self.state, &mut state);
+        core::mem::swap(&mut self.state, &mut state);
         self.state.extend(state);
     }
 

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -15,6 +15,10 @@ extern crate alloc;
 mod hashed_state;
 pub use hashed_state::*;
 
+/// Input for trie computation.
+mod input;
+pub use input::TrieInput;
+
 /// The implementation of hash builder.
 pub mod hash_builder;
 

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -29,10 +29,6 @@ pub mod walker;
 /// The iterators for traversing existing intermediate hashes and updated trie leaves.
 pub mod node_iter;
 
-/// Input for trie computation.
-mod input;
-pub use input::TrieInput;
-
 /// Merkle proof generation.
 pub mod proof;
 


### PR DESCRIPTION
Fixes `no-std` for storage-api crate (only works without db-api feature)

- Moved `TrieInput` to trie-common
- feature-gated `StateCommitmentProvider` and `trie-db` crate behind `db-api` feature as this crate depends on `db-api`