### PR TITLE
added chain condition and imports

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -263,4 +263,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -242,4 +242,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -233,4 +233,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -308,4 +308,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }

--- a/bin/reth/src/commands/debug_cmd/mod.rs
+++ b/bin/reth/src/commands/debug_cmd/mod.rs
@@ -7,6 +7,7 @@ use reth_cli_commands::common::CliNodeTypes;
 use reth_cli_runner::CliContext;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_node_ethereum::EthEngineTypes;
+use std::sync::Arc;
 
 mod build_block;
 mod execution;
@@ -50,6 +51,15 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             Subcommands::Merkle(command) => command.execute::<N>(ctx).await,
             Subcommands::InMemoryMerkle(command) => command.execute::<N>(ctx).await,
             Subcommands::BuildBlock(command) => command.execute::<N>(ctx).await,
+        }
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        match &self.command {
+            Subcommands::Execution(command) => command.chain_spec(),
+            Subcommands::Merkle(command) => command.chain_spec(),
+            Subcommands::InMemoryMerkle(command) => command.chain_spec(),
+            Subcommands::BuildBlock(command) => command.chain_spec(),
         }
     }
 }

--- a/book/cli/reth.md
+++ b/book/cli/reth.md
@@ -24,15 +24,6 @@ Commands:
   help          Print this message or the help of the given subcommand(s)
 
 Options:
-      --chain <CHAIN_OR_PATH>
-          The chain this node is running.
-          Possible values are either a built-in chain or the path to a chain specification file.
-
-          Built-in chains:
-              mainnet, sepolia, holesky, hoodi, dev
-
-          [default: mainnet]
-
       --instance <INSTANCE>
           Add a new instance of a node.
 

--- a/book/cli/reth/config.md
+++ b/book/cli/reth/config.md
@@ -15,15 +15,6 @@ Options:
       --default
           Show the default config
 
-      --chain <CHAIN_OR_PATH>
-          The chain this node is running.
-          Possible values are either a built-in chain or the path to a chain specification file.
-
-          Built-in chains:
-              mainnet, sepolia, holesky, hoodi, dev
-
-          [default: mainnet]
-
       --instance <INSTANCE>
           Add a new instance of a node.
 

--- a/book/cli/reth/debug.md
+++ b/book/cli/reth/debug.md
@@ -16,15 +16,6 @@ Commands:
   help              Print this message or the help of the given subcommand(s)
 
 Options:
-      --chain <CHAIN_OR_PATH>
-          The chain this node is running.
-          Possible values are either a built-in chain or the path to a chain specification file.
-
-          Built-in chains:
-              mainnet, sepolia, holesky, hoodi, dev
-
-          [default: mainnet]
-
       --instance <INSTANCE>
           Add a new instance of a node.
 

--- a/book/cli/reth/recover.md
+++ b/book/cli/reth/recover.md
@@ -13,15 +13,6 @@ Commands:
   help           Print this message or the help of the given subcommand(s)
 
 Options:
-      --chain <CHAIN_OR_PATH>
-          The chain this node is running.
-          Possible values are either a built-in chain or the path to a chain specification file.
-
-          Built-in chains:
-              mainnet, sepolia, holesky, hoodi, dev
-
-          [default: mainnet]
-
       --instance <INSTANCE>
           Add a new instance of a node.
 

--- a/book/cli/reth/stage.md
+++ b/book/cli/reth/stage.md
@@ -16,15 +16,6 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-      --chain <CHAIN_OR_PATH>
-          The chain this node is running.
-          Possible values are either a built-in chain or the path to a chain specification file.
-
-          Built-in chains:
-              mainnet, sepolia, holesky, hoodi, dev
-
-          [default: mainnet]
-
       --instance <INSTANCE>
           Add a new instance of a node.
 

--- a/crates/cli/commands/src/config_cmd.rs
+++ b/crates/cli/commands/src/config_cmd.rs
@@ -1,11 +1,10 @@
 //! CLI command to show configs.
 
-use std::path::PathBuf;
-
 use clap::Parser;
 use eyre::{bail, WrapErr};
+use reth_chainspec::ChainSpec;
 use reth_config::Config;
-
+use std::{path::PathBuf, sync::Arc};
 /// `reth config` command
 #[derive(Debug, Parser)]
 pub struct Command {
@@ -35,5 +34,9 @@ impl Command {
         };
         println!("{}", toml::to_string_pretty(&config)?);
         Ok(())
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<ChainSpec>> {
+        None
     }
 }

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -4,8 +4,10 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_db::version::{get_db_version, DatabaseVersionError, DB_VERSION};
 use reth_db_common::DbTool;
-use std::io::{self, Write};
-
+use std::{
+    io::{self, Write},
+    sync::Arc,
+};
 mod checksum;
 mod clear;
 mod diff;
@@ -152,6 +154,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         }
 
         Ok(())
+    }
+
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
     }
 }
 

--- a/crates/cli/commands/src/dump_genesis.rs
+++ b/crates/cli/commands/src/dump_genesis.rs
@@ -27,6 +27,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> DumpGenesisCommand<C> {
         println!("{}", serde_json::to_string_pretty(self.chain.genesis())?);
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.chain)
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -161,6 +161,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportComm
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }
 
 /// Builds import pipeline.

--- a/crates/cli/commands/src/init_cmd.rs
+++ b/crates/cli/commands/src/init_cmd.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_provider::BlockHashReader;
+use std::sync::Arc;
 use tracing::info;
 
 /// Initializes the database with the genesis block.
