### PR TITLE
feat(rpc): accept requests hash in engine_newPayloadV4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,8 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -145,7 +146,8 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -158,7 +160,8 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0fa0584d13dd0c4e79288d411222c4d7c3411c71b7fa637cefda9dcf9bb1f9"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -240,7 +243,8 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -281,7 +285,8 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b11774716152a5204aff0e86a8c841df499ea81464e2b1f82b3f72d6a2ef32"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -319,7 +324,8 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6929e607b0a56803c69c68adc6e8aae1644c94e37ea458aa2d0713fc77490e70"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -332,7 +338,8 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b14524c3605ed5ee173b966333089474415416a8cfd80ceb003c18fd6d1736"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -357,7 +364,8 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c06932646544ea341f0fda48d2c0fe4fda75bc132379cb84019cdfb6ddcb0fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -369,10 +377,10 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8702df5255ed061ccb452511328edf267ff8b1c356623e8f93a5b708d57273"
 dependencies = [
  "alloy-genesis",
- "alloy-hardforks",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -448,7 +456,8 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1ec2eabd9b3acc46e59247c35f75545960372431c68f7fdbfcfb970a486c30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -489,7 +498,8 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1cf194abddb88b034d22ab41449ed8532e5113e58699cd055bf21d98a0991ab"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -529,7 +539,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6213829d8eabc239c2f9572452a5993ebdf78b04c020abc450ae48c54261d4ce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -538,7 +549,6 @@ dependencies = [
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
- "async-stream",
  "futures",
  "pin-project",
  "reqwest",
@@ -548,7 +558,6 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
@@ -556,7 +565,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a153db94cf231b03238fe4da48f59dc6f36e01b5e4d5a2e30de33b95395380fa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -568,7 +578,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5275d2e24dbdd82032c3b305db359fb2681069cc75add7feb66863ce50b5cb5"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -579,7 +590,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5462937f088889c337c236c2509226e87a26301d2b01f9fafee246bd84cb0407"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -590,7 +602,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -600,7 +613,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c14f3c5747750f7373ec9f633230923ff149c2e31960513e31593bcfcf916be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -617,7 +631,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fa8f6e27d47b4c56c627cb03dc91624c26bd814f6609bb1d1a836148b76fc9b"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -626,7 +641,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -646,7 +662,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e18d94b1036302720b987564560e4a5b85035a17553c53a50afa2bd8762b487"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -657,7 +674,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "jsonrpsee-types",
  "serde",
  "serde_json",
@@ -667,7 +684,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec941a4b3eedf15daef2b7aeb7848dfc6e677f58b2a21eab0ac1efef1ffac62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -680,7 +698,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef4bba67ec601730ceb23e542980d73ae9f718819604dfdd8289b13a506e762"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -693,7 +712,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edc8512f919feb79dd30864ef7574d2877e71b73e30b5de4925ba9bc6bd4f96"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -704,7 +724,8 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -715,7 +736,8 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81755ed6a6a33061302ac95e9bb7b40ebf7078e4568397168024242bc31a3e58"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -729,7 +751,8 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa857621a5c95c13e640e18bb9c4720f4338a666d6276f55446477a6bc3912ff"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -816,14 +839,12 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c74598eb65cefa886be6ba624c14a6856d9d84339ec720520f3efcc03311716"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
- "derive_more 2.0.1",
- "futures",
  "futures-utils-wasm",
- "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -837,7 +858,8 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcd2f8ab2f053cd848ead5d625cb1b63716562951101588c1fa49300e3c6418"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -851,7 +873,8 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -870,7 +893,8 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ddcf4b98b3448eb998e057dc5a27345997863d6544ee7f0f79957616768dd3"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -11842,8 +11866,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,8 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -145,9 +144,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660705969af143897d83937d73f53c741c1587f49c27c2cfce594e188fcbc1e4"
+version = "0.12.5"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -160,8 +158,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0fa0584d13dd0c4e79288d411222c4d7c3411c71b7fa637cefda9dcf9bb1f9"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -243,8 +240,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -285,8 +281,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b11774716152a5204aff0e86a8c841df499ea81464e2b1f82b3f72d6a2ef32"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -324,8 +319,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6929e607b0a56803c69c68adc6e8aae1644c94e37ea458aa2d0713fc77490e70"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -338,8 +332,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b14524c3605ed5ee173b966333089474415416a8cfd80ceb003c18fd6d1736"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -364,8 +357,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c06932646544ea341f0fda48d2c0fe4fda75bc132379cb84019cdfb6ddcb0fb"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -377,10 +369,10 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8702df5255ed061ccb452511328edf267ff8b1c356623e8f93a5b708d57273"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-genesis",
+ "alloy-hardforks",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -456,8 +448,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1ec2eabd9b3acc46e59247c35f75545960372431c68f7fdbfcfb970a486c30"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -498,8 +489,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cf194abddb88b034d22ab41449ed8532e5113e58699cd055bf21d98a0991ab"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -539,8 +529,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6213829d8eabc239c2f9572452a5993ebdf78b04c020abc450ae48c54261d4ce"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -549,6 +538,7 @@ dependencies = [
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
+ "async-stream",
  "futures",
  "pin-project",
  "reqwest",
@@ -558,6 +548,7 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
+ "tracing-futures",
  "url",
  "wasmtimer",
 ]
