### PR TITLE
fix(eth_callBundle): Fix ethSentToCoinbase calculation

### DIFF
--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -136,7 +136,7 @@ where
         self.eth_api()
             .spawn_with_state_at_block(at, move |state| {
                 let coinbase = evm_env.block_env.beneficiary;
-                let basefee = Some(evm_env.block_env.basefee);
+                let basefee = evm_env.block_env.basefee;
                 let db = CacheDB::new(StateProviderDatabase::new(state));
 
                 let initial_coinbase = db
@@ -147,7 +147,7 @@ where
                 let mut coinbase_balance_before_tx = initial_coinbase;
                 let mut coinbase_balance_after_tx = initial_coinbase;
                 let mut total_gas_used = 0u64;
-                let mut total_gas_fess = U256::ZERO;
+                let mut total_gas_fees = U256::ZERO;
                 let mut hasher = Keccak256::new();
 
                 let mut evm = eth_api.evm_config().evm_with_env(db, evm_env);
@@ -174,16 +174,16 @@ where
                     };
 
                     hasher.update(*tx.tx_hash());
-                    let gas_price = tx.effective_gas_price(basefee);
                     let ResultAndState { result, state } = evm
                         .transact(eth_api.evm_config().tx_env(&tx))
                         .map_err(Eth::Error::from_evm_err)?;
 
+                    let gas_price = tx.effective_tip_per_gas(basefee).expect("fee is always valid; execution succeeded");
                     let gas_used = result.gas_used();
                     total_gas_used += gas_used;
 
                     let gas_fees = U256::from(gas_used) * U256::from(gas_price);
-                    total_gas_fess += gas_fees;
+                    total_gas_fees += gas_fees;
 
                     // coinbase is always present in the result state
                     coinbase_balance_after_tx =
@@ -230,7 +230,7 @@ where
                 // populate the response
 
                 let coinbase_diff = coinbase_balance_after_tx.saturating_sub(initial_coinbase);
-                let eth_sent_to_coinbase = coinbase_diff.saturating_sub(total_gas_fess);
+                let eth_sent_to_coinbase = coinbase_diff.saturating_sub(total_gas_fees);
                 let bundle_gas_price =
                     coinbase_diff.checked_div(U256::from(total_gas_used)).unwrap_or_default();
                 let res = EthCallBundleResponse {
@@ -238,7 +238,7 @@ where
                     bundle_hash: hasher.finalize(),
                     coinbase_diff,
                     eth_sent_to_coinbase,
-                    gas_fees: total_gas_fess,
+                    gas_fees: total_gas_fees,
                     results,
                     state_block_number,
                     total_gas_used,

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -178,7 +178,9 @@ where
                         .transact(eth_api.evm_config().tx_env(&tx))
                         .map_err(Eth::Error::from_evm_err)?;
 
-                    let gas_price = tx.effective_tip_per_gas(basefee).expect("fee is always valid; execution succeeded");
+                    let gas_price = tx
+                        .effective_tip_per_gas(basefee)
+                        .expect("fee is always valid; execution succeeded");
                     let gas_used = result.gas_used();
                     total_gas_used += gas_used;
 


### PR DESCRIPTION
Previously, `call_bundle` was using `tx.effective_gas_price(basefee)` which includes the burned gas, which threw off the `eth_sent_to_coinbase` calculation always leading it to be `0`.

With this fix sending eth to the coinbase is correctly tracked, for example this bundle sends 100gwei to the coinbase in the 2nd tx on a local devnet:

```
cast rpc eth_callBundle --raw '[{"txs":["0x02f86d8205390101840586ee6382520894c02aaa39b223fe8d0a0e5c4f27ead9083c756cc285174876e80080c001a0f6f2e5762c6496e74fb3f1750ef307467ca75d9a195b4194297a8f2afa906826a06760db1c59076103a1f16588559c5b2f3340926f1091f801afd21820b88d59f6","0x02f86d8205390201840586ee6382520894f39fd6e51aad88f6f4ce6ab8827279cfffb9226685174876e80080c080a021951a7d2ca2951d80ec3fbce3d8f9d0ee95019ca033edefffecd6f3acfea0fca04ab2ff08116a150dfdfaf08ac2b87e0dbe1e0ab3b563872ef87de3f2feab79fd"],"blockNumber":"0x17","stateBlockNumber":"latest","coinbase":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"}]' | jq .

{
  "bundleHash": "0xef5c5fb5bcbdab36e251092cc3419a6d83e742ffba8e6daea5a5c840627d4837",
  "bundleGasPrice": "2380953",
  "coinbaseDiff": "100000042000",
  "ethSentToCoinbase": "100000000000",
  "gasFees": "42000",
  "results": [
    {
      "coinbaseDiff": "21000",
      "ethSentToCoinbase": "0",
      "fromAddress": "0xa0ee7a142d267c1f36714e4a8f75612f20a79720",
      "gasFees": "21000",
      "gasPrice": "1",
      "gasUsed": "0x5208",
      "toAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
      "txHash": "0x0e7c97f4f5844c070a4740a359ed75f6ac72948a4fba091b130fbe188cb90632",
      "value": "0x"
    },
    {
      "coinbaseDiff": "100000021000",
      "ethSentToCoinbase": "100000000000",
      "fromAddress": "0xa0ee7a142d267c1f36714e4a8f75612f20a79720",
      "gasFees": "21000",
      "gasPrice": "1",
      "gasUsed": "0x5208",
      "toAddress": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
      "txHash": "0x0c21f551629ba86c70b31b92cee4bccc5aa805c42a191883bae790d21ca990c8",
      "value": "0x"
    }
  ],
  "stateBlockNumber": "0x1c",
  "totalGasUsed": "0xa410"
}
```