### PR TITLE
feat: Add EIP7702 tx handle logic for txpool

### DIFF
--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -115,7 +115,9 @@ where
                 NetworkWallet::<Ethereum>::sign_request(&EthereumWallet::new(signer.clone()), tx)
                     .await?;
 
-            pending.push(provider.send_tx_envelope(tx).await?);
+            if let Ok(res) = provider.send_tx_envelope(tx).await {
+                pending.push(res);
+            }
         }
 
         let payload = node.build_and_submit_payload().await?;

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -246,6 +246,7 @@ where
             state_nonce,
             transaction: valid_tx,
             propagate,
+            bytecode_hash,
         } = outcome
         {
             let mut l1_block_info = self.block_info.l1_block_info.read().clone();
@@ -283,6 +284,7 @@ where
                 state_nonce,
                 transaction: valid_tx,
                 propagate,
+                bytecode_hash,
             }
         }
         outcome

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -247,7 +247,7 @@ where
             transaction: valid_tx,
             propagate,
             bytecode_hash,
-            authorities: _,
+            authorities,
         } = outcome
         {
             let mut l1_block_info = self.block_info.l1_block_info.read().clone();
@@ -286,7 +286,7 @@ where
                 transaction: valid_tx,
                 propagate,
                 bytecode_hash,
-                authorities: None,
+                authorities,
             }
         }
         outcome

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -247,6 +247,7 @@ where
             transaction: valid_tx,
             propagate,
             bytecode_hash,
+            authorities: _,
         } = outcome
         {
             let mut l1_block_info = self.block_info.l1_block_info.read().clone();
@@ -285,6 +286,7 @@ where
                 transaction: valid_tx,
                 propagate,
                 bytecode_hash,
+                authorities: None,
             }
         }
         outcome

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -185,6 +185,12 @@ pub enum Eip7702PoolTransactionError {
     /// Thrown if the transaction has no items in its authorization list
     #[error("no items in authorization list for EIP7702 transaction")]
     MissingEip7702AuthorizationList,
+    /// Thrown if the transaction has no to
+    #[error("no to address for EIP7702 transaction")]
+    MissingEip7702To,
+    /// Thrown if any of the transaction authorities cannot be recovered
+    #[error("failed to recover authority from EIP7702 transaction")]
+    AuthorizationRecoverFailed,
 }
 
 /// Represents errors that can happen when validating transactions for the pool
@@ -333,7 +339,9 @@ impl InvalidPoolTransactionError {
                 }
             }
             Self::Eip7702(eip7702_err) => match eip7702_err {
-                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => false,
+                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => true,
+                Eip7702PoolTransactionError::MissingEip7702To => true,
+                Eip7702PoolTransactionError::AuthorizationRecoverFailed => true,
             },
         }
     }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -185,12 +185,19 @@ pub enum Eip7702PoolTransactionError {
     /// Thrown if the transaction has no items in its authorization list
     #[error("no items in authorization list for EIP7702 transaction")]
     MissingEip7702AuthorizationList,
-    /// Thrown if the transaction has no to
-    #[error("no to address for EIP7702 transaction")]
-    MissingEip7702To,
-    /// Thrown if any of the transaction authorities cannot be recovered
-    #[error("failed to recover authority from EIP7702 transaction")]
-    AuthorizationRecoverFailed,
+    /// Returned when the transaction with gapped
+    /// nonce received from the accounts with delegation or pending delegation.
+    #[error("gapped-nonce tx from delegated accounts")]
+    OutOfOrderTxFromDelegated,
+    /// Returned when the maximum number of in-flight
+    /// transactions is reached for specific accounts.
+    #[error("in-flight transaction limit reached for delegated accounts")]
+    InflightTxLimitReached,
+    /// Returned if a transaction has an authorization
+    /// signed by an address which already has in-flight transactions known to the
+    /// pool.
+    #[error("authority already reserved")]
+    AuthorityReserved,
 }
 
 /// Represents errors that can happen when validating transactions for the pool
