### PR TITLE
test(trie): fix the trie node iterator test and use hash builder for correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,8 +917,6 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,8 @@ dependencies = [
 [[package]]
 name = "alloy-trie"
 version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -232,13 +232,13 @@ mod tests {
         reth_tracing::init_test_tracing();
 
         // Extension (Key = 0000000000000000000000000000000000000000000000000000000000000)
-        // ├── 0 -> Branch (`branch_node`)
-        //       ├── 0 -> Branch (`child_branch_node`)
-        //       │      ├── 0 -> Leaf (account_1, marked as changed)
-        //       │      └── 1 -> Leaf (account_2)
-        //       ├── 1 -> Branch (`child_branch_node`)
-        //       │      ├── 0 -> Leaf (account_5)
-        //       │      └── 1 -> Leaf (account_6)
+        // └── Branch (`branch_node`)
+        //     ├── 0 -> Branch (`child_branch_node`)
+        //     │      ├── 0 -> Leaf (account_1, marked as changed)
+        //     │      └── 1 -> Leaf (account_2)
+        //     ├── 1 -> Branch (`child_branch_node`)
+        //     │      ├── 0 -> Leaf (account_5)
+        //     │      └── 1 -> Leaf (account_6)
 
         let account_1 = b256!("0x0000000000000000000000000000000000000000000000000000000000000000");
         let account_2 = b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
@@ -267,7 +267,10 @@ mod tests {
             Nibbles::from_nibbles([0; 62]),
             BranchNodeCompact::new(
                 TrieMask::new(0b11),
+                // Tree mask has no bits set, because both child branch nodes have empty tree and
+                // hash masks.
                 TrieMask::new(0b00),
+                // Hash mask bits are set, because both child nodes are branches.
                 TrieMask::new(0b11),
                 vec![
                     child_branch_node_rlp.as_hash().unwrap(),

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -181,10 +181,8 @@ mod tests {
 
     use super::{TrieElement, TrieNodeIter};
 
-    /// Calculate the state root by feeding the provided state to the hash builder and retaining the
-    /// proofs for the provided targets.
-    ///
-    /// Returns the state root and the retained proof nodes.
+    /// Calculate the branch node stored in the database by feeding the provided state to the hash
+    /// builder and taking the trie updates.
     fn get_hash_builder_branch_nodes(
         state: impl IntoIterator<Item = (Nibbles, Account)> + Clone,
     ) -> HashMap<Nibbles, BranchNodeCompact> {

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use alloy_primitives::{map::HashSet, B256};
 use reth_storage_errors::db::DatabaseError;
+use tracing::{instrument, trace};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::WalkerMetrics;
@@ -96,6 +97,7 @@ impl<C> TrieWalker<C> {
     }
 
     /// Returns the next unprocessed key in the trie.
+    #[instrument(level = "trace", skip(self), ret)]
     pub fn next_unprocessed_key(&self) -> Option<B256> {
         self.key()
             .and_then(|key| {
@@ -113,10 +115,18 @@ impl<C> TrieWalker<C> {
 
     /// Updates the skip node flag based on the walker's current state.
     fn update_skip_node(&mut self) {
+        let old = self.can_skip_current_node;
         self.can_skip_current_node = self
             .stack
             .last()
             .is_some_and(|node| !self.changes.contains(node.full_key()) && node.hash_flag());
+        trace!(
+            target: "trie::walker",
+            old,
+            new = self.can_skip_current_node,
+            last = ?self.stack.last(),
+            "updated skip node flag"
+        );
     }
 }
 
@@ -153,6 +163,11 @@ impl<C: TrieCursor> TrieWalker<C> {
     pub fn advance(&mut self) -> Result<(), DatabaseError> {
         if let Some(last) = self.stack.last() {
             if !self.can_skip_current_node && self.children_are_in_trie() {
+                trace!(
+                    target: "trie::walker",
+                    nibble = ?last.nibble(),
+                    "cannot skip current node and children are in the trie"
+                );
                 // If we can't skip the current node and the children are in the trie,
                 // either consume the next node or move to the next sibling.
                 match last.nibble() {
@@ -160,6 +175,7 @@ impl<C: TrieCursor> TrieWalker<C> {
                     _ => self.consume_node()?,
                 }
             } else {
+                trace!(target: "trie::walker", "can skip current node");
                 // If we can skip the current node, move to the next sibling.
                 self.move_to_next_sibling(false)?;
             }
@@ -184,6 +200,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Consumes the next node in the trie, updating the stack.
+    #[instrument(level = "trace", skip(self), ret)]
     fn consume_node(&mut self) -> Result<(), DatabaseError> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
@@ -229,6 +246,7 @@ impl<C: TrieCursor> TrieWalker<C> {
     }
 
     /// Moves to the next sibling node in the trie, updating the stack.
+    #[instrument(level = "trace", skip(self), ret)]
     fn move_to_next_sibling(
         &mut self,
         allow_root_to_child_nibble: bool,
@@ -251,10 +269,13 @@ impl<C: TrieCursor> TrieWalker<C> {
 
         // Find the next sibling with state.
         loop {
+            let nibble = subnode.nibble();
             if subnode.state_flag() {
+                trace!(target: "trie::walker", nibble, "found next sibling with state");
                 return Ok(())
             }
             if subnode.nibble() == 0xf {
+                trace!(target: "trie::walker", nibble, "checked all siblings");
                 break
             }
             subnode.inc_nibble();

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -274,7 +274,7 @@ impl<C: TrieCursor> TrieWalker<C> {
                 trace!(target: "trie::walker", nibble, "found next sibling with state");
                 return Ok(())
             }
-            if subnode.nibble() == 0xf {
+            if nibble == 0xf {
                 trace!(target: "trie::walker", nibble, "checked all siblings");
                 break
             }


### PR DESCRIPTION
Previous test wasn't really correct, because we fed into the iterator more nodes than would actually be stored when using the hash builder. I fixed the test and added an assertion against the hash builder trie updates output.