### PR TITLE
refactor(trie): introduce `SubNodePosition` enum

### DIFF
--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -6,7 +6,7 @@ use reth_storage_errors::db::DatabaseError;
 mod in_memory;
 
 /// Cursor for iterating over a subtrie.
-mod subnode;
+pub mod subnode;
 
 /// Noop trie cursor implementations.
 pub mod noop;
@@ -15,10 +15,7 @@ pub mod noop;
 #[cfg(test)]
 pub mod mock;
 
-pub use self::{
-    in_memory::*,
-    subnode::{CursorSubNode, Nibble},
-};
+pub use self::{in_memory::*, subnode::CursorSubNode};
 
 /// Factory for creating trie cursors.
 #[auto_impl::auto_impl(&)]

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -15,7 +15,10 @@ pub mod noop;
 #[cfg(test)]
 pub mod mock;
 
-pub use self::{in_memory::*, subnode::CursorSubNode};
+pub use self::{
+    in_memory::*,
+    subnode::{CursorSubNode, Nibble},
+};
 
 /// Factory for creating trie cursors.
 #[auto_impl::auto_impl(&)]

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -7,7 +7,7 @@ pub struct CursorSubNode {
     /// The key of the current node.
     pub key: Nibbles,
     /// The index of the next child to visit.
-    nibble: i8,
+    nibble: Nibble,
     /// The node itself.
     pub node: Option<BranchNodeCompact>,
     /// Full key
@@ -40,7 +40,7 @@ impl From<StoredSubNode> for CursorSubNode {
     /// Extracts necessary values from the `StoredSubNode` and constructs
     /// a corresponding `CursorSubNode`.
     fn from(value: StoredSubNode) -> Self {
-        let nibble = value.nibble.map_or(-1, |n| n as i8);
+        let nibble = value.nibble.map_or(Nibble::Parent, Nibble::Child);
         let key = Nibbles::from_nibbles_unchecked(value.key);
         let full_key = full_key(key.clone(), nibble);
         Self { key, nibble, node: value.node, full_key }
@@ -49,8 +49,7 @@ impl From<StoredSubNode> for CursorSubNode {
 
 impl From<CursorSubNode> for StoredSubNode {
     fn from(value: CursorSubNode) -> Self {
-        let nibble = (value.nibble >= 0).then_some(value.nibble as u8);
-        Self { key: value.key.to_vec(), nibble, node: value.node }
+        Self { key: value.key.to_vec(), nibble: value.nibble.as_child(), node: value.node }
     }
 }
 
@@ -58,8 +57,8 @@ impl CursorSubNode {
     /// Creates a new `CursorSubNode` from a key and an optional node.
     pub fn new(key: Nibbles, node: Option<BranchNodeCompact>) -> Self {
         // Find the first nibble that is set in the state mask of the node.
-        let nibble = node.as_ref().filter(|n| n.root_hash.is_none()).map_or(-1, |n| {
-            CHILD_INDEX_RANGE.clone().find(|i| n.state_mask.is_bit_set(*i)).unwrap() as i8
+        let nibble = node.as_ref().filter(|n| n.root_hash.is_none()).map_or(Nibble::Parent, |n| {
+            Nibble::Child(CHILD_INDEX_RANGE.clone().find(|i| n.state_mask.is_bit_set(*i)).unwrap())
         });
         let full_key = full_key(key.clone(), nibble);
         Self { key, node, nibble, full_key }
@@ -74,26 +73,26 @@ impl CursorSubNode {
     /// Returns `true` if the state flag is set for the current nibble.
     #[inline]
     pub fn state_flag(&self) -> bool {
-        self.node
-            .as_ref()
-            .is_none_or(|node| self.nibble < 0 || node.state_mask.is_bit_set(self.nibble as u8))
+        self.node.as_ref().is_none_or(|node| {
+            self.nibble.as_child().is_none_or(|nibble| node.state_mask.is_bit_set(nibble))
+        })
     }
 
     /// Returns `true` if the tree flag is set for the current nibble.
     #[inline]
     pub fn tree_flag(&self) -> bool {
-        self.node
-            .as_ref()
-            .is_none_or(|node| self.nibble < 0 || node.tree_mask.is_bit_set(self.nibble as u8))
+        self.node.as_ref().is_none_or(|node| {
+            self.nibble.as_child().is_none_or(|nibble| node.tree_mask.is_bit_set(nibble))
+        })
     }
 
     /// Returns `true` if the current nibble has a root hash.
     pub fn hash_flag(&self) -> bool {
         self.node.as_ref().is_some_and(|node| match self.nibble {
             // This guy has it
-            -1 => node.root_hash.is_some(),
+            Nibble::Parent => node.root_hash.is_some(),
             // Or get it from the children
-            _ => node.hash_mask.is_bit_set(self.nibble as u8),
+            Nibble::Child(nibble) => node.hash_mask.is_bit_set(nibble),
         })
     }
 
@@ -102,8 +101,8 @@ impl CursorSubNode {
         if self.hash_flag() {
             let node = self.node.as_ref().unwrap();
             match self.nibble {
-                -1 => node.root_hash,
-                _ => Some(node.hash_for_nibble(self.nibble as u8)),
+                Nibble::Parent => node.root_hash,
+                Nibble::Child(nibble) => Some(node.hash_for_nibble(nibble)),
             }
         } else {
             None
@@ -112,46 +111,113 @@ impl CursorSubNode {
 
     /// Returns the next child index to visit.
     #[inline]
-    pub const fn nibble(&self) -> i8 {
+    pub const fn nibble(&self) -> Nibble {
         self.nibble
     }
 
     /// Increments the nibble index.
     #[inline]
     pub fn inc_nibble(&mut self) {
-        self.nibble += 1;
-        update_full_key(&mut self.full_key, self.nibble - 1, self.nibble);
+        let old_nibble = self.nibble;
+        self.nibble.increment();
+        update_full_key(&mut self.full_key, old_nibble, self.nibble);
     }
 
     /// Sets the nibble index.
     #[inline]
-    pub fn set_nibble(&mut self, nibble: i8) {
+    pub fn set_nibble(&mut self, nibble: u8) {
         let old_nibble = self.nibble;
-        self.nibble = nibble;
+        self.nibble = Nibble::Child(nibble);
         update_full_key(&mut self.full_key, old_nibble, self.nibble);
+    }
+}
+
+/// Represents the nibble index of the current node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Nibble {
+    /// No nibble is set, pointing to the parent node that the children are contained in.
+    Parent,
+    /// A nibble is set, pointing to a child node.
+    Child(u8),
+}
+
+impl Nibble {
+    /// Returns `true` if the nibble is set to the parent node.
+    pub fn is_parent(&self) -> bool {
+        matches!(self, Self::Parent)
+    }
+
+    /// Returns `true` if the nibble is set to a child node.
+    pub fn is_child(&self) -> bool {
+        matches!(self, Self::Child(_))
+    }
+
+    /// Returns the child nibble if the nibble is set to a child node.
+    pub fn as_child(&self) -> Option<u8> {
+        match self {
+            Self::Child(nibble) => Some(*nibble),
+            _ => None,
+        }
+    }
+
+    fn increment(&mut self) {
+        match self {
+            Self::Parent => *self = Self::Child(0),
+            Self::Child(nibble) => *nibble += 1,
+        }
     }
 }
 
 /// Constructs a full key from the given `Nibbles` and `nibble`.
 #[inline]
-fn full_key(mut key: Nibbles, nibble: i8) -> Nibbles {
-    if nibble >= 0 {
-        key.push(nibble as u8);
+fn full_key(mut key: Nibbles, nibble: Nibble) -> Nibbles {
+    if let Some(nibble) = nibble.as_child() {
+        key.push(nibble);
     }
     key
 }
 
 /// Updates the key by replacing or appending a nibble based on the old and new nibble values.
 #[inline]
-fn update_full_key(key: &mut Nibbles, old_nibble: i8, new_nibble: i8) {
-    if new_nibble >= 0 {
-        if old_nibble >= 0 {
+fn update_full_key(key: &mut Nibbles, old_nibble: Nibble, new_nibble: Nibble) {
+    if let Some(new_nibble) = new_nibble.as_child() {
+        if old_nibble.is_child() {
             let last_index = key.len() - 1;
-            key.set_at(last_index, new_nibble as u8);
+            key.set_at(last_index, new_nibble);
         } else {
-            key.push(new_nibble as u8);
+            key.push(new_nibble);
         }
-    } else if old_nibble >= 0 {
+    } else if old_nibble.is_child() {
         key.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn nibble_order() {
+        let nibbles = [
+            Nibble::Parent,
+            Nibble::Child(0),
+            Nibble::Child(1),
+            Nibble::Child(2),
+            Nibble::Child(3),
+            Nibble::Child(4),
+            Nibble::Child(5),
+            Nibble::Child(6),
+            Nibble::Child(7),
+            Nibble::Child(8),
+            Nibble::Child(9),
+            Nibble::Child(10),
+            Nibble::Child(11),
+            Nibble::Child(12),
+            Nibble::Child(13),
+            Nibble::Child(14),
+            Nibble::Child(15),
+        ];
+        assert!(nibbles.is_sorted());
     }
 }

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -87,6 +87,21 @@ impl CursorSubNode {
         &self.full_key
     }
 
+    /// Updates the full key by replacing or appending a child nibble based on the old node pointer.
+    #[inline]
+    fn update_full_key(&mut self, old_pointer: NodePointer) {
+        if let Some(new_nibble) = self.pointer.as_child() {
+            if old_pointer.is_child() {
+                let last_index = self.full_key.len() - 1;
+                self.full_key.set_at(last_index, new_nibble);
+            } else {
+                self.full_key.push(new_nibble);
+            }
+        } else if old_pointer.is_child() {
+            self.full_key.pop();
+        }
+    }
+
     /// Returns `true` if either of these:
     /// - No current node is set.
     /// - The current node is a parent branch node.
@@ -158,21 +173,6 @@ impl CursorSubNode {
         let old_pointer = self.pointer;
         self.pointer = NodePointer::Child(nibble);
         self.update_full_key(old_pointer);
-    }
-
-    /// Updates the full key by replacing or appending a child nibble based on the old node pointer.
-    #[inline]
-    fn update_full_key(&mut self, old_pointer: NodePointer) {
-        if let Some(new_nibble) = self.pointer.as_child() {
-            if old_pointer.is_child() {
-                let last_index = self.full_key.len() - 1;
-                self.full_key.set_at(last_index, new_nibble);
-            } else {
-                self.full_key.push(new_nibble);
-            }
-        } else if old_pointer.is_child() {
-            self.full_key.pop();
-        }
     }
 }
 

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -160,18 +160,18 @@ impl CursorSubNode {
         self.update_full_key(old_pointer);
     }
 
-    /// Updates the key by replacing or appending a child nibble based on the old node pointer.
+    /// Updates the full key by replacing or appending a child nibble based on the old node pointer.
     #[inline]
     fn update_full_key(&mut self, old_pointer: NodePointer) {
         if let Some(new_nibble) = self.pointer.as_child() {
             if old_pointer.is_child() {
-                let last_index = self.key.len() - 1;
-                self.key.set_at(last_index, new_nibble);
+                let last_index = self.full_key.len() - 1;
+                self.full_key.set_at(last_index, new_nibble);
             } else {
-                self.key.push(new_nibble);
+                self.full_key.push(new_nibble);
             }
         } else if old_pointer.is_child() {
-            self.key.pop();
+            self.full_key.pop();
         }
     }
 }

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -142,7 +142,7 @@ impl CursorSubNode {
 
     /// Sets the nibble index.
     #[inline]
-    pub fn set_next_node_nibble(&mut self, nibble: u8) {
+    pub fn set_nibble(&mut self, nibble: u8) {
         let old_nibble = self.pointer;
         self.pointer = NodePointer::Child(nibble);
         update_full_key(&mut self.full_key, old_nibble, self.pointer);
@@ -174,6 +174,15 @@ impl NodePointer {
         match self {
             Self::Child(nibble) => Some(*nibble),
             _ => None,
+        }
+    }
+
+    /// Returns `true` if the pointer is set to a child node that is out of bounds (i.e. greater
+    /// than 0xf).
+    pub fn is_out_of_bounds(&self) -> bool {
+        match self {
+            Self::ParentBranch => false,
+            Self::Child(nibble) => *nibble >= 0xf,
         }
     }
 
@@ -216,8 +225,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn nibble_order() {
-        let nibbles = [
+    fn node_pointer() {
+        let pointers = [
             NodePointer::ParentBranch,
             NodePointer::Child(0),
             NodePointer::Child(1),
@@ -236,6 +245,9 @@ mod tests {
             NodePointer::Child(14),
             NodePointer::Child(15),
         ];
-        assert!(nibbles.is_sorted());
+        assert!(pointers.is_sorted());
+        assert!(pointers.iter().all(|pointer| !pointer.is_out_of_bounds()));
+
+        assert!(NodePointer::Child(16).is_out_of_bounds());
     }
 }

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -177,9 +177,9 @@ impl NodePointer {
         }
     }
 
-    /// Returns `true` if the pointer is set to a child node that is out of bounds (i.e. greater
-    /// than 0xf).
-    pub fn is_out_of_bounds(&self) -> bool {
+    /// Returns `true` if the pointer is set to a last child nibble (i.e. greater than or equal to
+    /// 0xf).
+    pub fn is_last_child(&self) -> bool {
         match self {
             Self::ParentBranch => false,
             Self::Child(nibble) => *nibble >= 0xf,
@@ -225,8 +225,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn node_pointer() {
-        let pointers = [
+    fn node_pointer_ord() {
+        assert!([
             NodePointer::ParentBranch,
             NodePointer::Child(0),
             NodePointer::Child(1),
@@ -244,10 +244,33 @@ mod tests {
             NodePointer::Child(13),
             NodePointer::Child(14),
             NodePointer::Child(15),
-        ];
-        assert!(pointers.is_sorted());
-        assert!(pointers.iter().all(|pointer| !pointer.is_out_of_bounds()));
+        ]
+        .is_sorted());
+    }
 
-        assert!(NodePointer::Child(16).is_out_of_bounds());
+    #[test]
+    fn node_pointer_is_last_child() {
+        assert!([
+            NodePointer::ParentBranch,
+            NodePointer::Child(0),
+            NodePointer::Child(1),
+            NodePointer::Child(2),
+            NodePointer::Child(3),
+            NodePointer::Child(4),
+            NodePointer::Child(5),
+            NodePointer::Child(6),
+            NodePointer::Child(7),
+            NodePointer::Child(8),
+            NodePointer::Child(9),
+            NodePointer::Child(10),
+            NodePointer::Child(11),
+            NodePointer::Child(12),
+            NodePointer::Child(13),
+            NodePointer::Child(14),
+        ]
+        .iter()
+        .all(|pointer| !pointer.is_last_child()));
+        assert!(NodePointer::Child(15).is_last_child());
+        assert!(NodePointer::Child(16).is_last_child());
     }
 }

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -75,8 +75,10 @@ impl CursorSubNode {
         &self.full_key
     }
 
-    /// Returns `true` if either no current node is set, or the current node is a child with state
-    /// mask bit set in the parent branch node.
+    /// Returns `true` if either of these:
+    /// - No current node is set.
+    /// - The current node is a parent branch node.
+    /// - The current node is a child with state mask bit set in the parent branch node.
     #[inline]
     pub fn state_flag(&self) -> bool {
         self.node.as_ref().is_none_or(|node| {
@@ -84,8 +86,10 @@ impl CursorSubNode {
         })
     }
 
-    /// Returns `true` if either no current node is set, or the current node is a child with tree
-    /// mask bit set in the parent branch node.
+    /// Returns `true` if either of these:
+    /// - No current node is set.
+    /// - The current node is a parent branch node.
+    /// - The current node is a child with tree mask bit set in the parent branch node.
     #[inline]
     pub fn tree_flag(&self) -> bool {
         self.node.as_ref().is_none_or(|node| {

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -6,8 +6,8 @@ use alloy_primitives::B256;
 pub struct CursorSubNode {
     /// The key of the current node.
     pub key: Nibbles,
-    /// The pointer to the current node.
-    pointer: NodePointer,
+    /// The position of the current subnode.
+    position: SubNodePosition,
     /// The node itself.
     pub node: Option<BranchNodeCompact>,
     /// Full key
@@ -24,7 +24,7 @@ impl std::fmt::Debug for CursorSubNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CursorSubNode")
             .field("key", &self.key)
-            .field("pointer", &self.pointer)
+            .field("position", &self.position)
             .field("state_flag", &self.state_flag())
             .field("tree_flag", &self.tree_flag())
             .field("hash_flag", &self.hash_flag())
@@ -40,15 +40,15 @@ impl From<StoredSubNode> for CursorSubNode {
     /// Extracts necessary values from the `StoredSubNode` and constructs
     /// a corresponding `CursorSubNode`.
     fn from(value: StoredSubNode) -> Self {
-        let pointer = value.nibble.map_or(NodePointer::ParentBranch, NodePointer::Child);
+        let position = value.nibble.map_or(SubNodePosition::ParentBranch, SubNodePosition::Child);
         let key = Nibbles::from_nibbles_unchecked(value.key);
-        Self::new_with_full_key(key, value.node, pointer)
+        Self::new_with_full_key(key, value.node, position)
     }
 }
 
 impl From<CursorSubNode> for StoredSubNode {
     fn from(value: CursorSubNode) -> Self {
-        Self { key: value.key.to_vec(), nibble: value.pointer.as_child(), node: value.node }
+        Self { key: value.key.to_vec(), nibble: value.position.as_child(), node: value.node }
     }
 }
 
@@ -56,29 +56,29 @@ impl CursorSubNode {
     /// Creates a new [`CursorSubNode`] from a key and an optional node.
     pub fn new(key: Nibbles, node: Option<BranchNodeCompact>) -> Self {
         // Find the first nibble that is set in the state mask of the node.
-        let pointer = node.as_ref().filter(|n| n.root_hash.is_none()).map_or(
-            NodePointer::ParentBranch,
+        let position = node.as_ref().filter(|n| n.root_hash.is_none()).map_or(
+            SubNodePosition::ParentBranch,
             |n| {
-                NodePointer::Child(
+                SubNodePosition::Child(
                     CHILD_INDEX_RANGE.clone().find(|i| n.state_mask.is_bit_set(*i)).unwrap(),
                 )
             },
         );
-        Self::new_with_full_key(key, node, pointer)
+        Self::new_with_full_key(key, node, position)
     }
 
     /// Creates a new [`CursorSubNode`] and sets the full key according to the provided key and
-    /// pointer.
+    /// position.
     fn new_with_full_key(
         key: Nibbles,
         node: Option<BranchNodeCompact>,
-        pointer: NodePointer,
+        position: SubNodePosition,
     ) -> Self {
         let mut full_key = key.clone();
-        if let Some(nibble) = pointer.as_child() {
+        if let Some(nibble) = position.as_child() {
             full_key.push(nibble);
         }
-        Self { key, node, pointer, full_key }
+        Self { key, node, position, full_key }
     }
 
     /// Returns the full key of the current node.
@@ -87,17 +87,18 @@ impl CursorSubNode {
         &self.full_key
     }
 
-    /// Updates the full key by replacing or appending a child nibble based on the old node pointer.
+    /// Updates the full key by replacing or appending a child nibble based on the old subnode
+    /// position.
     #[inline]
-    fn update_full_key(&mut self, old_pointer: NodePointer) {
-        if let Some(new_nibble) = self.pointer.as_child() {
-            if old_pointer.is_child() {
+    fn update_full_key(&mut self, old_position: SubNodePosition) {
+        if let Some(new_nibble) = self.position.as_child() {
+            if old_position.is_child() {
                 let last_index = self.full_key.len() - 1;
                 self.full_key.set_at(last_index, new_nibble);
             } else {
                 self.full_key.push(new_nibble);
             }
-        } else if old_pointer.is_child() {
+        } else if old_position.is_child() {
             self.full_key.pop();
         }
     }
@@ -109,7 +110,7 @@ impl CursorSubNode {
     #[inline]
     pub fn state_flag(&self) -> bool {
         self.node.as_ref().is_none_or(|node| {
-            self.pointer.as_child().is_none_or(|nibble| node.state_mask.is_bit_set(nibble))
+            self.position.as_child().is_none_or(|nibble| node.state_mask.is_bit_set(nibble))
         })
     }
 
@@ -120,7 +121,7 @@ impl CursorSubNode {
     #[inline]
     pub fn tree_flag(&self) -> bool {
         self.node.as_ref().is_none_or(|node| {
-            self.pointer.as_child().is_none_or(|nibble| node.tree_mask.is_bit_set(nibble))
+            self.position.as_child().is_none_or(|nibble| node.tree_mask.is_bit_set(nibble))
         })
     }
 
@@ -130,11 +131,11 @@ impl CursorSubNode {
     /// - Current node is a parent branch node, and it has a root hash.
     /// - Current node is a child node, and it has a hash mask bit set in the parent branch node.
     pub fn hash_flag(&self) -> bool {
-        self.node.as_ref().is_some_and(|node| match self.pointer {
+        self.node.as_ref().is_some_and(|node| match self.position {
             // Check if the parent branch node has a root hash
-            NodePointer::ParentBranch => node.root_hash.is_some(),
+            SubNodePosition::ParentBranch => node.root_hash.is_some(),
             // Or get it from the children
-            NodePointer::Child(nibble) => node.hash_mask.is_bit_set(nibble),
+            SubNodePosition::Child(nibble) => node.hash_mask.is_bit_set(nibble),
         })
     }
 
@@ -145,58 +146,58 @@ impl CursorSubNode {
     /// - Hash of the child node at the current nibble, if it has a hash mask bit set in the parent
     ///   branch node.
     pub fn hash(&self) -> Option<B256> {
-        self.node.as_ref().and_then(|node| match self.pointer {
+        self.node.as_ref().and_then(|node| match self.position {
             // Get the root hash for the parent branch node
-            NodePointer::ParentBranch => node.root_hash,
+            SubNodePosition::ParentBranch => node.root_hash,
             // Or get it from the children
-            NodePointer::Child(nibble) => Some(node.hash_for_nibble(nibble)),
+            SubNodePosition::Child(nibble) => Some(node.hash_for_nibble(nibble)),
         })
     }
 
-    /// Returns the pointer to the current node.
+    /// Returns the position to the current node.
     #[inline]
-    pub const fn pointer(&self) -> NodePointer {
-        self.pointer
+    pub const fn position(&self) -> SubNodePosition {
+        self.position
     }
 
     /// Increments the nibble index.
     #[inline]
     pub fn inc_nibble(&mut self) {
-        let old_pointer = self.pointer;
-        self.pointer.increment();
-        self.update_full_key(old_pointer);
+        let old_position = self.position;
+        self.position.increment();
+        self.update_full_key(old_position);
     }
 
     /// Sets the nibble index.
     #[inline]
     pub fn set_nibble(&mut self, nibble: u8) {
-        let old_pointer = self.pointer;
-        self.pointer = NodePointer::Child(nibble);
-        self.update_full_key(old_pointer);
+        let old_position = self.position;
+        self.position = SubNodePosition::Child(nibble);
+        self.update_full_key(old_position);
     }
 }
 
-/// Represents a pointer to a node.
+/// Represents a subnode position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum NodePointer {
-    /// Pointing to the parent branch node.
+pub enum SubNodePosition {
+    /// Positioned at the parent branch node.
     ParentBranch,
-    /// Pointing to a child node at the given nibble.
+    /// Positioned at a child node at the given nibble.
     Child(u8),
 }
 
-impl NodePointer {
-    /// Returns `true` if the pointer is set to the parent branch node.
+impl SubNodePosition {
+    /// Returns `true` if the position is set to the parent branch node.
     pub fn is_parent(&self) -> bool {
         matches!(self, Self::ParentBranch)
     }
 
-    /// Returns `true` if the pointer is set to a child node.
+    /// Returns `true` if the position is set to a child node.
     pub fn is_child(&self) -> bool {
         matches!(self, Self::Child(_))
     }
 
-    /// Returns the nibble of the child node if the pointer is set to a child node.
+    /// Returns the nibble of the child node if the position is set to a child node.
     pub fn as_child(&self) -> Option<u8> {
         match self {
             Self::Child(nibble) => Some(*nibble),
@@ -204,7 +205,7 @@ impl NodePointer {
         }
     }
 
-    /// Returns `true` if the pointer is set to a last child nibble (i.e. greater than or equal to
+    /// Returns `true` if the position is set to a last child nibble (i.e. greater than or equal to
     /// 0xf).
     pub fn is_last_child(&self) -> bool {
         match self {
@@ -226,52 +227,52 @@ mod tests {
     use super::*;
 
     #[test]
-    fn node_pointer_ord() {
+    fn subnode_position_ord() {
         assert!([
-            NodePointer::ParentBranch,
-            NodePointer::Child(0),
-            NodePointer::Child(1),
-            NodePointer::Child(2),
-            NodePointer::Child(3),
-            NodePointer::Child(4),
-            NodePointer::Child(5),
-            NodePointer::Child(6),
-            NodePointer::Child(7),
-            NodePointer::Child(8),
-            NodePointer::Child(9),
-            NodePointer::Child(10),
-            NodePointer::Child(11),
-            NodePointer::Child(12),
-            NodePointer::Child(13),
-            NodePointer::Child(14),
-            NodePointer::Child(15),
+            SubNodePosition::ParentBranch,
+            SubNodePosition::Child(0),
+            SubNodePosition::Child(1),
+            SubNodePosition::Child(2),
+            SubNodePosition::Child(3),
+            SubNodePosition::Child(4),
+            SubNodePosition::Child(5),
+            SubNodePosition::Child(6),
+            SubNodePosition::Child(7),
+            SubNodePosition::Child(8),
+            SubNodePosition::Child(9),
+            SubNodePosition::Child(10),
+            SubNodePosition::Child(11),
+            SubNodePosition::Child(12),
+            SubNodePosition::Child(13),
+            SubNodePosition::Child(14),
+            SubNodePosition::Child(15),
         ]
         .is_sorted());
     }
 
     #[test]
-    fn node_pointer_is_last_child() {
+    fn subnode_position_is_last_child() {
         assert!([
-            NodePointer::ParentBranch,
-            NodePointer::Child(0),
-            NodePointer::Child(1),
-            NodePointer::Child(2),
-            NodePointer::Child(3),
-            NodePointer::Child(4),
-            NodePointer::Child(5),
-            NodePointer::Child(6),
-            NodePointer::Child(7),
-            NodePointer::Child(8),
-            NodePointer::Child(9),
-            NodePointer::Child(10),
-            NodePointer::Child(11),
-            NodePointer::Child(12),
-            NodePointer::Child(13),
-            NodePointer::Child(14),
+            SubNodePosition::ParentBranch,
+            SubNodePosition::Child(0),
+            SubNodePosition::Child(1),
+            SubNodePosition::Child(2),
+            SubNodePosition::Child(3),
+            SubNodePosition::Child(4),
+            SubNodePosition::Child(5),
+            SubNodePosition::Child(6),
+            SubNodePosition::Child(7),
+            SubNodePosition::Child(8),
+            SubNodePosition::Child(9),
+            SubNodePosition::Child(10),
+            SubNodePosition::Child(11),
+            SubNodePosition::Child(12),
+            SubNodePosition::Child(13),
+            SubNodePosition::Child(14),
         ]
         .iter()
-        .all(|pointer| !pointer.is_last_child()));
-        assert!(NodePointer::Child(15).is_last_child());
-        assert!(NodePointer::Child(16).is_last_child());
+        .all(|position| !position.is_last_child()));
+        assert!(SubNodePosition::Child(15).is_last_child());
+        assert!(SubNodePosition::Child(16).is_last_child());
     }
 }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -255,7 +255,7 @@ impl<C: TrieCursor> TrieWalker<C> {
 
         // Check if the walker needs to backtrack to the previous level in the trie during its
         // traversal.
-        if subnode.pointer().is_out_of_bounds() ||
+        if subnode.pointer().is_last_child() ||
             (subnode.pointer().is_parent() && !allow_root_to_child_nibble)
         {
             self.stack.pop();
@@ -276,7 +276,7 @@ impl<C: TrieCursor> TrieWalker<C> {
                 trace!(target: "trie::walker", ?nibble, "found next sibling with state");
                 return Ok(())
             }
-            if nibble.is_out_of_bounds() {
+            if nibble.is_last_child() {
                 trace!(target: "trie::walker", ?nibble, "checked all siblings");
                 break
             }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -212,7 +212,7 @@ impl<C: TrieCursor> TrieWalker<C> {
         // We need to sync the stack with the trie structure when consuming a new node. This is
         // necessary for proper traversal and accurately representing the trie in the stack.
         if !key.is_empty() && !self.stack.is_empty() {
-            self.stack[0].set_next_node_nibble(key[0]);
+            self.stack[0].set_nibble(key[0]);
         }
 
         // The current tree mask might have been set incorrectly.
@@ -255,7 +255,7 @@ impl<C: TrieCursor> TrieWalker<C> {
 
         // Check if the walker needs to backtrack to the previous level in the trie during its
         // traversal.
-        if subnode.pointer().as_child().is_some_and(|nibble| nibble >= 0xf) ||
+        if subnode.pointer().is_out_of_bounds() ||
             (subnode.pointer().is_parent() && !allow_root_to_child_nibble)
         {
             self.stack.pop();
@@ -276,7 +276,7 @@ impl<C: TrieCursor> TrieWalker<C> {
                 trace!(target: "trie::walker", ?nibble, "found next sibling with state");
                 return Ok(())
             }
-            if nibble.as_child() == Some(0xf) {
+            if nibble.is_out_of_bounds() {
                 trace!(target: "trie::walker", ?nibble, "checked all siblings");
                 break
             }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -165,7 +165,7 @@ impl<C: TrieCursor> TrieWalker<C> {
             if !self.can_skip_current_node && self.children_are_in_trie() {
                 trace!(
                     target: "trie::walker",
-                    nibble = ?last.pointer(),
+                    pointer = ?last.pointer(),
                     "cannot skip current node and children are in the trie"
                 );
                 // If we can't skip the current node and the children are in the trie,

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -230,13 +230,13 @@ impl<C: TrieCursor> TrieWalker<C> {
 
         // Create a new CursorSubNode and push it to the stack.
         let subnode = CursorSubNode::new(key, Some(node));
-        let nibble = subnode.pointer();
+        let pointer = subnode.pointer();
         self.stack.push(subnode);
         self.update_skip_node();
 
         // Delete the current node if it's included in the prefix set or it doesn't contain the root
         // hash.
-        if !self.can_skip_current_node || nibble.is_child() {
+        if !self.can_skip_current_node || pointer.is_child() {
             if let Some((keys, key)) = self.removed_keys.as_mut().zip(self.cursor.current()?) {
                 keys.insert(key);
             }
@@ -271,13 +271,13 @@ impl<C: TrieCursor> TrieWalker<C> {
 
         // Find the next sibling with state.
         loop {
-            let nibble = subnode.pointer();
+            let pointer = subnode.pointer();
             if subnode.state_flag() {
-                trace!(target: "trie::walker", ?nibble, "found next sibling with state");
+                trace!(target: "trie::walker", ?pointer, "found next sibling with state");
                 return Ok(())
             }
-            if nibble.is_last_child() {
-                trace!(target: "trie::walker", ?nibble, "checked all siblings");
+            if pointer.is_last_child() {
+                trace!(target: "trie::walker", ?pointer, "checked all siblings");
                 break
             }
             subnode.inc_nibble();


### PR DESCRIPTION
Introduces a enum to distinguish between a `CursorSubNode` that's currently positioned at the branch node itself, or at one of its children. Additionally, adds more comments.