### PR TITLE
perf(trie): seek hashed cursors lazily in node iter

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -19,7 +19,7 @@ use reth_provider::{
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
-    node_iter::{TrieElement, TrieNodeIter},
+    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
     prefix_set::{PrefixSetMut, TriePrefixSetsMut},
     proof::StorageProof,
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
@@ -183,6 +183,7 @@ where
         let mut account_node_iter = TrieNodeIter::new(
             walker,
             hashed_cursor_factory.hashed_account_cursor().map_err(ProviderError::Database)?,
+            TrieNodeIterType::Account,
         );
         while let Some(account_node) =
             account_node_iter.try_next().map_err(ProviderError::Database)?

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -19,7 +19,8 @@ use reth_provider::{
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
-    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
+    metrics::TrieType,
+    node_iter::{TrieElement, TrieNodeIter},
     prefix_set::{PrefixSetMut, TriePrefixSetsMut},
     proof::StorageProof,
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
@@ -183,7 +184,7 @@ where
         let mut account_node_iter = TrieNodeIter::new(
             walker,
             hashed_cursor_factory.hashed_account_cursor().map_err(ProviderError::Database)?,
-            TrieNodeIterType::Account,
+            TrieType::State,
         );
         while let Some(account_node) =
             account_node_iter.try_next().map_err(ProviderError::Database)?

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -12,7 +12,7 @@ use reth_provider::{
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
-    node_iter::{TrieElement, TrieNodeIter},
+    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
     updates::TrieUpdates,
     walker::TrieWalker,
@@ -153,6 +153,7 @@ where
         let mut account_node_iter = TrieNodeIter::new(
             walker,
             hashed_cursor_factory.hashed_account_cursor().map_err(ProviderError::Database)?,
+            TrieNodeIterType::Account,
         );
 
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -12,7 +12,8 @@ use reth_provider::{
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
-    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
+    metrics::TrieType,
+    node_iter::{TrieElement, TrieNodeIter},
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
     updates::TrieUpdates,
     walker::TrieWalker,
@@ -153,7 +154,7 @@ where
         let mut account_node_iter = TrieNodeIter::new(
             walker,
             hashed_cursor_factory.hashed_account_cursor().map_err(ProviderError::Database)?,
-            TrieNodeIterType::Account,
+            TrieType::State,
         );
 
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
 use reth_trie::{
     hashed_cursor::{noop::NoopHashedStorageCursor, HashedPostStateStorageCursor},
-    node_iter::{TrieElement, TrieNodeIter},
+    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
     trie_cursor::{noop::NoopStorageTrieCursor, InMemoryStorageTrieCursor},
     updates::StorageTrieUpdates,
     walker::TrieWalker,
@@ -144,6 +144,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                         NoopHashedStorageCursor::default(),
                                         Some(&storage_sorted),
                                     ),
+                                    TrieNodeIterType::Account,
                                 );
 
                                 let mut hb = HashBuilder::default().with_updates(true);

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -6,7 +6,8 @@ use itertools::Itertools;
 use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
 use reth_trie::{
     hashed_cursor::{noop::NoopHashedStorageCursor, HashedPostStateStorageCursor},
-    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
+    metrics::TrieType,
+    node_iter::{TrieElement, TrieNodeIter},
     trie_cursor::{noop::NoopStorageTrieCursor, InMemoryStorageTrieCursor},
     updates::StorageTrieUpdates,
     walker::TrieWalker,
@@ -144,7 +145,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                         NoopHashedStorageCursor::default(),
                                         Some(&storage_sorted),
                                     ),
-                                    TrieNodeIterType::Account,
+                                    TrieType::State,
                                 );
 
                                 let mut hb = HashBuilder::default().with_updates(true);

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1591,7 +1591,8 @@ mod tests {
     use reth_provider::{test_utils::create_test_provider_factory, TrieWriter};
     use reth_trie::{
         hashed_cursor::{noop::NoopHashedAccountCursor, HashedPostStateAccountCursor},
-        node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
+        metrics::TrieType,
+        node_iter::{TrieElement, TrieNodeIter},
         trie_cursor::{noop::NoopAccountTrieCursor, TrieCursor, TrieCursorFactory},
         walker::TrieWalker,
         BranchNode, ExtensionNode, HashedPostState, LeafNode,
@@ -1651,7 +1652,7 @@ mod tests {
                 NoopHashedAccountCursor::default(),
                 hashed_post_state.accounts(),
             ),
-            TrieNodeIterType::Account,
+            TrieType::State,
         );
 
         while let Some(node) = node_iter.try_next().unwrap() {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1591,7 +1591,7 @@ mod tests {
     use reth_provider::{test_utils::create_test_provider_factory, TrieWriter};
     use reth_trie::{
         hashed_cursor::{noop::NoopHashedAccountCursor, HashedPostStateAccountCursor},
-        node_iter::{TrieElement, TrieNodeIter},
+        node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
         trie_cursor::{noop::NoopAccountTrieCursor, TrieCursor, TrieCursorFactory},
         walker::TrieWalker,
         BranchNode, ExtensionNode, HashedPostState, LeafNode,
@@ -1651,6 +1651,7 @@ mod tests {
                 NoopHashedAccountCursor::default(),
                 hashed_post_state.accounts(),
             ),
+            TrieNodeIterType::Account,
         );
 
         while let Some(node) = node_iter.try_next().unwrap() {

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -55,6 +55,7 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
     /// Flag indicating whether we should check the current walker key.
     current_walker_key_checked: bool,
 
+    #[cfg(feature = "metrics")]
     metrics: TrieNodeIterMetrics,
 }
 
@@ -69,6 +70,7 @@ impl<C, H: HashedCursor> TrieNodeIter<C, H> {
             hashed_cursor_next: false,
             current_hashed_entry: None,
             current_walker_key_checked: false,
+            #[cfg(feature = "metrics")]
             metrics: TrieNodeIterMetrics::new_with_labels(&[("type", trie_type.as_str())]),
         }
     }
@@ -127,6 +129,7 @@ where
                     self.current_hashed_entry = entry;
                 }
 
+                #[cfg(feature = "metrics")]
                 self.metrics.hashed_cursor_seeks_total.increment(1);
             }
 

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -1,4 +1,7 @@
-use crate::{hashed_cursor::HashedCursor, trie_cursor::TrieCursor, walker::TrieWalker, Nibbles};
+use crate::{
+    hashed_cursor::HashedCursor, metrics::TrieType, trie_cursor::TrieCursor, walker::TrieWalker,
+    Nibbles,
+};
 use alloy_primitives::B256;
 use metrics::Counter;
 use reth_metrics::Metrics;
@@ -57,7 +60,7 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
 
 impl<C, H: HashedCursor> TrieNodeIter<C, H> {
     /// Creates a new [`TrieNodeIter`].
-    pub fn new(walker: TrieWalker<C>, hashed_cursor: H, node_iter_type: TrieNodeIterType) -> Self {
+    pub fn new(walker: TrieWalker<C>, hashed_cursor: H, trie_type: TrieType) -> Self {
         Self {
             walker,
             hashed_cursor,
@@ -66,7 +69,7 @@ impl<C, H: HashedCursor> TrieNodeIter<C, H> {
             hashed_cursor_next: false,
             current_hashed_entry: None,
             current_walker_key_checked: false,
-            metrics: TrieNodeIterMetrics::new_with_labels(&[("type", node_iter_type.as_str())]),
+            metrics: TrieNodeIterMetrics::new_with_labels(&[("type", trie_type.as_str())]),
         }
     }
 
@@ -163,24 +166,6 @@ where
         }
 
         Ok(None)
-    }
-}
-
-/// The type of the node iter.
-#[derive(Debug)]
-pub enum TrieNodeIterType {
-    /// The node iter for the account trie.
-    Account,
-    /// The node iter for the storage trie.
-    Storage,
-}
-
-impl TrieNodeIterType {
-    fn as_str(&self) -> &'static str {
-        match self {
-            Self::Account => "account",
-            Self::Storage => "storage",
-        }
     }
 }
 

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -1,5 +1,7 @@
 use crate::{hashed_cursor::HashedCursor, trie_cursor::TrieCursor, walker::TrieWalker, Nibbles};
 use alloy_primitives::B256;
+use metrics::Counter;
+use reth_metrics::Metrics;
 use reth_storage_errors::db::DatabaseError;
 
 /// Represents a branch node in the trie.
@@ -49,11 +51,13 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
     current_hashed_entry: Option<(B256, <H as HashedCursor>::Value)>,
     /// Flag indicating whether we should check the current walker key.
     current_walker_key_checked: bool,
+
+    metrics: TrieNodeIterMetrics,
 }
 
 impl<C, H: HashedCursor> TrieNodeIter<C, H> {
     /// Creates a new [`TrieNodeIter`].
-    pub const fn new(walker: TrieWalker<C>, hashed_cursor: H) -> Self {
+    pub fn new(walker: TrieWalker<C>, hashed_cursor: H, node_iter_type: TrieNodeIterType) -> Self {
         Self {
             walker,
             hashed_cursor,
@@ -62,6 +66,7 @@ impl<C, H: HashedCursor> TrieNodeIter<C, H> {
             hashed_cursor_next: false,
             current_hashed_entry: None,
             current_walker_key_checked: false,
+            metrics: TrieNodeIterMetrics::new_with_labels(&[("type", node_iter_type.as_str())]),
         }
     }
 
@@ -118,6 +123,8 @@ where
                 } else {
                     self.current_hashed_entry = entry;
                 }
+
+                self.metrics.hashed_cursor_seeks_total.increment(1);
             }
 
             // If there's a hashed entry...
@@ -157,4 +164,29 @@ where
 
         Ok(None)
     }
