### PR TITLE
Remove unnecessary clone in `prague_custom()`

### DIFF
--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -155,7 +155,7 @@ impl<CTX: ContextTr> CustomPrecompiles<CTX> {
 pub fn prague_custom() -> &'static Precompiles {
     static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
     INSTANCE.get_or_init(|| {
-        let mut precompiles = Precompiles::prague().clone();
+        let mut precompiles = Precompiles::prague();
         // Custom precompile.
         precompiles.extend([(
             address!("0x0000000000000000000000000000000000000999"),


### PR DESCRIPTION
This pull request removes an unnecessary `.clone()` call when initializing `precompiles` in the `prague_custom()` function. Since `Precompiles::prague()` already returns an owned instance, cloning is redundant and wastes resources.