### PR TITLE
fix: `const fn new()` to remove incompatible `const` qualifier

### DIFF
--- a/crates/engine/tree/benches/channel_perf.rs
+++ b/crates/engine/tree/benches/channel_perf.rs
@@ -44,7 +44,7 @@ struct StdStateRootTask {
 }
 
 impl StdStateRootTask {
-    const fn new(rx: std::sync::mpsc::Receiver<EvmState>) -> Self {
+    fn new(rx: std::sync::mpsc::Receiver<EvmState>) -> Self {
         Self { rx }
     }
 


### PR DESCRIPTION
std::sync::mpsc::Receiver<EvmState>` isn't `const`-compatible since it can't be initialized in a `const fn`.

my pr removes the `const` qualifier from `new()` to ensure proper compilation.