@@ -565,8 +556,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a153db94cf231b03238fe4da48f59dc6f36e01b5e4d5a2e30de33b95395380fa"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -578,8 +568,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5275d2e24dbdd82032c3b305db359fb2681069cc75add7feb66863ce50b5cb5"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -590,8 +579,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5462937f088889c337c236c2509226e87a26301d2b01f9fafee246bd84cb0407"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -601,9 +589,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f726ebb03d5918a946d0a6e17829cabd90ffe928664dc3f7fdbba1be511760de"
+version = "0.12.5"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -613,8 +600,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c14f3c5747750f7373ec9f633230923ff149c2e31960513e31593bcfcf916be"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -631,8 +617,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa8f6e27d47b4c56c627cb03dc91624c26bd814f6609bb1d1a836148b76fc9b"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -641,8 +626,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -662,8 +646,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e18d94b1036302720b987564560e4a5b85035a17553c53a50afa2bd8762b487"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -684,8 +667,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec941a4b3eedf15daef2b7aeb7848dfc6e677f58b2a21eab0ac1efef1ffac62"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -698,8 +680,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef4bba67ec601730ceb23e542980d73ae9f718819604dfdd8289b13a506e762"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -712,8 +693,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edc8512f919feb79dd30864ef7574d2877e71b73e30b5de4925ba9bc6bd4f96"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -724,8 +704,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -736,8 +715,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81755ed6a6a33061302ac95e9bb7b40ebf7078e4568397168024242bc31a3e58"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -751,8 +729,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa857621a5c95c13e640e18bb9c4720f4338a666d6276f55446477a6bc3912ff"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -839,12 +816,14 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c74598eb65cefa886be6ba624c14a6856d9d84339ec720520f3efcc03311716"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
+ "derive_more 2.0.1",
+ "futures",
  "futures-utils-wasm",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -858,8 +837,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcd2f8ab2f053cd848ead5d625cb1b63716562951101588c1fa49300e3c6418"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -873,8 +851,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -893,8 +870,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ddcf4b98b3448eb998e057dc5a27345997863d6544ee7f0f79957616768dd3"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -2084,7 +2060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3031,7 +3007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4663,7 +4639,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5020,7 +4996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5724,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -6458,7 +6434,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10500,7 +10476,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10513,7 +10489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11391,7 +11367,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11866,6 +11842,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures",
+ "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -11954,7 +11932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12468,7 +12446,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -145,7 +145,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -158,7 +158,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -357,7 +357,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -448,7 +448,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -529,7 +529,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.12.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#26d14e07a4e56d67ca5e0fc6fb8f1ed20784a5dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=alexey%2Frequests-or-hash-untagged#e75c2ca8b07ede899c6e2b35f96d7f6e8aeb8bce"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -2060,7 +2060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4996,7 +4996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -11932,7 +11932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -12446,7 +12446,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -523,7 +523,7 @@ linked_hash_set = "0.1"
 modular-bitfield = "0.11.2"
 notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
 nybbles = { version = "0.3.0", default-features = false }
