### PR TITLE
chore: fix missing import for `rand::thread_rng()`

### DIFF
--- a/examples/bsc-p2p/tests/it/p2p.rs
+++ b/examples/bsc-p2p/tests/it/p2p.rs
@@ -9,6 +9,7 @@ use reth_network::{
 };
 use reth_provider::noop::NoopProvider;
 use secp256k1::{rand, SecretKey};
+use rand::thread_rng;
 use std::{
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,


### PR DESCRIPTION
`rand::thread_rng()` was being used without the necessary import for `rand::rngs::ThreadRng`.
however, since `rand` usually includes `thread_rng()` by default, i’ve removed the direct import of `ThreadRng` to clean things up. 