### PR TITLE
feat: add wait_time optional argument to reth-bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6906,6 +6906,7 @@ dependencies = [
  "csv",
  "eyre",
  "futures",
+ "humantime",
  "op-alloy-consensus",
  "reqwest",
  "reth-cli-runner",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -58,6 +58,7 @@ tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thre
 clap = { workspace = true, features = ["derive", "env"] }
 eyre.workspace = true
 thiserror.workspace = true
+humantime.workspace = true
 
 # for writing data
 csv.workspace = true

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -15,6 +15,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types_engine::{ExecutionPayload, ForkchoiceState};
 use clap::Parser;
 use csv::Writer;
+use humantime::parse_duration;
 use reth_cli_runner::CliContext;
 use reth_node_core::args::BenchmarkArgs;
 use std::time::{Duration, Instant};
@@ -26,6 +27,10 @@ pub struct Command {
     /// The RPC url to use for getting data.
     #[arg(long, value_name = "RPC_URL", verbatim_doc_comment)]
     rpc_url: String,
+
+    /// How long to wait after a forkchoice update before sending the next payload.
+    #[arg(long, value_name = "WAIT_TIME", value_parser = parse_duration, verbatim_doc_comment)]
+    wait_time: Option<Duration>,
 
     #[command(flatten)]
     benchmark: BenchmarkArgs,
@@ -137,6 +142,11 @@ impl Command {
 
             // convert gas used to gigagas, then compute gigagas per second
             info!(%combined_result);
+
+            // wait if we need to
+            if let Some(wait_time) = self.wait_time {
+                tokio::time::sleep(wait_time).await;
+            }
 
             // record the current result
             let gas_row = TotalGasRow { block_number, gas_used, time: current_duration };


### PR DESCRIPTION
This adds a wait time option to the new-payload-fcu scenario, to wait after a FCU for some amount of time. This can be useful when testing how the node performs if there is more vs less time to persist.