### PR TITLE
refactor: prepare BlockExecutionError for move to alloy-evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7823,7 +7823,6 @@ dependencies = [
 name = "reth-execution-errors"
 version = "1.2.2"
 dependencies = [
- "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -7845,7 +7844,6 @@ dependencies = [
  "derive_more 2.0.1",
  "rand 0.8.5",
  "reth-ethereum-primitives",
- "reth-execution-errors",
  "reth-primitives-traits",
  "reth-trie-common",
  "revm",

--- a/crates/errors/src/error.rs
+++ b/crates/errors/src/error.rs
@@ -67,8 +67,8 @@ mod size_asserts {
         };
     }
 
-    static_assert_size!(RethError, 64);
-    static_assert_size!(BlockExecutionError, 64);
+    static_assert_size!(RethError, 56);
+    static_assert_size!(BlockExecutionError, 56);
     static_assert_size!(ConsensusError, 48);
     static_assert_size!(DatabaseError, 32);
     static_assert_size!(ProviderError, 48);

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -17,7 +17,6 @@ reth-storage-errors.workspace = true
 alloy-evm.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
-alloy-eips.workspace = true
 nybbles.workspace = true
 
 revm-database-interface.workspace = true
@@ -27,7 +26,6 @@ thiserror.workspace = true
 [features]
 default = ["std"]
 std = [
-    "alloy-eips/std",
     "alloy-primitives/std",
     "alloy-rlp/std",
     "thiserror/std",

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -15,7 +15,6 @@ use alloc::{
     boxed::Box,
     string::{String, ToString},
 };
-use alloy_eips::BlockNumHash;
 use alloy_evm::{EvmError, InvalidTxError};
 use alloy_primitives::B256;
 use reth_storage_errors::provider::ProviderError;
@@ -161,7 +160,7 @@ impl BlockExecutionError {
 
 impl From<ProviderError> for BlockExecutionError {
     fn from(error: ProviderError) -> Self {
-        InternalBlockExecutionError::from(error).into()
+        Self::other(error)
     }
 }
 
@@ -170,16 +169,6 @@ impl revm_database_interface::DBErrorMarker for BlockExecutionError {}
 /// Internal (i.e., not validation or consensus related) `BlockExecutor` Errors
 #[derive(Error, Debug)]
 pub enum InternalBlockExecutionError {
-    /// Error when appending chain on fork is not possible
-    #[error(
-        "appending chain on fork (other_chain_fork:?) is not possible as the tip is {chain_tip:?}"
-    )]
-    AppendChainDoesntConnect {
-        /// The tip of the current chain
-        chain_tip: Box<BlockNumHash>,
-        /// The fork on the other chain
-        other_chain_fork: Box<BlockNumHash>,
-    },
     /// EVM error occurred when executing transaction. This is different from
     /// [`BlockValidationError::InvalidTx`] because it will only contain EVM errors which are not
     /// transaction validation errors and are assumed to be fatal.
@@ -190,9 +179,6 @@ pub enum InternalBlockExecutionError {
         /// The EVM error.
         error: Box<dyn core::error::Error + Send + Sync>,
     },
-    /// Error when fetching data from the db.
-    #[error(transparent)]
-    Provider(#[from] ProviderError),
     /// Arbitrary Block Executor Errors
     #[error(transparent)]
     Other(Box<dyn core::error::Error + Send + Sync + 'static>),

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 reth-ethereum-primitives.workspace = true
 reth-primitives-traits.workspace = true
-reth-execution-errors.workspace = true
 reth-trie-common.workspace = true
 
 revm.workspace = true
@@ -69,7 +68,6 @@ std = [
     "serde_with?/std",
     "derive_more/std",
     "reth-ethereum-primitives/std",
-    "reth-execution-errors/std",
     "reth-trie-common/std",
     "revm-database/std",
 ]


### PR DESCRIPTION
The `AppendChainDoesntConnect` is only relevant for single `Chain` method and does not belong to execution, so I've removed it in favor of returning the `other` value in `Err` variant. It seems that `Chain::append_chain` is unused in reth code as well.

`ProviderError` is now mapped to `Other` variant. Such errors occured during execution are usually irrecoverable and there's no benefit in carrying information about it around.