### PR TITLE
fix: compile error in `TrieStats::duration`

### DIFF
--- a/crates/trie/trie/src/stats.rs
+++ b/crates/trie/trie/src/stats.rs
@@ -10,7 +10,7 @@ pub struct TrieStats {
 
 impl TrieStats {
     /// Duration for root calculation.
-    pub const fn duration(&self) -> Duration {
+    pub fn duration(&self) -> Duration {
         self.duration
     }
 


### PR DESCRIPTION
replaced `const fn` with `fn` in `TrieStats::duration` — returning `Duration` in a `const fn` isn’t allowed.
other `const fn`s are fine.

p.s. `const fn` and `Duration` don't play well together...