### PR TITLE
fix: Fix type casting issue in `prague_custom` function

### DIFF
--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -159,11 +159,11 @@ pub fn prague_custom() -> &'static Precompiles {
         // Custom precompile.
         precompiles.extend([(
             address!("0x0000000000000000000000000000000000000999"),
-            |_, _| -> PrecompileResult {
-                PrecompileResult::Ok(PrecompileOutput::new(0, Bytes::new()))
-            } as PrecompileFn,
+                PrecompileFn::new(|_, _| -> PrecompileResult {
+            PrecompileResult::Ok(PrecompileOutput::new(0, Bytes::new()))
+            }),
         )
-            .into()]);
+            .into()]);       
         precompiles
     })
 }


### PR DESCRIPTION
Hi, team!

I’ve fixed an issue where the closure was incorrectly cast to the `PrecompileFn` type in the `prague_custom` function. The previous implementation didn’t handle the type casting properly, which caused potential issues with type safety.

Instead of casting the closure explicitly, I’ve adjusted the code to directly define the closure as a `PrecompileFn`. This ensures correct type usage and eliminates any type casting issues.

Here’s what I changed:

```rust
precompiles.extend([(
    address!("0x0000000000000000000000000000000000000999"),
    PrecompileFn::new(|_, _| -> PrecompileResult {
        PrecompileResult::Ok(PrecompileOutput::new(0, Bytes::new()))
    }),
)
.into()]);
```

This should resolve the issue and ensure better type safety when using `PrecompileFn`.