### PR TITLE
fix: incorrect `derive_more` import

### DIFF
--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -4,7 +4,7 @@ use crate::{
     CanDisconnect,
 };
 use bytes::{Bytes, BytesMut};
-use derive_more::with_trait::Debug;
+use derive_more::Debug;
 use futures::{Sink, SinkExt, Stream};
 use reth_eth_wire_types::{
     DisconnectReason, EthMessage, EthNetworkPrimitives, ProtocolMessage, Status,

--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -4,14 +4,13 @@ use crate::{
     CanDisconnect,
 };
 use bytes::{Bytes, BytesMut};
-use derive_more::Debug;
 use futures::{Sink, SinkExt, Stream};
 use reth_eth_wire_types::{
     DisconnectReason, EthMessage, EthNetworkPrimitives, ProtocolMessage, Status,
 };
 use reth_ethereum_forks::ForkFilter;
 use reth_primitives_traits::GotExpected;
-use std::{future::Future, pin::Pin, time::Duration};
+use std::{fmt::Debug, future::Future, pin::Pin, time::Duration};
 use tokio::time::timeout;
 use tokio_stream::StreamExt;
 use tracing::{debug, trace};

--- a/examples/bsc-p2p/src/handshake.rs
+++ b/examples/bsc-p2p/src/handshake.rs
@@ -1,6 +1,5 @@
 use crate::upgrade_status::{UpgradeStatus, UpgradeStatusExtension};
 use alloy_rlp::Decodable;
-use derive_more::Debug;
 use futures::SinkExt;
 use reth_eth_wire::{
     errors::{EthHandshakeError, EthStreamError},


### PR DESCRIPTION
`derive_more` import was incorrect. the code was using:  

```rust
use derive_more::with_trait::Debug;
```  

however, `derive_more` does not have a `with_trait::Debug` path. the correct import should be:  

```rust
use derive_more::Debug;
```  