-once_cell = { version = "1.21", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
 parking_lot = "0.12"
 paste = "1.0"
 rand = "0.8.5"
@@ -681,35 +681,35 @@ visibility = "0.1.1"
 walkdir = "2.3.3"
 vergen-git2 = "1.0.5"
 
-[patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+# [patch.crates-io]
+# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
 #
 # op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "ad607c1" }
 # op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "ad607c1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -523,7 +523,7 @@ linked_hash_set = "0.1"
 modular-bitfield = "0.11.2"
 notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
 nybbles = { version = "0.3.0", default-features = false }
-once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.21", default-features = false, features = ["critical-section"] }
 parking_lot = "0.12"
 paste = "1.0"
 rand = "0.8.5"
@@ -681,35 +681,35 @@ visibility = "0.1.1"
 walkdir = "2.3.3"
 vergen-git2 = "1.0.5"
 
-# [patch.crates-io]
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "cfb13aa" }
+[patch.crates-io]
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "alexey/requests-or-hash-untagged" }
 #
 # op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "ad607c1" }
 # op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "ad607c1" }

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -726,6 +726,9 @@ Engine:
       --engine.state-root-task-compare-updates
           Enable comparing trie updates from the state root task to the trie updates from the regular state root calculation
 
+      --engine.accept-execution-requests-hash
+          Enables accepting requests hash instead of an array of requests in `engine_newPayloadV4`
+
 Ress:
       --ress.enable
           Enable support for `ress` subprotocol

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -741,6 +741,7 @@ where
             client,
             EngineCapabilities::default(),
             engine_validator,
+            ctx.config.engine.accept_execution_requests_hash,
         ))
     }
 }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -37,7 +37,7 @@ pub struct EngineArgs {
     #[arg(long = "engine.state-root-task-compare-updates")]
     pub state_root_task_compare_updates: bool,
 
-    /// Enables accepting requests hash instead of an array of requests.
+    /// Enables accepting requests hash instead of an array of requests in `engine_newPayloadV4`.
     #[arg(long = "engine.accept-execution-requests-hash")]
     pub accept_execution_requests_hash: bool,
 }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -36,6 +36,10 @@ pub struct EngineArgs {
     /// state root calculation.
     #[arg(long = "engine.state-root-task-compare-updates")]
     pub state_root_task_compare_updates: bool,
+
+    /// Enables accepting requests hash instead of an array of requests.
+    #[arg(long = "engine.accept-execution-requests-hash")]
+    pub accept_execution_requests_hash: bool,
 }
 
 impl Default for EngineArgs {
@@ -47,6 +51,7 @@ impl Default for EngineArgs {
             state_root_task_compare_updates: false,
             caching_and_prewarming_enabled: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB,
+            accept_execution_requests_hash: false,
         }
     }
 }

--- a/crates/optimism/node/src/rpc.rs
+++ b/crates/optimism/node/src/rpc.rs
@@ -59,6 +59,7 @@ where
             client,
             EngineCapabilities::new(OP_ENGINE_CAPABILITIES.iter().copied()),
             engine_validator,
+            ctx.config.engine.accept_execution_requests_hash,
         );
 
         Ok(OpEngineApi::new(inner))

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -3,7 +3,7 @@
 //! This contains the `engine_` namespace and the subset of the `eth_` namespace that is exposed to
 //! the consensus client.
 
