### PR TITLE
fix: remove duplicate words

### DIFF
--- a/crates/payload/builder-primitives/src/events.rs
+++ b/crates/payload/builder-primitives/src/events.rs
@@ -102,7 +102,7 @@ impl<T: PayloadTypes> Stream for PayloadAttributeStream<T> {
                     continue
                 }
                 Some(Err(err)) => {
-                    debug!(%err, "payload event stream stream lagging behind");
+                    debug!(%err, "payload event stream lagging behind");
                     continue
                 }
                 None => Poll::Ready(None),


### PR DESCRIPTION
`payload event stream stream lagging` to `payload event stream lagging`