### PR TITLE
chore: bump revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=f9ed4d3#f9ed4d335b2e0002e257ead3198eb463a84c5219"
+source = "git+https://github.com/alloy-rs/evm?rev=8402f9c#8402f9c96026e8d37cad93782bb7d539a76dd751"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=f9ed4d3#f9ed4d335b2e0002e257ead3198eb463a84c5219"
+source = "git+https://github.com/alloy-rs/evm?rev=8402f9c#8402f9c96026e8d37cad93782bb7d539a76dd751"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -667,7 +667,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jsonrpsee-types",
  "serde",
  "serde_json",
@@ -5764,14 +5764,13 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0bce0ed6dd4f417e31ded4afa9dda6f9ee7c9c95c14f36f383f8bdc3af2356"
 dependencies = [
  "auto_impl",
  "once_cell",
  "revm",
- "revm-inspector",
- "revm-precompile",
  "serde",
 ]
 
@@ -9787,7 +9786,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "revm-interpreter",
- "revm-specification",
+ "revm-primitives",
  "rustc-hash 2.1.1",
  "schnellru",
  "serde",
@@ -9955,8 +9954,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "20.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "20.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e14f76761c84ee7256cbbd85666ba83f8345dd3180db1b56a837d262cf0072"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -9968,25 +9968,25 @@ dependencies = [
  "revm-interpreter",
  "revm-precompile",
  "revm-primitives",
- "revm-specification",
  "revm-state",
 ]
 
 [[package]]
 name = "revm-bytecode"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c5f38796260529303918286869e66eff8c9d6892102652f7ea9c1f77110a63"
 dependencies = [
  "bitvec",
  "revm-primitives",
- "revm-specification",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3513cebf0c298d396b7ba2d0ec552227366742e8e412d8b033aff33d3200f7ac"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9994,32 +9994,31 @@ dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-database-interface",
- "revm-interpreter",
  "revm-primitives",
- "revm-specification",
  "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-context-interface"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f57925129265cebccdc8ebb8f2cc6695f59dcf8850db9a2b07680395f1ae35"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "revm-database-interface",
  "revm-primitives",
- "revm-specification",
  "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-database"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c9de4fccce40aa44ae01ecf3c1c878c006344404eabde32af5f07177b9c5cc"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10031,8 +10030,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f040b4185db4f1e5d564526be8a9ab49ce1ee9e5f158241b5e187e5ec038022"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10042,8 +10042,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc4e4d82d28abf324db310aa814f033fa6d4f11482bb853826e415c40bf275d"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10053,15 +10054,15 @@ dependencies = [
  "revm-interpreter",
  "revm-precompile",
  "revm-primitives",
- "revm-specification",
  "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-inspector"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f1683c07741a337d1a157e6caeb56e512b95e91c43ffcb5a4ff9b07c06a7ea"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10078,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.16.0"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=9219073#9219073cb04a774d6ea12b44655bba92b08c1293"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=3c6cca4#3c6cca4722a00c49a75c95ffa9605c7efab0e6a1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10096,20 +10097,21 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "16.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "16.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbc3f38a094a3dab6e2222a9501558b2e9f2647c0a1ae28e5eb125e56f5cc4a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",
- "revm-specification",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "17.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "17.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5428daaeec82f857c5d7c15a40e7289d5466b4bf7157295f25305fa3da4fce5"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -10121,7 +10123,6 @@ dependencies = [
  "p256",
  "revm-context-interface",
  "revm-primitives",
- "revm-specification",
  "ripemd",
  "secp256k1",
  "sha2 0.10.8",
@@ -10130,31 +10131,24 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "16.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "16.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a2757e2b6518cf8385dabbe13b88a5023b16c9ca2e06f3117456d4dc35cc7f0"
 dependencies = [
  "alloy-primitives",
-]
-
-[[package]]
-name = "revm-specification"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
-dependencies = [
  "enumn",
- "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/bluealloy/revm?rev=19a5f3b#19a5f3be55d633f65bcb1291670292073046cdfc"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4ff1756009a50a449e2afab1ebf04552897ed496996175f70dcebe023823f0"
 dependencies = [
  "bitflags 2.9.0",
  "revm-bytecode",
  "revm-primitives",
- "revm-specification",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,25 +430,24 @@ reth-trie-sparse = { path = "crates/trie/sparse" }
 reth-zstd-compressors = { path = "crates/storage/zstd-compressors", default-features = false }
 
 # revm
-revm = { version = "20.0.0-alpha.1", default-features = false }
-revm-bytecode = { version = "1.0.0-alpha.1", default-features = false }
-revm-database = { version = "1.0.0-alpha.1", default-features = false }
-revm-state = { version = "1.0.0-alpha.1", default-features = false }
-revm-primitives = { version = "16.0.0-alpha.1", default-features = false }
-revm-interpreter = { version = "16.0.0-alpha.1", default-features = false }
-revm-inspector = { version = "1.0.0-alpha.1", default-features = false }
-revm-context = { version = "1.0.0-alpha.1", default-features = false }
-revm-context-interface = { version = "1.0.0-alpha.1", default-features = false }
-revm-database-interface = { version = "1.0.0-alpha.1", default-features = false }
-revm-specification = { version = "1.0.0-alpha.1", default-features = false }
-op-revm = { version = "1.0.0-alpha.1", default-features = false }
+revm = { version = "20.0.0-alpha.3", default-features = false }
+revm-bytecode = { version = "1.0.0-alpha.2", default-features = false }
+revm-database = { version = "1.0.0-alpha.2", default-features = false }
+revm-state = { version = "1.0.0-alpha.2", default-features = false }
+revm-primitives = { version = "16.0.0-alpha.2", default-features = false }
+revm-interpreter = { version = "16.0.0-alpha.3", default-features = false }
+revm-inspector = { version = "1.0.0-alpha.3", default-features = false }
+revm-context = { version = "1.0.0-alpha.2", default-features = false }
+revm-context-interface = { version = "1.0.0-alpha.2", default-features = false }
+revm-database-interface = { version = "1.0.0-alpha.2", default-features = false }
+op-revm = { version = "1.0.0-alpha.2", default-features = false }
 revm-inspectors = "0.16"
 
 # eth
 alloy-chains = { version = "0.1.64", default-features = false }
 alloy-dyn-abi = "0.8.20"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "f9ed4d3", default-features = false }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "8402f9c", default-features = false }
 alloy-primitives = { version = "0.8.20", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.20", default-features = false }
@@ -486,7 +485,7 @@ alloy-transport-ipc = { version = "0.12.4", default-features = false }
 alloy-transport-ws = { version = "0.12.4", default-features = false }
 
 # op
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "f9ed4d3", default-features = false }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "8402f9c", default-features = false }
 alloy-op-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "ae4176c" }
 op-alloy-rpc-types = { version = "0.11.0", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.11.0", default-features = false }
@@ -678,20 +677,7 @@ visibility = "0.1.1"
 walkdir = "2.3.3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-specification = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "9219073" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3c6cca4" }
 
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -13,17 +13,4 @@ reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-revm-specification = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "19a5f3b" }
-
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "9219073" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3c6cca4" }

