### PR TITLE
Notify payload job explicitly when resolving (#15154)

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -6,6 +6,7 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rlp::Decodable;
+use std::sync::atomic::AtomicBool;
 use alloy_rpc_types::engine::{BlobsBundleV1, PayloadAttributes};
 use clap::Parser;
 use eyre::Context;

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -215,6 +215,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             payload_config,
             CancelOnDrop::default(),
             None,
+            Arc::new(AtomicBool::new(false)),
         );
 
         let payload_builder = reth_ethereum_payload_builder::EthereumPayloadBuilder::new(

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -38,7 +38,11 @@ use reth_transaction_pool::{
 };
 use reth_trie::StateRoot;
 use reth_trie_db::DatabaseStateRoot;
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    path::PathBuf,
+    str::FromStr,
+    sync::{atomic::AtomicBool, Arc},
+};
 use tracing::*;
 
 /// `reth debug build-block` command

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -6,7 +6,6 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rlp::Decodable;
-use std::sync::atomic::AtomicBool;
 use alloy_rpc_types::engine::{BlobsBundleV1, PayloadAttributes};
 use clap::Parser;
 use eyre::Context;

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -25,6 +25,7 @@ use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
     ConfigureEvm, Evm, NextBlockEnvAttributes,
 };
+use std::sync::atomic::AtomicBool;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_payload_builder_primitives::PayloadBuilderError;
@@ -148,7 +149,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
 {
-    let BuildArguments { mut cached_reads, config, cancel, best_payload, is_resolving } = args;
+    let BuildArguments { mut cached_reads, config, cancel, best_payload, is_resolving: _ } = args;
     let PayloadConfig { parent_header, attributes } = config;
 
     let state_provider = client.state_by_block_hash(parent_header.hash())?;

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -25,7 +25,6 @@ use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
     ConfigureEvm, Evm, NextBlockEnvAttributes,
 };
-use std::sync::atomic::AtomicBool;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_payload_builder_primitives::PayloadBuilderError;
@@ -38,7 +37,7 @@ use reth_transaction_pool::{
     PoolTransaction, TransactionPool, ValidPoolTransaction,
 };
 use revm::context_interface::Block as _;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use tracing::{debug, trace, warn};
 
 mod config;
