### PR TITLE
chore: remove commented SparseTrieEvent

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1,6 +1,6 @@
 //! Multiproof task related functionality.
 
-use crate::tree::payload_processor::{executor::WorkloadExecutor, sparse_trie::SparseTrieEvent};
+use crate::tree::payload_processor::executor::WorkloadExecutor;
 use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, map::HashSet, B256};
 use derive_more::derive::Deref;
@@ -449,7 +449,7 @@ pub(super) struct MultiProofTask<Factory> {
     /// Sender for state root related messages.
     tx: Sender<MultiProofMessage>,
     /// Sender for state updates emitted by this type.
-    to_sparse_trie: Sender<SparseTrieEvent>,
+    to_sparse_trie: Sender<SparseTrieUpdate>,
     /// Proof targets that have been already fetched.
     fetched_proof_targets: MultiProofTargets,
     /// Proof sequencing handler.
@@ -469,7 +469,7 @@ where
     pub(super) fn new(
         config: MultiProofConfig<Factory>,
         executor: WorkloadExecutor,
-        to_sparse_trie: Sender<SparseTrieEvent>,
+        to_sparse_trie: Sender<SparseTrieUpdate>,
     ) -> Self {
         let (tx, rx) = channel();
         let metrics = MultiProofTaskMetrics::default();

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -34,7 +34,7 @@ pub(super) struct SparseTrieTask<F> {
     #[allow(unused)] // TODO use this for spawning trie tasks
     pub(super) executor: WorkloadExecutor,
     /// Receives updates from the state root task.
-    pub(super) updates: mpsc::Receiver<SparseTrieEvent>,
+    pub(super) updates: mpsc::Receiver<SparseTrieUpdate>,
     // TODO: ideally we need a way to create multiple readers on demand.
     pub(super) config: MultiProofConfig<F>,
     pub(super) metrics: MultiProofTaskMetrics,
@@ -114,18 +114,6 @@ pub struct StateRootComputeOutcome {
     /// The trie updates.
     pub trie_updates: TrieUpdates,
 }
-
-/// Aliased for now to not introduce too many changes at once.
-pub(super) type SparseTrieEvent = SparseTrieUpdate;
-
-// /// The event type the sparse trie task operates on.
-// pub(crate) enum SparseTrieEvent {
-//     /// Updates received from the multiproof task.
-//     ///
-//     /// This represents a stream of [`SparseTrieUpdate`] where a `None` indicates that all
-// updates     /// have been received.
-//     Update(Option<SparseTrieUpdate>),
-// }
 
 /// Updates the sparse trie with the given proofs and state, and returns the elapsed time.
 pub(crate) fn update_sparse_trie<BPF>(


### PR DESCRIPTION
It looks like this was never introduced in the refactor?