### PR TITLE
Fix: help merging `CachedReads` across blocks

### DIFF
--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -181,7 +181,7 @@ impl<DB: DatabaseRef> DatabaseRef for CachedReadsDBRef<'_, DB> {
     }
 }
 
-/// Cached account contains the account state with storage 
+/// Cached account contains the account state with storage
 /// but lacks the account status.
 #[derive(Debug, Clone)]
 pub struct CachedAccount {

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -26,9 +26,9 @@ use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct CachedReads {
-    accounts: HashMap<Address, CachedAccount>,
-    contracts: HashMap<B256, Bytecode>,
-    block_hashes: HashMap<u64, B256>,
+    pub accounts: HashMap<Address, CachedAccount>,
+    pub contracts: HashMap<B256, Bytecode>,
+    pub block_hashes: HashMap<u64, B256>,
 }
 
 // === impl CachedReads ===

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -26,8 +26,11 @@ use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct CachedReads {
+    /// Block state account with storage.
     pub accounts: HashMap<Address, CachedAccount>,
+    /// Created contracts.
     pub contracts: HashMap<B256, Bytecode>,
+    /// Block hash mapped to the block number.
     pub block_hashes: HashMap<u64, B256>,
 }
 
@@ -178,10 +181,14 @@ impl<DB: DatabaseRef> DatabaseRef for CachedReadsDBRef<'_, DB> {
     }
 }
 
+/// Cached account contains the account state with storage 
+/// but lacks the account status.
 #[derive(Debug, Clone)]
-struct CachedAccount {
-    info: Option<AccountInfo>,
-    storage: HashMap<U256, U256>,
+pub struct CachedAccount {
+    /// Account state.
+    pub info: Option<AccountInfo>,
+    /// Account's storage.
+    pub storage: HashMap<U256, U256>,
 }
 
 impl CachedAccount {


### PR DESCRIPTION
The fields of `CachedReads` are now private. 
We want to reuse `CachedReads` across blocks, but having private fields is making our codebase somewhat less clean. 
`reth` is using `CachedReads::insert_account`, but this isn't sufficient for us since it only replaces the data. We want to extend `storage`.

If you have any suggestions, please let me know.