### PR TITLE
 Fix Typographical Errors in Documentation

### DIFF
--- a/book/developers/exex/hello-world.md
+++ b/book/developers/exex/hello-world.md
@@ -67,7 +67,7 @@ Now, let's extend our simplest ExEx and start actually listening to new notifica
 {{#include ../../sources/exex/hello-world/src/bin/3.rs}}
 ```
 
-Woah, there's a lot of new stuff here! Let's go through it step by step:
+Whoa, there's a lot of new stuff here! Let's go through it step by step:
 
 - First, we've added a `while let Some(notification) = ctx.notifications.recv().await` loop that waits for new notifications to come in.
    - The main node is responsible for sending notifications to the ExEx, so we're waiting for them to come in.

--- a/book/developers/exex/remote.md
+++ b/book/developers/exex/remote.md
@@ -22,7 +22,7 @@ $ cd exex-remote
 ```
 
 We will also need a bunch of dependencies. Some of them you know from the [Hello World](./hello-world.md) chapter,
-but some of specific to what we need now.
+but some are specific to what we need now.
 
 ```toml
 {{#include ../../sources/exex/remote/Cargo.toml}}


### PR DESCRIPTION
File: book/developers/exex/hello-world.md

Old word: Woah
New word: Whoa
Reason: "Whoa" is the correct spelling in standard English. "Woah" is an informal and less common variant.
File: book/developers/exex/remote.md

Old phrase: but some of specific to what we need now.
New phrase: but some are specific to what we need now.
Reason: The original sentence was grammatically incorrect. "some of specific" does not make sense; the correct phrase is "some are specific."