### PR TITLE
chore: add serde feature to db-models

### DIFF
--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-codecs.workspace = true
-reth-db-models = { workspace = true, features = ["reth-codec"] }
+reth-db-models = { workspace = true, features = ["serde", "reth-codec"] }
 reth-ethereum-primitives = { workspace = true, features = ["reth-codec"] }
 reth-primitives-traits = { workspace = true, features = ["serde", "reth-codec"] }
 reth-stages-types = { workspace = true, features = ["serde", "reth-codec"] }

--- a/crates/storage/db-models/Cargo.toml
+++ b/crates/storage/db-models/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-codecs = { workspace = true, optional = true }
-reth-primitives-traits = { workspace = true, features = ["serde"] }
+reth-primitives-traits.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true
@@ -22,7 +22,7 @@ alloy-eips.workspace = true
 
 # codecs
 modular-bitfield = { workspace = true, optional = true }
-serde = { workspace = true, default-features = false }
+serde = { workspace = true, optional = true }
 
 # misc
 bytes = { workspace = true, optional = true }
@@ -32,7 +32,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 # reth
-reth-primitives-traits = { workspace = true, features = ["arbitrary"] }
+reth-primitives-traits = { workspace = true, features = ["arbitrary", "reth-codec"] }
 reth-codecs.workspace = true
 
 bytes.workspace = true
@@ -51,6 +51,14 @@ std = [
     "reth-primitives-traits/std",
     "bytes?/std",
     "serde/std",
+]
+serde = [
+    "dep:serde",
+    "alloy-eips/serde",
+    "alloy-primitives/serde",
+    "bytes?/serde",
+    "reth-codecs?/serde",
+    "reth-primitives-traits/serde",
 ]
 test-utils = [
     "reth-primitives-traits/test-utils",

--- a/crates/storage/db-models/src/accounts.rs
+++ b/crates/storage/db-models/src/accounts.rs
@@ -1,13 +1,12 @@
-use serde::Serialize;
-
 use alloy_primitives::Address;
 use reth_primitives_traits::Account;
 
 /// Account as it is saved in the database.
 ///
 /// [`Address`] is the subkey.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary, serde::Deserialize))]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 pub struct AccountBeforeTx {
     /// Address for the account. Acts as `DupSort::SubKey`.
@@ -19,7 +18,7 @@ pub struct AccountBeforeTx {
 // NOTE: Removing reth_codec and manually encode subkey
 // and compress second part of the value. If we have compression
 // over whole value (Even SubKey) that would mess up fetching of values with seek_by_key_subkey
-#[cfg(feature = "reth-codec")]
+#[cfg(any(test, feature = "reth-codec"))]
 impl reth_codecs::Compact for AccountBeforeTx {
     fn to_compact<B>(&self, buf: &mut B) -> usize
     where

--- a/crates/storage/db-models/src/blocks.rs
+++ b/crates/storage/db-models/src/blocks.rs
@@ -67,10 +67,11 @@ impl StoredBlockBodyIndices {
 }
 
 /// The storage representation of block withdrawals.
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoredBlockWithdrawals {
     /// The block withdrawals.
     pub withdrawals: Withdrawals,
@@ -78,9 +79,10 @@ pub struct StoredBlockWithdrawals {
 
 /// A storage representation of block withdrawals that is static file friendly. An inner `None`
 /// represents a pre-merge block.
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StaticFileBlockWithdrawals {
     /// The block withdrawals. A `None` value represents a pre-merge block.
     pub withdrawals: Option<Withdrawals>,

--- a/crates/storage/db-models/src/blocks.rs
+++ b/crates/storage/db-models/src/blocks.rs
@@ -10,10 +10,11 @@ pub type NumTransactions = u64;
 ///
 /// It has the pointer to the transaction Number of the first
 /// transaction in the block and the total number of transactions.
-#[derive(Debug, Default, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoredBlockBodyIndices {
     /// The number of the first transaction in this block
     ///
@@ -86,7 +87,7 @@ pub struct StaticFileBlockWithdrawals {
     pub withdrawals: Option<Withdrawals>,
 }
 
-#[cfg(feature = "reth-codec")]
+#[cfg(any(test, feature = "reth-codec"))]
 impl reth_codecs::Compact for StaticFileBlockWithdrawals {
     fn to_compact<B>(&self, buf: &mut B) -> usize
     where

--- a/crates/storage/db-models/src/blocks.rs
+++ b/crates/storage/db-models/src/blocks.rs
@@ -1,7 +1,6 @@
 use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::TxNumber;
 use core::ops::Range;
-use serde::{Deserialize, Serialize};
 
 /// Total number of transactions.
 pub type NumTransactions = u64;

--- a/crates/storage/db-models/src/client_version.rs
+++ b/crates/storage/db-models/src/client_version.rs
@@ -1,12 +1,12 @@
 //! Client version model.
 
 use alloc::string::String;
-use serde::{Deserialize, Serialize};
 
 /// Client version that accessed the database.
-#[derive(Clone, Eq, PartialEq, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Debug, Default)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientVersion {
     /// Client version
     pub version: String,
@@ -23,7 +23,7 @@ impl ClientVersion {
     }
 }
 
-#[cfg(feature = "reth-codec")]
+#[cfg(any(test, feature = "reth-codec"))]
 impl reth_codecs::Compact for ClientVersion {
     fn to_compact<B>(&self, buf: &mut B) -> usize
     where


### PR DESCRIPTION
found via https://github.com/paradigmxyz/reth/pull/15041

this was always enabling serde for reth-primitive-traits, messing with the Maybe traits...

