### PR TITLE
feat(engine):  Add Configurable Worker Threads to WorkloadExecutor

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -30,7 +30,7 @@ impl Default for WorkloadExecutor {
 
 impl WorkloadExecutor {
     /// Creates a new executor with the given number of threads for cpu bound work (rayon) and
-    /// and an optional number of worker threads for the tokio runtime.
+    /// an optional number of worker threads for the tokio runtime.
     #[allow(unused)]
     pub(super) fn with_num_cpu_threads(cpu_threads: usize, worker_threads: Option<usize>) -> Self {
         Self {

--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -69,14 +69,14 @@ struct WorkloadExecutorInner {
 }
 
 impl WorkloadExecutorInner {
-    /// Creates a new `WorkloadExecutorInner` with the given Rayon thread pool and an optional number
-    /// of worker threads for the Tokio runtime.
+    /// Creates a new `WorkloadExecutorInner` with the given Rayon thread pool and an optional
+    /// number of worker threads for the Tokio runtime.
     ///
-    /// Note: The Tokio runtime is lazily initialized using a static `OnceLock`. This means the runtime
-    /// is created only once, on the first call to this function, using the `worker_threads` value
-    /// provided at that time. Subsequent calls will ignore any different `worker_threads` values
-    /// and reuse the existing runtime. This is acceptable for our use case, as the executor is
-    /// initialized only once in the engine.
+    /// Note: The Tokio runtime is lazily initialized using a static `OnceLock`. This means the
+    /// runtime is created only once, on the first call to this function, using the
+    /// `worker_threads` value provided at that time. Subsequent calls will ignore any different
+    /// `worker_threads` values and reuse the existing runtime. This is acceptable for our use
+    /// case, as the executor is initialized only once in the engine.
     fn new(rayon_pool: rayon::ThreadPool, worker_threads: Option<usize>) -> Self {
         fn get_runtime_handle(worker_threads: Option<usize>) -> Handle {
             Handle::try_current().unwrap_or_else(|_| {

--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -69,6 +69,14 @@ struct WorkloadExecutorInner {
 }
 
 impl WorkloadExecutorInner {
+    /// Creates a new `WorkloadExecutorInner` with the given Rayon thread pool and an optional number
+    /// of worker threads for the Tokio runtime.
+    ///
+    /// Note: The Tokio runtime is lazily initialized using a static `OnceLock`. This means the runtime
+    /// is created only once, on the first call to this function, using the `worker_threads` value
+    /// provided at that time. Subsequent calls will ignore any different `worker_threads` values
+    /// and reuse the existing runtime. This is acceptable for our use case, as the executor is
+    /// initialized only once in the engine.
     fn new(rayon_pool: rayon::ThreadPool, worker_threads: Option<usize>) -> Self {
         fn get_runtime_handle(worker_threads: Option<usize>) -> Handle {
             Handle::try_current().unwrap_or_else(|_| {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -992,7 +992,7 @@ mod tests {
             + Clone
             + 'static,
     {
-        let executor = WorkloadExecutor::with_num_cpu_threads(2);
+        let executor = WorkloadExecutor::with_num_cpu_threads(2, None);
         let config = create_state_root_config(factory, TrieInput::default());
         let channel = channel();
 


### PR DESCRIPTION
This PR adds support for configurable worker threads in the `WorkloadExecutor`.

- Updated `WorkloadExecutor` to accept an optional `worker_threads` parameter.
- Used `tokio::runtime::Builder` to create a runtime with a custom thread count when specified.

Closes #14945 