### PR TITLE
feat: add new `NewBlockEvent` enum for different types of block announcement events

### DIFF
--- a/crates/net/network/src/import.rs
+++ b/crates/net/network/src/import.rs
@@ -1,6 +1,7 @@
 //! This module provides an abstraction over block import in the form of the `BlockImport` trait.
 
 use crate::message::NewBlockMessage;
+use reth_eth_wire_types::broadcast::NewBlockHashes;
 use reth_network_peers::PeerId;
 use std::{
     error::Error,
@@ -9,17 +10,28 @@ use std::{
 
 /// Abstraction over block import.
 pub trait BlockImport<B = reth_ethereum_primitives::Block>: std::fmt::Debug + Send + Sync {
-    /// Invoked for a received `NewBlock` broadcast message from the peer.
+    /// Invoked for a received block announcement from the peer.
     ///
+    /// For a `NewBlock` message:
     /// > When a `NewBlock` announcement message is received from a peer, the client first verifies
     /// > the basic header validity of the block, checking whether the proof-of-work value is valid.
     ///
-    /// This is supposed to start verification. The results are then expected to be returned via
-    /// [`BlockImport::poll`].
-    fn on_new_block(&mut self, peer_id: PeerId, incoming_block: NewBlockMessage<B>);
+    /// For a `NewBlockHashes` message, hash announcement should be processed accordingly.
+    ///
+    /// The results are expected to be returned via [`BlockImport::poll`].
+    fn on_new_block(&mut self, peer_id: PeerId, incoming_block: NewBlockEvent<B>);
 
     /// Returns the results of a [`BlockImport::on_new_block`]
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<BlockImportEvent<B>>;
+}
+
+/// Represents different types of block announcement events from the network.
+#[derive(Debug, Clone)]
+pub enum NewBlockEvent<B = reth_ethereum_primitives::Block> {
+    /// A new full block announcement
+    Block(NewBlockMessage<B>),
+    /// Only the hashes of new blocks
+    Hashes(NewBlockHashes),
 }
 
 /// Represents different types of block import events
@@ -34,13 +46,13 @@ pub enum BlockImportEvent<B = reth_ethereum_primitives::Block> {
 /// Outcome of the [`BlockImport`]'s block handling.
 #[derive(Debug)]
 pub struct BlockImportOutcome<B = reth_ethereum_primitives::Block> {
-    /// Sender of the `NewBlock` message.
+    /// Sender of the block announcement message.
     pub peer: PeerId,
     /// The result after validating the block
     pub result: Result<BlockValidation<B>, BlockImportError>,
 }
 
-/// Represents the successful validation of a received `NewBlock` message.
+/// Represents the successful validation of a received block announcement.
 #[derive(Debug)]
 pub enum BlockValidation<B> {
     /// Basic Header validity check, after which the block should be relayed to peers via a
@@ -76,7 +88,7 @@ pub enum BlockImportError {
 pub struct ProofOfStakeBlockImport;
 
 impl<B> BlockImport<B> for ProofOfStakeBlockImport {
-    fn on_new_block(&mut self, _peer_id: PeerId, _incoming_block: NewBlockMessage<B>) {}
+    fn on_new_block(&mut self, _peer_id: PeerId, _incoming_block: NewBlockEvent<B>) {}
 
     fn poll(&mut self, _cx: &mut Context<'_>) -> Poll<BlockImportEvent<B>> {
         Poll::Pending

--- a/examples/bsc-p2p/src/block_import/mod.rs
+++ b/examples/bsc-p2p/src/block_import/mod.rs
@@ -1,11 +1,11 @@
 #![allow(unused)]
 use handle::ImportHandle;
 use reth_engine_primitives::EngineTypes;
-use reth_network::import::BlockImport;
+use reth_network::import::{BlockImport, BlockImportOutcome, NewBlockEvent};
 use reth_network_peers::PeerId;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};
 use reth_primitives::NodePrimitives;
-use service::{BlockMsg, ImportEvent, Outcome};
+use service::{BlockMsg, BscBlock, ImportEvent, Outcome};
 use std::{
     fmt,
     task::{ready, Context, Poll},
@@ -25,12 +25,11 @@ impl<T: PayloadTypes> BscBlockImport<T> {
     }
 }
 
-impl<T: PayloadTypes>
-    BlockImport<<<T::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block>
-    for BscBlockImport<T>
-{
-    fn on_new_block(&mut self, peer_id: PeerId, incoming_block: BlockMsg<T>) {
-        let _ = self.handle.send_block(incoming_block, peer_id);
+impl<T: PayloadTypes> BlockImport<BscBlock<T>> for BscBlockImport<T> {
+    fn on_new_block(&mut self, peer_id: PeerId, incoming_block: NewBlockEvent<BscBlock<T>>) {
+        if let NewBlockEvent::Block(block) = incoming_block {
+            let _ = self.handle.send_block(block, peer_id);
+        }
     }
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<ImportEvent<T>> {

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -21,7 +21,7 @@ use std::{
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 /// The block type for a given engine
-type BscBlock<T> =
+pub type BscBlock<T> =
     <<<T as PayloadTypes>::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block;
 
 /// Network message containing a new block


### PR DESCRIPTION
Closes: #15100 

This PR adds forwarding of `NewBlockHashes` messages to the block import process. Previously, only full blocks were being processed by the block import, but now block hash announcements are also forwarded.