### PR TITLE
chore: add SignedTransaction trait for OpTxEnvelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada55b5ab26624766bb8c65f72516dee93eaf28d5d87fc18ff4324cd8c2a948d"
+checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4054f177d1600f17e2bc152f6a927592641b19861e6005cc51bdf7d4fa27a6"
+checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7283185baefbe66136649dc316c9dcc6f0e9f1d635ae19783615919f83bc298a"
+checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b007e002f1082b28827cc47d9c72562d412a98c06f29aa438118ff3036c43"
+checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0a9cb9b1afbcd3325e0fff9fdf98e6d095643fae9e5584e80597f0b79b6d6e"
+checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530c4863e707b95f99b37792cdfa94d30004ec552aed41e200a1d9264d44e669"
+checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
 dependencies = [
  "const-hex",
  "dunce",
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b210dd863afa9da93c488601a1f23bee1e3ce47e15519582320c205645a7a0"
+checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
  "winnow",
@@ -829,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5ff802859e2797d022dc812b5b4ee40d829e0fb446c269a87826c7f0021976"
+checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11360,9 +11360,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36dbbf0d465ab9fdfea3093e755ae8839bdc1263dbe18d35064d02d6060f949e"
+checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,12 +451,12 @@ revm-inspectors = "0.17.0-alpha.1"
 
 # eth
 alloy-chains = { version = "0.1.64", default-features = false }
-alloy-dyn-abi = "0.8.20"
+alloy-dyn-abi = "0.8.25"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
 alloy-evm = { version = "0.1.0-alpha.3", default-features = false }
-alloy-primitives = { version = "0.8.20", default-features = false, features = ["map-foldhash"] }
+alloy-primitives = { version = "0.8.25", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
-alloy-sol-types = { version = "0.8.20", default-features = false }
+alloy-sol-types = { version = "0.8.25", default-features = false }
 alloy-trie = { version = "0.7.9", default-features = false }
 
 alloy-hardforks = "0.1.2"

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{
     EthereumTxEnvelope, SignableTransaction,
 };
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
-use alloy_primitives::{keccak256, Address, PrimitiveSignature as Signature, TxHash, B256, U256};
+use alloy_primitives::{keccak256, Address, PrimitiveSignature as Signature, TxHash, B256};
 use alloy_rlp::{Decodable, Encodable};
 use core::hash::Hash;
 
@@ -186,6 +186,7 @@ where
 #[cfg(feature = "op")]
 mod op {
     use super::*;
+    use alloy_primitives::U256;
     use op_alloy_consensus::{OpPooledTransaction, OpTxEnvelope};
 
     const DEPOSIT_SIGNATURE: Signature = Signature::new(U256::ZERO, U256::ZERO, false);

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -184,45 +184,106 @@ where
 }
 
 #[cfg(feature = "op")]
-impl SignedTransaction for op_alloy_consensus::OpPooledTransaction {
-    fn tx_hash(&self) -> &TxHash {
-        match self {
-            Self::Legacy(tx) => tx.hash(),
-            Self::Eip2930(tx) => tx.hash(),
-            Self::Eip1559(tx) => tx.hash(),
-            Self::Eip7702(tx) => tx.hash(),
+mod op {
+    use super::*;
+    use op_alloy_consensus::{OpPooledTransaction, OpTxEnvelope};
+
+    impl SignedTransaction for OpPooledTransaction {
+        fn tx_hash(&self) -> &TxHash {
+            match self {
+                Self::Legacy(tx) => tx.hash(),
+                Self::Eip2930(tx) => tx.hash(),
+                Self::Eip1559(tx) => tx.hash(),
+                Self::Eip7702(tx) => tx.hash(),
+            }
+        }
+
+        fn signature(&self) -> &Signature {
+            match self {
+                Self::Legacy(tx) => tx.signature(),
+                Self::Eip2930(tx) => tx.signature(),
+                Self::Eip1559(tx) => tx.signature(),
+                Self::Eip7702(tx) => tx.signature(),
+            }
+        }
+
+        fn recover_signer(&self) -> Result<Address, RecoveryError> {
+            let signature_hash = self.signature_hash();
+            recover_signer(self.signature(), signature_hash)
+        }
+
+        fn recover_signer_unchecked_with_buf(
+            &self,
+            buf: &mut Vec<u8>,
+        ) -> Result<Address, RecoveryError> {
+            match self {
+                Self::Legacy(tx) => tx.tx().encode_for_signing(buf),
+                Self::Eip2930(tx) => tx.tx().encode_for_signing(buf),
+                Self::Eip1559(tx) => tx.tx().encode_for_signing(buf),
+                Self::Eip7702(tx) => tx.tx().encode_for_signing(buf),
+            }
+            let signature_hash = keccak256(buf);
+            recover_signer_unchecked(self.signature(), signature_hash)
         }
     }
 
-    fn signature(&self) -> &Signature {
-        match self {
-            Self::Legacy(tx) => tx.signature(),
-            Self::Eip2930(tx) => tx.signature(),
-            Self::Eip1559(tx) => tx.signature(),
-            Self::Eip7702(tx) => tx.signature(),
+    impl SignedTransaction for OpTxEnvelope {
+        fn tx_hash(&self) -> &TxHash {
+            match self {
+                Self::Legacy(tx) => tx.hash(),
+                Self::Eip2930(tx) => tx.hash(),
+                Self::Eip1559(tx) => tx.hash(),
+                Self::Eip7702(tx) => tx.hash(),
+                // TODO: update Deposit variant's matched response to tx.hash_ref() once implemented
+                // in alloys-rs since tx.hash() returns value instead of reference
+                Self::Deposit(tx) => tx.hash(),
+            }
         }
-    }
 
-    fn recover_signer(&self) -> Result<Address, RecoveryError> {
-        let signature_hash = self.signature_hash();
-        recover_signer(self.signature(), signature_hash)
-    }
-
-    fn recover_signer_unchecked_with_buf(
-        &self,
-        buf: &mut Vec<u8>,
-    ) -> Result<Address, RecoveryError> {
-        match self {
-            Self::Legacy(tx) => tx.tx().encode_for_signing(buf),
-            Self::Eip2930(tx) => tx.tx().encode_for_signing(buf),
-            Self::Eip1559(tx) => tx.tx().encode_for_signing(buf),
-            Self::Eip7702(tx) => tx.tx().encode_for_signing(buf),
+        fn signature(&self) -> &Signature {
+            match self {
+                Self::Legacy(tx) => tx.signature(),
+                Self::Eip2930(tx) => tx.signature(),
+                Self::Eip1559(tx) => tx.signature(),
+                Self::Eip7702(tx) => tx.signature(),
+                // TODO: The Deposit variant does not have a user signature since it originates
+                // from an L1 event. Decide how to represent or handle signature-less transactions.
+                Self::Deposit(_tx) => unimplemented!(),
+            }
         }
-        let signature_hash = keccak256(buf);
-        recover_signer_unchecked(self.signature(), signature_hash)
+
+        fn recover_signer(&self) -> Result<Address, RecoveryError> {
+            let signature_hash = match self {
+                Self::Legacy(tx) => tx.signature_hash(),
+                Self::Eip2930(tx) => tx.signature_hash(),
+                Self::Eip1559(tx) => tx.signature_hash(),
+                Self::Eip7702(tx) => tx.signature_hash(),
+                // TODO: The Deposit variant does not have a user signature since it originates
+                // from an L1 event. Decide how to represent or handle signature-less transactions.
+                Self::Deposit(_tx) => unimplemented!(),
+            };
+
+            recover_signer(self.signature(), signature_hash)
+        }
+
+        fn recover_signer_unchecked_with_buf(
+            &self,
+            buf: &mut Vec<u8>,
+        ) -> Result<Address, RecoveryError> {
+            match self {
+                Self::Legacy(tx) => tx.tx().encode_for_signing(buf),
+                Self::Eip2930(tx) => tx.tx().encode_for_signing(buf),
+                Self::Eip1559(tx) => tx.tx().encode_for_signing(buf),
+                Self::Eip7702(tx) => tx.tx().encode_for_signing(buf),
+                // TODO: The Deposit variant does not have a user signature since it originates
+                // from an L1 event. Decide how to represent or handle signature-less transactions.
+                Self::Deposit(_tx) => unimplemented!(),
+            }
+            let signature_hash = keccak256(buf);
+            recover_signer_unchecked(self.signature(), signature_hash)
+        }
     }
 }
-
 /// Opaque error type for sender recovery.
 #[derive(Debug, Default, thiserror::Error)]
 #[error("Failed to recover the signer")]


### PR DESCRIPTION
## Changes
- will close https://github.com/paradigmxyz/reth/issues/15221
- todo's are mentioned in the code, and I added some comments where feedback from the team would be greatly appreciated. Essentially, we are trying to implement the `SignedTransaction` trait for `OpTxEnvelope`, but a `Deposit` tsx from the L1 to the L2 is unsigned, so we can't properly implement the behaviors like `signature`, `recover_signer`, or `recover_signer_unchecked_with_buf`.  