### PR TITLE
perf(engine): use proof task as blinded node provider for sparse trie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10053,6 +10053,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "reth-trie-sparse",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -341,7 +341,7 @@ where
             state_root_message_sender,
         }: MultiproofInput<Factory>,
     ) {
-        let to_storage_proof_task = self.storage_proof_task_handle.sender();
+        let storage_proof_task_handle = self.storage_proof_task_handle.clone();
 
         self.executor.spawn_blocking(move || {
             let account_targets = proof_targets.len();
@@ -361,7 +361,7 @@ where
                 config.nodes_sorted,
                 config.state_sorted,
                 config.prefix_sets,
-                to_storage_proof_task.clone(),
+                storage_proof_task_handle.clone(),
             )
             .with_branch_node_masks(true)
             .multiproof(proof_targets);

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -58,12 +58,13 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 default = ["metrics"]
 metrics = ["reth-metrics", "dep:metrics", "reth-trie/metrics"]
 test-utils = [
-    "reth-trie/test-utils",
-    "reth-trie-common/test-utils",
-    "reth-provider/test-utils",
-    "reth-trie-db/test-utils",
-    "reth-primitives-traits/test-utils",
     "reth-db-api/test-utils",
+    "reth-primitives-traits/test-utils",
+    "reth-provider/test-utils",
+    "reth-trie-common/test-utils",
+    "reth-trie-db/test-utils",
+    "reth-trie-sparse/test-utils",
+    "reth-trie/test-utils",
 ]
 
 [[bench]]

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -13,13 +13,14 @@ workspace = true
 
 [dependencies]
 # reth
-reth-storage-errors.workspace = true
-reth-trie.workspace = true
-reth-trie-common.workspace = true
-reth-trie-db.workspace = true
 reth-db-api.workspace = true
 reth-execution-errors.workspace = true
 reth-provider.workspace = true
+reth-storage-errors.workspace = true
+reth-trie-common.workspace = true
+reth-trie-db.workspace = true
+reth-trie-sparse.workspace = true
+reth-trie.workspace = true
 
 # alloy
 alloy-rlp.workspace = true

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -1,6 +1,6 @@
 use crate::{
     metrics::ParallelTrieMetrics,
-    proof_task::{ProofTaskMessage, StorageProofInput},
+    proof_task::{ProofTaskKind, ProofTaskMessage, StorageProofInput},
     root::ParallelStateRootError,
     stats::ParallelTrieTracker,
     StorageRootTargets,
@@ -145,7 +145,9 @@ where
                 self.collect_branch_node_masks,
             );
             let (sender, receiver) = std::sync::mpsc::channel();
-            let _ = self.storage_proof_task.send(ProofTaskMessage::StorageProof((input, sender)));
+            let _ = self
+                .storage_proof_task
+                .send(ProofTaskMessage::QueueTask(ProofTaskKind::StorageProof(input, sender)));
 
             // store the receiver for that result with the hashed address so we can await this in
             // place when we iterate over the trie
@@ -353,7 +355,8 @@ mod tests {
 
         let rt = Runtime::new().unwrap();
 
-        let task_ctx = ProofTaskCtx::new(Default::default(), Default::default());
+        let task_ctx =
+            ProofTaskCtx::new(Default::default(), Default::default(), Default::default());
         let proof_task =
             ProofTaskManager::new(rt.handle().clone(), consistent_view.clone(), task_ctx, 1);
         let proof_task_handle = proof_task.handle();

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -1,6 +1,6 @@
 use crate::{
     metrics::ParallelTrieMetrics,
-    proof_task::{ProofTaskKind, ProofTaskManagerHandle, ProofTaskMessage, StorageProofInput},
+    proof_task::{ProofTaskKind, ProofTaskManagerHandle, StorageProofInput},
     root::ParallelStateRootError,
     stats::ParallelTrieTracker,
     StorageRootTargets,
@@ -147,7 +147,7 @@ where
             let (sender, receiver) = std::sync::mpsc::channel();
             let _ = self
                 .storage_proof_task_handle
-                .send(ProofTaskMessage::QueueTask(ProofTaskKind::StorageProof(input, sender)));
+                .queue_task(ProofTaskKind::StorageProof(input, sender));
 
             // store the receiver for that result with the hashed address so we can await this in
             // place when we iterate over the trie

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -1,6 +1,6 @@
 use crate::{
     metrics::ParallelTrieMetrics,
-    proof_task::{ProofTaskKind, ProofTaskMessage, StorageProofInput},
+    proof_task::{ProofTaskKind, ProofTaskManagerHandle, ProofTaskMessage, StorageProofInput},
     root::ParallelStateRootError,
     stats::ParallelTrieTracker,
     StorageRootTargets,
@@ -30,7 +30,7 @@ use reth_trie::{
 };
 use reth_trie_common::proof::ProofRetainer;
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::Arc;
 use tracing::debug;
 
 /// Parallel proof calculator.
@@ -52,8 +52,8 @@ pub struct ParallelProof<Factory: DatabaseProviderFactory> {
     pub prefix_sets: Arc<TriePrefixSetsMut>,
     /// Flag indicating whether to include branch node masks in the proof.
     collect_branch_node_masks: bool,
-    /// Sender to the storage proof task.
-    storage_proof_task: Sender<ProofTaskMessage<FactoryTx<Factory>>>,
+    /// Handle to the storage proof task.
+    storage_proof_task_handle: ProofTaskManagerHandle<FactoryTx<Factory>>,
     #[cfg(feature = "metrics")]
     metrics: ParallelTrieMetrics,
 }
@@ -65,7 +65,7 @@ impl<Factory: DatabaseProviderFactory> ParallelProof<Factory> {
         nodes_sorted: Arc<TrieUpdatesSorted>,
         state_sorted: Arc<HashedPostStateSorted>,
         prefix_sets: Arc<TriePrefixSetsMut>,
-        storage_proof_task: Sender<ProofTaskMessage<FactoryTx<Factory>>>,
+        storage_proof_task_handle: ProofTaskManagerHandle<FactoryTx<Factory>>,
     ) -> Self {
         Self {
             view,
@@ -73,7 +73,7 @@ impl<Factory: DatabaseProviderFactory> ParallelProof<Factory> {
             state_sorted,
             prefix_sets,
             collect_branch_node_masks: false,
-            storage_proof_task,
+            storage_proof_task_handle,
             #[cfg(feature = "metrics")]
             metrics: ParallelTrieMetrics::new_with_labels(&[("type", "proof")]),
         }
@@ -146,7 +146,7 @@ where
             );
             let (sender, receiver) = std::sync::mpsc::channel();
             let _ = self
-                .storage_proof_task
+                .storage_proof_task_handle
                 .send(ProofTaskMessage::QueueTask(ProofTaskKind::StorageProof(input, sender)));
 
             // store the receiver for that result with the hashed address so we can await this in
@@ -360,7 +360,6 @@ mod tests {
         let proof_task =
             ProofTaskManager::new(rt.handle().clone(), consistent_view.clone(), task_ctx, 1);
         let proof_task_handle = proof_task.handle();
-        let proof_task_sender = proof_task_handle.sender();
 
         // keep the join handle around to make sure it does not return any errors
         // after we compute the state root
@@ -371,7 +370,7 @@ mod tests {
             Default::default(),
             Default::default(),
             Default::default(),
-            proof_task_sender,
+            proof_task_handle.clone(),
         )
         .multiproof(targets.clone())
         .unwrap();

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -101,7 +101,7 @@ impl<Factory> ProofTaskManager<Factory>
 where
     Factory: DatabaseProviderFactory<Provider: BlockReader> + StateCommitmentProvider + 'static,
 {
-    /// Inserts the task the pending tasks queue.
+    /// Inserts the task into the pending tasks queue.
     pub fn queue_proof_task(&mut self, task: ProofTaskKind) {
         self.pending_tasks.push_back(task);
     }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -432,6 +432,9 @@ pub enum ProofTaskMessage<Tx> {
 }
 
 /// Proof task kind.
+///
+/// When queueing a task using [`ProofTaskMessage::QueueTask`], this enum
+/// specifies the type of proof task to be executed.
 #[derive(Debug)]
 pub enum ProofTaskKind {
     /// A storage proof request.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1,5 +1,5 @@
-//! A Task that manages sending storage multiproof requests to a number of tasks that have
-//! longer-running database transactions.
+//! A Task that manages sending proof requests to a number of tasks that have longer-running
+//! database transactions.
 //!
 //! The [`ProofTaskManager`] ensures that there are a max number of currently executing proof tasks,
 //! and is responsible for managing the fixed number of database transactions created at the start
@@ -39,6 +39,7 @@ use tokio::runtime::Handle;
 use tracing::debug;
 
 type StorageProofResult = Result<StorageMultiProof, ParallelStateRootError>;
+type BlindedNodeResult = Result<Option<RevealedNode>, SparseTrieError>;
 
 /// A task that manages sending multiproof requests to a number of tasks that have longer-running
 /// database transactions
@@ -276,7 +277,7 @@ where
     fn blinded_account_node(
         self,
         path: Nibbles,
-        result_sender: Sender<Result<Option<RevealedNode>, SparseTrieError>>,
+        result_sender: Sender<BlindedNodeResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
         let (trie_cursor_factory, hashed_cursor_factory) = self.prepare_factories();
@@ -299,7 +300,7 @@ where
         self,
         account: B256,
         path: Nibbles,
-        result_sender: Sender<Result<Option<RevealedNode>, SparseTrieError>>,
+        result_sender: Sender<BlindedNodeResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
         let (trie_cursor_factory, hashed_cursor_factory) = self.prepare_factories();

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -475,8 +475,7 @@ impl<Tx> ProofTaskManagerHandle<Tx> {
 
 impl<Tx> Clone for ProofTaskManagerHandle<Tx> {
     fn clone(&self) -> Self {
-        self.active_handles.fetch_add(1, Ordering::SeqCst);
-        Self { sender: self.sender.clone(), active_handles: self.active_handles.clone() }
+        Self::new(self.sender.clone(), self.active_handles.clone())
     }
 }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -462,15 +462,12 @@ impl<Tx> ProofTaskManagerHandle<Tx> {
         Self { sender, active_handles }
     }
 
-    /// Sends a message to the proof task manager.
-    pub fn send(
-        &self,
-        message: ProofTaskMessage<Tx>,
-    ) -> Result<(), SendError<ProofTaskMessage<Tx>>> {
-        self.sender.send(message)
+    /// Queues a task to the proof task manager.
+    pub fn queue_task(&self, task: ProofTaskKind) -> Result<(), SendError<ProofTaskMessage<Tx>>> {
+        self.sender.send(ProofTaskMessage::QueueTask(task))
     }
 
-    /// Sends a terminate message to the proof task manager.
+    /// Terminates the proof task manager.
     pub fn terminate(&self) {
         let _ = self.sender.send(ProofTaskMessage::Terminate);
     }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -53,7 +53,7 @@ pub struct ProofTaskManager<Factory: DatabaseProviderFactory> {
     view: ConsistentDbView<Factory>,
     /// Proof task context shared across all proof tasks
     task_ctx: ProofTaskCtx,
-    /// Profo tasks pending execution
+    /// Proof tasks pending execution
     pending_tasks: VecDeque<ProofTaskKind>,
     /// The underlying handle from which to spawn proof tasks
     executor: Handle,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -400,9 +400,9 @@ pub enum ProofTaskKind {
     /// A storage proof request.
     StorageProof(StorageProofInput, Sender<StorageProofResult>),
     /// A blinded account node request.
-    BlindedAccountNode(Nibbles, Sender<Result<Option<RevealedNode>, SparseTrieError>>),
+    BlindedAccountNode(Nibbles, Sender<BlindedNodeResult>),
     /// A blinded storage node request.
-    BlindedStorageNode(B256, Nibbles, Sender<Result<Option<RevealedNode>, SparseTrieError>>),
+    BlindedStorageNode(B256, Nibbles, Sender<BlindedNodeResult>),
 }
 
 /// A handle that wraps a single proof task sender that sends a terminate message on `Drop`.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -448,13 +448,13 @@ impl<Tx: DbTx> BlindedProvider for ProofTaskBlindedNodeProvider<Tx> {
     fn blinded_node(&self, path: &Nibbles) -> Result<Option<RevealedNode>, SparseTrieError> {
         let (tx, rx) = channel();
         match self {
-            Self::AccountNode { sender: tx_sender } => {
-                let _ = tx_sender.send(ProofTaskMessage::QueueTask(
+            Self::AccountNode { sender } => {
+                let _ = sender.send(ProofTaskMessage::QueueTask(
                     ProofTaskKind::BlindedAccountNode(path.clone(), tx),
                 ));
             }
-            Self::StorageNode { sender: tx_sender, account } => {
-                let _ = tx_sender.send(ProofTaskMessage::QueueTask(
+            Self::StorageNode { sender, account } => {
+                let _ = sender.send(ProofTaskMessage::QueueTask(
                     ProofTaskKind::BlindedStorageNode(*account, path.clone(), tx),
                 ));
             }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/14646

This PR does `impl BlindedProviderFactory for ProofTaskManagerHandle`, and passes the handle to the `SparseTrieTask`. That way, every blinded node lookup is done through the proof task, and a new database tx gets spawned if needed.

When implementing this, I realized that we didn't actually need to invert the provider access, and it would work to just initialize the `SparseStateTrie` with the `ProofTaskManagerHandle` as blinded node provider. This can be fixed simplified in a follow-up PR.