### PR TITLE
Add EIP7702 tx handle logic for txpool

### DIFF
--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -113,7 +113,9 @@ where
                 NetworkWallet::<Ethereum>::sign_request(&EthereumWallet::new(signer.clone()), tx)
                     .await?;
 
-            pending.push(provider.send_tx_envelope(tx).await?);
+            if let Ok(res) = provider.send_tx_envelope(tx).await {
+                pending.push(res);
+            }
         }
 
         let payload = node.build_and_submit_payload().await?;

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -158,6 +158,7 @@ where
             state_nonce,
             transaction: valid_tx,
             propagate,
+            bytecode_hash,
         } = outcome
         {
             let mut l1_block_info = self.block_info.l1_block_info.read().clone();
@@ -196,6 +197,7 @@ where
                 state_nonce,
                 transaction: valid_tx,
                 propagate,
+                bytecode_hash,
             }
         }
 

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -185,12 +185,19 @@ pub enum Eip7702PoolTransactionError {
     /// Thrown if the transaction has no items in its authorization list
     #[error("no items in authorization list for EIP7702 transaction")]
     MissingEip7702AuthorizationList,
-    /// Thrown if the transaction has no to
-    #[error("no to address for EIP7702 transaction")]
-    MissingEip7702To,
-    /// Thrown if any of the transaction authorities cannot be recovered
-    #[error("failed to recover authority from EIP7702 transaction")]
-    AuthorizationRecoverFailed,
+    /// Returned when the transaction with gapped
+    /// nonce received from the accounts with delegation or pending delegation.
+    #[error("gapped-nonce tx from delegated accounts")]
+    OutOfOrderTxFromDelegated,
+    /// Returned when the maximum number of in-flight
+    /// transactions is reached for specific accounts.
+    #[error("in-flight transaction limit reached for delegated accounts")]
+    InflightTxLimitReached,
+    /// Returned if a transaction has an authorization
+    /// signed by an address which already has in-flight transactions known to the
+    /// pool.
+    #[error("authority already reserved")]
+    AuthorityReserved,
 }
 
 /// Represents errors that can happen when validating transactions for the pool
@@ -330,8 +337,9 @@ impl InvalidPoolTransactionError {
             }
             Self::Eip7702(eip7702_err) => match eip7702_err {
                 Eip7702PoolTransactionError::MissingEip7702AuthorizationList => true,
-                Eip7702PoolTransactionError::MissingEip7702To => true,
-                Eip7702PoolTransactionError::AuthorizationRecoverFailed => true,
+                Eip7702PoolTransactionError::OutOfOrderTxFromDelegated => false,
+                Eip7702PoolTransactionError::InflightTxLimitReached => false,
+                Eip7702PoolTransactionError::AuthorityReserved => false,
             },
         }
     }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -185,6 +185,12 @@ pub enum Eip7702PoolTransactionError {
     /// Thrown if the transaction has no items in its authorization list
     #[error("no items in authorization list for EIP7702 transaction")]
     MissingEip7702AuthorizationList,
+    /// Thrown if the transaction has no to
+    #[error("no to address for EIP7702 transaction")]
+    MissingEip7702To,
+    /// Thrown if any of the transaction authorities cannot be recovered
+    #[error("failed to recover authority from EIP7702 transaction")]
+    AuthorizationRecoverFailed,
 }
 
 /// Represents errors that can happen when validating transactions for the pool
