### PR TITLE
fix: blob params parsing and configuring

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -277,11 +277,7 @@ impl HardforkBlobParams {
         let extract = |key: &str, default: fn() -> BlobParams| {
             blob_schedule
                 .get(key)
-                .map(|item| BlobParams {
-                    target_blob_count: item.target_blob_count,
-                    max_blob_count: item.max_blob_count,
-                    ..default()
-                })
+                .copied()
                 .unwrap_or_else(default) // Use default if key is missing
         };
 

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -276,7 +276,7 @@ impl HardforkBlobParams {
     pub fn from_schedule(blob_schedule: &BTreeMap<String, BlobParams>) -> Self {
         Self {
             cancun: blob_schedule.get("cancun").copied().unwrap_or_else(BlobParams::cancun),
-            prague: blob_schedule.get("prague").copied().unwrap_or_else(BlobParams::cancun),
+            prague: blob_schedule.get("prague").copied().unwrap_or_else(BlobParams::prague),
         }
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -272,15 +272,11 @@ pub struct HardforkBlobParams {
 
 impl HardforkBlobParams {
     /// Constructs params for chainspec from a provided blob schedule.
-    /// Falls back to defaults if the schedule is empty.
+    /// Falls back to defaults if the schedule is missing.
     pub fn from_schedule(blob_schedule: &BTreeMap<String, BlobParams>) -> Self {
-        let extract = |key: &str, default: fn() -> BlobParams| {
-            blob_schedule.get(key).copied().unwrap_or_else(default) // Use default if key is missing
-        };
-
         Self {
-            cancun: extract("cancun", BlobParams::cancun),
-            prague: extract("prague", BlobParams::prague),
+            cancun: blob_schedule.get("cancun").copied().unwrap_or_else(BlobParams::cancun),
+            prague: blob_schedule.get("prague").copied().unwrap_or_else(BlobParams::cancun),
         }
     }
 }

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -37,7 +37,7 @@ use revm::{
 };
 
 mod config;
-use alloy_eips::eip1559::INITIAL_BASE_FEE;
+use alloy_eips::{eip1559::INITIAL_BASE_FEE, eip7840::BlobParams};
 pub use config::{revm_spec, revm_spec_by_timestamp_and_block_number};
 use reth_ethereum_forks::EthereumHardfork;
 
@@ -134,14 +134,15 @@ where
         // configure evm env based on parent block
         let cfg_env = CfgEnv::new().with_chain_id(self.chain_spec().chain().id()).with_spec(spec);
 
-        // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current blobparams
-        let blob_excess_gas_and_price = header.excess_blob_gas.zip(self.chain_spec().blob_params_at_timestamp(header.timestamp)).map(|(excess_blob_gas, params)| {
-            let blob_gasprice = params.calc_blob_fee(excess_blob_gas);
-            BlobExcessGasAndPrice {
-                excess_blob_gas,
-                blob_gasprice,
-            }
-        });
+        // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current
+        // blobparams
+        let blob_excess_gas_and_price = header
+            .excess_blob_gas
+            .zip(self.chain_spec().blob_params_at_timestamp(header.timestamp))
+            .map(|(excess_blob_gas, params)| {
+                let blob_gasprice = params.calc_blob_fee(excess_blob_gas);
+                BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }
+            });
 
         let block_env = BlockEnv {
             number: header.number(),
@@ -151,7 +152,7 @@ where
             prevrandao: if spec >= SpecId::MERGE { header.mix_hash() } else { None },
             gas_limit: header.gas_limit(),
             basefee: header.base_fee_per_gas().unwrap_or_default(),
-            blob_excess_gas_and_price
+            blob_excess_gas_and_price,
         };
 
         EvmEnv { cfg_env, block_env }
@@ -172,14 +173,17 @@ where
         // configure evm env based on parent block
         let cfg = CfgEnv::new().with_chain_id(self.chain_spec().chain().id()).with_spec(spec_id);
 
+        let blob_params = self.chain_spec().blob_params_at_timestamp(attributes.timestamp);
         // if the parent block did not have excess blob gas (i.e. it was pre-cancun), but it is
         // cancun now, we need to set the excess blob gas to the default value(0)
         let blob_excess_gas_and_price = parent
-            .maybe_next_block_excess_blob_gas(
-                self.chain_spec().blob_params_at_timestamp(attributes.timestamp),
-            )
+            .maybe_next_block_excess_blob_gas(blob_params)
             .or_else(|| (spec_id == SpecId::CANCUN).then_some(0))
-            .map(|gas| BlobExcessGasAndPrice::new(gas, spec_id >= SpecId::PRAGUE));
+            .map(|excess_blob_gas| {
+                let blob_gasprice =
+                    blob_params.unwrap_or_else(BlobParams::cancun).calc_blob_fee(excess_blob_gas);
+                BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }
+            });
 
         let mut basefee = parent.next_block_base_fee(
             self.chain_spec().base_fee_params_at_timestamp(attributes.timestamp),


### PR DESCRIPTION
closes #15528


two bugs here that would affect non standard blob schedules (thanks for filing @rezbera)

1. we need to derive the evm blob fees from the current active blobparams, the revm constructor only uses standard eth values
2. the genesis format changed at some point so we converted them incorrectly, effectively stripping away the non eth baseFeeUpdateFraction
