### PR TITLE
feat(trie): update sparse trie storage roots independently

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -130,7 +130,7 @@ pub(super) type SparseTrieEvent = SparseTrieUpdate;
 /// Updates the sparse trie with the given proofs and state, and returns the elapsed time.
 pub(crate) fn update_sparse_trie<BPF>(
     trie: &mut SparseStateTrie<BPF>,
-    SparseTrieUpdate { state, multiproof }: SparseTrieUpdate,
+    SparseTrieUpdate { mut state, multiproof }: SparseTrieUpdate,
 ) -> SparseStateTrieResult<Duration>
 where
     BPF: BlindedProviderFactory + Send + Sync,
@@ -178,12 +178,24 @@ where
         })
         .for_each_init(|| tx.clone(), |tx, result| tx.send(result).unwrap());
     drop(tx);
+
+    // Update account storage roots
     for result in rx {
         let (address, storage_trie) = result?;
         trie.insert_storage_trie(address, storage_trie);
+
+        // If the account itself has an update, remove it from the state update and update in one
+        // go instead of doing it down below.
+        if let Some(account) = state.accounts.remove(&address) {
+            trace!(target: "engine::root::sparse", ?address, "Updating account and its storage root");
+            trie.update_account(address, account.unwrap_or_default())?;
+        } else {
+            trace!(target: "engine::root::sparse", ?address, "Updating account storage root");
+            trie.update_account_storage_root(address)?;
+        }
     }
 
-    // Update accounts with new values
+    // Update accounts
     for (address, account) in state.accounts {
         trace!(target: "engine::root::sparse", ?address, "Updating account");
         trie.update_account(address, account.unwrap_or_default())?;

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -184,12 +184,13 @@ where
         let (address, storage_trie) = result?;
         trie.insert_storage_trie(address, storage_trie);
 
-        // If the account itself has an update, remove it from the state update and update in one
-        // go instead of doing it down below.
         if let Some(account) = state.accounts.remove(&address) {
+            // If the account itself has an update, remove it from the state update and update in
+            // one go instead of doing it down below.
             trace!(target: "engine::root::sparse", ?address, "Updating account and its storage root");
             trie.update_account(address, account.unwrap_or_default())?;
-        } else {
+        } else if trie.is_account_revealed(address) {
+            // Otherwise, if the account is revealed, only update its storage root.
             trace!(target: "engine::root::sparse", ?address, "Updating account storage root");
             trie.update_account_storage_root(address)?;
         }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -596,7 +596,8 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         Ok(())
     }
 
-    /// Update or remove trie account based on new account info.
+    /// Update or remove trie account based on new account info. This method will either recompute
+    /// the storage root based on update storage trie or look it up from existing leaf value.
     ///
     /// If the new account info and storage trie are empty, the account leaf will be removed.
     pub fn update_account(&mut self, address: B256, account: Account) -> SparseStateTrieResult<()> {
@@ -621,15 +622,13 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
 
         if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
             trace!(target: "trie::sparse", ?address, "Removing account");
-            self.remove_account_leaf(&nibbles)?;
+            self.remove_account_leaf(&nibbles)
         } else {
             trace!(target: "trie::sparse", ?address, "Updating account");
             self.account_rlp_buf.clear();
             account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);
-            self.update_account_leaf(nibbles, self.account_rlp_buf.clone())?;
+            self.update_account_leaf(nibbles, self.account_rlp_buf.clone())
         }
-
-        Ok(())
     }
 
     /// Update the account storage root.
@@ -639,10 +638,10 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     /// If the new storage root is empty, and the account info was already empty, the account leaf
     /// will be removed.
     pub fn update_account_storage_root(&mut self, address: B256) -> SparseStateTrieResult<()> {
+        // Nothing to update if the account isn't revealed or doesn't exist in the trie.
         if !self.is_account_revealed(address) {
             return Ok(())
         }
-
         let Some(mut trie_account) = self
             .get_account_value(&address)
             .map(|v| TrieAccount::decode(&mut &v[..]))
@@ -651,6 +650,8 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
             return Ok(())
         };
 
+        // Calculate the new storage root. If the storage trie doesn't exist, the storage root will
+        // be empty.
         let storage_root = if let Some(storage_trie) = self.storages.get_mut(&address) {
             trace!(target: "trie::sparse", ?address, "Calculating storage root to update account");
             storage_trie.root().ok_or(SparseTrieErrorKind::Blind)?
@@ -658,13 +659,16 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
             EMPTY_ROOT_HASH
         };
 
+        // Update the account with the new storage root.
         trie_account.storage_root = storage_root;
 
         let nibbles = Nibbles::unpack(address);
         if trie_account == TrieAccount::default() {
+            // If the account is empty, remove it.
             trace!(target: "trie::sparse", ?address, "Removing account because the storage root is empty");
             self.remove_account_leaf(&nibbles)?;
         } else {
+            // Otherwise, update the account leaf.
             trace!(target: "trie::sparse", ?address, "Updating account with the new storage root");
             self.account_rlp_buf.clear();
             trie_account.encode(&mut self.account_rlp_buf);

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -631,17 +631,18 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         }
     }
 