-use alloy_eips::{eip4844::BlobAndProofV1, eip7685::Requests, BlockId, BlockNumberOrTag};
+use alloy_eips::{eip4844::BlobAndProofV1, eip7685::RequestsOrHash, BlockId, BlockNumberOrTag};
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, BlockHash, Bytes, B256, U256, U64};
 use alloy_rpc_types_engine::{
@@ -68,7 +68,7 @@ pub trait EngineApi<Engine: EngineTypes> {
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
-        execution_requests: Requests,
+        execution_requests: RequestsOrHash,
     ) -> RpcResult<PayloadStatus>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_forkchoiceupdatedv1>

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -53,6 +53,7 @@ pub async fn launch_auth(secret: JwtSecret) -> AuthServerHandle {
         client,
         EngineCapabilities::default(),
         EthereumEngineValidator::new(MAINNET.clone()),
+        false,
     );
     let module = AuthRpcModule::new(engine_api);
     module.start_server(config).await.unwrap()

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -946,8 +946,8 @@ where
     ) -> RpcResult<PayloadStatus> {
         trace!(target: "rpc::engine", "Serving engine_newPayloadV4");
 
-        if !self.inner.accept_execution_requests_hash && matches!(requests, RequestsOrHash::Hash(_))
-        {
+        // Accept requests as a hash only if it is explicitly allowed
+        if requests.is_hash() && !self.inner.accept_execution_requests_hash {
             return Err(EngineApiError::UnexpectedRequestsHash.into());
         }
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -2,10 +2,8 @@ use crate::{
     capabilities::EngineCapabilities, metrics::EngineApiMetrics, EngineApiError, EngineApiResult,
 };
 use alloy_eips::{
-    eip1898::BlockHashOrNumber,
-    eip4844::BlobAndProofV1,
-    eip4895::Withdrawals,
-    eip7685::{Requests, RequestsOrHash},
+    eip1898::BlockHashOrNumber, eip4844::BlobAndProofV1, eip4895::Withdrawals,
+    eip7685::RequestsOrHash,
 };
 use alloy_primitives::{BlockHash, BlockNumber, B256, U64};
 use alloy_rpc_types_engine::{
@@ -81,6 +79,7 @@ struct EngineApiInner<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec
     validator: Validator,
     /// Start time of the latest payload request
     latest_new_payload_response: Mutex<Option<Instant>>,
+    accept_execution_requests_hash: bool,
 }
 
 impl<Provider, EngineT, Pool, Validator, ChainSpec>
@@ -104,6 +103,7 @@ where
         client: ClientVersionV1,
         capabilities: EngineCapabilities,
         validator: Validator,
+        accept_execution_requests_hash: bool,
     ) -> Self {
         let inner = Arc::new(EngineApiInner {
             provider,
@@ -117,6 +117,7 @@ where
             tx_pool,
             validator,
             latest_new_payload_response: Mutex::new(None),
+            accept_execution_requests_hash,
         });
         Self { inner }
     }
@@ -941,14 +942,20 @@ where
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
-        execution_requests: Requests,
+        requests: RequestsOrHash,
     ) -> RpcResult<PayloadStatus> {
         trace!(target: "rpc::engine", "Serving engine_newPayloadV4");
+
+        if !self.inner.accept_execution_requests_hash && matches!(requests, RequestsOrHash::Hash(_))
+        {
+            return Err(EngineApiError::UnexpectedRequestsHash.into());
+        }
+
         let payload = ExecutionData {
             payload: payload.into(),
             sidecar: ExecutionPayloadSidecar::v4(
                 CancunPayloadFields { versioned_hashes, parent_beacon_block_root },
-                PraguePayloadFields { requests: RequestsOrHash::Requests(execution_requests) },
+                PraguePayloadFields { requests },
             ),
         };
 
@@ -1202,6 +1209,7 @@ mod tests {
             client,
             EngineCapabilities::default(),
             EthereumEngineValidator::new(chain_spec.clone()),
+            false,
         );
         let handle = EngineApiTestHandle { chain_spec, provider, from_api: engine_rx };
         (handle, api)

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -92,6 +92,9 @@ pub enum EngineApiError {
     /// The payload or attributes are known to be malformed before processing.
     #[error(transparent)]
     EngineObjectValidationError(#[from] EngineObjectValidationError),
+    /// Requests hash provided, but can't be accepted by the API.
+    #[error("requests hash cannot be accepted by the API without `--engine.accept-execution-requests-hash` flag")]
+    UnexpectedRequestsHash,
     /// Any other rpc error
     #[error("{0}")]
     Other(jsonrpsee_types::ErrorObject<'static>),
@@ -125,7 +128,8 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EngineApiError::EngineObjectValidationError(
                 EngineObjectValidationError::Payload(_) |
                 EngineObjectValidationError::InvalidParams(_),
-            ) => {
+            ) |
+            EngineApiError::UnexpectedRequestsHash => {
                 // Note: the data field is not required by the spec, but is also included by other
                 // clients
                 jsonrpsee_types::error::ErrorObject::owned(


### PR DESCRIPTION
We can't populate the `requests` field in `reth-bench` for `engine_newPayloadV4` because the node API doesn't return requests. So we need to be able to pass just the requests hash, and validate against it.