### PR TITLE
perf(trie): cache last hashed entry seek in trie node iter

### DIFF
--- a/crates/trie/trie/src/metrics.rs
+++ b/crates/trie/trie/src/metrics.rs
@@ -72,9 +72,12 @@ impl WalkerMetrics {
 pub struct TrieNodeIterMetrics {
     /// The number of branch nodes returned by the iterator.
     branch_nodes_returned_total: Counter,
-    /// The number of times same leaf node was seeked multiple times in a row by the iterator.
+    /// The number of times the same hashed cursor key was seeked multiple times in a row by the
+    /// iterator. It does not mean mean the database seek was actually done, as the trie node
+    /// iterator caches the last hashed cursor seek.
     leaf_nodes_same_seeked_total: Counter,
-    /// The number of times the same leaf node as we just advanced to was seeked by the iterator.
+    /// The number of times the same hashed cursor key as we just advanced to was seeked by the
+    /// iterator.
     leaf_nodes_same_seeked_as_advanced_total: Counter,
     /// The number of leaf nodes seeked by the iterator.
     leaf_nodes_seeked_total: Counter,

--- a/crates/trie/trie/src/metrics.rs
+++ b/crates/trie/trie/src/metrics.rs
@@ -76,8 +76,7 @@ pub struct TrieNodeIterMetrics {
     /// iterator. It does not mean mean the database seek was actually done, as the trie node
     /// iterator caches the last hashed cursor seek.
     leaf_nodes_same_seeked_total: Counter,
-    /// The number of times the same hashed cursor key as we just advanced to was seeked by the
-    /// iterator.
+    /// The number of times the same leaf node as we just advanced to was seeked by the iterator.
     leaf_nodes_same_seeked_as_advanced_total: Counter,
     /// The number of leaf nodes seeked by the iterator.
     leaf_nodes_seeked_total: Counter,

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -61,8 +61,6 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::TrieNodeIterMetrics,
     #[cfg(feature = "metrics")]
-    previously_seeked_key: Option<B256>,
-    #[cfg(feature = "metrics")]
     previously_advanced_to_key: Option<B256>,
 }
 
@@ -81,8 +79,6 @@ where
             last_seeked_hashed_entry: None,
             #[cfg(feature = "metrics")]
             metrics: crate::metrics::TrieNodeIterMetrics::new(trie_type),
-            #[cfg(feature = "metrics")]
-            previously_seeked_key: None,
             #[cfg(feature = "metrics")]
             previously_advanced_to_key: None,
         }
@@ -107,17 +103,13 @@ where
             .filter(|entry| entry.seeked_key == key)
             .map(|entry| entry.result)
         {
+            self.metrics.inc_leaf_nodes_same_seeked();
             return Ok(entry);
         }
 
         #[cfg(feature = "metrics")]
         {
             self.metrics.inc_leaf_nodes_seeked();
-
-            if Some(key) == self.previously_seeked_key {
-                self.metrics.inc_leaf_nodes_same_seeked();
-            }
-            self.previously_seeked_key = Some(key);
 
             if Some(key) == self.previously_advanced_to_key {
                 self.metrics.inc_leaf_nodes_same_seeked_as_advanced();

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -61,6 +61,8 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
     should_check_walker_key: bool,
 
     /// The last seeked hashed entry.
+    ///
+    /// We use it to not seek the same hashed entry twice, and instead re-use it.
     last_seeked_hashed_entry: Option<SeekedHashedEntry<H::Value>>,
 
     #[cfg(feature = "metrics")]
@@ -121,11 +123,7 @@ where
         {
             self.metrics.inc_leaf_nodes_seeked();
 
-            // If either the seek key or the result key is the same as the key we previously
-            // advanced to.
-            if Some(key) == self.previously_advanced_to_key ||
-                result.as_ref().map(|(k, _)| *k) == self.previously_advanced_to_key
-            {
+            if Some(key) == self.previously_advanced_to_key {
                 self.metrics.inc_leaf_nodes_same_seeked_as_advanced();
             }
         }

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -33,9 +33,14 @@ pub enum TrieElement<Value> {
     Leaf(B256, Value),
 }
 
+/// Result of calling [`HashedCursor::seek`].
 #[derive(Debug)]
 struct SeekedHashedEntry<V> {
+    /// The key that was seeked.
     seeked_key: B256,
+    /// The result of the seek.
+
+    /// If no entry was found for the provided key, this will be [`None`].
     result: Option<(B256, V)>,
 }
 
@@ -60,6 +65,7 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
 
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::TrieNodeIterMetrics,
+    /// The key that the [`HashedCursor`] previously advanced to using [`HashedCursor::next`].
     #[cfg(feature = "metrics")]
     previously_advanced_to_key: Option<B256>,
 }

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -107,16 +107,21 @@ where
             return Ok(entry);
         }
 
+        let result = self.hashed_cursor.seek(key)?;
+        self.last_seeked_hashed_entry = Some(SeekedHashedEntry { seeked_key: key, result });
+
         #[cfg(feature = "metrics")]
         {
             self.metrics.inc_leaf_nodes_seeked();
 
-            if Some(key) == self.previously_advanced_to_key {
+            // If either the seek key or the result key is the same as the key we previously
+            // advanced to.
+            if Some(key) == self.previously_advanced_to_key ||
+                result.as_ref().map(|(k, _)| *k) == self.previously_advanced_to_key
+            {
                 self.metrics.inc_leaf_nodes_same_seeked_as_advanced();
             }
         }
-        let result = self.hashed_cursor.seek(key)?;
-        self.last_seeked_hashed_entry = Some(SeekedHashedEntry { seeked_key: key, result });
         Ok(result)
     }
 

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -115,7 +115,9 @@ where
                 self.metrics.inc_leaf_nodes_same_seeked_as_advanced();
             }
         }
-        self.hashed_cursor.seek(key)
+        let result = self.hashed_cursor.seek(key)?;
+        self.last_seeked_hashed_entry = Some(SeekedHashedEntry { seeked_key: key, result });
+        Ok(result)
     }
 
     /// Advances the hashed cursor to the next entry.
@@ -483,11 +485,6 @@ mod tests {
                     visited_key: Some(account_1)
                 },
                 // Seek to the modified account.
-                KeyVisit {
-                    visit_type: KeyVisitType::SeekNonExact(account_3),
-                    visited_key: Some(account_3)
-                },
-                // Why do we seek the account 3 one more time?
                 KeyVisit {
                     visit_type: KeyVisitType::SeekNonExact(account_3),
                     visited_key: Some(account_3)

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -103,6 +103,7 @@ where
             .filter(|entry| entry.seeked_key == key)
             .map(|entry| entry.result)
         {
+            #[cfg(feature = "metrics")]
             self.metrics.inc_leaf_nodes_same_seeked();
             return Ok(entry);
         }


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/15327

This saves us about 10% of all hashed cursor seeks.