### PR TITLE
chore(op-txpool): Update `ExecutingDescriptor` serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9202,6 +9202,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
+ "alloy-serde",
  "c-kzg",
  "derive_more 2.0.1",
  "futures-util",

--- a/crates/optimism/txpool/Cargo.toml
+++ b/crates/optimism/txpool/Cargo.toml
@@ -19,6 +19,7 @@ alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-client = { workspace = true, features = ["reqwest", "default"] }
 alloy-json-rpc.workspace = true
+alloy-serde.workspace = true
 
 # reth
 reth-chainspec.workspace = true

--- a/crates/optimism/txpool/src/supervisor/message.rs
+++ b/crates/optimism/txpool/src/supervisor/message.rs
@@ -21,10 +21,11 @@
 #[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExecutingDescriptor {
     /// The timestamp used to enforce timestamp [invariant](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/derivation.md#invariants)
+    #[serde(with = "alloy_serde::quantity")]
     timestamp: u64,
     /// The timeout that requests verification to still hold at `timestamp+timeout`
     /// (message expiry may drop previously valid messages).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     timeout: Option<u64>,
 }
 


### PR DESCRIPTION
## Overview

Updates the serialization of the `ExecutingDescriptor` type to use hex strings for the `u64` values.

closes #15464 