### PR TITLE
feat: support simulation in blockbuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebc51302579bd1d3f99e854404238d3055f65303ba0c15865c08a7e7013d97c"
+checksum = "e158fd08c4be4fafe8c9fb7cb661f3b9585038446df0cd20b3d99e71f4166748"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1808b7c4197488ba531c7d435915c55c7d3113a3fe76beca7bfc285f90906f6f"
+checksum = "c6f49ab23b828db185eea248540f997cb5196ba0d76d5af10d0d5450eb19fab4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,7 +453,7 @@ revm-inspectors = "0.18.0"
 alloy-chains = { version = "0.1.68", default-features = false }
 alloy-dyn-abi = "0.8.25"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { version = "0.3.0", default-features = false }
+alloy-evm = { version = "0.3.1", default-features = false }
 alloy-primitives = { version = "0.8.25", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.25", default-features = false }
@@ -491,7 +491,7 @@ alloy-transport-ipc = { version = "0.13.0", default-features = false }
 alloy-transport-ws = { version = "0.13.0", default-features = false }
 
 # op
-alloy-op-evm = { version = "0.3.0", default-features = false }
+alloy-op-evm = { version = "0.3.1", default-features = false }
 alloy-op-hardforks = "0.1.2"
 op-alloy-rpc-types = { version = "0.12.0", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.12.0", default-features = false }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -3,6 +3,7 @@
 use crate::{ConfigureEvm, Database, OnStateHook};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
+use alloy_eips::eip2718::WithEncoded;
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
 use alloy_evm::{Evm, EvmEnv, EvmFactory};
 use alloy_primitives::B256;
@@ -233,6 +234,12 @@ pub trait BlockBuilder {
         Receipt = ReceiptTy<Self::Primitives>,
     >;
 
+    /// Marker for indicating that this block builder is used for simulation.
+    ///
+    /// This allows implementors to turn of certain restrictions, e.g. `eth_simulateV1`
+    // TODO(mattss): find a nicer workaround for this
+    fn set_simulate(&mut self, _simulated: bool) {}
+
     /// Invokes [`BlockExecutor::apply_pre_execution_changes`].
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError>;
 
@@ -280,6 +287,7 @@ where
     pub(crate) ctx: F::ExecutionCtx<'a>,
     pub(crate) parent: &'a SealedHeader<HeaderTy<N>>,
     pub(crate) assembler: Builder,
+    pub(crate) simulated: bool,
 }
 
 impl<'a, F, DB, Executor, Builder, N> BlockBuilder
@@ -311,8 +319,16 @@ where
         tx: Recovered<TxTy<Self::Primitives>>,
         f: impl FnOnce(&ExecutionResult<<F::EvmFactory as EvmFactory>::HaltReason>),
     ) -> Result<u64, BlockExecutionError> {
-        let gas_used =
-            self.executor.execute_transaction_with_result_closure(tx.as_recovered_ref(), f)?;
+        let gas_used = if self.simulated {
+            // if used in simulation we want to disable the L1 gas overhead by providing empty
+            // encoded bytes this is a workaround to get eth_simulate properly supported
+            // with the regular blockbuilder api
+            let tx = WithEncoded::new(Default::default(), &tx);
+            self.executor.execute_transaction_with_result_closure(&tx, f)?
+        } else {
+            self.executor.execute_transaction_with_result_closure(tx.as_recovered_ref(), f)?
+        };
+
         self.transactions.push(tx);
         Ok(gas_used)
     }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -237,7 +237,7 @@ pub trait BlockBuilder {
     /// Marker for indicating that this block builder is used for simulation.
     ///
     /// This allows implementors to turn of certain restrictions, e.g. `eth_simulateV1`
-    // TODO(mattss): find a nicer workaround for this
+    // TODO(mattsse): find a nicer workaround for this
     fn set_simulate(&mut self, _simulated: bool) {}
 
     /// Invokes [`BlockExecutor::apply_pre_execution_changes`].

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -254,6 +254,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
             assembler: self.block_assembler(),
             parent,
             transactions: Vec::new(),
+            simulated: false,
         }
     }
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -80,6 +80,9 @@ where
     S: BlockBuilder<Executor: BlockExecutor<Evm: Evm<DB: Database<Error: Into<EthApiError>>>>>,
     T: TransactionCompat<TxTy<S::Primitives>>,
 {
+    // Tell the block builder that it is used for simulation
+    builder.set_simulate(true);
+
     builder.apply_pre_execution_changes()?;
 
     let mut results = Vec::with_capacity(calls.len());


### PR DESCRIPTION
closes #15292

this introduces a work around to make ethsimulate work properly for op transactions, the proper fix would be accepting something that can be converted into `Recovered<TxTy<Self::Primitives>>` instead, but requires a bit more thinking.

for now this is sufficient