### PR TITLE
chore: remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,6 @@ dependencies = [
  "alloy-rpc-types",
  "bytes",
  "derive_more 2.0.1",
- "eyre",
  "futures",
  "reth-chainspec",
  "reth-discv4",
@@ -7656,7 +7655,6 @@ dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-signer",
@@ -7665,12 +7663,10 @@ dependencies = [
  "eyre",
  "futures-util",
  "jsonrpsee",
- "op-alloy-rpc-types-engine",
  "reth-chainspec",
  "reth-db",
  "reth-engine-local",
  "reth-ethereum-primitives",
- "reth-network",
  "reth-network-api",
  "reth-network-peers",
  "reth-node-api",
@@ -7680,10 +7676,8 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits",
  "reth-provider",
  "reth-rpc-api",
- "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-layer",
  "reth-rpc-server-types",
@@ -8096,7 +8090,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
  "arbitrary",
  "bincode",
  "derive_more 2.0.1",
@@ -8867,8 +8860,6 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "derive_more 2.0.1",
- "once_cell",
- "op-alloy-consensus",
  "op-alloy-rpc-types",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -8877,7 +8868,6 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "serde_json",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8969,13 +8959,9 @@ dependencies = [
  "alloy-genesis",
  "alloy-op-evm",
  "alloy-primitives",
- "derive_more 2.0.1",
  "op-alloy-consensus",
  "op-revm",
  "reth-chainspec",
- "reth-consensus",
- "reth-consensus-common",
- "reth-ethereum-forks",
  "reth-evm",
  "reth-execution-errors",
  "reth-execution-types",
@@ -8987,20 +8973,16 @@ dependencies = [
  "reth-revm",
  "revm",
  "thiserror 2.0.12",
- "tracing",
 ]
 
 [[package]]
 name = "reth-optimism-forks"
 version = "1.3.4"
 dependencies = [
- "alloy-chains",
  "alloy-op-hardforks",
  "alloy-primitives",
- "auto_impl",
  "once_cell",
  "reth-ethereum-forks",
- "serde",
 ]
 
 [[package]]
@@ -9188,7 +9170,6 @@ name = "reth-optimism-storage"
 version = "1.3.4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-codecs",
@@ -9199,8 +9180,6 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-api",
- "reth-trie-common",
- "revm",
 ]
 
 [[package]]
@@ -9505,11 +9484,8 @@ dependencies = [
  "futures",
  "parking_lot",
  "reth-chain-state",
- "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-network",
- "reth-network-api",
  "reth-node-api",
  "reth-primitives-traits",
  "reth-provider",
@@ -10226,15 +10202,12 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
- "metrics",
  "proptest",
  "proptest-arbitrary-interop",
  "reth-chainspec",
  "reth-db",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
@@ -10242,7 +10215,6 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-database",
- "serde",
  "serde_json",
  "similar-asserts",
  "tracing",
@@ -10305,7 +10277,6 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "smallvec",
- "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/book/sources/exex/remote/Cargo.toml
+++ b/book/sources/exex/remote/Cargo.toml
@@ -17,8 +17,6 @@ tokio-stream = "0.1"
 futures-util = "0.3"
 
 # grpc
-tonic = "0.11"
-prost = "0.12"
 bincode = "1"
 
 # misc

--- a/book/sources/exex/remote/Cargo.toml
+++ b/book/sources/exex/remote/Cargo.toml
@@ -17,6 +17,8 @@ tokio-stream = "0.1"
 futures-util = "0.3"
 
 # grpc
+tonic = "0.11"
+prost = "0.12"
 bincode = "1"
 
 # misc

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -23,7 +23,6 @@ reth-payload-builder = { workspace = true, features = ["test-utils"] }
 reth-payload-builder-primitives.workspace = true
 reth-payload-primitives.workspace = true
 reth-provider.workspace = true
-reth-network.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true
 reth-node-builder = { workspace = true, features = ["test-utils"] }
@@ -33,8 +32,6 @@ reth-network-peers.workspace = true
 reth-engine-local.workspace = true
 reth-tasks.workspace = true
 reth-node-ethereum.workspace = true
-reth-primitives-traits.workspace = true
-reth-rpc-builder.workspace = true
 reth-ethereum-primitives.workspace = true
 
 revm.workspace = true
@@ -46,8 +43,6 @@ url.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
-alloy-rlp.workspace = true
-op-alloy-rpc-types-engine.workspace = true
 
 futures-util.workspace = true
 eyre.workspace = true

--- a/crates/ethereum/primitives/Cargo.toml
+++ b/crates/ethereum/primitives/Cargo.toml
@@ -23,7 +23,6 @@ alloy-eips = { workspace = true, features = ["k256"] }
 alloy-primitives.workspace = true
 alloy-network = { workspace = true, optional = true }
 alloy-consensus = { workspace = true, features = ["serde"] }
-alloy-serde = { workspace = true, optional = true }
 alloy-rlp.workspace = true
 alloy-rpc-types-eth = { workspace = true, optional = true }
 revm-context.workspace = true
@@ -56,7 +55,7 @@ test-utils = [
     "reth-codecs?/test-utils",
     "reth-primitives-traits/test-utils",
 ]
-alloy-compat = ["dep:alloy-network", "dep:alloy-serde", "dep:alloy-rpc-types-eth"]
+alloy-compat = ["dep:alloy-network", "dep:alloy-rpc-types-eth"]
 std = [
     "alloy-consensus/std",
     "alloy-primitives/std",
@@ -67,7 +66,6 @@ std = [
     "alloy-eips/std",
     "derive_more/std",
     "secp256k1?/std",
-    "alloy-serde?/std",
     "alloy-rpc-types-eth?/std",
     "revm-context/std",
     "alloy-evm/std",
@@ -88,7 +86,6 @@ arbitrary = [
     "reth-codecs?/arbitrary",
     "reth-primitives-traits/arbitrary",
     "alloy-eips/arbitrary",
-    "alloy-serde?/arbitrary",
     "alloy-rpc-types-eth?/arbitrary",
 ]
 serde-bincode-compat = [

--- a/crates/ethereum/primitives/src/lib.rs
+++ b/crates/ethereum/primitives/src/lib.rs
@@ -6,6 +6,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -32,15 +32,12 @@ alloy-hardforks.workspace = true
 
 # op
 op-alloy-rpc-types.workspace = true
-op-alloy-consensus.workspace = true
 
 # io
 serde_json.workspace = true
 
 # misc
-thiserror.workspace = true
 derive_more.workspace = true
-once_cell.workspace = true
 
 [dev-dependencies]
 reth-chainspec = { workspace = true, features = ["test-utils"] }
@@ -61,10 +58,7 @@ std = [
     "reth-optimism-forks/std",
     "reth-optimism-primitives/std",
     "alloy-consensus/std",
-    "once_cell/std",
     "derive_more/std",
     "reth-network-peers/std",
-    "thiserror/std",
     "serde_json/std",
-    "op-alloy-consensus/std",
 ]

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -6,6 +6,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/crates/optimism/consensus/Cargo.toml
+++ b/crates/optimism/consensus/Cargo.toml
@@ -24,7 +24,6 @@ reth-trie-common.workspace = true
 
 # op-reth
 reth-optimism-forks.workspace = true
-reth-optimism-chainspec.workspace = true
 reth-optimism-primitives.workspace = true
 
 # ethereum

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate alloc;
 

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -13,13 +13,10 @@ workspace = true
 [dependencies]
 # Reth
 reth-chainspec.workspace = true
-reth-ethereum-forks.workspace = true
 reth-evm = { workspace = true, features = ["op"] }
 reth-primitives-traits.workspace = true
 reth-execution-errors.workspace = true
 reth-execution-types.workspace = true
-reth-consensus.workspace = true
-reth-consensus-common.workspace = true
 
 # ethereum
 alloy-eips.workspace = true
@@ -40,8 +37,6 @@ revm.workspace = true
 op-revm.workspace = true
 
 # misc
-derive_more.workspace = true
-tracing.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
@@ -55,7 +50,6 @@ reth-optimism-primitives = { workspace = true, features = ["arbitrary"] }
 [features]
 default = ["std"]
 std = [
-    "reth-consensus/std",
     "reth-revm/std",
     "alloy-consensus/std",
     "alloy-eips/std",
@@ -64,14 +58,11 @@ std = [
     "reth-primitives-traits/std",
     "revm/std",
     "reth-optimism-primitives/std",
-    "reth-ethereum-forks/std",
-    "derive_more/std",
     "reth-optimism-forks/std",
     "thiserror/std",
     "op-alloy-consensus/std",
     "reth-chainspec/std",
     "reth-optimism-consensus/std",
-    "reth-consensus-common/std",
     "reth-optimism-chainspec/std",
     "reth-execution-errors/std",
     "reth-execution-types/std",
@@ -79,6 +70,5 @@ std = [
     "alloy-op-evm/std",
     "op-revm/std",
     "reth-evm/std",
-    "tracing/std",
 ]
 portable = ["reth-revm/portable"]

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate alloc;
 

--- a/crates/optimism/hardforks/Cargo.toml
+++ b/crates/optimism/hardforks/Cargo.toml
@@ -17,14 +17,9 @@ reth-ethereum-forks.workspace = true
 
 # ethereum
 alloy-op-hardforks.workspace = true
-alloy-chains.workspace = true
 alloy-primitives.workspace = true
 
-# io
-serde = { workspace = true, optional = true }
-
 # misc
-auto_impl.workspace = true
 once_cell.workspace = true
 
 [features]
@@ -32,13 +27,9 @@ default = ["std"]
 std = [
     "alloy-primitives/std",
     "once_cell/std",
-    "serde?/std",
-    "alloy-chains/std",
     "reth-ethereum-forks/std",
 ]
 serde = [
-    "dep:serde",
-    "alloy-chains/serde",
     "alloy-primitives/serde",
     "reth-ethereum-forks/serde",
     "alloy-op-hardforks/serde",

--- a/crates/optimism/hardforks/src/lib.rs
+++ b/crates/optimism/hardforks/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate alloc;
 

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -61,8 +61,6 @@ clap.workspace = true
 serde.workspace = true
 eyre.workspace = true
 
-# rpc
-
 # test-utils dependencies
 reth-e2e-test-utils = { workspace = true, optional = true }
 alloy-genesis = { workspace = true, optional = true }

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -62,12 +62,12 @@ serde.workspace = true
 eyre.workspace = true
 
 # rpc
-serde_json.workspace = true
 
 # test-utils dependencies
 reth-e2e-test-utils = { workspace = true, optional = true }
 alloy-genesis = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-optimism-node = { workspace = true, features = ["test-utils"] }
@@ -103,6 +103,7 @@ test-utils = [
     "reth-e2e-test-utils",
     "alloy-genesis",
     "tokio",
+    "serde_json",
     "reth-node-builder/test-utils",
     "reth-chainspec/test-utils",
     "reth-consensus/test-utils",

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -13,12 +13,9 @@ workspace = true
 [dependencies]
 # reth
 reth-chainspec.workspace = true
-reth-db = { workspace = true, features = ["op"] }
 reth-engine-local = { workspace = true, features = ["op"] }
 reth-primitives-traits.workspace = true
 reth-payload-builder.workspace = true
-reth-payload-util.workspace = true
-reth-payload-validator.workspace = true
 reth-consensus.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
@@ -27,7 +24,6 @@ reth-provider.workspace = true
 reth-transaction-pool.workspace = true
 reth-network.workspace = true
 reth-evm.workspace = true
-reth-revm = { workspace = true, features = ["std"] }
 reth-trie-db.workspace = true
 reth-rpc-server-types.workspace = true
 reth-rpc-eth-api.workspace = true
@@ -53,7 +49,6 @@ revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg"] }
 op-revm.workspace = true
 
 # ethereum
-alloy-eips.workspace = true
 alloy-primitives.workspace = true
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true
@@ -76,18 +71,21 @@ tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-optimism-node = { workspace = true, features = ["test-utils"] }
-reth-db.workspace = true
+reth-db = { workspace = true, features = ["op"] }
 reth-node-core.workspace = true
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-revm = { workspace = true, features = ["test-utils"] }
 reth-tasks.workspace = true
+reth-payload-util.workspace = true
+reth-payload-validator.workspace = true
+reth-revm = { workspace = true, features = ["std"] }
 
 alloy-primitives.workspace = true
 op-alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-consensus.workspace = true
 futures.workspace = true
+alloy-eips.workspace = true
 
 [features]
 default = ["reth-codec"]

--- a/crates/optimism/storage/Cargo.toml
+++ b/crates/optimism/storage/Cargo.toml
@@ -16,14 +16,11 @@ reth-chainspec.workspace = true
 reth-primitives-traits.workspace = true
 reth-optimism-forks.workspace = true
 reth-optimism-primitives = { workspace = true, features = ["serde", "reth-codec"] }
-reth-trie-common.workspace = true
 reth-storage-api = { workspace = true, features = ["db-api"] }
 
 # ethereum
-alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
-revm.workspace = true
 
 [dev-dependencies]
 reth-codecs = { workspace = true, features = ["test-utils"] }
@@ -34,10 +31,8 @@ reth-stages-types.workspace = true
 [features]
 default = ["std"]
 std = [
-    "reth-trie-common/std",
     "reth-storage-api/std",
     "alloy-primitives/std",
-    "revm/std",
     "reth-prune-types/std",
     "reth-stages-types/std",
     "alloy-consensus/std",
@@ -45,5 +40,4 @@ std = [
     "reth-optimism-forks/std",
     "reth-optimism-primitives/std",
     "reth-primitives-traits/std",
-    "alloy-eips/std",
 ]

--- a/crates/optimism/storage/src/lib.rs
+++ b/crates/optimism/storage/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate alloc;
 

--- a/crates/ress/provider/Cargo.toml
+++ b/crates/ress/provider/Cargo.toml
@@ -14,13 +14,10 @@ workspace = true
 reth-ress-protocol.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
-reth-network.workspace = true
-reth-network-api.workspace = true
 reth-evm.workspace = true
 reth-revm = { workspace = true, features = ["witness"] }
 reth-chain-state.workspace = true
 reth-trie.workspace = true
-reth-engine-primitives.workspace = true
 reth-ethereum-primitives.workspace = true
 reth-tasks.workspace = true
 reth-tokio-util.workspace = true

--- a/crates/ress/provider/src/lib.rs
+++ b/crates/ress/provider/src/lib.rs
@@ -1,5 +1,7 @@
 //! Reth implementation of [`reth_ress_protocol::RessProtocolProvider`].
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 use alloy_consensus::BlockHeader as _;
 use alloy_primitives::{Bytes, B256};
 use parking_lot::Mutex;

--- a/crates/static-file/static-file/Cargo.toml
+++ b/crates/static-file/static-file/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 # reth
 reth-codecs.workspace = true
-reth-db.workspace = true
 reth-db-api.workspace = true
 reth-provider.workspace = true
 reth-storage-errors.workspace = true

--- a/crates/static-file/static-file/src/lib.rs
+++ b/crates/static-file/static-file/src/lib.rs
@@ -6,6 +6,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod segments;
 mod static_file_producer;

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -18,27 +18,11 @@ reth-execution-errors.workspace = true
 reth-db-api.workspace = true
 reth-trie.workspace = true
 
-revm.workspace = true
-
 # alloy
-alloy-rlp.workspace = true
 alloy-primitives.workspace = true
 
 # tracing
 tracing.workspace = true
-
-# misc
-derive_more.workspace = true
-
-# `metrics` feature
-reth-metrics = { workspace = true, optional = true }
-metrics = { workspace = true, optional = true }
-
-# `test-utils` feature
-triehash = { workspace = true, optional = true }
-
-# `serde` feature
-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 # reth
@@ -51,6 +35,8 @@ reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie = { workspace = true, features = ["test-utils"] }
 
 alloy-consensus.workspace = true
+alloy-rlp.workspace = true
+revm.workspace = true
 revm-database.workspace = true
 
 # trie
@@ -63,20 +49,18 @@ serde_json.workspace = true
 similar-asserts.workspace = true
 
 [features]
-metrics = ["reth-metrics", "reth-trie/metrics", "dep:metrics"]
+metrics = ["reth-trie/metrics"]
 serde = [
-    "dep:serde",
     "similar-asserts/serde",
-    "revm/serde",
     "alloy-consensus/serde",
     "alloy-primitives/serde",
     "reth-trie/serde",
     "reth-trie-common/serde",
     "reth-primitives-traits/serde",
     "revm-database/serde",
+    "revm/serde",
 ]
 test-utils = [
-    "triehash",
     "reth-trie-common/test-utils",
     "reth-primitives-traits/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -1,5 +1,7 @@
 //! An integration of [`reth-trie`] with [`reth-db`].
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 mod commitment;
 mod hashed_cursor;
 mod prefix_set;

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -25,7 +25,6 @@ alloy-rlp.workspace = true
 # misc
 auto_impl.workspace = true
 smallvec = { workspace = true, features = ["const_new"] }
-thiserror.workspace = true
 
 # metrics
 reth-metrics.workspace = true

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -1,5 +1,7 @@
 //! The implementation of sparse MPT.
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 mod state;
 pub use state::*;
 

--- a/examples/bsc-p2p/Cargo.toml
+++ b/examples/bsc-p2p/Cargo.toml
@@ -15,7 +15,6 @@ reth-eth-wire.workspace = true
 reth-eth-wire-types.workspace = true
 reth-network = { workspace = true, features = ["test-utils"] }
 reth-network-api.workspace = true
-reth-node-ethereum.workspace = true
 reth-network-peers.workspace = true
 reth-payload-primitives.workspace = true
 reth-primitives.workspace = true
@@ -31,7 +30,6 @@ alloy-rpc-types = { workspace = true, features = ["engine"] }
 # misc
 bytes.workspace = true
 derive_more.workspace = true
-eyre.workspace = true
 futures.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "std", "recovery"] }
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -40,6 +38,9 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+reth-node-ethereum.workspace = true
 
 [features]
 serde = [


### PR DESCRIPTION
obtained with `cargo-machete`, not adding to CI bc it also gives false positives:
```
$ cargo machete                                             
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in this directory:
reth-network-types -- ./crates/net/network-types/Cargo.toml:
	humantime-serde
reth-db-api -- ./crates/storage/db-api/Cargo.toml:
	modular-bitfield
reth-db-models -- ./crates/storage/db-models/Cargo.toml:
	modular-bitfield
reth-ethereum-primitives -- ./crates/ethereum/primitives/Cargo.toml:
	modular-bitfield
reth-optimism-primitives -- ./crates/optimism/primitives/Cargo.toml:
	modular-bitfield
reth-stages-types -- ./crates/stages/types/Cargo.toml:
	modular-bitfield
reth-primitives-traits -- ./crates/primitives-traits/Cargo.toml:
	modular-bitfield
reth-prune-types -- ./crates/prune/types/Cargo.toml:
	modular-bitfield
``` 