### PR TITLE
fix(l2-withdrawals-root): Compute op devnet genesis hash from genesis header

### DIFF
--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -3,7 +3,6 @@
 use alloc::sync::Arc;
 
 use alloy_chains::Chain;
-use alloy_consensus::constants::DEV_GENESIS_HASH;
 use alloy_primitives::U256;
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_optimism_forks::DEV_HARDFORKS;
@@ -19,13 +18,11 @@ pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
     let genesis = serde_json::from_str(include_str!("../res/genesis/dev.json"))
         .expect("Can't deserialize Dev testnet genesis json");
     let hardforks = DEV_HARDFORKS.clone();
+    let genesis_header = SealedHeader::seal_slow(make_op_genesis_header(&genesis, &hardforks));
     OpChainSpec {
         inner: ChainSpec {
             chain: Chain::dev(),
-            genesis_header: SealedHeader::new(
-                make_op_genesis_header(&genesis, &hardforks),
-                DEV_GENESIS_HASH,
-            ),
+            genesis_header,
             genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/14777

Fixes genesis upgrade path in devnet where isthmus is active since genesis. In this case, genesis hash can't be a constant because since isthmus, the l2 withdrawals root is a function of the state and not a constant (empty root hash) anymore.