### PR TITLE
refactor: unify EVM traits

### DIFF
--- a/crates/engine/local/src/service.rs
+++ b/crates/engine/local/src/service.rs
@@ -29,7 +29,7 @@ use reth_engine_tree::{
     persistence::PersistenceHandle,
     tree::{EngineApiTreeHandler, InvalidBlockHook, TreeConfig},
 };
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_node_types::BlockTy;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{PayloadAttributesBuilder, PayloadTypes};
@@ -85,7 +85,7 @@ where
     where
         B: PayloadAttributesBuilder<<N::Engine as PayloadTypes>::PayloadAttributes>,
         V: EngineValidator<N::Engine, Block = BlockTy<N>>,
-        C: ConfigureEvmEnv<Primitives = N::Primitives> + 'static,
+        C: ConfigureEvm<Primitives = N::Primitives> + 'static,
     {
         let chain_spec = provider.chain_spec();
         let engine_kind =

--- a/crates/engine/local/src/service.rs
+++ b/crates/engine/local/src/service.rs
@@ -29,8 +29,8 @@ use reth_engine_tree::{
     persistence::PersistenceHandle,
     tree::{EngineApiTreeHandler, InvalidBlockHook, TreeConfig},
 };
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
-use reth_node_types::{BlockTy, HeaderTy, TxTy};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+use reth_node_types::BlockTy;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{PayloadAttributesBuilder, PayloadTypes};
 use reth_provider::{
@@ -85,7 +85,7 @@ where
     where
         B: PayloadAttributesBuilder<<N::Engine as PayloadTypes>::PayloadAttributes>,
         V: EngineValidator<N::Engine, Block = BlockTy<N>>,
-        C: ConfigureEvm<Header = HeaderTy<N>, Transaction = TxTy<N>> + 'static,
+        C: ConfigureEvmEnv<Primitives = N::Primitives> + 'static,
     {
         let chain_spec = provider.chain_spec();
         let engine_kind =

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -14,9 +14,9 @@ pub use reth_engine_tree::{
     chain::{ChainEvent, ChainOrchestrator},
     engine::EngineApiEvent,
 };
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
 use reth_network_p2p::BlockClient;
-use reth_node_types::{BlockTy, HeaderTy, NodeTypes, NodeTypesWithEngine, TxTy};
+use reth_node_types::{BlockTy, NodeTypes, NodeTypesWithEngine};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_primitives::EthPrimitives;
 use reth_provider::{
@@ -93,7 +93,7 @@ where
     ) -> Self
     where
         V: EngineValidator<N::Engine, Block = BlockTy<N>>,
-        C: ConfigureEvm<Header = HeaderTy<N>, Transaction = TxTy<N>> + 'static,
+        C: ConfigureEvmEnv<Primitives = N::Primitives> + 'static,
     {
         let engine_kind =
             if chain_spec.is_optimism() { EngineApiKind::OpStack } else { EngineApiKind::Ethereum };

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -14,7 +14,7 @@ pub use reth_engine_tree::{
     chain::{ChainEvent, ChainOrchestrator},
     engine::EngineApiEvent,
 };
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_p2p::BlockClient;
 use reth_node_types::{BlockTy, NodeTypes, NodeTypesWithEngine};
 use reth_payload_builder::PayloadBuilderHandle;
@@ -93,7 +93,7 @@ where
     ) -> Self
     where
         V: EngineValidator<N::Engine, Block = BlockTy<N>>,
-        C: ConfigureEvmEnv<Primitives = N::Primitives> + 'static,
+        C: ConfigureEvm<Primitives = N::Primitives> + 'static,
     {
         let engine_kind =
             if chain_spec.is_optimism() { EngineApiKind::OpStack } else { EngineApiKind::Ethereum };

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -31,7 +31,7 @@ use reth_engine_primitives::{
 };
 use reth_errors::{ConsensusError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{EngineApiMessageVersion, PayloadBuilderAttributes};
 use reth_primitives_traits::{
@@ -638,7 +638,7 @@ where
     <P as DatabaseProviderFactory>::Provider:
         BlockReader<Block = N::Block, Header = N::BlockHeader>,
     E: BlockExecutorProvider<Primitives = N>,
-    C: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx> + 'static,
+    C: ConfigureEvmEnv<Primitives = N> + 'static,
     T: EngineTypes,
     V: EngineValidator<T, Block = N::Block>,
 {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -31,7 +31,7 @@ use reth_engine_primitives::{
 };
 use reth_errors::{ConsensusError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{EngineApiMessageVersion, PayloadBuilderAttributes};
 use reth_primitives_traits::{
@@ -638,7 +638,7 @@ where
     <P as DatabaseProviderFactory>::Provider:
         BlockReader<Block = N::Block, Header = N::BlockHeader>,
     E: BlockExecutorProvider<Primitives = N>,
-    C: ConfigureEvmEnv<Primitives = N> + 'static,
+    C: ConfigureEvm<Primitives = N> + 'static,
     T: EngineTypes,
     V: EngineValidator<T, Block = N::Block>,
 {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -16,7 +16,7 @@ use executor::WorkloadExecutor;
 use multiproof::*;
 use parking_lot::RwLock;
 use prewarm::PrewarmMetrics;
-use reth_evm::{ConfigureEvm, ConfigureEvmEnvFor, OnStateHook};
+use reth_evm::{ConfigureEvmEnv, OnStateHook};
 use reth_primitives_traits::{NodePrimitives, SealedHeaderFor};
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, StateCommitmentProvider,
@@ -75,10 +75,7 @@ impl<N, Evm> PayloadProcessor<N, Evm> {
 impl<N, Evm> PayloadProcessor<N, Evm>
 where
     N: NodePrimitives,
-    Evm: ConfigureEvmEnvFor<N>
-        + 'static
-        + ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
-        + 'static,
+    Evm: ConfigureEvmEnv<Primitives = N> + 'static,
 {
     /// Spawns all background tasks and returns a handle connected to the tasks.
     ///

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -16,7 +16,7 @@ use executor::WorkloadExecutor;
 use multiproof::*;
 use parking_lot::RwLock;
 use prewarm::PrewarmMetrics;
-use reth_evm::{ConfigureEvmEnv, OnStateHook};
+use reth_evm::{ConfigureEvm, OnStateHook};
 use reth_primitives_traits::{NodePrimitives, SealedHeaderFor};
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, StateCommitmentProvider,
@@ -75,7 +75,7 @@ impl<N, Evm> PayloadProcessor<N, Evm> {
 impl<N, Evm> PayloadProcessor<N, Evm>
 where
     N: NodePrimitives,
-    Evm: ConfigureEvmEnv<Primitives = N> + 'static,
+    Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Spawns all background tasks and returns a handle connected to the tasks.
     ///

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -10,7 +10,7 @@ use crate::tree::{
 use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{keccak256, map::B256Set, B256};
 use metrics::{Gauge, Histogram};
-use reth_evm::{ConfigureEvmEnv, Evm};
+use reth_evm::{ConfigureEvm, Evm};
 use reth_metrics::Metrics;
 use reth_primitives_traits::{header::SealedHeaderFor, NodePrimitives, SignedTransaction};
 use reth_provider::{BlockReader, StateCommitmentProvider, StateProviderFactory, StateReader};
@@ -52,7 +52,7 @@ impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + StateProviderFactory + StateReader + StateCommitmentProvider + Clone + 'static,
-    Evm: ConfigureEvmEnv<Primitives = N> + 'static,
+    Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Initializes the task with the given transactions pending execution
     pub(super) fn new(
@@ -201,7 +201,7 @@ impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + StateProviderFactory + StateReader + StateCommitmentProvider + Clone + 'static,
-    Evm: ConfigureEvmEnv<Primitives = N> + 'static,
+    Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Transacts the transactions and transform the state into [`MultiProofTargets`].
     fn prepare_multiproof_targets(self, tx: Recovered<N::SignedTx>) -> Option<MultiProofTargets> {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -10,7 +10,7 @@ use crate::tree::{
 use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{keccak256, map::B256Set, B256};
 use metrics::{Gauge, Histogram};
-use reth_evm::{ConfigureEvm, ConfigureEvmEnvFor, Evm};
+use reth_evm::{ConfigureEvmEnv, Evm};
 use reth_metrics::Metrics;
 use reth_primitives_traits::{header::SealedHeaderFor, NodePrimitives, SignedTransaction};
 use reth_provider::{BlockReader, StateCommitmentProvider, StateProviderFactory, StateReader};
@@ -52,10 +52,7 @@ impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + StateProviderFactory + StateReader + StateCommitmentProvider + Clone + 'static,
-    Evm: ConfigureEvmEnvFor<N>
-        + 'static
-        + ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
-        + 'static,
+    Evm: ConfigureEvmEnv<Primitives = N> + 'static,
 {
     /// Initializes the task with the given transactions pending execution
     pub(super) fn new(
@@ -204,10 +201,7 @@ impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + StateProviderFactory + StateReader + StateCommitmentProvider + Clone + 'static,
-    Evm: ConfigureEvmEnvFor<N>
-        + 'static
-        + ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
-        + 'static,
+    Evm: ConfigureEvmEnv<Primitives = N> + 'static,
 {
     /// Transacts the transactions and transform the state into [`MultiProofTargets`].
     fn prepare_multiproof_targets(self, tx: Recovered<N::SignedTx>) -> Option<MultiProofTargets> {

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -10,7 +10,10 @@ use reth_engine_primitives::{
     OnForkChoiceUpdated, PayloadValidator,
 };
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResult};
-use reth_evm::execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionStrategyFactory};
+use reth_evm::{
+    execute::{BlockBuilder, BlockBuilderOutcome},
+    ConfigureEvmEnv,
+};
 use reth_payload_primitives::{BuiltPayload, EngineApiMessageVersion};
 use reth_primitives::{NodePrimitives, SealedBlock};
 use reth_primitives_traits::{block::Block as _, BlockBody as _, SignedTransaction};
@@ -107,7 +110,7 @@ where
     Provider: BlockReader<Header = N::BlockHeader, Block = N::Block>
         + StateProviderFactory
         + ChainSpecProvider,
-    Evm: BlockExecutionStrategyFactory<Primitives = N>,
+    Evm: ConfigureEvmEnv<Primitives = N>,
     Validator: PayloadValidator<ExecutionData = Engine::ExecutionData, Block = N::Block>,
 {
     type Item = S::Item;
@@ -258,7 +261,7 @@ where
     Provider: BlockReader<Header = N::BlockHeader, Block = N::Block>
         + StateProviderFactory
         + ChainSpecProvider<ChainSpec: EthChainSpec>,
-    Evm: BlockExecutionStrategyFactory<Primitives = N>,
+    Evm: ConfigureEvmEnv<Primitives = N>,
     Validator: PayloadValidator<Block = N::Block>,
 {
     // Ensure next payload is valid.

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -12,7 +12,7 @@ use reth_engine_primitives::{
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError, RethResult};
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
-    ConfigureEvmEnv,
+    ConfigureEvm,
 };
 use reth_payload_primitives::{BuiltPayload, EngineApiMessageVersion};
 use reth_primitives::{NodePrimitives, SealedBlock};
@@ -110,7 +110,7 @@ where
     Provider: BlockReader<Header = N::BlockHeader, Block = N::Block>
         + StateProviderFactory
         + ChainSpecProvider,
-    Evm: ConfigureEvmEnv<Primitives = N>,
+    Evm: ConfigureEvm<Primitives = N>,
     Validator: PayloadValidator<ExecutionData = Engine::ExecutionData, Block = N::Block>,
 {
     type Item = S::Item;
@@ -261,7 +261,7 @@ where
     Provider: BlockReader<Header = N::BlockHeader, Block = N::Block>
         + StateProviderFactory
         + ChainSpecProvider<ChainSpec: EthChainSpec>,
-    Evm: ConfigureEvmEnv<Primitives = N>,
+    Evm: ConfigureEvm<Primitives = N>,
     Validator: PayloadValidator<Block = N::Block>,
 {
     // Ensure next payload is valid.

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -6,11 +6,9 @@ use alloy_eips::merge::BEACON_NONCE;
 use alloy_evm::{block::BlockExecutorFactory, eth::EthBlockExecutionCtx};
 use alloy_primitives::Bytes;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_evm::execute::{
-    BlockAssembler, BlockAssemblerInput, BlockExecutionError, BlockExecutionStrategyFactory,
-};
+use reth_evm::execute::{BlockAssembler, BlockAssemblerInput, BlockExecutionError};
 use reth_execution_types::BlockExecutionResult;
-use reth_primitives::{logs_bloom, EthPrimitives, Receipt, TransactionSigned};
+use reth_primitives::{logs_bloom, Receipt, TransactionSigned};
 
 /// Block builder for Ethereum.
 #[derive(Debug, Clone)]
@@ -28,17 +26,20 @@ impl<ChainSpec> EthBlockAssembler<ChainSpec> {
     }
 }
 
-impl<Evm, ChainSpec> BlockAssembler<Evm> for EthBlockAssembler<ChainSpec>
+impl<F, ChainSpec> BlockAssembler<F> for EthBlockAssembler<ChainSpec>
 where
-    Evm: for<'a> BlockExecutionStrategyFactory<
-        Primitives = EthPrimitives,
-        BlockExecutorFactory: BlockExecutorFactory<ExecutionCtx<'a> = EthBlockExecutionCtx<'a>>,
+    F: for<'a> BlockExecutorFactory<
+        ExecutionCtx<'a> = EthBlockExecutionCtx<'a>,
+        Transaction = TransactionSigned,
+        Receipt = Receipt,
     >,
     ChainSpec: EthChainSpec + EthereumHardforks,
 {
+    type Block = Block<TransactionSigned>;
+
     fn assemble_block(
         &self,
-        input: BlockAssemblerInput<'_, '_, Evm>,
+        input: BlockAssemblerInput<'_, '_, F>,
     ) -> Result<Block<TransactionSigned>, BlockExecutionError> {
         let BlockAssemblerInput {
             evm_env,

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -17,7 +17,7 @@
 
 extern crate alloc;
 
-use alloc::sync::Arc;
+use alloc::{borrow::Cow, sync::Arc};
 use alloy_consensus::{BlockHeader, Header};
 pub use alloy_evm::EthEvm;
 use alloy_evm::{
@@ -34,7 +34,6 @@ use revm::{
     context_interface::block::BlobExcessGasAndPrice,
     specification::hardfork::SpecId,
 };
-use std::borrow::Cow;
 
 mod config;
 use alloy_eips::eip1559::INITIAL_BASE_FEE;

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -27,7 +27,7 @@ use alloy_evm::{
 use alloy_primitives::{Bytes, U256};
 use core::{convert::Infallible, fmt::Debug};
 use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
-use reth_evm::{ConfigureEvmEnv, EvmEnv, EvmFactory, NextBlockEnvAttributes, TransactionEnv};
+use reth_evm::{ConfigureEvm, EvmEnv, EvmFactory, NextBlockEnvAttributes, TransactionEnv};
 use reth_primitives::{EthPrimitives, SealedBlock, SealedHeader, TransactionSigned};
 use revm::{
     context::{BlockEnv, CfgEnv},
@@ -100,7 +100,7 @@ impl<EvmFactory> EthEvmConfig<EvmFactory> {
     }
 }
 
-impl<EvmF> ConfigureEvmEnv for EthEvmConfig<EvmF>
+impl<EvmF> ConfigureEvm for EthEvmConfig<EvmF>
 where
     EvmF: EvmFactory<Tx: TransactionEnv + FromRecoveredTx<TransactionSigned>, Spec = SpecId>
         + Send

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -20,19 +20,21 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
 pub use alloy_evm::EthEvm;
-use alloy_evm::{eth::EthBlockExecutorFactory, EthEvmFactory, FromRecoveredTx};
+use alloy_evm::{
+    eth::{EthBlockExecutionCtx, EthBlockExecutorFactory},
+    EthEvmFactory, FromRecoveredTx,
+};
 use alloy_primitives::{Bytes, U256};
 use core::{convert::Infallible, fmt::Debug};
 use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
-use reth_evm::{
-    ConfigureEvm, ConfigureEvmEnv, EvmEnv, EvmFactory, NextBlockEnvAttributes, TransactionEnv,
-};
-use reth_primitives::TransactionSigned;
+use reth_evm::{ConfigureEvmEnv, EvmEnv, EvmFactory, NextBlockEnvAttributes, TransactionEnv};
+use reth_primitives::{EthPrimitives, SealedBlock, SealedHeader, TransactionSigned};
 use revm::{
     context::{BlockEnv, CfgEnv},
     context_interface::block::BlobExcessGasAndPrice,
     specification::hardfork::SpecId,
 };
+use std::borrow::Cow;
 
 mod config;
 use alloy_eips::eip1559::INITIAL_BASE_FEE;
@@ -104,16 +106,24 @@ where
         + Send
         + Sync
         + Unpin
-        + Clone,
+        + Clone
+        + 'static,
 {
-    type Header = Header;
-    type Transaction = TransactionSigned;
+    type Primitives = EthPrimitives;
     type Error = Infallible;
-    type TxEnv = EvmF::Tx;
-    type Spec = SpecId;
     type NextBlockEnvCtx = NextBlockEnvAttributes;
+    type BlockExecutorFactory = EthBlockExecutorFactory<RethReceiptBuilder, Arc<ChainSpec>, EvmF>;
+    type BlockAssembler = EthBlockAssembler<ChainSpec>;
 
-    fn evm_env(&self, header: &Self::Header) -> EvmEnv {
+    fn block_executor_factory(&self) -> &Self::BlockExecutorFactory {
+        &self.executor_factory
+    }
+
+    fn block_assembler(&self) -> &Self::BlockAssembler {
+        &self.block_assembler
+    }
+
+    fn evm_env(&self, header: &Header) -> EvmEnv {
         let spec = config::revm_spec(self.chain_spec(), header);
 
         // configure evm env based on parent block
@@ -138,7 +148,7 @@ where
 
     fn next_evm_env(
         &self,
-        parent: &Self::Header,
+        parent: &Header,
         attributes: &NextBlockEnvAttributes,
     ) -> Result<EvmEnv, Self::Error> {
         // ensure we're not missing any timestamp based hardforks
@@ -197,20 +207,27 @@ where
 
         Ok((cfg, block_env).into())
     }
-}
 
-impl<EvmF> ConfigureEvm for EthEvmConfig<EvmF>
-where
-    EvmF: EvmFactory<Tx: TransactionEnv + FromRecoveredTx<TransactionSigned>, Spec = SpecId>
-        + Send
-        + Sync
-        + Unpin
-        + Clone,
-{
-    type EvmFactory = EvmF;
+    fn context_for_block<'a>(&self, block: &'a SealedBlock) -> EthBlockExecutionCtx<'a> {
+        EthBlockExecutionCtx {
+            parent_hash: block.header().parent_hash,
+            parent_beacon_block_root: block.header().parent_beacon_block_root,
+            ommers: &block.body().ommers,
+            withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),
+        }
+    }
 
-    fn evm_factory(&self) -> &Self::EvmFactory {
-        self.executor_factory.evm_factory()
+    fn context_for_next_block(
+        &self,
+        parent: &SealedHeader,
+        attributes: Self::NextBlockEnvCtx,
+    ) -> EthBlockExecutionCtx<'_> {
+        EthBlockExecutionCtx {
+            parent_hash: parent.hash(),
+            parent_beacon_block_root: attributes.parent_beacon_block_root,
+            ommers: &[],
+            withdrawals: attributes.withdrawals.map(Cow::Owned),
+        }
     }
 }
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -9,7 +9,10 @@ use reth_ethereum_engine_primitives::{
     EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
 };
 use reth_ethereum_primitives::{EthPrimitives, PooledTransaction};
-use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm, NextBlockEnvAttributes};
+use reth_evm::{
+    execute::BasicBlockExecutorProvider, ConfigureEvmEnv, EvmFactory, EvmFactoryFor,
+    NextBlockEnvAttributes,
+};
 use reth_network::{EthNetworkPrimitives, NetworkHandle, PeersInfo};
 use reth_node_api::{AddOnsContext, BlockTy, FullNodeComponents, NodeAddOns, ReceiptTy, TxTy};
 use reth_node_builder::{
@@ -179,9 +182,10 @@ where
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx = NextBlockEnvAttributes>,
+        Evm: ConfigureEvmEnv<NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthApiError: FromEvmError<N::Evm>,
+    EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
 {
     type Handle = RpcHandle<N, EthApiFor<N>>;
 
@@ -219,9 +223,10 @@ where
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: ConfigureEvm<TxEnv = TxEnv, NextBlockEnvCtx = NextBlockEnvAttributes>,
+        Evm: ConfigureEvmEnv<NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthApiError: FromEvmError<N::Evm>,
+    EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
 {
     type EthApi = EthApiFor<N>;
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -10,7 +10,7 @@ use reth_ethereum_engine_primitives::{
 };
 use reth_ethereum_primitives::{EthPrimitives, PooledTransaction};
 use reth_evm::{
-    execute::BasicBlockExecutorProvider, ConfigureEvmEnv, EvmFactory, EvmFactoryFor,
+    execute::BasicBlockExecutorProvider, ConfigureEvm, EvmFactory, EvmFactoryFor,
     NextBlockEnvAttributes,
 };
 use reth_network::{EthNetworkPrimitives, NetworkHandle, PeersInfo};
@@ -182,7 +182,7 @@ where
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: ConfigureEvmEnv<NextBlockEnvCtx = NextBlockEnvAttributes>,
+        Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
@@ -223,7 +223,7 @@ where
             Primitives = EthPrimitives,
             Engine = EthEngineTypes,
         >,
-        Evm: ConfigureEvmEnv<NextBlockEnvCtx = NextBlockEnvAttributes>,
+        Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -6,7 +6,7 @@ use reth_ethereum_engine_primitives::{
 };
 use reth_ethereum_payload_builder::EthereumBuilderConfig;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_evm::ConfigureEvmFor;
+use reth_evm::ConfigureEvmEnv;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{FullNodeTypes, NodeTypesWithEngine, PrimitivesTy, TxTy};
 use reth_node_builder::{
@@ -33,7 +33,7 @@ impl EthereumPayloadBuilder {
     where
         Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
         Node: FullNodeTypes<Types = Types>,
-        Evm: ConfigureEvmFor<PrimitivesTy<Types>>,
+        Evm: ConfigureEvmEnv<Primitives = PrimitivesTy<Types>>,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -6,7 +6,7 @@ use reth_ethereum_engine_primitives::{
 };
 use reth_ethereum_payload_builder::EthereumBuilderConfig;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_evm::ConfigureEvmEnv;
+use reth_evm::ConfigureEvm;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_node_api::{FullNodeTypes, NodeTypesWithEngine, PrimitivesTy, TxTy};
 use reth_node_builder::{
@@ -33,7 +33,7 @@ impl EthereumPayloadBuilder {
     where
         Types: NodeTypesWithEngine<ChainSpec = ChainSpec, Primitives = EthPrimitives>,
         Node: FullNodeTypes<Types = Types>,
-        Evm: ConfigureEvmEnv<Primitives = PrimitivesTy<Types>>,
+        Evm: ConfigureEvm<Primitives = PrimitivesTy<Types>>,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -21,8 +21,8 @@ use reth_chainspec::{ChainSpec, ChainSpecProvider, EthChainSpec, EthereumHardfor
 use reth_errors::{BlockExecutionError, BlockValidationError};
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
-    execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionStrategyFactory},
-    Evm, NextBlockEnvAttributes,
+    execute::{BlockBuilder, BlockBuilderOutcome},
+    ConfigureEvmEnv, Evm, NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
@@ -76,10 +76,8 @@ impl<Pool, Client, EvmConfig> EthereumPayloadBuilder<Pool, Client, EvmConfig> {
 // Default implementation of [PayloadBuilder] for unit type
 impl<Pool, Client, EvmConfig> PayloadBuilder for EthereumPayloadBuilder<Pool, Client, EvmConfig>
 where
-    EvmConfig: BlockExecutionStrategyFactory<
-        Primitives = EthPrimitives,
-        NextBlockEnvCtx = NextBlockEnvAttributes,
-    >,
+    EvmConfig:
+        ConfigureEvmEnv<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
@@ -134,10 +132,8 @@ pub fn default_ethereum_payload<EvmConfig, Client, Pool, F>(
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
-    EvmConfig: BlockExecutionStrategyFactory<
-        Primitives = EthPrimitives,
-        NextBlockEnvCtx = NextBlockEnvAttributes,
-    >,
+    EvmConfig:
+        ConfigureEvmEnv<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -22,7 +22,7 @@ use reth_errors::{BlockExecutionError, BlockValidationError};
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
-    ConfigureEvmEnv, Evm, NextBlockEnvAttributes,
+    ConfigureEvm, Evm, NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
@@ -76,8 +76,7 @@ impl<Pool, Client, EvmConfig> EthereumPayloadBuilder<Pool, Client, EvmConfig> {
 // Default implementation of [PayloadBuilder] for unit type
 impl<Pool, Client, EvmConfig> PayloadBuilder for EthereumPayloadBuilder<Pool, Client, EvmConfig>
 where
-    EvmConfig:
-        ConfigureEvmEnv<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
+    EvmConfig: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
@@ -132,8 +131,7 @@ pub fn default_ethereum_payload<EvmConfig, Client, Pool, F>(
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
-    EvmConfig:
-        ConfigureEvmEnv<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
+    EvmConfig: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,

--- a/crates/evm/src/aliases.rs
+++ b/crates/evm/src/aliases.rs
@@ -1,46 +1,43 @@
-//! Helper aliases when working with [`ConfigureEvmEnv`] and the traits in this crate.
+//! Helper aliases when working with [`ConfigureEvm`] and the traits in this crate.
 
-use crate::ConfigureEvmEnv;
+use crate::ConfigureEvm;
 use alloy_evm::{block::BlockExecutorFactory, Database, EvmEnv, EvmFactory};
 use revm::{inspector::NoOpInspector, Inspector};
 
-/// Helper to access [`EvmFactory`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`EvmFactory`] for a given [`ConfigureEvm`].
 pub type EvmFactoryFor<Evm> =
-    <<Evm as ConfigureEvmEnv>::BlockExecutorFactory as BlockExecutorFactory>::EvmFactory;
+    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::EvmFactory;
 
-/// Helper to access [`EvmFactory::Spec`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`EvmFactory::Spec`] for a given [`ConfigureEvm`].
 pub type SpecFor<Evm> = <EvmFactoryFor<Evm> as EvmFactory>::Spec;
 
-/// Helper to access [`EvmFactory::Evm`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`EvmFactory::Evm`] for a given [`ConfigureEvm`].
 pub type EvmFor<Evm, DB, I = NoOpInspector> = <EvmFactoryFor<Evm> as EvmFactory>::Evm<DB, I>;
 
-/// Helper to access [`EvmFactory::Error`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`EvmFactory::Error`] for a given [`ConfigureEvm`].
 pub type EvmErrorFor<Evm, DB> = <EvmFactoryFor<Evm> as EvmFactory>::Error<DB>;
 
-/// Helper to access [`EvmFactory::Context`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`EvmFactory::Context`] for a given [`ConfigureEvm`].
 pub type EvmContextFor<Evm, DB> = <EvmFactoryFor<Evm> as EvmFactory>::Context<DB>;
 
-/// Helper to access [`EvmFactory::HaltReason`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`EvmFactory::HaltReason`] for a given [`ConfigureEvm`].
 pub type HaltReasonFor<Evm> = <EvmFactoryFor<Evm> as EvmFactory>::HaltReason;
 
-/// Helper to access [`EvmFactory::Tx`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`EvmFactory::Tx`] for a given [`ConfigureEvm`].
 pub type TxEnvFor<Evm> = <EvmFactoryFor<Evm> as EvmFactory>::Tx;
 
-/// Helper to access [`BlockExecutorFactory::ExecutionCtx`] for a given [`ConfigureEvmEnv`].
+/// Helper to access [`BlockExecutorFactory::ExecutionCtx`] for a given [`ConfigureEvm`].
 pub type ExecutionCtxFor<'a, Evm> =
-    <<Evm as ConfigureEvmEnv>::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>;
+    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>;
 
-/// Type alias for [`EvmEnv`] for a given [`ConfigureEvmEnv`].
+/// Type alias for [`EvmEnv`] for a given [`ConfigureEvm`].
 pub type EvmEnvFor<Evm> = EvmEnv<SpecFor<Evm>>;
 
-/// Helper trait to bound [`Inspector`] for a [`ConfigureEvmEnv`].
-pub trait InspectorFor<Evm: ConfigureEvmEnv, DB: Database>:
-    Inspector<EvmContextFor<Evm, DB>>
-{
-}
+/// Helper trait to bound [`Inspector`] for a [`ConfigureEvm`].
+pub trait InspectorFor<Evm: ConfigureEvm, DB: Database>: Inspector<EvmContextFor<Evm, DB>> {}
 impl<T, Evm, DB> InspectorFor<Evm, DB> for T
 where
-    Evm: ConfigureEvmEnv,
+    Evm: ConfigureEvm,
     DB: Database,
     T: Inspector<EvmContextFor<Evm, DB>>,
 {

--- a/crates/evm/src/aliases.rs
+++ b/crates/evm/src/aliases.rs
@@ -1,46 +1,47 @@
-//! Helper aliases when working with [`NodePrimitives`] and the traits in this crate.
-use crate::{ConfigureEvm, ConfigureEvmEnv};
-use alloy_evm::EvmFactory;
-use reth_primitives_traits::NodePrimitives;
-use revm::inspector::NoOpInspector;
+//! Helper aliases when working with [`ConfigureEvmEnv`] and the traits in this crate.
 
-/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
-/// [`ConfigureEvmEnv`] whose associated types match the [`NodePrimitives`] associated types.
-pub trait ConfigureEvmEnvFor<N: NodePrimitives>:
-    ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>
+use crate::ConfigureEvmEnv;
+use alloy_evm::{block::BlockExecutorFactory, Database, EvmEnv, EvmFactory};
+use revm::{inspector::NoOpInspector, Inspector};
+
+/// Helper to access [`EvmFactory`] for a given [`ConfigureEvmEnv`].
+pub type EvmFactoryFor<Evm> =
+    <<Evm as ConfigureEvmEnv>::BlockExecutorFactory as BlockExecutorFactory>::EvmFactory;
+
+/// Helper to access [`EvmFactory::Spec`] for a given [`ConfigureEvmEnv`].
+pub type SpecFor<Evm> = <EvmFactoryFor<Evm> as EvmFactory>::Spec;
+
+/// Helper to access [`EvmFactory::Evm`] for a given [`ConfigureEvmEnv`].
+pub type EvmFor<Evm, DB, I = NoOpInspector> = <EvmFactoryFor<Evm> as EvmFactory>::Evm<DB, I>;
+
+/// Helper to access [`EvmFactory::Error`] for a given [`ConfigureEvmEnv`].
+pub type EvmErrorFor<Evm, DB> = <EvmFactoryFor<Evm> as EvmFactory>::Error<DB>;
+
+/// Helper to access [`EvmFactory::Context`] for a given [`ConfigureEvmEnv`].
+pub type EvmContextFor<Evm, DB> = <EvmFactoryFor<Evm> as EvmFactory>::Context<DB>;
+
+/// Helper to access [`EvmFactory::HaltReason`] for a given [`ConfigureEvmEnv`].
+pub type HaltReasonFor<Evm> = <EvmFactoryFor<Evm> as EvmFactory>::HaltReason;
+
+/// Helper to access [`EvmFactory::Tx`] for a given [`ConfigureEvmEnv`].
+pub type TxEnvFor<Evm> = <EvmFactoryFor<Evm> as EvmFactory>::Tx;
+
+/// Helper to access [`BlockExecutorFactory::ExecutionCtx`] for a given [`ConfigureEvmEnv`].
+pub type ExecutionCtxFor<'a, Evm> =
+    <<Evm as ConfigureEvmEnv>::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>;
+
+/// Type alias for [`EvmEnv`] for a given [`ConfigureEvmEnv`].
+pub type EvmEnvFor<Evm> = EvmEnv<SpecFor<Evm>>;
+
+/// Helper trait to bound [`Inspector`] for a [`ConfigureEvmEnv`].
+pub trait InspectorFor<Evm: ConfigureEvmEnv, DB: Database>:
+    Inspector<EvmContextFor<Evm, DB>>
 {
 }
-
-impl<N, C> ConfigureEvmEnvFor<N> for C
+impl<T, Evm, DB> InspectorFor<Evm, DB> for T
 where
-    N: NodePrimitives,
-    C: ConfigureEvmEnv<Header = N::BlockHeader, Transaction = N::SignedTx>,
+    Evm: ConfigureEvmEnv,
+    DB: Database,
+    T: Inspector<EvmContextFor<Evm, DB>>,
 {
 }
-
-/// This is a type alias to make type bounds simpler when we have a [`NodePrimitives`] and need a
-/// [`ConfigureEvm`] whose associated types match the [`NodePrimitives`] associated types.
-pub trait ConfigureEvmFor<N: NodePrimitives>:
-    ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>
-{
-}
-
-impl<N, C> ConfigureEvmFor<N> for C
-where
-    N: NodePrimitives,
-    C: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
-{
-}
-
-/// Helper to access [`EvmFactory::Error`] for a given [`ConfigureEvm`].
-pub type EvmErrorFor<Evm, DB> = <<Evm as ConfigureEvm>::EvmFactory as EvmFactory>::Error<DB>;
-
-/// Helper to access [`EvmFactory::HaltReason`] for a given [`ConfigureEvm`].
-pub type HaltReasonFor<Evm> = <<Evm as ConfigureEvm>::EvmFactory as EvmFactory>::HaltReason;
-
-/// Helper to access [`ConfigureEvmEnv::Spec`] for a given [`ConfigureEvmEnv`].
-pub type SpecFor<Evm> = <Evm as ConfigureEvmEnv>::Spec;
-
-/// Helper to access [`EvmFactory::Evm`] for a given [`ConfigureEvm`].
-pub type EvmFor<Evm, DB, I = NoOpInspector> =
-    <<Evm as ConfigureEvm>::EvmFactory as EvmFactory>::Evm<DB, I>;

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -1,6 +1,6 @@
 //! Traits for execution.
 
-use crate::{ConfigureEvmEnv, Database, OnStateHook};
+use crate::{ConfigureEvm, Database, OnStateHook};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
@@ -382,7 +382,7 @@ impl<F> BasicBlockExecutorProvider<F> {
 
 impl<F> BlockExecutorProvider for BasicBlockExecutorProvider<F>
 where
-    F: ConfigureEvmEnv + 'static,
+    F: ConfigureEvm + 'static,
 {
     type Primitives = F::Primitives;
 
@@ -417,7 +417,7 @@ impl<F, DB: Database> BasicBlockExecutor<F, DB> {
 
 impl<F, DB> Executor<DB> for BasicBlockExecutor<F, DB>
 where
-    F: ConfigureEvmEnv,
+    F: ConfigureEvm,
     DB: Database,
 {
     type Primitives = F::Primitives;

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -1,35 +1,23 @@
 //! Traits for execution.
 
-use crate::{
-    ConfigureEvmFor, Database, EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, OnStateHook,
-};
+use crate::{ConfigureEvmEnv, Database, OnStateHook};
 use alloc::{boxed::Box, vec::Vec};
-use alloy_consensus::BlockHeader;
-pub use alloy_evm::block::BlockExecutor;
-use alloy_evm::{
-    block::{BlockExecutorFactory, BlockExecutorFor},
-    Evm,
-};
-use alloy_primitives::{
-    map::{DefaultHashBuilder, HashMap},
-    Address, B256,
-};
+use alloy_consensus::{BlockHeader, Header};
+pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
+use alloy_evm::{Evm, EvmEnv, EvmFactory};
+use alloy_primitives::B256;
 pub use reth_execution_errors::{
     BlockExecutionError, BlockValidationError, InternalBlockExecutionError,
 };
 use reth_execution_types::BlockExecutionResult;
 pub use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
 use reth_primitives_traits::{
-    BlockTy, HeaderTy, NodePrimitives, ReceiptTy, Recovered, RecoveredBlock, SealedBlock,
-    SealedHeader, TxTy,
+    Block, HeaderTy, NodePrimitives, ReceiptTy, Recovered, RecoveredBlock, SealedHeader, TxTy,
 };
 use reth_storage_api::StateProvider;
 pub use reth_storage_errors::provider::ProviderError;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use revm::{
-    context::result::ExecutionResult,
-    state::{Account, AccountStatus, EvmState},
-};
+use revm::context::result::ExecutionResult;
 use revm_database::{states::bundle_state::BundleRetention, BundleState, State};
 
 /// A type that knows how to execute a block. It is assumed to operate on a
@@ -176,141 +164,22 @@ pub struct ExecuteOutput<R> {
     pub gas_used: u64,
 }
 
-/// A factory that can create block execution strategies.
-///
-/// This trait extends [`crate::ConfigureEvm`] and provides a way to construct a
-/// [`BlockExecutor`]. Strategy is expected to derive most of the context for block
-/// execution from the EVM (which includes [`revm::context::BlockEnv`]), and any additional context
-/// should be contained in configured [`ExecutionCtx`].
-///
-/// Strategy is required to provide a way to obtain [`ExecutionCtx`] from either a complete
-/// [`SealedBlock`] (in case of execution of an externally obtained block), or from a parent header
-/// along with [`crate::ConfigureEvmEnv::NextBlockEnvCtx`] (in the case of block building).
-///
-/// For more context on the strategy design, see the documentation for [`BlockExecutor`].
-///
-/// Additionally, trait implementations are expected to define a [`BlockAssembler`] type that is
-/// used to assemble blocks. Assembler combined with strategy are used to create a [`BlockBuilder`].
-/// [`BlockBuilder`] exposes a simple API for building blocks and can be consumed by payload
-/// builder.
-///
-/// [`ExecutionCtx`]: BlockExecutorFactory::ExecutionCtx
-pub trait BlockExecutionStrategyFactory: ConfigureEvmFor<Self::Primitives> + 'static {
-    /// Primitive types used by the strategy.
-    type Primitives: NodePrimitives;
-
-    /// Block executor factory.
-    type BlockExecutorFactory: BlockExecutorFactory<
-        EvmFactory = Self::EvmFactory,
-        Transaction = TxTy<Self::Primitives>,
-        Receipt = ReceiptTy<Self::Primitives>,
-    >;
-
-    /// A type that knows how to build a block.
-    type BlockAssembler: BlockAssembler<Self>;
-
-    /// Provides reference to configured [`BlockExecutorFactory`].
-    fn block_executor_factory(&self) -> &Self::BlockExecutorFactory;
-
-    /// Provides reference to configured [`BlockAssembler`].
-    fn block_assembler(&self) -> &Self::BlockAssembler;
-
-    /// Returns the configured [`BlockExecutorFactory::ExecutionCtx`] for a given block.
-    fn context_for_block<'a>(
-        &self,
-        block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
-    ) -> <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>;
-
-    /// Returns the configured [`BlockExecutorFactory::ExecutionCtx`] for `parent + 1`
-    /// block.
-    fn context_for_next_block(
-        &self,
-        parent: &SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
-        attributes: Self::NextBlockEnvCtx,
-    ) -> <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'_>;
-
-    /// Creates a strategy with given EVM and execution context.
-    fn create_strategy<'a, DB, I>(
-        &'a self,
-        evm: EvmFor<Self, &'a mut State<DB>, I>,
-        ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
-    ) -> impl BlockExecutorFor<'a, Self::BlockExecutorFactory, DB, I>
-    where
-        DB: Database,
-        I: InspectorFor<&'a mut State<DB>, Self> + 'a,
-    {
-        self.block_executor_factory().create_executor(evm, ctx)
-    }
-
-    /// Creates a strategy for execution of a given block.
-    fn strategy_for_block<'a, DB: Database>(
-        &'a self,
-        db: &'a mut State<DB>,
-        block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
-    ) -> impl BlockExecutorFor<'a, Self::BlockExecutorFactory, DB> {
-        let evm = self.evm_for_block(db, block.header());
-        let ctx = self.context_for_block(block);
-        self.create_strategy(evm, ctx)
-    }
-
-    /// Creates a [`BlockBuilder`]. Should be used when building a new block.
-    ///
-    /// Block builder wraps an inner [`BlockExecutor`] and has a similar interface. Builder
-    /// collects all of the executed transactions, and once [`BlockBuilder::finish`] is called, it
-    /// invokes the configured [`BlockAssembler`] to create a block.
-    fn create_block_builder<'a, DB, I>(
-        &'a self,
-        evm: EvmFor<Self, &'a mut State<DB>, I>,
-        parent: &'a SealedHeader<HeaderTy<Self::Primitives>>,
-        ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
-    ) -> impl BlockBuilder<
-        Primitives = Self::Primitives,
-        Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, DB, I>,
-    >
-    where
-        DB: Database,
-        I: InspectorFor<&'a mut State<DB>, Self> + 'a,
-    {
-        BasicBlockBuilder {
-            executor: self.create_strategy(evm, ctx.clone()),
-            ctx,
-            assembler: self.block_assembler(),
-            parent,
-            transactions: Vec::new(),
-        }
-    }
-
-    /// Creates a [`BlockBuilder`] for building of a new block. This is a helper to invoke
-    /// [`BlockExecutionStrategyFactory::create_block_builder`].
-    fn builder_for_next_block<'a, DB: Database>(
-        &'a self,
-        db: &'a mut State<DB>,
-        parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
-        attributes: Self::NextBlockEnvCtx,
-    ) -> Result<impl BlockBuilder<Primitives = Self::Primitives>, Self::Error> {
-        let evm_env = self.next_evm_env(parent, &attributes)?;
-        let evm = self.evm_with_env(db, evm_env);
-        let ctx = self.context_for_next_block(parent, attributes);
-        Ok(self.create_block_builder(evm, parent, ctx))
-    }
-}
-
 /// Input for block building. Consumed by [`BlockAssembler`].
 #[derive(derive_more::Debug)]
 #[non_exhaustive]
-pub struct BlockAssemblerInput<'a, 'b, Evm: BlockExecutionStrategyFactory> {
+pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory, H = Header> {
     /// Configuration of EVM used when executing the block.
     ///
     /// Contains context relevant to EVM such as [`revm::context::BlockEnv`].
-    pub evm_env: EvmEnvFor<Evm>,
+    pub evm_env: EvmEnv<<F::EvmFactory as EvmFactory>::Spec>,
     /// [`BlockExecutorFactory::ExecutionCtx`] used to execute the block.
-    pub execution_ctx: <Evm::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
+    pub execution_ctx: F::ExecutionCtx<'a>,
     /// Parent block header.
-    pub parent: &'a SealedHeader<HeaderTy<Evm::Primitives>>,
+    pub parent: &'a SealedHeader<H>,
     /// Transactions that were executed in this block.
-    pub transactions: Vec<TxTy<Evm::Primitives>>,
+    pub transactions: Vec<F::Transaction>,
     /// Output of block execution.
-    pub output: &'b BlockExecutionResult<ReceiptTy<Evm::Primitives>>,
+    pub output: &'b BlockExecutionResult<F::Receipt>,
     /// [`BundleState`] after the block execution.
     pub bundle_state: &'a BundleState,
     /// Provider with access to state.
@@ -322,12 +191,15 @@ pub struct BlockAssemblerInput<'a, 'b, Evm: BlockExecutionStrategyFactory> {
 
 /// A type that knows how to assemble a block.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait BlockAssembler<Evm: BlockExecutionStrategyFactory> {
+pub trait BlockAssembler<F: BlockExecutorFactory> {
+    /// The block type produced by the assembler.
+    type Block: Block;
+
     /// Builds a block. see [`BlockAssemblerInput`] documentation for more details.
     fn assemble_block(
         &self,
-        input: BlockAssemblerInput<'_, '_, Evm>,
-    ) -> Result<BlockTy<Evm::Primitives>, BlockExecutionError>;
+        input: BlockAssemblerInput<'_, '_, F, <Self::Block as Block>::Header>,
+    ) -> Result<Self::Block, BlockExecutionError>;
 }
 
 /// Output of block building.
@@ -396,29 +268,35 @@ pub trait BlockBuilder {
     fn into_executor(self) -> Self::Executor;
 }
 
-struct BasicBlockBuilder<'a, Evm, Executor, Builder>
+pub(crate) struct BasicBlockBuilder<'a, F, Executor, Builder, N: NodePrimitives>
 where
-    Evm: BlockExecutionStrategyFactory,
+    F: BlockExecutorFactory,
 {
-    executor: Executor,
-    transactions: Vec<Recovered<TxTy<Evm::Primitives>>>,
-    ctx: <Evm::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
-    parent: &'a SealedHeader<HeaderTy<Evm::Primitives>>,
-    assembler: Builder,
+    pub(crate) executor: Executor,
+    pub(crate) transactions: Vec<Recovered<TxTy<N>>>,
+    pub(crate) ctx: F::ExecutionCtx<'a>,
+    pub(crate) parent: &'a SealedHeader<HeaderTy<N>>,
+    pub(crate) assembler: Builder,
 }
 
-impl<'a, E, DB, Executor, Builder> BlockBuilder for BasicBlockBuilder<'a, E, Executor, Builder>
+impl<'a, F, DB, Executor, Builder, N> BlockBuilder
+    for BasicBlockBuilder<'a, F, Executor, Builder, N>
 where
-    E: BlockExecutionStrategyFactory,
+    F: BlockExecutorFactory<Transaction = N::SignedTx, Receipt = N::Receipt>,
     Executor: BlockExecutor<
-        Receipt = ReceiptTy<E::Primitives>,
-        Transaction = TxTy<E::Primitives>,
-        Evm: Evm<Spec = E::Spec, HaltReason = HaltReasonFor<E>, DB = &'a mut State<DB>>,
+        Evm: Evm<
+            Spec = <F::EvmFactory as EvmFactory>::Spec,
+            HaltReason = <F::EvmFactory as EvmFactory>::HaltReason,
+            DB = &'a mut State<DB>,
+        >,
+        Transaction = N::SignedTx,
+        Receipt = N::Receipt,
     >,
     DB: Database + 'a,
-    Builder: BlockAssembler<E>,
+    Builder: BlockAssembler<F, Block = N::Block>,
+    N: NodePrimitives,
 {
-    type Primitives = E::Primitives;
+    type Primitives = N;
     type Executor = Executor;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
@@ -428,7 +306,7 @@ where
     fn execute_transaction_with_result_closure(
         &mut self,
         tx: Recovered<TxTy<Self::Primitives>>,
-        f: impl FnOnce(&ExecutionResult<HaltReasonFor<E>>),
+        f: impl FnOnce(&ExecutionResult<<F::EvmFactory as EvmFactory>::HaltReason>),
     ) -> Result<u64, BlockExecutionError> {
         let gas_used =
             self.executor.execute_transaction_with_result_closure(tx.as_recovered_ref(), f)?;
@@ -439,7 +317,7 @@ where
     fn finish(
         self,
         state: impl StateProvider,
-    ) -> Result<BlockBuilderOutcome<E::Primitives>, BlockExecutionError> {
+    ) -> Result<BlockBuilderOutcome<N>, BlockExecutionError> {
         let (evm, result) = self.executor.finish()?;
         let (db, evm_env) = evm.finish();
 
@@ -504,7 +382,7 @@ impl<F> BasicBlockExecutorProvider<F> {
 
 impl<F> BlockExecutorProvider for BasicBlockExecutorProvider<F>
 where
-    F: BlockExecutionStrategyFactory + 'static,
+    F: ConfigureEvmEnv + 'static,
 {
     type Primitives = F::Primitives;
 
@@ -539,7 +417,7 @@ impl<F, DB: Database> BasicBlockExecutor<F, DB> {
 
 impl<F, DB> Executor<DB> for BasicBlockExecutor<F, DB>
 where
-    F: BlockExecutionStrategyFactory,
+    F: ConfigureEvmEnv,
     DB: Database,
 {
     type Primitives = F::Primitives;
@@ -550,7 +428,7 @@ where
         block: &RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
     ) -> Result<BlockExecutionResult<<Self::Primitives as NodePrimitives>::Receipt>, Self::Error>
     {
-        let mut strategy = self.strategy_factory.strategy_for_block(&mut self.db, block);
+        let mut strategy = self.strategy_factory.executor_for_block(&mut self.db, block);
 
         strategy.apply_pre_execution_changes()?;
         for tx in block.transactions_recovered() {
@@ -573,7 +451,7 @@ where
     {
         let mut strategy = self
             .strategy_factory
-            .strategy_for_block(&mut self.db, block)
+            .executor_for_block(&mut self.db, block)
             .with_state_hook(Some(Box::new(state_hook)));
 
         strategy.apply_pre_execution_changes()?;
@@ -596,47 +474,13 @@ where
     }
 }
 
-/// Creates an `EvmState` from a map of balance increments and the current state
-/// to load accounts from. No balance increment is done in the function.
-/// Zero balance increments are ignored and won't create state entries.
-pub fn balance_increment_state<DB>(
-    balance_increments: &HashMap<Address, u128, DefaultHashBuilder>,
-    state: &mut State<DB>,
-) -> Result<EvmState, BlockExecutionError>
-where
-    DB: Database,
-{
-    let mut load_account = |address: &Address| -> Result<(Address, Account), BlockExecutionError> {
-        let cache_account = state.load_cache_account(*address).map_err(|_| {
-            BlockExecutionError::msg("could not load account for balance increment")
-        })?;
-
-        let account = cache_account.account.as_ref().ok_or_else(|| {
-            BlockExecutionError::msg("could not load account for balance increment")
-        })?;
-
-        Ok((
-            *address,
-            Account {
-                info: account.info.clone(),
-                storage: Default::default(),
-                status: AccountStatus::Touched,
-            },
-        ))
-    };
-
-    balance_increments
-        .iter()
-        .filter(|(_, &balance)| balance != 0)
-        .map(|(addr, _)| load_account(addr))
-        .collect::<Result<EvmState, _>>()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Address;
     use alloy_consensus::constants::KECCAK_EMPTY;
-    use alloy_primitives::{address, U256};
+    use alloy_evm::block::state_changes::balance_increment_state;
+    use alloy_primitives::{address, map::HashMap, U256};
     use core::marker::PhantomData;
     use reth_ethereum_primitives::EthPrimitives;
     use revm::state::AccountInfo;
@@ -722,7 +566,7 @@ mod tests {
         let addr = address!("0x1000000000000000000000000000000000000000");
         let mut state = setup_state_with_account(addr, 100, 1);
 
-        let mut increments = HashMap::<Address, u128, DefaultHashBuilder>::default();
+        let mut increments = HashMap::default();
         increments.insert(addr, 0);
 
         let result = balance_increment_state(&increments, &mut state).unwrap();
@@ -736,7 +580,7 @@ mod tests {
             .with_bundle_update()
             .build();
 
-        let increments = HashMap::<Address, u128, DefaultHashBuilder>::default();
+        let increments = HashMap::default();
         let result = balance_increment_state(&increments, &mut state).unwrap();
         assert!(result.is_empty(), "Empty increments map should return empty state");
     }
@@ -752,7 +596,7 @@ mod tests {
             AccountInfo { balance: U256::from(200), nonce: 1, code_hash: KECCAK_EMPTY, code: None };
         state.insert_account(addr2, account2);
 
-        let mut increments = HashMap::<Address, u128, DefaultHashBuilder>::default();
+        let mut increments = HashMap::default();
         increments.insert(addr1, 50);
         increments.insert(addr2, 100);
 
@@ -774,7 +618,7 @@ mod tests {
             AccountInfo { balance: U256::from(200), nonce: 1, code_hash: KECCAK_EMPTY, code: None };
         state.insert_account(addr2, account2);
 
-        let mut increments = HashMap::<Address, u128, DefaultHashBuilder>::default();
+        let mut increments = HashMap::default();
         increments.insert(addr1, 0);
         increments.insert(addr2, 100);
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -18,6 +18,7 @@
 extern crate alloc;
 
 use crate::execute::BasicBlockBuilder;
+use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip4895::Withdrawals};
 pub use alloy_evm::evm::EvmFactory;
 use alloy_evm::{

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -79,21 +79,21 @@ pub use alloy_evm::block::state_changes as state_change;
 ///     2. Block building when we know parent block and some additional context obtained from
 ///       payload attributes or alike.
 ///
-/// First case is handled by [`ConfigureEvmEnv::evm_env`] and [`ConfigureEvmEnv::context_for_block`]
+/// First case is handled by [`ConfigureEvm::evm_env`] and [`ConfigureEvm::context_for_block`]
 /// which implement a conversion from [`NodePrimitives::Block`] to [`EvmEnv`] and [`ExecutionCtx`],
 /// and allow configuring EVM and block execution environment at a given block.
 ///
-/// Second case is handled by similar [`ConfigureEvmEnv::next_evm_env`] and
-/// [`ConfigureEvmEnv::context_for_next_block`] which take parent [`NodePrimitives::BlockHeader`]
+/// Second case is handled by similar [`ConfigureEvm::next_evm_env`] and
+/// [`ConfigureEvm::context_for_next_block`] which take parent [`NodePrimitives::BlockHeader`]
 /// along with [`NextBlockEnvCtx`]. [`NextBlockEnvCtx`] is very similar to payload attributes and
 /// simply contains context for next block that is generally received from a CL node (timestamp,
 /// beneficiary, withdrawals, etc.).
 ///
 /// [`ExecutionCtx`]: BlockExecutorFactory::ExecutionCtx
-/// [`NextBlockEnvCtx`]: ConfigureEvmEnv::NextBlockEnvCtx
+/// [`NextBlockEnvCtx`]: ConfigureEvm::NextBlockEnvCtx
 /// [`BlockExecutor`]: alloy_evm::block::BlockExecutor
 #[auto_impl::auto_impl(&, Arc)]
-pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
+pub trait ConfigureEvm: Send + Sync + Unpin + Clone {
     /// The primitives type used by the EVM.
     type Primitives: NodePrimitives;
 
@@ -172,7 +172,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
 
     /// Returns a new EVM with the given database configured with `cfg` and `block_env`
     /// configuration derived from the given header. Relies on
-    /// [`ConfigureEvmEnv::evm_env`].
+    /// [`ConfigureEvm::evm_env`].
     ///
     /// # Caution
     ///
@@ -258,7 +258,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
     }
 
     /// Creates a [`BlockBuilder`] for building of a new block. This is a helper to invoke
-    /// [`ConfigureEvmEnv::create_block_builder`].
+    /// [`ConfigureEvm::create_block_builder`].
     fn builder_for_next_block<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -274,7 +274,7 @@ pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
 
 /// Represents additional attributes required to configure the next block.
 /// This is used to configure the next block's environment
-/// [`ConfigureEvmEnv::next_evm_env`] and contains fields that can't be derived from the
+/// [`ConfigureEvm::next_evm_env`] and contains fields that can't be derived from the
 /// parent header alone (attributes that are determined by the CL.)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NextBlockEnvAttributes {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -17,13 +17,21 @@
 
 extern crate alloc;
 
+use crate::execute::BasicBlockBuilder;
 use alloy_eips::{eip2930::AccessList, eip4895::Withdrawals};
 pub use alloy_evm::evm::EvmFactory;
-use alloy_evm::IntoTxEnv;
+use alloy_evm::{
+    block::{BlockExecutorFactory, BlockExecutorFor},
+    IntoTxEnv,
+};
 use alloy_primitives::{Address, B256};
-use core::fmt::Debug;
-use reth_primitives_traits::{BlockHeader, SignedTransaction};
-use revm::{context::TxEnv, inspector::Inspector};
+use core::{error::Error, fmt::Debug};
+use execute::{BlockAssembler, BlockBuilder};
+use reth_primitives_traits::{
+    BlockTy, HeaderTy, NodePrimitives, ReceiptTy, SealedBlock, SealedHeader, TxTy,
+};
+use revm::context::TxEnv;
+use revm_database::State;
 
 pub mod either;
 /// EVM environment configuration.
@@ -46,35 +54,119 @@ pub use alloy_evm::{
 
 pub use alloy_evm::block::state_changes as state_change;
 
-/// Alias for `EvmEnv<<Evm as ConfigureEvmEnv>::Spec>`
-pub type EvmEnvFor<Evm> = EvmEnv<<Evm as ConfigureEvmEnv>::Spec>;
+/// A complete configuration of EVM for Reth.
+///
+/// This trait encapsulates complete configuration required for transaction execution and block
+/// execution/building.
+///
+/// The EVM abstraction consists of the following layers:
+///     - [`Evm`] produced by [`EvmFactory`]: The EVM implementation responsilble for executing
+///       individual transactions and producing output for them including state changes, logs, gas
+///       usage, etc.
+///     - [`BlockExecutor`] produced by [`BlockExecutorFactory`]: Executor operates on top of
+///       [`Evm`] and is responsible for executing entire blocks. This is different from simply
+///       aggregating outputs of transactions execution as it also involves higher level state
+///       changes such as receipt building, applying block rewards, system calls, etc.
+///     - [`BlockAssembler`]: Encapsulates logic for assembling blocks. It operates on context and
+///       output of [`BlockExecutor`], and is required to know how to assemble a next block to
+///       include in the chain.
+///
+/// All of the above components need configuration environment which we are abstracting over to
+/// allow plugging EVM implementation into Reth SDK.
+///
+/// The abstraction is designed to serve 2 codepaths:
+///     1. Externally provided complete block (e.g received while syncing).
+///     2. Block building when we know parent block and some additional context obtained from
+///       payload attributes or alike.
+///
+/// First case is handled by [`ConfigureEvmEnv::evm_env`] and [`ConfigureEvmEnv::context_for_block`]
+/// which implement a conversion from [`NodePrimitives::Block`] to [`EvmEnv`] and [`ExecutionCtx`],
+/// and allow configuring EVM and block execution environment at a given block.
+///
+/// Second case is handled by similar [`ConfigureEvmEnv::next_evm_env`] and
+/// [`ConfigureEvmEnv::context_for_next_block`] which take parent [`NodePrimitives::BlockHeader`]
+/// along with [`NextBlockEnvCtx`]. [`NextBlockEnvCtx`] is very similar to payload attributes and
+/// simply contains context for next block that is generally received from a CL node (timestamp,
+/// beneficiary, withdrawals, etc.).
+///
+/// [`ExecutionCtx`]: BlockExecutorFactory::ExecutionCtx
+/// [`NextBlockEnvCtx`]: ConfigureEvmEnv::NextBlockEnvCtx
+/// [`BlockExecutor`]: alloy_evm::block::BlockExecutor
+#[auto_impl::auto_impl(&, Arc)]
+pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
+    /// The primitives type used by the EVM.
+    type Primitives: NodePrimitives;
 
-/// Helper trait to bound [`Inspector`] for a [`ConfigureEvm`].
-pub trait InspectorFor<DB: Database, Evm: ConfigureEvm>:
-    Inspector<<Evm::EvmFactory as EvmFactory>::Context<DB>>
-{
-}
-impl<T, DB, Evm> InspectorFor<DB, Evm> for T
-where
-    DB: Database,
-    Evm: ConfigureEvm,
-    T: Inspector<<Evm::EvmFactory as EvmFactory>::Context<DB>>,
-{
-}
+    /// The error type that is returned by [`Self::next_evm_env`].
+    type Error: Error + Send + Sync + 'static;
 
-/// Trait for configuring the EVM for executing full blocks.
-pub trait ConfigureEvm: ConfigureEvmEnv {
-    /// The EVM factory.
-    type EvmFactory: EvmFactory<Tx = Self::TxEnv, Spec = Self::Spec>;
+    /// Context required for configuring next block environment.
+    ///
+    /// Contains values that can't be derived from the parent block.
+    type NextBlockEnvCtx: Debug + Clone;
+
+    /// Configured [`BlockExecutorFactory`], contains [`EvmFactory`] internally.
+    type BlockExecutorFactory: BlockExecutorFactory<
+        Transaction = TxTy<Self::Primitives>,
+        Receipt = ReceiptTy<Self::Primitives>,
+        EvmFactory: EvmFactory<Tx: TransactionEnv + FromRecoveredTx<TxTy<Self::Primitives>>>,
+    >;
+
+    /// A type that knows how to build a block.
+    type BlockAssembler: BlockAssembler<
+        Self::BlockExecutorFactory,
+        Block = BlockTy<Self::Primitives>,
+    >;
+
+    /// Returns reference to the configured [`BlockExecutorFactory`].
+    fn block_executor_factory(&self) -> &Self::BlockExecutorFactory;
+
+    /// Returns reference to the configured [`BlockAssembler`].
+    fn block_assembler(&self) -> &Self::BlockAssembler;
+
+    /// Creates a new [`EvmEnv`] for the given header.
+    fn evm_env(&self, header: &HeaderTy<Self::Primitives>) -> EvmEnvFor<Self>;
+
+    /// Returns the configured [`EvmEnv`] for `parent + 1` block.
+    ///
+    /// This is intended for usage in block building after the merge and requires additional
+    /// attributes that can't be derived from the parent block: attributes that are determined by
+    /// the CL, such as the timestamp, suggested fee recipient, and randomness value.
+    fn next_evm_env(
+        &self,
+        parent: &HeaderTy<Self::Primitives>,
+        attributes: &Self::NextBlockEnvCtx,
+    ) -> Result<EvmEnvFor<Self>, Self::Error>;
+
+    /// Returns the configured [`BlockExecutorFactory::ExecutionCtx`] for a given block.
+    fn context_for_block<'a>(
+        &self,
+        block: &'a SealedBlock<BlockTy<Self::Primitives>>,
+    ) -> ExecutionCtxFor<'a, Self>;
+
+    /// Returns the configured [`BlockExecutorFactory::ExecutionCtx`] for `parent + 1`
+    /// block.
+    fn context_for_next_block(
+        &self,
+        parent: &SealedHeader<HeaderTy<Self::Primitives>>,
+        attributes: Self::NextBlockEnvCtx,
+    ) -> ExecutionCtxFor<'_, Self>;
+
+    /// Returns a [`TxEnv`] from a transaction and [`Address`].
+    fn tx_env(&self, transaction: impl IntoTxEnv<TxEnvFor<Self>>) -> TxEnvFor<Self> {
+        transaction.into_tx_env()
+    }
 
     /// Provides a reference to [`EvmFactory`] implementation.
-    fn evm_factory(&self) -> &Self::EvmFactory;
+    fn evm_factory(&self) -> &EvmFactoryFor<Self> {
+        self.block_executor_factory().evm_factory()
+    }
 
     /// Returns a new EVM with the given database configured with the given environment settings,
     /// including the spec id and transaction environment.
     ///
     /// This will preserve any handler modifications
-    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv<Self::Spec>) -> EvmFor<Self, DB> {
+    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnvFor<Self>) -> EvmFor<Self, DB> {
         self.evm_factory().create_evm(db, evm_env)
     }
 
@@ -85,7 +177,11 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     /// # Caution
     ///
     /// This does not initialize the tx environment.
-    fn evm_for_block<DB: Database>(&self, db: DB, header: &Self::Header) -> EvmFor<Self, DB> {
+    fn evm_for_block<DB: Database>(
+        &self,
+        db: DB,
+        header: &HeaderTy<Self::Primitives>,
+    ) -> EvmFor<Self, DB> {
         let evm_env = self.evm_env(header);
         self.evm_with_env(db, evm_env)
     }
@@ -99,94 +195,81 @@ pub trait ConfigureEvm: ConfigureEvmEnv {
     fn evm_with_env_and_inspector<DB, I>(
         &self,
         db: DB,
-        evm_env: EvmEnv<Self::Spec>,
+        evm_env: EvmEnvFor<Self>,
         inspector: I,
     ) -> EvmFor<Self, DB, I>
     where
         DB: Database,
-        I: InspectorFor<DB, Self>,
+        I: InspectorFor<Self, DB>,
     {
         self.evm_factory().create_evm_with_inspector(db, evm_env, inspector)
     }
-}
 
-impl<'b, T> ConfigureEvm for &'b T
-where
-    T: ConfigureEvm,
-    &'b T: ConfigureEvmEnv<Header = T::Header, TxEnv = T::TxEnv, Spec = T::Spec>,
-{
-    type EvmFactory = T::EvmFactory;
-
-    fn evm_factory(&self) -> &Self::EvmFactory {
-        (*self).evm_factory()
-    }
-
-    fn evm_for_block<DB: Database>(&self, db: DB, header: &Self::Header) -> EvmFor<Self, DB> {
-        (*self).evm_for_block(db, header)
-    }
-
-    fn evm_with_env<DB: Database>(&self, db: DB, evm_env: EvmEnv<Self::Spec>) -> EvmFor<Self, DB> {
-        (*self).evm_with_env(db, evm_env)
-    }
-
-    fn evm_with_env_and_inspector<DB, I>(
-        &self,
-        db: DB,
-        evm_env: EvmEnv<Self::Spec>,
-        inspector: I,
-    ) -> EvmFor<Self, DB, I>
+    /// Creates a strategy with given EVM and execution context.
+    fn create_executor<'a, DB, I>(
+        &'a self,
+        evm: EvmFor<Self, &'a mut State<DB>, I>,
+        ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
+    ) -> impl BlockExecutorFor<'a, Self::BlockExecutorFactory, DB, I>
     where
         DB: Database,
-        I: InspectorFor<DB, Self>,
+        I: InspectorFor<Self, &'a mut State<DB>> + 'a,
     {
-        (*self).evm_with_env_and_inspector(db, evm_env, inspector)
-    }
-}
-
-/// This represents the set of methods used to configure the EVM's environment before block
-/// execution.
-///
-/// Default trait method  implementation is done w.r.t. L1.
-#[auto_impl::auto_impl(&, Arc)]
-pub trait ConfigureEvmEnv: Send + Sync + Unpin + Clone {
-    /// The header type used by the EVM.
-    type Header: BlockHeader;
-
-    /// The transaction type.
-    type Transaction: SignedTransaction;
-
-    /// Transaction environment used by EVM.
-    type TxEnv: TransactionEnv + FromRecoveredTx<Self::Transaction> + IntoTxEnv<Self::TxEnv>;
-
-    /// The error type that is returned by [`Self::next_evm_env`].
-    type Error: core::error::Error + Send + Sync + 'static;
-
-    /// Identifier of the EVM specification.
-    type Spec: Debug + Copy + Send + Sync + 'static;
-
-    /// Context required for configuring next block environment.
-    ///
-    /// Contains values that can't be derived from the parent block.
-    type NextBlockEnvCtx: Debug + Clone;
-
-    /// Returns a [`TxEnv`] from a transaction and [`Address`].
-    fn tx_env(&self, transaction: impl IntoTxEnv<Self::TxEnv>) -> Self::TxEnv {
-        transaction.into_tx_env()
+        self.block_executor_factory().create_executor(evm, ctx)
     }
 
-    /// Creates a new [`EvmEnv`] for the given header.
-    fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec>;
+    /// Creates a strategy for execution of a given block.
+    fn executor_for_block<'a, DB: Database>(
+        &'a self,
+        db: &'a mut State<DB>,
+        block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
+    ) -> impl BlockExecutorFor<'a, Self::BlockExecutorFactory, DB> {
+        let evm = self.evm_for_block(db, block.header());
+        let ctx = self.context_for_block(block);
+        self.create_executor(evm, ctx)
+    }
 
-    /// Returns the configured [`EvmEnv`] for `parent + 1` block.
+    /// Creates a [`BlockBuilder`]. Should be used when building a new block.
     ///
-    /// This is intended for usage in block building after the merge and requires additional
-    /// attributes that can't be derived from the parent block: attributes that are determined by
-    /// the CL, such as the timestamp, suggested fee recipient, and randomness value.
-    fn next_evm_env(
-        &self,
-        parent: &Self::Header,
-        attributes: &Self::NextBlockEnvCtx,
-    ) -> Result<EvmEnv<Self::Spec>, Self::Error>;
+    /// Block builder wraps an inner [`alloy_evm::block::BlockExecutor`] and has a similar
+    /// interface. Builder collects all of the executed transactions, and once
+    /// [`BlockBuilder::finish`] is called, it invokes the configured [`BlockAssembler`] to
+    /// create a block.
+    fn create_block_builder<'a, DB, I>(
+        &'a self,
+        evm: EvmFor<Self, &'a mut State<DB>, I>,
+        parent: &'a SealedHeader<HeaderTy<Self::Primitives>>,
+        ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
+    ) -> impl BlockBuilder<
+        Primitives = Self::Primitives,
+        Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, DB, I>,
+    >
+    where
+        DB: Database,
+        I: InspectorFor<Self, &'a mut State<DB>> + 'a,
+    {
+        BasicBlockBuilder {
+            executor: self.create_executor(evm, ctx.clone()),
+            ctx,
+            assembler: self.block_assembler(),
+            parent,
+            transactions: Vec::new(),
+        }
+    }
+
+    /// Creates a [`BlockBuilder`] for building of a new block. This is a helper to invoke
+    /// [`ConfigureEvmEnv::create_block_builder`].
+    fn builder_for_next_block<'a, DB: Database>(
+        &'a self,
+        db: &'a mut State<DB>,
+        parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
+        attributes: Self::NextBlockEnvCtx,
+    ) -> Result<impl BlockBuilder<Primitives = Self::Primitives>, Self::Error> {
+        let evm_env = self.next_evm_env(parent, &attributes)?;
+        let evm = self.evm_with_env(db, evm_env);
+        let ctx = self.context_for_next_block(parent, attributes);
+        Ok(self.create_block_builder(evm, parent, ctx))
+    }
 }
 
 /// Represents additional attributes required to configure the next block.

--- a/crates/node/api/src/lib.rs
+++ b/crates/node/api/src/lib.rs
@@ -21,7 +21,7 @@ pub use reth_payload_builder_primitives as payload_builder;
 pub use reth_payload_builder_primitives::*;
 
 /// Traits and helper types used to abstract over EVM methods and types.
-pub use reth_evm::{ConfigureEvmEnv, NextBlockEnvAttributes};
+pub use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
 
 pub mod node;
 pub use node::*;

--- a/crates/node/api/src/lib.rs
+++ b/crates/node/api/src/lib.rs
@@ -21,7 +21,7 @@ pub use reth_payload_builder_primitives as payload_builder;
 pub use reth_payload_builder_primitives::*;
 
 /// Traits and helper types used to abstract over EVM methods and types.
-pub use reth_evm::{ConfigureEvm, ConfigureEvmEnv, NextBlockEnvAttributes};
+pub use reth_evm::{ConfigureEvmEnv, NextBlockEnvAttributes};
 
 pub mod node;
 pub use node::*;

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -6,7 +6,7 @@ use reth_basic_payload_builder::PayloadBuilder;
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
 use reth_engine_primitives::{BeaconConsensusEngineEvent, BeaconConsensusEngineHandle};
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
 use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine, TxTy};
@@ -68,7 +68,7 @@ pub trait FullNodeComponents: FullNodeTypes + Clone + 'static {
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvmEnv<Primitives = <Self::Types as NodeTypes>::Primitives>;
+    type Evm: ConfigureEvm<Primitives = <Self::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <Self::Types as NodeTypes>::Primitives>;

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -6,7 +6,7 @@ use reth_basic_payload_builder::PayloadBuilder;
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
 use reth_engine_primitives::{BeaconConsensusEngineEvent, BeaconConsensusEngineHandle};
-use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
 use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter, NodeTypesWithEngine, TxTy};
@@ -68,7 +68,7 @@ pub trait FullNodeComponents: FullNodeTypes + Clone + 'static {
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: BlockExecutionStrategyFactory<Primitives = <Self::Types as NodeTypes>::Primitives>;
+    type Evm: ConfigureEvmEnv<Primitives = <Self::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <Self::Types as NodeTypes>::Primitives>;

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -5,10 +5,10 @@ use crate::{
         Components, ConsensusBuilder, ExecutorBuilder, NetworkBuilder, NodeComponents,
         PayloadServiceBuilder, PoolBuilder,
     },
-    BuilderContext, FullNodeTypes,
+    BuilderContext, ConfigureEvmEnv, FullNodeTypes,
 };
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
+use reth_evm::execute::BlockExecutorProvider;
 use reth_network::NetworkPrimitives;
 use reth_node_api::{BlockTy, BodyTy, HeaderTy, PrimitivesTy, TxTy};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -402,7 +402,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static,
+    EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     Cons:
         FullConsensus<PrimitivesTy<Node::Types>, Error = ConsensusError> + Clone + Unpin + 'static,

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -5,7 +5,7 @@ use crate::{
         Components, ConsensusBuilder, ExecutorBuilder, NetworkBuilder, NodeComponents,
         PayloadServiceBuilder, PoolBuilder,
     },
-    BuilderContext, ConfigureEvmEnv, FullNodeTypes,
+    BuilderContext, ConfigureEvm, FullNodeTypes,
 };
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_evm::execute::BlockExecutorProvider;
@@ -402,7 +402,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static,
+    EVM: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     Cons:
         FullConsensus<PrimitivesTy<Node::Types>, Error = ConsensusError> + Clone + Unpin + 'static,

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -1,5 +1,5 @@
 //! EVM component for the node builder.
-use crate::{BuilderContext, ConfigureEvmEnv, FullNodeTypes};
+use crate::{BuilderContext, ConfigureEvm, FullNodeTypes};
 use reth_evm::execute::BlockExecutorProvider;
 use reth_node_api::PrimitivesTy;
 use std::future::Future;
@@ -9,7 +9,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
     /// The EVM config to use.
     ///
     /// This provides the node with the necessary configuration to configure an EVM.
-    type EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static;
+    type EVM: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + 'static;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>;
@@ -24,7 +24,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
 impl<Node, F, Fut, EVM, Executor> ExecutorBuilder<Node> for F
 where
     Node: FullNodeTypes,
-    EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static,
+    EVM: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<(EVM, Executor)>> + Send,

--- a/crates/node/builder/src/components/execute.rs
+++ b/crates/node/builder/src/components/execute.rs
@@ -1,6 +1,6 @@
 //! EVM component for the node builder.
-use crate::{BuilderContext, FullNodeTypes};
-use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
+use crate::{BuilderContext, ConfigureEvmEnv, FullNodeTypes};
+use reth_evm::execute::BlockExecutorProvider;
 use reth_node_api::PrimitivesTy;
 use std::future::Future;
 
@@ -9,7 +9,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
     /// The EVM config to use.
     ///
     /// This provides the node with the necessary configuration to configure an EVM.
-    type EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static;
+    type EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>;
@@ -24,7 +24,7 @@ pub trait ExecutorBuilder<Node: FullNodeTypes>: Send {
 impl<Node, F, Fut, EVM, Executor> ExecutorBuilder<Node> for F
 where
     Node: FullNodeTypes,
-    EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static,
+    EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     F: FnOnce(&BuilderContext<Node>) -> Fut + Send,
     Fut: Future<Output = eyre::Result<(EVM, Executor)>> + Send,

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -23,7 +23,7 @@ pub use pool::*;
 use reth_network_p2p::BlockClient;
 use reth_payload_builder::PayloadBuilderHandle;
 
-use crate::{ConfigureEvmEnv, FullNodeTypes};
+use crate::{ConfigureEvm, FullNodeTypes};
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_evm::execute::BlockExecutorProvider;
 use reth_network::{NetworkHandle, NetworkPrimitives};
@@ -43,7 +43,7 @@ pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'stati
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<T::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: ConfigureEvmEnv<Primitives = <T::Types as NodeTypes>::Primitives>;
+    type Evm: ConfigureEvm<Primitives = <T::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <T::Types as NodeTypes>::Primitives>;
@@ -110,7 +110,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static,
+    EVM: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     Cons:
         FullConsensus<PrimitivesTy<Node::Types>, Error = ConsensusError> + Clone + Unpin + 'static,
@@ -153,7 +153,7 @@ where
     N: NetworkPrimitives,
     Node: FullNodeTypes,
     Pool: TransactionPool,
-    EVM: ConfigureEvmEnv,
+    EVM: ConfigureEvm,
     Executor: BlockExecutorProvider,
     Cons: Clone,
 {

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -23,9 +23,9 @@ pub use pool::*;
 use reth_network_p2p::BlockClient;
 use reth_payload_builder::PayloadBuilderHandle;
 
-use crate::{ConfigureEvm, FullNodeTypes};
+use crate::{ConfigureEvmEnv, FullNodeTypes};
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::execute::{BlockExecutionStrategyFactory, BlockExecutorProvider};
+use reth_evm::execute::BlockExecutorProvider;
 use reth_network::{NetworkHandle, NetworkPrimitives};
 use reth_network_api::FullNetwork;
 use reth_node_api::{
@@ -43,7 +43,7 @@ pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'stati
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<T::Types>>> + Unpin;
 
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: BlockExecutionStrategyFactory<Primitives = <T::Types as NodeTypes>::Primitives>;
+    type Evm: ConfigureEvmEnv<Primitives = <T::Types as NodeTypes>::Primitives>;
 
     /// The type that knows how to execute blocks.
     type Executor: BlockExecutorProvider<Primitives = <T::Types as NodeTypes>::Primitives>;
@@ -110,7 +110,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    EVM: BlockExecutionStrategyFactory<Primitives = PrimitivesTy<Node::Types>> + 'static,
+    EVM: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>> + 'static,
     Executor: BlockExecutorProvider<Primitives = PrimitivesTy<Node::Types>>,
     Cons:
         FullConsensus<PrimitivesTy<Node::Types>, Error = ConsensusError> + Clone + Unpin + 'static,
@@ -153,7 +153,7 @@ where
     N: NetworkPrimitives,
     Node: FullNodeTypes,
     Pool: TransactionPool,
-    EVM: ConfigureEvm,
+    EVM: ConfigureEvmEnv,
     Executor: BlockExecutorProvider,
     Cons: Clone,
 {

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -22,7 +22,7 @@ use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
 use op_revm::{OpSpecId, OpTransaction};
 use reth_chainspec::EthChainSpec;
-use reth_evm::{ConfigureEvmEnv, EvmEnv};
+use reth_evm::{ConfigureEvm, EvmEnv};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::next_block_base_fee;
 use reth_optimism_forks::OpHardforks;
@@ -97,7 +97,7 @@ impl<ChainSpec, N: NodePrimitives, R> OpEvmConfig<ChainSpec, N, R> {
     }
 }
 
-impl<ChainSpec, N, R> ConfigureEvmEnv for OpEvmConfig<ChainSpec, N, R>
+impl<ChainSpec, N, R> ConfigureEvm for OpEvmConfig<ChainSpec, N, R>
 where
     ChainSpec: EthChainSpec + OpHardforks,
     N: NodePrimitives<

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -11,20 +11,23 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{BlockHeader, Header};
 use alloy_evm::FromRecoveredTx;
-use alloy_op_evm::{OpBlockExecutorFactory, OpEvmFactory};
+use alloy_op_evm::{
+    block::receipt_builder::OpReceiptBuilder, OpBlockExecutionCtx, OpBlockExecutorFactory,
+    OpEvmFactory,
+};
 use alloy_primitives::U256;
 use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
 use op_revm::{OpSpecId, OpTransaction};
 use reth_chainspec::EthChainSpec;
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv, EvmEnv};
+use reth_evm::{ConfigureEvmEnv, EvmEnv};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::next_block_base_fee;
 use reth_optimism_forks::OpHardforks;
-use reth_optimism_primitives::OpPrimitives;
-use reth_primitives_traits::NodePrimitives;
+use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
+use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader, SignedTransaction};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
     context_interface::block::BlobExcessGasAndPrice,
@@ -97,18 +100,24 @@ impl<ChainSpec, N: NodePrimitives, R> OpEvmConfig<ChainSpec, N, R> {
 impl<ChainSpec, N, R> ConfigureEvmEnv for OpEvmConfig<ChainSpec, N, R>
 where
     ChainSpec: EthChainSpec + OpHardforks,
-    N: NodePrimitives,
+    N: NodePrimitives<
+        Receipt = R::Receipt,
+        SignedTx = R::Transaction,
+        BlockHeader = Header,
+        BlockBody = alloy_consensus::BlockBody<R::Transaction>,
+        Block = alloy_consensus::Block<R::Transaction>,
+    >,
     OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx>,
-    Self: Send + Sync + Unpin + Clone,
+    R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
+    Self: Send + Sync + Unpin + Clone + 'static,
 {
-    type Header = N::BlockHeader;
-    type Transaction = N::SignedTx;
+    type Primitives = N;
     type Error = EIP1559ParamError;
-    type TxEnv = OpTransaction<TxEnv>;
-    type Spec = OpSpecId;
     type NextBlockEnvCtx = OpNextBlockEnvAttributes;
+    type BlockExecutorFactory = OpBlockExecutorFactory<R, Arc<ChainSpec>>;
+    type BlockAssembler = OpBlockAssembler<ChainSpec>;
 
-    fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec> {
+    fn evm_env(&self, header: &Header) -> EvmEnv<OpSpecId> {
         let spec = config::revm_spec(self.chain_spec(), header);
 
         let cfg_env = CfgEnv::new().with_chain_id(self.chain_spec().chain().id()).with_spec(spec);
@@ -140,9 +149,9 @@ where
 
     fn next_evm_env(
         &self,
-        parent: &Self::Header,
+        parent: &Header,
         attributes: &Self::NextBlockEnvCtx,
-    ) -> Result<EvmEnv<Self::Spec>, Self::Error> {
+    ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
         // ensure we're not missing any timestamp based hardforks
         let spec_id = revm_spec_by_timestamp_after_bedrock(self.chain_spec(), attributes.timestamp);
 
@@ -174,22 +183,35 @@ where
 
         Ok(EvmEnv { cfg_env, block_env })
     }
-}
 
-impl<ChainSpec, N, R> ConfigureEvm for OpEvmConfig<ChainSpec, N, R>
-where
-    ChainSpec: EthChainSpec + OpHardforks,
-    N: NodePrimitives,
-    OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx>,
-    Self: Send + Sync + Unpin + Clone,
-{
-    type EvmFactory = OpEvmFactory;
+    fn block_executor_factory(&self) -> &Self::BlockExecutorFactory {
+        &self.executor_factory
+    }
 
-    fn evm_factory(&self) -> &Self::EvmFactory {
-        self.executor_factory.evm_factory()
+    fn block_assembler(&self) -> &Self::BlockAssembler {
+        &self.block_assembler
+    }
+
+    fn context_for_block(&self, block: &'_ SealedBlock<N::Block>) -> OpBlockExecutionCtx {
+        OpBlockExecutionCtx {
+            parent_hash: block.header().parent_hash(),
+            parent_beacon_block_root: block.header().parent_beacon_block_root(),
+            extra_data: block.header().extra_data().clone(),
+        }
+    }
+
+    fn context_for_next_block(
+        &self,
+        parent: &SealedHeader<N::BlockHeader>,
+        attributes: Self::NextBlockEnvCtx,
+    ) -> OpBlockExecutionCtx {
+        OpBlockExecutionCtx {
+            parent_hash: parent.hash(),
+            parent_beacon_block_root: attributes.parent_beacon_block_root,
+            extra_data: attributes.extra_data,
+        }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -8,9 +8,7 @@ use crate::{
 };
 use op_alloy_consensus::OpPooledTransaction;
 use reth_chainspec::{EthChainSpec, Hardforks};
-use reth_evm::{
-    execute::BasicBlockExecutorProvider, ConfigureEvm, ConfigureEvmEnv, ConfigureEvmFor,
-};
+use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvmEnv, EvmFactory, EvmFactoryFor};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, KeyHasherTy, NodeAddOns, NodePrimitives, PrimitivesTy, TxTy,
@@ -279,13 +277,11 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Evm: ConfigureEvmEnv<
-            TxEnv = op_revm::OpTransaction<TxEnv>,
-            NextBlockEnvCtx = OpNextBlockEnvAttributes,
-        >,
+        Evm: ConfigureEvmEnv<NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     >,
     OpEthApiError: FromEvmError<N::Evm>,
-    <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: MaybeConditionalTransaction,
+    <N::Pool as TransactionPool>::Transaction: MaybeConditionalTransaction,
+    EvmFactoryFor<N::Evm>: EvmFactory<Tx = op_revm::OpTransaction<TxEnv>>,
 {
     type Handle = RpcHandle<N, OpEthApi<N>>;
 
@@ -353,13 +349,11 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Evm: ConfigureEvm<
-            TxEnv = op_revm::OpTransaction<TxEnv>,
-            NextBlockEnvCtx = OpNextBlockEnvAttributes,
-        >,
+        Evm: ConfigureEvmEnv<NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     >,
     OpEthApiError: FromEvmError<N::Evm>,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: MaybeConditionalTransaction,
+    EvmFactoryFor<N::Evm>: EvmFactory<Tx = op_revm::OpTransaction<TxEnv>>,
 {
     type EthApi = OpEthApi<N>;
 
@@ -658,7 +652,7 @@ impl<Txs> OpPayloadBuilder<Txs> {
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,
-        Evm: ConfigureEvmFor<PrimitivesTy<Node::Types>>,
+        Evm: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>>,
         Txs: OpPayloadTransactions<Pool::Transaction>,
     {
         let payload_builder = reth_optimism_payload_builder::OpPayloadBuilder::with_builder_config(

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use op_alloy_consensus::OpPooledTransaction;
 use reth_chainspec::{EthChainSpec, Hardforks};
-use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvmEnv, EvmFactory, EvmFactoryFor};
+use reth_evm::{execute::BasicBlockExecutorProvider, ConfigureEvm, EvmFactory, EvmFactoryFor};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, KeyHasherTy, NodeAddOns, NodePrimitives, PrimitivesTy, TxTy,
@@ -277,7 +277,7 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Evm: ConfigureEvmEnv<NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+        Evm: ConfigureEvm<NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     >,
     OpEthApiError: FromEvmError<N::Evm>,
     <N::Pool as TransactionPool>::Transaction: MaybeConditionalTransaction,
@@ -349,7 +349,7 @@ where
             Storage = OpStorage,
             Engine = OpEngineTypes,
         >,
-        Evm: ConfigureEvmEnv<NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+        Evm: ConfigureEvm<NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     >,
     OpEthApiError: FromEvmError<N::Evm>,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: MaybeConditionalTransaction,
@@ -652,7 +652,7 @@ impl<Txs> OpPayloadBuilder<Txs> {
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,
-        Evm: ConfigureEvmEnv<Primitives = PrimitivesTy<Node::Types>>,
+        Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>>,
         Txs: OpPayloadTransactions<Pool::Transaction>,
     {
         let payload_builder = reth_optimism_payload_builder::OpPayloadBuilder::with_builder_config(

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -17,10 +17,9 @@ use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::{
     execute::{
-        BlockBuilder, BlockBuilderOutcome, BlockExecutionError, BlockExecutionStrategyFactory,
-        BlockExecutor, BlockValidationError,
+        BlockBuilder, BlockBuilderOutcome, BlockExecutionError, BlockExecutor, BlockValidationError,
     },
-    Database, Evm,
+    ConfigureEvmEnv, Database, Evm,
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
@@ -125,7 +124,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
     N: OpPayloadPrimitives,
-    Evm: BlockExecutionStrategyFactory<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
 {
     /// Constructs an Optimism payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
@@ -200,7 +199,7 @@ where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
     N: OpPayloadPrimitives,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
-    Evm: BlockExecutionStrategyFactory<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     Txs: OpPayloadTransactions<Pool::Transaction>,
 {
     type Attributes = OpPayloadBuilderAttributes<N::SignedTx>;
@@ -278,10 +277,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx: OpPayloadBuilderCtx<EvmConfig, ChainSpec>,
     ) -> Result<BuildOutcomeKind<OpBuiltPayload<N>>, PayloadBuilderError>
     where
-        EvmConfig: BlockExecutionStrategyFactory<
-            Primitives = N,
-            NextBlockEnvCtx = OpNextBlockEnvAttributes,
-        >,
+        EvmConfig: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
@@ -362,10 +358,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx: &OpPayloadBuilderCtx<Evm, ChainSpec>,
     ) -> Result<ExecutionWitness, PayloadBuilderError>
     where
-        Evm: BlockExecutionStrategyFactory<
-            Primitives = N,
-            NextBlockEnvCtx = OpNextBlockEnvAttributes,
-        >,
+        Evm: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
@@ -467,7 +460,7 @@ impl ExecutionInfo {
 
 /// Container type that holds all necessities to build a new payload.
 #[derive(derive_more::Debug)]
-pub struct OpPayloadBuilderCtx<Evm: BlockExecutionStrategyFactory, ChainSpec> {
+pub struct OpPayloadBuilderCtx<Evm: ConfigureEvmEnv, ChainSpec> {
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: Evm,
     /// The DA config for the payload builder
@@ -484,7 +477,7 @@ pub struct OpPayloadBuilderCtx<Evm: BlockExecutionStrategyFactory, ChainSpec> {
 
 impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
 where
-    Evm: BlockExecutionStrategyFactory<
+    Evm: ConfigureEvmEnv<
         Primitives: OpPayloadPrimitives,
         NextBlockEnvCtx = OpNextBlockEnvAttributes,
     >,
@@ -564,7 +557,7 @@ where
 
 impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
 where
-    Evm: BlockExecutionStrategyFactory<
+    Evm: ConfigureEvmEnv<
         Primitives: OpPayloadPrimitives,
         NextBlockEnvCtx = OpNextBlockEnvAttributes,
     >,

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -19,7 +19,7 @@ use reth_evm::{
     execute::{
         BlockBuilder, BlockBuilderOutcome, BlockExecutionError, BlockExecutor, BlockValidationError,
     },
-    ConfigureEvmEnv, Database, Evm,
+    ConfigureEvm, Database, Evm,
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
@@ -124,7 +124,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
     N: OpPayloadPrimitives,
-    Evm: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
 {
     /// Constructs an Optimism payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
@@ -199,7 +199,7 @@ where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
     N: OpPayloadPrimitives,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
-    Evm: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     Txs: OpPayloadTransactions<Pool::Transaction>,
 {
     type Attributes = OpPayloadBuilderAttributes<N::SignedTx>;
@@ -277,7 +277,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx: OpPayloadBuilderCtx<EvmConfig, ChainSpec>,
     ) -> Result<BuildOutcomeKind<OpBuiltPayload<N>>, PayloadBuilderError>
     where
-        EvmConfig: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+        EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
@@ -358,7 +358,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx: &OpPayloadBuilderCtx<Evm, ChainSpec>,
     ) -> Result<ExecutionWitness, PayloadBuilderError>
     where
-        Evm: ConfigureEvmEnv<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+        Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
@@ -460,7 +460,7 @@ impl ExecutionInfo {
 
 /// Container type that holds all necessities to build a new payload.
 #[derive(derive_more::Debug)]
-pub struct OpPayloadBuilderCtx<Evm: ConfigureEvmEnv, ChainSpec> {
+pub struct OpPayloadBuilderCtx<Evm: ConfigureEvm, ChainSpec> {
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: Evm,
     /// The DA config for the payload builder
@@ -477,10 +477,7 @@ pub struct OpPayloadBuilderCtx<Evm: ConfigureEvmEnv, ChainSpec> {
 
 impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
 where
-    Evm: ConfigureEvmEnv<
-        Primitives: OpPayloadPrimitives,
-        NextBlockEnvCtx = OpNextBlockEnvAttributes,
-    >,
+    Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     ChainSpec: EthChainSpec + OpHardforks,
 {
     /// Returns the parent block the payload will be build on.
@@ -557,10 +554,7 @@ where
 
 impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
 where
-    Evm: ConfigureEvmEnv<
-        Primitives: OpPayloadPrimitives,
-        NextBlockEnvCtx = OpNextBlockEnvAttributes,
-    >,
+    Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     ChainSpec: EthChainSpec + OpHardforks,
 {
     /// Executes all sequencer transactions that are included in the payload attributes.

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -4,8 +4,9 @@ use alloy_consensus::TxType;
 use alloy_primitives::{Bytes, TxKind, U256};
 use alloy_rpc_types_eth::transaction::TransactionRequest;
 use op_revm::OpTransaction;
-use reth_evm::{ConfigureEvm, EvmEnv, SpecFor};
-use reth_provider::ProviderHeader;
+use reth_evm::{execute::BlockExecutorFactory, ConfigureEvmEnv, EvmEnv, EvmFactory, SpecFor};
+use reth_node_api::NodePrimitives;
+use reth_provider::{ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadBlock, LoadState, SpawnBlocking},
     FromEthApiError, FromEvmError, FullEthApiTypes, IntoEthApiError,
@@ -31,9 +32,14 @@ where
 impl<N> Call for OpEthApi<N>
 where
     Self: LoadState<
-            Evm: ConfigureEvm<
-                Header = ProviderHeader<Self::Provider>,
-                TxEnv = OpTransaction<TxEnv>,
+            Evm: ConfigureEvmEnv<
+                Primitives: NodePrimitives<
+                    BlockHeader = ProviderHeader<Self::Provider>,
+                    SignedTx = ProviderTx<Self::Provider>,
+                >,
+                BlockExecutorFactory: BlockExecutorFactory<
+                    EvmFactory: EvmFactory<Tx = OpTransaction<TxEnv>>,
+                >,
             >,
             Error: FromEvmError<Self::Evm>,
         > + SpawnBlocking,

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -4,7 +4,7 @@ use alloy_consensus::TxType;
 use alloy_primitives::{Bytes, TxKind, U256};
 use alloy_rpc_types_eth::transaction::TransactionRequest;
 use op_revm::OpTransaction;
-use reth_evm::{execute::BlockExecutorFactory, ConfigureEvmEnv, EvmEnv, EvmFactory, SpecFor};
+use reth_evm::{execute::BlockExecutorFactory, ConfigureEvm, EvmEnv, EvmFactory, SpecFor};
 use reth_node_api::NodePrimitives;
 use reth_provider::{ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::{
@@ -32,7 +32,7 @@ where
 impl<N> Call for OpEthApi<N>
 where
     Self: LoadState<
-            Evm: ConfigureEvmEnv<
+            Evm: ConfigureEvm<
                 Primitives: NodePrimitives<
                     BlockHeader = ProviderHeader<Self::Provider>,
                     SignedTx = ProviderTx<Self::Provider>,

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -13,7 +13,7 @@ pub use receipt::{OpReceiptBuilder, OpReceiptFieldsBuilder};
 use alloy_primitives::U256;
 use op_alloy_network::Optimism;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_evm::ConfigureEvmEnv;
+use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
 use reth_node_api::{BlockTy, FullNodeComponents, NodePrimitives, ReceiptTy};
 use reth_node_builder::rpc::EthApiBuilder;
@@ -249,7 +249,7 @@ impl<N> Trace for OpEthApi<N>
 where
     Self: RpcNodeCore<Provider: BlockReader>
         + LoadState<
-            Evm: ConfigureEvmEnv<
+            Evm: ConfigureEvm<
                 Primitives: NodePrimitives<
                     BlockHeader = ProviderHeader<Self::Provider>,
                     SignedTx = ProviderTx<Self::Provider>,

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -13,9 +13,9 @@ pub use receipt::{OpReceiptBuilder, OpReceiptFieldsBuilder};
 use alloy_primitives::U256;
 use op_alloy_network::Optimism;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmEnv;
 use reth_network_api::NetworkInfo;
-use reth_node_api::{BlockTy, FullNodeComponents, ReceiptTy};
+use reth_node_api::{BlockTy, FullNodeComponents, NodePrimitives, ReceiptTy};
 use reth_node_builder::rpc::EthApiBuilder;
 use reth_optimism_primitives::OpPrimitives;
 use reth_provider::{
@@ -249,9 +249,11 @@ impl<N> Trace for OpEthApi<N>
 where
     Self: RpcNodeCore<Provider: BlockReader>
         + LoadState<
-            Evm: ConfigureEvm<
-                Header = ProviderHeader<Self::Provider>,
-                Transaction = ProviderTx<Self::Provider>,
+            Evm: ConfigureEvmEnv<
+                Primitives: NodePrimitives<
+                    BlockHeader = ProviderHeader<Self::Provider>,
+                    SignedTx = ProviderTx<Self::Provider>,
+                >,
             >,
             Error: FromEvmError<Self::Evm>,
         >,

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -5,7 +5,7 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use reth_chainspec::EthChainSpec;
-use reth_evm::execute::BlockExecutionStrategyFactory;
+use reth_evm::ConfigureEvmEnv;
 use reth_node_api::NodePrimitives;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_forks::OpHardforks;
@@ -41,7 +41,7 @@ where
         > + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<N::Provider>>>,
-        Evm: BlockExecutionStrategyFactory<
+        Evm: ConfigureEvmEnv<
             Primitives: NodePrimitives<
                 SignedTx = ProviderTx<Self::Provider>,
                 BlockHeader = ProviderHeader<Self::Provider>,

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -5,7 +5,7 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use reth_chainspec::EthChainSpec;
-use reth_evm::ConfigureEvmEnv;
+use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_forks::OpHardforks;
@@ -41,7 +41,7 @@ where
         > + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<N::Provider>>>,
-        Evm: ConfigureEvmEnv<
+        Evm: ConfigureEvm<
             Primitives: NodePrimitives<
                 SignedTx = ProviderTx<Self::Provider>,
                 BlockHeader = ProviderHeader<Self::Provider>,
@@ -64,7 +64,7 @@ where
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
-    ) -> Result<<Self::Evm as reth_evm::ConfigureEvmEnv>::NextBlockEnvCtx, Self::Error> {
+    ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
         Ok(OpNextBlockEnvAttributes {
             timestamp: parent.timestamp().saturating_add(12),
             suggested_fee_recipient: parent.beneficiary(),

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee_core::{async_trait, RpcResult};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::ChainSpecProvider;
-use reth_evm::ConfigureEvmEnv;
+use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
@@ -41,7 +41,7 @@ impl<Pool, Provider, EvmConfig> OpDebugWitnessApi<Pool, Provider, EvmConfig> {
 
 impl<Pool, Provider, EvmConfig> OpDebugWitnessApi<Pool, Provider, EvmConfig>
 where
-    EvmConfig: ConfigureEvmEnv,
+    EvmConfig: ConfigureEvm,
     Provider: NodePrimitivesProvider + BlockReaderIdExt<Header = reth_primitives::Header>,
 {
     /// Fetches the parent header by hash.
@@ -68,10 +68,8 @@ where
         + ChainSpecProvider<ChainSpec = OpChainSpec>
         + Clone
         + 'static,
-    EvmConfig: ConfigureEvmEnv<
-            Primitives = Provider::Primitives,
-            NextBlockEnvCtx = OpNextBlockEnvAttributes,
-        > + 'static,
+    EvmConfig: ConfigureEvm<Primitives = Provider::Primitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>
+        + 'static,
 {
     async fn execute_payload(
         &self,

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee_core::{async_trait, RpcResult};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::ChainSpecProvider;
-use reth_evm::{execute::BlockExecutionStrategyFactory, ConfigureEvm};
+use reth_evm::ConfigureEvmEnv;
 use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
@@ -41,7 +41,7 @@ impl<Pool, Provider, EvmConfig> OpDebugWitnessApi<Pool, Provider, EvmConfig> {
 
 impl<Pool, Provider, EvmConfig> OpDebugWitnessApi<Pool, Provider, EvmConfig>
 where
-    EvmConfig: ConfigureEvm,
+    EvmConfig: ConfigureEvmEnv,
     Provider: NodePrimitivesProvider + BlockReaderIdExt<Header = reth_primitives::Header>,
 {
     /// Fetches the parent header by hash.
@@ -68,7 +68,7 @@ where
         + ChainSpecProvider<ChainSpec = OpChainSpec>
         + Clone
         + 'static,
-    EvmConfig: BlockExecutionStrategyFactory<
+    EvmConfig: ConfigureEvmEnv<
             Primitives = Provider::Primitives,
             NextBlockEnvCtx = OpNextBlockEnvAttributes,
         > + 'static,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -755,7 +755,7 @@ where
     /// use reth_evm::ConfigureEvm;
     /// use reth_evm_ethereum::execute::EthExecutorProvider;
     /// use reth_network_api::noop::NoopNetwork;
-    /// use reth_primitives::{Header, TransactionSigned};
+    /// use reth_primitives::{EthPrimitives, Header, TransactionSigned};
     /// use reth_provider::test_utils::{NoopProvider, TestCanonStateSubscriptions};
     /// use reth_rpc::EthApi;
     /// use reth_rpc_builder::RpcModuleBuilder;
@@ -765,7 +765,7 @@ where
     ///
     /// fn init<Evm>(evm: Evm)
     /// where
-    ///     Evm: ConfigureEvm<Header = Header, Transaction = TransactionSigned> + 'static,
+    ///     Evm: ConfigureEvm<Primitives = EthPrimitives> + 'static,
     /// {
     ///     let builder = RpcModuleBuilder::default()
     ///         .with_provider(NoopProvider::default())

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```
 //! use reth_consensus::{ConsensusError, FullConsensus};
 //! use reth_engine_primitives::PayloadValidator;
-//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
+//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
 //! use reth_evm_ethereum::EthEvmConfig;
 //! use reth_network_api::{NetworkInfo, Peers};
 //! use reth_primitives::{Header, PooledTransaction, TransactionSigned};
@@ -88,7 +88,7 @@
 //! ```
 //! use reth_consensus::{ConsensusError, FullConsensus};
 //! use reth_engine_primitives::PayloadValidator;
-//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
+//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
 //! use reth_evm_ethereum::EthEvmConfig;
 //! use reth_network_api::{NetworkInfo, Peers};
 //! use reth_primitives::{Header, PooledTransaction, TransactionSigned};
@@ -185,7 +185,7 @@ use jsonrpsee::{
 };
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives::NodePrimitives;
 use reth_provider::{
@@ -273,7 +273,7 @@ where
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+    EvmConfig: ConfigureEvmEnv<Primitives = N>,
     EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
     BlockExecutor: BlockExecutorProvider<Primitives = N>,
 {
@@ -693,7 +693,7 @@ where
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: ConfigureEvm<Header = N::BlockHeader, Transaction = N::SignedTx>,
+    EvmConfig: ConfigureEvmEnv<Primitives = N>,
     BlockExecutor: BlockExecutorProvider<Primitives = N>,
     Consensus: FullConsensus<N, Error = ConsensusError> + Clone + 'static,
 {
@@ -752,7 +752,7 @@ where
     /// ```no_run
     /// use reth_consensus::noop::NoopConsensus;
     /// use reth_engine_primitives::PayloadValidator;
-    /// use reth_evm::ConfigureEvm;
+    /// use reth_evm::ConfigureEvmEnv;
     /// use reth_evm_ethereum::execute::EthExecutorProvider;
     /// use reth_network_api::noop::NoopNetwork;
     /// use reth_primitives::{Header, TransactionSigned};
@@ -765,7 +765,7 @@ where
     ///
     /// fn init<Evm>(evm: Evm)
     /// where
-    ///     Evm: ConfigureEvm<Header = Header, Transaction = TransactionSigned> + 'static,
+    ///     Evm: ConfigureEvmEnv<Header = Header, Transaction = TransactionSigned> + 'static,
     /// {
     ///     let builder = RpcModuleBuilder::default()
     ///         .with_provider(NoopProvider::default())
@@ -988,7 +988,7 @@ where
         block_executor: BlockExecutor,
     ) -> Self
     where
-        EvmConfig: ConfigureEvm<Header = Provider::Header>,
+        EvmConfig: ConfigureEvmEnv<Primitives = N>,
     {
         let blocking_pool_guard = BlockingTaskGuard::new(config.eth.max_tracing_requests);
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```
 //! use reth_consensus::{ConsensusError, FullConsensus};
 //! use reth_engine_primitives::PayloadValidator;
-//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_evm_ethereum::EthEvmConfig;
 //! use reth_network_api::{NetworkInfo, Peers};
 //! use reth_primitives::{Header, PooledTransaction, TransactionSigned};
@@ -88,7 +88,7 @@
 //! ```
 //! use reth_consensus::{ConsensusError, FullConsensus};
 //! use reth_engine_primitives::PayloadValidator;
-//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+//! use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 //! use reth_evm_ethereum::EthEvmConfig;
 //! use reth_network_api::{NetworkInfo, Peers};
 //! use reth_primitives::{Header, PooledTransaction, TransactionSigned};
@@ -185,7 +185,7 @@ use jsonrpsee::{
 };
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::{execute::BlockExecutorProvider, ConfigureEvmEnv};
+use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives::NodePrimitives;
 use reth_provider::{
@@ -273,7 +273,7 @@ where
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: ConfigureEvmEnv<Primitives = N>,
+    EvmConfig: ConfigureEvm<Primitives = N>,
     EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
     BlockExecutor: BlockExecutorProvider<Primitives = N>,
 {
@@ -693,7 +693,7 @@ where
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     Tasks: TaskSpawner + Clone + 'static,
-    EvmConfig: ConfigureEvmEnv<Primitives = N>,
+    EvmConfig: ConfigureEvm<Primitives = N>,
     BlockExecutor: BlockExecutorProvider<Primitives = N>,
     Consensus: FullConsensus<N, Error = ConsensusError> + Clone + 'static,
 {
@@ -752,7 +752,7 @@ where
     /// ```no_run
     /// use reth_consensus::noop::NoopConsensus;
     /// use reth_engine_primitives::PayloadValidator;
-    /// use reth_evm::ConfigureEvmEnv;
+    /// use reth_evm::ConfigureEvm;
     /// use reth_evm_ethereum::execute::EthExecutorProvider;
     /// use reth_network_api::noop::NoopNetwork;
     /// use reth_primitives::{Header, TransactionSigned};
@@ -765,7 +765,7 @@ where
     ///
     /// fn init<Evm>(evm: Evm)
     /// where
-    ///     Evm: ConfigureEvmEnv<Header = Header, Transaction = TransactionSigned> + 'static,
+    ///     Evm: ConfigureEvm<Header = Header, Transaction = TransactionSigned> + 'static,
     /// {
     ///     let builder = RpcModuleBuilder::default()
     ///         .with_provider(NoopProvider::default())
@@ -988,7 +988,7 @@ where
         block_executor: BlockExecutor,
     ) -> Self
     where
-        EvmConfig: ConfigureEvmEnv<Primitives = N>,
+        EvmConfig: ConfigureEvm<Primitives = N>,
     {
         let blocking_pool_guard = BlockingTaskGuard::new(config.eth.max_tracing_requests);
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -17,7 +17,7 @@ use alloy_rpc_types_eth::{
 use futures::Future;
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
-    ConfigureEvmEnv, Evm, EvmEnv, EvmEnvFor, HaltReasonFor, InspectorFor, SpecFor, TransactionEnv,
+    ConfigureEvm, Evm, EvmEnv, EvmEnvFor, HaltReasonFor, InspectorFor, SpecFor, TransactionEnv,
     TxEnvFor,
 };
 use reth_node_api::{BlockBody, NodePrimitives};
@@ -432,7 +432,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 /// Executes code on state.
 pub trait Call:
     LoadState<
-        Evm: ConfigureEvmEnv<
+        Evm: ConfigureEvm<
             Primitives: NodePrimitives<
                 BlockHeader = ProviderHeader<Self::Provider>,
                 SignedTx = ProviderTx<Self::Provider>,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -17,13 +17,13 @@ use alloy_rpc_types_eth::{
 use futures::Future;
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
-    execute::BlockExecutionStrategyFactory, ConfigureEvm, ConfigureEvmEnv, Evm, EvmEnv,
-    HaltReasonFor, InspectorFor, SpecFor, TransactionEnv,
+    ConfigureEvmEnv, Evm, EvmEnv, EvmEnvFor, HaltReasonFor, InspectorFor, SpecFor, TransactionEnv,
+    TxEnvFor,
 };
-use reth_node_api::BlockBody;
+use reth_node_api::{BlockBody, NodePrimitives};
 use reth_primitives::{Recovered, SealedHeader};
 use reth_primitives_traits::SignedTransaction;
-use reth_provider::{BlockIdReader, ProviderHeader};
+use reth_provider::{BlockIdReader, ProviderHeader, ProviderTx};
 use reth_revm::{
     database::StateProviderDatabase,
     db::{CacheDB, State},
@@ -359,7 +359,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     /// [`BlockId`].
     fn create_access_list_with(
         &self,
-        mut evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
+        mut evm_env: EvmEnvFor<Self::Evm>,
         at: BlockId,
         mut request: TransactionRequest,
     ) -> Result<AccessListResult, Self::Error>
@@ -432,7 +432,12 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 /// Executes code on state.
 pub trait Call:
     LoadState<
-        Evm: ConfigureEvm<Header = ProviderHeader<Self::Provider>>,
+        Evm: ConfigureEvmEnv<
+            Primitives: NodePrimitives<
+                BlockHeader = ProviderHeader<Self::Provider>,
+                SignedTx = ProviderTx<Self::Provider>,
+            >,
+        >,
         Error: FromEvmError<Self::Evm>,
     > + SpawnBlocking
 {
@@ -459,13 +464,10 @@ pub trait Call:
     fn transact<DB>(
         &self,
         db: DB,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-        tx_env: <Self::Evm as ConfigureEvmEnv>::TxEnv,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
     ) -> Result<
-        (
-            ResultAndState<HaltReasonFor<Self::Evm>>,
-            (EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>, <Self::Evm as ConfigureEvmEnv>::TxEnv),
-        ),
+        (ResultAndState<HaltReasonFor<Self::Evm>>, (EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>)),
         Self::Error,
     >
     where
@@ -483,19 +485,16 @@ pub trait Call:
     fn transact_with_inspector<DB, I>(
         &self,
         db: DB,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-        tx_env: <Self::Evm as ConfigureEvmEnv>::TxEnv,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
         inspector: I,
     ) -> Result<
-        (
-            ResultAndState<HaltReasonFor<Self::Evm>>,
-            (EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>, <Self::Evm as ConfigureEvmEnv>::TxEnv),
-        ),
+        (ResultAndState<HaltReasonFor<Self::Evm>>, (EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>)),
         Self::Error,
     >
     where
         DB: Database<Error = ProviderError>,
-        I: InspectorFor<DB, Self::Evm>,
+        I: InspectorFor<Self::Evm, DB>,
     {
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env.clone(), inspector);
         let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
@@ -512,13 +511,7 @@ pub trait Call:
         overrides: EvmOverrides,
     ) -> impl Future<
         Output = Result<
-            (
-                ResultAndState<HaltReasonFor<Self::Evm>>,
-                (
-                    EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-                    <Self::Evm as ConfigureEvmEnv>::TxEnv,
-                ),
-            ),
+            (ResultAndState<HaltReasonFor<Self::Evm>>, (EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>)),
             Self::Error,
         >,
     > + Send
@@ -573,8 +566,8 @@ pub trait Call:
         Self: LoadPendingBlock,
         F: FnOnce(
                 StateCacheDbRefMutWrapper<'_, '_>,
-                EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-                <Self::Evm as ConfigureEvmEnv>::TxEnv,
+                EvmEnvFor<Self::Evm>,
+                TxEnvFor<Self::Evm>,
             ) -> Result<R, Self::Error>
             + Send
             + 'static,
@@ -663,14 +656,13 @@ pub trait Call:
     fn replay_transactions_until<'a, DB, I>(
         &self,
         db: &mut DB,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
+        evm_env: EvmEnvFor<Self::Evm>,
         transactions: I,
         target_tx_hash: B256,
     ) -> Result<usize, Self::Error>
     where
         DB: Database<Error = ProviderError> + DatabaseCommit,
-        I: IntoIterator<Item = Recovered<&'a <Self::Evm as ConfigureEvmEnv>::Transaction>>,
-        <Self::Evm as ConfigureEvmEnv>::Transaction: SignedTransaction,
+        I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
         let mut evm = self.evm_config().evm_with_env(db, evm_env);
         let mut index = 0;
@@ -696,7 +688,7 @@ pub trait Call:
         evm_env: &EvmEnv<SpecFor<Self::Evm>>,
         request: TransactionRequest,
         db: impl Database<Error: Into<EthApiError>>,
-    ) -> Result<<Self::Evm as ConfigureEvmEnv>::TxEnv, Self::Error>;
+    ) -> Result<TxEnvFor<Self::Evm>, Self::Error>;
 
     /// Prepares the [`EvmEnv`] for execution of calls.
     ///
@@ -714,14 +706,11 @@ pub trait Call:
     #[expect(clippy::type_complexity)]
     fn prepare_call_env<DB>(
         &self,
-        mut evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
+        mut evm_env: EvmEnvFor<Self::Evm>,
         mut request: TransactionRequest,
         db: &mut CacheDB<DB>,
         overrides: EvmOverrides,
-    ) -> Result<
-        (EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>, <Self::Evm as ConfigureEvmEnv>::TxEnv),
-        Self::Error,
-    >
+    ) -> Result<(EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>), Self::Error>
     where
         DB: DatabaseRef,
         EthApiError: From<<DB as DatabaseRef>::Error>,

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_eth::{state::StateOverride, transaction::TransactionRequest,
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_errors::ProviderError;
-use reth_evm::{ConfigureEvmEnv, Database, EvmEnv, TransactionEnv};
+use reth_evm::{Database, EvmEnvFor, TransactionEnv, TxEnvFor};
 use reth_provider::StateProvider;
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};
 use reth_rpc_eth_types::{
@@ -35,7 +35,7 @@ pub trait EstimateCall: Call {
     ///  - `nonce` is set to `None`
     fn estimate_gas_with<S>(
         &self,
-        mut evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
+        mut evm_env: EvmEnvFor<Self::Evm>,
         mut request: TransactionRequest,
         state: S,
         state_override: Option<StateOverride>,
@@ -287,8 +287,8 @@ pub trait EstimateCall: Call {
     fn map_out_of_gas_err<DB>(
         &self,
         env_gas_limit: u64,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-        mut tx_env: <Self::Evm as ConfigureEvmEnv>::TxEnv,
+        evm_env: EvmEnvFor<Self::Evm>,
+        mut tx_env: TxEnvFor<Self::Evm>,
         db: &mut DB,
     ) -> Self::Error
     where

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -10,8 +10,8 @@ use futures::Future;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError};
 use reth_evm::{
-    execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionStrategyFactory},
-    ConfigureEvmEnv, Evm,
+    execute::{BlockBuilder, BlockBuilderOutcome},
+    ConfigureEvmEnv, Evm, SpecFor,
 };
 use reth_node_api::NodePrimitives;
 use reth_primitives::{InvalidTransactionError, RecoveredBlock, SealedHeader};
@@ -45,7 +45,7 @@ pub trait LoadPendingBlock:
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
-        Evm: BlockExecutionStrategyFactory<
+        Evm: ConfigureEvmEnv<
             Primitives: NodePrimitives<
                 BlockHeader = ProviderHeader<Self::Provider>,
                 SignedTx = ProviderTx<Self::Provider>,
@@ -73,7 +73,7 @@ pub trait LoadPendingBlock:
         PendingBlockEnv<
             ProviderBlock<Self::Provider>,
             ProviderReceipt<Self::Provider>,
-            <Self::Evm as ConfigureEvmEnv>::Spec,
+            SpecFor<Self::Evm>,
         >,
         Self::Error,
     > {

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -11,7 +11,7 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError};
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
-    ConfigureEvmEnv, Evm, SpecFor,
+    ConfigureEvm, Evm, SpecFor,
 };
 use reth_node_api::NodePrimitives;
 use reth_primitives::{InvalidTransactionError, RecoveredBlock, SealedHeader};
@@ -45,7 +45,7 @@ pub trait LoadPendingBlock:
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
-        Evm: ConfigureEvmEnv<
+        Evm: ConfigureEvm<
             Primitives: NodePrimitives<
                 BlockHeader = ProviderHeader<Self::Provider>,
                 SignedTx = ProviderTx<Self::Provider>,
@@ -114,11 +114,11 @@ pub trait LoadPendingBlock:
         Ok(PendingBlockEnv::new(evm_env, PendingBlockEnvOrigin::DerivedFromLatest(latest)))
     }
 
-    /// Returns [`ConfigureEvmEnv::NextBlockEnvCtx`] for building a local pending block.
+    /// Returns [`ConfigureEvm::NextBlockEnvCtx`] for building a local pending block.
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
-    ) -> Result<<Self::Evm as ConfigureEvmEnv>::NextBlockEnvCtx, Self::Error>;
+    ) -> Result<<Self::Evm as ConfigureEvm>::NextBlockEnvCtx, Self::Error>;
 
     /// Returns the locally built pending block
     #[expect(clippy::type_complexity)]

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -10,7 +10,7 @@ use alloy_serde::JsonStorageKey;
 use futures::Future;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
-use reth_evm::{ConfigureEvmEnv, EvmEnvFor};
+use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_provider::{
     BlockIdReader, BlockNumReader, ChainSpecProvider, StateProvider, StateProviderBox,
     StateProviderFactory,

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -42,7 +42,7 @@ pub trait Trace:
     Error: FromEvmError<Self::Evm>,
 >
 {
-    /// Executes the [`EvmEnv`] against the given [Database] without committing state
+    /// Executes the [`reth_evm::EvmEnv`] against the given [Database] without committing state
     /// changes.
     #[expect(clippy::type_complexity)]
     fn inspect<DB, I>(
@@ -68,7 +68,7 @@ pub trait Trace:
     /// config.
     ///
     /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`EvmEnv`] was inspected.
+    /// the configured [`reth_evm::EvmEnv`] was inspected.
     ///
     /// Caution: this is blocking
     fn trace_at<F, R>(
@@ -100,7 +100,7 @@ pub trait Trace:
     /// config.
     ///
     /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`EvmEnv`] was inspected.
+    /// the configured [`reth_evm::EvmEnv`] was inspected.
     fn spawn_trace_at_with_state<F, R>(
         &self,
         evm_env: EvmEnvFor<Self::Evm>,

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -9,9 +9,10 @@ use futures::Future;
 use reth_chainspec::ChainSpecProvider;
 use reth_errors::ProviderError;
 use reth_evm::{
-    system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, Database, Evm, EvmEnv,
-    HaltReasonFor, InspectorFor,
+    system_calls::SystemCaller, ConfigureEvmEnv, Database, Evm, EvmEnvFor, HaltReasonFor,
+    InspectorFor, TxEnvFor,
 };
+use reth_node_api::NodePrimitives;
 use reth_primitives::RecoveredBlock;
 use reth_primitives_traits::{BlockBody, SignedTransaction};
 use reth_provider::{BlockReader, ProviderBlock, ProviderHeader, ProviderTx};
@@ -32,9 +33,11 @@ use std::sync::Arc;
 pub trait Trace:
     LoadState<
     Provider: BlockReader,
-    Evm: ConfigureEvm<
-        Header = ProviderHeader<Self::Provider>,
-        Transaction = ProviderTx<Self::Provider>,
+    Evm: ConfigureEvmEnv<
+        Primitives: NodePrimitives<
+            BlockHeader = ProviderHeader<Self::Provider>,
+            SignedTx = ProviderTx<Self::Provider>,
+        >,
     >,
     Error: FromEvmError<Self::Evm>,
 >
@@ -45,19 +48,16 @@ pub trait Trace:
     fn inspect<DB, I>(
         &self,
         db: DB,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-        tx_env: <Self::Evm as ConfigureEvmEnv>::TxEnv,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
         inspector: I,
     ) -> Result<
-        (
-            ResultAndState<HaltReasonFor<Self::Evm>>,
-            (EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>, <Self::Evm as ConfigureEvmEnv>::TxEnv),
-        ),
+        (ResultAndState<HaltReasonFor<Self::Evm>>, (EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>)),
         Self::Error,
     >
     where
         DB: Database<Error = ProviderError>,
-        I: InspectorFor<DB, Self::Evm>,
+        I: InspectorFor<Self::Evm, DB>,
     {
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env.clone(), inspector);
         let res = evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err)?;
@@ -73,8 +73,8 @@ pub trait Trace:
     /// Caution: this is blocking
     fn trace_at<F, R>(
         &self,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-        tx_env: <Self::Evm as ConfigureEvmEnv>::TxEnv,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
         config: TracingInspectorConfig,
         at: BlockId,
         f: F,
@@ -103,8 +103,8 @@ pub trait Trace:
     /// the configured [`EvmEnv`] was inspected.
     fn spawn_trace_at_with_state<F, R>(
         &self,
-        evm_env: EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
-        tx_env: <Self::Evm as ConfigureEvmEnv>::TxEnv,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
         config: TracingInspectorConfig,
         at: BlockId,
         f: F,
@@ -185,7 +185,7 @@ pub trait Trace:
             + Send
             + 'static,
         Insp:
-            for<'a, 'b> InspectorFor<StateCacheDbRefMutWrapper<'a, 'b>, Self::Evm> + Send + 'static,
+            for<'a, 'b> InspectorFor<Self::Evm, StateCacheDbRefMutWrapper<'a, 'b>> + Send + 'static,
         R: Send + 'static,
     {
         async move {
@@ -292,7 +292,7 @@ pub trait Trace:
             + 'static,
         Setup: FnMut() -> Insp + Send + 'static,
         Insp:
-            for<'a, 'b> InspectorFor<StateCacheDbRefMutWrapper<'a, 'b>, Self::Evm> + Send + 'static,
+            for<'a, 'b> InspectorFor<Self::Evm, StateCacheDbRefMutWrapper<'a, 'b>> + Send + 'static,
         R: Send + 'static,
     {
         async move {
@@ -451,7 +451,7 @@ pub trait Trace:
             + 'static,
         Setup: FnMut() -> Insp + Send + 'static,
         Insp:
-            for<'a, 'b> InspectorFor<StateCacheDbRefMutWrapper<'a, 'b>, Self::Evm> + Send + 'static,
+            for<'a, 'b> InspectorFor<Self::Evm, StateCacheDbRefMutWrapper<'a, 'b>> + Send + 'static,
         R: Send + 'static,
     {
         self.trace_block_until_with_inspector(block_id, block, None, insp_setup, f)
@@ -466,7 +466,7 @@ pub trait Trace:
         &self,
         block: &RecoveredBlock<ProviderBlock<Self::Provider>>,
         db: &mut DB,
-        evm_env: &EvmEnv<<Self::Evm as ConfigureEvmEnv>::Spec>,
+        evm_env: &EvmEnvFor<Self::Evm>,
     ) -> Result<(), Self::Error> {
         let mut system_caller = SystemCaller::new(self.provider().chain_spec());
 

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -9,7 +9,7 @@ use futures::Future;
 use reth_chainspec::ChainSpecProvider;
 use reth_errors::ProviderError;
 use reth_evm::{
-    system_calls::SystemCaller, ConfigureEvmEnv, Database, Evm, EvmEnvFor, HaltReasonFor,
+    system_calls::SystemCaller, ConfigureEvm, Database, Evm, EvmEnvFor, HaltReasonFor,
     InspectorFor, TxEnvFor,
 };
 use reth_node_api::NodePrimitives;
@@ -33,7 +33,7 @@ use std::sync::Arc;
 pub trait Trace:
     LoadState<
     Provider: BlockReader,
-    Evm: ConfigureEvmEnv<
+    Evm: ConfigureEvm<
         Primitives: NodePrimitives<
             BlockHeader = ProviderHeader<Self::Provider>,
             SignedTx = ProviderTx<Self::Provider>,

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -3,7 +3,7 @@
 
 use crate::EthApiError;
 use reth_errors::ProviderError;
-use reth_evm::{ConfigureEvmEnv, EvmErrorFor, HaltReasonFor};
+use reth_evm::{ConfigureEvm, EvmErrorFor, HaltReasonFor};
 use revm::context_interface::result::HaltReason;
 
 use super::RpcInvalidTransactionError;
@@ -82,7 +82,7 @@ impl AsEthApiError for EthApiError {
 }
 
 /// Helper trait to convert from revm errors.
-pub trait FromEvmError<Evm: ConfigureEvmEnv>:
+pub trait FromEvmError<Evm: ConfigureEvm>:
     From<EvmErrorFor<Evm, ProviderError>> + FromEvmHalt<HaltReasonFor<Evm>>
 {
     /// Converts from EVM error to this type.
@@ -94,7 +94,7 @@ pub trait FromEvmError<Evm: ConfigureEvmEnv>:
 impl<T, Evm> FromEvmError<Evm> for T
 where
     T: From<EvmErrorFor<Evm, ProviderError>> + FromEvmHalt<HaltReasonFor<Evm>>,
-    Evm: ConfigureEvmEnv,
+    Evm: ConfigureEvm,
 {
 }
 

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -3,7 +3,7 @@
 
 use crate::EthApiError;
 use reth_errors::ProviderError;
-use reth_evm::{ConfigureEvm, EvmErrorFor, HaltReasonFor};
+use reth_evm::{ConfigureEvmEnv, EvmErrorFor, HaltReasonFor};
 use revm::context_interface::result::HaltReason;
 
 use super::RpcInvalidTransactionError;
@@ -82,7 +82,7 @@ impl AsEthApiError for EthApiError {
 }
 
 /// Helper trait to convert from revm errors.
-pub trait FromEvmError<Evm: ConfigureEvm>:
+pub trait FromEvmError<Evm: ConfigureEvmEnv>:
     From<EvmErrorFor<Evm, ProviderError>> + FromEvmHalt<HaltReasonFor<Evm>>
 {
     /// Converts from EVM error to this type.
@@ -94,7 +94,7 @@ pub trait FromEvmError<Evm: ConfigureEvm>:
 impl<T, Evm> FromEvmError<Evm> for T
 where
     T: From<EvmErrorFor<Evm, ProviderError>> + FromEvmHalt<HaltReasonFor<Evm>>,
-    Evm: ConfigureEvm,
+    Evm: ConfigureEvmEnv,
 {
 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -18,7 +18,7 @@ use jsonrpsee::core::RpcResult;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
     execute::{BlockExecutorProvider, Executor},
-    ConfigureEvmEnv, EvmEnvFor, TxEnvFor,
+    ConfigureEvm, EvmEnvFor, TxEnvFor,
 };
 use reth_primitives::{NodePrimitives, ReceiptWithBloom, RecoveredBlock};
 use reth_primitives_traits::{Block as _, BlockBody, SignedTransaction};

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -18,7 +18,7 @@ use jsonrpsee::core::RpcResult;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
     execute::{BlockExecutorProvider, Executor},
-    ConfigureEvmEnv, EvmEnv,
+    ConfigureEvmEnv, EvmEnvFor, TxEnvFor,
 };
 use reth_primitives::{NodePrimitives, ReceiptWithBloom, RecoveredBlock};
 use reth_primitives_traits::{Block as _, BlockBody, SignedTransaction};
@@ -97,7 +97,7 @@ where
     async fn trace_block(
         &self,
         block: Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>,
-        evm_env: EvmEnv<<Eth::Evm as ConfigureEvmEnv>::Spec>,
+        evm_env: EvmEnvFor<Eth::Evm>,
         opts: GethDebugTracingOptions,
     ) -> Result<Vec<TraceResult>, Eth::Error> {
         // replay all transactions of the block
@@ -687,8 +687,8 @@ where
     fn trace_transaction(
         &self,
         opts: &GethDebugTracingOptions,
-        evm_env: EvmEnv<<Eth::Evm as ConfigureEvmEnv>::Spec>,
-        tx_env: <Eth::Evm as ConfigureEvmEnv>::TxEnv,
+        evm_env: EvmEnvFor<Eth::Evm>,
+        tx_env: TxEnvFor<Eth::Evm>,
         db: &mut StateCacheDb<'_>,
         transaction_context: Option<TransactionContext>,
         fused_inspector: &mut Option<TracingInspector>,

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -5,7 +5,7 @@ use alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK;
 use alloy_primitives::{Keccak256, U256};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use jsonrpsee::core::RpcResult;
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv, Evm};
+use reth_evm::{ConfigureEvmEnv, Evm};
 use reth_primitives_traits::SignedTransaction;
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};
 use reth_rpc_eth_api::{

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -5,7 +5,7 @@ use alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK;
 use alloy_primitives::{Keccak256, U256};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use jsonrpsee::core::RpcResult;
-use reth_evm::{ConfigureEvmEnv, Evm};
+use reth_evm::{ConfigureEvm, Evm};
 use reth_primitives_traits::SignedTransaction;
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};
 use reth_rpc_eth_api::{

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -5,7 +5,7 @@ use alloy_consensus::TxType;
 use alloy_evm::block::BlockExecutorFactory;
 use alloy_primitives::{TxKind, U256};
 use alloy_rpc_types::TransactionRequest;
-use reth_evm::{ConfigureEvmEnv, EvmEnv, EvmFactory, SpecFor};
+use reth_evm::{ConfigureEvm, EvmEnv, EvmFactory, SpecFor};
 use reth_node_api::NodePrimitives;
 use reth_provider::{BlockReader, ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::{
@@ -25,7 +25,7 @@ where
 impl<Provider, Pool, Network, EvmConfig> Call for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: LoadState<
-            Evm: ConfigureEvmEnv<
+            Evm: ConfigureEvm<
                 BlockExecutorFactory: BlockExecutorFactory<EvmFactory: EvmFactory<Tx = TxEnv>>,
                 Primitives: NodePrimitives<
                     BlockHeader = ProviderHeader<Self::Provider>,

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -1,11 +1,13 @@
 //! Contains RPC handler implementations specific to endpoints that call/execute within evm.
 
 use crate::EthApi;
-use alloy_consensus::{Header, TxType};
+use alloy_consensus::TxType;
+use alloy_evm::block::BlockExecutorFactory;
 use alloy_primitives::{TxKind, U256};
 use alloy_rpc_types::TransactionRequest;
-use reth_evm::{ConfigureEvm, EvmEnv, SpecFor};
-use reth_provider::{BlockReader, ProviderHeader};
+use reth_evm::{ConfigureEvmEnv, EvmEnv, EvmFactory, SpecFor};
+use reth_node_api::NodePrimitives;
+use reth_provider::{BlockReader, ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEthApiError, FromEvmError, FullEthApiTypes, IntoEthApiError,
@@ -23,10 +25,15 @@ where
 impl<Provider, Pool, Network, EvmConfig> Call for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: LoadState<
-            Evm: ConfigureEvm<TxEnv = TxEnv, Header = ProviderHeader<Self::Provider>>,
+            Evm: ConfigureEvmEnv<
+                BlockExecutorFactory: BlockExecutorFactory<EvmFactory: EvmFactory<Tx = TxEnv>>,
+                Primitives: NodePrimitives<
+                    BlockHeader = ProviderHeader<Self::Provider>,
+                    SignedTx = ProviderTx<Self::Provider>,
+                >,
+            >,
             Error: FromEvmError<Self::Evm>,
         > + SpawnBlocking,
-    EvmConfig: ConfigureEvm<Header = Header>,
     Provider: BlockReader,
 {
     #[inline]

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -2,7 +2,7 @@
 
 use alloy_consensus::BlockHeader;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_evm::{ConfigureEvmEnv, NextBlockEnvAttributes};
+use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
 use reth_node_api::NodePrimitives;
 use reth_primitives::SealedHeader;
 use reth_provider::{
@@ -37,7 +37,7 @@ where
             Pool: TransactionPool<
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
-            Evm: ConfigureEvmEnv<
+            Evm: ConfigureEvm<
                 Primitives: NodePrimitives<
                     BlockHeader = ProviderHeader<Self::Provider>,
                     SignedTx = ProviderTx<Self::Provider>,
@@ -61,7 +61,7 @@ where
     fn next_env_attributes(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
-    ) -> Result<<Self::Evm as reth_evm::ConfigureEvmEnv>::NextBlockEnvCtx, Self::Error> {
+    ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
         Ok(NextBlockEnvAttributes {
             timestamp: parent.timestamp().saturating_add(12),
             suggested_fee_recipient: parent.beneficiary(),

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -2,7 +2,7 @@
 
 use alloy_consensus::BlockHeader;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_evm::{execute::BlockExecutionStrategyFactory, NextBlockEnvAttributes};
+use reth_evm::{ConfigureEvmEnv, NextBlockEnvAttributes};
 use reth_node_api::NodePrimitives;
 use reth_primitives::SealedHeader;
 use reth_provider::{
@@ -37,7 +37,7 @@ where
             Pool: TransactionPool<
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
-            Evm: BlockExecutionStrategyFactory<
+            Evm: ConfigureEvmEnv<
                 Primitives: NodePrimitives<
                     BlockHeader = ProviderHeader<Self::Provider>,
                     SignedTx = ProviderTx<Self::Provider>,

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -1,6 +1,6 @@
 //! Contains RPC handler implementations specific to tracing.
 
-use reth_evm::ConfigureEvmEnv;
+use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
 use reth_provider::{BlockReader, ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::{
@@ -14,7 +14,7 @@ impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Networ
 where
     Self: LoadState<
         Provider: BlockReader,
-        Evm: ConfigureEvmEnv<
+        Evm: ConfigureEvm<
             Primitives: NodePrimitives<
                 BlockHeader = ProviderHeader<Self::Provider>,
                 SignedTx = ProviderTx<Self::Provider>,

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -1,6 +1,7 @@
 //! Contains RPC handler implementations specific to tracing.
 
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmEnv;
+use reth_node_api::NodePrimitives;
 use reth_provider::{BlockReader, ProviderHeader, ProviderTx};
 use reth_rpc_eth_api::{
     helpers::{LoadState, Trace},
@@ -13,9 +14,11 @@ impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Networ
 where
     Self: LoadState<
         Provider: BlockReader,
-        Evm: ConfigureEvm<
-            Header = ProviderHeader<Self::Provider>,
-            Transaction = ProviderTx<Self::Provider>,
+        Evm: ConfigureEvmEnv<
+            Primitives: NodePrimitives<
+                BlockHeader = ProviderHeader<Self::Provider>,
+                SignedTx = ProviderTx<Self::Provider>,
+            >,
         >,
         Error: FromEvmError<Self::Evm>,
     >,

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_mev::{
     SimBundleOverrides, SimBundleResponse, Validity,
 };
 use jsonrpsee::core::RpcResult;
-use reth_evm::{ConfigureEvmEnv, Evm};
+use reth_evm::{ConfigureEvm, Evm};
 use reth_primitives::Recovered;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::ProviderTx;

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_mev::{
     SimBundleOverrides, SimBundleResponse, Validity,
 };
 use jsonrpsee::core::RpcResult;
-use reth_evm::{ConfigureEvm, ConfigureEvmEnv, Evm};
+use reth_evm::{ConfigureEvmEnv, Evm};
 use reth_primitives::Recovered;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::ProviderTx;

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -16,7 +16,7 @@ use alloy_rpc_types_trace::{
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{EthChainSpec, EthereumHardfork, MAINNET, SEPOLIA};
-use reth_evm::ConfigureEvmEnv;
+use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{BlockBody, BlockHeader};
 use reth_provider::{BlockNumReader, BlockReader, ChainSpecProvider};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -26,7 +26,7 @@ use reth_db_api::{
     transaction::DbTx,
     Database,
 };
-use reth_evm::{ConfigureEvmEnv, EvmEnv};
+use reth_evm::{ConfigureEvm, EvmEnv};
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives::{

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -12,7 +12,7 @@ use alloy_evm::{
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 use reth::{
-    api::{ConfigureEvmEnv, NodeTypesWithEngine},
+    api::{ConfigureEvm, NodeTypesWithEngine},
     builder::{components::ExecutorBuilder, BuilderContext, FullNodeTypes},
     cli::Cli,
     providers::BlockExecutionResult,
@@ -118,10 +118,10 @@ impl BlockExecutorFactory for CustomEvmConfig {
     }
 }
 
-impl ConfigureEvmEnv for CustomEvmConfig {
-    type Primitives = <EthEvmConfig as ConfigureEvmEnv>::Primitives;
-    type Error = <EthEvmConfig as ConfigureEvmEnv>::Error;
-    type NextBlockEnvCtx = <EthEvmConfig as ConfigureEvmEnv>::NextBlockEnvCtx;
+impl ConfigureEvm for CustomEvmConfig {
+    type Primitives = <EthEvmConfig as ConfigureEvm>::Primitives;
+    type Error = <EthEvmConfig as ConfigureEvm>::Error;
+    type NextBlockEnvCtx = <EthEvmConfig as ConfigureEvm>::NextBlockEnvCtx;
     type BlockExecutorFactory = Self;
     type BlockAssembler = EthBlockAssembler<ChainSpec>;
 

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -12,7 +12,7 @@ use alloy_evm::{
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 use reth::{
-    api::{ConfigureEvm, NodeTypesWithEngine},
+    api::{ConfigureEvmEnv, NodeTypesWithEngine},
     builder::{components::ExecutorBuilder, BuilderContext, FullNodeTypes},
     cli::Cli,
     providers::BlockExecutionResult,
@@ -20,21 +20,19 @@ use reth::{
         context::{result::ExecutionResult, TxEnv},
         db::State,
         primitives::{address, Address},
+        specification::hardfork::SpecId,
         DatabaseCommit,
     },
 };
 use reth_chainspec::ChainSpec;
 use reth_evm::{
-    execute::{
-        BlockExecutionError, BlockExecutionStrategyFactory, BlockExecutor,
-        InternalBlockExecutionError,
-    },
-    ConfigureEvmEnv, Database, Evm, EvmEnv, InspectorFor, NextBlockEnvAttributes, OnStateHook,
+    execute::{BlockExecutionError, BlockExecutor, InternalBlockExecutionError},
+    Database, Evm, EvmEnv, InspectorFor, NextBlockEnvAttributes, OnStateHook,
 };
 use reth_evm_ethereum::{EthBlockAssembler, EthEvmConfig, RethReceiptBuilder};
 use reth_node_ethereum::{node::EthereumAddOns, BasicBlockExecutorProvider, EthereumNode};
 use reth_primitives::{
-    EthPrimitives, Receipt, Recovered, SealedBlock, SealedHeader, TransactionSigned,
+    EthPrimitives, Header, Receipt, Recovered, SealedBlock, SealedHeader, TransactionSigned,
 };
 use std::{fmt::Display, sync::Arc};
 
@@ -90,35 +88,6 @@ pub struct CustomEvmConfig {
     inner: EthEvmConfig,
 }
 
-impl ConfigureEvmEnv for CustomEvmConfig {
-    type Error = <EthEvmConfig as ConfigureEvmEnv>::Error;
-    type Header = <EthEvmConfig as ConfigureEvmEnv>::Header;
-    type Spec = <EthEvmConfig as ConfigureEvmEnv>::Spec;
-    type Transaction = <EthEvmConfig as ConfigureEvmEnv>::Transaction;
-    type TxEnv = <EthEvmConfig as ConfigureEvmEnv>::TxEnv;
-    type NextBlockEnvCtx = NextBlockEnvAttributes;
-
-    fn evm_env(&self, header: &Self::Header) -> EvmEnv<Self::Spec> {
-        self.inner.evm_env(header)
-    }
-
-    fn next_evm_env(
-        &self,
-        parent: &Self::Header,
-        attributes: &NextBlockEnvAttributes,
-    ) -> Result<EvmEnv<Self::Spec>, Self::Error> {
-        self.inner.next_evm_env(parent, attributes)
-    }
-}
-
-impl ConfigureEvm for CustomEvmConfig {
-    type EvmFactory = <EthEvmConfig as ConfigureEvm>::EvmFactory;
-
-    fn evm_factory(&self) -> &Self::EvmFactory {
-        self.inner.evm_factory()
-    }
-}
-
 impl BlockExecutorFactory for CustomEvmConfig {
     type EvmFactory = EthEvmFactory;
     type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
@@ -136,7 +105,7 @@ impl BlockExecutorFactory for CustomEvmConfig {
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
         DB: Database + 'a,
-        I: InspectorFor<&'a mut State<DB>, Self> + 'a,
+        I: InspectorFor<Self, &'a mut State<DB>> + 'a,
     {
         CustomBlockExecutor {
             inner: EthBlockExecutor::new(
@@ -149,8 +118,10 @@ impl BlockExecutorFactory for CustomEvmConfig {
     }
 }
 
-impl BlockExecutionStrategyFactory for CustomEvmConfig {
-    type Primitives = EthPrimitives;
+impl ConfigureEvmEnv for CustomEvmConfig {
+    type Primitives = <EthEvmConfig as ConfigureEvmEnv>::Primitives;
+    type Error = <EthEvmConfig as ConfigureEvmEnv>::Error;
+    type NextBlockEnvCtx = <EthEvmConfig as ConfigureEvmEnv>::NextBlockEnvCtx;
     type BlockExecutorFactory = Self;
     type BlockAssembler = EthBlockAssembler<ChainSpec>;
 
@@ -160,6 +131,18 @@ impl BlockExecutionStrategyFactory for CustomEvmConfig {
 
     fn block_assembler(&self) -> &Self::BlockAssembler {
         self.inner.block_assembler()
+    }
+
+    fn evm_env(&self, header: &Header) -> EvmEnv<SpecId> {
+        self.inner.evm_env(header)
+    }
+
+    fn next_evm_env(
+        &self,
+        parent: &Header,
+        attributes: &NextBlockEnvAttributes,
+    ) -> Result<EvmEnv<SpecId>, Self::Error> {
+        self.inner.next_evm_env(parent, attributes)
     }
 
     fn context_for_block<'a>(&self, block: &'a SealedBlock) -> EthBlockExecutionCtx<'a> {

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -29,7 +29,7 @@ use reth::{
     rpc::api::eth::helpers::Call,
     transaction_pool::TransactionPool,
 };
-use reth_evm::ConfigureEvm;
+use reth_evm::ConfigureEvmEnv;
 use reth_node_ethereum::node::EthereumNode;
 
 fn main() {

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -29,7 +29,7 @@ use reth::{
     rpc::api::eth::helpers::Call,
     transaction_pool::TransactionPool,
 };
-use reth_evm::ConfigureEvmEnv;
+use reth_evm::ConfigureEvm;
 use reth_node_ethereum::node::EthereumNode;
 
 fn main() {


### PR DESCRIPTION
Right now `EvmConfig` is required to implement 3 traits: `ConfigureEvmEnv`, `ConfigureEvm` and `BlockExecutionStrategyFactory`.

Given that we've now extracted logic for instantiating factories and block executors to alloy-evm, those traits altogether are now only required to implement 4 methods for setting up EVM/block environment.

This PR unifies all of the EVM configuration under `ConfigureEvm` which mostly consists of methods with default implementations, and only requires implementation to provide `BlockExecutorFactory` and methods to construct environments.

I've also added more docs for it as it's now core abstraction point for tx/block execution:
https://github.com/paradigmxyz/reth/blob/4fa0d3af8faa7cdf97cd96a24cc73f3dd8ac49ea/crates/evm/src/lib.rs#L57-L94