### PR TITLE
fix: always set empty request hash after isthmus

### DIFF
--- a/crates/optimism/evm/src/build.rs
+++ b/crates/optimism/evm/src/build.rs
@@ -112,7 +112,7 @@ where
             requests_hash: self
                 .chain_spec
                 .is_isthmus_active_at_timestamp(timestamp)
-                .then(|| EMPTY_REQUESTS_HASH),
+                .then_some(EMPTY_REQUESTS_HASH),
         };
 
         Ok(Block::new(

--- a/crates/optimism/evm/src/build.rs
+++ b/crates/optimism/evm/src/build.rs
@@ -67,7 +67,12 @@ where
             calculate_receipt_root_no_memo_optimism(receipts, &self.chain_spec, timestamp);
         let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| r.logs()));
 
+        let mut requests_hash = None;
+
         let withdrawals_root = if self.chain_spec.is_isthmus_active_at_timestamp(timestamp) {
+            // always empty requests hash post isthmus
+            requests_hash = Some(EMPTY_REQUESTS_HASH);
+
             // withdrawals root field in block header is used for storage root of L2 predeploy
             // `l2tol1-message-passer`
             Some(
@@ -108,11 +113,7 @@ where
             parent_beacon_block_root: ctx.parent_beacon_block_root,
             blob_gas_used,
             excess_blob_gas,
-            // always empty requests hash post isthmus
-            requests_hash: self
-                .chain_spec
-                .is_isthmus_active_at_timestamp(timestamp)
-                .then_some(EMPTY_REQUESTS_HASH),
+            requests_hash,
         };
 
         Ok(Block::new(

--- a/crates/optimism/evm/src/build.rs
+++ b/crates/optimism/evm/src/build.rs
@@ -3,7 +3,7 @@ use alloy_consensus::{
     constants::EMPTY_WITHDRAWALS, proofs, Block, BlockBody, Header, TxReceipt,
     EMPTY_OMMER_ROOT_HASH,
 };
-use alloy_eips::merge::BEACON_NONCE;
+use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::block::BlockExecutorFactory;
 use alloy_op_evm::OpBlockExecutionCtx;
 use alloy_primitives::logs_bloom;
@@ -108,7 +108,11 @@ where
             parent_beacon_block_root: ctx.parent_beacon_block_root,
             blob_gas_used,
             excess_blob_gas,
-            requests_hash: None,
+            // always empty requests hash post isthmus
+            requests_hash: self
+                .chain_spec
+                .is_isthmus_active_at_timestamp(timestamp)
+                .then(|| EMPTY_REQUESTS_HASH),
         };
 
         Ok(Block::new(


### PR DESCRIPTION
ref #15435

this must be set to empty requests hash post isthmus because this is what is expected post isthmus since newPayload V4 accepts an empty requests vec


ref: 

https://github.com/alloy-rs/op-alloy/blob/d02cea30037482e80ecd93cd7cdca603613289bc/crates/rpc-types-engine/src/payload/mod.rs#L519-L519

FYI @ferranbt 