### PR TITLE
chore: reenable default impl for `SparseStateTrie`

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -41,7 +41,6 @@ pub struct SparseStateTrie<F: BlindedProviderFactory = DefaultBlindedProviderFac
     metrics: SparseStateTrieMetrics,
 }
 
-#[cfg(test)]
 impl Default for SparseStateTrie {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
## Description

Reenable default impl for `SparseStateTrie`.