### PR TITLE
chore: remove StateRoot variant from BlockValidationError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7828,7 +7828,6 @@ dependencies = [
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "revm-database-interface",
  "thiserror 2.0.11",
 ]
 

--- a/crates/evm/execution-errors/Cargo.toml
+++ b/crates/evm/execution-errors/Cargo.toml
@@ -19,8 +19,6 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 nybbles.workspace = true
 
-revm-database-interface.workspace = true
-
 thiserror.workspace = true
 
 [features]
@@ -30,7 +28,6 @@ std = [
     "alloy-rlp/std",
     "thiserror/std",
     "nybbles/std",
-    "revm-database-interface/std",
     "reth-storage-errors/std",
     "alloy-evm/std",
 ]

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -37,9 +37,6 @@ pub enum BlockValidationError {
     /// Error when incrementing balance in post execution
     #[error("incrementing balance in post execution failed")]
     IncrementBalanceFailed,
-    /// Error when the state root does not match the expected value.
-    #[error(transparent)]
-    StateRoot(#[from] StateRootError),
     /// Error when transaction gas limit exceeds available block gas
     #[error(
         "transaction gas limit {transaction_gas_limit} is more than blocks available gas {block_available_gas}"
@@ -137,11 +134,6 @@ impl BlockExecutionError {
         }
     }
 
-    /// Returns `true` if the error is a state root error.
-    pub const fn is_state_root_error(&self) -> bool {
-        matches!(self, Self::Validation(BlockValidationError::StateRoot(_)))
-    }
-
     /// Handles an EVM error occurred when executing a transaction.
     ///
     /// If an error matches [`EvmError::InvalidTransaction`], it will be wrapped into
@@ -163,8 +155,6 @@ impl From<ProviderError> for BlockExecutionError {
         Self::other(error)
     }
 }
-
-impl revm_database_interface::DBErrorMarker for BlockExecutionError {}
 
 /// Internal (i.e., not validation or consensus related) `BlockExecutor` Errors
 #[derive(Error, Debug)]

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -700,7 +700,7 @@ mod tests {
     use core::marker::PhantomData;
     use reth_primitives::EthPrimitives;
     use revm::state::AccountInfo;
-    use revm_database::{CacheDB, EmptyDBTyped};
+    use revm_database::{CacheDB, EmptyDB};
 
     #[derive(Clone, Default)]
     struct TestExecutorProvider;
@@ -754,7 +754,7 @@ mod tests {
     #[test]
     fn test_provider() {
         let provider = TestExecutorProvider;
-        let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
+        let db = CacheDB::<EmptyDB>::default();
         let executor = provider.executor(db);
         let _ = executor.execute(&Default::default());
     }
@@ -763,8 +763,8 @@ mod tests {
         addr: Address,
         balance: u128,
         nonce: u64,
-    ) -> State<CacheDB<EmptyDBTyped<BlockExecutionError>>> {
-        let db = CacheDB::<EmptyDBTyped<BlockExecutionError>>::default();
+    ) -> State<CacheDB<EmptyDB>> {
+        let db = CacheDB::<EmptyDB>::default();
         let mut state = State::builder().with_database(db).with_bundle_update().build();
 
         let account_info = AccountInfo {
@@ -792,7 +792,7 @@ mod tests {
     #[test]
     fn test_balance_increment_state_empty_increments_map() {
         let mut state = State::builder()
-            .with_database(CacheDB::<EmptyDBTyped<BlockExecutionError>>::default())
+            .with_database(CacheDB::<EmptyDB>::default())
             .with_bundle_update()
             .build();
 

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -23,10 +23,7 @@ pub enum BlockErrorKind {
 impl BlockErrorKind {
     /// Returns `true` if the error is a state root error.
     pub const fn is_state_root_error(&self) -> bool {
-        match self {
-            Self::Validation(err) => err.is_state_root_error(),
-            Self::Execution(err) => err.is_state_root_error(),
-        }
+        matches!(self, Self::Validation(err) if err.is_state_root_error())
     }
 }
 


### PR DESCRIPTION
Followup for #14857 

Removes `BlockValidationError::StateRoot` variant which is never initialized.

Also removed revm's DBErrorMarker impl by using `EmptyDB` instead of `EmptyDBTyped<BlockExecutionError>` in tests