@@ -323,7 +329,9 @@ impl InvalidPoolTransactionError {
                 }
             }
             Self::Eip7702(eip7702_err) => match eip7702_err {
-                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => false,
+                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => true,
+                Eip7702PoolTransactionError::MissingEip7702To => true,
+                Eip7702PoolTransactionError::AuthorizationRecoverFailed => true,
             },
         }
     }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -337,6 +337,7 @@ impl<T: EthPoolTransaction> TransactionValidator for MockTransactionValidator<T>
         TransactionValidationOutcome::Valid {
             balance: U256::MAX,
             state_nonce: 0,
+            bytecode_hash: None,
             transaction: ValidTransaction::new(transaction, maybe_sidecar),
             propagate: match origin {
                 TransactionOrigin::External => true,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -2,8 +2,11 @@
 
 use crate::{
     config::{LocalTransactionConfig, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER},
-    error::{Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError, PoolErrorKind},
-    identifier::{SenderId, TransactionId},
+    error::{
+        Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
+        PoolError, PoolErrorKind,
+    },
+    identifier::{SenderId, SenderIdentifiers, TransactionId},
     metrics::{AllTransactionsMetrics, TxPoolMetrics},
     pool::{
         best::BestTransactions,
@@ -19,7 +22,7 @@ use crate::{
     ValidPoolTransaction, U256,
 };
 use alloy_consensus::constants::{
-    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID, KECCAK_EMPTY,
     LEGACY_TX_TYPE_ID,
 };
 use alloy_eips::{
@@ -28,6 +31,8 @@ use alloy_eips::{
     Typed2718,
 };
 use alloy_primitives::{Address, TxHash, B256};
+use parking_lot::RwLock;
+use reth_execution_types::ChangedAccount;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::{
@@ -82,6 +87,8 @@ use tracing::trace;
 ///   new --> |apply state changes| pool
 /// ```
 pub struct TxPool<T: TransactionOrdering> {
+    /// Internal mapping of addresses to plain ints.
+    identifiers: RwLock<SenderIdentifiers>,
     /// Contains the currently known information about the senders.
     sender_info: FxHashMap<SenderId, SenderInfo>,
     /// pending subpool
@@ -123,6 +130,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// Create a new graph pool instance.
     pub fn new(ordering: T, config: PoolConfig) -> Self {
         Self {
+            identifiers: Default::default(),
             sender_info: Default::default(),
             pending_pool: PendingPool::with_buffer(
                 ordering,
@@ -136,6 +144,27 @@ impl<T: TransactionOrdering> TxPool<T> {
             metrics: Default::default(),
             latest_update_kind: None,
         }
+    }
+
+    /// Returns the internal [`SenderId`] for this address
+    pub fn get_sender_id(&self, addr: Address) -> SenderId {
+        self.identifiers.write().sender_id_or_create(addr)
+    }
+
+    /// Converts the changed accounts to a map of sender ids to sender info (internal identifier
+    /// used for accounts)
+    pub(crate) fn changed_senders(
+        &self,
+        accs: impl Iterator<Item = ChangedAccount>,
+    ) -> FxHashMap<SenderId, SenderInfo> {
+        let mut identifiers = self.identifiers.write();
+        accs.into_iter()
+            .map(|acc| {
+                let ChangedAccount { address, nonce, balance } = acc;
+                let sender_id = identifiers.sender_id_or_create(address);
+                (sender_id, SenderInfo { state_nonce: nonce, balance })
+            })
+            .collect()
     }
 
     /// Retrieves the highest nonce for a specific sender from the transaction pool.
@@ -622,10 +651,13 @@ impl<T: TransactionOrdering> TxPool<T> {
         tx: ValidPoolTransaction<T::Transaction>,
         on_chain_balance: U256,
         on_chain_nonce: u64,
+        on_chain_code_hash: Option<B256>,
     ) -> PoolResult<AddedTransaction<T::Transaction>> {
         if self.contains(tx.hash()) {
             return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported))
         }
+
+        self.validate_auth(&tx, on_chain_nonce, on_chain_code_hash)?;
 
         // Update sender info with balance and nonce
         self.sender_info
@@ -716,6 +748,82 @@ impl<T: TransactionOrdering> TxPool<T> {
                 }
             }
         }
+    }
+
+    // check_delegation_limit determines if the tx sender is delegated or has a
+    // pending delegation, and if so, ensures they have at most one in-flight
+    // **executable** transaction, e.g. disallow stacked and gapped transactions
+    // from the account.
+    fn check_delegation_limit(
+        &self,
+        transaction: &ValidPoolTransaction<T::Transaction>,
+        on_chain_nonce: u64,
+        on_chain_code_hash: Option<B256>,
+    ) -> Result<(), PoolError> {
+        // Short circuit if the sender has neither delegation nor pending delegation.
+        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY)) &&
+            !self.all_transactions.auths.contains_key(transaction.sender_ref())
+        {
+            return Ok(())
+        }
+
+        let pending_txs = self.pending_pool.get_txs_by_sender(transaction.sender_id());
+        if pending_txs.is_empty() {
+            // Transaction with gapped nonce is not supported for delegated accounts
+            if transaction.nonce() > on_chain_nonce {
+                return Err(PoolError::new(
+                    *transaction.hash(),
+                    PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
+                        Eip7702PoolTransactionError::OutOfOrderTxFromDelegated,
+                    )),
+                ))
+            }
+            return Ok(())
+        }
+
+        // Transaction replacement is supported
+        if pending_txs.contains(&transaction.transaction_id) {
+            return Ok(())
+        }
+
+        Err(PoolError::new(
+            *transaction.hash(),
+            PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
+                Eip7702PoolTransactionError::InflightTxLimitReached,
+            )),
+        ))
+    }
+
+    // validate_auth verifies that the transaction complies with code authorization
+    // restrictions brought by SetCode transaction type.
+    fn validate_auth(
+        &self,
+        transaction: &ValidPoolTransaction<T::Transaction>,
+        on_chain_nonce: u64,
+        on_chain_code_hash: Option<B256>,
+    ) -> Result<(), PoolError> {
+        // Allow at most one in-flight tx for delegated accounts or those with a
+        // pending authorization.
+        self.check_delegation_limit(transaction, on_chain_nonce, on_chain_code_hash)?;
+
+        if let Some(authority_list) = transaction.authority_list() {
+            for addr in authority_list {
+                let sender_id = self.get_sender_id(addr);
+                if !self.pending_pool.get_txs_by_sender(sender_id).is_empty() ||
+                    !self.queued_pool.get_txs_by_sender(sender_id).is_empty() ||
+                    !self.basefee_pool.get_txs_by_sender(sender_id).is_empty()
+                {
+                    return Err(PoolError::new(
+                        *transaction.hash(),
+                        PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
+                            Eip7702PoolTransactionError::AuthorityReserved,
+                        )),
+                    ))
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Maintenance task to apply a series of updates.
@@ -1118,6 +1226,8 @@ pub(crate) struct AllTransactions<T: PoolTransaction> {
     price_bumps: PriceBumpConfig,
     /// How to handle [`TransactionOrigin::Local`](crate::TransactionOrigin) transactions.
     local_transactions_config: LocalTransactionConfig,
+    /// All accounts with a pooled authorization
+    auths: HashMap<Address, HashSet<TxHash>>,
     /// All Transactions metrics
     metrics: AllTransactionsMetrics,
 }
@@ -1455,6 +1565,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
     ) -> Option<(Arc<ValidPoolTransaction<T>>, SubPool)> {
         let tx = self.by_hash.remove(tx_hash)?;
         let internal = self.txs.remove(&tx.transaction_id)?;
+        self.remove_auths(&internal);
         // decrement the counter for the sender.
         self.tx_decr(tx.sender_id());
         self.update_size_metrics();
@@ -1478,9 +1589,25 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let result =
             self.by_hash.remove(internal.transaction.hash()).map(|tx| (tx, internal.subpool));
 
+        self.remove_auths(&internal);
+
         self.update_size_metrics();
 
         result
+    }
+
+    fn remove_auths(&mut self, tx: &PoolInternalTransaction<T>) {
+        if let Some(auths) = tx.transaction.authority_list() {
+            let tx_hash = tx.transaction.hash();
+            for auth in auths {
+                if let Some(list) = self.auths.get_mut(&auth) {
+                    list.remove(tx_hash);
+                    if list.is_empty() {
+                        self.auths.remove(&auth);
+                    }
+                }
+            }
+        }
     }
 
     /// Checks if the given transaction's type conflicts with an existing transaction.
@@ -1721,8 +1848,18 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 let replaced = entry.insert(pool_tx);
                 self.by_hash.remove(replaced.transaction.hash());
                 self.by_hash.insert(new_hash, new_transaction);
+
+                self.remove_auths(&replaced);
+
                 // also remove the hash
                 replaced_tx = Some((replaced.transaction, replaced.subpool));
+            }
+        }
+
+        if let Some(auths) = transaction.authority_list() {
+            let tx_hash = transaction.hash();
+            for auth in auths {
+                self.auths.entry(auth).or_default().insert(*tx_hash);
             }
         }
 