@@ -340,8 +347,9 @@ impl InvalidPoolTransactionError {
             }
             Self::Eip7702(eip7702_err) => match eip7702_err {
                 Eip7702PoolTransactionError::MissingEip7702AuthorizationList => true,
-                Eip7702PoolTransactionError::MissingEip7702To => true,
-                Eip7702PoolTransactionError::AuthorizationRecoverFailed => true,
+                Eip7702PoolTransactionError::OutOfOrderTxFromDelegated => false,
+                Eip7702PoolTransactionError::InflightTxLimitReached => false,
+                Eip7702PoolTransactionError::AuthorityReserved => false,
             },
         }
     }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -346,7 +346,12 @@ impl InvalidPoolTransactionError {
                 }
             }
             Self::Eip7702(eip7702_err) => match eip7702_err {
-                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => true,
+                Eip7702PoolTransactionError::MissingEip7702AuthorizationList => {
+                    // as EIP-7702 specifies, 7702 transactions must have an non-empty authorization
+                    // list so this is a malformed transaction and should not be
+                    // sent over the network
+                    true
+                }
                 Eip7702PoolTransactionError::OutOfOrderTxFromDelegated => false,
                 Eip7702PoolTransactionError::InflightTxLimitReached => false,
                 Eip7702PoolTransactionError::AuthorityReserved => false,

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -185,8 +185,8 @@ pub enum Eip7702PoolTransactionError {
     /// Thrown if the transaction has no items in its authorization list
     #[error("no items in authorization list for EIP7702 transaction")]
     MissingEip7702AuthorizationList,
-    /// Returned when the transaction with gapped
-    /// nonce received from the accounts with delegation or pending delegation.
+    /// Returned when a transaction with a nonce
+    /// gap is received from accounts with a deployed delegation or pending delegation.
     #[error("gapped-nonce tx from delegated accounts")]
     OutOfOrderTxFromDelegated,
     /// Returned when the maximum number of in-flight

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -367,6 +367,7 @@ impl<T: EthPoolTransaction> TransactionValidator for MockTransactionValidator<T>
                 TransactionOrigin::Local => self.propagate_local,
                 TransactionOrigin::Private => false,
             },
+            authorities: None,
         }
     }
 }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -360,6 +360,7 @@ impl<T: EthPoolTransaction> TransactionValidator for MockTransactionValidator<T>
         TransactionValidationOutcome::Valid {
             balance: U256::MAX,
             state_nonce: 0,
+            bytecode_hash: None,
             transaction: ValidTransaction::new(transaction, maybe_sidecar),
             propagate: match origin {
                 TransactionOrigin::External => true,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -68,7 +68,7 @@
 use crate::{
     blobstore::BlobStore,
     error::{PoolError, PoolErrorKind, PoolResult},
-    identifier::{SenderId, TransactionId},
+    identifier::{SenderId, SenderIdentifiers, TransactionId},
     metrics::BlobStoreMetrics,
     pool::{
         listener::{
@@ -131,6 +131,8 @@ pub struct PoolInner<V, T, S>
 where
     T: TransactionOrdering,
 {
+    /// Internal mapping of addresses to plain ints.
+    identifiers: RwLock<SenderIdentifiers>,
     /// Transaction validator.
     validator: V,
     /// Storage for blob transactions
@@ -162,6 +164,7 @@ where
     /// Create a new transaction pool instance.
     pub fn new(validator: V, ordering: T, blob_store: S, config: PoolConfig) -> Self {
         Self {
+            identifiers: Default::default(),
             validator,
             event_listener: Default::default(),
             pool: RwLock::new(TxPool::new(ordering, config.clone())),
@@ -195,7 +198,7 @@ where
 
     /// Returns the internal [`SenderId`] for this address
     pub fn get_sender_id(&self, addr: Address) -> SenderId {
-        self.pool.write().get_sender_id(addr)
+        self.identifiers.write().sender_id_or_create(addr)
     }
 
     /// Returns all senders in the pool
@@ -209,7 +212,14 @@ where
         &self,
         accs: impl Iterator<Item = ChangedAccount>,
     ) -> FxHashMap<SenderId, SenderInfo> {
-        self.pool.write().changed_senders(accs)
+        let mut identifiers = self.identifiers.write();
+        accs.into_iter()
+            .map(|acc| {
+                let ChangedAccount { address, nonce, balance } = acc;
+                let sender_id = identifiers.sender_id_or_create(address);
+                (sender_id, SenderInfo { state_nonce: nonce, balance })
+            })
+            .collect()
     }
 
     /// Get the config the pool was configured with.
@@ -430,8 +440,9 @@ where
                 transaction,
                 propagate,
                 bytecode_hash,
+                authorities,
             } => {
-                let sender_id = pool.get_sender_id(transaction.sender());
+                let sender_id = self.get_sender_id(transaction.sender());
                 let transaction_id = TransactionId::new(sender_id, transaction.nonce());
 
                 // split the valid transaction and the blob sidecar if it has any
@@ -452,6 +463,8 @@ where
                     propagate,
                     timestamp: Instant::now(),
                     origin,
+                    authority_ids: authorities
+                        .map(|auths| auths.iter().map(|auth| self.get_sender_id(*auth)).collect()),
                 };
 
                 let added = pool.add_transaction(tx, balance, state_nonce, bytecode_hash)?;
@@ -1249,6 +1262,7 @@ mod tests {
                         sidecar: sidecar.clone(),
                     },
                     propagate: true,
+                    authorities: None,
                 }],
             );
         }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -68,7 +68,7 @@
 use crate::{
     blobstore::BlobStore,
     error::{PoolError, PoolErrorKind, PoolResult},
-    identifier::{SenderId, SenderIdentifiers, TransactionId},
+    identifier::{SenderId, TransactionId},
     metrics::BlobStoreMetrics,
     pool::{
         listener::{
@@ -131,8 +131,6 @@ pub struct PoolInner<V, T, S>
 where
     T: TransactionOrdering,
 {
-    /// Internal mapping of addresses to plain ints.
-    identifiers: RwLock<SenderIdentifiers>,
     /// Transaction validator.
     validator: V,
     /// Storage for blob transactions
@@ -164,7 +162,6 @@ where
     /// Create a new transaction pool instance.
     pub fn new(validator: V, ordering: T, blob_store: S, config: PoolConfig) -> Self {
         Self {
-            identifiers: Default::default(),
             validator,
             event_listener: Default::default(),
             pool: RwLock::new(TxPool::new(ordering, config.clone())),
@@ -198,7 +195,7 @@ where
 
     /// Returns the internal [`SenderId`] for this address
     pub fn get_sender_id(&self, addr: Address) -> SenderId {
-        self.identifiers.write().sender_id_or_create(addr)
+        self.pool.write().get_sender_id(addr)
     }
 
     /// Returns all senders in the pool
@@ -212,14 +209,7 @@ where
         &self,
         accs: impl Iterator<Item = ChangedAccount>,
     ) -> FxHashMap<SenderId, SenderInfo> {
-        let mut identifiers = self.identifiers.write();
-        accs.into_iter()
-            .map(|acc| {
-                let ChangedAccount { address, nonce, balance } = acc;
-                let sender_id = identifiers.sender_id_or_create(address);
-                (sender_id, SenderInfo { state_nonce: nonce, balance })
-            })
-            .collect()
+        self.pool.write().changed_senders(accs)
     }
 
     /// Get the config the pool was configured with.
@@ -439,8 +429,9 @@ where
                 state_nonce,
                 transaction,
                 propagate,
+                bytecode_hash,
             } => {
-                let sender_id = self.get_sender_id(transaction.sender());
+                let sender_id = pool.get_sender_id(transaction.sender());
                 let transaction_id = TransactionId::new(sender_id, transaction.nonce());
 
                 // split the valid transaction and the blob sidecar if it has any
@@ -463,7 +454,7 @@ where
                     origin,
                 };
 
-                let added = pool.add_transaction(tx, balance, state_nonce)?;
+                let added = pool.add_transaction(tx, balance, state_nonce, bytecode_hash)?;
                 let hash = *added.hash();
 
                 // transaction was successfully inserted into the pool
@@ -1252,6 +1243,7 @@ mod tests {
                 [TransactionValidationOutcome::Valid {
                     balance: U256::from(1_000),
                     state_nonce: 0,
+                    bytecode_hash: None,
                     transaction: ValidTransaction::ValidWithSidecar {
                         transaction: tx,
                         sidecar: sidecar.clone(),

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3602,7 +3602,7 @@ mod tests {
             tx6.clone(),
             tx7.clone(),
         ] {
-            pool.add_transaction(f.validated(tx.clone()), on_chain_balance, on_chain_nonce)
+            pool.add_transaction(f.validated(tx.clone()), on_chain_balance, on_chain_nonce, None)
                 .unwrap();
         }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3396,7 +3396,7 @@ mod tests {
         let v2 = f.validated(tx_2);
         let v3 = f.validated(tx_3);
 
-        // Add them to the pool
+        // Add them to the  pool
         let _res =
             pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
         let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -724,10 +724,10 @@ impl<T: TransactionOrdering> TxPool<T> {
         }
     }
 
-    // check_delegation_limit determines if the tx sender is delegated or has a
-    // pending delegation, and if so, ensures they have at most one in-flight
-    // **executable** transaction, e.g. disallow stacked and gapped transactions
-    // from the account.
+    /// Determines if the tx sender is delegated or has a
+    /// pending delegation, and if so, ensures they have at most one in-flight
+    /// **executable** transaction, e.g. disallow stacked and nonce-gapped transactions
+    /// from the account.
     fn check_delegation_limit(
         &self,
         transaction: &ValidPoolTransaction<T::Transaction>,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -768,14 +768,14 @@ impl<T: TransactionOrdering> TxPool<T> {
         ))
     }
 
-    // validate_auth verifies that the transaction complies with code authorization
-    // restrictions brought by SetCode transaction type:
-    // 1. Any account with a deployed delegation or an in-flight authorization to deploy a
-    //    delegation will only be allowed a single transaction slot instead of the standard number.
-    //    This is due to the possibility of the account being sweeped by an unrelated account.
-    // 2. In case the pool is tracking a pending / queued transaction from a specific account, it
-    //    will reject new transactions with delegations from that account with standard in-flight
-    //    transactions.
+    /// This verifies that the transaction complies with code authorization
+    /// restrictions brought by EIP-7702 transaction type:
+    /// 1. Any account with a deployed delegation or an in-flight authorization to deploy a
+    ///    delegation will only be allowed a single transaction slot instead of the standard limit.
+    ///    This is due to the possibility of the account being sweeped by an unrelated account.
+    /// 2. In case the pool is tracking a pending / queued transaction from a specific account, it
+    ///    will reject new transactions with delegations from that account with standard in-flight
+    ///    transactions.
     fn validate_auth(
         &self,
         transaction: &ValidPoolTransaction<T::Transaction>,
@@ -1591,14 +1591,14 @@ impl<T: PoolTransaction> AllTransactions<T> {
     }
 
     fn remove_auths(&mut self, tx: &PoolInternalTransaction<T>) {
-        if let Some(auths) = &tx.transaction.authority_ids {
-            let tx_hash = tx.transaction.hash();
-            for auth in auths {
-                if let Some(list) = self.auths.get_mut(auth) {
-                    list.remove(tx_hash);
-                    if list.is_empty() {
-                        self.auths.remove(auth);
-                    }
+        let Some(auths) = &tx.transaction.authority_ids else { return };
+
+        let tx_hash = tx.transaction.hash();
+        for auth in auths {
+            if let Some(list) = self.auths.get_mut(auth) {
+                list.remove(tx_hash);
+                if list.is_empty() {
+                    self.auths.remove(auth);
                 }
             }
         }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3157,9 +3157,10 @@ mod tests {
         let v1 = f.validated(tx_1);
         let v2 = f.validated(tx_2);
 
-        let _res = pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce).unwrap();
+        let _res =
+            pool.add_transaction(v0.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
 
         // The sender does not have enough balance to put all txs into pending.
         assert_eq!(1, pool.pending_transactions().len());
@@ -3319,10 +3320,11 @@ mod tests {
         let v3 = f.validated(tx_3);
 
         // Add them to the pool
-        let _res = pool.add_transaction(v0, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce).unwrap();
-        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce).unwrap();
+        let _res = pool.add_transaction(v0, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res =
+            pool.add_transaction(v1.clone(), on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v2, on_chain_balance, on_chain_nonce, None).unwrap();
+        let _res = pool.add_transaction(v3, on_chain_balance, on_chain_nonce, None).unwrap();
 
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(4, pool.pending_transactions().len());
@@ -3336,7 +3338,7 @@ mod tests {
         // reinsert
         let removed_tx = removed_txs.pop().unwrap();
         let v1 = f.validated(removed_tx.transaction.clone());
-        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce).unwrap();
+        let _res = pool.add_transaction(v1, on_chain_balance, on_chain_nonce, None).unwrap();
         assert_eq!(0, pool.queued_transactions().len());
         assert_eq!(4, pool.pending_transactions().len());
     }

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1349,6 +1349,7 @@ impl MockTransactionFactory {
             transaction,
             timestamp: Instant::now(),
             origin,
+            authority_ids: None,
         }
     }
 

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -122,7 +122,8 @@ impl<R: Rng> MockTransactionSimulator<R> {
                     .with_gas_price(self.base_fee);
                 let valid_tx = self.validator.validated(tx);
 
-                let res = pool.add_transaction(valid_tx, on_chain_balance, on_chain_nonce).unwrap();
+                let res =
+                    pool.add_transaction(valid_tx, on_chain_balance, on_chain_nonce, None).unwrap();
 
                 // TODO(mattsse): need a way expect based on the current state of the pool and tx
                 // settings

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -561,6 +561,9 @@ where
             }
         }
 
+        let authorities = transaction.authorization_list().map(|auths| {
+            auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>()
+        });
         // Return the valid transaction
         TransactionValidationOutcome::Valid {
             balance: account.balance,
@@ -575,6 +578,7 @@ where
                 }
                 TransactionOrigin::Private => false,
             },
+            authorities,
         }
     }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -390,11 +390,30 @@ where
                 ))
             }
 
+            if transaction.to().is_none() {
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    Eip7702PoolTransactionError::MissingEip7702To.into(),
+                )
+            }
+
             if transaction.authorization_list().is_none_or(|l| l.is_empty()) {
                 return Err(TransactionValidationOutcome::Invalid(
                     transaction,
                     Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into(),
                 ))
+            }
+
+            let has_invalid_auth = transaction
+                .authorization_list()
+                .unwrap()
+                .iter()
+                .any(|auth| auth.recover_authority().is_err());
+            if has_invalid_auth {
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    Eip7702PoolTransactionError::AuthorizationRecoverFailed.into(),
+                )
             }
         }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -390,30 +390,11 @@ where
                 ))
             }
 
-            if transaction.to().is_none() {
-                return TransactionValidationOutcome::Invalid(
-                    transaction,
-                    Eip7702PoolTransactionError::MissingEip7702To.into(),
-                )
-            }
-
             if transaction.authorization_list().is_none_or(|l| l.is_empty()) {
                 return Err(TransactionValidationOutcome::Invalid(
                     transaction,
                     Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into(),
                 ))
-            }
-
-            let has_invalid_auth = transaction
-                .authorization_list()
-                .unwrap()
-                .iter()
-                .any(|auth| auth.recover_authority().is_err());
-            if has_invalid_auth {
-                return TransactionValidationOutcome::Invalid(
-                    transaction,
-                    Eip7702PoolTransactionError::AuthorizationRecoverFailed.into(),
-                )
             }
         }
 
