### PR TITLE
chore: bump alloy-evm and revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "aligned-vec"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+checksum = "af15ccceeacb9304119d97925de463bc97ae3555ee8dc8056f67b119f66e5934"
 dependencies = [
  "equator",
 ]
@@ -170,7 +170,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ dependencies = [
  "crc",
  "rand 0.8.5",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -261,12 +261,12 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=68735f2#68735f245cf331ffebfc6bc867406cddf56ae0d4"
+source = "git+https://github.com/alloy-rs/evm?rev=205303a#205303a572132971e84d1a12fbdf3e03aaabfa78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
+ "op-revm",
  "revm",
- "revm-optimism",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "alloy-hardforks"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/hardforks?rev=c577698#c577698563a10311d6cdcc09c2f271542a7ee69b"
+source = "git+https://github.com/alloy-rs/hardforks?rev=42a3427#42a3427e19ec7a7dccfab308b21252ab62c2c5ae"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -317,7 +317,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -343,7 +343,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "url",
 ]
@@ -382,18 +382,18 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=68735f2#68735f245cf331ffebfc6bc867406cddf56ae0d4"
+source = "git+https://github.com/alloy-rs/evm?rev=205303a#205303a572132971e84d1a12fbdf3e03aaabfa78"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
+ "op-revm",
  "revm",
- "revm-optimism",
 ]
 
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/hardforks?rev=c577698#c577698563a10311d6cdcc09c2f271542a7ee69b"
+source = "git+https://github.com/alloy-rs/hardforks?rev=42a3427#42a3427e19ec7a7dccfab308b21252ab62c2c5ae"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -466,7 +466,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
@@ -511,7 +511,7 @@ checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -601,7 +601,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -654,7 +654,7 @@ dependencies = [
  "jsonrpsee-types",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -739,7 +739,7 @@ dependencies = [
  "coins-bip39",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -769,7 +769,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -785,7 +785,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "syn-solidity",
 ]
 
@@ -823,7 +823,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "aquamarine"
@@ -992,7 +992,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1190,7 +1190,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1226,18 +1226,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ dependencies = [
  "static_assertions",
  "tap",
  "thin-vec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -1593,7 +1593,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -1694,9 +1694,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecount"
@@ -1706,9 +1706,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1721,7 +1721,7 @@ checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1732,9 +1732,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -1780,7 +1780,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
 ]
@@ -1793,7 +1793,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1801,16 +1801,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1966,7 +1966,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -2469,7 +2469,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2493,7 +2493,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2504,7 +2504,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2558,7 +2558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2595,7 +2595,7 @@ checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2637,7 +2637,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2648,7 +2648,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2677,7 +2677,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "unicode-xid",
 ]
 
@@ -2690,7 +2690,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "unicode-xid",
 ]
 
@@ -2804,7 +2804,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2821,9 +2821,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -2886,7 +2886,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "walkdir",
 ]
 
@@ -2936,7 +2936,7 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.5",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "sha3",
  "zeroize",
@@ -2951,7 +2951,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2962,27 +2962,27 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "equator"
-version = "0.2.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
 dependencies = [
  "equator-macro",
 ]
 
 [[package]]
 name = "equator-macro"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3047,7 +3047,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3071,7 +3071,7 @@ dependencies = [
  "reth-node-ethereum",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3108,7 +3108,7 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-tracing",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_json",
  "tokio",
@@ -3169,7 +3169,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie-db",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -3279,7 +3279,7 @@ dependencies = [
  "reth-network",
  "reth-network-peers",
  "reth-primitives",
- "secp256k1 0.30.0",
+ "secp256k1",
  "tokio",
 ]
 
@@ -3349,7 +3349,7 @@ dependencies = [
  "reth-network-api",
  "reth-primitives",
  "reth-tracing",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -3635,7 +3635,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3966,7 +3966,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.0",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3990,7 +3990,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -4107,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -4337,7 +4337,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4394,7 +4394,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4447,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "infer"
@@ -4515,7 +4515,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4625,9 +4625,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -4773,7 +4773,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5177,7 +5177,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5579,7 +5579,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5647,7 +5647,7 @@ dependencies = [
  "derive_more 1.0.0",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5715,7 +5715,7 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "snap",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5734,6 +5734,19 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-optimism-rpc",
  "tracing",
+]
+
+[[package]]
+name = "op-revm"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+dependencies = [
+ "auto_impl",
+ "once_cell",
+ "revm",
+ "revm-inspector",
+ "revm-precompile",
+ "serde",
 ]
 
 [[package]]
@@ -5818,7 +5831,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5889,7 +5902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -5933,7 +5946,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5947,22 +5960,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5989,9 +6002,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain_hasher"
@@ -6104,12 +6117,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6160,14 +6173,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -6235,7 +6248,7 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6301,7 +6314,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -6320,7 +6333,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6342,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -6388,7 +6401,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.21",
+ "zerocopy 0.8.22",
 ]
 
 [[package]]
