### PR TITLE
Fix: Ensure --datadir argument is fully respected on all platforms (f…

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -213,11 +213,11 @@ impl<DB, ChainSpec: EthChainSpec> NodeBuilder<DB, ChainSpec> {
     ) -> WithLaunchContext<
         NodeBuilder<Arc<reth_db::test_utils::TempDatabase<reth_db::DatabaseEnv>>, ChainSpec>,
     > {
-        let path = reth_node_core::dirs::MaybePlatformPath::<DataDirPath>::from(
-            reth_db::test_utils::tempdir_path(),
-        );
+        let temp_path = reth_db::test_utils::tempdir_path();
+        let path = reth_node_core::dirs::MaybePlatformPath::<DataDirPath>::from(temp_path.clone());
+        
         self.config = self.config.with_datadir_args(reth_node_core::args::DatadirArgs {
-            datadir: path.clone(),
+            datadir: Some(temp_path),
             ..Default::default()
         });
 

--- a/crates/node/core/src/args/datadir_args.rs
+++ b/crates/node/core/src/args/datadir_args.rs
@@ -1,6 +1,6 @@
 //! clap [Args](clap::Args) for datadir config
 
-use crate::dirs::{ChainPath, DataDirPath, MaybePlatformPath};
+use crate::dirs::{ChainPath, DataDirPath, MaybePlatformPath, PlatformPath};
 use clap::Args;
 use reth_chainspec::Chain;
 use std::path::PathBuf;
@@ -11,15 +11,18 @@ use std::path::PathBuf;
 pub struct DatadirArgs {
     /// The path to the data dir for all reth files and subdirectories.
     ///
-    /// Defaults to the OS-specific data directory:
+    /// IMPORTANT: This path will be used exactly as specified, without any platform-specific
+    /// modifications. This ensures the --datadir argument is fully respected.
     ///
+    /// Only if no path is provided, defaults to OS-specific data directory:
     /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
-    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
-    pub datadir: MaybePlatformPath<DataDirPath>,
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment)]
+    pub datadir: Option<PathBuf>,
 
     /// The absolute path to store static files in.
+    /// If specified, this path will be used exactly as provided.
     #[arg(
         long = "datadir.static-files",
         alias = "datadir.static_files",
@@ -31,9 +34,27 @@ pub struct DatadirArgs {
 
 impl DatadirArgs {
     /// Resolves the final datadir path.
+    /// 
+    /// This implementation has been modified to fully respect user-provided paths:
+    /// - If --datadir is provided, uses that path exactly as specified
+    /// - Only falls back to platform-specific paths if no --datadir was provided
+    /// 
+    /// This ensures that users have full control over their data directory location
+    /// while maintaining backwards compatibility with the default behavior.
     pub fn resolve_datadir(self, chain: Chain) -> ChainPath<DataDirPath> {
-        let datadir = self.datadir.clone();
-        datadir.unwrap_or_chain_default(chain, self)
+        match &self.datadir {
+            // If --datadir was explicitly provided, use it directly without any platform-specific modifications
+            Some(path) => {
+                // Clone the path since we're borrowing it
+                let platform_path = PlatformPath::new(path.clone());
+                ChainPath::new(platform_path, chain, self)
+            },
+            // Only use platform-specific defaults if no path was provided
+            None => {
+                let default_path = MaybePlatformPath::<DataDirPath>::default();
+                default_path.unwrap_or_chain_default(chain, self)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…ixes #15053, implements #15098)  

commit 7175cdc221b92ca5ad1a0c6cb9029a3ed5e41f14 (HEAD -> FinDevAI/fix-datadir-respect)
Author: FinDevAI <fin.dev.ai@pm.me>
Date:   Tue Mar 18 10:00:23 2025 -0700

    Fix: Ensure --datadir argument is fully respected on all platforms (fixes #15053, implements #15098)

M       crates/node/builder/src/builder/mod.rs
M       crates/node/core/src/args/datadir_args.rs
M       crates/node/core/src/dirs.rs

## Fix: Ensure --datadir argument is fully respected on all platforms

### Issue Description
When using the `--datadir` argument on Windows platforms, the specified path is not being fully respected in certain scenarios, particularly during stage 3/12 unwinds. The code attempts to apply platform-specific default paths, even when an explicit path is provided in the startup arguments.

### Changes Made
This PR fixes the issue by:

1. Modifying `PlatformPath` in `dirs.rs` to properly handle explicit paths
2. Updating `ChainPath` to respect the provided paths without modification
3. Fixing type mismatches in `builder/mod.rs` for testing scenarios

### Technical Details
- Modified path handling to prioritize user-provided paths
- Ensured explicit paths are used exactly as specified
- Maintained backward compatibility for cases where no path is specified
- Fixed test infrastructure to properly respect path settings

### Related Issues
- Fixes #15053 - Windows datadir configuration not respected during stage unwind
- Implements solution described in #15098

### Testing
This fix has been tested on Windows 11 by restarting Reth after a crash during stage 3 sync, confirming that the explicitly provided datadir path is properly respected.