@@ -114,8 +113,13 @@ where
         &self,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<EthBuiltPayload, PayloadBuilderError> {
-        let args = BuildArguments::new(Default::default(), config, Default::default(), None, Arc::new(AtomicBool::new(false)));
-
+        let args = BuildArguments::new(
+            Default::default(),
+            config,
+            Default::default(),
+            None,
+            Arc::new(AtomicBool::new(false)),
+        );
         default_ethereum_payload(
             self.evm_config.clone(),
             self.client.clone(),

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -101,7 +101,7 @@ where
         &self,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<EthBuiltPayload, PayloadBuilderError> {
-        let args = BuildArguments::new(Default::default(), config, Default::default(), None);
+        let args = BuildArguments::new(Default::default(), config, Default::default(), None, Arc::new(AtomicBool::new(false)));
 
         default_ethereum_payload(
             self.evm_config.clone(),
@@ -136,7 +136,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
 {
-    let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
+    let BuildArguments { mut cached_reads, config, cancel, best_payload, is_resolving } = args;
     let PayloadConfig { parent_header, attributes } = config;
 
     let state_provider = client.state_by_block_hash(parent_header.hash())?;

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -143,8 +143,8 @@ where
     where
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     {
-        let BuildArguments { mut cached_reads, config, cancel, best_payload, is_resolving: _ } = args;
-
+        let BuildArguments { mut cached_reads, config, cancel, best_payload, is_resolving: _ } =
+            args;
         let ctx = OpPayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
             da_config: self.config.da_config.clone(),

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -37,7 +37,7 @@ use reth_revm::{
 };
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
 use revm::context::{Block, BlockEnv};
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use tracing::{debug, trace, warn};
 
 /// Optimism's payload builder
@@ -143,7 +143,7 @@ where
     where
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     {
-        let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
+        let BuildArguments { mut cached_reads, config, cancel, best_payload, is_resolving: _ } = args;
 
         let ctx = OpPayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
@@ -234,6 +234,7 @@ where
             cached_reads: Default::default(),
             cancel: Default::default(),
             best_payload: None,
+            is_resolving: Arc::new(AtomicBool::new(false)),
         };
         self.build_payload(args, |_| NoopPayloadTransactions::<Pool::Transaction>::default())?
             .into_payload()

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -355,8 +355,13 @@ where
         self.executor.spawn_blocking(Box::pin(async move {
             // acquire the permit for executing the task
             let _permit = guard.acquire().await;
-            let args =
-                BuildArguments { cached_reads, config: payload_config, cancel, best_payload, is_resolving, };
+            let args = BuildArguments { 
+                cached_reads,
+                config: payload_config,
+                cancel,
+                best_payload,
+                is_resolving,
+            };
             let result = builder.try_build(args);
             let _ = tx.send(result);
         }));
@@ -803,7 +808,7 @@ impl<Attributes, Payload: BuiltPayload> BuildArguments<Attributes, Payload> {
         cancel: CancelOnDrop,
         best_payload: Option<Payload>,
     ) -> Self {
-        Self { cached_reads, config, cancel, best_payload, is_resolving, }
+        Self { cached_reads, config, cancel, best_payload, is_resolving }
     }
 }
 

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -334,7 +334,7 @@ where
     /// See [`PayloadBuilder`]
     builder: Builder,
     /// Flag indicating whether this payload job is currently resolving.
-    is_resolving:Arc<AtomicBool>
+    is_resolving: Arc<AtomicBool>,
 }
 
 impl<Tasks, Builder> BasicPayloadJob<Tasks, Builder>
@@ -356,11 +356,11 @@ where
         self.metrics.inc_initiated_payload_builds();
         let cached_reads = self.cached_reads.take().unwrap_or_default();
         let builder = self.builder.clone();
-        let is_resolving= self.is_resolving.clone();
+        let is_resolving = self.is_resolving.clone();
         self.executor.spawn_blocking(Box::pin(async move {
             // acquire the permit for executing the task
             let _permit = guard.acquire().await;
-            let args = BuildArguments { 
+            let args = BuildArguments {
                 cached_reads,
                 config: payload_config,
                 cancel,
@@ -813,7 +813,7 @@ impl<Attributes, Payload: BuiltPayload> BuildArguments<Attributes, Payload> {
         config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
         cancel: CancelOnDrop,
         best_payload: Option<Payload>,
-        is_resolving: Arc<AtomicBool>
+        is_resolving: Arc<AtomicBool>,
     ) -> Self {
         Self { cached_reads, config, cancel, best_payload, is_resolving }
     }

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -64,7 +64,7 @@ pub struct BasicPayloadJobGenerator<Client, Tasks, Builder> {
     builder: Builder,
     /// Stored `cached_reads` for new payload jobs.
     pre_cached: Option<PrecachedState>,
-    is_resolving: Arc<AtomicBool>,
+    pub is_resolving: Arc<AtomicBool>,
 }
 
 // === impl BasicPayloadJobGenerator ===

--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -210,6 +210,7 @@ where
                             None
                         }
                     }),
+                    is_resolving: args.is_resolving.clone(),
                 };
 
                 self.left.try_build(left_args).map(|out| out.map_payload(Either::Left))
@@ -229,6 +230,7 @@ where
                             None
                         }
                     }),
+                    is_resolving: args.is_resolving.clone(),
                 };
 
                 self.right.try_build(right_args).map(|out| out.map_payload(Either::Right))

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -392,7 +392,7 @@ where
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
-        let BuildArguments { cached_reads, config, cancel, best_payload } = args;
+        let BuildArguments { cached_reads, config, cancel, best_payload, is_resolving: _ } = args;
         let PayloadConfig { parent_header, attributes } = config;
 
         // This reuses the default EthereumPayloadBuilder to build the payload
@@ -402,6 +402,7 @@ where
             config: PayloadConfig { parent_header, attributes: attributes.0 },
             cancel,
             best_payload,
+            is_resolving: Arc::new(AtomicBool::new(false)),
         })
     }
 

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -28,7 +28,6 @@ use alloy_rpc_types::{
     },
     Withdrawal,
 };
-use std::sync::atomic::AtomicBool;
 use reth::{
     api::{InvalidPayloadAttributesError, PayloadTypes},
     builder::{
@@ -65,7 +64,10 @@ use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes, Payload
 use reth_tracing::{RethTracer, Tracer};
 use reth_trie_db::MerklePatriciaTrie;
 use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, sync::Arc};
+use std::{
+    convert::Infallible,
+    sync::{atomic::AtomicBool, Arc},
+};
 use thiserror::Error;
 
 /// A custom payload attributes type.

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -28,6 +28,7 @@ use alloy_rpc_types::{
     },
     Withdrawal,
 };
+use std::sync::atomic::AtomicBool;
 use reth::{
     api::{InvalidPayloadAttributesError, PayloadTypes},
     builder::{


### PR DESCRIPTION
Hello @mattsse , do check out this pr , once free!

Description
This PR addresses issue #15154 by explicitly notifying the payload build job when it's resolving, preventing unnecessary racing against empty blocks.

Changes:
Introduced an atomic boolean flag (is_resolving) within BasicPayloadJob and BuildArguments to indicate resolution status.
Set this flag explicitly when the payload resolution begins in resolve_kind.
Updated payload transaction-building loop to regularly check the `is_resolving flag` and exit immediately when resolution starts.

Resolves #15154