### PR TITLE
chore: use B256 Display for state root test assertion

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -520,12 +520,12 @@ mod tests {
         }
         drop(state_hook);
 
-        let root_from_task = handle.state_root().expect("task failed").state_root.0;
+        let root_from_task = handle.state_root().expect("task failed").state_root;
         let root_from_regular = state_root(accumulated_state);
 
         assert_eq!(
             root_from_task, root_from_regular,
-            "State root mismatch: task={root_from_task:?}, base={root_from_regular:?}"
+            "State root mismatch: task={root_from_task}, base={root_from_regular}"
         );
     }
 }


### PR DESCRIPTION
Previously the error would look like:
```
assertion `left == right` failed: State root mismatch: task=[248, 209, 48, 242, 228, 181, 89, 94, 161, 128, 5, 95, 68, 131, 25, 123, 223, 190, 190, 29, 15, 137, 41, 250, 22, 108, 79, 250, 218, 203, 146, 35], base=0x959e02b8f42788f55c4767dc451b01f893f6e3f32d745af13cf88ed069a06287
  left: [248, 209, 48, 242, 228, 181, 89, 94, 161, 128, 5, 95, 68, 131, 25, 123, 223, 190, 190, 29, 15, 137, 41, 250, 22, 108, 79, 250, 218, 203, 146, 35]
 right: 0x959e02b8f42788f55c4767dc451b01f893f6e3f32d745af13cf88ed069a06287
```

Now it looks like:
```
assertion `left == right` failed: State root mismatch: task=0x3044a7db8e89ff8b3a86a7f0b143672c2a73c1b2f42d2b4922c0cac8efe841e4, base=0x046106e531475cc9212b155a3eb5b097c3c0b1de9c0fa227a761b21bd7c945d7
  left: 0x3044a7db8e89ff8b3a86a7f0b143672c2a73c1b2f42d2b4922c0cac8efe841e4
 right: 0x046106e531475cc9212b155a3eb5b097c3c0b1de9c0fa227a761b21bd7c945d7
```