### PR TITLE
feat(evm): Accept executable transaction as the input for block builder

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -254,7 +254,6 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
             assembler: self.block_assembler(),
             parent,
             transactions: Vec::new(),
-            simulated: false,
         }
     }
 


### PR DESCRIPTION
Closes #15480

The recent changes to block builder added an if statement solution to have a different logic for simulated transactions.

This PR applies an object oriented approach to implement different conversion logic and have one specific for simulation.