### PR TITLE
chore(ci): bump eest release and pin eest simulator versions

### DIFF
--- a/.github/assets/hive/build_simulators.sh
+++ b/.github/assets/hive/build_simulators.sh
@@ -11,7 +11,7 @@ go build .
 
 # Run each hive command in the background for each simulator and wait
 echo "Building images"
-./hive -client reth --sim "ethereum/eest" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gz -sim.timelimit 1s || true &
+./hive -client reth --sim "ethereum/eest" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v4.1.0/fixtures_develop.tar.gz --sim.buildarg branch=v4.1.0 -sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/engine" -sim.timelimit 1s || true &
 ./hive -client reth --sim "devp2p" -sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/rpc-compat" -sim.timelimit 1s || true &


### PR DESCRIPTION
A mistake in `ethereum/execution-spec-tests` (EEST) dependency pinning inadvertently broke the `ethereum/eest` simulator build in `ethereum/hive` master with default values (`branch=main`). Full details here:
- https://github.com/ethereum/execution-spec-tests/pull/1352

This PR updates `build_simulators.sh` to specify a tagged version of EEST to use when building the simulators to avoid reth's ci being effected by changes on the EEST main branch.

It additionally bumps the release used to EEST's latest `develop` release v4.1.0, which contains additional coverage for Prague. Note: The `develop` tarball contains all of EEST's tests, filled for all forks up to and including Prague (`stable` omits Prague; it only contains tests filled for deployed forks).