--- a/crates/ethereum/evm/src/config.rs
+++ b/crates/ethereum/evm/src/config.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::Header;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_ethereum_forks::EthereumHardfork;
-use revm::specification::hardfork::SpecId;
+use revm::primitives::hardfork::SpecId;
 
 /// Map the latest active hardfork at the given header to a revm [`SpecId`].
 pub fn revm_spec(chain_spec: &ChainSpec, header: &Header) -> SpecId {

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -32,7 +32,7 @@ use reth_primitives::{EthPrimitives, SealedBlock, SealedHeader, TransactionSigne
 use revm::{
     context::{BlockEnv, CfgEnv},
     context_interface::block::BlobExcessGasAndPrice,
-    specification::hardfork::SpecId,
+    primitives::hardfork::SpecId,
 };
 
 mod config;

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -89,7 +89,6 @@ test-utils = [
     "reth-provider/test-utils",
     "reth-transaction-pool/test-utils",
     "reth-trie-db/test-utils",
-    "revm/test-utils",
     "reth-evm/test-utils",
     "reth-primitives/test-utils",
 ]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -75,7 +75,6 @@ test-utils = [
     "dep:parking_lot",
     "reth-ethereum-primitives/test-utils",
     "reth-primitives-traits/test-utils",
-    "revm/test-utils",
     "reth-trie-common/test-utils",
 ]
 op = [

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -50,7 +50,7 @@ pub mod test_utils;
 
 pub use alloy_evm::{
     block::{state_changes, system_calls, OnStateHook},
-    Database, Evm, EvmEnv, EvmError, FromRecoveredTx, InvalidTxError,
+    env, Database, Evm, EvmEnv, EvmError, FromRecoveredTx, InvalidTxError,
 };
 
 pub use alloy_evm::block::state_changes as state_change;

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -405,7 +405,7 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        // 1. Check once whether we need to retrieve a notifiaction gap from the WAL.
+        // 1. Check once whether we need to retrieve a notification gap from the WAL.
         if this.pending_check_canonical {
             if let Some(canonical_notification) = this.check_canonical()? {
                 return Poll::Ready(Some(Ok(canonical_notification)))

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -13,9 +13,7 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
 use alloy_evm::FromRecoveredTx;
-use alloy_op_evm::{
-    block::receipt_builder::OpReceiptBuilder, OpBlockExecutionCtx,
-};
+use alloy_op_evm::{block::receipt_builder::OpReceiptBuilder, OpBlockExecutionCtx};
 use alloy_primitives::U256;
 use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
@@ -30,7 +28,7 @@ use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader, SignedTr
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
     context_interface::block::BlobExcessGasAndPrice,
-    specification::hardfork::SpecId,
+    primitives::hardfork::SpecId,
 };
 
 mod config;

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -14,8 +14,7 @@ use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
 use alloy_evm::FromRecoveredTx;
 use alloy_op_evm::{
-    block::receipt_builder::OpReceiptBuilder, OpBlockExecutionCtx, OpBlockExecutorFactory,
-    OpEvmFactory,
+    block::receipt_builder::OpReceiptBuilder, OpBlockExecutionCtx,
 };
 use alloy_primitives::U256;
 use core::fmt::Debug;
@@ -47,6 +46,8 @@ pub use build::OpBlockAssembler;
 
 mod error;
 pub use error::OpBlockExecutionError;
+
+pub use alloy_op_evm::{OpBlockExecutorFactory, OpEvm, OpEvmFactory};
 
 /// Optimism-related EVM configuration.
 #[derive(Debug)]

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -118,7 +118,6 @@ test-utils = [
     "reth-provider/test-utils",
     "reth-transaction-pool/test-utils",
     "reth-trie-db/test-utils",
-    "revm/test-utils",
     "reth-optimism-node/test-utils",
     "reth-optimism-primitives/arbitrary",
     "reth-primitives-traits/test-utils",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -48,6 +48,5 @@ test-utils = [
     "alloy-primitives",
     "reth-chain-state/test-utils",
     "reth-primitives/test-utils",
-    "revm/test-utils",
     "reth-primitives-traits/test-utils",
 ]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -50,7 +50,6 @@ test-utils = [
     "dep:reth-trie",
     "reth-primitives-traits/test-utils",
     "reth-trie?/test-utils",
-    "revm/test-utils",
 ]
 serde = [
     "revm/serde",

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -29,7 +29,7 @@ pub use revm_inspector as inspector;
 pub mod test_utils;
 
 // Convenience re-exports.
-pub use revm::{self, *};
+pub use revm::{self, database::State, *};
 
 /// Either type for flexible usage of different database types in the same context.
 pub mod either;

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -23,7 +23,7 @@ reth-fs-util.workspace = true
 reth-storage-api.workspace = true
 reth-tasks.workspace = true
 revm-interpreter.workspace = true
-revm-specification.workspace = true
+revm-primitives.workspace = true
 
 # ethereum
 alloy-eips = { workspace = true, features = ["kzg"] }
@@ -86,7 +86,7 @@ serde = [
     "rand?/serde",
     "smallvec/serde",
     "revm-interpreter/serde",
-    "revm-specification/serde",
+    "revm-primitives/serde",
     "reth-primitives-traits/serde",
 ]
 test-utils = [

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -886,7 +886,7 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
     transaction: &T,
     fork_tracker: &ForkTracker,
 ) -> Result<(), InvalidPoolTransactionError> {
-    use revm_specification::hardfork::SpecId;
+    use revm_primitives::hardfork::SpecId;
     let spec_id = if fork_tracker.is_prague_activated() {
         SpecId::PRAGUE
     } else if fork_tracker.is_shanghai_activated() {

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -78,7 +78,6 @@ serde = [
 ]
 test-utils = [
     "triehash",
-    "revm/test-utils",
     "reth-trie-common/test-utils",
     "reth-primitives-traits/test-utils",
     "reth-chainspec/test-utils",

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -19,8 +19,7 @@ use reth::{
     revm::{
         context::{result::ExecutionResult, TxEnv},
         db::State,
-        primitives::{address, Address},
-        specification::hardfork::SpecId,
+        primitives::{address, hardfork::SpecId, Address},
         DatabaseCommit,
     },
 };

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -23,7 +23,7 @@ use reth::{
         precompile::{
             PrecompileError, PrecompileFn, PrecompileOutput, PrecompileResult, Precompiles,
         },
-        specification::hardfork::SpecId,
+        primitives::hardfork::SpecId,
         MainBuilder, MainContext,
     },
     rpc::types::engine::PayloadAttributes,

--- a/examples/stateful-precompile/src/main.rs
+++ b/examples/stateful-precompile/src/main.rs
@@ -18,7 +18,7 @@ use reth::{
         inspector::{Inspector, NoOpInspector},
         interpreter::{interpreter::EthInterpreter, InterpreterResult},
         precompile::PrecompileError,
-        specification::hardfork::SpecId,
+        primitives::hardfork::SpecId,
         MainBuilder, MainContext,
     },
     tasks::TaskManager,


### PR DESCRIPTION
Updates revm to latest pre-release version.

Also added some re-exports that were removed