### PR TITLE
[WIP] Move rpc block conversion to TransactionCompat trait

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -15,7 +15,7 @@ use reth_primitives::{RecoveredBlock, SealedBlock};
 use reth_provider::{
     BlockIdReader, BlockReader, BlockReaderIdExt, ProviderHeader, ProviderReceipt,
 };
-use reth_rpc_types_compat::block::from_block;
+use reth_rpc_types_compat::TransactionCompat;
 use revm_primitives::U256;
 use std::sync::Arc;
 
@@ -60,7 +60,7 @@ pub trait EthBlocks: LoadBlock {
         async move {
             let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
 
-            let block = from_block((*block).clone(), full.into(), self.tx_resp_builder())?;
+            let block = self.tx_resp_builder().from_block((*block).clone(), full.into())?;
             Ok(Some(block))
         }
     }

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -4,7 +4,7 @@
 
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
-use reth_primitives::{Recovered, TransactionSigned};
+use reth_primitives::{NodePrimitives, Recovered, TransactionSigned};
 use reth_primitives_traits::SignedTransaction;
 use reth_rpc_types_compat::TransactionCompat;
 
@@ -39,7 +39,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     }
 
     /// Conversion into network specific transaction type.
-    pub fn into_transaction<Builder: TransactionCompat<T>>(
+    pub fn into_transaction<N: NodePrimitives<SignedTx = T>, Builder: TransactionCompat<N>>(
         self,
         resp_builder: &Builder,
     ) -> Result<Builder::Transaction, Builder::Error> {

--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -9,103 +9,103 @@ use alloy_rpc_types_eth::{
 use reth_primitives::RecoveredBlock;
 use reth_primitives_traits::{Block as BlockTrait, BlockBody, SealedHeader, SignedTransaction};
 
-/// Converts the given primitive block into a [`Block`] response with the given
-/// [`BlockTransactionsKind`]
-///
-/// If a `block_hash` is provided, then this is used, otherwise the block hash is computed.
-#[expect(clippy::type_complexity)]
-pub fn from_block<T, B>(
-    block: RecoveredBlock<B>,
-    kind: BlockTransactionsKind,
-    tx_resp_builder: &T,
-) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
-where
-    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
-    B: BlockTrait,
-{
-    match kind {
-        BlockTransactionsKind::Hashes => Ok(from_block_with_tx_hashes::<T::Transaction, B>(block)),
-        BlockTransactionsKind::Full => from_block_full::<T, B>(block, tx_resp_builder),
-    }
-}
-
-/// Create a new [`Block`] response from a [primitive block](reth_primitives::Block), using the
-/// total difficulty to populate its field in the rpc response.
-///
-/// This will populate the `transactions` field with only the hashes of the transactions in the
-/// block: [`BlockTransactions::Hashes`]
-pub fn from_block_with_tx_hashes<T, B>(block: RecoveredBlock<B>) -> Block<T, Header<B::Header>>
-where
-    B: BlockTrait,
-{
-    let transactions = block.body().transaction_hashes_iter().copied().collect();
-    let rlp_length = block.rlp_length();
-    let (header, body) = block.into_sealed_block().split_sealed_header_body();
-    from_block_with_transactions::<T, B>(
-        rlp_length,
-        header,
-        body,
-        BlockTransactions::Hashes(transactions),
-    )
-}
-
-/// Create a new [`Block`] response from a [primitive block](reth_primitives::Block), using the
-/// total difficulty to populate its field in the rpc response.
-///
-/// This will populate the `transactions` field with the _full_
-/// [`TransactionCompat::Transaction`] objects: [`BlockTransactions::Full`]
-#[expect(clippy::type_complexity)]
-pub fn from_block_full<T, B>(
-    block: RecoveredBlock<B>,
-    tx_resp_builder: &T,
-) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
-where
-    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
-    B: BlockTrait,
-{
-    let block_number = block.header().number();
-    let base_fee = block.header().base_fee_per_gas();
-    let block_length = block.rlp_length();
-    let block_hash = Some(block.hash());
-
-    let transactions = block
-        .transactions_recovered()
-        .enumerate()
-        .map(|(idx, tx)| {
-            let tx_info = TransactionInfo {
-                hash: Some(*tx.tx_hash()),
-                block_hash,
-                block_number: Some(block_number),
-                base_fee,
-                index: Some(idx as u64),
-            };
-
-            tx_resp_builder.fill(tx.cloned(), tx_info)
-        })
-        .collect::<Result<Vec<_>, T::Error>>()?;
-
-    let (header, body) = block.into_sealed_block().split_sealed_header_body();
-    Ok(from_block_with_transactions::<_, B>(
-        block_length,
-        header,
-        body,
-        BlockTransactions::Full(transactions),
-    ))
-}
-
-#[inline]
-fn from_block_with_transactions<T, B: BlockTrait>(
-    block_length: usize,
-    header: SealedHeader<B::Header>,
-    body: B::Body,
-    transactions: BlockTransactions<T>,
-) -> Block<T, Header<B::Header>> {
-    let withdrawals =
-        header.withdrawals_root().is_some().then(|| body.withdrawals().cloned()).flatten();
-
-    let uncles =
-        body.ommers().map(|o| o.iter().map(|h| h.hash_slow()).collect()).unwrap_or_default();
-    let header = Header::from_consensus(header.into(), None, Some(U256::from(block_length)));
-
-    Block { header, uncles, transactions, withdrawals }
-}
+// /// Converts the given primitive block into a [`Block`] response with the given
+// /// [`BlockTransactionsKind`]
+// ///
+// /// If a `block_hash` is provided, then this is used, otherwise the block hash is computed.
+// #[expect(clippy::type_complexity)]
+// pub fn from_block<T, B>(
+//     block: RecoveredBlock<B>,
+//     kind: BlockTransactionsKind,
+//     tx_resp_builder: &T,
+// ) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
+// where
+//     T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
+//     B: BlockTrait,
+// {
+//     match kind {
+//         BlockTransactionsKind::Hashes => Ok(from_block_with_tx_hashes::<T::Transaction, B>(block)),
+//         BlockTransactionsKind::Full => from_block_full::<T, B>(block, tx_resp_builder),
+//     }
+// }
+//
+// /// Create a new [`Block`] response from a [primitive block](reth_primitives::Block), using the
+// /// total difficulty to populate its field in the rpc response.
+// ///
+// /// This will populate the `transactions` field with only the hashes of the transactions in the
+// /// block: [`BlockTransactions::Hashes`]
+// pub fn from_block_with_tx_hashes<T, B>(block: RecoveredBlock<B>) -> Block<T, Header<B::Header>>
+// where
+//     B: BlockTrait,
+// {
+//     let transactions = block.body().transaction_hashes_iter().copied().collect();
+//     let rlp_length = block.rlp_length();
+//     let (header, body) = block.into_sealed_block().split_sealed_header_body();
+//     from_block_with_transactions::<T, B>(
+//         rlp_length,
+//         header,
+//         body,
+//         BlockTransactions::Hashes(transactions),
+//     )
+// }
+//
+// /// Create a new [`Block`] response from a [primitive block](reth_primitives::Block), using the
+// /// total difficulty to populate its field in the rpc response.
+// ///
+// /// This will populate the `transactions` field with the _full_
+// /// [`TransactionCompat::Transaction`] objects: [`BlockTransactions::Full`]
+// #[expect(clippy::type_complexity)]
+// pub fn from_block_full<T, B>(
+//     block: RecoveredBlock<B>,
+//     tx_resp_builder: &T,
+// ) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
+// where
+//     T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
+//     B: BlockTrait,
+// {
+//     let block_number = block.header().number();
+//     let base_fee = block.header().base_fee_per_gas();
+//     let block_length = block.rlp_length();
+//     let block_hash = Some(block.hash());
+//
+//     let transactions = block
+//         .transactions_recovered()
+//         .enumerate()
+//         .map(|(idx, tx)| {
+//             let tx_info = TransactionInfo {
+//                 hash: Some(*tx.tx_hash()),
+//                 block_hash,
+//                 block_number: Some(block_number),
+//                 base_fee,
+//                 index: Some(idx as u64),
+//             };
+//
+//             tx_resp_builder.fill(tx.cloned(), tx_info)
+//         })
+//         .collect::<Result<Vec<_>, T::Error>>()?;
+//
+//     let (header, body) = block.into_sealed_block().split_sealed_header_body();
+//     Ok(from_block_with_transactions::<_, B>(
+//         block_length,
+//         header,
+//         body,
+//         BlockTransactions::Full(transactions),
+//     ))
+// }
+//
+// #[inline]
+// fn from_block_with_transactions<T, B: BlockTrait>(
+//     block_length: usize,
+//     header: SealedHeader<B::Header>,
+//     body: B::Body,
+//     transactions: BlockTransactions<T>,
+// ) -> Block<T, Header<B::Header>> {
+//     let withdrawals =
+//         header.withdrawals_root().is_some().then(|| body.withdrawals().cloned()).flatten();
+//
+//     let uncles =
+//         body.ommers().map(|o| o.iter().map(|h| h.hash_slow()).collect()).unwrap_or_default();
+//     let header = Header::from_consensus(header.into(), None, Some(U256::from(block_length)));
+//
+//     Block { header, uncles, transactions, withdrawals }
+// }

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -3,13 +3,22 @@
 use core::error;
 use std::fmt;
 
-use alloy_rpc_types_eth::{request::TransactionRequest, TransactionInfo};
-use reth_primitives::{Recovered, TransactionSigned};
+use alloy_consensus::{BlockHeader, Sealable};
+use alloy_primitives::U256;
+use alloy_rpc_types_eth::{
+    request::TransactionRequest, Block, BlockTransactions, BlockTransactionsKind, Header,
+    TransactionInfo,
+};
+use reth_primitives::{NodePrimitives, Recovered, RecoveredBlock, TransactionSigned};
+use reth_primitives_traits::{Block as BlockTrait, BlockBody, SealedHeader, SignedTransaction};
 use serde::{Deserialize, Serialize};
 
 /// Builds RPC transaction w.r.t. network.
-pub trait TransactionCompat<T = TransactionSigned>:
-    Send + Sync + Unpin + Clone + fmt::Debug
+pub trait TransactionCompat<
+    N: NodePrimitives,
+    //N: NodePrimitives<SignedTx = T>,
+    //T: SignedTransaction + Clone = TransactionSigned,
+>: Send + Sync + Unpin + Clone + fmt::Debug
 {
     /// RPC transaction response type.
     type Transaction: Serialize
@@ -26,7 +35,7 @@ pub trait TransactionCompat<T = TransactionSigned>:
     /// Wrapper for `fill()` with default `TransactionInfo`
     /// Create a new rpc transaction result for a _pending_ signed transaction, setting block
     /// environment related fields to `None`.
-    fn fill_pending(&self, tx: Recovered<T>) -> Result<Self::Transaction, Self::Error> {
+    fn fill_pending(&self, tx: Recovered<N::SignedTx>) -> Result<Self::Transaction, Self::Error> {
         self.fill(tx, TransactionInfo::default())
     }
 
@@ -37,16 +46,110 @@ pub trait TransactionCompat<T = TransactionSigned>:
     /// transaction was mined.
     fn fill(
         &self,
-        tx: Recovered<T>,
+        tx: Recovered<N::SignedTx>,
         tx_inf: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error>;
 
     /// Builds a fake transaction from a transaction request for inclusion into block built in
     /// `eth_simulateV1`.
-    fn build_simulate_v1_transaction(&self, request: TransactionRequest) -> Result<T, Self::Error>;
+    fn build_simulate_v1_transaction(&self, request: TransactionRequest) -> Result<N::SignedTx, Self::Error>;
 
     /// Truncates the input of a transaction to only the first 4 bytes.
     // todo: remove in favour of using constructor on `TransactionResponse` or similar
     // <https://github.com/alloy-rs/alloy/issues/1315>.
     fn otterscan_api_truncate_input(tx: &mut Self::Transaction);
+
+    /// Converts the given primitive block into a [`Block`] response with the given
+    /// [`BlockTransactionsKind`]
+    ///
+    /// If a `block_hash` is provided, then this is used, otherwise the block hash is computed.
+    #[expect(clippy::type_complexity)]
+    fn from_block(
+        &self,
+        block: RecoveredBlock<N::Block>,
+        kind: BlockTransactionsKind,
+    ) -> Result<Block<Self::Transaction, Header<<N::Block as BlockTrait>::Header>>, Self::Error>
+    {
+        match kind {
+            BlockTransactionsKind::Hashes => Ok(Self::from_block_with_tx_hashes(block)),
+            BlockTransactionsKind::Full => self.from_block_full(block),
+        }
+    }
+
+    /// Create a new [`Block`] response from a [primitive block](reth_primitives::Block), using the
+    /// total difficulty to populate its field in the rpc response.
+    ///
+    /// This will populate the `transactions` field with only the hashes of the transactions in the
+    /// block: [`BlockTransactions::Hashes`]
+    fn from_block_with_tx_hashes(
+        block: RecoveredBlock<N::Block>,
+    ) -> Block<Self::Transaction, Header<<N::Block as BlockTrait>::Header>> {
+        let transactions = block.body().transaction_hashes_iter().copied().collect();
+        let rlp_length = block.rlp_length();
+        let (header, body) = block.into_sealed_block().split_sealed_header_body();
+        Self::from_block_with_transactions::<N::Block>(
+            rlp_length,
+            header,
+            body,
+            BlockTransactions::Hashes(transactions),
+        )
+    }
+
+    /// Create a new [`Block`] response from a [primitive block](reth_primitives::Block), using the
+    /// total difficulty to populate its field in the rpc response.
+    ///
+    /// This will populate the `transactions` field with the _full_
+    /// [`TransactionCompat::Transaction`] objects: [`BlockTransactions::Full`]
+    #[expect(clippy::type_complexity)]
+    fn from_block_full(
+        &self,
+        block: RecoveredBlock<N::Block>,
+    ) -> Result<Block<Self::Transaction, Header<<N::Block as BlockTrait>::Header>>, Self::Error>
+    {
+        let block_number = block.header().number();
+        let base_fee = block.header().base_fee_per_gas();
+        let block_length = block.rlp_length();
+        let block_hash = Some(block.hash());
+
+        let transactions = block
+            .transactions_recovered()
+            .enumerate()
+            .map(|(idx, tx)| {
+                let tx_info = TransactionInfo {
+                    hash: Some(*tx.tx_hash()),
+                    block_hash,
+                    block_number: Some(block_number),
+                    base_fee,
+                    index: Some(idx as u64),
+                };
+
+                self.fill(tx.cloned(), tx_info)
+            })
+            .collect::<Result<Vec<_>, Self::Error>>()?;
+
+        let (header, body) = block.into_sealed_block().split_sealed_header_body();
+        Ok(Self::from_block_with_transactions::<N::Block>(
+            block_length,
+            header,
+            body,
+            BlockTransactions::Full(transactions),
+        ))
+    }
+
+    #[inline]
+    fn from_block_with_transactions<B: BlockTrait>(
+        block_length: usize,
+        header: SealedHeader<B::Header>,
+        body: B::Body,
+        transactions: BlockTransactions<Self::Transaction>,
+    ) -> Block<Self::Transaction, Header<B::Header>> {
+        let withdrawals =
+            header.withdrawals_root().is_some().then(|| body.withdrawals().cloned()).flatten();
+
+        let uncles =
+            body.ommers().map(|o| o.iter().map(|h| h.hash_slow()).collect()).unwrap_or_default();
+        let header = Header::from_consensus(header.into(), None, Some(U256::from(block_length)));
+
+        Block { header, uncles, transactions, withdrawals }
+    }
 }

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -5,7 +5,7 @@ use alloy_network::{Ethereum, Network};
 use alloy_primitives::PrimitiveSignature as Signature;
 use alloy_rpc_types::TransactionRequest;
 use alloy_rpc_types_eth::{Transaction, TransactionInfo};
-use reth_primitives::{Recovered, TransactionSigned};
+use reth_primitives::{NodePrimitives, Recovered, TransactionSigned};
 use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::TransactionCompat;
@@ -29,7 +29,7 @@ impl EthApiTypes for EthereumEthApiTypes {
 #[non_exhaustive]
 pub struct EthTxBuilder;
 
-impl TransactionCompat for EthTxBuilder
+impl<N: NodePrimitives<SignedTx = TransactionSigned>> TransactionCompat<N> for EthTxBuilder
 where
     Self: Send + Sync,
 {

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -61,9 +61,10 @@ impl<Eth> EthPubSubApiServer<RpcTransaction<Eth::NetworkTypes>> for EthPubSub<Et
 where
     Eth: RpcNodeCore<
             Provider: BlockNumReader + CanonStateSubscriptions,
+            Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Eth::Pool>>,
             Pool: TransactionPool,
             Network: NetworkInfo,
-        > + EthApiTypes<TransactionCompat: TransactionCompat<PoolConsensusTx<Eth::Pool>>>
+        > + EthApiTypes<TransactionCompat: TransactionCompat<Eth::Primitives>>
         + 'static,
 {
     /// Handler for `eth_subscribe`
@@ -93,9 +94,10 @@ async fn handle_accepted<Eth>(
 where
     Eth: RpcNodeCore<
             Provider: BlockNumReader + CanonStateSubscriptions,
+            Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Eth::Pool>>,
             Pool: TransactionPool,
             Network: NetworkInfo,
-        > + EthApiTypes<TransactionCompat: TransactionCompat<PoolConsensusTx<Eth::Pool>>>,
+        > + EthApiTypes<TransactionCompat: TransactionCompat<Eth::Primitives>>,
 {
     match kind {
         SubscriptionKind::NewHeads => {


### PR DESCRIPTION
WIP, towards https://github.com/paradigmxyz/reth/issues/14863

---

compilation failing at:
```
   Compiling reth v1.2.2 (/home/yohkaz/projects/reth/bin/reth)
error[E0275]: overflow evaluating the requirement `EthStorage: ChainStorage<EthPrimitives>`
  |
  = note: required for `NodeTypesWithDBAdapter<EthereumNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>` to implement `NodeTypesForProvider`
  = note: required for `NodeTypesWithDBAdapter<EthereumNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>` to implement `ProviderNodeTypes`
  = note: required for `BlockchainProvider<NodeTypesWithDBAdapter<EthereumNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>>` to implement `StateProviderFactory`
  = note: required for `EthTransactionValidator<BlockchainProvider<NodeTypesWithDBAdapter<EthereumNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>>, EthPooledTransaction>` to implement `TransactionValidator`
  = note: required for `Pool<TransactionValidationTaskExecutor<EthTransactionValidator<BlockchainProvider<...>, ...>>, ..., ...>` to implement `TransactionPool`
  = note: required for `EthTxBuilder` to implement `TransactionCompat<EthPrimitives>`
  = note: the full name for the type has been written to '/home/yohkaz/projects/reth/target/debug/deps/reth-f66433e8bfa116b6.long-type-13505355246900291464.txt'
  = note: consider using `--verbose` to print the full type name to the console

For more information about this error, try `rustc --explain E0275`.
error: could not compile `reth` (bin "reth") due to 1 previous error
```