### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx_load.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx_load.c
@@ -3950,12 +3950,12 @@ typedef struct MDBX_node {
 #error "Oops, some flags overlapped or wrong"
 #endif
 
-/* Max length of iov-vector passed to writev() call, used for auxilary writes */
-#define MDBX_AUXILARY_IOV_MAX 64
-#if defined(IOV_MAX) && IOV_MAX < MDBX_AUXILARY_IOV_MAX
-#undef MDBX_AUXILARY_IOV_MAX
-#define MDBX_AUXILARY_IOV_MAX IOV_MAX
-#endif /* MDBX_AUXILARY_IOV_MAX */
+/* Max length of iov-vector passed to writev() call, used for auxiliary writes */
+#define MDBX_AUXILIARY_IOV_MAX 64
+#if defined(IOV_MAX) && IOV_MAX < MDBX_AUXILIARY_IOV_MAX
+#undef MDBX_AUXILIARY_IOV_MAX
+#define MDBX_AUXILIARY_IOV_MAX IOV_MAX
+#endif /* MDBX_AUXILIARY_IOV_MAX */
 
 /*
  *                /

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx_stat.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx_stat.c
@@ -3950,12 +3950,12 @@ typedef struct MDBX_node {
 #error "Oops, some flags overlapped or wrong"
 #endif
 
-/* Max length of iov-vector passed to writev() call, used for auxilary writes */
-#define MDBX_AUXILARY_IOV_MAX 64
-#if defined(IOV_MAX) && IOV_MAX < MDBX_AUXILARY_IOV_MAX
-#undef MDBX_AUXILARY_IOV_MAX
-#define MDBX_AUXILARY_IOV_MAX IOV_MAX
-#endif /* MDBX_AUXILARY_IOV_MAX */
+/* Max length of iov-vector passed to writev() call, used for auxiliary writes */
+#define MDBX_AUXILIARY_IOV_MAX 64
+#if defined(IOV_MAX) && IOV_MAX < MDBX_AUXILIARY_IOV_MAX
+#undef MDBX_AUXILIARY_IOV_MAX
+#define MDBX_AUXILIARY_IOV_MAX IOV_MAX
+#endif /* MDBX_AUXILIARY_IOV_MAX */
 
 /*
  *                /


### PR DESCRIPTION
Corrected `auxilary` → `auxiliary`
