### PR TITLE
feat(full-provider): Add Debug trait to FullProvider.

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -21,6 +21,7 @@ use alloy_eips::{
 use alloy_genesis::Genesis;
 use alloy_primitives::{address, b256, Address, BlockNumber, B256, U256};
 use alloy_trie::root::state_root_ref_unhashed;
+use core::fmt::Debug;
 use derive_more::From;
 use reth_ethereum_forks::{
     ChainHardforks, DisplayHardforks, EthereumHardfork, EthereumHardforks, ForkCondition,
@@ -811,7 +812,7 @@ impl EthereumHardforks for ChainSpec {
 
 /// A trait for reading the current chainspec.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait ChainSpecProvider: Send + Sync {
+pub trait ChainSpecProvider: Debug + Send + Sync {
     /// The chain spec type.
     type ChainSpec: EthChainSpec + 'static;
 

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -103,10 +103,11 @@ impl<EvmFactory> EthEvmConfig<EvmFactory> {
 impl<EvmF> ConfigureEvm for EthEvmConfig<EvmF>
 where
     EvmF: EvmFactory<Tx: TransactionEnv + FromRecoveredTx<TransactionSigned>, Spec = SpecId>
+        + Clone
+        + Debug
         + Send
         + Sync
         + Unpin
-        + Clone
         + 'static,
 {
     type Primitives = EthPrimitives;

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -6,6 +6,7 @@ use alloy_consensus::{BlockHeader, Header};
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
 use alloy_evm::{Evm, EvmEnv, EvmFactory};
 use alloy_primitives::B256;
+use core::fmt::Debug;
 pub use reth_execution_errors::{
     BlockExecutionError, BlockValidationError, InternalBlockExecutionError,
 };
@@ -128,7 +129,7 @@ pub trait Executor<DB: Database>: Sized {
 }
 
 /// A type that can create a new executor for block execution.
-pub trait BlockExecutorProvider: Send + Sync + Clone + Unpin + 'static {
+pub trait BlockExecutorProvider: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Receipt type.
     type Primitives: NodePrimitives;
 
@@ -370,7 +371,7 @@ where
 }
 
 /// A generic block executor provider that can create executors using a strategy factory.
-#[expect(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct BasicBlockExecutorProvider<F> {
     strategy_factory: F,
 }
@@ -490,7 +491,7 @@ mod tests {
         state::AccountInfo,
     };
 
-    #[derive(Clone, Default)]
+    #[derive(Clone, Debug, Default)]
     struct TestExecutorProvider;
 
     impl BlockExecutorProvider for TestExecutorProvider {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -89,7 +89,7 @@ pub use alloy_evm::block::state_changes as state_change;
 /// [`NextBlockEnvCtx`]: ConfigureEvm::NextBlockEnvCtx
 /// [`BlockExecutor`]: alloy_evm::block::BlockExecutor
 #[auto_impl::auto_impl(&, Arc)]
-pub trait ConfigureEvm: Send + Sync + Unpin + Clone {
+pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// The primitives type used by the EVM.
     type Primitives: NodePrimitives;
 

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -15,13 +15,13 @@ use reth_provider::FullProvider;
 use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
-use std::{future::Future, marker::PhantomData};
+use std::{fmt::Debug, future::Future, marker::PhantomData};
 
 /// A helper trait that is downstream of the [`NodeTypesWithEngine`] trait and adds stateful
 /// components to the node.
 ///
 /// Its types are configured by node internally and are not intended to be user configurable.
-pub trait FullNodeTypes: Clone + Send + Sync + Unpin + 'static {
+pub trait FullNodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Node's types with the database.
     type Types: NodeTypesWithEngine;
     /// Underlying database type used by the node to store and retrieve data.

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -16,7 +16,7 @@ use reth_exex::ExExContext;
 use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes};
 use reth_node_core::node_config::NodeConfig;
 use reth_tasks::TaskExecutor;
-use std::{fmt, future::Future};
+use std::{fmt, fmt::Debug, future::Future};
 
 /// A node builder that also has the configured types.
 pub struct NodeBuilderWithTypes<T: FullNodeTypes> {
@@ -72,6 +72,7 @@ impl<T: FullNodeTypes> fmt::Debug for NodeTypesAdapter<T> {
 
 /// Container for the node's types and the components and other internals that can be used by
 /// addons of the node.
+#[derive(Debug)]
 pub struct NodeAdapter<T: FullNodeTypes, C: NodeComponents<T>> {
     /// The components of the node.
     pub components: C,

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -22,6 +22,7 @@ pub use payload::*;
 pub use pool::*;
 use reth_network_p2p::BlockClient;
 use reth_payload_builder::PayloadBuilderHandle;
+use std::fmt::Debug;
 
 use crate::{ConfigureEvm, FullNodeTypes};
 use reth_consensus::{ConsensusError, FullConsensus};
@@ -38,7 +39,7 @@ use reth_transaction_pool::{PoolTransaction, TransactionPool};
 ///  - transaction pool
 ///  - network
 ///  - payload builder.
-pub trait NodeComponents<T: FullNodeTypes>: Clone + Unpin + Send + Sync + 'static {
+pub trait NodeComponents<T: FullNodeTypes>: Clone + Debug + Unpin + Send + Sync + 'static {
     /// The transaction pool of the node.
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<T::Types>>> + Unpin;
 

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -2,12 +2,6 @@
 pub use reth_node_api::{FullNodeTypes, NodeTypes, NodeTypesWithEngine};
 use reth_payload_builder::PayloadBuilderHandle;
 
-use std::{
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
-
 use reth_node_api::{EngineTypes, FullNodeComponents, PayloadTypes};
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
@@ -17,6 +11,12 @@ use reth_provider::ChainSpecProvider;
 use reth_rpc_api::EngineApiClient;
 use reth_rpc_builder::{auth::AuthServerHandle, RpcServerHandle};
 use reth_tasks::TaskExecutor;
+use std::{
+    fmt::Debug,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use crate::{components::NodeComponentsBuilder, rpc::RethRpcAddOns, NodeAdapter, NodeAddOns};
 
@@ -63,8 +63,8 @@ impl<N, C, AO> AnyNode<N, C, AO> {
 impl<N, C, AO> NodeTypes for AnyNode<N, C, AO>
 where
     N: FullNodeTypes,
-    C: Clone + Send + Sync + Unpin + 'static,
-    AO: Send + Sync + Unpin + Clone + 'static,
+    C: Clone + Debug + Send + Sync + Unpin + 'static,
+    AO: Clone + Debug + Send + Sync + Unpin + 'static,
 {
     type Primitives = <N::Types as NodeTypes>::Primitives;
 
@@ -78,8 +78,8 @@ where
 impl<N, C, AO> NodeTypesWithEngine for AnyNode<N, C, AO>
 where
     N: FullNodeTypes,
-    C: Clone + Send + Sync + Unpin + 'static,
-    AO: Send + Sync + Unpin + Clone + 'static,
+    C: Clone + Debug + Send + Sync + Unpin + 'static,
+    AO: Clone + Debug + Send + Sync + Unpin + 'static,
 {
     type Payload = <N::Types as NodeTypesWithEngine>::Payload;
 }
@@ -87,8 +87,8 @@ where
 impl<N, C, AO> Node<N> for AnyNode<N, C, AO>
 where
     N: FullNodeTypes + Clone,
-    C: NodeComponentsBuilder<N> + Clone + Sync + Unpin + 'static,
-    AO: NodeAddOns<NodeAdapter<N, C::Components>> + Clone + Sync + Unpin + 'static,
+    C: NodeComponentsBuilder<N> + Clone + Debug + Sync + Unpin + 'static,
+    AO: NodeAddOns<NodeAdapter<N, C::Components>> + Clone + Debug + Sync + Unpin + 'static,
 {
     type ComponentsBuilder = C;
     type AddOns = AO;

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -25,7 +25,7 @@ use reth_trie_db::StateCommitment;
 /// This includes the primitive types of a node and chain specification.
 ///
 /// This trait is intended to be stateless and only define the types of the node.
-pub trait NodeTypes: Clone + Send + Sync + Unpin + 'static {
+pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// The node's primitive types, defining basic operations and structures.
     type Primitives: NodePrimitives;
     /// The type used for configuration of the EVM.
@@ -68,7 +68,7 @@ impl<Types, DB> NodeTypesWithDBAdapter<Types, DB> {
 impl<Types, DB> NodeTypes for NodeTypesWithDBAdapter<Types, DB>
 where
     Types: NodeTypes,
-    DB: Clone + Send + Sync + Unpin + 'static,
+    DB: Clone + Debug + Send + Sync + Unpin + 'static,
 {
     type Primitives = Types::Primitives;
     type ChainSpec = Types::ChainSpec;
@@ -79,7 +79,7 @@ where
 impl<Types, DB> NodeTypesWithEngine for NodeTypesWithDBAdapter<Types, DB>
 where
     Types: NodeTypesWithEngine,
-    DB: Clone + Send + Sync + Unpin + 'static,
+    DB: Clone + Debug + Send + Sync + Unpin + 'static,
 {
     type Payload = Types::Payload;
 }

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -109,7 +109,8 @@ where
         Block = alloy_consensus::Block<R::Transaction>,
     >,
     OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx>,
-    R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
+    // Can remove Debug on R once it's added as OpReceiptBuilder constraint
+    R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction> + Debug,
     Self: Send + Sync + Unpin + Clone + 'static,
 {
     type Primitives = N;

--- a/crates/storage/db-api/src/transaction.rs
+++ b/crates/storage/db-api/src/transaction.rs
@@ -3,9 +3,10 @@ use crate::{
     table::{DupSort, Encode, Table},
     DatabaseError,
 };
+use std::fmt::Debug;
 
 /// Read only transaction
-pub trait DbTx: Send + Sync {
+pub trait DbTx: Debug + Send + Sync {
     /// Cursor type for this read-only transaction
     type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
     /// `DupCursor` type for this read-only transaction

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -222,7 +222,7 @@ impl<TX, N: NodeTypes> StaticFileProviderFactory for DatabaseProvider<TX, N> {
     }
 }
 
-impl<TX: Send + Sync, N: NodeTypes<ChainSpec: EthChainSpec + 'static>> ChainSpecProvider
+impl<TX: Debug + Send + Sync, N: NodeTypes<ChainSpec: EthChainSpec + 'static>> ChainSpecProvider
     for DatabaseProvider<TX, N>
 {
     type ChainSpec = N::ChainSpec;

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -9,6 +9,7 @@ use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
 use reth_chainspec::EthereumHardforks;
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_storage_api::NodePrimitivesProvider;
+use std::fmt::Debug;
 
 /// Helper trait to unify all provider traits for simplicity.
 pub trait FullProvider<N: NodeTypesWithDB>:
@@ -28,6 +29,7 @@ pub trait FullProvider<N: NodeTypesWithDB>:
     + ForkChoiceSubscriptions<Header = HeaderTy<N>>
     + StageCheckpointReader
     + Clone
+    + Debug
     + Unpin
     + 'static
 {
@@ -50,6 +52,7 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
         + ForkChoiceSubscriptions<Header = HeaderTy<N>>
         + StageCheckpointReader
         + Clone
+        + Debug
         + Unpin
         + 'static
 {

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -15,6 +15,7 @@ use alloy_primitives::{
     Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, B256, U256,
 };
 use core::{
+    fmt::Debug,
     marker::PhantomData,
     ops::{RangeBounds, RangeInclusive},
 };
@@ -106,7 +107,7 @@ impl<ChainSpec: Send + Sync, N: Send + Sync> BlockNumReader for NoopProvider<Cha
     }
 }
 
-impl<ChainSpec: EthChainSpec + 'static, N: Send + Sync + 'static> ChainSpecProvider
+impl<ChainSpec: EthChainSpec + 'static, N: Debug + Send + Sync + 'static> ChainSpecProvider
     for NoopProvider<ChainSpec, N>
 {
     type ChainSpec = ChainSpec;

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -1,6 +1,6 @@
 use crate::traits::PoolTransaction;
 use alloy_primitives::U256;
-use std::{fmt, marker::PhantomData};
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Priority of the transaction that can be missing.
 ///
@@ -24,11 +24,11 @@ impl<T: Ord + Clone> From<Option<T>> for Priority<T> {
 /// Decides how transactions should be ordered within the pool, depending on a `Priority` value.
 ///
 /// The returned priority must reflect [total order](https://en.wikipedia.org/wiki/Total_order).
-pub trait TransactionOrdering: Send + Sync + 'static {
+pub trait TransactionOrdering: Debug + Send + Sync + 'static {
     /// Priority of a transaction.
     ///
     /// Higher is better.
-    type PriorityValue: Ord + Clone + Default + fmt::Debug + Send + Sync;
+    type PriorityValue: Ord + Clone + Default + Debug + Send + Sync;
 
     /// The transaction type to determine the priority of.
     type Transaction: PoolTransaction;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fmt,
+    fmt::Debug,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -59,7 +60,7 @@ pub type PoolPooledTx<P> = <<P as TransactionPool>::Transaction as PoolTransacti
 /// Note: This requires `Clone` for convenience, since it is assumed that this will be implemented
 /// for a wrapped `Arc` type, see also [`Pool`](crate::Pool).
 #[auto_impl::auto_impl(&, Arc)]
-pub trait TransactionPool: Send + Sync + Clone {
+pub trait TransactionPool: Clone + Debug + Send + Sync {
     /// The transaction type of the pool
     type Transaction: EthPoolTransaction;
 
@@ -938,7 +939,7 @@ impl BestTransactionsAttributes {
 /// handling of all valid `Consensus` transactions that can't be pooled (e.g Deposit transactions or
 /// blob-less EIP-4844 transactions).
 pub trait PoolTransaction:
-    alloy_consensus::Transaction + InMemorySize + fmt::Debug + Send + Sync + Clone
+    alloy_consensus::Transaction + InMemorySize + Debug + Send + Sync + Clone
 {
     /// Associated error type for the `try_from_consensus` method.
     type TryFromConsensusError: fmt::Display;

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -10,7 +10,7 @@ use alloy_eips::eip4844::BlobTransactionSidecar;
 use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
 use reth_primitives_traits::{Recovered, SealedBlock};
-use std::{fmt, future::Future, time::Instant};
+use std::{fmt, fmt::Debug, future::Future, time::Instant};
 
 mod constants;
 mod eth;
@@ -150,7 +150,7 @@ impl<T: PoolTransaction> ValidTransaction<T> {
 }
 
 /// Provides support for validating transaction at any given state of the chain
-pub trait TransactionValidator: Send + Sync {
+pub trait TransactionValidator: Debug + Send + Sync {
     /// The transaction type to validate.
     type Transaction: PoolTransaction;
 

--- a/examples/network-txpool/src/main.rs
+++ b/examples/network-txpool/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> eyre::Result<()> {
 ///
 /// CAUTION: This validator is not safe to use since it doesn't actually validate the transaction's
 /// properties such as chain id, balance, nonce, etc.
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[non_exhaustive]
 struct OkValidator;
 


### PR DESCRIPTION
closes #14953  

At first it seems like a small change, but when I added the `Debug` trait to `FullProvider`, it impacts quite a few traits and structs. If needed, we could "break" this constraint chain and manually add the `Debug` trait to `NodeComponents`, making the changes smaller.  

Also, if `alloy-op-evm::OpReceiptBuilder` gets the `Debug` constraint, we can drop the changes `crates/optimism/evm/src/lib.rs`. Happy to work on that if it’s needed.

