### PR TITLE
feat: make MissingPayloadBehaviour configurable in EthereumPayloadBuilder

### DIFF
--- a/crates/ethereum/payload/src/config.rs
+++ b/crates/ethereum/payload/src/config.rs
@@ -6,6 +6,8 @@ use reth_primitives_traits::constants::GAS_LIMIT_BOUND_DIVISOR;
 pub struct EthereumBuilderConfig {
     /// Desired gas limit.
     pub desired_gas_limit: u64,
+    /// Waits for a payload when there is no payload yet.
+    pub await_payload_on_missing: bool,
 }
 
 impl Default for EthereumBuilderConfig {
@@ -17,7 +19,7 @@ impl Default for EthereumBuilderConfig {
 impl EthereumBuilderConfig {
     /// Create new payload builder config.
     pub const fn new() -> Self {
-        Self { desired_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M }
+        Self { desired_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M, await_payload_on_missing: false }
     }
 
     /// Set desired gas limit.

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -15,7 +15,7 @@ pub use validator::EthereumExecutionPayloadValidator;
 use alloy_consensus::{Transaction, Typed2718};
 use alloy_primitives::U256;
 use reth_basic_payload_builder::{
-    is_better_payload, BuildArguments, BuildOutcome, PayloadBuilder, PayloadConfig,
+    is_better_payload, BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
 };
 use reth_chainspec::{ChainSpec, ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError};
@@ -95,6 +95,17 @@ where
             args,
             |attributes| self.pool.best_transactions_with_attributes(attributes),
         )
+    }
+
+    fn on_missing_payload(
+        &self,
+        _args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+    ) -> MissingPayloadBehaviour<Self::BuiltPayload> {
+        if self.builder_config.await_payload_on_missing {
+            MissingPayloadBehaviour::AwaitInProgress
+        } else {
+            MissingPayloadBehaviour::RaceEmptyPayload
+        }
     }
 
     fn build_empty_payload(

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -15,7 +15,8 @@ pub use validator::EthereumExecutionPayloadValidator;
 use alloy_consensus::{Transaction, Typed2718};
 use alloy_primitives::U256;
 use reth_basic_payload_builder::{
-    is_better_payload, BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
+    is_better_payload, BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder,
+    PayloadConfig,
 };
 use reth_chainspec::{ChainSpec, ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError};


### PR DESCRIPTION
This PR 
- introduces a new bool in `EthereumBuilderConfig` that determines whether the payload in progress should be awaited `AwaitInProgress`
- implements `on_missing_payload` `PayloadBuilder` trait method for `EthereumPayloadBuilder`

resolves: <https://github.com/paradigmxyz/reth/issues/15156>