### PR TITLE
test(op): add Op e2e testsuite example

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions.rs
@@ -1,12 +1,12 @@
 //! Actions that can be performed in tests.
 
 use crate::testsuite::Environment;
-use alloy_primitives::{Address, Bytes, B256};
-use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes, PayloadStatusEnum};
+use alloy_primitives::{Bytes, B256};
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
 use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction};
 use eyre::Result;
 use futures_util::future::BoxFuture;
-use reth_node_api::EngineTypes;
+use reth_node_api::{EngineTypes, PayloadTypes};
 use reth_rpc_api::clients::{EngineApiClient, EthApiClient};
 use std::{future::Future, marker::PhantomData};
 use tracing::debug;
@@ -54,28 +54,46 @@ where
 /// Mine a single block with the given transactions and verify the block was created
 /// successfully.
 #[derive(Debug)]
-pub struct AssertMineBlock<Engine> {
+pub struct AssertMineBlock<Engine>
+where
+    Engine: PayloadTypes,
+{
     /// The node index to mine
     pub node_idx: usize,
     /// Transactions to include in the block
     pub transactions: Vec<Bytes>,
     /// Expected block hash (optional)
     pub expected_hash: Option<B256>,
+    /// Block's payload attributes
+    pub payload_attributes: Engine::PayloadAttributes,
     /// Tracks engine type
     _phantom: PhantomData<Engine>,
 }
 
-impl<Engine> AssertMineBlock<Engine> {
+impl<Engine> AssertMineBlock<Engine>
+where
+    Engine: PayloadTypes,
+{
     /// Create a new `AssertMineBlock` action
-    pub fn new(node_idx: usize, transactions: Vec<Bytes>, expected_hash: Option<B256>) -> Self {
-        Self { node_idx, transactions, expected_hash, _phantom: Default::default() }
+    pub fn new(
+        node_idx: usize,
+        transactions: Vec<Bytes>,
+        expected_hash: Option<B256>,
+        payload_attributes: Engine::PayloadAttributes,
+    ) -> Self {
+        Self {
+            node_idx,
+            transactions,
+            expected_hash,
+            payload_attributes,
+            _phantom: Default::default(),
+        }
     }
 }
 
 impl<Engine> Action<Engine> for AssertMineBlock<Engine>
 where
     Engine: EngineTypes,
-    Engine::PayloadAttributes: From<PayloadAttributes>,
 {
     fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {
@@ -108,26 +126,10 @@ where
                 finalized_block_hash: parent_hash,
             };
 
-            let timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-
-            // create payload attributes for the new block
-            let payload_attributes = PayloadAttributes {
-                timestamp,
-                prev_randao: B256::random(),
-                suggested_fee_recipient: Address::random(),
-                withdrawals: Some(vec![]),
-                parent_beacon_block_root: Some(B256::ZERO),
-            };
-
-            let engine_payload_attributes: Engine::PayloadAttributes = payload_attributes.into();
-
             let fcu_result = EngineApiClient::<Engine>::fork_choice_updated_v3(
                 engine_client,
                 fork_choice_state,
-                Some(engine_payload_attributes),
+                Some(self.payload_attributes.clone()),
             )
             .await?;
 

--- a/crates/e2e-test-utils/src/testsuite/actions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions.rs
@@ -65,6 +65,7 @@ where
     /// Expected block hash (optional)
     pub expected_hash: Option<B256>,
     /// Block's payload attributes
+    // TODO: refactor once we have actions to generate payload attributes.
     pub payload_attributes: Engine::PayloadAttributes,
     /// Tracks engine type
     _phantom: PhantomData<Engine>,

--- a/crates/e2e-test-utils/src/testsuite/actions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions.rs
@@ -126,7 +126,7 @@ where
                 finalized_block_hash: parent_hash,
             };
 
-            let fcu_result = EngineApiClient::<Engine>::fork_choice_updated_v3(
+            let fcu_result = EngineApiClient::<Engine>::fork_choice_updated_v2(
                 engine_client,
                 fork_choice_state,
                 Some(self.payload_attributes.clone()),
@@ -143,7 +143,7 @@ where
 
                         // get the payload that was built
                         let _engine_payload =
-                            EngineApiClient::<Engine>::get_payload_v3(engine_client, payload_id)
+                            EngineApiClient::<Engine>::get_payload_v2(engine_client, payload_id)
                                 .await?;
                         Ok(())
                     } else {

--- a/crates/e2e-test-utils/src/testsuite/actions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions.rs
@@ -249,7 +249,6 @@ impl<Engine> Default for ProduceBlocks<Engine> {
 impl<Engine> Action<Engine> for ProduceBlocks<Engine>
 where
     Engine: EngineTypes,
-    Engine::PayloadAttributes: From<PayloadAttributes>,
 {
     fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {

--- a/crates/e2e-test-utils/src/testsuite/examples.rs
+++ b/crates/e2e-test-utils/src/testsuite/examples.rs
@@ -31,6 +31,7 @@ async fn test_testsuite_assert_mine_block() -> Result<()> {
             0,
             vec![],
             Some(B256::ZERO),
+            // TODO: refactor once we have actions to generate payload attributes.
             PayloadAttributes {
                 timestamp: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)

--- a/crates/e2e-test-utils/src/testsuite/examples.rs
+++ b/crates/e2e-test-utils/src/testsuite/examples.rs
@@ -21,7 +21,7 @@ async fn test_testsuite_assert_mine_block() -> Result<()> {
             ChainSpecBuilder::default()
                 .chain(MAINNET.chain)
                 .genesis(serde_json::from_str(include_str!("assets/genesis.json")).unwrap())
-                .cancun_activated()
+                .paris_activated()
                 .build(),
         ))
         .with_network(NetworkSetup::single_node());
@@ -39,8 +39,8 @@ async fn test_testsuite_assert_mine_block() -> Result<()> {
                     .as_secs(),
                 prev_randao: B256::random(),
                 suggested_fee_recipient: Address::random(),
-                withdrawals: Some(vec![]),
-                parent_beacon_block_root: Some(B256::ZERO),
+                withdrawals: None,
+                parent_beacon_block_root: None,
             },
         ));
 

--- a/crates/e2e-test-utils/src/testsuite/examples.rs
+++ b/crates/e2e-test-utils/src/testsuite/examples.rs
@@ -5,7 +5,8 @@ use crate::testsuite::{
     setup::{NetworkSetup, Setup},
     TestBuilder,
 };
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
+use alloy_rpc_types_engine::PayloadAttributes;
 use eyre::Result;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_node_ethereum::{EthEngineTypes, EthereumNode};
@@ -25,9 +26,22 @@ async fn test_testsuite_assert_mine_block() -> Result<()> {
         ))
         .with_network(NetworkSetup::single_node());
 
-    let test = TestBuilder::new()
-        .with_setup(setup)
-        .with_action(AssertMineBlock::<EthEngineTypes>::new(0, vec![], Some(B256::ZERO)));
+    let test =
+        TestBuilder::new().with_setup(setup).with_action(AssertMineBlock::<EthEngineTypes>::new(
+            0,
+            vec![],
+            Some(B256::ZERO),
+            PayloadAttributes {
+                timestamp: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+                prev_randao: B256::random(),
+                suggested_fee_recipient: Address::random(),
+                withdrawals: Some(vec![]),
+                parent_beacon_block_root: Some(B256::ZERO),
+            },
+        ));
 
     test.run::<EthereumNode>().await?;
 

--- a/crates/optimism/node/tests/e2e/main.rs
+++ b/crates/optimism/node/tests/e2e/main.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
 mod p2p;
+mod testsuite;
 
 const fn main() {}

--- a/crates/optimism/node/tests/e2e/testsuite.rs
+++ b/crates/optimism/node/tests/e2e/testsuite.rs
@@ -1,0 +1,33 @@
+use alloy_primitives::B256;
+use eyre::Result;
+use reth_e2e_test_utils::testsuite::{
+    actions::AssertMineBlock,
+    setup::{NetworkSetup, Setup},
+    TestBuilder,
+};
+use reth_optimism_chainspec::{OpChainSpecBuilder, OP_MAINNET};
+use reth_optimism_node::{OpEngineTypes, OpNode};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_testsuite_op_assert_mine_block() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = Setup::default()
+        .with_chain_spec(Arc::new(
+            OpChainSpecBuilder::default()
+                .chain(OP_MAINNET.chain)
+                .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+                .build()
+                .into(),
+        ))
+        .with_network(NetworkSetup::single_node());
+
+    let test = TestBuilder::new()
+        .with_setup(setup)
+        .with_action(AssertMineBlock::<OpEngineTypes>::new(0, vec![], Some(B256::ZERO)));
+
+    test.run::<OpNode>().await?;
+
+    Ok(())
+}

--- a/crates/optimism/node/tests/e2e/testsuite.rs
+++ b/crates/optimism/node/tests/e2e/testsuite.rs
@@ -43,7 +43,7 @@ async fn test_testsuite_op_assert_mine_block() -> Result<()> {
                 transactions: None,
                 no_tx_pool: None,
                 eip_1559_params: None,
-                gas_limit: None,
+                gas_limit: Some(30_000_000),
             },
         ));
 

--- a/crates/optimism/node/tests/e2e/testsuite.rs
+++ b/crates/optimism/node/tests/e2e/testsuite.rs
@@ -38,7 +38,7 @@ async fn test_testsuite_op_assert_mine_block() -> Result<()> {
                     prev_randao: B256::random(),
                     suggested_fee_recipient: Address::random(),
                     withdrawals: None,
-                    parent_beacon_block_root: Some(B256::ZERO),
+                    parent_beacon_block_root: None,
                 },
                 transactions: None,
                 no_tx_pool: None,

--- a/crates/optimism/node/tests/e2e/testsuite.rs
+++ b/crates/optimism/node/tests/e2e/testsuite.rs
@@ -1,5 +1,6 @@
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use eyre::Result;
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_e2e_test_utils::testsuite::{
     actions::AssertMineBlock,
     setup::{NetworkSetup, Setup},
@@ -23,9 +24,28 @@ async fn test_testsuite_op_assert_mine_block() -> Result<()> {
         ))
         .with_network(NetworkSetup::single_node());
 
-    let test = TestBuilder::new()
-        .with_setup(setup)
-        .with_action(AssertMineBlock::<OpEngineTypes>::new(0, vec![], Some(B256::ZERO)));
+    let test =
+        TestBuilder::new().with_setup(setup).with_action(AssertMineBlock::<OpEngineTypes>::new(
+            0,
+            vec![],
+            Some(B256::ZERO),
+            OpPayloadAttributes {
+                payload_attributes: alloy_rpc_types_engine::PayloadAttributes {
+                    timestamp: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs(),
+                    prev_randao: B256::random(),
+                    suggested_fee_recipient: Address::random(),
+                    withdrawals: Some(vec![]),
+                    parent_beacon_block_root: Some(B256::ZERO),
+                },
+                transactions: None,
+                no_tx_pool: None,
+                eip_1559_params: None,
+                gas_limit: None,
+            },
+        ));
 
     test.run::<OpNode>().await?;
 

--- a/crates/optimism/node/tests/e2e/testsuite.rs
+++ b/crates/optimism/node/tests/e2e/testsuite.rs
@@ -29,6 +29,7 @@ async fn test_testsuite_op_assert_mine_block() -> Result<()> {
             0,
             vec![],
             Some(B256::ZERO),
+            // TODO: refactor once we have actions to generate payload attributes.
             OpPayloadAttributes {
                 payload_attributes: alloy_rpc_types_engine::PayloadAttributes {
                     timestamp: std::time::SystemTime::now()

--- a/crates/optimism/node/tests/e2e/testsuite.rs
+++ b/crates/optimism/node/tests/e2e/testsuite.rs
@@ -37,7 +37,7 @@ async fn test_testsuite_op_assert_mine_block() -> Result<()> {
                         .as_secs(),
                     prev_randao: B256::random(),
                     suggested_fee_recipient: Address::random(),
-                    withdrawals: Some(vec![]),
+                    withdrawals: None,
                     parent_beacon_block_root: Some(B256::ZERO),
                 },
                 transactions: None,


### PR DESCRIPTION
Closes #14989

The goal is to show how OP e2e tests look like using `testsuite`. Now both the eth example in `reth-e2e-test-utils` and the op example in `reth-optimism-node` use the same action `AssertMineBlock`, which should be deprecated once #15108 is done. After that we can rework this one to make it similar to the current `test_testsuite_produce_blocks` with concrete op actions  when needed.