### PR TITLE
refactor: prepare EthereumHardforks for move to alloy-evm

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -4,7 +4,7 @@ use alloy_chains::Chain;
 use alloy_consensus::Header;
 use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_genesis::Genesis;
-use alloy_primitives::B256;
+use alloy_primitives::{B256, U256};
 use core::fmt::{Debug, Display};
 use reth_ethereum_forks::EthereumHardforks;
 use reth_network_peers::NodeRecord;
@@ -62,6 +62,9 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     fn is_ethereum(&self) -> bool {
         self.chain().is_ethereum()
     }
+
+    /// Returns the final total difficulty if the Paris hardfork is known.
+    fn final_paris_total_difficulty(&self) -> Option<U256>;
 }
 
 impl EthChainSpec for ChainSpec {
@@ -119,5 +122,9 @@ impl EthChainSpec for ChainSpec {
 
     fn is_optimism(&self) -> bool {
         false
+    }
+
+    fn final_paris_total_difficulty(&self) -> Option<U256> {
+        self.paris_block_and_final_difficulty.map(|(_, final_difficulty)| final_difficulty)
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -437,17 +437,6 @@ impl ChainSpec {
         self.paris_block_and_final_difficulty.map(|(_, final_difficulty)| final_difficulty)
     }
 
-    /// Returns the final total difficulty if the given block number is after the Paris hardfork.
-    ///
-    /// Note: technically this would also be valid for the block before the paris upgrade, but this
-    /// edge case is omitted here.
-    #[inline]
-    pub fn final_paris_total_difficulty(&self, block_number: u64) -> Option<U256> {
-        self.paris_block_and_final_difficulty.and_then(|(activated_at, final_difficulty)| {
-            (block_number >= activated_at).then_some(final_difficulty)
-        })
-    }
-
     /// Get the fork filter for the given hardfork
     pub fn hardfork_fork_filter<H: Hardfork + Clone>(&self, fork: H) -> Option<ForkFilter> {
         match self.hardforks.fork(fork.clone()) {
@@ -784,14 +773,6 @@ impl Hardforks for ChainSpec {
 impl EthereumHardforks for ChainSpec {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
         self.fork(fork)
-    }
-
-    fn get_final_paris_total_difficulty(&self) -> Option<U256> {
-        self.get_final_paris_total_difficulty()
-    }
-
-    fn final_paris_total_difficulty(&self, block_number: u64) -> Option<U256> {
-        self.final_paris_total_difficulty(block_number)
     }
 }
 

--- a/crates/ethereum-forks/src/hardforks/ethereum.rs
+++ b/crates/ethereum-forks/src/hardforks/ethereum.rs
@@ -1,10 +1,8 @@
-use alloy_primitives::U256;
-
 use crate::{EthereumHardfork, ForkCondition};
 
 /// Helper methods for Ethereum forks.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait EthereumHardforks: Clone {
+pub trait EthereumHardforks {
     /// Retrieves [`ForkCondition`] by an [`EthereumHardfork`]. If `fork` is not present, returns
     /// [`ForkCondition::Never`].
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition;
@@ -82,13 +80,4 @@ pub trait EthereumHardforks: Clone {
             _ => false,
         }
     }
-
-    /// Returns the final total difficulty if the Paris hardfork is known.
-    fn get_final_paris_total_difficulty(&self) -> Option<U256>;
-
-    /// Returns the final total difficulty if the given block number is after the Paris hardfork.
-    ///
-    /// Note: technically this would also be valid for the block before the paris upgrade, but this
-    /// edge case is omitted here.
-    fn final_paris_total_difficulty(&self, block_number: u64) -> Option<U256>;
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -991,12 +991,18 @@ impl<L, R> Attached<L, R> {
 
 /// Helper container type to bundle the initial [`NodeConfig`] and the loaded settings from the
 /// reth.toml config
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct WithConfigs<ChainSpec> {
     /// The configured, usually derived from the CLI.
     pub config: NodeConfig<ChainSpec>,
     /// The loaded reth.toml config.
     pub toml_config: reth_config::Config,
+}
+
+impl<ChainSpec> Clone for WithConfigs<ChainSpec> {
+    fn clone(&self) -> Self {
+        Self { config: self.config.clone(), toml_config: self.toml_config.clone() }
+    }
 }
 
 /// Helper container type to bundle the [`ProviderFactory`] and the metrics

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -358,9 +358,7 @@ where
                                         hash: head.hash(),
                                         difficulty: head.difficulty(),
                                         timestamp: head.timestamp(),
-                                        total_difficulty: chainspec
-                                            .final_paris_total_difficulty(head.number())
-                                            .unwrap_or_default(),
+                                        total_difficulty: chainspec.final_paris_total_difficulty().filter(|_| chainspec.is_paris_active_at_block(head.number())).unwrap_or_default(),
                                     };
                                     network_handle.update_status(head_block);
                                 }

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -241,6 +241,10 @@ impl EthChainSpec for OpChainSpec {
     fn is_optimism(&self) -> bool {
         true
     }
+
+    fn final_paris_total_difficulty(&self) -> Option<U256> {
+        self.inner.final_paris_total_difficulty()
+    }
 }
 
 impl Hardforks for OpChainSpec {
@@ -268,14 +272,6 @@ impl Hardforks for OpChainSpec {
 impl EthereumHardforks for OpChainSpec {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
         self.fork(fork)
-    }
-
-    fn get_final_paris_total_difficulty(&self) -> Option<U256> {
-        self.inner.get_final_paris_total_difficulty()
-    }
-
-    fn final_paris_total_difficulty(&self, block_number: u64) -> Option<U256> {
-        self.inner.final_paris_total_difficulty(block_number)
     }
 }
 

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -112,7 +112,7 @@ where
             chain_id: self.chain_spec.chain().id(),
             terminal_total_difficulty_passed: self
                 .chain_spec
-                .get_final_paris_total_difficulty()
+                .final_paris_total_difficulty()
                 .is_some(),
             terminal_total_difficulty: self
                 .chain_spec

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1163,7 +1163,7 @@ impl<N: ProviderNodeTypes> OmmersProvider for ConsistentProvider<N> {
             id,
             |db_provider| db_provider.ommers(id),
             |block_state| {
-                if self.chain_spec().final_paris_total_difficulty(block_state.number()).is_some() {
+                if self.chain_spec().is_paris_active_at_block(block_state.number()) {
                     return Ok(Some(Vec::new()))
                 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -11,7 +11,7 @@ use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{eip4895::Withdrawals, BlockHashOrNumber};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use core::fmt;
-use reth_chainspec::{ChainInfo, EthereumHardforks};
+use reth_chainspec::ChainInfo;
 use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
@@ -257,18 +257,7 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     }
 
     fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        if let Some(td) = self.chain_spec.final_paris_total_difficulty(number) {
-            // if this block is higher than the final paris(merge) block, return the final paris
-            // difficulty
-            return Ok(Some(td))
-        }
-
-        self.static_file_provider.get_with_static_file_or_database(
-            StaticFileSegment::Headers,
-            number,
-            |static_file| static_file.header_td_by_number(number),
-            || self.provider()?.header_td_by_number(number),
-        )
+        self.provider()?.header_td_by_number(number)
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1011,10 +1011,12 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
     }
 
     fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        if let Some(td) = self.chain_spec.final_paris_total_difficulty(number) {
-            // if this block is higher than the final paris(merge) block, return the final paris
-            // difficulty
-            return Ok(Some(td))
+        if self.chain_spec.is_paris_active_at_block(number) {
+            if let Some(td) = self.chain_spec.final_paris_total_difficulty() {
+                // if this block is higher than the final paris(merge) block, return the final paris
+                // difficulty
+                return Ok(Some(td))
+            }
         }
 
         self.static_file_provider.get_with_static_file_or_database(
@@ -1604,7 +1606,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> OmmersProvider for DatabasePro
         if let Some(number) = self.convert_hash_or_number(id)? {
             // If the Paris (Merge) hardfork block is known and block is after it, return empty
             // ommers.
-            if self.chain_spec.final_paris_total_difficulty(number).is_some() {
+            if self.chain_spec.is_paris_active_at_block(number) {
                 return Ok(Some(Vec::new()))
             }
 

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -177,7 +177,7 @@ where
             } else {
                 None
             };
-            let ommers = if chain_spec.final_paris_total_difficulty(header.number()).is_some() {
+            let ommers = if chain_spec.is_paris_active_at_block(header.number()) {
                 Vec::new()
             } else {
                 provider.ommers(header.number().into())?.unwrap_or_default()


### PR DESCRIPTION
This PR removes paris TD related methods from `EthereumHardforks` and adds a single `final_paris_total_difficulty` method to `EthChainSpec` trait. That way `EthereumHardforks` is only responsible for providing data about fork activations.