### PR TITLE
Refactor Optimism Transaction Validator: Extract OP-Specific Checks & Enable Batch Processing

### DIFF
--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -162,6 +162,7 @@ where
         transactions.into_iter().map(|(origin, tx)| self.validate_one(origin, tx)).collect()
     }
 
+    /// Performs the necessary opstack specific checks based on top of the regular eth outcome.
     fn apply_op_checks(
         &self,
         outcome: TransactionValidationOutcome<Tx>,

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -159,20 +159,7 @@ where
         &self,
         transactions: Vec<(TransactionOrigin, Tx)>,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
-        transactions
-            .into_iter()
-            .map(|(origin, tx)| {
-                if tx.is_eip4844() {
-                    TransactionValidationOutcome::Invalid(
-                        tx,
-                        InvalidTransactionError::TxTypeNotSupported.into(),
-                    )
-                } else {
-                    let outcome = self.inner.validate_one(origin, tx);
-                    self.apply_op_checks(outcome)
-                }
-            })
-            .collect()
+        transactions.into_iter().map(|(origin, tx)| self.validate_one(origin, tx)).collect()
     }
 
     fn apply_op_checks(

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -10,8 +10,8 @@ use reth_primitives_traits::{
 };
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_transaction_pool::{
-    EthPoolTransaction, EthTransactionValidator, PoolTransaction, TransactionOrigin,
-    TransactionValidationOutcome, TransactionValidator,
+    EthPoolTransaction, EthTransactionValidator, TransactionOrigin, TransactionValidationOutcome,
+    TransactionValidator,
 };
 use std::sync::{
     atomic::{AtomicU64, Ordering},
@@ -27,14 +27,6 @@ pub struct OpL1BlockInfo {
     timestamp: AtomicU64,
     /// Current block number.
     number: AtomicU64,
-}
-
-/// Intermediary outcome for transaction validation.
-enum IntermediaryTxValidationOutcome<Tx: PoolTransaction> {
-    /// Represents an invalid EIP-4844 transaction.
-    InvalidEip4844(TransactionValidationOutcome<Tx>),
-    /// Represents a transaction pending further validation.
-    Pending { origin: TransactionOrigin, tx: Tx },
 }
 
 /// Validator for Optimism transactions.
@@ -167,41 +159,20 @@ where
         &self,
         transactions: Vec<(TransactionOrigin, Tx)>,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
-        let mut intermediaries = Vec::with_capacity(transactions.len());
-
-        for (origin, tx) in transactions {
-            if tx.is_eip4844() {
-                intermediaries.push(IntermediaryTxValidationOutcome::InvalidEip4844(
+        transactions
+            .into_iter()
+            .map(|(origin, tx)| {
+                if tx.is_eip4844() {
                     TransactionValidationOutcome::Invalid(
                         tx,
                         InvalidTransactionError::TxTypeNotSupported.into(),
-                    ),
-                ));
-            } else {
-                intermediaries.push(IntermediaryTxValidationOutcome::Pending { origin, tx });
-            }
-        }
-
-        let pending_transactions: Vec<_> = intermediaries
-            .iter()
-            .filter_map(|intermediary| {
-                if let IntermediaryTxValidationOutcome::Pending { origin, tx } = intermediary {
-                    Some((*origin, tx.clone()))
+                    )
                 } else {
-                    None
+                    let outcome = self.inner.validate_one(origin, tx);
+                    self.apply_op_checks(outcome)
                 }
             })
-            .collect();
-
-        let mut outcomes = self.inner.validate_all(pending_transactions);
-
-        for intermediary in intermediaries {
-            if let IntermediaryTxValidationOutcome::InvalidEip4844(invalid_outcome) = intermediary {
-                outcomes.push(invalid_outcome);
-            }
-        }
-
-        outcomes.into_iter().map(|outcome| self.apply_op_checks(outcome)).collect()
+            .collect()
     }
 
     fn apply_op_checks(

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -163,7 +163,10 @@ where
         outcomes.into_iter().map(|outcome| self.apply_op_checks(outcome)).collect()
     }
 
-    fn apply_op_checks(&self, outcome: TransactionValidationOutcome<Tx>) -> TransactionValidationOutcome<Tx> {
+    fn apply_op_checks(
+        &self,
+        outcome: TransactionValidationOutcome<Tx>,
+    ) -> TransactionValidationOutcome<Tx> {
         if !self.requires_l1_data_gas_fee() {
             // no need to check L1 gas fee
             return outcome
@@ -203,7 +206,7 @@ where
                     InvalidTransactionError::InsufficientFunds(
                         GotExpected { got: balance, expected: cost }.into(),
                     )
-                        .into(),
+                    .into(),
                 )
             }
 


### PR DESCRIPTION
This PR refactors the Optimism transaction validation(https://github.com/paradigmxyz/reth/issues/13902). The changes decouple the Ethereum (ETH) standard validation from the additional Optimism-specific logic (i.e., ensuring the sender can cover the L1 gas fee). In addition, batch validation is now optimized by delegating to the inner validator’s batch method and then applying the OP-specific checks on the resulting outcomes.

### Detailed Changes

1. **Extracted OP-Specific Validation Logic**
   - Introduced a new private helper method `apply_op_checks` that encapsulates the Optimism-specific checks.  
   - The method verifies, for transactions deemed valid by the inner validator, that the sender’s balance is sufficient to cover both the intrinsic cost and the additional L1 data fee.
   - If the fee calculation fails or the total cost exceeds the balance, an appropriate error is returned.

2. **Simplified Single Transaction Validation**
   - The `validate_one` method now:
     - First checks if the transaction is of type EIP-4844, immediately rejecting unsupported transactions.
     - Delegates initial validation to the inner (ETH) validator.
     - Applies the additional OP checks via the newly created `apply_op_checks` method.
   - This cleanly separates standard ETH validation from the Optimism-specific fee requirements.

3. **Optimized Batch Transaction Validation**
   - Updated the `validate_all` method to use the inner validator’s batch validation (`validate_all`) which internally use ('validate_batch') instead of iterating over transactions one-by-one.
   - After obtaining batch results, each outcome is passed through `apply_op_checks`, ensuring that the extra L1 gas fee validation is applied consistently and efficiently.


This is my first contribution to reth, and I'm eager to receive any feedback or suggestions for improvement.