### PR TITLE
chore: ignore ethereum-tests in local codespell check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,7 @@ clippy:
 	-- -D warnings
 
 lint-codespell: ensure-codespell
-	codespell --skip "*.json"
+	codespell --skip "*.json" --skip "./testing/ef-tests/ethereum-tests"
 
 ensure-codespell:
 	@if ! command -v codespell &> /dev/null; then \


### PR DESCRIPTION
testing out the `make lint` etc commands does not work if `ethereum-tests` is populated in `ef-tests`