### PR TITLE
chore: silence warning in optimized build

### DIFF
--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -177,3 +177,5 @@ pub use reth_network_p2p as p2p;
 pub use reth_eth_wire_types as types;
 
 use aquamarine as _;
+
+use smallvec as _;

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -52,8 +52,6 @@ use reth_network_p2p::error::{RequestError, RequestResult};
 use reth_network_peers::PeerId;
 use reth_primitives_traits::SignedTransaction;
 use schnellru::ByLength;
-#[cfg(debug_assertions)]
-use smallvec::{smallvec, SmallVec};
 use std::{
     collections::HashMap,
     pin::Pin,
@@ -1180,7 +1178,7 @@ impl<T: SignedTransaction> VerifyPooledTransactionsResponse for UnverifiedPooled
         let Self { mut txns } = self;
 
         #[cfg(debug_assertions)]
-        let mut tx_hashes_not_requested: SmallVec<[TxHash; 16]> = smallvec!();
+        let mut tx_hashes_not_requested: smallvec::SmallVec<[TxHash; 16]> = smallvec::smallvec!();
         #[cfg(not(debug_assertions))]
         let mut tx_hashes_not_requested_count = 0;
 


### PR DESCRIPTION
if compiled without debug assert this would show up:

```
warning: extern crate `smallvec` is unused in crate `reth_network`
    |
    = help: remove the dependency or add `use smallvec as _;` to the crate root
note: the lint level is defined here
   --> crates/net/network/src/lib.rs:118:29
    |
118 | #![cfg_attr(not(test), warn(unused_crate_dependencies))]
```