@@ -584,6 +565,7 @@ where
         TransactionValidationOutcome::Valid {
             balance: account.balance,
             state_nonce: account.nonce,
+            bytecode_hash: account.bytecode_hash,
             transaction: ValidTransaction::new(transaction, maybe_blob_sidecar),
             // by this point assume all external transactions should be propagated
             propagate: match origin {

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -46,6 +46,8 @@ pub enum TransactionValidationOutcome<T: PoolTransaction> {
         transaction: ValidTransaction<T>,
         /// Whether to propagate the transaction to the network.
         propagate: bool,
+        /// The authorities of EIP-7702 transaction.
+        authorities: Option<Vec<Address>>,
     },
     /// The transaction is considered invalid indefinitely: It violates constraints that prevent
     /// this transaction from ever becoming valid.
@@ -270,6 +272,8 @@ pub struct ValidPoolTransaction<T: PoolTransaction> {
     pub timestamp: Instant,
     /// Where this transaction originated from.
     pub origin: TransactionOrigin,
+    /// The sender ids of the 7702 transaction authorities.
+    pub authority_ids: Option<Vec<SenderId>>,
 }
 
 // === impl ValidPoolTransaction ===
@@ -481,6 +485,7 @@ impl<T: PoolTransaction> Clone for ValidPoolTransaction<T> {
             propagate: self.propagate,
             timestamp: self.timestamp,
             origin: self.origin,
+            authority_ids: self.authority_ids.clone(),
         }
     }
 }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -389,15 +389,6 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         self.transaction.authorization_list()
     }
 