@@ -1845,6 +1982,7 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
             pending_fees: Default::default(),
             price_bumps: Default::default(),
             local_transactions_config: Default::default(),
+            auths: Default::default(),
             metrics: Default::default(),
         }
     }
@@ -2055,7 +2193,7 @@ mod tests {
 
         let validated = f.validated(tx.clone());
         let id = *validated.id();
-        pool.add_transaction(validated, on_chain_balance, on_chain_nonce).unwrap();
+        pool.add_transaction(validated, on_chain_balance, on_chain_nonce, None).unwrap();
 
         // assert pool lengths
         assert!(pool.blob_pool.is_empty());
@@ -2095,7 +2233,7 @@ mod tests {
 
         let validated = f.validated(tx.clone());
         let id = *validated.id();
-        pool.add_transaction(validated, on_chain_balance, on_chain_nonce).unwrap();
+        pool.add_transaction(validated, on_chain_balance, on_chain_nonce, None).unwrap();
 
         // assert pool lengths
         assert!(pool.pending_pool.is_empty());
@@ -2298,7 +2436,7 @@ mod tests {
 
             let validated = f.validated(tx.clone());
             let id = *validated.id();
-            pool.add_transaction(validated, on_chain_balance, on_chain_nonce).unwrap();
+            pool.add_transaction(validated, on_chain_balance, on_chain_nonce, None).unwrap();
 
             // assert pool lengths
             promotion_test.assert_single_tx_starting_subpool(&pool);
@@ -2400,8 +2538,8 @@ mod tests {
         let mut pool = TxPool::new(MockOrdering::default(), Default::default());
         let tx = MockTransaction::eip1559().inc_price().inc_limit();
         let tx = f.validated(tx);
-        pool.add_transaction(tx.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        match pool.add_transaction(tx, on_chain_balance, on_chain_nonce).unwrap_err().kind {
+        pool.add_transaction(tx.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        match pool.add_transaction(tx, on_chain_balance, on_chain_nonce, None).unwrap_err().kind {
             PoolErrorKind::AlreadyImported => {}
             _ => unreachable!(),
         }
@@ -2438,10 +2576,12 @@ mod tests {
 
         let tx = MockTransaction::eip1559().inc_price().inc_limit();
         let first = f.validated(tx.clone());
-        let first_added = pool.add_transaction(first, on_chain_balance, on_chain_nonce).unwrap();
+        let first_added =
+            pool.add_transaction(first, on_chain_balance, on_chain_nonce, None).unwrap();
         let replacement = f.validated(tx.rng_hash().inc_price());
-        let replacement_added =
-            pool.add_transaction(replacement.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        let replacement_added = pool
+            .add_transaction(replacement.clone(), on_chain_balance, on_chain_nonce, None)
+            .unwrap();
 
         // // ensure replaced tx removed
         assert!(!pool.contains(first_added.hash()));
@@ -2733,7 +2873,7 @@ mod tests {
         let tx = MockTransaction::eip1559().inc_price_by(10);
         let validated = f.validated(tx.clone());
         let id = *validated.id();
-        pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
         assert_eq!(pool.pending_pool.len(), 1);
 
@@ -2753,7 +2893,7 @@ mod tests {
         let tx = MockTransaction::eip1559().inc_price_by(10);
         let validated = f.validated(tx.clone());
         let id = *validated.id();
-        pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
         assert_eq!(pool.pending_pool.len(), 1);
 
@@ -2776,14 +2916,14 @@ mod tests {
 
         // Create a mock transaction and add it to the pool.
         let tx = MockTransaction::eip1559();
-        pool.add_transaction(f.validated(tx.clone()), U256::from(1_000), 0).unwrap();
+        pool.add_transaction(f.validated(tx.clone()), U256::from(1_000), 0, None).unwrap();
 
         // Create another mock transaction with an incremented price.
         let tx1 = tx.inc_price().next();
 
         // Validate the second mock transaction and add it to the pool.
         let tx1_validated = f.validated(tx1.clone());
-        pool.add_transaction(tx1_validated, U256::from(1_000), 0).unwrap();
+        pool.add_transaction(tx1_validated, U256::from(1_000), 0, None).unwrap();
 
         // Ensure that the calculated next nonce for the sender matches the expected value.
         assert_eq!(
@@ -2815,7 +2955,7 @@ mod tests {
             mock_tx.set_nonce(nonce);
 
             let validated_tx = f.validated(mock_tx);
-            pool.add_transaction(validated_tx, U256::from(1000), 0).unwrap();
+            pool.add_transaction(validated_tx, U256::from(1000), 0, None).unwrap();
         }
 
         // Get last consecutive transaction
@@ -2849,11 +2989,11 @@ mod tests {
         let tx = MockTransaction::eip1559().inc_price_by(10);
         let validated = f.validated(tx.clone());
         let id = *validated.id();
-        pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
         let next = tx.next();
         let validated = f.validated(next.clone());
-        pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+        pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
         assert_eq!(pool.pending_pool.len(), 2);
 
@@ -2901,7 +3041,7 @@ mod tests {
 
         // add all the transactions to the parked pool
         for tx in a_txs {
-            pool.add_transaction(f.validated(tx), U256::from(1_000), 0).unwrap();
+            pool.add_transaction(f.validated(tx), U256::from(1_000), 0, None).unwrap();
         }
 
         // truncate the pool, it should remove at least one transaction
@@ -2939,7 +3079,7 @@ mod tests {
 
         // add all the transactions to the parked pool
         for tx in a_txs {
-            pool.add_transaction(f.validated(tx), U256::from(1_000), 0).unwrap();
+            pool.add_transaction(f.validated(tx), U256::from(1_000), 0, None).unwrap();
         }
 
         // truncate the pool, it should remove at least one transaction
@@ -2959,7 +3099,7 @@ mod tests {
             let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
             let validated = f.validated(tx.clone());
             let _id = *validated.id();
-            pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
         }
 
         let size = pool.size();
@@ -2969,7 +3109,7 @@ mod tests {
             let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
             let validated = f.validated(tx.clone());
             let _id = *validated.id();
-            pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
             pool.discard_worst();
             pool.assert_invariants();
@@ -2989,7 +3129,7 @@ mod tests {
             let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
             let validated = f.validated(tx.clone());
             let _id = *validated.id();
-            pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
         }
 
         let size = pool.size();
@@ -2999,7 +3139,7 @@ mod tests {
             let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
             let validated = f.validated(tx.clone());
             let _id = *validated.id();
-            pool.add_transaction(validated, U256::from(1_000), 0).unwrap();
+            pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
             pool.discard_worst();
             pool.assert_invariants();
@@ -3024,8 +3164,9 @@ mod tests {
         let v2 = f.validated(tx_2);
 
         // Add first 2 to the pool
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert!(pool.queued_transactions().is_empty());
         assert_eq!(2, pool.pending_transactions().len());
@@ -3034,7 +3175,7 @@ mod tests {
         pool.prune_transaction_by_hash(v0.hash());
 
         // Now add transaction with nonce 2
-        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
 
         // v2 is in the queue now. v1 is still in 'pending'.
         assert_eq!(1, pool.queued_transactions().len());
@@ -3068,8 +3209,10 @@ mod tests {
         let v1 = f.validated(tx_1);
 
         // Add them to the pool
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(2, pool.pending_transactions().len());
@@ -3099,10 +3242,14 @@ mod tests {
         let v3 = f.validated(tx_3);
 
         // Add them to the pool
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v3.clone(), on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v3.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(4, pool.pending_transactions().len());
@@ -3136,11 +3283,13 @@ mod tests {
         let v4 = f.validated(tx_4);
 
         // Add them to the pool
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v4, on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v4, on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(5, pool.pending_transactions().len());
@@ -3169,10 +3318,11 @@ mod tests {
         let v3 = f.validated(tx_3);
 
         // Add them to the pool
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(4, pool.pending_transactions().len());
@@ -3206,11 +3356,14 @@ mod tests {
         let v4 = f.validated(tx_4);
 
         // Add them to the pool
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v4, on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v2.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v4, on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(5, pool.pending_transactions().len());
@@ -3241,8 +3394,9 @@ mod tests {
         let v3 = f.validated(tx_3);
 
         // Add first 2 to the pool
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(2, pool.pending_transactions().len());
@@ -3251,7 +3405,7 @@ mod tests {
         pool.remove_transaction(v0.id());
 
         // Now add transaction with nonce 2
-        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
 
         // v2 is in the queue now. v1 is still in 'pending'.
         assert_eq!(1, pool.queued_transactions().len());
@@ -3272,7 +3426,7 @@ mod tests {
         assert_eq!(2, pool.pending_transactions().len());
 
         // Add transaction v3 - it 'unclogs' everything.
-        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(3, pool.pending_transactions().len());
 
@@ -3296,11 +3450,11 @@ mod tests {
         let v1 = f.validated(tx_1);
 
         // nonce gap, tx should be queued
-        pool.add_transaction(v0.clone(), U256::MAX, 0).unwrap();
+        pool.add_transaction(v0.clone(), U256::MAX, 0, None).unwrap();
         assert_eq!(1, pool.queued_transactions().len());
 
         // nonce gap is closed on-chain, both transactions should be moved to pending
-        pool.add_transaction(v1, U256::MAX, 1).unwrap();
+        pool.add_transaction(v1, U256::MAX, 1, None).unwrap();
 
         assert_eq!(2, pool.pending_transactions().len());
         assert_eq!(0, pool.queued_transactions().len());
@@ -3329,7 +3483,7 @@ mod tests {
         for tx_nonce in 40..48 {
             let tx = f.validated(template.clone().with_nonce(tx_nonce).rng_hash());
             submitted_txs.push(*tx.id());
-            pool.add_transaction(tx, on_chain_balance, on_chain_nonce).unwrap();
+            pool.add_transaction(tx, on_chain_balance, on_chain_nonce, None).unwrap();
         }
 
         // A block is mined with two txs (so nonce is changed from 40 to 42).
@@ -3345,6 +3499,7 @@ mod tests {
                 f.validated(template.clone().with_nonce(tx_nonce).rng_hash()),
                 on_chain_balance,
                 on_chain_nonce,
+                None,
             )
             .unwrap();
         }

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -122,7 +122,8 @@ impl<R: Rng> MockTransactionSimulator<R> {
                     .with_gas_price(self.base_fee);
                 let valid_tx = self.validator.validated(tx);
 
-                let res = pool.add_transaction(valid_tx, on_chain_balance, on_chain_nonce).unwrap();
+                let res =
+                    pool.add_transaction(valid_tx, on_chain_balance, on_chain_nonce, None).unwrap();
 
                 // TODO(mattsse): need a way expect based on the current state of the pool and tx
                 // settings

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -309,29 +309,10 @@ where
                 )
             }
 
-            if transaction.to().is_none() {
-                return TransactionValidationOutcome::Invalid(
-                    transaction,
-                    Eip7702PoolTransactionError::MissingEip7702To.into(),
-                )
-            }
-
             if transaction.authorization_list().is_none_or(|l| l.is_empty()) {
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into(),
-                )
-            }
-
-            let has_invalid_auth = transaction
-                .authorization_list()
-                .unwrap()
-                .iter()
-                .any(|auth| auth.recover_authority().is_err());
-            if has_invalid_auth {
-                return TransactionValidationOutcome::Invalid(
-                    transaction,
-                    Eip7702PoolTransactionError::AuthorizationRecoverFailed.into(),
                 )
             }
         }
@@ -501,6 +482,7 @@ where
         TransactionValidationOutcome::Valid {
             balance: account.balance,
             state_nonce: account.nonce,
+            bytecode_hash: account.bytecode_hash,
             transaction: ValidTransaction::new(transaction, maybe_blob_sidecar),
             // by this point assume all external transactions should be propagated
             propagate: match origin {

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -309,10 +309,29 @@ where
                 )
             }
 
+            if transaction.to().is_none() {
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    Eip7702PoolTransactionError::MissingEip7702To.into(),
+                )
+            }
+
             if transaction.authorization_list().is_none_or(|l| l.is_empty()) {
                 return TransactionValidationOutcome::Invalid(
                     transaction,
                     Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into(),
+                )
+            }
+
+            let has_invalid_auth = transaction
+                .authorization_list()
+                .unwrap()
+                .iter()
+                .any(|auth| auth.recover_authority().is_err());
+            if has_invalid_auth {
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    Eip7702PoolTransactionError::AuthorizationRecoverFailed.into(),
                 )
             }
         }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::{PoolTransaction, TransactionOrigin},
     PriceBumpConfig,
 };
-use alloy_eips::eip4844::BlobTransactionSidecar;
+use alloy_eips::{eip4844::BlobTransactionSidecar, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
 use reth_primitives_traits::{Recovered, SealedBlock};
@@ -35,6 +35,8 @@ pub enum TransactionValidationOutcome<T: PoolTransaction> {
         balance: U256,
         /// Current nonce of the sender.
         state_nonce: u64,
+        /// Code hash of the sender.
+        bytecode_hash: Option<B256>,
         /// The validated transaction.
         ///
         /// See also [`ValidTransaction`].
@@ -374,6 +376,31 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     /// The heap allocated size of this transaction.
     pub(crate) fn size(&self) -> usize {
         self.transaction.size()
+    }
+
+    /// Returns the [`SignedAuthorization`] list of the transaction.
+    ///
+    /// Returns `None` if this transaction is not EIP-7702.
+    pub fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.transaction.authorization_list()
+    }
+
+    /// Returns the Authority list of the transaction.
+    ///
+    /// Returns `None` if this transaction is not EIP-7702.
+    pub fn authority_list(&self) -> Option<Vec<Address>> {
+        self.transaction
+            .authorization_list()
+            .map(|auths| auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>())
+    }
+
+    /// Returns the number of blobs of [`SignedAuthorization`] in this transactions
+    ///
+    /// This is convenience function for `len(authorization_list)`.
+    ///
+    /// Returns `None` for non-eip7702 transactions.
+    pub fn authorization_count(&self) -> Option<u64> {
+        self.transaction.authorization_count()
     }
 
     /// EIP-4844 blob transactions and normal transactions are treated as mutually exclusive per

--- a/examples/network-txpool/src/main.rs
+++ b/examples/network-txpool/src/main.rs
@@ -89,6 +89,7 @@ impl TransactionValidator for OkValidator {
         TransactionValidationOutcome::Valid {
             balance: *transaction.cost(),
             state_nonce: transaction.nonce(),
+            bytecode_hash: None,
             transaction: ValidTransaction::Valid(transaction),
             propagate: false,
         }


### PR DESCRIPTION
This PR is a mirror of Geth's relative PR https://github.com/ethereum/go-ethereum/pull/31073

Which add two new rules for 7702 TX:
1.  In addition to tracking transactions, the pool also tracks a set of pending SetCode
authorizations (EIP7702).  As a standard rule, any account with a deployed
delegation or an in-flight authorization to deploy a delegation will only be allowed a
single transaction slot instead of the standard number. This is due to the possibility
of the account being sweeped by an unrelated account.

2. In case the pool is tracking a pending / queued transaction from a specific account, it
will reject new transactions with delegations from that account with standard in-flight
transactions.

Additionally, the identifiers were moved from the PoolInner struct to the TxPool struct because they are needed to obtain the senderId of the auth signature address, which is then used to determine whether they have transactions in the pending and queue pools.