### PR TITLE
chore: simplify revm imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5847,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bace6de3cbeca7d98d49354b3812c6d72fc609c54e162ce9db0dae1c82d2eb57"
+checksum = "61d0efbcc12d851c5f1e034d97f055491424b35515a2956ff8c3886fd9e0c148"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -7911,7 +7911,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
- "revm-database",
 ]
 
 [[package]]
@@ -7963,7 +7962,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "revm",
- "revm-database",
  "serde",
  "serde_with",
 ]
@@ -8747,8 +8745,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "revm",
- "revm-database",
- "revm-primitives",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -9291,8 +9287,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "revm",
- "revm-database",
- "revm-inspector",
 ]
 
 [[package]]
@@ -9575,9 +9569,7 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie",
  "revm",
- "revm-database",
  "revm-inspectors",
- "revm-primitives",
  "schnellru",
  "serde",
  "serde_json",
@@ -10067,9 +10059,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "20.0.0-alpha.5"
+version = "20.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4eafd506f0f00559874b343901fb441771b8d3722724d08dab6859d3339289f"
+checksum = "33790dc343daaa413e5426a508094e2055db97200e6e1a9362339e672058259d"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10086,9 +10078,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad4e81fd3d5241ba201d2514a21835d8d06fa8bb7a2fb5b733a424a4776f0c4"
+checksum = "0a1f19307417b325447bcb4bb12586d47c91df6551d33e4b6ced89eeedae7f5b"
 dependencies = [
  "bitvec",
  "phf",
@@ -10098,9 +10090,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aa6c3cd7ddd1aa68a0478f101fb5ebff83ee0566064b458cb3769725cde7fa"
+checksum = "e100b379bda77580ad0fe7cc54b87675bfb1d4762ac6747b7933f01984e238cb"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10114,9 +10106,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117c87d8d2fce323ea208a091a1b399fd0f74a208679952e0e88a8da061f016e"
+checksum = "828f3d1147ac4eff5c98e4c3714f659a97781aa4f8f0f67087c9639bdc44cb61"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10129,9 +10121,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8e7b21693b74dbd9ee824a00225aad6a4ec9db903625304ae1ce0f4c0940c4"
+checksum = "af1ade2662c72125f191296da438fdb42388311b0080db660459015dacfeeb9f"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -10144,9 +10136,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd54a44b415d510cffea16955888544ce54f987958578b40a52d15963462b259"
+checksum = "830335bea29c435ad60d532198444af1fa9d9de6724887c36156dc643c3b6f62"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10156,9 +10148,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6048d06362493e8f0864d99ede5092ee2324db37e1e7d592fcb3c50e4af482"
+checksum = "278c4ce30c07a5a5ac26b4f5f72fed5120e764bd051ec5eeb6fbdb4ff537383e"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10174,9 +10166,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b97116c773f9330b5d7f01796f57282f075389145d8e8932ac144d448356ad"
+checksum = "8faa8ebce23b85a42f660560dd3553371e5b97352a2fe229a9e849e91cd0a113"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10212,9 +10204,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "16.0.0-alpha.5"
+version = "16.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7273ce9185b2a63cbd6bc6cfb3bc2a611923f9fb0bd432bd565c4d8c0d5f606f"
+checksum = "5a86403b3a0ddf4b5aa8da800a73ab500e947150ecd5b453a93b42482dde2c1c"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10224,9 +10216,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "17.0.0-alpha.5"
+version = "17.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e812019b128ea7f33efa36e88f68ed5d9400e835055fe31e2b7162bd9ddc97ef"
+checksum = "20da0ec6e79a5420d7619e8d5fa900b8632f076fb35579b5463949fe2b328da7"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -10246,9 +10238,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "16.0.0-alpha.3"
+version = "16.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa626cac49fb6bfdbfed2a1cd232eb5f54d36281703092eaeec859111b1a220e"
+checksum = "7b719ced7ba199ea5e7a18fe62d75537e852dfc6b6afe608aac0c4cdc51af87d"
 dependencies = [
  "alloy-primitives",
  "enumn",
@@ -10257,9 +10249,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3869d401da38fcf76021a6f5e4182fa027976f54763bc6ab2c477e440c6cd8f"
+checksum = "2a268b9798bbaa1e7d52c22d94ef231dae692d66f7c5ef29ff03e0776357156e"
 dependencies = [
  "bitflags 2.9.0",
  "revm-bytecode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5847,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d0efbcc12d851c5f1e034d97f055491424b35515a2956ff8c3886fd9e0c148"
+checksum = "bace6de3cbeca7d98d49354b3812c6d72fc609c54e162ce9db0dae1c82d2eb57"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -10059,9 +10059,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "20.0.0-alpha.6"
+version = "20.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33790dc343daaa413e5426a508094e2055db97200e6e1a9362339e672058259d"
+checksum = "f4eafd506f0f00559874b343901fb441771b8d3722724d08dab6859d3339289f"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10078,9 +10078,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1f19307417b325447bcb4bb12586d47c91df6551d33e4b6ced89eeedae7f5b"
+checksum = "6ad4e81fd3d5241ba201d2514a21835d8d06fa8bb7a2fb5b733a424a4776f0c4"
 dependencies = [
  "bitvec",
  "phf",
@@ -10090,9 +10090,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e100b379bda77580ad0fe7cc54b87675bfb1d4762ac6747b7933f01984e238cb"
+checksum = "d6aa6c3cd7ddd1aa68a0478f101fb5ebff83ee0566064b458cb3769725cde7fa"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10106,9 +10106,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828f3d1147ac4eff5c98e4c3714f659a97781aa4f8f0f67087c9639bdc44cb61"
+checksum = "117c87d8d2fce323ea208a091a1b399fd0f74a208679952e0e88a8da061f016e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10121,9 +10121,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1ade2662c72125f191296da438fdb42388311b0080db660459015dacfeeb9f"
+checksum = "cd8e7b21693b74dbd9ee824a00225aad6a4ec9db903625304ae1ce0f4c0940c4"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -10136,9 +10136,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830335bea29c435ad60d532198444af1fa9d9de6724887c36156dc643c3b6f62"
+checksum = "bd54a44b415d510cffea16955888544ce54f987958578b40a52d15963462b259"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10148,9 +10148,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278c4ce30c07a5a5ac26b4f5f72fed5120e764bd051ec5eeb6fbdb4ff537383e"
+checksum = "dc6048d06362493e8f0864d99ede5092ee2324db37e1e7d592fcb3c50e4af482"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10166,9 +10166,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8faa8ebce23b85a42f660560dd3553371e5b97352a2fe229a9e849e91cd0a113"
+checksum = "b8b97116c773f9330b5d7f01796f57282f075389145d8e8932ac144d448356ad"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10204,9 +10204,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "16.0.0-alpha.6"
+version = "16.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a86403b3a0ddf4b5aa8da800a73ab500e947150ecd5b453a93b42482dde2c1c"
+checksum = "7273ce9185b2a63cbd6bc6cfb3bc2a611923f9fb0bd432bd565c4d8c0d5f606f"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10216,9 +10216,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "17.0.0-alpha.6"
+version = "17.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20da0ec6e79a5420d7619e8d5fa900b8632f076fb35579b5463949fe2b328da7"
+checksum = "e812019b128ea7f33efa36e88f68ed5d9400e835055fe31e2b7162bd9ddc97ef"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -10238,9 +10238,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "16.0.0-alpha.4"
+version = "16.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b719ced7ba199ea5e7a18fe62d75537e852dfc6b6afe608aac0c4cdc51af87d"
+checksum = "aa626cac49fb6bfdbfed2a1cd232eb5f54d36281703092eaeec859111b1a220e"
 dependencies = [
  "alloy-primitives",
  "enumn",
@@ -10249,9 +10249,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a268b9798bbaa1e7d52c22d94ef231dae692d66f7c5ef29ff03e0776357156e"
+checksum = "d3869d401da38fcf76021a6f5e4182fa027976f54763bc6ab2c477e440c6cd8f"
 dependencies = [
  "bitflags 2.9.0",
  "revm-bytecode",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -23,7 +23,6 @@ reth-trie-common.workspace = true
 reth-ethereum-primitives = { workspace = true, optional = true }
 
 revm.workspace = true
-revm-database.workspace = true
 op-revm = { workspace = true, optional = true }
 
 # alloy
@@ -56,7 +55,6 @@ std = [
     "reth-ethereum-forks/std",
     "reth-ethereum-primitives?/std",
     "alloy-evm/std",
-    "revm-database/std",
     "op-revm?/std",
     "reth-execution-errors/std",
     "reth-execution-types/std",
@@ -66,19 +64,11 @@ std = [
     "reth-storage-api/std",
     "reth-trie-common/std",
 ]
-metrics = [
-    "std",
-    "dep:metrics",
-    "dep:reth-metrics",
-]
+metrics = ["std", "dep:metrics", "dep:reth-metrics"]
 test-utils = [
     "dep:parking_lot",
     "reth-ethereum-primitives/test-utils",
     "reth-primitives-traits/test-utils",
     "reth-trie-common/test-utils",
 ]
-op = [
-    "op-revm",
-    "alloy-evm/op",
-    "reth-primitives-traits/op",
-]
+op = ["op-revm", "alloy-evm/op", "reth-primitives-traits/op"]

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -29,10 +29,7 @@ serde_with = { workspace = true, optional = true }
 derive_more.workspace = true
 
 [dev-dependencies]
-reth-primitives-traits = { workspace = true, features = [
-    "test-utils",
-    "arbitrary",
-] }
+reth-primitives-traits = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-ethereum-primitives = { workspace = true, features = ["arbitrary"] }
 alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 arbitrary.workspace = true

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -16,7 +16,6 @@ reth-primitives-traits.workspace = true
 reth-trie-common.workspace = true
 
 revm.workspace = true
-revm-database.workspace = true
 
 # alloy
 alloy-evm.workspace = true
@@ -30,7 +29,10 @@ serde_with = { workspace = true, optional = true }
 derive_more.workspace = true
 
 [dev-dependencies]
-reth-primitives-traits = { workspace = true, features = ["test-utils", "arbitrary"] }
+reth-primitives-traits = { workspace = true, features = [
+    "test-utils",
+    "arbitrary",
+] }
 reth-ethereum-primitives = { workspace = true, features = ["arbitrary"] }
 alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 arbitrary.workspace = true
@@ -47,7 +49,6 @@ serde = [
     "alloy-primitives/serde",
     "reth-primitives-traits/serde",
     "alloy-consensus/serde",
-    "revm-database/serde",
     "reth-trie-common/serde",
 ]
 serde-bincode-compat = [
@@ -70,6 +71,5 @@ std = [
     "derive_more/std",
     "reth-ethereum-primitives/std",
     "reth-trie-common/std",
-    "revm-database/std",
     "alloy-evm/std",
 ]

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -140,13 +140,13 @@ impl<N: NodePrimitives> Chain<N> {
         block_number: BlockNumber,
     ) -> Option<ExecutionOutcome<N::Receipt>> {
         if self.tip().number() == block_number {
-            return Some(self.execution_outcome.clone());
+            return Some(self.execution_outcome.clone())
         }
 
         if self.blocks.contains_key(&block_number) {
             let mut execution_outcome = self.execution_outcome.clone();
             execution_outcome.revert_to(block_number);
-            return Some(execution_outcome);
+            return Some(execution_outcome)
         }
         None
     }
@@ -278,7 +278,7 @@ impl<N: NodePrimitives> Chain<N> {
         let chain_tip = self.tip();
         let other_fork_block = other.fork_block();
         if chain_tip.hash() != other_fork_block.hash {
-            return Err(other);
+            return Err(other)
         }
 
         // Insert blocks from other chain
@@ -315,7 +315,7 @@ impl<N: NodePrimitives> Chain<N> {
         let block_number = match split_at {
             ChainSplitTarget::Hash(block_hash) => {
                 let Some(block_number) = self.block_number(block_hash) else {
-                    return ChainSplit::NoSplitPending(self);
+                    return ChainSplit::NoSplitPending(self)
                 };
                 // If block number is same as tip whole chain is becoming canonical.
                 if block_number == chain_tip {
@@ -325,13 +325,13 @@ impl<N: NodePrimitives> Chain<N> {
             }
             ChainSplitTarget::Number(block_number) => {
                 if block_number > chain_tip {
-                    return ChainSplit::NoSplitPending(self);
+                    return ChainSplit::NoSplitPending(self)
                 }
                 if block_number == chain_tip {
                     return ChainSplit::NoSplitCanonical(self);
                 }
                 if block_number < *self.blocks.first_entry().expect("chain is never empty").key() {
-                    return ChainSplit::NoSplitPending(self);
+                    return ChainSplit::NoSplitPending(self)
                 }
                 block_number
             }

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -11,7 +11,7 @@ use reth_primitives_traits::{
     SealedHeader,
 };
 use reth_trie_common::updates::TrieUpdates;
-use revm_database::BundleState;
+use revm::database::BundleState;
 
 /// A chain of blocks and their final state.
 ///
@@ -140,13 +140,13 @@ impl<N: NodePrimitives> Chain<N> {
         block_number: BlockNumber,
     ) -> Option<ExecutionOutcome<N::Receipt>> {
         if self.tip().number() == block_number {
-            return Some(self.execution_outcome.clone())
+            return Some(self.execution_outcome.clone());
         }
 
         if self.blocks.contains_key(&block_number) {
             let mut execution_outcome = self.execution_outcome.clone();
             execution_outcome.revert_to(block_number);
-            return Some(execution_outcome)
+            return Some(execution_outcome);
         }
         None
     }
@@ -278,7 +278,7 @@ impl<N: NodePrimitives> Chain<N> {
         let chain_tip = self.tip();
         let other_fork_block = other.fork_block();
         if chain_tip.hash() != other_fork_block.hash {
-            return Err(other)
+            return Err(other);
         }
 
         // Insert blocks from other chain
@@ -315,23 +315,23 @@ impl<N: NodePrimitives> Chain<N> {
         let block_number = match split_at {
             ChainSplitTarget::Hash(block_hash) => {
                 let Some(block_number) = self.block_number(block_hash) else {
-                    return ChainSplit::NoSplitPending(self)
+                    return ChainSplit::NoSplitPending(self);
                 };
                 // If block number is same as tip whole chain is becoming canonical.
                 if block_number == chain_tip {
-                    return ChainSplit::NoSplitCanonical(self)
+                    return ChainSplit::NoSplitCanonical(self);
                 }
                 block_number
             }
             ChainSplitTarget::Number(block_number) => {
                 if block_number > chain_tip {
-                    return ChainSplit::NoSplitPending(self)
+                    return ChainSplit::NoSplitPending(self);
                 }
                 if block_number == chain_tip {
-                    return ChainSplit::NoSplitCanonical(self)
+                    return ChainSplit::NoSplitCanonical(self);
                 }
                 if block_number < *self.blocks.first_entry().expect("chain is never empty").key() {
-                    return ChainSplit::NoSplitPending(self)
+                    return ChainSplit::NoSplitPending(self);
                 }
                 block_number
             }

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -319,7 +319,7 @@ impl<N: NodePrimitives> Chain<N> {
                 };
                 // If block number is same as tip whole chain is becoming canonical.
                 if block_number == chain_tip {
-                    return ChainSplit::NoSplitCanonical(self);
+                    return ChainSplit::NoSplitCanonical(self)
                 }
                 block_number
             }
@@ -328,7 +328,7 @@ impl<N: NodePrimitives> Chain<N> {
                     return ChainSplit::NoSplitPending(self)
                 }
                 if block_number == chain_tip {
-                    return ChainSplit::NoSplitCanonical(self);
+                    return ChainSplit::NoSplitCanonical(self)
                 }
                 if block_number < *self.blocks.first_entry().expect("chain is never empty").key() {
                     return ChainSplit::NoSplitPending(self)

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,4 +1,4 @@
-use revm_database::BundleState;
+use revm::database::BundleState;
 
 pub use alloy_evm::block::BlockExecutionResult;
 

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -296,7 +296,7 @@ impl<T> ExecutionOutcome<T> {
         T: Clone,
     {
         if at == self.first_block {
-            return (None, self);
+            return (None, self)
         }
 
         let (mut lower_state, mut higher_state) = (self.clone(), self);

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -203,11 +203,11 @@ impl<T> ExecutionOutcome<T> {
     /// Transform block number to the index of block.
     pub fn block_number_to_index(&self, block_number: BlockNumber) -> Option<usize> {
         if self.first_block > block_number {
-            return None;
+            return None
         }
         let index = block_number - self.first_block;
         if index >= self.receipts.len() as u64 {
-            return None;
+            return None
         }
         Some(index as usize)
     }

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -4,8 +4,10 @@ use alloy_eips::eip7685::Requests;
 use alloy_primitives::{logs_bloom, map::HashMap, Address, BlockNumber, Bloom, Log, B256, U256};
 use reth_primitives_traits::{Account, Bytecode, Receipt, StorageEntry};
 use reth_trie_common::{HashedPostState, KeyHasher};
-use revm::state::AccountInfo;
-use revm_database::{states::BundleState, BundleAccount};
+use revm::{
+    database::{states::BundleState, BundleAccount},
+    state::AccountInfo,
+};
 
 /// Type used to initialize revms bundle state.
 pub type BundleStateInit =
@@ -201,11 +203,11 @@ impl<T> ExecutionOutcome<T> {
     /// Transform block number to the index of block.
     pub fn block_number_to_index(&self, block_number: BlockNumber) -> Option<usize> {
         if self.first_block > block_number {
-            return None
+            return None;
         }
         let index = block_number - self.first_block;
         if index >= self.receipts.len() as u64 {
-            return None
+            return None;
         }
         Some(index as usize)
     }
@@ -294,7 +296,7 @@ impl<T> ExecutionOutcome<T> {
         T: Clone,
     {
         if at == self.first_block {
-            return (None, self)
+            return (None, self);
         }
 
         let (mut lower_state, mut higher_state) = (self.clone(), self);
@@ -405,7 +407,7 @@ pub(super) mod serde_bincode_compat {
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::BlockNumber;
     use reth_primitives_traits::serde_bincode_compat::SerdeBincodeCompat;
-    use revm_database::BundleState;
+    use revm::database::BundleState;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -81,7 +81,7 @@ where
         state: F,
     ) -> Result<BlockExecutionOutput<<Self::Primitives as NodePrimitives>::Receipt>, Self::Error>
     where
-        F: FnMut(&revm_database::State<DB>),
+        F: FnMut(&revm::database::State<DB>),
     {
         match self {
             Self::Left(a) => a.execute_with_state_closure(block, state),
@@ -89,7 +89,7 @@ where
         }
     }
 
-    fn into_state(self) -> revm_database::State<DB> {
+    fn into_state(self) -> revm::database::State<DB> {
         match self {
             Self::Left(a) => a.into_state(),
             Self::Right(b) => b.into_state(),

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -17,8 +17,10 @@ use reth_primitives_traits::{
 use reth_storage_api::StateProvider;
 pub use reth_storage_errors::provider::ProviderError;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use revm::context::result::ExecutionResult;
-use revm_database::{states::bundle_state::BundleRetention, BundleState, State};
+use revm::{
+    context::result::ExecutionResult,
+    database::{states::bundle_state::BundleRetention, BundleState, State},
+};
 
 /// A type that knows how to execute a block. It is assumed to operate on a
 /// [`crate::Evm`] internally and use [`State`] as database.
@@ -483,8 +485,10 @@ mod tests {
     use alloy_primitives::{address, map::HashMap, U256};
     use core::marker::PhantomData;
     use reth_ethereum_primitives::EthPrimitives;
-    use revm::state::AccountInfo;
-    use revm_database::{CacheDB, EmptyDB};
+    use revm::{
+        database::{CacheDB, EmptyDB},
+        state::AccountInfo,
+    };
 
     #[derive(Clone, Default)]
     struct TestExecutorProvider;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -27,8 +27,7 @@ use execute::{BlockAssembler, BlockBuilder};
 use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, ReceiptTy, SealedBlock, SealedHeader, TxTy,
 };
-use revm::context::TxEnv;
-use revm_database::State;
+use revm::{context::TxEnv, database::State};
 
 pub mod either;
 /// EVM environment configuration.

--- a/crates/evm/src/metrics.rs
+++ b/crates/evm/src/metrics.rs
@@ -145,10 +145,10 @@ mod tests {
     use reth_ethereum_primitives::EthPrimitives;
     use reth_execution_types::BlockExecutionResult;
     use revm::{
+        database::State,
         database_interface::EmptyDB,
         state::{Account, AccountInfo, AccountStatus, EvmStorage, EvmStorageSlot},
     };
-    use revm_database::State;
     use std::sync::mpsc;
 
     /// A mock executor that simulates state changes
@@ -190,7 +190,7 @@ mod tests {
             })
         }
 
-        fn into_state(self) -> revm_database::State<DB> {
+        fn into_state(self) -> revm::database::State<DB> {
             State::builder().with_database(Default::default()).build()
         }
 
@@ -253,9 +253,9 @@ mod tests {
 
         for metric in snapshot {
             let metric_name = metric.0.key().name();
-            if metric_name == "sync.execution.accounts_loaded_histogram" ||
-                metric_name == "sync.execution.storage_slots_loaded_histogram" ||
-                metric_name == "sync.execution.bytecodes_loaded_histogram"
+            if metric_name == "sync.execution.accounts_loaded_histogram"
+                || metric_name == "sync.execution.storage_slots_loaded_histogram"
+                || metric_name == "sync.execution.bytecodes_loaded_histogram"
             {
                 if let DebugValue::Histogram(vs) = metric.3 {
                     assert!(

--- a/crates/evm/src/metrics.rs
+++ b/crates/evm/src/metrics.rs
@@ -253,9 +253,9 @@ mod tests {
 
         for metric in snapshot {
             let metric_name = metric.0.key().name();
-            if metric_name == "sync.execution.accounts_loaded_histogram"
-                || metric_name == "sync.execution.storage_slots_loaded_histogram"
-                || metric_name == "sync.execution.bytecodes_loaded_histogram"
+            if metric_name == "sync.execution.accounts_loaded_histogram" ||
+                metric_name == "sync.execution.storage_slots_loaded_histogram" ||
+                metric_name == "sync.execution.bytecodes_loaded_histogram"
             {
                 if let DebugValue::Histogram(vs) = metric.3 {
                     assert!(

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -51,7 +51,7 @@ impl<DB: Database, P: NodePrimitives> Executor<DB> for NoopBlockExecutorProvider
         Err(BlockExecutionError::msg(UNAVAILABLE_FOR_NOOP))
     }
 
-    fn into_state(self) -> revm_database::State<DB> {
+    fn into_state(self) -> revm::database::State<DB> {
         unreachable!()
     }
 

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -11,7 +11,7 @@ use reth_ethereum_primitives::EthPrimitives;
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::{BlockExecutionResult, ExecutionOutcome};
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock};
-use revm_database::State;
+use revm::database::State;
 
 /// A [`BlockExecutorProvider`] that returns mocked execution results.
 #[derive(Clone, Debug, Default)]
@@ -97,7 +97,7 @@ impl<DB: Database> Executor<DB> for MockExecutorProvider {
         _f: F,
     ) -> Result<BlockExecutionOutput<<Self::Primitives as NodePrimitives>::Receipt>, Self::Error>
     where
-        F: FnMut(&revm_database::State<DB>),
+        F: FnMut(&revm::database::State<DB>),
     {
         <Self as Executor<DB>>::execute(self, block)
     }
@@ -113,7 +113,7 @@ impl<DB: Database> Executor<DB> for MockExecutorProvider {
         <Self as Executor<DB>>::execute(self, block)
     }
 
-    fn into_state(self) -> revm_database::State<DB> {
+    fn into_state(self) -> revm::database::State<DB> {
         unreachable!()
     }
 

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -37,8 +37,6 @@ reth-optimism-primitives.workspace = true
 
 # revm
 revm.workspace = true
-revm-database.workspace = true
-revm-primitives.workspace = true
 op-revm.workspace = true
 
 # misc
@@ -63,7 +61,6 @@ std = [
     "alloy-eips/std",
     "alloy-genesis/std",
     "alloy-primitives/std",
-    "revm-primitives/std",
     "reth-primitives-traits/std",
     "revm/std",
     "reth-optimism-primitives/std",
@@ -80,7 +77,6 @@ std = [
     "reth-execution-types/std",
     "alloy-evm/std",
     "alloy-op-evm/std",
-    "revm-database/std",
     "op-revm/std",
     "reth-evm/std",
     "tracing/std",

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::BlockHeader;
 use op_revm::OpSpecId;
 use reth_optimism_forks::OpHardforks;
-use revm_primitives::{Address, Bytes, B256};
+use revm::primitives::{Address, Bytes, B256};
 
 /// Context relevant for execution of a next block w.r.t OP.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -227,9 +227,13 @@ mod tests {
     use reth_optimism_chainspec::BASE_MAINNET;
     use reth_optimism_primitives::{OpBlock, OpPrimitives, OpReceipt};
     use reth_primitives_traits::{Account, RecoveredBlock};
-    use revm::{database_interface::EmptyDBTyped, inspector::NoOpInspector, state::AccountInfo};
-    use revm_database::{BundleState, CacheDB};
-    use revm_primitives::Log;
+    use revm::{
+        database::{BundleState, CacheDB},
+        database_interface::EmptyDBTyped,
+        inspector::NoOpInspector,
+        primitives::Log,
+        state::AccountInfo,
+    };
     use std::sync::Arc;
 
     fn test_evm_config() -> OpEvmConfig {

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -23,8 +23,6 @@ alloy-primitives.workspace = true
 
 # revm
 revm.workspace = true
-revm-database.workspace = true
-revm-inspector.workspace = true
 
 [dev-dependencies]
 reth-trie.workspace = true
@@ -40,8 +38,6 @@ std = [
     "revm/std",
     "alloy-consensus/std",
     "reth-ethereum-forks/std",
-    "revm-database/std",
-    "revm-inspector/std",
     "reth-storage-api/std",
     "reth-storage-errors/std",
 ]
@@ -57,8 +53,6 @@ serde = [
     "alloy-consensus/serde",
     "reth-trie?/serde",
     "reth-ethereum-forks/serde",
-    "revm-database/serde",
     "reth-primitives-traits/serde",
-    "revm-inspector/serde",
 ]
 portable = ["revm/portable"]

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -21,8 +21,7 @@ pub mod cancelled;
 /// Contains glue code for integrating reth database into revm's [Database].
 pub mod database;
 
-pub use revm::database as db;
-pub use revm::inspector as inspector;
+pub use revm::{database as db, inspector};
 
 /// Common test helpers
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -21,8 +21,8 @@ pub mod cancelled;
 /// Contains glue code for integrating reth database into revm's [Database].
 pub mod database;
 
-pub use revm_database as db;
-pub use revm_inspector as inspector;
+pub use revm::database as db;
+pub use revm::inspector as inspector;
 
 /// Common test helpers
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -145,7 +145,7 @@ impl StateProofProvider for StateProviderTest {
 }
 
 impl HashedPostStateProvider for StateProviderTest {
-    fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
+    fn hashed_post_state(&self, bundle_state: &revm::database::BundleState) -> HashedPostState {
         HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
     }
 }

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_primitives::{keccak256, Bytes, B256};
 use reth_trie::{HashedPostState, HashedStorage};
-use revm_database::State;
+use revm::database::State;
 
 /// Tracks state changes during execution.
 #[derive(Debug, Clone, Default)]

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -35,9 +35,7 @@ alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
 alloy-rpc-types-eth.workspace = true
 revm.workspace = true
-revm-database.workspace = true
 revm-inspectors.workspace = true
-revm-primitives.workspace = true
 
 # rpc
 jsonrpsee-core.workspace = true

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -7,11 +7,12 @@ use reth_errors::ProviderResult;
 use reth_revm::{database::StateProviderDatabase, DatabaseRef};
 use reth_storage_api::{HashedPostStateProvider, StateProvider};
 use reth_trie::{HashedStorage, MultiProofTargets};
+use revm::database::CacheDB;
 use revm::{
+    database::BundleState,
     state::{AccountInfo, Bytecode},
     Database,
 };
-use revm_database::CacheDB;
 
 /// Helper alias type for the state's [`CacheDB`]
 pub type StateCacheDb<'a> = CacheDB<StateProviderDatabase<StateProviderTraitObjWrapper<'a>>>;
@@ -83,7 +84,7 @@ impl reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'_> {
     fn proof(
         &self,
         input: reth_trie::TrieInput,
-        address: revm_primitives::Address,
+        address: Address,
         slots: &[B256],
     ) -> reth_errors::ProviderResult<reth_trie::AccountProof> {
         self.0.proof(input, address, slots)
@@ -109,7 +110,7 @@ impl reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper<'_> {
 impl reth_storage_api::AccountReader for StateProviderTraitObjWrapper<'_> {
     fn basic_account(
         &self,
-        address: &revm_primitives::Address,
+        address: &Address,
     ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Account>> {
         self.0.basic_account(address)
     }
@@ -140,10 +141,7 @@ impl reth_storage_api::BlockHashReader for StateProviderTraitObjWrapper<'_> {
 }
 
 impl HashedPostStateProvider for StateProviderTraitObjWrapper<'_> {
-    fn hashed_post_state(
-        &self,
-        bundle_state: &revm_database::BundleState,
-    ) -> reth_trie::HashedPostState {
+    fn hashed_post_state(&self, bundle_state: &BundleState) -> reth_trie::HashedPostState {
         self.0.hashed_post_state(bundle_state)
     }
 }
@@ -151,7 +149,7 @@ impl HashedPostStateProvider for StateProviderTraitObjWrapper<'_> {
 impl StateProvider for StateProviderTraitObjWrapper<'_> {
     fn storage(
         &self,
-        account: revm_primitives::Address,
+        account: Address,
         storage_key: alloy_primitives::StorageKey,
     ) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>> {
         self.0.storage(account, storage_key)
@@ -166,22 +164,16 @@ impl StateProvider for StateProviderTraitObjWrapper<'_> {
 
     fn account_code(
         &self,
-        addr: &revm_primitives::Address,
+        addr: &Address,
     ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Bytecode>> {
         self.0.account_code(addr)
     }
 
-    fn account_balance(
-        &self,
-        addr: &revm_primitives::Address,
-    ) -> reth_errors::ProviderResult<Option<U256>> {
+    fn account_balance(&self, addr: &Address) -> reth_errors::ProviderResult<Option<U256>> {
         self.0.account_balance(addr)
     }
 
-    fn account_nonce(
-        &self,
-        addr: &revm_primitives::Address,
-    ) -> reth_errors::ProviderResult<Option<u64>> {
+    fn account_nonce(&self, addr: &Address) -> reth_errors::ProviderResult<Option<u64>> {
         self.0.account_nonce(addr)
     }
 }
@@ -193,10 +185,7 @@ pub struct StateCacheDbRefMutWrapper<'a, 'b>(pub &'b mut StateCacheDb<'a>);
 
 impl<'a> Database for StateCacheDbRefMutWrapper<'a, '_> {
     type Error = <StateCacheDb<'a> as Database>::Error;
-    fn basic(
-        &mut self,
-        address: revm_primitives::Address,
-    ) -> Result<Option<AccountInfo>, Self::Error> {
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.0.basic(address)
     }
 
@@ -204,11 +193,7 @@ impl<'a> Database for StateCacheDbRefMutWrapper<'a, '_> {
         self.0.code_by_hash(code_hash)
     }
 
-    fn storage(
-        &mut self,
-        address: revm_primitives::Address,
-        index: U256,
-    ) -> Result<U256, Self::Error> {
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         self.0.storage(address, index)
     }
 
@@ -220,10 +205,7 @@ impl<'a> Database for StateCacheDbRefMutWrapper<'a, '_> {
 impl<'a> DatabaseRef for StateCacheDbRefMutWrapper<'a, '_> {
     type Error = <StateCacheDb<'a> as Database>::Error;
 
-    fn basic_ref(
-        &self,
-        address: revm_primitives::Address,
-    ) -> Result<Option<AccountInfo>, Self::Error> {
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.0.basic_ref(address)
     }
 
@@ -231,11 +213,7 @@ impl<'a> DatabaseRef for StateCacheDbRefMutWrapper<'a, '_> {
         self.0.code_by_hash_ref(code_hash)
     }
 
-    fn storage_ref(
-        &self,
-        address: revm_primitives::Address,
-        index: U256,
-    ) -> Result<U256, Self::Error> {
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         self.0.storage_ref(address, index)
     }
 

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -7,9 +7,8 @@ use reth_errors::ProviderResult;
 use reth_revm::{database::StateProviderDatabase, DatabaseRef};
 use reth_storage_api::{HashedPostStateProvider, StateProvider};
 use reth_trie::{HashedStorage, MultiProofTargets};
-use revm::database::CacheDB;
 use revm::{
-    database::BundleState,
+    database::{BundleState, CacheDB},
     state::{AccountInfo, Bytecode},
     Database,
 };

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -811,7 +811,7 @@ pub fn ensure_success<Halt, Error: FromEvmHalt<Halt> + FromEthApiError>(
 mod tests {
     use super::*;
     use alloy_sol_types::{Revert, SolError};
-    use revm_primitives::b256;
+    use revm::primitives::b256;
 
     #[test]
     fn timed_out_error() {

--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -111,8 +111,8 @@ impl CallFees {
                     let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or(U256::ZERO);
 
                     // only enforce the fee cap if provided input is not zero
-                    if !(max_fee.is_zero() && max_priority_fee_per_gas.is_zero())
-                        && max_fee < block_base_fee
+                    if !(max_fee.is_zero() && max_priority_fee_per_gas.is_zero()) &&
+                        max_fee < block_base_fee
                     {
                         // `base_fee_per_gas` is greater than the `max_fee_per_gas`
                         return Err(RpcInvalidTransactionError::FeeCapTooLow.into());

--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -115,13 +115,13 @@ impl CallFees {
                         max_fee < block_base_fee
                     {
                         // `base_fee_per_gas` is greater than the `max_fee_per_gas`
-                        return Err(RpcInvalidTransactionError::FeeCapTooLow.into());
+                        return Err(RpcInvalidTransactionError::FeeCapTooLow.into())
                     }
                     if max_fee < max_priority_fee_per_gas {
                         return Err(
                             // `max_priority_fee_per_gas` is greater than the `max_fee_per_gas`
                             RpcInvalidTransactionError::TipAboveFeeCap.into(),
-                        );
+                        )
                     }
                     // ref <https://github.com/ethereum/go-ethereum/blob/0dd173a727dd2d2409b8e401b22e85d20c25b71f/internal/ethapi/transaction_args.go#L446-L446>
                     Ok(min(
@@ -176,7 +176,7 @@ impl CallFees {
                 // Ensure blob_hashes are present
                 if !has_blob_hashes {
                     // Blob transaction but no blob hashes
-                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into());
+                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into())
                 }
 
                 Ok(Self {

--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -8,10 +8,10 @@ use alloy_rpc_types_eth::{
 use reth_evm::TransactionEnv;
 use revm::{
     context::BlockEnv,
+    database::{CacheDB, State},
     state::{Account, AccountStatus, Bytecode, EvmStorageSlot},
     Database, DatabaseCommit,
 };
-use revm_database::{CacheDB, State};
 use std::{
     cmp::min,
     collections::{BTreeMap, HashMap},
@@ -111,17 +111,17 @@ impl CallFees {
                     let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or(U256::ZERO);
 
                     // only enforce the fee cap if provided input is not zero
-                    if !(max_fee.is_zero() && max_priority_fee_per_gas.is_zero()) &&
-                        max_fee < block_base_fee
+                    if !(max_fee.is_zero() && max_priority_fee_per_gas.is_zero())
+                        && max_fee < block_base_fee
                     {
                         // `base_fee_per_gas` is greater than the `max_fee_per_gas`
-                        return Err(RpcInvalidTransactionError::FeeCapTooLow.into())
+                        return Err(RpcInvalidTransactionError::FeeCapTooLow.into());
                     }
                     if max_fee < max_priority_fee_per_gas {
                         return Err(
                             // `max_priority_fee_per_gas` is greater than the `max_fee_per_gas`
                             RpcInvalidTransactionError::TipAboveFeeCap.into(),
-                        )
+                        );
                     }
                     // ref <https://github.com/ethereum/go-ethereum/blob/0dd173a727dd2d2409b8e401b22e85d20c25b71f/internal/ethapi/transaction_args.go#L446-L446>
                     Ok(min(
@@ -176,7 +176,7 @@ impl CallFees {
                 // Ensure blob_hashes are present
                 if !has_blob_hashes {
                     // Blob transaction but no blob hashes
-                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into())
+                    return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into());
                 }
 
                 Ok(Self {

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -17,8 +17,11 @@ use reth_primitives_traits::{
 use reth_rpc_server_types::result::rpc_err;
 use reth_rpc_types_compat::{block::from_block, TransactionCompat};
 use reth_storage_api::noop::NoopProvider;
-use revm::{context_interface::result::ExecutionResult, Database};
-use revm_primitives::{Address, Bytes, TxKind};
+use revm::{
+    context_interface::result::ExecutionResult,
+    primitives::{Address, Bytes, TxKind},
+    Database,
+};
 
 use crate::{
     error::{

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -215,7 +215,7 @@ impl HashedPostState {
                     let mut storage_not_in_targets = HashedStorage::default();
                     storage.storage.retain(|&slot, value| {
                         if storage_in_targets.contains(&slot) {
-                            return true
+                            return true;
                         }
 
                         storage_not_in_targets.storage.insert(slot, *value);
@@ -250,7 +250,7 @@ impl HashedPostState {
         });
         self.accounts.retain(|&address, account| {
             if targets.contains_key(&address) {
-                return true
+                return true;
             }
 
             state_updates_not_in_targets.accounts.insert(address, *account);
@@ -579,8 +579,11 @@ mod tests {
     use super::*;
     use crate::KeccakKeyHasher;
     use alloy_primitives::Bytes;
-    use revm_database::{states::StorageSlot, StorageWithOriginalValues};
-    use revm_state::{AccountInfo, Bytecode};
+    use revm_database::{
+        state::{AccountInfo, Bytecode},
+        states::StorageSlot,
+        StorageWithOriginalValues,
+    };
 
     #[test]
     fn hashed_state_wiped_extension() {

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -215,7 +215,7 @@ impl HashedPostState {
                     let mut storage_not_in_targets = HashedStorage::default();
                     storage.storage.retain(|&slot, value| {
                         if storage_in_targets.contains(&slot) {
-                            return true;
+                            return true
                         }
 
                         storage_not_in_targets.storage.insert(slot, *value);
@@ -250,7 +250,7 @@ impl HashedPostState {
         });
         self.accounts.retain(|&address, account| {
             if targets.contains_key(&address) {
-                return true;
+                return true
             }
 
             state_updates_not_in_targets.accounts.insert(address, *account);
@@ -579,11 +579,8 @@ mod tests {
     use super::*;
     use crate::KeccakKeyHasher;
     use alloy_primitives::Bytes;
-    use revm_database::{
-        state::{AccountInfo, Bytecode},
-        states::StorageSlot,
-        StorageWithOriginalValues,
-    };
+    use revm_database::{states::StorageSlot, StorageWithOriginalValues};
+    use revm_state::{AccountInfo, Bytecode};
 
     #[test]
     fn hashed_state_wiped_extension() {


### PR DESCRIPTION
Remove few imports as they can be derived from other crates