### PR TITLE
chore: fixed dead link `lighthouse-book`

### DIFF
--- a/examples/beacon-api-sse/src/main.rs
+++ b/examples/beacon-api-sse/src/main.rs
@@ -13,7 +13,7 @@
 //! **NOTE**: This expects that the CL client is running an http server on `localhost:5052` and is
 //! configured to emit payload attributes events.
 //!
-//! See lighthouse beacon Node API: <https://lighthouse-book.sigmaprime.io/api-bn.html#beacon-node-api>
+//! See lighthouse beacon Node API: <https://lighthouse-book.sigmaprime.io/api_bn.html#beacon-node-api>
 
 #![warn(unused_crate_dependencies)]
 


### PR DESCRIPTION
hey! I corrects a broken documentation link in the Beacon API SSE example.