### PR TITLE
chore: remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9006,7 +9006,6 @@ dependencies = [
  "reth-consensus",
  "reth-db",
  "reth-e2e-test-utils",
- "reth-engine-local",
  "reth-evm",
  "reth-network",
  "reth-node-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9006,6 +9006,7 @@ dependencies = [
  "reth-consensus",
  "reth-db",
  "reth-e2e-test-utils",
+ "reth-engine-local",
  "reth-evm",
  "reth-network",
  "reth-node-api",

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -102,3 +102,6 @@ test-utils = [
     "reth-provider/test-utils",
     "reth-transaction-pool/test-utils",
 ]
+op = [
+    "reth-engine-local/op",
+]

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -103,5 +103,8 @@ test-utils = [
     "reth-transaction-pool/test-utils",
 ]
 op = [
+    "reth-db/op",
+    "reth-db-api/op",
     "reth-engine-local/op",
+    "reth-evm/op",
 ]

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -41,7 +41,7 @@ reth-node-events.workspace = true
 reth-optimism-evm.workspace = true
 reth-cli.workspace = true
 reth-cli-runner.workspace = true
-reth-node-builder.workspace = true
+reth-node-builder = {workspace = true, features = ["op"] }
 reth-tracing.workspace = true
 
 # eth

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -41,7 +41,7 @@ reth-node-events.workspace = true
 reth-optimism-evm.workspace = true
 reth-cli.workspace = true
 reth-cli-runner.workspace = true
-reth-node-builder = {workspace = true, features = ["op"] }
+reth-node-builder = { workspace = true, features = ["op"] }
 reth-tracing.workspace = true
 
 # eth

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 # reth
 reth-chainspec.workspace = true
-reth-engine-local = { workspace = true, features = ["op"] }
 reth-primitives-traits.workspace = true
 reth-payload-builder.workspace = true
 reth-consensus.workspace = true

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -76,6 +76,7 @@ reth-tasks.workspace = true
 reth-payload-util.workspace = true
 reth-payload-validator.workspace = true
 reth-revm = { workspace = true, features = ["std"] }
+reth-engine-local = { workspace = true, features = ["op"] }
 
 alloy-primitives.workspace = true
 op-alloy-consensus.workspace = true

--- a/crates/optimism/node/src/lib.rs
+++ b/crates/optimism/node/src/lib.rs
@@ -9,6 +9,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 /// CLI argument parsing for the optimism node.
 pub mod args;


### PR DESCRIPTION
followup of #15416 in this case we were relying on the `op` feature being set for `reth-engine-local` in `reth-optimism-node`, even though it was not being used in that crate. 

we need to properly propragate the `op` feature because otherwise just removing the unused `reth-engine-local` dep from the `reth-optimism-node` crate gives this error on `cargo run --bin op-reth --features "dev" --manifest-path crates/optimism/bin/Cargo.toml -- test-vectors compact --read`:
```
error[E0277]: the trait bound `DebugNodeLauncher: LaunchNode<NodeBuilderWithComponents<..., ..., ...>>` is not satisfied
   --> crates/optimism/bin/src/main.rs:23:56
    |
23  |                 builder.node(OpNode::new(rollup_args)).launch_with_debug_capabilities().await?;
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `reth_node_builder::launch::LaunchNode<reth_node_builder::builder::states::NodeBuilderWithComponents<reth_node_api::node::FullNodeTypesAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>, reth_provider::providers::blockchain_provider::BlockchainProvider<reth_node_types::NodeTypesWithDBAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>>>, reth_node_builder::components::builder::ComponentsBuilder<reth_node_api::node::FullNodeTypesAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>, reth_provider::providers::blockchain_provider::BlockchainProvider<reth_node_types::NodeTypesWithDBAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>>>, OpPoolBuilder, reth_node_builder::components::payload::BasicPayloadServiceBuilder<reth_optimism_node::node::OpPayloadBuilder>, OpNetworkBuilder, OpExecutorBuilder, OpConsensusBuilder>, OpAddOns<reth_node_builder::builder::states::NodeAdapter<reth_node_api::node::FullNodeTypesAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>, reth_provider::providers::blockchain_provider::BlockchainProvider<reth_node_types::NodeTypesWithDBAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>>>, reth_node_builder::components::Components<reth_node_api::node::FullNodeTypesAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>, reth_provider::providers::blockchain_provider::BlockchainProvider<reth_node_types::NodeTypesWithDBAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>>>, OpNetworkPrimitives, reth_transaction_pool::Pool<reth_transaction_pool::validate::task::TransactionValidationTaskExecutor<OpTransactionValidator<reth_provider::providers::blockchain_provider::BlockchainProvider<reth_node_types::NodeTypesWithDBAdapter<OpNode, Arc<reth_db::implementation::mdbx::DatabaseEnv>>>, OpPooledTransaction>>, reth_transaction_pool::ordering::CoinbaseTipOrdering<OpPooledTransaction>, reth_transaction_pool::blobstore::disk::DiskFileBlobStore>, OpEvmConfig, reth_evm::execute::BasicBlockExecutorProvider<OpEvmConfig>, Arc<reth_optimism_consensus::OpBeaconConsensus<reth_optimism_chainspec::OpChainSpec>>>>>>>` is not implemented for `reth_node_builder::launch::debug::DebugNodeLauncher`
    = help: the trait `reth_node_builder::launch::LaunchNode<Target>` is implemented for `reth_node_builder::launch::debug::DebugNodeLauncher<L>`
note: required by a bound in `reth_node_builder::builder::WithLaunchContext::<reth_node_builder::builder::states::NodeBuilderWithComponents<T, CB, AO>>::launch_with_debug_capabilities`
   --> /home/dappnode/workspace/paradigm/reth/crates/node/builder/src/builder/mod.rs:570:28
    |
565 |     pub async fn launch_with_debug_capabilities(
    |                  ------------------------------ required by a bound in this associated function
...
570 |         DebugNodeLauncher: LaunchNode<NodeBuilderWithComponents<T, CB, AO>>,
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `WithLaunchContext::<NodeBuilderWithComponents<T, CB, AO>>::launch_with_debug_capa
```