### PR TITLE
Fix: Increase gas limit in chain config

### DIFF
--- a/examples/custom-dev-node/src/main.rs
+++ b/examples/custom-dev-node/src/main.rs
@@ -62,7 +62,7 @@ fn custom_chain() -> Arc<ChainSpec> {
     "nonce": "0x42",
     "timestamp": "0x0",
     "extraData": "0x5343",
-    "gasLimit": "0x1388",
+    "gasLimit": "0x5208",
     "difficulty": "0x400000000",
     "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "coinbase": "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/14829

Increase `gaslimit` to a value enough for code to run.