@@ -27,5 +28,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitComman
 
         info!(target: "reth::cli", hash = ?hash, "Genesis block written");
         Ok(())
+    }
+
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
     }
 }

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -11,7 +11,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::{
     BlockNumReader, DatabaseProviderFactory, StaticFileProviderFactory, StaticFileWriter,
 };
-use std::{io::BufReader, path::PathBuf, str::FromStr};
+use std::{io::BufReader, path::PathBuf, str::FromStr, sync::Arc};
 use tracing::info;
 
 pub mod without_evm;
@@ -129,5 +129,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateC
 
         info!(target: "reth::cli", hash = ?hash, "Genesis block written");
         Ok(())
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
     }
 }

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -202,6 +202,10 @@ impl<
 
         launcher(builder, ext).await
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.chain)
+    }
 }
 
 /// No Additional arguments

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -162,4 +162,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.chain)
+    }
 }

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -5,6 +5,7 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_prune::PrunerBuilder;
 use reth_static_file::StaticFileProducer;
+use std::sync::Arc;
 use tracing::info;
 
 /// Prunes according to the configuration without any limits
@@ -41,5 +42,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
         }
 
         Ok(())
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
     }
 }

--- a/crates/cli/commands/src/recover/mod.rs
+++ b/crates/cli/commands/src/recover/mod.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
+use std::sync::Arc;
 
 mod storage_tries;
 
@@ -30,6 +31,12 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
     ) -> eyre::Result<()> {
         match self.command {
             Subcommands::StorageTries(command) => command.execute::<N>(ctx).await,
+        }
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        match &self.command {
+            Subcommands::StorageTries(command) => command.chain_spec(),
         }
     }
 }

--- a/crates/cli/commands/src/recover/storage_tries.rs
+++ b/crates/cli/commands/src/recover/storage_tries.rs
@@ -12,6 +12,7 @@ use reth_db_api::{
 use reth_provider::{BlockNumReader, HeaderProvider, ProviderError};
 use reth_trie::StateRoot;
 use reth_trie_db::DatabaseStateRoot;
+use std::sync::Arc;
 use tracing::*;
 
 /// `reth recover storage-tries` command
@@ -64,5 +65,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         info!(target: "reth::cli", deleted = deleted_tries, "Finished recovery");
 
         Ok(())
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
     }
 }

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -21,6 +21,7 @@ use reth_provider::{
 use reth_prune::PruneSegment;
 use reth_stages::StageId;
 use reth_static_file_types::StaticFileSegment;
+use std::sync::Arc;
 
 /// `reth drop-stage` command
 #[derive(Debug, Parser)]
@@ -162,6 +163,10 @@ impl<C: ChainSpecParser> Command<C> {
         UnifiedStorageWriter::commit_unwind(provider_rw)?;
 
         Ok(())
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
     }
 }
 

--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -112,6 +112,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }
 
 /// Sets up the database and initial state on [`tables::BlockBodyIndices`]. Also returns the tip

--- a/crates/cli/commands/src/stage/mod.rs
+++ b/crates/cli/commands/src/stage/mod.rs
@@ -55,4 +55,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             Subcommands::Unwind(command) => command.execute::<N>().await,
         }
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        match self.command {
+            Subcommands::Run(ref command) => command.chain_spec(),
+            Subcommands::Drop(ref command) => command.chain_spec(),
+            Subcommands::Dump(ref command) => command.chain_spec(),
+            Subcommands::Unwind(ref command) => command.chain_spec(),
+        }
+    }
 }

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -380,4 +380,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
         Ok(())
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -157,6 +157,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         );
         Ok(pipeline)
     }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
 }
 
 /// `reth stage unwind` subcommand

--- a/crates/cli/commands/src/test_vectors/mod.rs
+++ b/crates/cli/commands/src/test_vectors/mod.rs
@@ -1,6 +1,8 @@
 //! Command for generating test vectors.
 
 use clap::{Parser, Subcommand};
+use reth_chainspec::ChainSpec;
+use std::sync::Arc;
 
 pub mod compact;
 pub mod tables;
@@ -54,5 +56,10 @@ impl Command {
             }
         }
         Ok(())
+    }
+
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<ChainSpec>> {
+        None
     }
 }

--- a/crates/optimism/cli/src/commands/test_vectors.rs
+++ b/crates/optimism/cli/src/commands/test_vectors.rs
@@ -3,6 +3,7 @@
 use clap::{Parser, Subcommand};
 use op_alloy_consensus::TxDeposit;
 use proptest::test_runner::TestRunner;
+use reth_chainspec::ChainSpec;
 use reth_cli_commands::{
     compact_types,
     test_vectors::{
@@ -14,6 +15,7 @@ use reth_cli_commands::{
         tables,
     },
 };
+use std::sync::Arc;
 
 /// Generate test-vectors for different data types.
 #[derive(Debug, Parser)]
@@ -68,5 +70,9 @@ impl Command {
             }
         }
         Ok(())
+    }
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<ChainSpec>> {
+        None
     }
 }


### PR DESCRIPTION
### Closes-  #14160

### Changes
- Removed the global chain argument from the CLI struct
- Added a `chain_spec()` helper method to the `Commands` enum that returns the chain specification if available
- Modified the logging directory setup to use the chain specification from the command context
- Ensured backward compatibility by maintaining the chain specification access through the command interface

