### PR TITLE
fix: generate-jwt.sh dir with whitespace

### DIFF
--- a/etc/generate-jwt.sh
+++ b/etc/generate-jwt.sh
@@ -3,10 +3,10 @@
 # See https://github.com/remyroy/ethstaker/blob/main/prepare-for-the-merge.md#configuring-a-jwt-token-file
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-mkdir -p ${SCRIPT_DIR}/jwttoken
-if [[ ! -f ${SCRIPT_DIR}/jwttoken/jwt.hex ]]
+mkdir -p "${SCRIPT_DIR}/jwttoken"
+if [[ ! -f "${SCRIPT_DIR}/jwttoken/jwt.hex" ]]
 then
-  openssl rand -hex 32 | tr -d "\n" | tee > ${SCRIPT_DIR}/jwttoken/jwt.hex
+  openssl rand -hex 32 | tr -d "\n" | tee > "${SCRIPT_DIR}/jwttoken/jwt.hex"
 else
   echo "${SCRIPT_DIR}/jwttoken/jwt.hex already exists!"
 fi


### PR DESCRIPTION
Fixes `etc/generate-jwt.sh` to correctly work in directories with whitespace