### PR TITLE
refactor(trie): initialize sparse trie with the provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10056,6 +10056,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "assert_matches",
+ "auto_impl",
  "codspeed-criterion-compat",
  "itertools 0.14.0",
  "metrics",

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -36,7 +36,7 @@ pub(super) struct SparseTrieTask<BPF> {
 
 impl<BPF> SparseTrieTask<BPF>
 where
-    BPF: BlindedProviderFactory + Send + Sync,
+    BPF: BlindedProviderFactory + Clone + Send + Sync,
     BPF::AccountNodeProvider: BlindedProvider + Send + Sync,
     BPF::StorageNodeProvider: BlindedProvider + Send + Sync,
 {
@@ -62,7 +62,8 @@ where
         let now = Instant::now();
 
         let mut num_iterations = 0;
-        let mut trie = SparseStateTrie::default().with_updates(true);
+        let mut trie =
+            SparseStateTrie::new(self.blinded_provider_factory.clone()).with_updates(true);
 
         while let Ok(mut update) = self.updates.recv() {
             num_iterations += 1;
@@ -80,10 +81,9 @@ where
                 "Updating sparse trie"
             );
 
-            let elapsed = update_sparse_trie(&mut trie, update, &self.blinded_provider_factory)
-                .map_err(|e| {
-                    ParallelStateRootError::Other(format!("could not calculate state root: {e:?}"))
-                })?;
+            let elapsed = update_sparse_trie(&mut trie, update).map_err(|e| {
+                ParallelStateRootError::Other(format!("could not calculate state root: {e:?}"))
+            })?;
             self.metrics.sparse_trie_update_duration_histogram.record(elapsed);
             trace!(target: "engine::root", ?elapsed, num_iterations, "Root calculation completed");
         }
@@ -91,10 +91,9 @@ where
         debug!(target: "engine::root", num_iterations, "All proofs processed, ending calculation");
 
         let start = Instant::now();
-        let (state_root, trie_updates) =
-            trie.root_with_updates(&self.blinded_provider_factory).map_err(|e| {
-                ParallelStateRootError::Other(format!("could not calculate state root: {e:?}"))
-            })?;
+        let (state_root, trie_updates) = trie.root_with_updates().map_err(|e| {
+            ParallelStateRootError::Other(format!("could not calculate state root: {e:?}"))
+        })?;
 
         self.metrics.sparse_trie_final_update_duration_histogram.record(start.elapsed());
         self.metrics.sparse_trie_total_duration_histogram.record(now.elapsed());
@@ -115,9 +114,8 @@ pub struct StateRootComputeOutcome {
 
 /// Updates the sparse trie with the given proofs and state, and returns the elapsed time.
 pub(crate) fn update_sparse_trie<BPF>(
-    trie: &mut SparseStateTrie,
+    trie: &mut SparseStateTrie<BPF>,
     SparseTrieUpdate { mut state, multiproof }: SparseTrieUpdate,
-    blinded_provider_factory: &BPF,
 ) -> SparseStateTrieResult<Duration>
 where
     BPF: BlindedProviderFactory + Send + Sync,
@@ -148,7 +146,6 @@ where
             let _enter = span.enter();
             trace!(target: "engine::root::sparse", "Updating storage");
             let mut storage_trie = storage_trie.ok_or(SparseTrieErrorKind::Blind)?;
-            let provider = blinded_provider_factory.storage_node_provider(address);
 
             if storage.wiped {
                 trace!(target: "engine::root::sparse", "Wiping storage");
@@ -158,14 +155,11 @@ where
                 let slot_nibbles = Nibbles::unpack(slot);
                 if value.is_zero() {
                     trace!(target: "engine::root::sparse", ?slot, "Removing storage slot");
-                    storage_trie.remove_leaf(&slot_nibbles, &provider)?;
+                    storage_trie.remove_leaf(&slot_nibbles)?;
                 } else {
                     trace!(target: "engine::root::sparse", ?slot, "Updating storage slot");
-                    storage_trie.update_leaf(
-                        slot_nibbles,
-                        alloy_rlp::encode_fixed_size(&value).to_vec(),
-                        &provider,
-                    )?;
+                    storage_trie
+                        .update_leaf(slot_nibbles, alloy_rlp::encode_fixed_size(&value).to_vec())?;
                 }
             }
 
@@ -185,18 +179,18 @@ where
             // If the account itself has an update, remove it from the state update and update in
             // one go instead of doing it down below.
             trace!(target: "engine::root::sparse", ?address, "Updating account and its storage root");
-            trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)?;
+            trie.update_account(address, account.unwrap_or_default())?;
         } else if trie.is_account_revealed(address) {
             // Otherwise, if the account is revealed, only update its storage root.
             trace!(target: "engine::root::sparse", ?address, "Updating account storage root");
-            trie.update_account_storage_root(address, blinded_provider_factory)?;
+            trie.update_account_storage_root(address)?;
         }
     }
 
     // Update accounts
     for (address, account) in state.accounts {
         trace!(target: "engine::root::sparse", ?address, "Updating account");
-        trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)?;
+        trie.update_account(address, account.unwrap_or_default())?;
     }
 
     let elapsed_before = started_at.elapsed();

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -36,7 +36,7 @@ pub(super) struct SparseTrieTask<BPF> {
 
 impl<BPF> SparseTrieTask<BPF>
 where
-    BPF: BlindedProviderFactory + Clone + Send + Sync,
+    BPF: BlindedProviderFactory + Send + Sync,
     BPF::AccountNodeProvider: BlindedProvider + Send + Sync,
     BPF::StorageNodeProvider: BlindedProvider + Send + Sync,
 {
@@ -62,8 +62,7 @@ where
         let now = Instant::now();
 
         let mut num_iterations = 0;
-        let mut trie =
-            SparseStateTrie::new(self.blinded_provider_factory.clone()).with_updates(true);
+        let mut trie = SparseStateTrie::new(&self.blinded_provider_factory).with_updates(true);
 
         while let Ok(mut update) = self.updates.recv() {
             num_iterations += 1;

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -23,6 +23,7 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 
 # misc
+auto_impl.workspace = true
 smallvec = { workspace = true, features = ["const_new"] }
 thiserror.workspace = true
 

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -7,7 +7,7 @@ use proptest::{prelude::*, test_runner::TestRunner};
 use rand::seq::IteratorRandom;
 use reth_testing_utils::generators;
 use reth_trie::Nibbles;
-use reth_trie_sparse::{blinded::DefaultBlindedProvider, RevealedSparseTrie};
+use reth_trie_sparse::RevealedSparseTrie;
 
 fn update_rlp_node_level(c: &mut Criterion) {
     let mut rng = generators::rng();
@@ -25,11 +25,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
         let mut sparse = RevealedSparseTrie::default();
         for (key, value) in &state {
             sparse
-                .update_leaf(
-                    Nibbles::unpack(key),
-                    alloy_rlp::encode_fixed_size(value).to_vec(),
-                    &DefaultBlindedProvider,
-                )
+                .update_leaf(Nibbles::unpack(key), alloy_rlp::encode_fixed_size(value).to_vec())
                 .unwrap();
         }
         sparse.root();
@@ -43,7 +39,6 @@ fn update_rlp_node_level(c: &mut Criterion) {
                     .update_leaf(
                         Nibbles::unpack(key),
                         alloy_rlp::encode_fixed_size(&rng.gen::<U256>()).to_vec(),
-                        &DefaultBlindedProvider,
                     )
                     .unwrap();
             }

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -13,7 +13,7 @@ use reth_trie::{
     HashedStorage,
 };
 use reth_trie_common::{HashBuilder, Nibbles};
-use reth_trie_sparse::{blinded::DefaultBlindedProvider, SparseTrie};
+use reth_trie_sparse::SparseTrie;
 
 fn calculate_root_from_leaves(c: &mut Criterion) {
     let mut group = c.benchmark_group("calculate root from leaves");
@@ -47,7 +47,6 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
                         .update_leaf(
                             Nibbles::unpack(key),
                             alloy_rlp::encode_fixed_size(value).to_vec(),
-                            &DefaultBlindedProvider,
                         )
                         .unwrap();
                 }
@@ -189,7 +188,6 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     .update_leaf(
                                         Nibbles::unpack(key),
                                         alloy_rlp::encode_fixed_size(value).to_vec(),
-                                        &DefaultBlindedProvider,
                                     )
                                     .unwrap();
                             }
@@ -203,7 +201,6 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                         .update_leaf(
                                             Nibbles::unpack(key),
                                             alloy_rlp::encode_fixed_size(value).to_vec(),
-                                            &DefaultBlindedProvider,
                                         )
                                         .unwrap();
                                 }

--- a/crates/trie/sparse/src/blinded.rs
+++ b/crates/trie/sparse/src/blinded.rs
@@ -5,6 +5,7 @@ use reth_execution_errors::SparseTrieError;
 use reth_trie_common::{Nibbles, TrieMask};
 
 /// Factory for instantiating blinded node providers.
+#[auto_impl::auto_impl(&)]
 pub trait BlindedProviderFactory {
     /// Type capable of fetching blinded account nodes.
     type AccountNodeProvider: BlindedProvider;
@@ -30,6 +31,7 @@ pub struct RevealedNode {
 }
 
 /// Trie node provider for retrieving blinded nodes.
+#[auto_impl::auto_impl(&)]
 pub trait BlindedProvider {
     /// Retrieve blinded node by path.
     fn blinded_node(&self, path: &Nibbles) -> Result<Option<RevealedNode>, SparseTrieError>;

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1,13 +1,15 @@
 use crate::{
-    blinded::{BlindedProvider, BlindedProviderFactory},
+    blinded::{BlindedProvider, BlindedProviderFactory, DefaultBlindedProviderFactory},
     metrics::SparseStateTrieMetrics,
     RevealedSparseTrie, SparseTrie, TrieMasks,
 };
 use alloy_primitives::{
+    hex,
     map::{B256Map, HashMap, HashSet},
     Bytes, B256,
 };
 use alloy_rlp::{Decodable, Encodable};
+use core::fmt;
 use reth_execution_errors::{SparseStateTrieErrorKind, SparseStateTrieResult, SparseTrieErrorKind};
 use reth_primitives_traits::Account;
 use reth_tracing::tracing::trace;
@@ -20,12 +22,13 @@ use reth_trie_common::{
 use std::{collections::VecDeque, iter::Peekable};
 
 /// Sparse state trie representing lazy-loaded Ethereum state trie.
-#[derive(Debug)]
-pub struct SparseStateTrie {
+pub struct SparseStateTrie<F: BlindedProviderFactory = DefaultBlindedProviderFactory> {
+    /// Blinded node provider factory.
+    provider_factory: F,
     /// Sparse account trie.
-    state: SparseTrie,
+    state: SparseTrie<F::AccountNodeProvider>,
     /// Sparse storage tries.
-    storages: B256Map<SparseTrie>,
+    storages: B256Map<SparseTrie<F::StorageNodeProvider>>,
     /// Collection of revealed account trie paths.
     revealed_account_paths: HashSet<Nibbles>,
     /// Collection of revealed storage trie paths, per account.
@@ -38,9 +41,11 @@ pub struct SparseStateTrie {
     metrics: SparseStateTrieMetrics,
 }
 
+#[cfg(test)]
 impl Default for SparseStateTrie {
     fn default() -> Self {
         Self {
+            provider_factory: DefaultBlindedProviderFactory,
             state: Default::default(),
             storages: Default::default(),
             revealed_account_paths: Default::default(),
@@ -52,6 +57,20 @@ impl Default for SparseStateTrie {
     }
 }
 
+impl<P: BlindedProviderFactory> fmt::Debug for SparseStateTrie<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SparseStateTrie")
+            .field("state", &self.state)
+            .field("storages", &self.storages)
+            .field("revealed_account_paths", &self.revealed_account_paths)
+            .field("revealed_storage_paths", &self.revealed_storage_paths)
+            .field("retain_updates", &self.retain_updates)
+            .field("account_rlp_buf", &hex::encode(&self.account_rlp_buf))
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
 impl SparseStateTrie {
     /// Create state trie from state trie.
     pub fn from_state(state: SparseTrie) -> Self {
@@ -59,7 +78,21 @@ impl SparseStateTrie {
     }
 }
 
-impl SparseStateTrie {
+impl<F: BlindedProviderFactory> SparseStateTrie<F> {
+    /// Create new [`SparseStateTrie`] with blinded node provider factory.
+    pub fn new(provider_factory: F) -> Self {
+        Self {
+            provider_factory,
+            state: Default::default(),
+            storages: Default::default(),
+            revealed_account_paths: Default::default(),
+            revealed_storage_paths: Default::default(),
+            retain_updates: false,
+            account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
+            metrics: Default::default(),
+        }
+    }
+
     /// Set the retention of branch node updates and deletions.
     pub const fn with_updates(mut self, retain_updates: bool) -> Self {
         self.retain_updates = retain_updates;
@@ -89,27 +122,40 @@ impl SparseStateTrie {
     }
 
     /// Returns reference to state trie if it was revealed.
-    pub const fn state_trie_ref(&self) -> Option<&RevealedSparseTrie> {
+    pub const fn state_trie_ref(&self) -> Option<&RevealedSparseTrie<F::AccountNodeProvider>> {
         self.state.as_revealed_ref()
     }
 
     /// Returns reference to storage trie if it was revealed.
-    pub fn storage_trie_ref(&self, address: &B256) -> Option<&RevealedSparseTrie> {
+    pub fn storage_trie_ref(
+        &self,
+        address: &B256,
+    ) -> Option<&RevealedSparseTrie<F::StorageNodeProvider>> {
         self.storages.get(address).and_then(|e| e.as_revealed_ref())
     }
 
     /// Returns mutable reference to storage sparse trie if it was revealed.
-    pub fn storage_trie_mut(&mut self, address: &B256) -> Option<&mut RevealedSparseTrie> {
+    pub fn storage_trie_mut(
+        &mut self,
+        address: &B256,
+    ) -> Option<&mut RevealedSparseTrie<F::StorageNodeProvider>> {
         self.storages.get_mut(address).and_then(|e| e.as_revealed_mut())
     }
 
     /// Takes the storage trie for the provided address.
-    pub fn take_storage_trie(&mut self, address: &B256) -> Option<SparseTrie> {
+    pub fn take_storage_trie(
+        &mut self,
+        address: &B256,
+    ) -> Option<SparseTrie<F::StorageNodeProvider>> {
         self.storages.remove(address)
     }
 
     /// Inserts storage trie for the provided address.
-    pub fn insert_storage_trie(&mut self, address: B256, storage_trie: SparseTrie) {
+    pub fn insert_storage_trie(
+        &mut self,
+        address: B256,
+        storage_trie: SparseTrie<F::StorageNodeProvider>,
+    ) {
         self.storages.insert(address, storage_trie);
     }
 
@@ -135,6 +181,7 @@ impl SparseStateTrie {
 
         // Reveal root node if it wasn't already.
         let trie = self.state.reveal_root_with_provider(
+            self.provider_factory.account_node_provider(),
             root_node,
             TrieMasks::none(),
             self.retain_updates,
@@ -178,6 +225,7 @@ impl SparseStateTrie {
 
         // Reveal root node if it wasn't already.
         let trie = self.storages.entry(account).or_default().reveal_root_with_provider(
+            self.provider_factory.storage_node_provider(account),
             root_node,
             TrieMasks::none(),
             self.retain_updates,
@@ -239,6 +287,7 @@ impl SparseStateTrie {
         if let Some(root_node) = self.validate_root_node(&mut account_nodes)? {
             // Reveal root node if it wasn't already.
             let trie = self.state.reveal_root_with_provider(
+                self.provider_factory.account_node_provider(),
                 root_node,
                 TrieMasks {
                     hash_mask: branch_node_hash_masks.get(&Nibbles::default()).copied(),
@@ -288,6 +337,7 @@ impl SparseStateTrie {
         if let Some(root_node) = self.validate_root_node(&mut nodes)? {
             // Reveal root node if it wasn't already.
             let trie = self.storages.entry(account).or_default().reveal_root_with_provider(
+                self.provider_factory.storage_node_provider(account),
                 root_node,
                 TrieMasks {
                     hash_mask: storage_subtree
@@ -397,6 +447,7 @@ impl SparseStateTrie {
                     if path.is_empty() {
                         // Handle special storage state root node case.
                         storage_trie_entry.reveal_root_with_provider(
+                            self.provider_factory.storage_node_provider(account),
                             trie_node,
                             TrieMasks::none(),
                             self.retain_updates,
@@ -418,6 +469,7 @@ impl SparseStateTrie {
                 if path.is_empty() {
                     // Handle special state root node case.
                     self.state.reveal_root_with_provider(
+                        self.provider_factory.account_node_provider(),
                         trie_node,
                         TrieMasks::none(),
                         self.retain_updates,
@@ -488,11 +540,11 @@ impl SparseStateTrie {
     /// If the trie is not revealed yet, its root will be revealed using the blinded node provider.
     fn revealed_trie_mut(
         &mut self,
-        provider_factory: &impl BlindedProviderFactory,
-    ) -> SparseStateTrieResult<&mut RevealedSparseTrie> {
+    ) -> SparseStateTrieResult<&mut RevealedSparseTrie<F::AccountNodeProvider>> {
         match self.state {
             SparseTrie::Blind => {
-                let (root_node, hash_mask, tree_mask) = provider_factory
+                let (root_node, hash_mask, tree_mask) = self
+                    .provider_factory
                     .account_node_provider()
                     .blinded_node(&Nibbles::default())?
                     .map(|node| {
@@ -503,6 +555,7 @@ impl SparseStateTrie {
                     .unwrap_or((TrieNode::EmptyRoot, None, None));
                 self.state
                     .reveal_root_with_provider(
+                        self.provider_factory.account_node_provider(),
                         root_node,
                         TrieMasks { hash_mask, tree_mask },
                         self.retain_updates,
@@ -516,26 +569,20 @@ impl SparseStateTrie {
     /// Returns sparse trie root.
     ///
     /// If the trie has not been revealed, this function reveals the root node and returns its hash.
-    pub fn root(
-        &mut self,
-        provider_factory: &impl BlindedProviderFactory,
-    ) -> SparseStateTrieResult<B256> {
+    pub fn root(&mut self) -> SparseStateTrieResult<B256> {
         // record revealed node metrics
         self.metrics.record();
 
-        Ok(self.revealed_trie_mut(provider_factory)?.root())
+        Ok(self.revealed_trie_mut()?.root())
     }
 
     /// Returns sparse trie root and trie updates if the trie has been revealed.
-    pub fn root_with_updates(
-        &mut self,
-        provider_factory: &impl BlindedProviderFactory,
-    ) -> SparseStateTrieResult<(B256, TrieUpdates)> {
+    pub fn root_with_updates(&mut self) -> SparseStateTrieResult<(B256, TrieUpdates)> {
         // record revealed node metrics
         self.metrics.record();
 
         let storage_tries = self.storage_trie_updates();
-        let revealed = self.revealed_trie_mut(provider_factory)?;
+        let revealed = self.revealed_trie_mut()?;
 
         let (root, updates) = (revealed.root(), revealed.take_updates());
         let updates = TrieUpdates {
@@ -586,13 +633,12 @@ impl SparseStateTrie {
         &mut self,
         path: Nibbles,
         value: Vec<u8>,
-        provider_factory: &impl BlindedProviderFactory,
     ) -> SparseStateTrieResult<()> {
         if !self.revealed_account_paths.contains(&path) {
             self.revealed_account_paths.insert(path.clone());
         }
 
-        self.state.update_leaf(path, value, &provider_factory.account_node_provider())?;
+        self.state.update_leaf(path, value)?;
         Ok(())
     }
 
@@ -602,14 +648,13 @@ impl SparseStateTrie {
         address: B256,
         slot: Nibbles,
         value: Vec<u8>,
-        provider_factory: &impl BlindedProviderFactory,
     ) -> SparseStateTrieResult<()> {
         if !self.revealed_storage_paths.get(&address).is_some_and(|slots| slots.contains(&slot)) {
             self.revealed_storage_paths.entry(address).or_default().insert(slot.clone());
         }
 
         let storage_trie = self.storages.get_mut(&address).ok_or(SparseTrieErrorKind::Blind)?;
-        storage_trie.update_leaf(slot, value, &provider_factory.storage_node_provider(address))?;
+        storage_trie.update_leaf(slot, value)?;
         Ok(())
     }
 
@@ -617,12 +662,7 @@ impl SparseStateTrie {
     /// the storage root based on update storage trie or look it up from existing leaf value.
     ///
     /// If the new account info and storage trie are empty, the account leaf will be removed.
-    pub fn update_account(
-        &mut self,
-        address: B256,
-        account: Account,
-        provider_factory: &impl BlindedProviderFactory,
-    ) -> SparseStateTrieResult<()> {
+    pub fn update_account(&mut self, address: B256, account: Account) -> SparseStateTrieResult<()> {
         let nibbles = Nibbles::unpack(address);
 
         let storage_root = if let Some(storage_trie) = self.storages.get_mut(&address) {
@@ -644,12 +684,12 @@ impl SparseStateTrie {
 
         if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
             trace!(target: "trie::sparse", ?address, "Removing account");
-            self.remove_account_leaf(&nibbles, provider_factory)
+            self.remove_account_leaf(&nibbles)
         } else {
             trace!(target: "trie::sparse", ?address, "Updating account");
             self.account_rlp_buf.clear();
             account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);
-            self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)
+            self.update_account_leaf(nibbles, self.account_rlp_buf.clone())
         }
     }
 
@@ -659,11 +699,7 @@ impl SparseStateTrie {
     ///
     /// If the new storage root is empty, and the account info was already empty, the account leaf
     /// will be removed.
-    pub fn update_account_storage_root(
-        &mut self,
-        address: B256,
-        provider_factory: &impl BlindedProviderFactory,
-    ) -> SparseStateTrieResult<()> {
+    pub fn update_account_storage_root(&mut self, address: B256) -> SparseStateTrieResult<()> {
         if !self.is_account_revealed(address) {
             return Err(SparseTrieErrorKind::Blind.into())
         }
@@ -694,25 +730,21 @@ impl SparseStateTrie {
         if trie_account == TrieAccount::default() {
             // If the account is empty, remove it.
             trace!(target: "trie::sparse", ?address, "Removing account because the storage root is empty");
-            self.remove_account_leaf(&nibbles, provider_factory)?;
+            self.remove_account_leaf(&nibbles)?;
         } else {
             // Otherwise, update the account leaf.
             trace!(target: "trie::sparse", ?address, "Updating account with the new storage root");
             self.account_rlp_buf.clear();
             trie_account.encode(&mut self.account_rlp_buf);
-            self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)?;
+            self.update_account_leaf(nibbles, self.account_rlp_buf.clone())?;
         }
 
         Ok(())
     }
 
     /// Remove the account leaf node.
-    pub fn remove_account_leaf(
-        &mut self,
-        path: &Nibbles,
-        provider_factory: &impl BlindedProviderFactory,
-    ) -> SparseStateTrieResult<()> {
-        self.state.remove_leaf(path, &provider_factory.account_node_provider())?;
+    pub fn remove_account_leaf(&mut self, path: &Nibbles) -> SparseStateTrieResult<()> {
+        self.state.remove_leaf(path)?;
         Ok(())
     }
 
@@ -721,18 +753,15 @@ impl SparseStateTrie {
         &mut self,
         address: B256,
         slot: &Nibbles,
-        provider_factory: &impl BlindedProviderFactory,
     ) -> SparseStateTrieResult<()> {
         let storage_trie = self.storages.get_mut(&address).ok_or(SparseTrieErrorKind::Blind)?;
-        storage_trie.remove_leaf(slot, &provider_factory.account_node_provider())?;
+        storage_trie.remove_leaf(slot)?;
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::blinded::DefaultBlindedProviderFactory;
-
     use super::*;
     use alloy_primitives::{
         b256,
@@ -852,9 +881,7 @@ mod tests {
 
         // Remove the leaf node and check that the state trie does not contain the leaf node and
         // value
-        sparse
-            .remove_account_leaf(&Nibbles::from_nibbles([0x0]), &DefaultBlindedProviderFactory)
-            .unwrap();
+        sparse.remove_account_leaf(&Nibbles::from_nibbles([0x0])).unwrap();
         assert!(!sparse
             .state_trie_ref()
             .unwrap()
@@ -936,13 +963,7 @@ mod tests {
 
         // Remove the leaf node and check that the storage trie does not contain the leaf node and
         // value
-        sparse
-            .remove_storage_leaf(
-                B256::ZERO,
-                &Nibbles::from_nibbles([0x0]),
-                &DefaultBlindedProviderFactory,
-            )
-            .unwrap();
+        sparse.remove_storage_leaf(B256::ZERO, &Nibbles::from_nibbles([0x0])).unwrap();
         assert!(!sparse
             .storage_trie_ref(&B256::ZERO)
             .unwrap()
@@ -1056,49 +1077,24 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(sparse.root(&DefaultBlindedProviderFactory).unwrap(), root);
+        assert_eq!(sparse.root().unwrap(), root);
 
         let address_3 = b256!("0x2000000000000000000000000000000000000000000000000000000000000000");
         let address_path_3 = Nibbles::unpack(address_3);
         let account_3 = Account { nonce: account_1.nonce + 1, ..account_1 };
         let trie_account_3 = account_3.into_trie_account(EMPTY_ROOT_HASH);
 
-        sparse
-            .update_account_leaf(
-                address_path_3,
-                alloy_rlp::encode(trie_account_3),
-                &DefaultBlindedProviderFactory,
-            )
-            .unwrap();
+        sparse.update_account_leaf(address_path_3, alloy_rlp::encode(trie_account_3)).unwrap();
 
-        sparse
-            .update_storage_leaf(
-                address_1,
-                slot_path_3,
-                alloy_rlp::encode(value_3),
-                &DefaultBlindedProviderFactory,
-            )
-            .unwrap();
+        sparse.update_storage_leaf(address_1, slot_path_3, alloy_rlp::encode(value_3)).unwrap();
         trie_account_1.storage_root = sparse.storage_root(address_1).unwrap();
-        sparse
-            .update_account_leaf(
-                address_path_1,
-                alloy_rlp::encode(trie_account_1),
-                &DefaultBlindedProviderFactory,
-            )
-            .unwrap();
+        sparse.update_account_leaf(address_path_1, alloy_rlp::encode(trie_account_1)).unwrap();
 
         sparse.wipe_storage(address_2).unwrap();
         trie_account_2.storage_root = sparse.storage_root(address_2).unwrap();
-        sparse
-            .update_account_leaf(
-                address_path_2,
-                alloy_rlp::encode(trie_account_2),
-                &DefaultBlindedProviderFactory,
-            )
-            .unwrap();
+        sparse.update_account_leaf(address_path_2, alloy_rlp::encode(trie_account_2)).unwrap();
 
-        sparse.root(&DefaultBlindedProviderFactory).unwrap();
+        sparse.root().unwrap();
 
         let sparse_updates = sparse.take_trie_updates().unwrap();
         // TODO(alexey): assert against real state root calculation updates


### PR DESCRIPTION
Now that https://github.com/paradigmxyz/reth/pull/15152 is in, I realized that we don't need to invert the provider access and can instead just pass the `ProofTaskManagerHandle` into the `SparseStateTrie` and it will act as the blinded node provider https://github.com/paradigmxyz/reth/blob/f043b02350d7e15264067d4495927a9fe80f4f36/crates/engine/tree/src/tree/payload_processor/mod.rs#L168-L173 https://github.com/paradigmxyz/reth/blob/f043b02350d7e15264067d4495927a9fe80f4f36/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs#L65-L65