### PR TITLE
fix: bytecode jumptable bit len set

### DIFF
--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{keccak256, Bytes, B256, U256};
@@ -50,9 +49,9 @@ impl Account {
     /// After `SpuriousDragon` empty account is defined as account with nonce == 0 && balance == 0
     /// && bytecode = None (or hash is [`KECCAK_EMPTY`]).
     pub fn is_empty(&self) -> bool {
-        self.nonce == 0
-            && self.balance.is_zero()
-            && self.bytecode_hash.is_none_or(|hash| hash == KECCAK_EMPTY)
+        self.nonce == 0 &&
+            self.balance.is_zero() &&
+            self.bytecode_hash.is_none_or(|hash| hash == KECCAK_EMPTY)
     }
 
     /// Returns an account bytecode's hash.
@@ -182,7 +181,7 @@ impl reth_codecs::Compact for Bytecode {
                 Self(RevmBytecode::new_analyzed(
                     bytes,
                     original_len,
-                    revm_bytecode::JumpTable(Arc::new(bitvec)),
+                    revm_bytecode::JumpTable(alloc::sync::Arc::new(bitvec)),
                 ))
             }
             EOF_BYTECODE_ID | EIP7702_BYTECODE_ID => {

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -238,9 +238,10 @@ impl From<Account> for AccountInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::sync::Arc;
     use alloy_primitives::{hex_literal::hex, B256, U256};
     use reth_codecs::Compact;
-    use revm_bytecode::{JumpTable, LegacyAnalyzedBytecode};
+    use revm_bytecode::{bitvec::vec::BitVec, JumpTable, LegacyAnalyzedBytecode};
 
     #[test]
     fn test_account() {
@@ -296,10 +297,12 @@ mod tests {
         assert_eq!(len, 53);
 
         let mut buf = vec![];
+        let mut bitvec = BitVec::from_slice(&[0]);
+        unsafe { bitvec.set_len(2) };
         let bytecode = Bytecode(RevmBytecode::LegacyAnalyzed(LegacyAnalyzedBytecode::new(
             Bytes::from(&hex!("ff00")),
             2,
-            JumpTable::from_slice(&[0]),
+            JumpTable(Arc::new(bitvec)),
         )));
         let len = bytecode.to_compact(&mut buf);
         assert_eq!(len, 16);


### PR DESCRIPTION
Align jumptable length to the original_len or the `bytes.len()` 