### PR TITLE
chore: Iterate each test case in ef-tests in parallel

### DIFF
--- a/testing/ef-tests/src/case.rs
+++ b/testing/ef-tests/src/case.rs
@@ -1,6 +1,7 @@
 //! Test case definitions
 
 use crate::result::{CaseResult, Error};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
     fmt::Debug,
     path::{Path, PathBuf},
@@ -34,6 +35,9 @@ pub struct Cases<T> {
 impl<T: Case> Cases<T> {
     /// Run the contained test cases.
     pub fn run(&self) -> Vec<CaseResult> {
-        self.test_cases.iter().map(|(path, case)| CaseResult::new(path, case, case.run())).collect()
+        self.test_cases
+            .par_iter()
+            .map(|(path, case)| CaseResult::new(path, case, case.run()))
+            .collect()
     }
 }


### PR DESCRIPTION
When calling `make ef-tests` my laptop timeouts on the blockchain tests. 

Replacing `iter` with `par_iter` speeds up the tests to the point that it no longer times out on my laptop.