### PR TITLE
feat(storage): Implement `Compact` for `OpTxEnvelope` from `op_alloy` using blanket impl

### DIFF
--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -778,3 +778,37 @@ pub mod serde_bincode_compat {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::proptest;
+    use proptest_arbitrary_interop::arb;
+    use reth_codecs::Compact;
+
+    proptest! {
+        #[test]
+        fn test_roundtrip_compact_encode_envelope(reth_tx in arb::<OpTransactionSigned>()) {
+            let mut expected_buf = Vec::<u8>::new();
+            let expected_len = reth_tx.to_compact(&mut expected_buf);
+
+            let mut actual_but  = Vec::<u8>::new();
+            let alloy_tx = OpTxEnvelope::from(reth_tx);
+            let actual_len = alloy_tx.to_compact(&mut actual_but);
+
+            assert_eq!(actual_but, expected_buf);
+            assert_eq!(actual_len, expected_len);
+        }
+
+        #[test]
+        fn test_roundtrip_compact_decode_envelope(reth_tx in arb::<OpTransactionSigned>()) {
+            let mut buf = Vec::<u8>::new();
+            let len = reth_tx.to_compact(&mut buf);
+
+            let (actual_tx, _) = OpTxEnvelope::from_compact(&buf, len);
+            let expected_tx = OpTxEnvelope::from(reth_tx);
+
+            assert_eq!(actual_tx, expected_tx);
+        }
+    }
+}

--- a/crates/storage/codecs/src/alloy/transaction/optimism.rs
+++ b/crates/storage/codecs/src/alloy/transaction/optimism.rs
@@ -1,12 +1,21 @@
 //! Compact implementation for [`AlloyTxDeposit`]
 
-use alloy_consensus::constants::EIP7702_TX_TYPE_ID;
-use crate::Compact;
-use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
-use op_alloy_consensus::{OpTxType, OpTypedTransaction, TxDeposit as AlloyTxDeposit};
+use crate::{
+    alloy::transaction::ethereum::{CompactEnvelope, Envelope, FromTxCompact, ToTxCompact},
+    generate_tests,
+    txtype::{
+        COMPACT_EXTENDED_IDENTIFIER_FLAG, COMPACT_IDENTIFIER_EIP1559, COMPACT_IDENTIFIER_EIP2930,
+        COMPACT_IDENTIFIER_LEGACY,
+    },
+    Compact,
+};
+use alloy_consensus::{
+    constants::EIP7702_TX_TYPE_ID, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+};
+use alloy_primitives::{Address, Bytes, PrimitiveSignature, Sealed, TxKind, B256, U256};
+use bytes::BufMut;
+use op_alloy_consensus::{OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit as AlloyTxDeposit};
 use reth_codecs_derive::add_arbitrary_tests;
-use crate::txtype::{COMPACT_EXTENDED_IDENTIFIER_FLAG, COMPACT_IDENTIFIER_EIP1559, COMPACT_IDENTIFIER_EIP2930, COMPACT_IDENTIFIER_LEGACY};
-use crate::generate_tests;
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
 ///
@@ -68,7 +77,6 @@ impl Compact for AlloyTxDeposit {
         (alloy_tx, buf)
     }
 }
-
 
 impl crate::Compact for OpTxType {
     fn to_compact<B>(&self, buf: &mut B) -> usize
@@ -157,6 +165,88 @@ impl Compact for OpTypedTransaction {
                 (Self::Deposit(tx), buf)
             }
         }
+    }
+}
+
+impl ToTxCompact for OpTxEnvelope {
+    fn to_tx_compact(&self, buf: &mut (impl BufMut + AsMut<[u8]>)) {
+        match self {
+            Self::Legacy(tx) => tx.tx().to_compact(buf),
+            Self::Eip2930(tx) => tx.tx().to_compact(buf),
+            Self::Eip1559(tx) => tx.tx().to_compact(buf),
+            Self::Eip7702(tx) => tx.tx().to_compact(buf),
+            Self::Deposit(tx) => tx.to_compact(buf),
+        };
+    }
+}
+
+impl FromTxCompact for OpTxEnvelope {
+    type TxType = OpTxType;
+
+    fn from_tx_compact(
+        buf: &[u8],
+        tx_type: OpTxType,
+        signature: PrimitiveSignature,
+    ) -> (Self, &[u8]) {
+        match tx_type {
+            OpTxType::Legacy => {
+                let (tx, buf) = TxLegacy::from_compact(buf, buf.len());
+                let tx = Signed::new_unhashed(tx, signature);
+                (Self::Legacy(tx), buf)
+            }
+            OpTxType::Eip2930 => {
+                let (tx, buf) = TxEip2930::from_compact(buf, buf.len());
+                let tx = Signed::new_unhashed(tx, signature);
+                (Self::Eip2930(tx), buf)
+            }
+            OpTxType::Eip1559 => {
+                let (tx, buf) = TxEip1559::from_compact(buf, buf.len());
+                let tx = Signed::new_unhashed(tx, signature);
+                (Self::Eip1559(tx), buf)
+            }
+            OpTxType::Eip7702 => {
+                let (tx, buf) = TxEip7702::from_compact(buf, buf.len());
+                let tx = Signed::new_unhashed(tx, signature);
+                (Self::Eip7702(tx), buf)
+            }
+            OpTxType::Deposit => {
+                let (tx, buf) = op_alloy_consensus::TxDeposit::from_compact(buf, buf.len());
+                let tx = Sealed::new(tx);
+                (Self::Deposit(tx), buf)
+            }
+        }
+    }
+}
+
+const DEPOSIT_SIGNATURE: PrimitiveSignature =
+    PrimitiveSignature::new(U256::ZERO, U256::ZERO, false);
+
+impl Envelope for OpTxEnvelope {
+    fn signature(&self) -> &PrimitiveSignature {
+        match self {
+            Self::Legacy(tx) => tx.signature(),
+            Self::Eip2930(tx) => tx.signature(),
+            Self::Eip1559(tx) => tx.signature(),
+            Self::Eip7702(tx) => tx.signature(),
+            Self::Deposit(_) => &DEPOSIT_SIGNATURE,
+        }
+    }
+
+    fn tx_type(&self) -> Self::TxType {
+        Self::tx_type(self)
+    }
+}
+
+impl Compact for OpTxEnvelope {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: BufMut + AsMut<[u8]>,
+    {
+        CompactEnvelope::to_compact(self, buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        CompactEnvelope::from_compact(buf, len)
     }
 }
 


### PR DESCRIPTION
Part of #14961
Closes #14962

This is an alternative to #15229 that solves the same problem without the use of macros. Only one of these should be merged.

To do this, it uses blanket implementation.

There is one caveat, which is that the blanket implementation cannot be made directly to `Compact` trait as that triggers a compile error due to a possible overlap with existing `impl<T: Compact> Compact for &T`.

To solve this, a proxy trait `CompactEnvelope` is introduced, which is a copy of `Compact`. The blanket implementation is then made to this trait, and a trivial implementation for `Compact` is made manually for both Ethereum and Optimism.