+}
+
+/// The type of the node iter.
+#[derive(Debug)]
+pub enum TrieNodeIterType {
+    /// The node iter for the account trie.
+    Account,
+    /// The node iter for the storage trie.
+    Storage,
+}
+
+impl TrieNodeIterType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Account => "account",
+            Self::Storage => "storage",
+        }
+    }
+}
+
+#[derive(Metrics)]
+#[metrics(scope = "trie.node_iter")]
+struct TrieNodeIterMetrics {
+    /// The number of times the hashed cursor was seeked.
+    pub hashed_cursor_seeks_total: Counter,
 }

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     hashed_cursor::{HashedCursorFactory, HashedStorageCursor},
-    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
+    metrics::TrieType,
+    node_iter::{TrieElement, TrieNodeIter},
     prefix_set::{PrefixSetMut, TriePrefixSetsMut},
     trie_cursor::TrieCursorFactory,
     walker::TrieWalker,
@@ -125,7 +126,7 @@ where
             targets.keys().map(|key| (*key, StorageMultiProof::empty())).collect();
         let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
         let mut account_node_iter =
-            TrieNodeIter::new(walker, hashed_account_cursor, TrieNodeIterType::Account);
+            TrieNodeIter::new(walker, hashed_account_cursor, TrieType::State);
         while let Some(account_node) = account_node_iter.try_next()? {
             match account_node {
                 TrieElement::Branch(node) => {
@@ -290,7 +291,7 @@ where
             .with_proof_retainer(retainer)
             .with_updates(self.collect_branch_node_masks);
         let mut storage_node_iter =
-            TrieNodeIter::new(walker, hashed_storage_cursor, TrieNodeIterType::Storage);
+            TrieNodeIter::new(walker, hashed_storage_cursor, TrieType::Storage);
         while let Some(node) = storage_node_iter.try_next()? {
             match node {
                 TrieElement::Branch(node) => {

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     hashed_cursor::{HashedCursorFactory, HashedStorageCursor},
-    node_iter::{TrieElement, TrieNodeIter},
+    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
     prefix_set::{PrefixSetMut, TriePrefixSetsMut},
     trie_cursor::TrieCursorFactory,
     walker::TrieWalker,
@@ -124,7 +124,8 @@ where
         let mut storages: B256Map<_> =
             targets.keys().map(|key| (*key, StorageMultiProof::empty())).collect();
         let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
-        let mut account_node_iter = TrieNodeIter::new(walker, hashed_account_cursor);
+        let mut account_node_iter =
+            TrieNodeIter::new(walker, hashed_account_cursor, TrieNodeIterType::Account);
         while let Some(account_node) = account_node_iter.try_next()? {
             match account_node {
                 TrieElement::Branch(node) => {
@@ -288,7 +289,8 @@ where
         let mut hash_builder = HashBuilder::default()
             .with_proof_retainer(retainer)
             .with_updates(self.collect_branch_node_masks);
-        let mut storage_node_iter = TrieNodeIter::new(walker, hashed_storage_cursor);
+        let mut storage_node_iter =
+            TrieNodeIter::new(walker, hashed_storage_cursor, TrieNodeIterType::Storage);
         while let Some(node) = storage_node_iter.try_next()? {
             match node {
                 TrieElement::Branch(node) => {

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -1,6 +1,7 @@
 use crate::{
     hashed_cursor::{HashedCursorFactory, HashedStorageCursor},
-    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
+    metrics::TrieType,
+    node_iter::{TrieElement, TrieNodeIter},
     prefix_set::{PrefixSet, TriePrefixSets},
     progress::{IntermediateStateRootState, StateRootProgress},
     stats::TrieTracker,
@@ -165,17 +166,15 @@ where
                     self.prefix_sets.account_prefix_set,
                 )
                 .with_deletions_retained(retain_updates);
-                let node_iter =
-                    TrieNodeIter::new(walker, hashed_account_cursor, TrieNodeIterType::Account)
-                        .with_last_hashed_key(state.last_account_key);
+                let node_iter = TrieNodeIter::new(walker, hashed_account_cursor, TrieType::State)
+                    .with_last_hashed_key(state.last_account_key);
                 (hash_builder, node_iter)
             }
             None => {
                 let hash_builder = HashBuilder::default().with_updates(retain_updates);
                 let walker = TrieWalker::new(trie_cursor, self.prefix_sets.account_prefix_set)
                     .with_deletions_retained(retain_updates);
-                let node_iter =
-                    TrieNodeIter::new(walker, hashed_account_cursor, TrieNodeIterType::Account);
+                let node_iter = TrieNodeIter::new(walker, hashed_account_cursor, TrieType::State);
                 (hash_builder, node_iter)
             }
         };
@@ -415,7 +414,7 @@ where
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);
 
         let mut storage_node_iter =
-            TrieNodeIter::new(walker, hashed_storage_cursor, TrieNodeIterType::Storage);
+            TrieNodeIter::new(walker, hashed_storage_cursor, TrieType::Storage);
         while let Some(node) = storage_node_iter.try_next()? {
             match node {
                 TrieElement::Branch(node) => {

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -1,6 +1,6 @@
 use crate::{
     hashed_cursor::{HashedCursorFactory, HashedStorageCursor},
-    node_iter::{TrieElement, TrieNodeIter},
+    node_iter::{TrieElement, TrieNodeIter, TrieNodeIterType},
     prefix_set::{PrefixSet, TriePrefixSets},
     progress::{IntermediateStateRootState, StateRootProgress},
     stats::TrieTracker,
@@ -165,15 +165,17 @@ where
                     self.prefix_sets.account_prefix_set,
                 )
                 .with_deletions_retained(retain_updates);
-                let node_iter = TrieNodeIter::new(walker, hashed_account_cursor)
-                    .with_last_hashed_key(state.last_account_key);
+                let node_iter =
+                    TrieNodeIter::new(walker, hashed_account_cursor, TrieNodeIterType::Account)
+                        .with_last_hashed_key(state.last_account_key);
                 (hash_builder, node_iter)
             }
             None => {
                 let hash_builder = HashBuilder::default().with_updates(retain_updates);
                 let walker = TrieWalker::new(trie_cursor, self.prefix_sets.account_prefix_set)
                     .with_deletions_retained(retain_updates);
-                let node_iter = TrieNodeIter::new(walker, hashed_account_cursor);
+                let node_iter =
+                    TrieNodeIter::new(walker, hashed_account_cursor, TrieNodeIterType::Account);
                 (hash_builder, node_iter)
             }
         };
@@ -412,7 +414,8 @@ where
 
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);
 
-        let mut storage_node_iter = TrieNodeIter::new(walker, hashed_storage_cursor);
+        let mut storage_node_iter =
+            TrieNodeIter::new(walker, hashed_storage_cursor, TrieNodeIterType::Storage);
         while let Some(node) = storage_node_iter.try_next()? {
             match node {
                 TrieElement::Branch(node) => {


### PR DESCRIPTION
## Holesky
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/624a113d-241b-459c-8aec-1dc9c30836bb" />

## Base
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/e23e0949-b109-488c-8e39-ed2fe96c2493" />