-    /// Returns the Authority list of the transaction.
-    ///
-    /// Returns `None` if this transaction is not EIP-7702.
-    pub fn authority_list(&self) -> Option<Vec<Address>> {
-        self.transaction
-            .authorization_list()
-            .map(|auths| auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>())
-    }
-
     /// Returns the number of blobs of [`SignedAuthorization`] in this transactions
     ///
     /// This is convenience function for `len(authorization_list)`.

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::{PoolTransaction, TransactionOrigin},
     PriceBumpConfig,
 };
-use alloy_eips::eip4844::BlobTransactionSidecar;
+use alloy_eips::{eip4844::BlobTransactionSidecar, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
 use reth_primitives_traits::{Recovered, SealedBlock};
@@ -35,6 +35,8 @@ pub enum TransactionValidationOutcome<T: PoolTransaction> {
         balance: U256,
         /// Current nonce of the sender.
         state_nonce: u64,
+        /// Code hash of the sender.
+        bytecode_hash: Option<B256>,
         /// The validated transaction.
         ///
         /// See also [`ValidTransaction`].
@@ -374,6 +376,31 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     /// The heap allocated size of this transaction.
     pub(crate) fn size(&self) -> usize {
         self.transaction.size()
+    }
+
+    /// Returns the [`SignedAuthorization`] list of the transaction.
+    ///
+    /// Returns `None` if this transaction is not EIP-7702.
+    pub fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.transaction.authorization_list()
+    }
+
+    /// Returns the Authority list of the transaction.
+    ///
+    /// Returns `None` if this transaction is not EIP-7702.
+    pub fn authority_list(&self) -> Option<Vec<Address>> {
+        self.transaction
+            .authorization_list()
+            .map(|auths| auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>())
+    }
+
+    /// Returns the number of blobs of [`SignedAuthorization`] in this transactions
+    ///
+    /// This is convenience function for `len(authorization_list)`.
+    ///
+    /// Returns `None` for non-eip7702 transactions.
+    pub fn authorization_count(&self) -> Option<u64> {
+        self.transaction.authorization_count()
     }
 
     /// EIP-4844 blob transactions and normal transactions are treated as mutually exclusive per

--- a/examples/network-txpool/src/main.rs
+++ b/examples/network-txpool/src/main.rs
@@ -91,6 +91,7 @@ impl TransactionValidator for OkValidator {
         TransactionValidationOutcome::Valid {
             balance: *transaction.cost(),
             state_nonce: transaction.nonce(),
+            bytecode_hash: None,
             transaction: ValidTransaction::Valid(transaction),
             propagate: false,
         }

--- a/examples/network-txpool/src/main.rs
+++ b/examples/network-txpool/src/main.rs
@@ -88,12 +88,16 @@ impl TransactionValidator for OkValidator {
         transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
         // Always return valid
+        let authorities = transaction.authorization_list().map(|auths| {
+            auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>()
+        });
         TransactionValidationOutcome::Valid {
             balance: *transaction.cost(),
             state_nonce: transaction.nonce(),
             bytecode_hash: None,
             transaction: ValidTransaction::Valid(transaction),
             propagate: false,
+            authorities,
         }
     }
 }


### PR DESCRIPTION
This PR is a mirror of Geth's relative PR https://github.com/ethereum/go-ethereum/pull/31073

Which add two new rules for 7702 TX:
1.  In addition to tracking transactions, the pool also tracks a set of pending SetCode
authorizations (EIP7702).  As a standard rule, any account with a deployed
delegation or an in-flight authorization to deploy a delegation will only be allowed a
single transaction slot instead of the standard number. This is due to the possibility
of the account being sweeped by an unrelated account.

2. In case the pool is tracking a pending / queued transaction from a specific account, it
will reject new transactions with delegations from that account with standard in-flight
transactions.
