### PR TITLE
fix: op-reth chain arg

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -268,7 +268,7 @@ pub enum Commands<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> {
 
 impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Commands<C, Ext> {
     /// Returns the underlying chain being used for commands
-    fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         match self {
             Self::Node(cmd) => cmd.chain_spec(),
             Self::Init(cmd) => cmd.chain_spec(),
@@ -280,7 +280,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Co
             Self::P2P(cmd) => cmd.chain_spec(),
             #[cfg(feature = "dev")]
             Self::TestVectors(cmd) => cmd.chain_spec(),
-            Self::Config(cmd) => cmd.chain_spec(),
+            Self::Config(_) => None,
             Self::Debug(cmd) => cmd.chain_spec(),
             Self::Recover(cmd) => cmd.chain_spec(),
             Self::Prune(cmd) => cmd.chain_spec(),

--- a/crates/cli/commands/src/config_cmd.rs
+++ b/crates/cli/commands/src/config_cmd.rs
@@ -2,9 +2,8 @@
 
 use clap::Parser;
 use eyre::{bail, WrapErr};
-use reth_chainspec::ChainSpec;
 use reth_config::Config;
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 /// `reth config` command
 #[derive(Debug, Parser)]
 pub struct Command {
@@ -34,9 +33,5 @@ impl Command {
         };
         println!("{}", toml::to_string_pretty(&config)?);
         Ok(())
-    }
-    /// Returns the underlying chain being used to run this command
-    pub fn chain_spec(&self) -> Option<&Arc<ChainSpec>> {
-        None
     }
 }

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -128,6 +128,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateC
         info!(target: "reth::cli", hash = ?hash, "Genesis block written");
         Ok(())
     }
+}
+
+impl<C: ChainSpecParser> InitStateCommand<C> {
     /// Returns the underlying chain being used to run this command
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         Some(&self.env.chain)

--- a/crates/cli/commands/src/recover/mod.rs
+++ b/crates/cli/commands/src/recover/mod.rs
@@ -33,6 +33,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
             Subcommands::StorageTries(command) => command.execute::<N>(ctx).await,
         }
     }
+}
+
+impl<C: ChainSpecParser> Command<C> {
     /// Returns the underlying chain being used to run this command
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         match &self.command {

--- a/crates/cli/commands/src/recover/storage_tries.rs
+++ b/crates/cli/commands/src/recover/storage_tries.rs
@@ -66,6 +66,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 
         Ok(())
     }
+}
+
+impl<C: ChainSpecParser> Command<C> {
     /// Returns the underlying chain being used to run this command
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         Some(&self.env.chain)

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -157,3 +157,10 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ImportOpCommand<C> {
         Ok(())
     }
 }
+
+impl<C: ChainSpecParser> ImportOpCommand<C> {
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
+    }
+}

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -1,8 +1,7 @@
 //! Command that imports OP mainnet receipts from Bedrock datadir, exported via
 //! <https://github.com/testinprod-io/op-geth/pull/1>.
 
-use std::path::{Path, PathBuf};
-
+use crate::receipt_file_codec::OpGethReceiptFileCodec;
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
@@ -24,9 +23,11 @@ use reth_provider::{
 };
 use reth_stages::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tracing::{debug, info, trace, warn};
-
-use crate::receipt_file_codec::OpGethReceiptFileCodec;
 
 /// Initializes the database with the genesis block.
 #[derive(Debug, Parser)]
@@ -77,6 +78,13 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ImportReceiptsOpCommand<C> {
             },
         )
         .await
+    }
+}
+
+impl<C: ChainSpecParser> ImportReceiptsOpCommand<C> {
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        Some(&self.env.chain)
     }
 }
 

--- a/crates/optimism/cli/src/commands/init_state.rs
+++ b/crates/optimism/cli/src/commands/init_state.rs
@@ -14,7 +14,7 @@ use reth_provider::{
     BlockNumReader, ChainSpecProvider, DatabaseProviderFactory, StaticFileProviderFactory,
     StaticFileWriter,
 };
-use std::io::BufReader;
+use std::{io::BufReader, sync::Arc};
 use tracing::info;
 
 /// Initializes the database with the genesis block.
@@ -82,5 +82,12 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitStateCommandOp<C> {
 
         info!(target: "reth::cli", hash = ?hash, "Genesis block written");
         Ok(())
+    }
+}
+
+impl<C: ChainSpecParser> InitStateCommandOp<C> {
+    /// Returns the underlying chain being used to run this command
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        self.init_state.chain_spec()
     }
 }

--- a/crates/optimism/cli/src/commands/mod.rs
+++ b/crates/optimism/cli/src/commands/mod.rs
@@ -2,13 +2,14 @@ use crate::chainspec::OpChainSpecParser;
 use clap::Subcommand;
 use import::ImportOpCommand;
 use import_receipts::ImportReceiptsOpCommand;
+use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     config_cmd, db, dump_genesis, init_cmd,
     node::{self, NoArgs},
     p2p, prune, recover, stage,
 };
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 pub mod import;
 pub mod import_receipts;
@@ -61,4 +62,30 @@ pub enum Commands<Spec: ChainSpecParser = OpChainSpecParser, Ext: clap::Args + f
     #[cfg(feature = "dev")]
     #[command(name = "test-vectors")]
     TestVectors(test_vectors::Command),
+}
+
+impl<
+        C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>,
+        Ext: clap::Args + fmt::Debug,
+    > Commands<C, Ext>
+{
+    /// Returns the underlying chain being used for commands
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        match self {
+            Self::Node(cmd) => cmd.chain_spec(),
+            Self::Init(cmd) => cmd.chain_spec(),
+            Self::InitState(cmd) => cmd.chain_spec(),
+            Self::DumpGenesis(cmd) => cmd.chain_spec(),
+            Self::Db(cmd) => cmd.chain_spec(),
+            Self::Stage(cmd) => cmd.chain_spec(),
+            Self::P2P(cmd) => cmd.chain_spec(),
+            Self::Config(_) => None,
+            Self::Recover(cmd) => cmd.chain_spec(),
+            Self::Prune(cmd) => cmd.chain_spec(),
+            Self::ImportOp(cmd) => cmd.chain_spec(),
+            Self::ImportReceiptsOp(cmd) => cmd.chain_spec(),
+            #[cfg(feature = "dev")]
+            Self::TestVectors(_) => None,
+        }
+    }
 }


### PR DESCRIPTION
all my homies hate global args, super cancer.

although the alternative, making all commands self contained is preferred, comes with more boiler plate. but having top level global args is really bad.