### PR TITLE
fix: disable not only if requested

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -471,7 +471,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
 
     /// Disables all discovery.
     pub fn disable_discovery(self) -> Self {
-        self.disable_discv4_discovery().disable_dns_discovery().disable_nat()
+        self.disable_discv4_discovery().disable_discv5_discovery().disable_dns_discovery()
     }
 
     /// Disables all discovery if the given condition is true.
@@ -489,6 +489,12 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
         self
     }
 
+    /// Disable the Discv5 discovery.
+    pub fn disable_discv5_discovery(mut self) -> Self {
+        self.discovery_v5_builder = None;
+        self
+    }
+
     /// Disable the DNS discovery if the given condition is true.
     pub fn disable_dns_discovery_if(self, disable: bool) -> Self {
         if disable {
@@ -502,6 +508,15 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
     pub fn disable_discv4_discovery_if(self, disable: bool) -> Self {
         if disable {
             self.disable_discv4_discovery()
+        } else {
+            self
+        }
+    }
+
+    /// Disable the Discv5 discovery if the given condition is true.
+    pub fn disable_discv5_discovery_if(self, disable: bool) -> Self {
+        if disable {
+            self.disable_discv5_discovery()
         } else {
             self
         }

--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -128,6 +128,7 @@ async fn test_node_record_address_with_nat_disable_discovery() {
     let config = NetworkConfigBuilder::eth(secret_key)
         .add_nat(Some(NatResolver::ExternalIp("10.1.1.1".parse().unwrap())))
         .disable_discovery()
+        .disable_nat()
         .listener_port(0)
         .build_with_noop_provider(MAINNET.clone());
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -426,7 +426,8 @@ impl DiscoveryArgs {
             network_config_builder = network_config_builder.disable_discv4_discovery();
         }
 
-        if self.disable_discovery || self.disable_nat {
+        if self.disable_nat {
+            // we only check for `disable-nat` here and not for disable discovery because nat:extip can be used without discovery: <https://github.com/paradigmxyz/reth/issues/14878>
             network_config_builder = network_config_builder.disable_nat();
         }
 


### PR DESCRIPTION
closes #14878

there were two things wrong --disable-discovery for op

it always disables nat as well, which would disable ext:IP as well.

didn't disable discv5 

cc @cody-wang-cb 