### PR TITLE
fix: apply eip2935 for op

### DIFF
--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -162,6 +162,7 @@ where
             self.chain_spec.is_spurious_dragon_active_at_block(self.evm.block().number);
         self.evm.db_mut().set_state_clear_flag(state_clear_flag);
 
+        self.system_caller.apply_blockhashes_contract_call(self.ctx.parent_hash, &mut self.evm)?;
         self.system_caller
             .apply_beacon_root_contract_call(self.ctx.parent_beacon_block_root, &mut self.evm)?;
 


### PR DESCRIPTION
this is also part of pectra in opstack

mirrors eth:

https://github.com/paradigmxyz/reth/blob/34b71454c49416be8c12b8cbb0d27d7ee22285a8/crates/ethereum/evm/src/execute.rs#L145-L147