### PR TITLE
feat(transaction-pool): check on disk store in case of blob cache misses

### DIFF
--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -196,6 +196,7 @@ impl DiskFileBlobStoreInner {
 
     /// Ensures blob is in the blob cache and written to the disk.
     fn insert_one(&self, tx: B256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError> {
+        // WIP : Need to have a method to get the version hash to insert into the versioned_hashes_to_txhash
         let versioned_mappings: Vec<(B256, B256)> =
             data.blobs.iter().map(|blob| (blob.versioned_hash(), tx)).collect();
 
@@ -218,6 +219,7 @@ impl DiskFileBlobStoreInner {
 
     /// Ensures blobs are in the blob cache and written to the disk.
     fn insert_many(&self, txs: Vec<(B256, BlobTransactionSidecar)>) -> Result<(), BlobStoreError> {
+        // WIP : Need to have a method to get the version hash to insert into the versioned_hashes_to_txhash
         let versioned_hash_mappings: Vec<(B256, B256)> = txs
             .iter()
             .flat_map(|(tx, data)| {

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -217,9 +217,9 @@ impl DiskFileBlobStoreInner {
     fn insert_many(&self, txs: Vec<(B256, BlobTransactionSidecar)>) -> Result<(), BlobStoreError> {
         {
             let mut map = self.versioned_hashes_to_txhash.lock();
-            for (tx, data) in txs {
+            for (tx, data) in &txs {
                 data.versioned_hashes().for_each(|hash| {
-                    map.insert(hash, tx);
+                    map.insert(hash, *tx);
                 })
             }
         }

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -198,9 +198,8 @@ impl DiskFileBlobStoreInner {
     fn insert_one(&self, tx: B256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError> {
         {
             let mut map = self.versioned_hashes_to_txhash.lock();
-            if let Some(first_hash) = data.versioned_hashes().next() {
-                map.insert(tx, first_hash);
-            }
+            data.versioned_hashes()
+                .for_each(|hash| { map.insert(hash, tx); })
         }
 
         let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
@@ -217,10 +216,9 @@ impl DiskFileBlobStoreInner {
     fn insert_many(&self, txs: Vec<(B256, BlobTransactionSidecar)>) -> Result<(), BlobStoreError> {
         {
             let mut map = self.versioned_hashes_to_txhash.lock();
-            for (tx, data) in &txs {
-                if let Some(first_hash) = data.versioned_hashes().next() {
-                    map.insert(*tx, first_hash);
-                }
+            for (tx, data) in txs.iter() {
+                data.versioned_hashes()
+                    .for_each(|hash| { map.insert(hash, *tx); })
             }
         }
 

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -198,8 +198,9 @@ impl DiskFileBlobStoreInner {
     fn insert_one(&self, tx: B256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError> {
         {
             let mut map = self.versioned_hashes_to_txhash.lock();
-            data.versioned_hashes()
-                .for_each(|hash| { map.insert(hash, tx); })
+            data.versioned_hashes().for_each(|hash| {
+                map.insert(hash, tx);
+            })
         }
 
         let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
@@ -217,8 +218,9 @@ impl DiskFileBlobStoreInner {
         {
             let mut map = self.versioned_hashes_to_txhash.lock();
             for (tx, data) in txs.iter() {
-                data.versioned_hashes()
-                    .for_each(|hash| { map.insert(hash, *tx); })
+                data.versioned_hashes().for_each(|hash| {
+                    map.insert(hash, *tx);
+                })
             }
         }
 

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -217,9 +217,9 @@ impl DiskFileBlobStoreInner {
     fn insert_many(&self, txs: Vec<(B256, BlobTransactionSidecar)>) -> Result<(), BlobStoreError> {
         {
             let mut map = self.versioned_hashes_to_txhash.lock();
-            for (tx, data) in txs.iter() {
+            for (tx, data) in txs {
                 data.versioned_hashes().for_each(|hash| {
-                    map.insert(hash, *tx);
+                    map.insert(hash, tx);
                 })
             }
         }

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -196,10 +196,8 @@ impl DiskFileBlobStoreInner {
 
     /// Ensures blob is in the blob cache and written to the disk.
     fn insert_one(&self, tx: B256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError> {
-        let versioned_mappings: Vec<(B256, B256)> = data.blobs
-            .iter()
-            .map(|blob| (blob.versioned_hash(), tx))
-            .collect();
+        let versioned_mappings: Vec<(B256, B256)> =
+            data.blobs.iter().map(|blob| (blob.versioned_hash(), tx)).collect();
 
         if !versioned_mappings.is_empty() {
             let mut map = self.versioned_hashes_to_txhash.lock();
@@ -223,10 +221,7 @@ impl DiskFileBlobStoreInner {
         let versioned_hash_mappings: Vec<(B256, B256)> = txs
             .iter()
             .flat_map(|(tx, data)| {
-                data.blobs
-                    .iter()
-                    .map(|blob| (blob.versioned_hash(), *tx))
-                    .collect::<Vec<_>>()
+                data.blobs.iter().map(|blob| (blob.versioned_hash(), *tx)).collect::<Vec<_>>()
             })
             .collect();
 

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -141,6 +141,14 @@ impl BlobStore for DiskFileBlobStore {
                 break;
             }
         }
+
+        for (idx, blob_and_proof) in result.iter_mut().enumerate() {
+            if blob_and_proof.is_none() {
+                let versioned_hash = versioned_hashes[idx];
+                let _tx_hash = self.inner.versioned_hashes_to_txhash.lock().get(&versioned_hash);
+            }
+        }
+
         Ok(result)
     }
 

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -197,8 +197,10 @@ impl DiskFileBlobStoreInner {
 
     /// Ensures blob is in the blob cache and written to the disk.
     fn insert_one(&self, tx: B256, data: BlobTransactionSidecar) -> Result<(), BlobStoreError> {
-        let mut map = self.versioned_hashes_to_txhash.lock();
-        map.insert(tx, data.versioned_hashes());
+        {
+            let mut map = self.versioned_hashes_to_txhash.lock();
+            map.insert(tx, data.versioned_hashes());
+        }
 
         let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
         data.rlp_encode_fields(&mut buf);
@@ -212,9 +214,11 @@ impl DiskFileBlobStoreInner {
 
     /// Ensures blobs are in the blob cache and written to the disk.
     fn insert_many(&self, txs: Vec<(B256, BlobTransactionSidecar)>) -> Result<(), BlobStoreError> {
-        let mut map = self.versioned_hashes_to_txhash.lock();
-        for (tx, data) in &txs {
-            map.insert(*tx, data.versioned_hashes());
+        {
+            let mut map = self.versioned_hashes_to_txhash.lock();
+            for (tx, data) in &txs {
+                map.insert(*tx, data.versioned_hashes());
+            }
         }
 
         let raw = txs


### PR DESCRIPTION
I added the new field & filling the `LruMap` on `insert_one`and `insert_many`

Can you explain what's needed for step 3?

Do we want to include a check-up in `read_one` and `read_many`? @mattsse 

This should close the following [issue](https://github.com/paradigmxyz/reth/issues/15160)