### PR TITLE
chore(ci): Remove redundant licenses from allow list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0384 used by sse example
     "RUSTSEC-2024-0384",
+    # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
+    "RUSTSEC-2024-0436"
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/deny.toml
+++ b/deny.toml
@@ -61,11 +61,6 @@ exceptions = [
 ]
 
 [[licenses.clarify]]
-name = "ring"
-expression = "LicenseRef-ring"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-[[licenses.clarify]]
 name = "rustls-webpki"
 expression = "LicenseRef-rustls-webpki"
 license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,7 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0384 used by sse example
     "RUSTSEC-2024-0384",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
-    "RUSTSEC-2024-0436"
+    "RUSTSEC-2024-0436",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/deny.toml
+++ b/deny.toml
@@ -44,12 +44,9 @@ allow = [
     "0BSD",
     "CC0-1.0",
     "ISC",
-    "Unicode-DFS-2016",
     "Unlicense",
     "Unicode-3.0",
     "Zlib",
-    # https://github.com/briansmith/ring/issues/902
-    "LicenseRef-ring",
     # https://github.com/rustls/webpki/blob/main/LICENSE ISC Style
     "LicenseRef-rustls-webpki",
 ]


### PR DESCRIPTION
Removes redundant `LicenseRef-ring` (https://github.com/briansmith/ring/issues/902) and outdated `Unicode-DFS-2016` from allow list in `deny.toml`