-    /// Update the account storage root.
+    /// Update the storage root of a revealed account.
     ///
-    /// If the account isn't revealed or doesn't exist in the trie, the function is a no-op.
+    /// If the account doesn't exist in the trie, the function is a no-op.
     ///
     /// If the new storage root is empty, and the account info was already empty, the account leaf
     /// will be removed.
     pub fn update_account_storage_root(&mut self, address: B256) -> SparseStateTrieResult<()> {
-        // Nothing to update if the account isn't revealed or doesn't exist in the trie.
         if !self.is_account_revealed(address) {
-            return Ok(())
+            return Err(SparseTrieErrorKind::Blind.into())
         }
+
+        // Nothing to update if the account doesn't exist in the trie.
         let Some(mut trie_account) = self
             .get_account_value(&address)
             .map(|v| TrieAccount::decode(&mut &v[..]))

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -596,20 +596,19 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         Ok(())
     }
 
-    /// Update or remove trie account based on new account info. This method will either recompute
-    /// the storage root based on update storage trie or look it up from existing leaf value.
+    /// Update or remove trie account based on new account info.
     ///
     /// If the new account info and storage trie are empty, the account leaf will be removed.
     pub fn update_account(&mut self, address: B256, account: Account) -> SparseStateTrieResult<()> {
         let nibbles = Nibbles::unpack(address);
+
         let storage_root = if let Some(storage_trie) = self.storages.get_mut(&address) {
             trace!(target: "trie::sparse", ?address, "Calculating storage root to update account");
             storage_trie.root().ok_or(SparseTrieErrorKind::Blind)?
         } else if self.is_account_revealed(address) {
             trace!(target: "trie::sparse", ?address, "Retrieving storage root from account leaf to update account");
-            let state = self.state.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;
             // The account was revealed, either...
-            if let Some(value) = state.get_leaf_value(&nibbles) {
+            if let Some(value) = self.get_account_value(&address) {
                 // ..it exists and we should take it's current storage root or...
                 TrieAccount::decode(&mut &value[..])?.storage_root
             } else {
@@ -622,13 +621,57 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
 
         if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
             trace!(target: "trie::sparse", ?address, "Removing account");
-            self.remove_account_leaf(&nibbles)
+            self.remove_account_leaf(&nibbles)?;
         } else {
             trace!(target: "trie::sparse", ?address, "Updating account");
             self.account_rlp_buf.clear();
             account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);
-            self.update_account_leaf(nibbles, self.account_rlp_buf.clone())
+            self.update_account_leaf(nibbles, self.account_rlp_buf.clone())?;
         }
+
+        Ok(())
+    }
+
+    /// Update the account storage root.
+    ///
+    /// If the account isn't revealed or doesn't exist in the trie, the function is a no-op.
+    ///
+    /// If the new storage root is empty, and the account info was already empty, the account leaf
+    /// will be removed.
+    pub fn update_account_storage_root(&mut self, address: B256) -> SparseStateTrieResult<()> {
+        if !self.is_account_revealed(address) {
+            return Ok(())
+        }
+
+        let Some(mut trie_account) = self
+            .get_account_value(&address)
+            .map(|v| TrieAccount::decode(&mut &v[..]))
+            .transpose()?
+        else {
+            return Ok(())
+        };
+
+        let storage_root = if let Some(storage_trie) = self.storages.get_mut(&address) {
+            trace!(target: "trie::sparse", ?address, "Calculating storage root to update account");
+            storage_trie.root().ok_or(SparseTrieErrorKind::Blind)?
+        } else {
+            EMPTY_ROOT_HASH
+        };
+
+        trie_account.storage_root = storage_root;
+
+        let nibbles = Nibbles::unpack(address);
+        if trie_account == TrieAccount::default() {
+            trace!(target: "trie::sparse", ?address, "Removing account because the storage root is empty");
+            self.remove_account_leaf(&nibbles)?;
+        } else {
+            trace!(target: "trie::sparse", ?address, "Updating account with the new storage root");
+            self.account_rlp_buf.clear();
+            trie_account.encode(&mut self.account_rlp_buf);
+            self.update_account_leaf(nibbles, self.account_rlp_buf.clone())?;
+        }
+
+        Ok(())
     }
 
     /// Remove the account leaf node.


### PR DESCRIPTION
This PR removes the relying on the assumption that all accounts with storage updates in `HashedPostState.storages` are also present in `HashedPostState.accounts`.

While this is true for the sparse trie part of the code https://github.com/paradigmxyz/reth/blob/c40e260e15cec9e137beab40624709f8b91a7364/crates/engine/tree/src/tree/payload_processor/multiproof.rs#L208-L238 it can be a footgun when chunking the `HashedPostState`, as it means that storage updates should come first, and account updates later, because only account updates actually update the accounts storage root in the sparse trie.