### PR TITLE
chore: bump revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,8 +266,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=a5722ee#a5722ee078c13338784ca41f89e93d5e73890458"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68af08d4a6c5b66b45e80e9811b9fa3dccd3cc08465246107b98fcf87afbf020"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -297,7 +298,8 @@ dependencies = [
 [[package]]
 name = "alloy-hardforks"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/hardforks?rev=ae4176c#ae4176c0027171d38832644f63f05f4f80861c6e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac52fcdca02c101b5e651af856702dd35b1af31cb00a87350f562ada636b5033"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -394,8 +396,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm?rev=a5722ee#a5722ee078c13338784ca41f89e93d5e73890458"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571af6233a65bdad21f8d91ef1a45c48e0f5f2d50b998c65b9dfb38ee438e1f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -411,7 +414,8 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/hardforks?rev=ae4176c#ae4176c0027171d38832644f63f05f4f80861c6e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc1c4dadbc9b38160d19699bd8849eab195a24d40a181f8a77e9d08fbafff03"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -5832,9 +5836,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a5d1edc7adb25c34869eaa5578d9c1a11eb03ffc0ba8555afa0844e4e52d2f"
+checksum = "bace6de3cbeca7d98d49354b3812c6d72fc609c54e162ce9db0dae1c82d2eb57"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -10054,9 +10058,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "20.0.0-alpha.4"
+version = "20.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdd8fcd919cbc149a81965cae6d60bc5d99d4ea3e5ed4d7154872a2004972f8"
+checksum = "f4eafd506f0f00559874b343901fb441771b8d3722724d08dab6859d3339289f"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10085,11 +10089,10 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532674640ae1d9619fe31b418f63a41fe3ad55bbb63665ff634e5ec95f09fc41"
+checksum = "d6aa6c3cd7ddd1aa68a0478f101fb5ebff83ee0566064b458cb3769725cde7fa"
 dependencies = [
- "auto_impl",
  "cfg-if",
  "derive-where",
  "revm-bytecode",
@@ -10102,9 +10105,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f16203c3bf03b78f7604ea4880af307c655dc2946c6134c749952d4fa87064"
+checksum = "117c87d8d2fce323ea208a091a1b399fd0f74a208679952e0e88a8da061f016e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10144,9 +10147,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d0f306d5de38834abdd7c871c686c6e81721e527de87e8f2f73db79437e13e"
+checksum = "dc6048d06362493e8f0864d99ede5092ee2324db37e1e7d592fcb3c50e4af482"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10162,9 +10165,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d871e7fa03ecc4ddbe91c17c63fe0c3a6d6f740d0ba213ea8600351b268db99f"
+checksum = "b8b97116c773f9330b5d7f01796f57282f075389145d8e8932ac144d448356ad"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10180,8 +10183,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.16.0"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=667180b#667180b4a3624b9630387276ff2e9a56745a093c"
+version = "0.17.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1504e2851a11562fb350a9f408e5783351650aef11790aea0b0d0d9ab961c40"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10199,9 +10203,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "16.0.0-alpha.4"
+version = "16.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963145b74a8652afa04051ecb8dd5bd89f1d97fbe58883852359ac12872cddf5"
+checksum = "7273ce9185b2a63cbd6bc6cfb3bc2a611923f9fb0bd432bd565c4d8c0d5f606f"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10211,9 +10215,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "17.0.0-alpha.4"
+version = "17.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5610cc025e936511898418d70d4bd2eaa3f772a9859585c950b23cd2dfbe8a16"
+checksum = "e812019b128ea7f33efa36e88f68ed5d9400e835055fe31e2b7162bd9ddc97ef"
 dependencies = [
  "aurora-engine-modexp",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,30 +433,30 @@ reth-ress-protocol = { path = "crates/ress/protocol" }
 reth-ress-provider = { path = "crates/ress/provider" }
 
 # revm
-revm = { version = "20.0.0-alpha.4", default-features = false }
+revm = { version = "20.0.0-alpha.5", default-features = false }
 revm-bytecode = { version = "1.0.0-alpha.3", default-features = false }
 revm-database = { version = "1.0.0-alpha.3", default-features = false }
 revm-state = { version = "1.0.0-alpha.3", default-features = false }
 revm-primitives = { version = "16.0.0-alpha.3", default-features = false }
-revm-interpreter = { version = "16.0.0-alpha.4", default-features = false }
-revm-inspector = { version = "1.0.0-alpha.4", default-features = false }
-revm-context = { version = "1.0.0-alpha.3", default-features = false }
-revm-context-interface = { version = "1.0.0-alpha.3", default-features = false }
+revm-interpreter = { version = "16.0.0-alpha.5", default-features = false }
+revm-inspector = { version = "1.0.0-alpha.5", default-features = false }
+revm-context = { version = "1.0.0-alpha.4", default-features = false }
+revm-context-interface = { version = "1.0.0-alpha.4", default-features = false }
 revm-database-interface = { version = "1.0.0-alpha.3", default-features = false }
-op-revm = { version = "1.0.0-alpha.3", default-features = false }
-revm-inspectors = "0.16"
+op-revm = { version = "1.0.0-alpha.4", default-features = false }
+revm-inspectors = "0.17.0-alpha.1"
 
 # eth
 alloy-chains = { version = "0.1.64", default-features = false }
 alloy-dyn-abi = "0.8.20"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "a5722ee", default-features = false }
+alloy-evm = { version = "0.1.0-alpha.1", default-features = false }
 alloy-primitives = { version = "0.8.20", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.20", default-features = false }
 alloy-trie = { version = "0.7.9", default-features = false }
 
-alloy-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "ae4176c" }
+alloy-hardforks = "0.1"
 
 alloy-consensus = { version = "0.12.5", default-features = false }
 alloy-contract = { version = "0.12.5", default-features = false }
@@ -488,8 +488,8 @@ alloy-transport-ipc = { version = "0.12.5", default-features = false }
 alloy-transport-ws = { version = "0.12.5", default-features = false }
 
 # op
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "a5722ee", default-features = false }
-alloy-op-hardforks = { git = "https://github.com/alloy-rs/hardforks", rev = "ae4176c" }
+alloy-op-evm = { version = "0.1.0-alpha.1", default-features = false }
+alloy-op-hardforks = "0.1"
 op-alloy-rpc-types = { version = "0.11.1", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.11.1", default-features = false }
 op-alloy-network = { version = "0.11.1", default-features = false }
@@ -680,9 +680,7 @@ visibility = "0.1.1"
 walkdir = "2.3.3"
 vergen-git2 = "1.0.5"
 
-[patch.crates-io]
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "667180b" }
-
+# [patch.crates-io]
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }

