### PR TITLE
refactor: use tokio to fetch storage proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9866,6 +9866,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "thiserror 2.0.11",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -34,6 +34,11 @@ impl WorkloadExecutor {
         }
     }
 
+    /// Returns the handle to the tokio runtime
+    pub(super) fn handle(&self) -> &Handle {
+        &self.inner.handle
+    }
+
     /// Shorthand for [`Runtime::spawn_blocking`]
     #[track_caller]
     pub(super) fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -352,7 +352,7 @@ where
                 config.nodes_sorted,
                 config.state_sorted,
                 config.prefix_sets,
-                executor.rayon_pool().clone(),
+                executor.handle().clone(),
             )
             .with_branch_node_masks(true)
             .multiproof(proof_targets);

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -33,6 +33,7 @@ thiserror.workspace = true
 derive_more.workspace = true
 rayon.workspace = true
 itertools.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }
@@ -50,6 +51,7 @@ rayon.workspace = true
 criterion.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["metrics"]

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -101,7 +101,7 @@ where
             account_prefix_set: PrefixSetMut::from(targets.keys().copied().map(Nibbles::unpack)),
             storage_prefix_sets: targets
                 .iter()
-                .filter(|&(_hashed_address, slots)| (!slots.is_empty()))
+                .filter(|&(_hashed_address, slots)| !slots.is_empty())
                 .map(|(hashed_address, slots)| {
                     (*hashed_address, PrefixSetMut::from(slots.iter().map(Nibbles::unpack)))
                 })
@@ -125,6 +125,8 @@ where
         // Pre-calculate storage roots for accounts which were changed.
         tracker.set_precomputed_storage_roots(storage_root_targets_len as u64);
 
+        // stores the receiver for the storage proof outcome for the hashed addresses
+        // this way we can lazily await the outcome when we iterate over the map
         let mut storage_proofs =
             B256Map::with_capacity_and_hasher(storage_root_targets.len(), Default::default());
 
@@ -333,6 +335,10 @@ where
         Ok(MultiProof { account_subtree, branch_node_hash_masks, branch_node_tree_masks, storages })
     }
 }
+
+
+
+
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
closes #14820

this now spawns the storageproof fetches to a tokio blocking tasks and no longer rayon.

this mostly does IO, and tokio's blocking pool has access to more tasks and can scale them on demand.

I think this could be further optimized if we change this to yet another background task that instead of spawning one task per storage proof, distributes storage proofs targets across a pool of tasks.