### PR TITLE
Extend eth state cache with get receipts maybe block

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -3,6 +3,7 @@
 use super::{EthStateCacheConfig, MultiConsumerLruCache};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::B256;
+use alloy_rpc_types_eth::BlockNumHash;
 use futures::{future::Either, Stream, StreamExt};
 use reth_chain_state::CanonStateNotification;
 use reth_errors::{ProviderError, ProviderResult};
@@ -37,6 +38,8 @@ type BlockWithSendersResponseSender<B> =
 
 /// The type that can send the response to the requested receipts of a block.
 type ReceiptsResponseSender<R> = oneshot::Sender<ProviderResult<Option<Arc<Vec<R>>>>>;
+
+type CachedBlockResponseSender<B> = oneshot::Sender<Option<Arc<RecoveredBlock<B>>>>;
 
 /// The type that can send the response to a requested header
 type HeaderResponseSender<H> = oneshot::Sender<ProviderResult<H>>;
@@ -173,6 +176,25 @@ impl<B: Block, R: Send + Sync> EthStateCache<B, R> {
         let (block, receipts) = futures::try_join!(block, receipts)?;
 
         Ok(block.zip(receipts))
+    }
+
+    /// Retrieves receipts and blocks from cache if block is in the cache, otherwise only receipts.
+    pub async fn get_receipts_and_maybe_block(
+        &self,
+        block_num_hash: &BlockNumHash,
+    ) -> ProviderResult<Option<(Arc<Vec<R>>, Option<Arc<RecoveredBlock<B>>>)>> {
+        // The last 4 blocks are most likely cached, so we can just fetch them
+        let (response_tx, rx) = oneshot::channel();
+        let _ = self
+            .to_service
+            .send(CacheAction::GetCachedBlock { block_hash: block_num_hash.hash, response_tx });
+
+        let receipts = self.get_receipts(block_num_hash.hash);
+
+        let (receipts, block) = futures::join!(receipts, rx);
+
+        let block = block.map_err(|_| ProviderError::CacheServiceUnavailable)?;
+        Ok(receipts?.map(|r| (r, block)))
     }
 
     /// Requests the header for the given hash.
