### PR TITLE
perf(engine): collect sparse trie updates in a vector

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -128,10 +128,11 @@ where
     trace!(target: "engine::root::sparse", "Updating sparse trie");
     let started_at = Instant::now();
 
-    // Reveal new accounts and storage slots.
     let mut state = HashedPostState::default();
     for update in updates {
+        // Reveal new accounts and storage slots.
         trie.reveal_multiproof(update.multiproof)?;
+        // Extend the state with the new updates.
         state.extend(update.state);
     }
     let reveal_multiproof_elapsed = started_at.elapsed();


### PR DESCRIPTION
## Problem

`MultiProof::extend` calls are expensive, so we can just collect them into a vector and reveal one by one.

## Before
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/d96f1d34-56dc-44f4-a477-600111199c7e" />

## After
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/3d40fa7e-9daf-4575-80fc-55e510d7bd82" />
