### PR TITLE
Replace None with RecoveryError in transaction signature recovery

### DIFF
--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -73,7 +73,7 @@ pub trait SignedTransaction:
     /// Recover signer from signature and hash _without ensuring that the signature has a low `s`
     /// value_.
     ///
-    /// Returns `None` if the transaction's signature is invalid, see also
+    /// Returns `RecoveryError` if the transaction's signature is invalid, see also
     /// `reth_primitives::transaction::recover_signer_unchecked`.
     fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
         self.recover_signer_unchecked_with_buf(&mut Vec::new())
@@ -121,7 +121,7 @@ pub trait SignedTransaction:
     /// Consumes the type, recover signer and return [`Recovered`] _without
     /// ensuring that the signature has a low `s` value_ (EIP-2).
     ///
-    /// Returns `None` if the transaction's signature is invalid.
+    /// Returns `RecoveryError` if the transaction's signature is invalid.
     #[auto_impl(keep_default_for(&, Arc))]
     fn into_recovered_unchecked(self) -> Result<Recovered<Self>, RecoveryError> {
         self.recover_signer_unchecked().map(|signer| Recovered::new_unchecked(self, signer))

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -125,7 +125,7 @@ pub trait TransactionPool: Send + Sync + Clone {
 
     /// Returns a new transaction change event stream for the given transaction.
     ///
-    /// Returns `None` if the transaction is not in the pool.
+    /// Returns `RecoveryError` if the transaction is not in the pool.
     fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents>;
 
     /// Returns a new transaction change event stream for _all_ transactions in the pool.
@@ -400,7 +400,7 @@ pub trait TransactionPool: Send + Sync + Clone {
     ///
     /// For example, for a given on chain nonce of `5`, the next transaction must have that nonce.
     /// If the pool contains txs `[5,6,7]` this returns tx `7`.
-    /// If the pool contains txs `[6,7]` this returns `None` because the next valid nonce (5) is
+    /// If the pool contains txs `[6,7]` this returns `RecoveryError` because the next valid nonce (5) is
     /// missing, which means txs `[6,7]` are nonce gapped.
     fn get_highest_consecutive_transaction_by_sender(
         &self,
@@ -1080,7 +1080,7 @@ pub trait EthPoolTransaction: PoolTransaction {
 
     /// Tries to convert the `Consensus` type with a blob sidecar into the `Pooled` type.
     ///
-    /// Returns `None` if passed transaction is not a blob transaction.
+    /// Returns `RecoveryError` if passed transaction is not a blob transaction.
     fn try_from_eip4844(
         tx: Recovered<Self::Consensus>,
         sidecar: BlobTransactionSidecar,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -125,7 +125,7 @@ pub trait TransactionPool: Send + Sync + Clone {
 
     /// Returns a new transaction change event stream for the given transaction.
     ///
-    /// Returns `RecoveryError` if the transaction is not in the pool.
+    /// Returns `None` if the transaction is not in the pool.
     fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents>;
 
     /// Returns a new transaction change event stream for _all_ transactions in the pool.
@@ -400,7 +400,7 @@ pub trait TransactionPool: Send + Sync + Clone {
     ///
     /// For example, for a given on chain nonce of `5`, the next transaction must have that nonce.
     /// If the pool contains txs `[5,6,7]` this returns tx `7`.
-    /// If the pool contains txs `[6,7]` this returns `RecoveryError` because the next valid nonce (5) is
+    /// If the pool contains txs `[6,7]` this returns `None` because the next valid nonce (5) is
     /// missing, which means txs `[6,7]` are nonce gapped.
     fn get_highest_consecutive_transaction_by_sender(
         &self,
@@ -1080,7 +1080,7 @@ pub trait EthPoolTransaction: PoolTransaction {
 
     /// Tries to convert the `Consensus` type with a blob sidecar into the `Pooled` type.
     ///
-    /// Returns `RecoveryError` if passed transaction is not a blob transaction.
+    /// Returns `None` if passed transaction is not a blob transaction.
     fn try_from_eip4844(
         tx: Recovered<Self::Consensus>,
         sidecar: BlobTransactionSidecar,


### PR DESCRIPTION


Description:
This PR updates the return type documentation in `SignedTransaction` trait to better reflect error handling behavior. Instead of returning `None` when a transaction's signature is invalid, we now explicitly return `RecoveryError`. This change makes the error handling more explicit and consistent with the actual implementation.

Changes:
- Updated documentation comments to indicate `RecoveryError` instead of `None` as return type for invalid signatures
- Affects both `recover_signer_unchecked` and `into_recovered_unchecked` methods
- No functional changes, only documentation improvements

This change improves code clarity by making the error handling more explicit in the documentation.
