### PR TITLE
refactor: simplify code structure in `tokio::select!` block

### DIFF
--- a/examples/network-proxy/src/main.rs
+++ b/examples/network-proxy/src/main.rs
@@ -69,10 +69,8 @@ async fn main() -> eyre::Result<()> {
     loop {
         // receive incoming eth requests and transaction messages from the second peer
         tokio::select! {
-              eth_request = requests_rx.recv() => {
-                    let Some(eth_request) = eth_request else {break};
-                    match eth_request {
-                        IncomingEthRequest::GetBlockHeaders { peer_id, request, response } => {
+              eth_request = requests_rx.recv() => match eth_request {
+                    Some(IncomingEthRequest::GetBlockHeaders { peer_id, request, response }) => {
                             println!("Received block headers request: {peer_id:?}, {request:?}");
                             response.send(Ok(vec![DEV.genesis_header().clone()].into())).unwrap();
                         }


### PR DESCRIPTION
Refactored the code inside the `tokio::select!` block to use `match` instead of `if let Some(...)`.
This change simplifies the code, reduces nesting, and makes it easier to follow the logic.