### PR TITLE
fix: send_rpc_call deserialization

### DIFF
--- a/crates/optimism/rpc/src/sequencer.rs
+++ b/crates/optimism/rpc/src/sequencer.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Arc;
 
-use alloy_json_rpc::RpcSend;
-use alloy_primitives::{hex, Bytes};
+use alloy_json_rpc::{RpcRecv, RpcSend};
+use alloy_primitives::{hex, B256};
 use alloy_rpc_client::{ClientBuilder, RpcClient as Client};
 use alloy_rpc_types_eth::erc4337::TransactionConditional;
 use alloy_transport_http::Http;
@@ -48,35 +48,38 @@ impl SequencerClient {
     }
 
     /// Sends a [`alloy_rpc_client::RpcCall`] request to the sequencer endpoint.
-    async fn send_rpc_call<Params: RpcSend>(
+    async fn send_rpc_call<Params: RpcSend, Resp: RpcRecv>(
         &self,
         method: &str,
         params: Params,
-    ) -> Result<(), SequencerClientError> {
-        self.http_client().request::<Params, Bytes>(method.to_string(), params).await.inspect_err(
-            |err| {
+    ) -> Result<Resp, SequencerClientError> {
+        let resp = self
+            .http_client()
+            .request::<Params, Resp>(method.to_string(), params)
+            .await
+            .inspect_err(|err| {
                 warn!(
                     target: "rpc::sequencer",
                     %err,
                     "HTTP request to sequencer failed",
                 );
-            },
-        )?;
-        Ok(())
+            })?;
+        Ok(resp)
     }
 
     /// Forwards a transaction to the sequencer endpoint.
-    pub async fn forward_raw_transaction(&self, tx: &[u8]) -> Result<(), SequencerClientError> {
+    pub async fn forward_raw_transaction(&self, tx: &[u8]) -> Result<B256, SequencerClientError> {
         let rlp_hex = hex::encode_prefixed(tx);
-        self.send_rpc_call("eth_sendRawTransaction", (rlp_hex,)).await.inspect_err(|err| {
-            warn!(
-                target: "rpc::eth",
-                %err,
-                "Failed to forward transaction to sequencer",
-            );
-        })?;
+        let tx_hash: B256 =
+            self.send_rpc_call("eth_sendRawTransaction", (rlp_hex,)).await.inspect_err(|err| {
+                warn!(
+                    target: "rpc::eth",
+                    %err,
+                    "Failed to forward transaction to sequencer",
+                );
+            })?;
 
-        Ok(())
+        Ok(tx_hash)
     }
 
     /// Forwards a transaction conditional to the sequencer endpoint.
@@ -84,9 +87,10 @@ impl SequencerClient {
         &self,
         tx: &[u8],
         condition: TransactionConditional,
-    ) -> Result<(), SequencerClientError> {
+    ) -> Result<B256, SequencerClientError> {
         let rlp_hex = hex::encode_prefixed(tx);
-        self.send_rpc_call("eth_sendRawTransactionConditional", (rlp_hex, condition))
+        let tx_hash: B256 = self
+            .send_rpc_call("eth_sendRawTransactionConditional", (rlp_hex, condition))
             .await
             .inspect_err(|err| {
                 warn!(
@@ -95,7 +99,7 @@ impl SequencerClient {
                     "Failed to forward transaction conditional for sequencer",
                 );
             })?;
-        Ok(())
+        Ok(tx_hash)
     }
 }
 

--- a/crates/optimism/rpc/src/sequencer.rs
+++ b/crates/optimism/rpc/src/sequencer.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use alloy_json_rpc::RpcSend;
-use alloy_primitives::hex;
+use alloy_primitives::{hex, Bytes};
 use alloy_rpc_client::{ClientBuilder, RpcClient as Client};
 use alloy_rpc_types_eth::erc4337::TransactionConditional;
 use alloy_transport_http::Http;
@@ -53,7 +53,7 @@ impl SequencerClient {
         method: &str,
         params: Params,
     ) -> Result<(), SequencerClientError> {
-        self.http_client().request::<Params, ()>(method.to_string(), params).await.inspect_err(
+        self.http_client().request::<Params, Bytes>(method.to_string(), params).await.inspect_err(
             |err| {
                 warn!(
                     target: "rpc::sequencer",

--- a/crates/optimism/rpc/src/sequencer.rs
+++ b/crates/optimism/rpc/src/sequencer.rs
@@ -70,7 +70,7 @@ impl SequencerClient {
     /// Forwards a transaction to the sequencer endpoint.
     pub async fn forward_raw_transaction(&self, tx: &[u8]) -> Result<B256, SequencerClientError> {
         let rlp_hex = hex::encode_prefixed(tx);
-        let tx_hash: B256 =
+        let tx_hash =
             self.send_rpc_call("eth_sendRawTransaction", (rlp_hex,)).await.inspect_err(|err| {
                 warn!(
                     target: "rpc::eth",
@@ -89,7 +89,7 @@ impl SequencerClient {
         condition: TransactionConditional,
     ) -> Result<B256, SequencerClientError> {
         let rlp_hex = hex::encode_prefixed(tx);
-        let tx_hash: B256 = self
+        let tx_hash = self
             .send_rpc_call("eth_sendRawTransactionConditional", (rlp_hex, condition))
             .await
             .inspect_err(|err| {


### PR DESCRIPTION
Patches deserialization issue when forwarding transactions to the sequencer as the Response type was set incorrectly.

```
2025-04-03 18:33:03 2025-04-04T01:33:03.912182Z  WARN Failed to forward transaction to sequencer err=deserialization error: invalid type: string "0x428de0c87937d95ec82b22c461d66db736cbb5decc806bb60ffaf143ada70af9", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912229Z  WARN HTTP request to sequencer failed err=deserialization error: invalid type: string "0x8b735d8933dc624cb4dab7cf73f4efd37c601d72cb682e3ace2c0506a9b020ea", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912232Z  WARN Failed to forward transaction to sequencer err=deserialization error: invalid type: string "0x8b735d8933dc624cb4dab7cf73f4efd37c601d72cb682e3ace2c0506a9b020ea", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912258Z  WARN HTTP request to sequencer failed err=deserialization error: invalid type: string "0x52bc939d12955b3fb5130d12246c9d2b561c59d0043ce5a244d68b5e24c36f1e", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912260Z  WARN Failed to forward transaction to sequencer err=deserialization error: invalid type: string "0x52bc939d12955b3fb5130d12246c9d2b561c59d0043ce5a244d68b5e24c36f1e", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912285Z  WARN HTTP request to sequencer failed err=deserialization error: invalid type: string "0xfa8ead2ca8f72c0c0a66d31c79bc6c443db476186652e9612e407ca25e9c8325", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912286Z  WARN Failed to forward transaction to sequencer err=deserialization error: invalid type: string "0xfa8ead2ca8f72c0c0a66d31c79bc6c443db476186652e9612e407ca25e9c8325", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912338Z  WARN HTTP request to sequencer failed err=deserialization error: invalid type: string "0xf411b8942507aa358117cc178e6c6eca2e6f78dc2e96945699340ba8d79c7cfb", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912352Z  WARN Failed to forward transaction to sequencer err=deserialization error: invalid type: string "0xf411b8942507aa358117cc178e6c6eca2e6f78dc2e96945699340ba8d79c7cfb", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912373Z  WARN HTTP request to sequencer failed err=deserialization error: invalid type: string "0x8dd39dd4881e4c6e1a75cbbc58e808c43060f0208741521cabc91b97dd0705bc", expected unit at line 1 column 68
2025-04-03 18:33:03 2025-04-04T01:33:03.912382Z  WARN Failed to forward transaction to sequencer err=deserialization error: invalid type: string "0x8dd39dd4881e4c6e1a75cbbc58e808c43060f0208741521cabc91b97dd0705bc", expected unit at line 1 column 68
```