### PR TITLE
Feat: add validate_one_with_state implemenation for op and eth validator

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -76,6 +76,21 @@ where
         self.inner.validate_one(origin, transaction)
     }
 
+    /// Validates a single transaction with the provided state provider.
+    ///
+    /// This allows reusing the same provider across multiple transaction validations,
+    /// which can improve performance when validating many transactions.
+    ///
+    /// If `state` is `None`, a new state provider will be created.
+    pub fn validate_one_with_state(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+        state: &mut Option<Box<dyn StateProvider>>,
+    ) -> TransactionValidationOutcome<Tx> {
+        self.inner.validate_one_with_provider(origin, transaction, state)
+    }
+
     /// Validates all given transactions.
     ///
     /// Returns all outcomes for the given transactions in the same order.


### PR DESCRIPTION
Closes: #15298

Adds `validate_one_with_state` impl for `OpTransactionValidator` and `EthTransactionValidator`.
I choose this solution The new method has better name that clearly communicates its purpose - validating a transaction with an optional state provider. By this way we don't risk breaking existing code that calls `validate_one`.

cc @emhane Let me know what do you think, Also do you think I should add test for these changes.