### PR TITLE
move tx pool events and listener code into its own file

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -164,7 +164,7 @@ pub use crate::{
     ordering::{CoinbaseTipOrdering, Priority, TransactionOrdering},
     pool::{
         blob_tx_priority, fee_delta, state::SubPool, AllTransactionsEvents, FullTransactionEvent,
-        TransactionEvent, TransactionEvents,
+        NewTransactionEvent, TransactionEvent, TransactionEvents, TransactionListenerKind,
     },
     traits::*,
     validate::{

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -6,10 +6,8 @@
 use crate::{
     blobstore::BlobStoreError,
     error::PoolError,
-    traits::{
-        BestTransactionsAttributes, GetPooledTransactionLimit, NewBlobSidecar,
-        TransactionListenerKind,
-    },
+    pool::TransactionListenerKind,
+    traits::{BestTransactionsAttributes, GetPooledTransactionLimit, NewBlobSidecar},
     validate::ValidTransaction,
     AllPoolTransactions, AllTransactionsEvents, BestTransactions, BlockInfo, EthPoolTransaction,
     EthPooledTransaction, NewTransactionEvent, PoolResult, PoolSize, PoolTransaction,

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -1,4 +1,4 @@
-use crate::{traits::PropagateKind, PoolTransaction, ValidPoolTransaction};
+use crate::{traits::PropagateKind, PoolTransaction, SubPool, ValidPoolTransaction};
 use alloy_primitives::{TxHash, B256};
 use std::sync::Arc;
 
@@ -81,5 +81,20 @@ impl TransactionEvent {
     /// hash.
     pub const fn is_final(&self) -> bool {
         matches!(self, Self::Replaced(_) | Self::Mined(_) | Self::Discarded)
+    }
+}
+
+/// Represents a new transaction
+#[derive(Debug)]
+pub struct NewTransactionEvent<T: PoolTransaction> {
+    /// The pool which the transaction was moved to.
+    pub subpool: SubPool,
+    /// Actual transaction
+    pub transaction: Arc<ValidPoolTransaction<T>>,
+}
+
+impl<T: PoolTransaction> Clone for NewTransactionEvent<T> {
+    fn clone(&self) -> Self {
+        Self { subpool: self.subpool, transaction: self.transaction.clone() }
     }
 }

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -1,8 +1,8 @@
 //! Listeners for the transaction-pool
 
 use crate::{
-    pool::events::{FullTransactionEvent, TransactionEvent},
-    traits::PropagateKind,
+    pool::events::{FullTransactionEvent, NewTransactionEvent, TransactionEvent},
+    traits::{NewBlobSidecar, PropagateKind},
     PoolTransaction, ValidPoolTransaction,
 };
 use alloy_primitives::{TxHash, B256};
@@ -14,9 +14,9 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::sync::mpsc::{
-    error::TrySendError, Receiver, Sender, UnboundedReceiver, UnboundedSender,
+    self as mpsc, error::TrySendError, Receiver, Sender, UnboundedReceiver, UnboundedSender,
 };
-
+use tracing::debug;
 /// The size of the event channel used to propagate transaction events.
 const TX_POOL_EVENT_CHANNEL_SIZE: usize = 1024;
 
@@ -225,5 +225,110 @@ impl PoolEventBroadcaster {
     // Broadcast an event to all listeners. Dropped listeners are silently evicted.
     fn broadcast(&mut self, event: TransactionEvent) {
         self.senders.retain(|sender| sender.send(event.clone()).is_ok())
+    }
+}
+
+/// An active listener for new pending transactions.
+#[derive(Debug)]
+pub(crate) struct PendingTransactionHashListener {
+    pub(crate) sender: mpsc::Sender<TxHash>,
+    /// Whether to include transactions that should not be propagated over the network.
+    pub(crate) kind: TransactionListenerKind,
+}
+
+impl PendingTransactionHashListener {
+    /// Attempts to send all hashes to the listener.
+    ///
+    /// Returns false if the channel is closed (receiver dropped)
+    pub(crate) fn send_all(&self, hashes: impl IntoIterator<Item = TxHash>) -> bool {
+        for tx_hash in hashes {
+            match self.sender.try_send(tx_hash) {
+                Ok(()) => {}
+                Err(err) => {
+                    return if matches!(err, mpsc::error::TrySendError::Full(_)) {
+                        debug!(
+                            target: "txpool",
+                            "[{:?}] failed to send pending tx; channel full",
+                            tx_hash,
+                        );
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        }
+        true
+    }
+}
+
+/// An active listener for new pending transactions.
+#[derive(Debug)]
+pub(crate) struct TransactionListener<T: PoolTransaction> {
+    pub(crate) sender: mpsc::Sender<NewTransactionEvent<T>>,
+    /// Whether to include transactions that should not be propagated over the network.
+    pub(crate) kind: TransactionListenerKind,
+}
+
+impl<T: PoolTransaction> TransactionListener<T> {
+    /// Attempts to send the event to the listener.
+    ///
+    /// Returns false if the channel is closed (receiver dropped)
+    pub(crate) fn send(&self, event: NewTransactionEvent<T>) -> bool {
+        self.send_all(std::iter::once(event))
+    }
+
+    /// Attempts to send all events to the listener.
+    ///
+    /// Returns false if the channel is closed (receiver dropped)
+    pub(crate) fn send_all(
+        &self,
+        events: impl IntoIterator<Item = NewTransactionEvent<T>>,
+    ) -> bool {
+        for event in events {
+            match self.sender.try_send(event) {
+                Ok(()) => {}
+                Err(err) => {
+                    return if let mpsc::error::TrySendError::Full(event) = err {
+                        debug!(
+                            target: "txpool",
+                            "[{:?}] failed to send pending tx; channel full",
+                            event.transaction.hash(),
+                        );
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        }
+        true
+    }
+}
+
+/// An active listener for new blobs
+#[derive(Debug)]
+pub(crate) struct BlobTransactionSidecarListener {
+    pub(crate) sender: mpsc::Sender<NewBlobSidecar>,
+}
+
+/// Determines what kind of new transactions should be emitted by a stream of transactions.
+///
+/// This gives control whether to include transactions that are allowed to be propagated.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TransactionListenerKind {
+    /// Any new pending transactions
+    All,
+    /// Only transactions that are allowed to be propagated.
+    ///
+    /// See also [`ValidPoolTransaction`]
+    PropagateOnly,
+}
+
+impl TransactionListenerKind {
+    /// Returns true if we're only interested in transactions that are allowed to be propagated.
+    #[inline]
+    pub const fn is_propagate_only(&self) -> bool {
+        matches!(self, Self::PropagateOnly)
     }
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -11,7 +11,7 @@ use crate::{
         parked::{BasefeeOrd, ParkedPool, QueuedOrd},
         pending::PendingPool,
         state::{SubPool, TxState},
-        update::{Destination, PoolUpdate},
+        update::{Destination, PoolUpdate, UpdateOutcome},
         AddedPendingTransaction, AddedTransaction, OnNewCanonicalStateOutcome,
     },
     traits::{BestTransactionsAttributes, BlockInfo, PoolSize},
@@ -1939,21 +1939,6 @@ pub(crate) struct PoolInternalTransaction<T: PoolTransaction> {
 impl<T: PoolTransaction> PoolInternalTransaction<T> {
     fn next_cumulative_cost(&self) -> U256 {
         self.cumulative_cost + self.transaction.cost()
-    }
-}
-
-/// Tracks the result after updating the pool
-#[derive(Debug)]
-pub(crate) struct UpdateOutcome<T: PoolTransaction> {
-    /// transactions promoted to the pending pool
-    pub(crate) promoted: Vec<Arc<ValidPoolTransaction<T>>>,
-    /// transaction that failed and were discarded
-    pub(crate) discarded: Vec<Arc<ValidPoolTransaction<T>>>,
-}
-
-impl<T: PoolTransaction> Default for UpdateOutcome<T> {
-    fn default() -> Self {
-        Self { promoted: vec![], discarded: vec![] }
     }
 }
 

--- a/crates/transaction-pool/src/pool/update.rs
+++ b/crates/transaction-pool/src/pool/update.rs
@@ -1,7 +1,10 @@
 //! Support types for updating the pool.
 
-use crate::{identifier::TransactionId, pool::state::SubPool};
+use crate::{
+    identifier::TransactionId, pool::state::SubPool, PoolTransaction, ValidPoolTransaction,
+};
 use alloy_primitives::TxHash;
+use std::sync::Arc;
 
 /// A change of the transaction's location
 ///
@@ -30,5 +33,20 @@ pub(crate) enum Destination {
 impl From<SubPool> for Destination {
     fn from(sub_pool: SubPool) -> Self {
         Self::Pool(sub_pool)
+    }
+}
+
+/// Tracks the result after updating the pool
+#[derive(Debug)]
+pub(crate) struct UpdateOutcome<T: PoolTransaction> {
+    /// transactions promoted to the pending pool
+    pub(crate) promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+    /// transaction that failed and were discarded
+    pub(crate) discarded: Vec<Arc<ValidPoolTransaction<T>>>,
+}
+
+impl<T: PoolTransaction> Default for UpdateOutcome<T> {
+    fn default() -> Self {
+        Self { promoted: vec![], discarded: vec![] }
     }
 }


### PR DESCRIPTION
This is a code structure optimization pr, which move events and listener related code into their own file