### PR TITLE
fix: fix log key format for target_block_number argument

### DIFF
--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -125,7 +125,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         .retry(backoff)
         .notify(|err, _| warn!(target: "reth::cli", "Error requesting header: {err}. Retrying..."))
         .await?;
-        info!(target: "reth::cli", target_block_number=self.to, "Finished downloading tip of block range");
+        info!(target: "reth::cli", target_block_number = self.to, "Finished downloading tip of block range");
 
         // build the full block client
         let consensus: Arc<dyn Consensus<BlockTy<N>, Error = ConsensusError>> =


### PR DESCRIPTION
i’ve corrected the format for the target_block_number argument, it should now follow the key = value structure, ensuring proper functionality when processing logs.