### PR TITLE
fix: mark chain as global and update usage

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -58,7 +58,7 @@ jobs:
             | grep ${{ matrix.chain.tip }}
       - name: Run stage unwind for 100 blocks
         run: |
-          ${{ matrix.chain.bin }} stage --chain ${{ matrix.chain.chain }} unwind num-blocks 100
+          ${{ matrix.chain.bin }} stage unwind num-blocks 100 --chain ${{ matrix.chain.chain }}
       - name: Run stage unwind to block hash
         run: |
-          ${{ matrix.chain.bin }} stage --chain ${{ matrix.chain.chain }} unwind to-block ${{ matrix.chain.unwind-target }}
+          ${{ matrix.chain.bin }} stage unwind to-block ${{ matrix.chain.unwind-target }} --chain ${{ matrix.chain.chain }} 

--- a/book/cli/reth/db/checksum.md
+++ b/book/cli/reth/db/checksum.md
@@ -36,6 +36,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/clear.md
+++ b/book/cli/reth/db/clear.md
@@ -28,6 +28,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/clear/mdbx.md
+++ b/book/cli/reth/db/clear/mdbx.md
@@ -27,6 +27,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/clear/static-file.md
+++ b/book/cli/reth/db/clear/static-file.md
@@ -31,6 +31,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/diff.md
+++ b/book/cli/reth/db/diff.md
@@ -60,6 +60,16 @@ Database:
       --output <OUTPUT>
           The output directory for the diff report.
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/drop.md
+++ b/book/cli/reth/db/drop.md
@@ -26,6 +26,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/get.md
+++ b/book/cli/reth/db/get.md
@@ -28,6 +28,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/get/mdbx.md
+++ b/book/cli/reth/db/get/mdbx.md
@@ -36,6 +36,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/get/static-file.md
+++ b/book/cli/reth/db/get/static-file.md
@@ -37,6 +37,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/list.md
+++ b/book/cli/reth/db/list.md
@@ -69,6 +69,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/path.md
+++ b/book/cli/reth/db/path.md
@@ -23,6 +23,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/stats.md
+++ b/book/cli/reth/db/stats.md
@@ -36,6 +36,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/db/version.md
+++ b/book/cli/reth/db/version.md
@@ -23,6 +23,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/dump/account-hashing.md
+++ b/book/cli/reth/stage/dump/account-hashing.md
@@ -35,6 +35,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/dump/execution.md
+++ b/book/cli/reth/stage/dump/execution.md
@@ -35,6 +35,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/dump/merkle.md
+++ b/book/cli/reth/stage/dump/merkle.md
@@ -35,6 +35,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/dump/storage-hashing.md
+++ b/book/cli/reth/stage/dump/storage-hashing.md
@@ -35,6 +35,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/unwind/num-blocks.md
+++ b/book/cli/reth/stage/unwind/num-blocks.md
@@ -27,6 +27,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/book/cli/reth/stage/unwind/to-block.md
+++ b/book/cli/reth/stage/unwind/to-block.md
@@ -27,6 +27,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -44,7 +44,8 @@ pub struct EnvironmentArgs<C: ChainSpecParser> {
         value_name = "CHAIN_OR_PATH",
         long_help = C::help_message(),
         default_value = C::SUPPORTED_CHAINS[0],
-        value_parser = C::parser()
+        value_parser = C::parser(),
+        global = true
     )]
     pub chain: Arc<C::ChainSpec>,
 


### PR DESCRIPTION
fixes a regression from #15386

we removed the top level chain arg because we had this multiple times in the cli graph.

but this means we now need to adjust the --chain arg and move to the actual command.

this also marks the chain arg as global so it propagates down