### PR TITLE
feat: add inverse conversion for rpc proof types

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -1006,8 +1006,9 @@ mod tests {
         // make account empty
         acc.info.as_mut().unwrap().nonce = 0;
         let rpc_proof = acc.clone().into_eip1186_response(Vec::new());
-        let mut inverse: AccountProof = rpc_proof.into();
-        inverse.info.take();
+        let inverse: AccountProof = rpc_proof.into();
+        acc.info.take();
+        acc.storage_root = EMPTY_ROOT_HASH;
         assert_eq!(acc, inverse);
     }
 }


### PR DESCRIPTION
ported from https://github.com/succinctlabs/rsp/blob/7f954c7d8ca25e76199749a9b90285b07008adac/crates/primitives/src/account_proof.rs#L6

we already have the inverse conversion with given storage keys

cc @leruaa 