### PR TITLE
chore: use Histogram for trie input duration

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -68,7 +68,7 @@ pub(crate) struct BlockValidationMetrics {
     /// Latest state root duration
     pub(crate) state_root_duration: Gauge,
     /// Trie input computation duration
-    pub(crate) trie_input_duration: Gauge,
+    pub(crate) trie_input_duration: Histogram,
 }
 
 impl BlockValidationMetrics {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2399,7 +2399,7 @@ where
             self.metrics
                 .block_validation
                 .trie_input_duration
-                .set(trie_input_start.elapsed().as_secs_f64());
+                .record(trie_input_start.elapsed().as_secs_f64());
 
             self.payload_processor.spawn(header, txs, provider_builder, consistent_view, trie_input)
         } else {


### PR DESCRIPTION
This is more useful as a histogram especially when benchmarking