### PR TITLE
fix(ress): do not terminate on dropped commands sender

### DIFF
--- a/crates/ress/protocol/src/connection.rs
+++ b/crates/ress/protocol/src/connection.rs
@@ -273,8 +273,7 @@ where
         }
 
         'conn: loop {
-            if let Poll::Ready(maybe_cmd) = this.commands.poll_next_unpin(cx) {
-                let Some(cmd) = maybe_cmd else { break 'conn };
+            if let Poll::Ready(Some(cmd)) = this.commands.poll_next_unpin(cx) {
                 let message = this.on_command(cmd);
                 let encoded = message.encoded();
                 trace!(target: "ress::net::connection", peer_id = %this.peer_id, ?message, encoded = alloy_primitives::hex::encode(&encoded), "Sending peer command");


### PR DESCRIPTION
## Description

It is okay to drop the commands sender. The connection should remain active.