### PR TITLE
chore: enable revm portable by default for op-reth

### DIFF
--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -27,7 +27,7 @@ tracing.workspace = true
 workspace = true
 
 [features]
-default = ["jemalloc"]
+default = ["jemalloc", "reth-optimism-evm/portable"]
 
 jemalloc = ["reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc"]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -85,3 +85,4 @@ std = [
     "reth-evm/std",
     "tracing/std",
 ]
+portable = ["reth-revm/portable"]


### PR DESCRIPTION
Missed op-reth with the last PR