### PR TITLE
Fixes #15321 feat(txpool): properly parse supervisor RPC errors into interop variants 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9006,6 +9006,7 @@ version = "1.3.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-json-rpc",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",

--- a/crates/optimism/txpool/Cargo.toml
+++ b/crates/optimism/txpool/Cargo.toml
@@ -18,6 +18,7 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-client = { workspace = true, features = ["reqwest", "default"] }
+alloy-json-rpc.workspace = true
 
 # reth
 reth-chainspec.workspace = true

--- a/crates/optimism/txpool/src/supervisor/errors.rs
+++ b/crates/optimism/txpool/src/supervisor/errors.rs
@@ -139,6 +139,7 @@ impl InteropTxValidatorError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_json_rpc::RpcError;
 
     const MIN_SAFETY_CROSS_UNSAFE_ERROR: &str = "message {0x4200000000000000000000000000000000000023 4 1 1728507701 901} (safety level: unsafe) does not meet the minimum safety cross-unsafe";
     const MIN_SAFETY_UNSAFE_ERROR: &str = "message {0x4200000000000000000000000000000000000023 1091637521 4369 0 901} (safety level: invalid) does not meet the minimum safety unsafe";

--- a/crates/optimism/txpool/src/supervisor/errors.rs
+++ b/crates/optimism/txpool/src/supervisor/errors.rs
@@ -139,7 +139,7 @@ impl InteropTxValidatorError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_json_rpc::RpcError;
+    use alloy_json_rpc::{ErrorPayload, RpcError};
 
     const MIN_SAFETY_CROSS_UNSAFE_ERROR: &str = "message {0x4200000000000000000000000000000000000023 4 1 1728507701 901} (safety level: unsafe) does not meet the minimum safety cross-unsafe";
     const MIN_SAFETY_UNSAFE_ERROR: &str = "message {0x4200000000000000000000000000000000000023 1091637521 4369 0 901} (safety level: invalid) does not meet the minimum safety unsafe";
@@ -184,7 +184,9 @@ mod tests {
 
     #[test]
     fn test_client_error_parsing() {
-        let rpc_err = RpcError::Custom(MIN_SAFETY_CROSS_UNSAFE_ERROR.to_string());
+        let err =
+            ErrorPayload { code: 0, message: MIN_SAFETY_CROSS_UNSAFE_ERROR.into(), data: None };
+        let rpc_err = RpcError::<InvalidInboxEntry>::ErrorResp(err);
         let error = InteropTxValidatorError::client(rpc_err);
 
         assert!(matches!(
@@ -196,7 +198,8 @@ mod tests {
         ));
 
         // Testing with Unknown message
-        let rpc_err = RpcError::Custom("unknown error".to_string());
+        let err = ErrorPayload { code: 0, message: "unknown error".into(), data: None };
+        let rpc_err = RpcError::<InvalidInboxEntry>::ErrorResp(err);
         let error = InteropTxValidatorError::client(rpc_err);
         assert!(matches!(error, InteropTxValidatorError::RpcClientError(_)));
     }


### PR DESCRIPTION
Fixes #15321 Enhances error handling to properly map RPC errors from the supervisor into 
specific InvalidInboxEntry variants by parsing error messages. Adds tests to 
verify error mapping behavior for safety level and chain ID errors.