### PR TITLE
chore(cli): fix clap deprecated warnings

### DIFF
--- a/crates/cli/commands/src/p2p/rlpx.rs
+++ b/crates/cli/commands/src/p2p/rlpx.rs
@@ -11,7 +11,7 @@ use tokio::net::TcpStream;
 /// RLPx commands
 #[derive(Parser, Debug)]
 pub struct Command {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: Subcommands,
 }
 


### PR DESCRIPTION
follow up:https://github.com/paradigmxyz/reth/pull/15015
Fix all warnings reported by `cargo check --features clap/deprecated`