### PR TITLE
test(trie): fix cursor mocks

### DIFF
--- a/crates/trie/trie/src/hashed_cursor/mock.rs
+++ b/crates/trie/trie/src/hashed_cursor/mock.rs
@@ -103,11 +103,8 @@ impl<T: Debug + Clone> HashedCursor for MockHashedCursor<T> {
 
     #[instrument(level = "trace", skip(self), ret)]
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        // Find the first key that has a prefix of the given key.
-        let entry = self
-            .values
-            .iter()
-            .find_map(|(k, v)| k.starts_with(key.as_slice()).then(|| (*k, v.clone())));
+        // Find the first key that is greater than or equal to the given key.
+        let entry = self.values.iter().find_map(|(k, v)| (k >= &key).then(|| (*k, v.clone())));
         if let Some((key, _)) = &entry {
             self.current_key = Some(*key);
         }

--- a/crates/trie/trie/src/trie_cursor/mock.rs
+++ b/crates/trie/trie/src/trie_cursor/mock.rs
@@ -123,11 +123,9 @@ impl TrieCursor for MockTrieCursor {
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        // Find the first key that has a prefix of the given key.
-        let entry = self
-            .trie_nodes
-            .iter()
-            .find_map(|(k, v)| k.starts_with(&key).then(|| (k.clone(), v.clone())));
+        // Find the first key that is greater than or equal to the given key.
+        let entry =
+            self.trie_nodes.iter().find_map(|(k, v)| (k >= &key).then(|| (k.clone(), v.clone())));
         if let Some((key, _)) = &entry {
             self.current_key = Some(key.clone());
         }


### PR DESCRIPTION
`seek` had wrong implementations