### PR TITLE
Polishing up any minor spelling errors

### DIFF
--- a/crates/rpc/rpc-api/src/miner.rs
+++ b/crates/rpc/rpc-api/src/miner.rs
@@ -17,5 +17,5 @@ pub trait MinerApi {
 
     /// Sets the gaslimit to target towards during mining.
     #[method(name = "setGasLimit")]
-    fn set_gas_limit(&self, gas_price: U128) -> RpcResult<bool>;
+    fn set_gas_limit(&self, gas_limit: U128) -> RpcResult<bool>;
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -33,7 +33,7 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         self.tracing_task_guard().clone().acquire_owned()
     }
 
-    /// See also  [`Semaphore::acquire_many_owned`](`tokio::sync::Semaphore::acquire_many_owned`).
+    /// See also [`Semaphore::acquire_many_owned`](`tokio::sync::Semaphore::acquire_many_owned`).
     fn acquire_many_owned(
         &self,
         n: u32,

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -184,7 +184,7 @@ pub trait EthFees: LoadFee {
                             / alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK as f64,
                     );
 
-                    // Percentiles were specified, so we need to collect reward percentile ino
+                    // Percentiles were specified, so we need to collect reward percentile info
                     if let Some(percentiles) = &reward_percentiles {
                         let (block, receipts) = self.cache()
                             .get_block_and_receipts(header.hash())

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -49,7 +49,7 @@ use std::sync::Arc;
 pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     /// Returns a handle for signing data.
     ///
-    /// Singer access in default (L1) trait method implementations.
+    /// Signer access in default (L1) trait method implementations.
     #[expect(clippy::type_complexity)]
     fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>>;
 


### PR DESCRIPTION
hey team , spotted a few nits in the code. It’s minor stuff , but I’d love to fix it up and make it a bit better

crates/rpc/rpc-api/src/miner.rs
fn set_gas_limit(&self, `gas_price:` - `gas_limit:`

crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
`deleted double space`

crates/rpc/rpc-eth-api/src/helpers/fee.rs
`ino` - `info`

crates/rpc/rpc-eth-api/src/helpers/transaction.rs
`Singer` - `Signer`