--- a/book/sources/Cargo.toml
+++ b/book/sources/Cargo.toml
@@ -11,6 +11,3 @@ reth-exex = { path = "../../crates/exex/exex" }
 reth-node-ethereum = { path = "../../crates/ethereum/node" }
 reth-tracing = { path = "../../crates/tracing" }
 reth-node-api = { path = "../../crates/node/api" }
-
-[patch.crates-io]
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "667180b" }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -20,11 +20,7 @@ extern crate alloc;
 use crate::execute::BasicBlockBuilder;
 use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip4895::Withdrawals};
-pub use alloy_evm::evm::EvmFactory;
-use alloy_evm::{
-    block::{BlockExecutorFactory, BlockExecutorFor},
-    IntoTxEnv,
-};
+use alloy_evm::block::{BlockExecutorFactory, BlockExecutorFor};
 use alloy_primitives::{Address, B256};
 use core::{error::Error, fmt::Debug};
 use execute::{BlockAssembler, BlockBuilder};
@@ -50,7 +46,7 @@ pub mod test_utils;
 
 pub use alloy_evm::{
     block::{state_changes, system_calls, OnStateHook},
-    env, Database, Evm, EvmEnv, EvmError, FromRecoveredTx, InvalidTxError,
+    *,
 };
 
 pub use alloy_evm::block::state_changes as state_change;


### PR DESCRIPTION
Bumps revm, alloy-evm, revm-inspectors and alloy-hardforks, removing all git dependencies and patches from codebase.

Also re-exports alloy_evm from reth-evm crate.