@@ -6498,9 +6511,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.4.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -6533,9 +6546,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -6795,7 +6808,7 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -6923,7 +6936,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_json",
  "tokio",
@@ -6951,10 +6964,10 @@ dependencies = [
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "snmalloc-rs",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tikv-jemallocator",
  "tracy-client",
 ]
@@ -6990,7 +7003,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "similar-asserts",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7018,7 +7031,7 @@ dependencies = [
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7088,7 +7101,7 @@ dependencies = [
  "strum 0.27.1",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7146,7 +7159,7 @@ dependencies = [
  "reth-trie-db",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -7186,9 +7199,9 @@ dependencies = [
  "reth-network-peers",
  "reth-tracing",
  "schnellru",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7212,8 +7225,8 @@ dependencies = [
  "reth-metrics",
  "reth-network-peers",
  "reth-tracing",
- "secp256k1 0.30.0",
- "thiserror 2.0.11",
+ "secp256k1",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -7237,10 +7250,10 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "schnellru",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7278,7 +7291,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7352,10 +7365,10 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
- "secp256k1 0.30.0",
+ "secp256k1",
  "sha2 0.10.8",
  "sha3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7413,7 +7426,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -7441,7 +7454,7 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
 ]
@@ -7503,7 +7516,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "schnellru",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -7551,7 +7564,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-fs-util",
  "reth-storage-errors",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7580,11 +7593,11 @@ dependencies = [
  "reth-primitives",
  "reth-primitives-traits",
  "reth-tracing",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "snap",
  "test-fuzz",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7613,7 +7626,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7751,7 +7764,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-zstd-compressors",
  "revm-context",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "test-fuzz",
 ]
@@ -7779,6 +7792,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "metrics-util",
+ "op-revm",
  "parking_lot",
  "reth-chainspec",
  "reth-consensus-common",
@@ -7794,7 +7808,6 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-database",
- "revm-optimism",
 ]
 
 [[package]]
@@ -7815,7 +7828,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-testing-utils",
  "revm",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde_json",
 ]
 
@@ -7830,7 +7843,7 @@ dependencies = [
  "nybbles",
  "reth-storage-errors",
  "revm-database-interface",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7890,9 +7903,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "rmp-serde",
- "secp256k1 0.30.0",
+ "secp256k1",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
@@ -7927,7 +7940,7 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie-db",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -7954,7 +7967,7 @@ version = "1.2.2"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7997,7 +8010,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-tracing",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8021,7 +8034,7 @@ dependencies = [
  "reth-mdbx-sys",
  "smallvec",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -8060,7 +8073,7 @@ dependencies = [
  "reqwest",
  "reth-tracing",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -8116,12 +8129,12 @@ dependencies = [
  "reth-transaction-pool",
  "rustc-hash 2.1.1",
  "schnellru",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serial_test",
  "smallvec",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8146,7 +8159,7 @@ dependencies = [
  "reth-network-types",
  "reth-tokio-util",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
 ]
@@ -8181,10 +8194,10 @@ dependencies = [
  "alloy-rlp",
  "enr",
  "rand 0.8.5",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde_json",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "url",
 ]
@@ -8241,7 +8254,7 @@ dependencies = [
  "reth-fs-util",
  "serde",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "zstd",
 ]
@@ -8326,7 +8339,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1 0.30.0",
+ "secp256k1",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -8372,11 +8385,11 @@ dependencies = [
  "reth-storage-errors",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "shellexpand",
  "strum 0.27.1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tracing",
@@ -8553,7 +8566,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8631,7 +8644,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "revm",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -8647,6 +8660,7 @@ dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
  "op-alloy-consensus",
+ "op-revm",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -8662,9 +8676,8 @@ dependencies = [
  "reth-revm",
  "revm",
  "revm-database",
- "revm-optimism",
  "revm-primitives",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -8697,6 +8710,7 @@ dependencies = [
  "futures",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
+ "op-revm",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",
@@ -8733,7 +8747,6 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "revm",
- "revm-optimism",
  "serde",
  "serde_json",
  "tokio",
@@ -8772,7 +8785,7 @@ dependencies = [
  "reth-transaction-pool",
  "revm",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -8793,6 +8806,7 @@ dependencies = [
  "derive_more 2.0.1",
  "modular-bitfield",
  "op-alloy-consensus",
+ "op-revm",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
@@ -8800,9 +8814,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-zstd-compressors",
  "revm-context",
- "revm-optimism",
  "rstest",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_json",
 ]
@@ -8827,6 +8840,7 @@ dependencies = [
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
+ "op-revm",
  "parking_lot",
  "reqwest",
  "reth-chainspec",
@@ -8852,9 +8866,8 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "revm",
- "revm-optimism",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -8893,6 +8906,7 @@ dependencies = [
  "metrics",
  "op-alloy-consensus",
  "op-alloy-flz",
+ "op-revm",
  "parking_lot",
  "reth-chain-state",
  "reth-chainspec",
@@ -8905,7 +8919,6 @@ dependencies = [
  "reth-provider",
  "reth-storage-api",
  "reth-transaction-pool",
- "revm-optimism",
 ]
 
 [[package]]
@@ -8956,7 +8969,7 @@ dependencies = [
  "reth-errors",
  "reth-primitives",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -9031,12 +9044,12 @@ dependencies = [
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_json",
  "serde_with",
  "test-fuzz",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9117,7 +9130,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "rustc-hash 2.1.1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -9137,7 +9150,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-fuzz",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "toml",
 ]
 
@@ -9222,7 +9235,7 @@ dependencies = [
  "revm-primitives",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -9319,7 +9332,7 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tower 0.4.13",
@@ -9358,7 +9371,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -9445,7 +9458,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9548,7 +9561,7 @@ dependencies = [
  "reth-trie-db",
  "serde",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -9576,7 +9589,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-testing-utils",
  "reth-tokio-util",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9670,7 +9683,7 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9684,7 +9697,7 @@ dependencies = [
  "pin-project",
  "rayon",
  "reth-metrics",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -9701,7 +9714,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-primitives",
  "reth-primitives-traits",
- "secp256k1 0.30.0",
+ "secp256k1",
 ]
 
 [[package]]
@@ -9768,7 +9781,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9888,7 +9901,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -9917,7 +9930,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9930,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "20.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -9949,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "bitvec",
  "revm-primitives",
@@ -9960,10 +9973,8 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
  "auto_impl",
  "cfg-if",
  "derive-where",
@@ -9980,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -9995,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10008,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10019,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10037,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10054,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.15.0"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=8900c2b#8900c2bf8430e41f1a1cc92dbc1cf0615f00a26b"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=237f5b5#237f5b54a1fac8f0e9415ea87718581da0a202fd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10067,13 +10078,13 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "revm-interpreter"
 version = "16.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10083,22 +10094,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-optimism"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
-dependencies = [
- "auto_impl",
- "once_cell",
- "revm",
- "revm-inspector",
- "revm-precompile",
- "serde",
-]
-
-[[package]]
 name = "revm-precompile"
 version = "17.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -10112,7 +10110,7 @@ dependencies = [
  "revm-primitives",
  "revm-specification",
  "ripemd",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.8",
  "substrate-bn",
 ]
@@ -10120,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "16.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "alloy-primitives",
 ]
@@ -10128,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "revm-specification"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "enumn",
  "revm-primitives",
@@ -10138,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=a8a9893b#a8a9893b11c480a4f1c2fa8742d8ca60bf3d7ba4"
+source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
 dependencies = [
  "bitflags 2.9.0",
  "revm-bytecode",
@@ -10287,7 +10285,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.98",
+ "syn 2.0.99",
  "unicode-ident",
 ]
 
@@ -10366,7 +10364,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -10480,9 +10478,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty-fork"
@@ -10498,9 +10496,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "ryu-js"
@@ -10581,16 +10579,6 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "rand 0.8.5",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
@@ -10658,9 +10646,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -10712,14 +10700,14 @@ checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "indexmap 2.7.1",
  "itoa",
@@ -10787,7 +10775,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10820,7 +10808,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10971,7 +10959,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -11146,7 +11134,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11159,7 +11147,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11183,9 +11171,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.13.4"
+version = "12.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6189977df1d6ec30c920647919d76f29fb8d8f25e8952e835b0fcda25e8f792"
+checksum = "918a8461341098b48201d587de5e059f46a21e3bb871b4c6f2be4f95f01bbe69"
 dependencies = [
  "debugid",
  "memmap2",
@@ -11195,9 +11183,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.13.4"
+version = "12.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d234917f7986498e7f62061438cee724bafb483fe84cfbe2486f68dce48240d7"
+checksum = "59a41a39f701a19a0f7db09520b2e15c70f59fd16abc1c4f3d34e265ffef9228"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -11217,9 +11205,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11235,7 +11223,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11255,7 +11243,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11317,7 +11305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04fc3fa0293849f8762c3e8427cb11a73b8bfc2157f2713029d93df554da052"
 dependencies = [
  "bincode",
- "cargo_metadata 0.19.1",
+ "cargo_metadata 0.19.2",
  "serde",
 ]
 
@@ -11333,7 +11321,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11366,11 +11354,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -11381,18 +11369,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11447,9 +11435,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "bb041120f25f8fbe8fd2dbe4671c7c2ed74d83be2e7a77529bf7e0790ae3f472"
 dependencies = [
  "deranged",
  "itoa",
@@ -11465,15 +11453,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -11510,9 +11498,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -11549,7 +11537,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11750,7 +11738,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11897,7 +11885,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "utf-8",
 ]
 
@@ -11951,9 +11939,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -12091,7 +12079,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -12171,7 +12159,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -12206,7 +12194,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -12375,7 +12363,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -12386,7 +12374,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -12397,7 +12385,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -12408,7 +12396,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -12698,7 +12686,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -12714,11 +12702,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+checksum = "09612fda0b63f7cb9e0af7e5916fe5a1f8cdcb066829f10f36883207628a4872"
 dependencies = [
- "zerocopy-derive 0.8.21",
+ "zerocopy-derive 0.8.22",
 ]
 
 [[package]]
@@ -12729,18 +12717,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+checksum = "79f81d38d7a2ed52d8f034e62c568e111df9bf8aba2f7cf19ddc5bf7bd89d520"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -12760,7 +12748,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -12781,7 +12769,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -12803,7 +12791,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=205303a#205303a572132971e84d1a12fbdf3e03aaabfa78"
+source = "git+https://github.com/alloy-rs/evm?rev=7b49e05#7b49e053b1262ce4da73a6bb1347a8ba799a7855"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=205303a#205303a572132971e84d1a12fbdf3e03aaabfa78"
+source = "git+https://github.com/alloy-rs/evm?rev=7b49e05#7b49e053b1262ce4da73a6bb1347a8ba799a7855"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -5739,7 +5739,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "20.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "bitvec",
  "revm-primitives",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9991,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10006,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10019,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.15.0"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=237f5b5#237f5b54a1fac8f0e9415ea87718581da0a202fd"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=ff73346#ff73346dc5b254ff76fb8b430d489fe8b2e5314a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "16.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "17.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "16.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "alloy-primitives",
 ]
@@ -10126,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "revm-specification"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "enumn",
  "revm-primitives",
@@ -10136,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=6d51b47#6d51b47d883d65a0c5ca14ef5c67365fdba681c7"
+source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
 dependencies = [
  "bitflags 2.9.0",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,7 +448,7 @@ revm-inspectors = "0.15"
 alloy-chains = { version = "0.1.32", default-features = false }
 alloy-dyn-abi = "0.8.20"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "205303a", default-features = false }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "7b49e05", default-features = false }
 alloy-primitives = { version = "0.8.20", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.20", default-features = false }
@@ -486,7 +486,7 @@ alloy-transport-ipc = { version = "0.11.1", default-features = false }
 alloy-transport-ws = { version = "0.11.1", default-features = false }
 
 # op
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "205303a", default-features = false }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "7b49e05", default-features = false }
 alloy-op-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "42a3427" }
 op-alloy-rpc-types = { version = "0.10.7", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.10.7", default-features = false }
@@ -678,20 +678,20 @@ visibility = "0.1.1"
 walkdir = "2.3.3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-specification = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-specification = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
 
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "237f5b5" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "ff73346" }
 
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -441,20 +441,20 @@ revm-context = { version = "1.0.0-alpha.1", default-features = false }
 revm-context-interface = { version = "1.0.0-alpha.1", default-features = false }
 revm-database-interface = { version = "1.0.0-alpha.1", default-features = false }
 revm-specification = { version = "1.0.0-alpha.1", default-features = false }
-revm-optimism = { version = "1.0.0-alpha.1", default-features = false }
+op-revm = { version = "1.0.0-alpha.1", default-features = false }
 revm-inspectors = "0.15"
 
 # eth
 alloy-chains = { version = "0.1.32", default-features = false }
 alloy-dyn-abi = "0.8.20"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { version = "0.1", default-features = false }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "205303a", default-features = false }
 alloy-primitives = { version = "0.8.20", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.20", default-features = false }
 alloy-trie = { version = "0.7", default-features = false }
 
-alloy-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "c577698" }
+alloy-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "42a3427" }
 
 alloy-consensus = { version = "0.11.1", default-features = false }
 alloy-contract = { version = "0.11.1", default-features = false }
@@ -486,8 +486,8 @@ alloy-transport-ipc = { version = "0.11.1", default-features = false }
 alloy-transport-ws = { version = "0.11.1", default-features = false }
 
 # op
-alloy-op-evm = { version = "0.1", default-features = false }
-alloy-op-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "c577698" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "205303a", default-features = false }
+alloy-op-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "42a3427" }
 op-alloy-rpc-types = { version = "0.10.7", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.10.7", default-features = false }
 op-alloy-network = { version = "0.10.7", default-features = false }
@@ -678,23 +678,20 @@ visibility = "0.1.1"
 walkdir = "2.3.3"
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "68735f2" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "68735f2" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-specification = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
 
-revm = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-specification = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-revm-optimism = { git = "https://github.com/bluealloy/revm", rev = "a8a9893b" }
-
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "8900c2b" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "237f5b5" }
 
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,17 +13,17 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-revm-specification = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+revm-specification = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
 
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "237f5b5" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "ff73346" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -26,4 +26,4 @@ revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6d
 revm-specification = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
 op-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
 
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "74b6aa4" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "237f5b5" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,20 +13,17 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "68735f2" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "68735f2" }
-
-revm = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-specification = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
-revm-optimism = { git = "https://github.com/bluealloy/revm", rev = "a8b9b1e" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm-specification = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
 
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "74b6aa4" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,17 +13,17 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-revm-specification = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47d" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+revm-specification = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "6d51b47" }
 
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "237f5b5" }

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -619,7 +619,9 @@ mod tests {
     fn create_database_with_block_hashes(latest_block: u64) -> CacheDB<EmptyDB> {
         let mut db = CacheDB::new(Default::default());
         for block_number in 0..=latest_block {
-            db.block_hashes.insert(U256::from(block_number), keccak256(block_number.to_string()));
+            db.cache
+                .block_hashes
+                .insert(U256::from(block_number), keccak256(block_number.to_string()));
         }
 
         let blockhashes_contract_account = AccountInfo {

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -25,7 +25,7 @@ reth-trie-common.workspace = true
 
 revm.workspace = true
 revm-database.workspace = true
-revm-optimism = { workspace = true, optional = true }
+op-revm = { workspace = true, optional = true }
 
 # alloy
 alloy-primitives.workspace = true
@@ -61,7 +61,7 @@ std = [
     "reth-consensus-common/std",
     "alloy-evm/std",
     "revm-database/std",
-    "revm-optimism?/std",
+    "op-revm?/std",
     "reth-execution-errors/std",
     "reth-execution-types/std",
     "reth-storage-errors/std",
@@ -85,7 +85,7 @@ test-utils = [
     "reth-trie-common/test-utils",
 ]
 op = [
-    "revm-optimism",
+    "op-revm",
     "alloy-evm/op",
     "reth-primitives-traits/op",
 ]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -260,7 +260,7 @@ impl TransactionEnv for TxEnv {
 }
 
 #[cfg(feature = "op")]
-impl<T: TransactionEnv> TransactionEnv for revm_optimism::OpTransaction<T> {
+impl<T: TransactionEnv> TransactionEnv for op_revm::OpTransaction<T> {
     fn set_gas_limit(&mut self, gas_limit: u64) {
         self.base.set_gas_limit(gas_limit);
     }

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -39,7 +39,7 @@ reth-optimism-primitives.workspace = true
 revm.workspace = true
 revm-database.workspace = true
 revm-primitives.workspace = true
-revm-optimism.workspace = true
+op-revm.workspace = true
 
 # misc
 derive_more.workspace = true
@@ -81,7 +81,7 @@ std = [
     "alloy-evm/std",
     "alloy-op-evm/std",
     "revm-database/std",
-    "revm-optimism/std",
+    "op-revm/std",
     "reth-evm/std",
     "tracing/std",
 ]

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::BlockHeader;
+use op_revm::OpSpecId;
 use reth_optimism_forks::OpHardforks;
-use revm_optimism::OpSpecId;
 use revm_primitives::{Address, Bytes, B256};
 
 /// Context relevant for execution of a next block w.r.t OP.

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -42,7 +42,7 @@ where
         BlockHeader = Header,
         BlockBody = alloy_consensus::BlockBody<T>,
     >,
-    revm_optimism::OpTransaction<TxEnv>: FromRecoveredTx<T>,
+    op_revm::OpTransaction<TxEnv>: FromRecoveredTx<T>,
 {
     type Primitives = N;
     type Strategy<'a, DB: Database + 'a, I: InspectorFor<&'a mut State<DB>, Self> + 'a> =
@@ -332,13 +332,13 @@ mod tests {
         b256, Address, PrimitiveSignature as Signature, StorageKey, StorageValue, U256,
     };
     use op_alloy_consensus::{OpTypedTransaction, TxDeposit};
+    use op_revm::constants::L1_BLOCK_CONTRACT;
     use reth_chainspec::MIN_TRANSACTION_GAS;
     use reth_evm::execute::{BasicBlockExecutorProvider, BlockExecutorProvider, Executor};
     use reth_optimism_chainspec::OpChainSpecBuilder;
     use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
     use reth_primitives_traits::{Account, RecoveredBlock};
     use reth_revm::{database::StateProviderDatabase, test_utils::StateProviderTest};
-    use revm_optimism::constants::L1_BLOCK_CONTRACT;
     use std::{collections::HashMap, str::FromStr};
 
     fn create_op_state_provider() -> StateProviderTest {

--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -3,11 +3,11 @@
 use crate::{error::L1BlockInfoError, OpBlockExecutionError};
 use alloy_consensus::Transaction;
 use alloy_primitives::{address, b256, hex, Address, Bytes, B256, U256};
+use op_revm::{L1BlockInfo, OpSpecId};
 use reth_execution_errors::BlockExecutionError;
 use reth_optimism_forks::OpHardforks;
 use reth_primitives_traits::BlockBody;
 use revm::{primitives::HashMap, state::Bytecode, DatabaseCommit};
-use revm_optimism::{L1BlockInfo, OpSpecId};
 use tracing::trace;
 
 /// The address of the create2 deployer

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -17,6 +17,7 @@ use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::U256;
 use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
+use op_revm::{OpHaltReason, OpSpecId, OpTransaction};
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, ConfigureEvmEnv, EvmEnv};
 use reth_optimism_chainspec::OpChainSpec;
@@ -29,7 +30,6 @@ use revm::{
     context_interface::block::BlobExcessGasAndPrice,
     specification::hardfork::SpecId,
 };
-use revm_optimism::{OpHaltReason, OpSpecId, OpTransaction};
 
 mod config;
 pub use config::{revm_spec, revm_spec_by_timestamp_after_bedrock, OpNextBlockEnvAttributes};
@@ -192,6 +192,7 @@ mod tests {
     use alloy_eips::eip7685::Requests;
     use alloy_genesis::Genesis;
     use alloy_primitives::{bytes, map::HashMap, Address, LogData, B256};
+    use op_revm::OpSpecId;
     use reth_chainspec::ChainSpec;
     use reth_evm::execute::ProviderError;
     use reth_execution_types::{
@@ -202,7 +203,6 @@ mod tests {
     use reth_primitives_traits::{Account, RecoveredBlock};
     use revm::{database_interface::EmptyDBTyped, inspector::NoOpInspector, state::AccountInfo};
     use revm_database::{BundleState, CacheDB};
-    use revm_optimism::OpSpecId;
     use revm_primitives::Log;
     use std::sync::Arc;
 

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -50,7 +50,7 @@ reth-optimism-primitives = { workspace = true, features = ["serde", "serde-binco
 
 # revm with required optimism features
 revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg"] }
-revm-optimism.workspace = true
+op-revm.workspace = true
 
 # ethereum
 alloy-eips.workspace = true

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -280,7 +280,7 @@ where
             Engine = OpEngineTypes,
         >,
         Evm: ConfigureEvmEnv<
-            TxEnv = revm_optimism::OpTransaction<TxEnv>,
+            TxEnv = op_revm::OpTransaction<TxEnv>,
             NextBlockEnvCtx = OpNextBlockEnvAttributes,
         >,
     >,
@@ -354,7 +354,7 @@ where
             Engine = OpEngineTypes,
         >,
         Evm: ConfigureEvm<
-            TxEnv = revm_optimism::OpTransaction<TxEnv>,
+            TxEnv = op_revm::OpTransaction<TxEnv>,
             NextBlockEnvCtx = OpNextBlockEnvAttributes,
         >,
     >,

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -24,7 +24,7 @@ alloy-consensus.workspace = true
 alloy-rlp.workspace = true
 alloy-eips = { workspace = true, features = ["k256"] }
 revm-context.workspace = true
-revm-optimism.workspace = true
+op-revm.workspace = true
 secp256k1 = { workspace = true, optional = true }
 
 # op
@@ -71,7 +71,7 @@ std = [
     "alloy-rlp/std",
     "reth-zstd-compressors?/std",
     "op-alloy-consensus/std",
-    "revm-optimism/std",
+    "op-revm/std",
     "alloy-rpc-types-eth?/std",
     "alloy-serde?/std",
     "revm-context/std",
@@ -100,7 +100,7 @@ serde = [
     "op-alloy-consensus/serde",
     "rand?/serde",
     "secp256k1?/serde",
-    "revm-optimism/serde",
+    "op-revm/serde",
     "alloy-rpc-types-eth?/serde",
     "revm-context/serde",
 ]

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -24,6 +24,7 @@ use derive_more::{AsRef, Deref};
 use op_alloy_consensus::{
     DepositTransaction, OpPooledTransaction, OpTxEnvelope, OpTypedTransaction, TxDeposit,
 };
+use op_revm::transaction::deposit::DepositTransactionParts;
 #[cfg(any(test, feature = "reth-codec"))]
 use proptest as _;
 use reth_primitives_traits::{
@@ -33,7 +34,6 @@ use reth_primitives_traits::{
     InMemorySize, SignedTransaction,
 };
 use revm_context::TxEnv;
-use revm_optimism::transaction::deposit::DepositTransactionParts;
 
 /// Signed transaction.
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(rlp))]
@@ -214,7 +214,7 @@ impl OpTransaction for OpTransactionSigned {
     }
 }
 
-impl FromRecoveredTx<OpTransactionSigned> for revm_optimism::OpTransaction<TxEnv> {
+impl FromRecoveredTx<OpTransactionSigned> for op_revm::OpTransaction<TxEnv> {
     fn from_recovered_tx(tx: &OpTransactionSigned, sender: Address) -> Self {
         let envelope = tx.encoded_2718();
 

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -52,7 +52,7 @@ op-alloy-rpc-types-engine.workspace = true
 op-alloy-rpc-jsonrpsee.workspace = true
 op-alloy-consensus.workspace = true
 revm.workspace = true
-revm-optimism.workspace = true
+op-revm.workspace = true
 
 # async
 parking_lot.workspace = true

--- a/crates/optimism/rpc/src/error.rs
+++ b/crates/optimism/rpc/src/error.rs
@@ -2,12 +2,12 @@
 
 use alloy_rpc_types_eth::{error::EthRpcErrorCode, BlockError};
 use jsonrpsee_types::error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
+use op_revm::{OpHaltReason, OpTransactionError};
 use reth_optimism_evm::OpBlockExecutionError;
 use reth_rpc_eth_api::AsEthApiError;
 use reth_rpc_eth_types::{error::api::FromEvmHalt, EthApiError};
 use reth_rpc_server_types::result::{internal_rpc_err, rpc_err};
 use revm::context_interface::result::{EVMError, InvalidTransaction};
-use revm_optimism::{OpHaltReason, OpTransactionError};
 use std::fmt::Display;
 
 /// Optimism specific errors, that extend [`EthApiError`].

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -3,6 +3,7 @@ use crate::{OpEthApi, OpEthApiError};
 use alloy_consensus::TxType;
 use alloy_primitives::{Bytes, TxKind, U256};
 use alloy_rpc_types_eth::transaction::TransactionRequest;
+use op_revm::OpTransaction;
 use reth_evm::{ConfigureEvm, EvmEnv, SpecFor};
 use reth_provider::ProviderHeader;
 use reth_rpc_eth_api::{
@@ -11,7 +12,6 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{revm_utils::CallFees, EthApiError, RpcInvalidTransactionError};
 use revm::{context::TxEnv, context_interface::Block, Database};
-use revm_optimism::OpTransaction;
 
 impl<N> EthCall for OpEthApi<N>
 where

--- a/crates/optimism/rpc/src/eth/ext.rs
+++ b/crates/optimism/rpc/src/eth/ext.rs
@@ -56,7 +56,7 @@ where
         self.inner.provider()
     }
 
-    /// Validates the conditional's `known acounts` settings against the current state.
+    /// Validates the conditional's `known accounts` settings against the current state.
     async fn validate_known_accounts(
         &self,
         condition: &TransactionConditional,

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -111,12 +111,12 @@ impl OpReceiptFieldsBuilder {
         }
     }
 
-    /// Applies [`L1BlockInfo`](revm_optimism::L1BlockInfo).
+    /// Applies [`L1BlockInfo`](op_revm::L1BlockInfo).
     pub fn l1_block_info(
         mut self,
         chain_spec: &OpChainSpec,
         tx: &OpTransactionSigned,
-        l1_block_info: &mut revm_optimism::L1BlockInfo,
+        l1_block_info: &mut op_revm::L1BlockInfo,
     ) -> Result<Self, OpEthApiError> {
         let raw_tx = tx.encoded_2718();
         let block_number = self.block_number;
@@ -218,7 +218,7 @@ impl OpReceiptBuilder {
         meta: TransactionMeta,
         receipt: &OpReceipt,
         all_receipts: &[OpReceipt],
-        l1_block_info: &mut revm_optimism::L1BlockInfo,
+        l1_block_info: &mut op_revm::L1BlockInfo,
     ) -> Result<Self, OpEthApiError> {
         let timestamp = meta.timestamp;
         let block_number = meta.block_number;

--- a/crates/optimism/txpool/Cargo.toml
+++ b/crates/optimism/txpool/Cargo.toml
@@ -26,7 +26,7 @@ reth-storage-api.workspace = true
 reth-transaction-pool.workspace = true
 
 # revm
-revm-optimism.workspace = true
+op-revm.workspace = true
 
 # optimism
 op-alloy-consensus.workspace = true

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -1,5 +1,6 @@
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::Encodable2718;
+use op_revm::L1BlockInfo;
 use parking_lot::RwLock;
 use reth_chainspec::ChainSpecProvider;
 use reth_optimism_evm::RethL1BlockInfo;
@@ -12,7 +13,6 @@ use reth_transaction_pool::{
     EthPoolTransaction, EthTransactionValidator, TransactionOrigin, TransactionValidationOutcome,
     TransactionValidator,
 };
-use revm_optimism::L1BlockInfo;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -282,7 +282,7 @@ mod tests {
         let mut buf = vec![];
         let bytecode = Bytecode::new_raw(Bytes::default());
         let len = bytecode.to_compact(&mut buf);
-        assert_eq!(len, 46);
+        assert_eq!(len, 51);
 
         let mut buf = vec![];
         let bytecode = Bytecode::new_raw(Bytes::from(&hex!("ffff")));

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -173,13 +173,11 @@ impl reth_codecs::Compact for Bytecode {
             REMOVED_BYTECODE_ID => {
                 unreachable!("Junk data in database: checked Bytecode variant was removed")
             }
-            LEGACY_ANALYZED_BYTECODE_ID => Self(unsafe {
-                RevmBytecode::new_analyzed(
-                    bytes,
-                    buf.read_u64::<byteorder::BigEndian>().unwrap() as usize,
-                    revm_bytecode::JumpTable::from_slice(buf),
-                )
-            }),
+            LEGACY_ANALYZED_BYTECODE_ID => Self(RevmBytecode::new_analyzed(
+                bytes,
+                buf.read_u64::<byteorder::BigEndian>().unwrap() as usize,
+                revm_bytecode::JumpTable::from_slice(buf),
+            )),
             EOF_BYTECODE_ID | EIP7702_BYTECODE_ID => {
                 // EOF and EIP-7702 bytecode objects will be decoded from the raw bytecode
                 Self(RevmBytecode::new_raw(bytes))

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -287,11 +287,11 @@ mod tests {
         let mut buf = vec![];
         let bytecode = Bytecode::new_raw(Bytes::from(&hex!("ffff")));
         let len = bytecode.to_compact(&mut buf);
-        assert_eq!(len, 49);
+        assert_eq!(len, 53);
 
         let mut buf = vec![];
         let bytecode = Bytecode(RevmBytecode::LegacyAnalyzed(LegacyAnalyzedBytecode::new(
-            Bytes::from(&hex!("ffff")),
+            Bytes::from(&hex!("ff00")),
             2,
             JumpTable::from_slice(&[0]),
         )));

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -570,7 +570,7 @@ impl From<InvalidTransaction> for RpcInvalidTransactionError {
             InvalidTransaction::BlobVersionNotSupported => Self::BlobHashVersionMismatch,
             InvalidTransaction::TooManyBlobs { have, .. } => Self::TooManyBlobs { have },
             InvalidTransaction::BlobCreateTransaction => Self::BlobTransactionIsCreate,
-            InvalidTransaction::EofCrateShouldHaveToAddress => Self::EofCrateShouldHaveToAddress,
+            InvalidTransaction::EofCreateShouldHaveToAddress => Self::EofCrateShouldHaveToAddress,
             InvalidTransaction::AuthorizationListNotSupported => {
                 Self::AuthorizationListNotSupported
             }

--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -203,7 +203,8 @@ pub trait OverrideBlockHashes {
 
 impl<DB> OverrideBlockHashes for CacheDB<DB> {
     fn override_block_hashes(&mut self, block_hashes: BTreeMap<u64, B256>) {
-        self.block_hashes
+        self.cache
+            .block_hashes
             .extend(block_hashes.into_iter().map(|(num, hash)| (U256::from(num), hash)))
     }
 }

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -65,7 +65,7 @@ pub mod gas_oracle {
     /// The default maximum number of blocks to use for the gas price oracle.
     pub const MAX_HEADER_HISTORY: u64 = 1024;
 
-    /// The default maximum nunber of allowed reward percentiles
+    /// The default maximum number of allowed reward percentiles
     pub const MAX_REWARD_PERCENTILE_COUNT: u64 = 100;
 
     /// Number of recent blocks to check for gas price

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -20,7 +20,9 @@ use reth::{
         handler::{EthPrecompiles, PrecompileProvider},
         inspector::{Inspector, NoOpInspector},
         interpreter::{interpreter::EthInterpreter, InterpreterResult},
-        precompile::{PrecompileFn, PrecompileOutput, PrecompileResult, Precompiles},
+        precompile::{
+            PrecompileError, PrecompileFn, PrecompileOutput, PrecompileResult, Precompiles,
+        },
         specification::hardfork::SpecId,
         MainBuilder, MainContext,
     },
@@ -185,7 +187,7 @@ impl<CTX: ContextTr> PrecompileProvider for CustomPrecompiles<CTX> {
         address: &Address,
         bytes: &Bytes,
         gas_limit: u64,
-    ) -> Result<Option<Self::Output>, reth::revm::precompile::PrecompileErrors> {
+    ) -> Result<Option<Self::Output>, PrecompileError> {
         self.precompiles.run(context, address, bytes, gas_limit)
     }
 

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -17,7 +17,7 @@ use reth::{
         handler::{EthPrecompiles, PrecompileProvider},
         inspector::{Inspector, NoOpInspector},
         interpreter::{interpreter::EthInterpreter, InterpreterResult},
-        precompile::PrecompileErrors,
+        precompile::PrecompileError,
         specification::hardfork::SpecId,
         MainBuilder, MainContext,
     },
@@ -36,7 +36,7 @@ use schnellru::{ByLength, LruMap};
 use std::{collections::HashMap, sync::Arc};
 
 /// Type alias for the LRU cache used within the [`PrecompileCache`].
-type PrecompileLRUCache = LruMap<(SpecId, Bytes, u64), Result<InterpreterResult, PrecompileErrors>>;
+type PrecompileLRUCache = LruMap<(SpecId, Bytes, u64), Result<InterpreterResult, PrecompileError>>;
 
 type WrappedEthEvm<DB, I> = EthEvm<DB, I, WrappedPrecompile<EthPrecompiles<EthEvmContext<DB>>>>;
 
@@ -127,7 +127,7 @@ impl<P: PrecompileProvider<Output = InterpreterResult>> PrecompileProvider
         address: &Address,
         bytes: &Bytes,
         gas_limit: u64,
-    ) -> Result<Option<Self::Output>, reth::revm::precompile::PrecompileErrors> {
+    ) -> Result<Option<Self::Output>, PrecompileError> {
         let mut cache = self.cache.write();
         let key = (self.spec, bytes.clone(), gas_limit);
 


### PR DESCRIPTION
Bumps alloy-evm and revm to latest commits and converts alloy-evm to git dependency instead of using patch for it