### PR TITLE
fix windows msvc build

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -429,7 +429,7 @@ impl Info {
     /// Return the mode of the database
     #[inline]
     pub const fn mode(&self) -> Mode {
-        let mode = self.0.mi_mode;
+        let mode = self.0.mi_mode as ffi::MDBX_env_flags_t;
         if (mode & ffi::MDBX_RDONLY) != 0 {
             Mode::ReadOnly
         } else if (mode & ffi::MDBX_UTTERLY_NOSYNC) != 0 {


### PR DESCRIPTION
Fixes the build for the `x86_64-pc-windows-msvc` toolchain

See https://github.com/rust-lang/rust-bindgen/issues/1244#issuecomment-362840540

MSVC treats `MDBX_env_flags_t` as signed, but `mi_mode` is explicitly defined as unsigned, which causes the following compilation error:

```
error[E0308]: mismatched types
   --> crates\storage\libmdbx-rs\src\environment.rs:433:20
    |
433 |         if (mode & ffi::MDBX_RDONLY) != 0 {
    |                    ^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0277]: no implementation for `u32 & i32`                                                                             
   --> crates\storage\libmdbx-rs\src\environment.rs:433:18
    |
433 |         if (mode & ffi::MDBX_RDONLY) != 0 {
    |                  ^ no implementation for `u32 & i32`
    |
    = help: the trait `BitAnd<i32>` is not implemented for `u32`
    = help: the following other types implement trait `BitAnd<Rhs>`:
              `&u32` implements `BitAnd<u32>`
              `&u32` implements `BitAnd`
              `u32` implements `BitAnd<&u32>`
              `u32` implements `BitAnd`

error[E0308]: mismatched types
   --> crates\storage\libmdbx-rs\src\environment.rs:435:27
    |
435 |         } else if (mode & ffi::MDBX_UTTERLY_NOSYNC) != 0 {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0277]: no implementation for `u32 & i32`
   --> crates\storage\libmdbx-rs\src\environment.rs:435:25
    |
435 |         } else if (mode & ffi::MDBX_UTTERLY_NOSYNC) != 0 {
    |                         ^ no implementation for `u32 & i32`
    |
    = help: the trait `BitAnd<i32>` is not implemented for `u32`
    = help: the following other types implement trait `BitAnd<Rhs>`:
              `&u32` implements `BitAnd<u32>`
              `&u32` implements `BitAnd`
              `u32` implements `BitAnd<&u32>`
              `u32` implements `BitAnd`

error[E0308]: mismatched types
   --> crates\storage\libmdbx-rs\src\environment.rs:437:27
    |
437 |         } else if (mode & ffi::MDBX_NOMETASYNC) != 0 {
    |                           ^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0277]: no implementation for `u32 & i32`
   --> crates\storage\libmdbx-rs\src\environment.rs:437:25
    |
437 |         } else if (mode & ffi::MDBX_NOMETASYNC) != 0 {
    |                         ^ no implementation for `u32 & i32`
    |
    = help: the trait `BitAnd<i32>` is not implemented for `u32`
    = help: the following other types implement trait `BitAnd<Rhs>`:
              `&u32` implements `BitAnd<u32>`
              `&u32` implements `BitAnd`
              `u32` implements `BitAnd<&u32>`
              `u32` implements `BitAnd`

error[E0308]: mismatched types
   --> crates\storage\libmdbx-rs\src\environment.rs:439:27
    |
439 |         } else if (mode & ffi::MDBX_SAFE_NOSYNC) != 0 {
    |                           ^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0277]: no implementation for `u32 & i32`
   --> crates\storage\libmdbx-rs\src\environment.rs:439:25
    |
439 |         } else if (mode & ffi::MDBX_SAFE_NOSYNC) != 0 {
    |                         ^ no implementation for `u32 & i32`
    |
    = help: the trait `BitAnd<i32>` is not implemented for `u32`
    = help: the following other types implement trait `BitAnd<Rhs>`:
              `&u32` implements `BitAnd<u32>`
              `&u32` implements `BitAnd`
              `u32` implements `BitAnd<&u32>`
              `u32` implements `BitAnd`

Some errors have detailed explanations: E0277, E0308.                                                                       
For more information about an error, try `rustc --explain E0277`.
error: could not compile `reth-libmdbx` (lib) due to 8 previous errors 
```