### PR TITLE
feat: remove deprecated #[clap] attribute 

### DIFF
--- a/crates/cli/commands/src/db/clear.rs
+++ b/crates/cli/commands/src/db/clear.rs
@@ -13,7 +13,7 @@ use reth_static_file_types::StaticFileSegment;
 /// The arguments for the `reth db clear` command
 #[derive(Parser, Debug)]
 pub struct Command {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: Subcommands,
 }
 


### PR DESCRIPTION
updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.