### PR TITLE
feat: retry dns resolution for trusted peers in-case for disconnections

### DIFF
--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -9,6 +9,7 @@ pub use reputation::{Reputation, ReputationChange, ReputationChangeKind, Reputat
 
 use alloy_eip2124::ForkId;
 use tracing::trace;
+use reth_network_peers::TrustedPeer;
 
 use crate::{
     is_banned_reputation, PeerAddr, PeerConnectionState, PeerKind, ReputationChangeOutcome,
@@ -35,6 +36,8 @@ pub struct Peer {
     /// Counts number of times the peer was backed off due to a severe
     /// [`BackoffKind`](crate::BackoffKind).
     pub severe_backoff_counter: u8,
+    /// Original TrustedPeer information for DNS-based peers, set only for local trusted peers, `admin_addTrustedPeer` does not support hostname for node address
+    pub trusted_peer_info: Option<TrustedPeer>,
 }
 
 // === impl Peer ===
@@ -46,8 +49,12 @@ impl Peer {
     }
 
     /// Returns a new trusted peer for given [`PeerAddr`].
-    pub fn trusted(addr: PeerAddr) -> Self {
-        Self { kind: PeerKind::Trusted, ..Self::new(addr) }
+    pub fn trusted(addr: PeerAddr, trusted_peer: TrustedPeer) -> Self {
+        Self { 
+            kind: PeerKind::Trusted, 
+            trusted_peer_info: Some(trusted_peer),
+            ..Self::new(addr) 
+        }
     }
 
     /// Returns the reputation of the peer
@@ -66,6 +73,7 @@ impl Peer {
             kind: Default::default(),
             backed_off: false,
             severe_backoff_counter: 0,
+            trusted_peer_info: None,
         }
     }
 

--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -8,8 +8,8 @@ pub use config::{ConnectionsConfig, PeersConfig};
 pub use reputation::{Reputation, ReputationChange, ReputationChangeKind, ReputationChangeWeights};
 
 use alloy_eip2124::ForkId;
-use tracing::trace;
 use reth_network_peers::TrustedPeer;
+use tracing::trace;
 
 use crate::{
     is_banned_reputation, PeerAddr, PeerConnectionState, PeerKind, ReputationChangeOutcome,
@@ -36,7 +36,8 @@ pub struct Peer {
     /// Counts number of times the peer was backed off due to a severe
     /// [`BackoffKind`](crate::BackoffKind).
     pub severe_backoff_counter: u8,
-    /// Original TrustedPeer information for DNS-based peers, set only for local trusted peers, `admin_addTrustedPeer` does not support hostname for node address
+    /// Original [`TrustedPeer`] information for hostname-based peers, set only for local trusted
+    /// peers, `admin_addTrustedPeer` does not support hostname for node address
     pub trusted_peer_info: Option<TrustedPeer>,
 }
 
@@ -50,11 +51,7 @@ impl Peer {
 
     /// Returns a new trusted peer for given [`PeerAddr`].
     pub fn trusted(addr: PeerAddr, trusted_peer: TrustedPeer) -> Self {
-        Self { 
-            kind: PeerKind::Trusted, 
-            trusted_peer_info: Some(trusted_peer),
-            ..Self::new(addr) 
-        }
+        Self { kind: PeerKind::Trusted, trusted_peer_info: Some(trusted_peer), ..Self::new(addr) }
     }
 
     /// Returns the reputation of the peer

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -15,9 +15,7 @@ use reth_network_types::{
     peers::{
         config::PeerBackoffDurations,
         reputation::{DEFAULT_REPUTATION, MAX_TRUSTED_PEER_REPUTATION_CHANGE},
-    },
-    ConnectionsConfig, Peer, PeerAddr, PeerConnectionState, PeerKind, PeersConfig,
-    ReputationChangeKind, ReputationChangeOutcome, ReputationChangeWeights,
+    }, BackoffKind, ConnectionsConfig, Peer, PeerAddr, PeerConnectionState, PeerKind, PeersConfig, ReputationChangeKind, ReputationChangeOutcome, ReputationChangeWeights
 };
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
@@ -910,7 +908,8 @@ impl PeersManager {
                             }
                             Err(err) => {
                                 warn!(target: "net::peers", ?peer_id, ?trusted_peer, ?err, "Failed to re-resolve trusted peer, backing off");
-                                self.backoff_peer_until(peer_id, std::time::Instant::now() + self.refill_slots_interval.period());
+                                let backoff_counter = peer.severe_backoff_counter;
+                                self.backoff_peer_until(peer_id, self.backoff_durations.backoff_until(BackoffKind::Low, backoff_counter));
                                 continue;
                             }
                         }

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -33,7 +33,7 @@ use tokio::{
     time::{Instant, Interval},
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{error, trace, warn};
+use tracing::{trace, warn};
 
 /// Maintains the state of _all_ the peers known to the network.
 ///
@@ -920,10 +920,6 @@ impl PeersManager {
                                 continue;
                             }
                         }
-                    } else {
-                        error!(target: "net::peers", ?peer_id, "Trusted peer info is missing for a trusted peer, banning peer");
-                        self.ban_peer(peer_id);
-                        continue;
                     }
                 }
 

--- a/crates/net/peers/src/trusted_peer.rs
+++ b/crates/net/peers/src/trusted_peer.rs
@@ -17,8 +17,6 @@ use url::Host;
 ///
 /// This is useful when specifying nodes which are in internal infrastructure and may only be
 /// discoverable reliably using DNS.
-///
-/// This should NOT be used for any use case other than in trusted peer lists.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, SerializeDisplay, DeserializeFromStr)]
 pub struct TrustedPeer {
     /// The host of a node.


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/14824

CLI argument allows Host names to be provided for TrustedPeers, host names resolved only during initialization, re-connections missing the domain resolution step completely. Kubernetes like environments can cause Dockerized Reth instances to change IP addresses under same host name. Thus those trusted peers remains disconnected until a restart. This PR resolves host name again through DNS when a TrustedPeer is configured with hostname when an outgoing connection slot becomes available.

## Notes
* In case of DNS resolution fails, Peer is backed off for next interval
* After several back-offs, banning can be considered but in general design, it seemed trusted peers should not be banned

## RPC Admin interface
TrustedPeers can be specified through CLI argument, or through admin RPC interface with [admin_addTrustedPeer](https://reth.rs/jsonrpc/admin.html#admin_addtrustedpeer). But RPC interface only allows IP configurations.

## Testing
Manual testing through deployment. Implementing a unit-test requires trait for TrustedPeers so that DNS resolution can be mocked which brings lots of changes for a simple feature.