### PR TITLE
 Fix grammar, typing, and API consistency in Debug and Anvil Modules  

### DIFF
--- a/crates/rpc/rpc-api/src/anvil.rs
+++ b/crates/rpc/rpc-api/src/anvil.rs
@@ -126,7 +126,7 @@ pub trait AnvilApi {
 
     /// Jump forward in time by the given amount of time, in seconds.
     #[method(name = "increaseTime")]
-    async fn anvil_increase_time(&self, seconds: U256) -> RpcResult<i64>;
+    async fn anvil_increase_time(&self, seconds: i64) -> RpcResult<i64>;
 
     /// Similar to `evm_increaseTime` but takes the exact timestamp that you want in the next block.
     #[method(name = "setNextBlockTimestamp")]
@@ -140,7 +140,7 @@ pub trait AnvilApi {
     #[method(name = "setBlockTimestampInterval")]
     async fn anvil_set_block_timestamp_interval(&self, seconds: u64) -> RpcResult<()>;
 
-    /// Sets an interval for the block timestamp.
+    /// Removes the interval for the block timestamp.
     #[method(name = "removeBlockTimestampInterval")]
     async fn anvil_remove_block_timestamp_interval(&self) -> RpcResult<bool>;
 

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -48,9 +48,9 @@ pub trait DebugApi {
     ) -> RpcResult<Vec<BlockTraceResult>>;
 
     /// The `debug_traceBlock` method will return a full stack trace of all invoked opcodes of all
-    /// transaction that were included in this block.
+    /// transactions that were included in this block.
     ///
-    /// This expects an rlp encoded block
+    /// This expects an RLP-encoded block
     ///
     /// Note, the parent of this block must be present, or it will fail. For the second parameter
     /// see [GethDebugTracingOptions] reference.
@@ -115,13 +115,13 @@ pub trait DebugApi {
     ///
     /// The first argument is a list of bundles. Each bundle can overwrite the block headers. This
     /// will affect all transaction in that bundle.
-    /// BlockNumber and transaction_index are optional. Transaction_index
+    /// BlockNumber and transaction index are optional. Transaction_index
     /// specifies the number of tx in the block to replay and -1 means all transactions should be
     /// replayed.
     /// The trace can be configured similar to `debug_traceTransaction`.
-    /// State override apply to all bundles.
+    /// State overrides apply to all bundles.
     ///
-    /// This methods is similar to many `eth_callMany`, hence this returns nested lists of traces.
+    /// This method is similar to many `eth_callMany`, hence this returns nested lists of traces.
     /// Where the length of the outer list is the number of bundles and the length of the inner list
     /// (`Vec<GethTrace>`) is the number of transactions in the bundle.
     #[method(name = "traceCallMany")]
@@ -382,7 +382,7 @@ pub trait DebugApi {
 
     /// Returns the structured logs created during the execution of EVM against a block pulled
     /// from the pool of bad ones and returns them as a JSON object. For the second parameter see
-    /// TraceConfig reference.
+    /// [TraceConfig] reference.
     #[method(name = "traceBadBlock")]
     async fn debug_trace_bad_block(
         &self,


### PR DESCRIPTION
`anvil.rs`:
1. Fixed incorrect argument type in `increaseTime`:  
  - Changed `seconds: U256` → `seconds: i64` to match expected time format. 
  
2. Clarified `removeBlockTimestampInterval` description:  
  - Changed **"Sets an interval for the block timestamp"** → **"Removes the interval for the block timestamp"** to accurately describe its function.  

`debug.rs`:
1. Fixed grammar errors:
  - `"transaction that were included"` → `"transactions that were included"`.  
  - `"State override apply"` → `"State overrides apply"`.  
  - `"This methods is"` → `"This method is"`.  

2. Fixed incorrect documentation references:
  - `"TraceConfig reference"` → `"[TraceConfig] reference"`, following correct Rust doc syntax.  
- Improved clarity of `traceCallMany` method documentation.