### PR TITLE
chore: set prewarm concurrency to 64

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -70,8 +70,7 @@ where
             pending,
             ctx,
             in_progress: 0,
-            // TODO settings
-            max_concurrency: 4,
+            max_concurrency: 64,
             to_multi_proof,
             actions_rx,
             actions_tx,


### PR DESCRIPTION
This just bumps the number of prewarm tasks to spawn to 64, instead of 4.