### PR TITLE
chore: bump alloy-chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "jsonrpsee-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,7 +445,7 @@ op-revm = { version = "1.0.0-alpha.1", default-features = false }
 revm-inspectors = "0.16"
 
 # eth
-alloy-chains = { version = "0.1.32", default-features = false }
+alloy-chains = { version = "0.1.64", default-features = false }
 alloy-dyn-abi = "0.8.20"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
 alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "f9ed4d3", default-features = false }


### PR DESCRIPTION
We depend on `Unichain` variant added in 0.1.60 https://github.com/alloy-rs/chains/pull/139