### PR TITLE
chore: add alias for ws.origins

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -74,7 +74,7 @@ pub struct RpcServerArgs {
     pub ws_port: u16,
 
     /// Origins from which to accept `WebSocket` requests
-    #[arg(id = "ws.origins", long = "ws.origins")]
+    #[arg(id = "ws.origins", long = "ws.origins", alias = "ws.corsdomain")]
     pub ws_allowed_origins: Option<String>,
 
     /// Rpc Modules to be configured for the WS server


### PR DESCRIPTION
this is just cors, adds an alias to mirror:

https://github.com/paradigmxyz/reth/blob/ac772e717fdf57ba136f5e201a211aeb2c832295/crates/node/core/src/args/rpc_server.rs#L61-L62