### PR TITLE
fix: correctly configure `extraData` for Ethereum blocks

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -224,7 +224,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             blockchain_db.clone(),
             transaction_pool,
             EthEvmConfig::new(provider_factory.chain_spec()),
-            EthereumBuilderConfig::new(Default::default()),
+            EthereumBuilderConfig::new(),
         );
 
         match payload_builder.try_build(args)? {

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -21,7 +21,7 @@ use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
 pub use alloy_evm::EthEvm;
 use alloy_evm::{EthEvmFactory, FromRecoveredTx};
-use alloy_primitives::U256;
+use alloy_primitives::{Bytes, U256};
 use core::{convert::Infallible, fmt::Debug};
 use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
 use reth_evm::{
@@ -88,6 +88,12 @@ impl<EvmFactory> EthEvmConfig<EvmFactory> {
     /// Returns the chain spec associated with this configuration.
     pub const fn chain_spec(&self) -> &Arc<ChainSpec> {
         &self.chain_spec
+    }
+
+    /// Sets the extra data for the block assembler.
+    pub fn with_extra_data(mut self, extra_data: Bytes) -> Self {
+        self.block_assembler.extra_data = extra_data;
+        self
     }
 }
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -22,7 +22,8 @@ use reth_node_builder::{
         EngineValidatorAddOn, EngineValidatorBuilder, EthApiBuilder, RethRpcAddOns, RpcAddOns,
         RpcHandle,
     },
-    BuilderContext, DebugNode, Node, NodeAdapter, NodeComponentsBuilder, PayloadTypes,
+    BuilderContext, DebugNode, Node, NodeAdapter, NodeComponentsBuilder, PayloadBuilderConfig,
+    PayloadTypes,
 };
 use reth_provider::{providers::ProviderFactoryBuilder, CanonStateSubscriptions, EthStorage};
 use reth_rpc::{eth::core::EthApiFor, ValidationApi};
@@ -306,7 +307,8 @@ where
         self,
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
-        let evm_config = EthEvmConfig::new(ctx.chain_spec());
+        let evm_config = EthEvmConfig::new(ctx.chain_spec())
+            .with_extra_data(ctx.payload_builder_config().extra_data_bytes());
         let executor = BasicBlockExecutorProvider::new(evm_config.clone());
 
         Ok((evm_config, executor))

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -48,7 +48,7 @@ impl EthereumPayloadBuilder {
             ctx.provider().clone(),
             pool,
             evm_config,
-            EthereumBuilderConfig::new(conf.extra_data_bytes()).with_gas_limit(conf.gas_limit()),
+            EthereumBuilderConfig::new().with_gas_limit(conf.gas_limit()),
         ))
     }
 }

--- a/crates/ethereum/payload/src/config.rs
+++ b/crates/ethereum/payload/src/config.rs
@@ -1,20 +1,23 @@
 use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
-use alloy_primitives::Bytes;
 use reth_primitives_traits::constants::GAS_LIMIT_BOUND_DIVISOR;
 
 /// Settings for the Ethereum builder.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct EthereumBuilderConfig {
-    /// Block extra data.
-    pub extra_data: Bytes,
     /// Desired gas limit.
     pub desired_gas_limit: u64,
 }
 