@@ -361,6 +383,10 @@ where
                 }
                 Some(action) => {
                     match action {
+                        CacheAction::GetCachedBlock { block_hash, response_tx } => {
+                            let _ =
+                                response_tx.send(this.full_block_cache.get(&block_hash).cloned());
+                        }
                         CacheAction::GetBlockWithSenders { block_hash, response_tx } => {
                             if let Some(block) = this.full_block_cache.get(&block_hash).cloned() {
                                 let _ = response_tx.send(Ok(Some(block)));
@@ -512,6 +538,7 @@ enum CacheAction<B: Block, R> {
     GetBlockWithSenders { block_hash: B256, response_tx: BlockWithSendersResponseSender<B> },
     GetHeader { block_hash: B256, response_tx: HeaderResponseSender<B::Header> },
     GetReceipts { block_hash: B256, response_tx: ReceiptsResponseSender<R> },
+    GetCachedBlock { block_hash: B256, response_tx: CachedBlockResponseSender<B> },
     BlockWithSendersResult { block_hash: B256, res: ProviderResult<Option<Arc<RecoveredBlock<B>>>> },
     ReceiptsResult { block_hash: B256, res: ProviderResult<Option<Arc<Vec<R>>>> },
     HeaderResult { block_hash: B256, res: Box<ProviderResult<B::Header>> },

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -433,7 +433,7 @@ where
                 // not, in case the block hash been reorged
                 let (receipts, maybe_block) = self
                     .eth_cache()
-                    .get_receipts_and_maybe_block(&block_num_hash)
+                    .get_receipts_and_maybe_block(block_num_hash.hash)
                     .await?
                     .ok_or(EthApiError::HeaderNotFound(block_hash.into()))?;
 
@@ -548,7 +548,7 @@ where
 
                     let num_hash = BlockNumHash::new(header.number(), block_hash);
                     if let Some((receipts, maybe_block)) =
-                        self.eth_cache().get_receipts_and_maybe_block(&num_hash).await?
+                        self.eth_cache().get_receipts_and_maybe_block(num_hash.hash).await?
                     {
                         append_matching_block_logs(
                             &mut all_logs,

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -9,7 +9,6 @@ use alloy_rpc_types_eth::{
 use async_trait::async_trait;
 use futures::future::TryFutureExt;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
-use reth_chainspec::ChainInfo;
 use reth_errors::ProviderError;
 use reth_primitives_traits::RecoveredBlock;
 use reth_rpc_eth_api::{
@@ -250,7 +249,6 @@ where
                         &filter,
                         from_block_number,
                         to_block_number,
-                        info,
                         self.inner.query_limits,
                     )
                     .await?;
@@ -435,10 +433,8 @@ where
                 // we also need to ensure that the receipts are available and return an error if
                 // not, in case the block hash been reorged
                 let (receipts, maybe_block) = self
-                    .receipts_and_maybe_block(
-                        &block_num_hash,
-                        self.provider().chain_info()?.best_number,
-                    )
+                    .eth_cache()
+                    .get_receipts_and_maybe_block(&block_num_hash)
                     .await?
                     .ok_or(EthApiError::HeaderNotFound(block_hash.into()))?;
 
@@ -473,14 +469,8 @@ where
                     .flatten();
                 let (from_block_number, to_block_number) =
                     logs_utils::get_filter_block_range(from, to, start_block, info);
-                self.get_logs_in_block_range(
-                    &filter,
-                    from_block_number,
-                    to_block_number,
-                    info,
-                    limits,
-                )
-                .await
+                self.get_logs_in_block_range(&filter, from_block_number, to_block_number, limits)
+                    .await
             }
         }
     }
@@ -514,7 +504,6 @@ where
         filter: &Filter,
         from_block: u64,
         to_block: u64,
-        chain_info: ChainInfo,
         limits: QueryLimits,
     ) -> Result<Vec<Log>, EthFilterError> {
         trace!(target: "rpc::eth::filter", from=from_block, to=to_block, ?filter, "finding logs in range");
@@ -560,7 +549,7 @@ where
 
                     let num_hash = BlockNumHash::new(header.number(), block_hash);
                     if let Some((receipts, maybe_block)) =
-                        self.receipts_and_maybe_block(&num_hash, chain_info.best_number).await?
+                        self.eth_cache().get_receipts_and_maybe_block(&num_hash).await?
                     {
                         append_matching_block_logs(
                             &mut all_logs,
@@ -592,31 +581,6 @@ where
         }
 
         Ok(all_logs)
-    }
-
-    /// Retrieves receipts and block from cache if near the tip (4 blocks), otherwise only receipts.
-    async fn receipts_and_maybe_block(
-        &self,
-        block_num_hash: &BlockNumHash,
-        best_number: u64,
-    ) -> Result<
-        Option<(
-            Arc<Vec<ProviderReceipt<Eth::Provider>>>,
-            Option<Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>>,
-        )>,
-        EthFilterError,
-    > {
-        // The last 4 blocks are most likely cached, so we can just fetch them
-        let cached_range = best_number.saturating_sub(4)..=best_number;
-        let receipts_block = if cached_range.contains(&block_num_hash.number) {
-            self.eth_cache()
-                .get_block_and_receipts(block_num_hash.hash)
-                .await?
-                .map(|(b, r)| (r, Some(b)))
-        } else {
-            self.eth_cache().get_receipts(block_num_hash.hash).await?.map(|r| (r, None))
-        };
-        Ok(receipts_block)
     }
 }
 

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use futures::future::TryFutureExt;
 use jsonrpsee::{core::RpcResult, server::IdProvider};
 use reth_errors::ProviderError;
-use reth_primitives_traits::RecoveredBlock;
 use reth_rpc_eth_api::{
     EngineEthFilter, EthApiTypes, EthFilterApiServer, FullEthApiTypes, QueryLimits, RpcNodeCoreExt,
     RpcTransaction, TransactionCompat,


### PR DESCRIPTION
This PR:
- introduces a new command variant: `GetCachedBlock`
- moves the  behaviour of `get_receipts_and_maybe_block` into `EthStateCache`

resolves: <https://github.com/paradigmxyz/reth/issues/15339>