### PR TITLE
chore: add warning unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8243,7 +8243,6 @@ dependencies = [
  "reth-discv5",
  "reth-dns-discovery",
  "reth-ecies",
- "reth-engine-primitives",
  "reth-eth-wire",
  "reth-eth-wire-types",
  "reth-ethereum-forks",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -22,7 +22,6 @@ reth-network-p2p.workspace = true
 reth-discv4.workspace = true
 reth-discv5.workspace = true
 reth-dns-discovery.workspace = true
-reth-engine-primitives.workspace = true
 reth-ethereum-forks.workspace = true
 reth-eth-wire.workspace = true
 reth-eth-wire-types.workspace = true

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -71,7 +71,6 @@ secp256k1 = { workspace = true, features = ["global-context", "std", "recovery"]
 derive_more.workspace = true
 schnellru.workspace = true
 itertools.workspace = true
-tempfile = { workspace = true, optional = true }
 smallvec.workspace = true
 
 [dev-dependencies]
@@ -129,7 +128,6 @@ serde = [
     "reth-network-api/serde",
 ]
 test-utils = [
-    "dep:tempfile",
     "reth-transaction-pool/test-utils",
     "reth-network-types/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -115,6 +115,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![allow(unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -174,3 +175,5 @@ pub use reth_network_p2p as p2p;
 
 /// re-export types crate
 pub use reth_eth_wire_types as types;
+
+use aquamarine as _;


### PR DESCRIPTION
we were missing the unused dep warning, likely because the aquamarine dep always causes issues here