### PR TITLE
chore(optimism): Remove interop L1 info transaction variant

### DIFF
--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -14,9 +14,6 @@ const L1_BLOCK_ECOTONE_SELECTOR: [u8; 4] = hex!("440a5e20");
 /// The function selector of the "setL1BlockValuesIsthmus" function in the `L1Block` contract.
 const L1_BLOCK_ISTHMUS_SELECTOR: [u8; 4] = hex!("098999be");
 
-/// The function selector of the "setL1BlockValuesInterop" function in the `L1Block` contract.
-const L1_BLOCK_INTEROP_SELECTOR: [u8; 4] = hex!("760ee04d");
-
 /// Extracts the [`L1BlockInfo`] from the L2 block. The L1 info transaction is always the first
 /// transaction in the L2 block.
 ///
@@ -54,13 +51,12 @@ pub fn extract_l1_info_from_tx<T: Transaction>(
 /// # Panics
 /// If the input is shorter than 4 bytes.
 pub fn parse_l1_info(input: &[u8]) -> Result<L1BlockInfo, OpBlockExecutionError> {
-    // If the first 4 bytes of the calldata are the L1BlockInfoEcotone selector, then we parse the
-    // calldata as an Ecotone hardfork L1BlockInfo transaction. Otherwise, we parse it as a
-    // Bedrock hardfork L1BlockInfo transaction.
-    if input[0..4] == L1_BLOCK_INTEROP_SELECTOR {
-        // TODO: update once interop is compatible with isthmus, for now it only works with ecotone: <https://github.com/paradigmxyz/reth/pull/14869/files#r1987107404>
-        parse_l1_info_tx_ecotone(input[4..].as_ref())
-    } else if input[0..4] == L1_BLOCK_ISTHMUS_SELECTOR {
+    // Parse the L1 info transaction into an L1BlockInfo struct, depending on the function selector.
+    // There are currently 3 variants:
+    // - Isthmus
+    // - Ecotone
+    // - Bedrock
+    if input[0..4] == L1_BLOCK_ISTHMUS_SELECTOR {
         parse_l1_info_tx_isthmus(input[4..].as_ref())
     } else if input[0..4] == L1_BLOCK_ECOTONE_SELECTOR {
         parse_l1_info_tx_ecotone(input[4..].as_ref())


### PR DESCRIPTION
## Overview

Removes the stubbed-out L1 info transaction variant for the interop hardfork. This was removed recently, and the interop hardfork will continue to use the Isthmus variant of the `L1Block` contract.

closes #14941