### PR TITLE
spelling and grammar issues

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1193,7 +1193,7 @@ Post-merge hard forks (timestamp based):
             happy_path_head, happy_path_expected,
             "expected satisfy() to return {happy_path_expected:#?}, but got {happy_path_head:#?} "
         );
-        // multiple timestamp test case (i.e Shanghai -> Cancun)
+        // multiple timestamp test case (i.e. Shanghai -> Cancun)
         let multiple_timestamp_fork_case = ChainSpec::builder()
             .chain(Chain::mainnet())
             .genesis(empty_genesis.clone())

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -25,7 +25,7 @@ use std::pin::Pin;
 use tokio_stream::StreamExt;
 use url::Url;
 
-/// An helper struct to handle node actions
+/// A helper struct to handle node actions
 #[expect(missing_debug_implementations)]
 pub struct NodeTestContext<Node, AddOns>
 where

--- a/crates/engine/util/src/skip_fcu.rs
+++ b/crates/engine/util/src/skip_fcu.rs
@@ -20,7 +20,7 @@ pub struct EngineSkipFcu<S> {
 }
 
 impl<S> EngineSkipFcu<S> {
-    /// Creates new [`EngineSkipFcu`] stream wrapper.
+    /// Creates a new [`EngineSkipFcu`] stream wrapper.
     pub const fn new(stream: S, threshold: usize) -> Self {
         Self {
             stream,

--- a/crates/engine/util/src/skip_new_payload.rs
+++ b/crates/engine/util/src/skip_new_payload.rs
@@ -21,7 +21,7 @@ pub struct EngineSkipNewPayload<S> {
 }
 
 impl<S> EngineSkipNewPayload<S> {
-    /// Creates new [`EngineSkipNewPayload`] stream wrapper.
+    /// Creates a new [`EngineSkipNewPayload`] stream wrapper.
     pub const fn new(stream: S, threshold: usize) -> Self {
         Self { stream, threshold, skipped: 0 }
     }


### PR DESCRIPTION
changed:

i.e Shanghai - i.e. Shanghai

An helper - A helper

Creates new [`EngineSkipFcu`] - Creates a new [`EngineSkipFcu`]

Creates new [`EngineSkipNewPayload`] - Creates a new [`EngineSkipNewPayload`]