### PR TITLE
Fix: Update commet about Eip7702 transaction type

### DIFF
--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -100,9 +100,9 @@ pub enum Transaction {
     Eip4844(TxEip4844),
     /// EOA Set Code Transactions ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)), type `0x4`.
     ///
-    /// EOA Set Code Transactions give the ability to temporarily set contract code for an
-    /// EOA for a single transaction. This allows for temporarily adding smart contract
-    /// functionality to the EOA.
+    /// EOA Set Code Transactions give the ability to set contract code for an EOA in perpetuity
+    /// until re-assigned by the same EOA. This allows for adding smart contract functionality to
+    /// the EOA.
     Eip7702(TxEip7702),
 }
 


### PR DESCRIPTION
As per [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702#in-protocol-revocation) spec in its current form, the delegation exists indefinitely. The updated comment follows the latest spec. 