### PR TITLE
export `LowestAvailableBlocks` in `reth_provider::providers`

### DIFF
--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -15,7 +15,7 @@ pub use static_file::{
 
 mod state;
 pub use state::{
-    historical::{HistoricalStateProvider, HistoricalStateProviderRef},
+    historical::{HistoricalStateProvider, HistoricalStateProviderRef, LowestAvailableBlocks},
     latest::{LatestStateProvider, LatestStateProviderRef},
 };
 


### PR DESCRIPTION
The public method [`HistoricalStateProviderRef::new_with_lowest_available_blocks`](https://reth.rs/docs/reth_provider/providers/struct.HistoricalStateProviderRef.html#method.new_with_lowest_available_blocks) takes [`LowestAvailableBlocks`](https://github.com/paradigmxyz/reth/blob/faedf98db3b1c965052b12b1663038a078807780/crates/storage/provider/src/providers/state/historical.rs#L510) as an argument, which is not exported, making this method unusable from outside the crate