### PR TITLE
add nightly builds

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,0 +1,42 @@
+# Publishes the nightly Docker image.
+
+name: docker-nightly
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+env:
+  REPO_NAME: ${{ github.repository_owner }}/reth
+  IMAGE_NAME: ${{ github.repository_owner }}/reth
+  OP_IMAGE_NAME: ${{ github.repository_owner }}/op-reth
+  CARGO_TERM_COLOR: always
+  DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/reth
+  OP_DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/op-reth
+  DOCKER_USERNAME: ${{ github.actor }}
+
+jobs:
+  build:
+    name: build and push
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@cross
+      - name: Log in to Docker
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
+      - name: Set up Docker builder
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
+          docker buildx create --use --name cross-builder
+      - name: Build and push the nightly reth image
+        run: make PROFILE=maxperf docker-build-push-nightly
+      - name: Build and push the nightly op-reth image
+        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-nightly

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ docker-build-push-latest: ## Build and push a cross-arch Docker image tagged wit
 # `docker buildx create --use --name cross-builder`
 .PHONY: docker-build-push-nightly
 docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
-	$(call docker_build_push,$(GIT_TAG)-nightly,latest-nightly)
+	$(call docker_build_push,nightly,nightly)
 
 # Create a cross-arch Docker image with the given tags and push it
 define docker_build_push
@@ -290,7 +290,7 @@ op-docker-build-push-latest: ## Build and push a cross-arch Docker image tagged 
 # `docker buildx create --use --name cross-builder`
 .PHONY: op-docker-build-push-nightly
 op-docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
-	$(call op_docker_build_push,$(GIT_TAG)-nightly,latest-nightly)
+	$(call op_docker_build_push,nightly,nightly)
 
 # Create a cross-arch Docker image with the given tags and push it
 define op_docker_build_push


### PR DESCRIPTION
* Changes `op-docker-build-push-nightly` and `docker-build-push-nightly` to use to build and push `nightly` instead of `$(GIT_TAG)-nightly` & `latest-nightly`
* Adds docker-nightly GitHub Action workflow