### PR TITLE
Push nightly image with profiling profile

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -32,7 +32,7 @@ jobs:
           - name: 'Build and push the nightly op-reth image'
             command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-nightly'
           - name: 'Build and push the nightly profiling op-reth image'
-            command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-nightly-profiling'
+            command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=profiling op-docker-build-push-nightly-profiling'
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -31,6 +31,8 @@ jobs:
             command: 'make PROFILE=profiling docker-build-push-profiling'
           - name: 'Build and push the nightly op-reth image'
             command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-nightly'
+          - name: 'Build and push the nightly profiling op-reth image'
+            command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-nightly-profiling'
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -27,6 +27,8 @@ jobs:
         build:
           - name: 'Build and push the nightly reth image'
             command: 'make PROFILE=maxperf docker-build-push-nightly'
+          - name: 'Build and push the nightly profiling reth image'
+            command: 'make PROFILE=profiling docker-build-push-profiling'
           - name: 'Build and push the nightly op-reth image'
             command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-nightly'
     steps:

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -28,7 +28,7 @@ jobs:
           - name: 'Build and push the nightly reth image'
             command: 'make PROFILE=maxperf docker-build-push-nightly'
           - name: 'Build and push the nightly profiling reth image'
-            command: 'make PROFILE=profiling docker-build-push-profiling'
+            command: 'make PROFILE=profiling docker-build-push-nightly-profiling'
           - name: 'Build and push the nightly op-reth image'
             command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-nightly'
           - name: 'Build and push the nightly profiling op-reth image'

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ docker-build-push-nightly-profiling: ## Build and push cross-arch Docker image w
 # `docker buildx create --use --name cross-builder`
 .PHONY: op-docker-build-push-nightly-profiling
 op-docker-build-push-nightly-profiling: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
-	$(call op_docker_build_push,nightly,nightly-profiling)
+	$(call op_docker_build_push,nightly-profiling,nightly-profiling)
 
 
 # Create a cross-arch Docker image with the given tags and push it

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ docker-build-push-profiling: ## Build and push cross-arch Docker image with prof
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --name cross-builder`
 .PHONY: op-docker-build-push-nightly-profiling
-op-docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
+op-docker-build-push-nightly-profiling: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
 	$(call op_docker_build_push,nightly,nightly-profiling)
 
 

--- a/Makefile
+++ b/Makefile
@@ -296,9 +296,18 @@ op-docker-build-push-nightly: ## Build and push cross-arch Docker image tagged w
 #
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --name cross-builder`
-.PHONY: docker-build-push-profiling
+.PHONY: docker-build-push-nightly-profiling
 docker-build-push-profiling: ## Build and push cross-arch Docker image with profiling profile tagged with nightly-profiling.
 	$(call docker_build_push,nightly-profiling,nightly-profiling)
+
+	# Note: This requires a buildx builder with emulation support. For example:
+#
+# `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
+# `docker buildx create --use --name cross-builder`
+.PHONY: op-docker-build-push-nightly-profiling
+op-docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
+	$(call op_docker_build_push,nightly,nightly-profiling)
+
 
 # Create a cross-arch Docker image with the given tags and push it
 define op_docker_build_push

--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,14 @@ op-docker-build-push-latest: ## Build and push a cross-arch Docker image tagged 
 op-docker-build-push-nightly: ## Build and push cross-arch Docker image tagged with the latest git tag with a `-nightly` suffix, and `latest-nightly`.
 	$(call op_docker_build_push,nightly,nightly)
 
+# Note: This requires a buildx builder with emulation support. For example:
+#
+# `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
+# `docker buildx create --use --name cross-builder`
+.PHONY: docker-build-push-profiling
+docker-build-push-profiling: ## Build and push cross-arch Docker image with profiling profile tagged with nightly-profiling.
+	$(call docker_build_push,nightly-profiling,nightly-profiling)
+
 # Create a cross-arch Docker image with the given tags and push it
 define op_docker_build_push
 	$(MAKE) op-build-x86_64-unknown-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ op-docker-build-push-nightly: ## Build and push cross-arch Docker image tagged w
 # `docker run --privileged --rm tonistiigi/binfmt --install amd64,arm64`
 # `docker buildx create --use --name cross-builder`
 .PHONY: docker-build-push-nightly-profiling
-docker-build-push-profiling: ## Build and push cross-arch Docker image with profiling profile tagged with nightly-profiling.
+docker-build-push-nightly-profiling: ## Build and push cross-arch Docker image with profiling profile tagged with nightly-profiling.
 	$(call docker_build_push,nightly-profiling,nightly-profiling)
 
 	# Note: This requires a buildx builder with emulation support. For example:


### PR DESCRIPTION
# Description
For running automated benchmarking we will need a docker image built with profiling profile. This PR adds this to our nightly build workflow.

Note: Thought about whether to make the profiling profile default in nightly tag, but decided against it since some teams use the `nightly` tag (built with `maxperf`) and just pushing a separate image with new tag called `nightly-profiling`. 