### PR TITLE
Add PubSub subscribe to custom node rpc example

### DIFF
--- a/examples/node-custom-rpc/Cargo.toml
+++ b/examples/node-custom-rpc/Cargo.toml
@@ -12,6 +12,6 @@ reth-node-ethereum.workspace = true
 
 clap = { workspace = true, features = ["derive"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
-tokio = { workspace = true }
+tokio.workspace = true
 [dev-dependencies]
 tokio.workspace = true

--- a/examples/node-custom-rpc/Cargo.toml
+++ b/examples/node-custom-rpc/Cargo.toml
@@ -12,6 +12,6 @@ reth-node-ethereum.workspace = true
 
 clap = { workspace = true, features = ["derive"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
-
+tokio = { workspace = true }
 [dev-dependencies]
 tokio.workspace = true

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
                 .node(EthereumNode::default())
                 .extend_rpc_modules(move |ctx| {
                     if !args.enable_ext {
-                        return Ok(());
+                        return Ok(())
                     }
 
                     // here we get the configured pool.

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -15,8 +15,11 @@
 #![warn(unused_crate_dependencies)]
 
 use clap::Parser;
-use jsonrpsee::core::SubscriptionResult;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc, PendingSubscriptionSink, SubscriptionMessage};
+use jsonrpsee::{
+    core::{RpcResult, SubscriptionResult},
+    proc_macros::rpc,
+    PendingSubscriptionSink, SubscriptionMessage,
+};
 use reth::{chainspec::EthereumChainSpecParser, cli::Cli};
 use reth_node_ethereum::EthereumNode;
 use reth_transaction_pool::TransactionPool;
@@ -73,7 +76,10 @@ pub trait TxpoolExtApi {
 
     /// Creates a subscription that returns the number of transactions in the pool every 10s.
     #[subscription(name = "subscribeTransactionCount", item = usize)]
-    fn subscribe_transaction_count(&self, #[argument(rename = "delay")] delay: Option<u64>) -> SubscriptionResult;
+    fn subscribe_transaction_count(
+        &self,
+        #[argument(rename = "delay")] delay: Option<u64>,
+    ) -> SubscriptionResult;
 }
 
 /// The type that implements the `txpool` rpc namespace trait
@@ -122,8 +128,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jsonrpsee::ws_client::WsClientBuilder;
-    use jsonrpsee::{http_client::HttpClientBuilder, server::ServerBuilder};
+    use jsonrpsee::{
+        http_client::HttpClientBuilder, server::ServerBuilder, ws_client::WsClientBuilder,
+    };
     use reth_transaction_pool::noop::NoopTransactionPool;
 
     #[cfg(test)]


### PR DESCRIPTION
This is just a small improvement to the example for adding a custom rpc to a node to demonstrate how to create a subscribe type rpc, with an optional parameter. I also added a test for it as well. It is not much but I figured the example would be more complete with this shown as well.  Hopefully someone finds it useful!