+impl Default for EthereumBuilderConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EthereumBuilderConfig {
     /// Create new payload builder config.
-    pub const fn new(extra_data: Bytes) -> Self {
-        Self { extra_data, desired_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M }
+    pub const fn new() -> Self {
+        Self { desired_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M }
     }
 
     /// Set desired gas limit.
@@ -25,11 +28,6 @@ impl EthereumBuilderConfig {
 }
 
 impl EthereumBuilderConfig {
-    /// Returns owned extra data bytes for the block.
-    pub fn extra_data(&self) -> Bytes {
-        self.extra_data.clone()
-    }
-
     /// Returns the gas limit for the next block based
     /// on parent and desired gas limits.
     pub fn gas_limit(&self, parent_gas_limit: u64) -> u64 {

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -253,7 +253,7 @@ pub trait BlockExecutionStrategy {
 /// For more context on the strategy design, see the documentation for [`BlockExecutionStrategy`].
 ///
 /// Additionally, trait implementations are expected to define a [`BlockAssembler`] type that is
-/// used to assemble blocks. Assember combined with strategy are used to create a [`BlockBuilder`].
+/// used to assemble blocks. Assembler combined with strategy are used to create a [`BlockBuilder`].
 /// [`BlockBuilder`] exposes a simple API for building blocks and can be consumed by payload
 /// builder.
 ///

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -50,7 +50,7 @@ where
     type BlockAssembler = OpBlockAssembler<ChainSpec>;
 
     fn block_assembler(&self) -> &Self::BlockAssembler {
-        &self.block_assember
+        &self.block_assembler
     }
 
     fn context_for_block<'a>(&self, block: &'a SealedBlock<N::Block>) -> Self::ExecutionCtx<'a> {

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -51,7 +51,7 @@ pub struct OpEvmConfig<ChainSpec = OpChainSpec, N: NodePrimitives = OpPrimitives
     chain_spec: Arc<ChainSpec>,
     evm_factory: OpEvmFactory,
     receipt_builder: Arc<dyn OpReceiptBuilder<N::SignedTx, OpHaltReason, Receipt = N::Receipt>>,
-    block_assember: OpBlockAssembler<ChainSpec>,
+    block_assembler: OpBlockAssembler<ChainSpec>,
 }
 
 impl<ChainSpec, N: NodePrimitives> Clone for OpEvmConfig<ChainSpec, N> {
@@ -60,7 +60,7 @@ impl<ChainSpec, N: NodePrimitives> Clone for OpEvmConfig<ChainSpec, N> {
             chain_spec: self.chain_spec.clone(),
             evm_factory: OpEvmFactory::default(),
             receipt_builder: self.receipt_builder.clone(),
-            block_assember: self.block_assember.clone(),
+            block_assembler: self.block_assembler.clone(),
         }
     }
 }
@@ -79,7 +79,7 @@ impl<ChainSpec, N: NodePrimitives> OpEvmConfig<ChainSpec, N> {
         receipt_builder: impl OpReceiptBuilder<N::SignedTx, OpHaltReason, Receipt = N::Receipt>,
     ) -> Self {
         Self {
-            block_assember: OpBlockAssembler::new(chain_spec.clone()),
+            block_assembler: OpBlockAssembler::new(chain_spec.clone()),
             chain_spec,
             evm_factory: OpEvmFactory::default(),
             receipt_builder: Arc::new(receipt_builder),

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -41,7 +41,6 @@ use reth::{
     rpc::types::engine::ExecutionPayload,
     tasks::TaskManager,
     transaction_pool::{PoolTransaction, TransactionPool},
-    version::default_extra_data_bytes,
 };
 use reth_basic_payload_builder::{BuildArguments, BuildOutcome, PayloadBuilder, PayloadConfig};
 use reth_chainspec::{Chain, ChainSpec, ChainSpecProvider};
@@ -367,7 +366,7 @@ where
                 ctx.provider().clone(),
                 pool,
                 EthEvmConfig::new(ctx.provider().chain_spec().clone()),
-                EthereumBuilderConfig::new(default_extra_data_bytes()),
+                EthereumBuilderConfig::new(),
             ),
         };
         Ok(payload_builder)

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -52,13 +52,12 @@ where
         pool: Pool,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>> {
         tracing::info!("Spawning a custom payload builder");
-        let conf = ctx.payload_builder_config();
 
         let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
             ctx.provider().clone(),
             pool,
             EthEvmConfig::new(ctx.chain_spec()),
-            EthereumBuilderConfig::new(conf.extra_data_bytes()),
+            EthereumBuilderConfig::new(),
         );
 
         let conf = ctx.payload_builder_config();


### PR DESCRIPTION
`extra_data` is now configured on `EthBlockAssembler` so we need to correctly pass it from the node builder