### PR TITLE
chore: auto_impl TrieCursorFactory for reference

### DIFF
--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -14,6 +14,7 @@ pub mod noop;
 pub use self::{in_memory::*, subnode::CursorSubNode};
 
 /// Factory for creating trie cursors.
+#[auto_impl::auto_impl(&)]
 pub trait TrieCursorFactory {
     /// The account trie cursor type.
     type AccountTrieCursor: TrieCursor;


### PR DESCRIPTION
Just implements this for references, so that the cursor factory does not have to be fully owned by things like `StorageProof`