### PR TITLE
fix: set None storage lookup to NotCached

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -537,7 +537,8 @@ impl AccountStorageCache {
     /// - `Value`: The slot has a specific value
     pub(crate) fn get_storage(&self, key: &StorageKey) -> SlotStatus {
         match self.slots.get(key) {
-            None | Some(None) => SlotStatus::Empty,
+            None => SlotStatus::NotCached,
+            Some(None) => SlotStatus::Empty,
             Some(Some(value)) => SlotStatus::Value(value),
         }
     }


### PR DESCRIPTION
None actually means it's not in the cache, the previous way of doing this meant that all uncached values ended up empty