### PR TITLE
chore: remove serde from reth-provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
- "serde",
 ]
 
 [[package]]
@@ -5570,9 +5569,6 @@ name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ntapi"

--- a/crates/exex/exex/Cargo.toml
+++ b/crates/exex/exex/Cargo.toml
@@ -69,7 +69,6 @@ tempfile.workspace = true
 [features]
 default = []
 serde = [
-    "reth-provider/serde",
     "reth-exex-types/serde",
     "reth-revm/serde",
     "alloy-consensus/serde",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -125,7 +125,6 @@ serde = [
     "url/serde",
     "reth-primitives-traits/serde",
     "reth-ethereum-forks/serde",
-    "reth-provider/serde",
     "reth-transaction-pool/serde",
 ]
 test-utils = [

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -95,7 +95,6 @@ serde = [
     "alloy-primitives/serde",
     "op-alloy-consensus/serde",
     "reth-execution-types/serde",
-    "reth-provider/serde",
     "reth-optimism-primitives/serde",
     "reth-primitives-traits/serde",
 ]

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -87,26 +87,6 @@ eyre.workspace = true
 alloy-consensus.workspace = true
 
 [features]
-serde = [
-    "dashmap/serde",
-    "notify/serde",
-    "parking_lot/serde",
-    "rand/serde",
-    "alloy-primitives/serde",
-    "alloy-consensus/serde",
-    "alloy-eips/serde",
-    "alloy-rpc-types-engine/serde",
-    "reth-codecs/serde",
-    "reth-primitives-traits/serde",
-    "reth-execution-types/serde",
-    "reth-trie-db/serde",
-    "reth-trie/serde",
-    "reth-stages-types/serde",
-    "reth-prune-types/serde",
-    "revm-database/serde",
-    "revm-database-interface/serde",
-    "revm-state?/serde",
-]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -76,7 +76,6 @@ serde = [
     "dep:serde",
     "reth-execution-types/serde",
     "reth-eth-wire-types/serde",
-    "reth-provider/serde",
     "alloy-consensus/serde",
     "alloy-eips/serde",
     "alloy-primitives/serde",

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -72,7 +72,6 @@ serde = [
     "alloy-primitives/serde",
     "reth-trie/serde",
     "reth-trie-common/serde",
-    "reth-provider/serde",
     "reth-primitives-traits/serde",
     "revm-database/serde",
 ]

--- a/examples/bsc-p2p/Cargo.toml
+++ b/examples/bsc-p2p/Cargo.toml
@@ -49,7 +49,6 @@ serde = [
     "reth-eth-wire/serde",
     "reth-eth-wire-types/serde",
     "reth-ethereum-forks/serde",
-    "reth-provider/serde",
     "reth-primitives-traits/serde",
     "secp256k1/serde",
     "bytes/serde",


### PR DESCRIPTION
this feature pass through is causing issues for https://github.com/paradigmxyz/ress/pull/150

because reth-provider doesn't have a serde dep directly.

we used to have this but have since extracted all types from this crate so we can remove this feature entirely.