### PR TITLE
chore: fix handling of forkchoice state retrieval

### DIFF
--- a/crates/engine/primitives/src/forkchoice.rs
+++ b/crates/engine/primitives/src/forkchoice.rs
@@ -40,8 +40,8 @@ impl ForkchoiceStateTracker {
     /// Returns the [`ForkchoiceStatus`] of the latest received FCU.
     ///
     /// Caution: this can be invalid.
-    pub(crate) fn latest_status(&self) -> Option<ForkchoiceStatus> {
-        self.latest.as_ref().map(|s| s.status)
+    pub const fn latest_state(&self) -> Option<ForkchoiceState> {
+        self.latest.as_ref().map(|received| received.state)
     }
 
     /// Returns whether the latest received FCU is valid: [`ForkchoiceStatus::Valid`]


### PR DESCRIPTION
Fixed the logic for `latest_state` and `last_valid_state` methods.
Now, `latest_state` correctly extracts the `ForkchoiceState` from the `latest` field, and `last_valid_state` simply returns the value from the `last_valid` field.