### PR TITLE
feat(ress): max witness window

### DIFF
--- a/bin/reth/src/ress.rs
+++ b/bin/reth/src/ress.rs
@@ -41,9 +41,10 @@ where
         provider,
         block_executor,
         Box::new(task_executor.clone()),
-        pending_state,
+        args.max_witness_window,
         args.witness_max_parallel,
         args.witness_cache_size,
+        pending_state,
     )?;
     network.add_rlpx_sub_protocol(
         RessProtocolHandler {

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -730,6 +730,11 @@ Ress:
 
           [default: 5]
 
+      --ress.max-witness-window <MAX_WITNESS_WINDOW>
+          The maximum witness lookback window
+
+          [default: 1024]
+
       --ress.witness-max-parallel <WITNESS_MAX_PARALLEL>
           The maximum number of witnesses to generate in parallel
 

--- a/crates/node/core/src/args/ress_args.rs
+++ b/crates/node/core/src/args/ress_args.rs
@@ -3,6 +3,9 @@ use clap::Args;
 /// The default number of maximum active connections.
 const MAX_ACTIVE_CONNECTIONS_DEFAULT: u64 = 5;
 
+/// The default maximum witness lookback window.
+const MAX_WITNESS_WINDOW_DEFAULT: u64 = 1024;
+
 /// The default maximum number of witnesses to generate in parallel.
 const WITNESS_MAX_PARALLEL_DEFAULT: usize = 5;
 
@@ -21,6 +24,10 @@ pub struct RessArgs {
     #[arg(long = "ress.max-active-connections", default_value_t = MAX_ACTIVE_CONNECTIONS_DEFAULT)]
     pub max_active_connections: u64,
 
+    /// The maximum witness lookback window.
+    #[arg(long = "ress.max-witness-window", default_value_t = MAX_WITNESS_WINDOW_DEFAULT)]
+    pub max_witness_window: u64,
+
     /// The maximum number of witnesses to generate in parallel.
     #[arg(long = "ress.witness-max-parallel", default_value_t = WITNESS_MAX_PARALLEL_DEFAULT)]
     pub witness_max_parallel: usize,
@@ -35,6 +42,7 @@ impl Default for RessArgs {
         Self {
             enabled: false,
             max_active_connections: MAX_ACTIVE_CONNECTIONS_DEFAULT,
+            max_witness_window: MAX_WITNESS_WINDOW_DEFAULT,
             witness_max_parallel: WITNESS_MAX_PARALLEL_DEFAULT,
             witness_cache_size: WITNESS_CACHE_SIZE_DEFAULT,
         }


### PR DESCRIPTION
## Description

Limit the number of historical blocks witness can be generated for.