### PR TITLE
chore: add status enum for handshake to support status69 decoding

### DIFF
--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod status;
-pub use status::{Status, StatusBuilder, StatusEth69};
+pub use status::{Status, StatusBuilder, StatusEth69, StatusPayload};
 
 pub mod version;
 pub use version::{EthVersion, ProtocolVersion};

--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod status;
-pub use status::{Status, StatusBuilder, StatusEth69, StatusPayload};
+pub use status::{Status, StatusBuilder, StatusEth69, StatusMessage};
 
 pub mod version;
 pub use version::{EthVersion, ProtocolVersion};

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -1,7 +1,7 @@
 use crate::EthVersion;
 use alloy_chains::{Chain, NamedChain};
 use alloy_hardforks::{EthereumHardfork, ForkId, Head};
-use alloy_primitives::{hex, FixedBytes, B256, U256};
+use alloy_primitives::{hex, B256, U256};
 use alloy_rlp::{BufMut, Encodable, RlpDecodable, RlpEncodable};
 use core::fmt::{Debug, Display};
 use reth_chainspec::{EthChainSpec, Hardforks, MAINNET};
@@ -319,8 +319,7 @@ pub enum StatusMessage {
 
 impl StatusMessage {
     /// Returns the genesis hash from the status message.
-    #[inline]
-    pub fn genesis(&self) -> FixedBytes<32> {
+    pub const fn genesis(&self) -> B256 {
         match self {
             Self::Legacy(legacy_status) => legacy_status.genesis,
             Self::Eth69(status_69) => status_69.genesis,
@@ -328,8 +327,7 @@ impl StatusMessage {
     }
 
     /// Returns the protocol version.
-    #[inline]
-    pub fn version(&self) -> EthVersion {
+    pub const fn version(&self) -> EthVersion {
         match self {
             Self::Legacy(legacy_status) => legacy_status.version,
             Self::Eth69(status_69) => status_69.version,
@@ -337,8 +335,7 @@ impl StatusMessage {
     }
 
     /// Returns the chain identifier.
-    #[inline]
-    pub fn chain(&self) -> &Chain {
+    pub const fn chain(&self) -> &Chain {
         match self {
             Self::Legacy(legacy_status) => &legacy_status.chain,
             Self::Eth69(status_69) => &status_69.chain,
@@ -346,8 +343,7 @@ impl StatusMessage {
     }
 
     /// Returns the fork identifier.
-    #[inline]
-    pub fn forkid(&self) -> ForkId {
+    pub const fn forkid(&self) -> ForkId {
         match self {
             Self::Legacy(legacy_status) => legacy_status.forkid,
             Self::Eth69(status_69) => status_69.forkid,

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -1,7 +1,7 @@
 use crate::EthVersion;
 use alloy_chains::{Chain, NamedChain};
 use alloy_hardforks::{EthereumHardfork, ForkId, Head};
-use alloy_primitives::{hex, B256, U256};
+use alloy_primitives::{hex, FixedBytes, B256, U256};
 use alloy_rlp::{BufMut, Encodable, RlpDecodable, RlpEncodable};
 use core::fmt::{Debug, Display};
 use reth_chainspec::{EthChainSpec, Hardforks, MAINNET};
@@ -306,32 +306,74 @@ impl From<Status> for StatusEth69 {
     }
 }
 
-impl From<StatusEth69> for Status {
-    fn from(s: StatusEth69) -> Self {
-        Self {
-            version: s.version,
-            chain: s.chain,
-            // Eth69 doesn't include total_difficulty so we choose a default
-            total_difficulty: U256::default(),
-            blockhash: s.blockhash,
-            genesis: s.genesis,
-            forkid: s.forkid,
-        }
-    }
-}
-
-/// `StatusPayload` can store either the Legacy version (with TD) or the
+/// `StatusMessage` can store either the Legacy version (with TD) or the
 /// eth/69 version (omits TD).
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum StatusPayload {
+pub enum StatusMessage {
     /// The legacy status (`eth/66` through `eth/68`) with `total_difficulty`.
     Legacy(Status),
     /// The new `eth/69` status with no `total_difficulty`.
     Eth69(StatusEth69),
 }
 
-impl Encodable for StatusPayload {
+impl StatusMessage {
+    /// Returns the genesis hash from the status message.
+    #[inline]
+    pub fn genesis(&self) -> FixedBytes<32> {
+        match self {
+            Self::Legacy(legacy_status) => legacy_status.genesis,
+            Self::Eth69(status_69) => status_69.genesis,
+        }
+    }
+
+    /// Returns the protocol version.
+    #[inline]
+    pub fn version(&self) -> EthVersion {
+        match self {
+            Self::Legacy(legacy_status) => legacy_status.version,
+            Self::Eth69(status_69) => status_69.version,
+        }
+    }
+
+    /// Returns the chain identifier.
+    #[inline]
+    pub fn chain(&self) -> &Chain {
+        match self {
+            Self::Legacy(legacy_status) => &legacy_status.chain,
+            Self::Eth69(status_69) => &status_69.chain,
+        }
+    }
+
+    /// Returns the fork identifier.
+    #[inline]
+    pub fn forkid(&self) -> ForkId {
+        match self {
+            Self::Legacy(legacy_status) => legacy_status.forkid,
+            Self::Eth69(status_69) => status_69.forkid,
+        }
+    }
+
+    /// Converts to legacy Status since full support for EIP-7642
+    /// is not fully implemented
+    /// `<https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7642.md>`
+    pub fn to_legacy(self) -> Status {
+        match self {
+            Self::Legacy(legacy_status) => legacy_status,
+            Self::Eth69(status_69) => Status {
+                version: status_69.version,
+                chain: status_69.chain,
+                // total_difficulty is omitted in Eth69.
+                total_difficulty: U256::default(),
+                blockhash: status_69.blockhash,
+                genesis: status_69.genesis,
+                forkid: status_69.forkid,
+            },
+        }
+    }
+}
+
+impl Encodable for StatusMessage {
     fn encode(&self, out: &mut dyn BufMut) {
         match self {
             Self::Legacy(s) => s.encode(out),

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -2,7 +2,7 @@ use crate::EthVersion;
 use alloy_chains::{Chain, NamedChain};
 use alloy_hardforks::{EthereumHardfork, ForkId, Head};
 use alloy_primitives::{hex, B256, U256};
-use alloy_rlp::{RlpDecodable, RlpEncodable};
+use alloy_rlp::{BufMut, Encodable, RlpDecodable, RlpEncodable};
 use core::fmt::{Debug, Display};
 use reth_chainspec::{EthChainSpec, Hardforks, MAINNET};
 use reth_codecs_derive::add_arbitrary_tests;
@@ -303,6 +303,47 @@ impl Default for StatusEth69 {
 impl From<Status> for StatusEth69 {
     fn from(status: Status) -> Self {
         status.into_eth69()
+    }
+}
+
+impl From<StatusEth69> for Status {
+    fn from(s: StatusEth69) -> Self {
+        Self {
+            version: s.version,
+            chain: s.chain,
+            // Eth69 doesn't include total_difficulty so we choose a default
+            total_difficulty: U256::default(),
+            blockhash: s.blockhash,
+            genesis: s.genesis,
+            forkid: s.forkid,
+        }
+    }
+}
+
+/// `StatusPayload` can store either the Legacy version (with TD) or the
+/// eth/69 version (omits TD).
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StatusPayload {
+    /// The legacy status (`eth/66` through `eth/68`) with `total_difficulty`.
+    Legacy(Status),
+    /// The new `eth/69` status with no `total_difficulty`.
+    Eth69(StatusEth69),
+}
+
+impl Encodable for StatusPayload {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(s) => s.encode(out),
+            Self::Eth69(s) => s.encode(out),
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::Legacy(s) => s.length(),
+            Self::Eth69(s) => s.length(),
+        }
     }
 }
 

--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -6,7 +6,7 @@ use crate::{
 use bytes::{Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream};
 use reth_eth_wire_types::{
-    DisconnectReason, EthMessage, EthNetworkPrimitives, ProtocolMessage, Status, StatusPayload,
+    DisconnectReason, EthMessage, EthNetworkPrimitives, ProtocolMessage, Status, StatusMessage,
 };
 use reth_ethereum_forks::ForkFilter;
 use reth_primitives_traits::GotExpected;
@@ -90,7 +90,7 @@ where
             alloy_rlp::encode(ProtocolMessage::<EthNetworkPrimitives>::from(EthMessage::<
                 EthNetworkPrimitives,
             >::Status(
-                StatusPayload::Legacy(status),
+                StatusMessage::Legacy(status),
             )))
             .into();
         unauth.send(status_msg).await.map_err(EthStreamError::from)?;
@@ -135,43 +135,43 @@ where
 
         // Validate peer response
         match msg.message {
-            EthMessage::Status(their_status_payload) => {
+            EthMessage::Status(their_status_message) => {
                 trace!("Validating incoming ETH status from peer");
-                let their_status = match their_status_payload {
-                    StatusPayload::Legacy(s) => s,
-                    StatusPayload::Eth69(s) => s.into(),
-                };
 
-                if status.genesis != their_status.genesis {
+                if status.genesis != their_status_message.genesis() {
                     unauth
                         .disconnect(DisconnectReason::ProtocolBreach)
                         .await
                         .map_err(EthStreamError::from)?;
                     return Err(EthHandshakeError::MismatchedGenesis(
-                        GotExpected { expected: status.genesis, got: their_status.genesis }.into(),
+                        GotExpected {
+                            expected: status.genesis,
+                            got: their_status_message.genesis(),
+                        }
+                        .into(),
                     )
                     .into());
                 }
 
-                if status.version != their_status.version {
+                if status.version != their_status_message.version() {
                     unauth
                         .disconnect(DisconnectReason::ProtocolBreach)
                         .await
                         .map_err(EthStreamError::from)?;
                     return Err(EthHandshakeError::MismatchedProtocolVersion(GotExpected {
-                        got: their_status.version,
+                        got: their_status_message.version(),
                         expected: status.version,
                     })
                     .into());
                 }
 
-                if status.chain != their_status.chain {
+                if status.chain != *their_status_message.chain() {
                     unauth
                         .disconnect(DisconnectReason::ProtocolBreach)
                         .await
                         .map_err(EthStreamError::from)?;
                     return Err(EthHandshakeError::MismatchedChain(GotExpected {
-                        got: their_status.chain,
+                        got: *their_status_message.chain(),
                         expected: status.chain,
                     })
                     .into());
@@ -192,7 +192,7 @@ where
 
                 // Fork validation
                 if let Err(err) = fork_filter
-                    .validate(their_status.forkid)
+                    .validate(their_status_message.forkid())
                     .map_err(EthHandshakeError::InvalidFork)
                 {
                     unauth
@@ -202,7 +202,7 @@ where
                     return Err(err.into());
                 }
 
-                Ok(their_status)
+                Ok(their_status_message.to_legacy())
             }
             _ => {
                 unauth


### PR DESCRIPTION
## Changes
- This PR will close out https://github.com/paradigmxyz/reth/issues/15513

## Thoughts
Based on the ticket, the focus is on decoding—the PR implements a new `StatusPayload` enum and updates `ProtocolMessage::decode_message` + handshake validation so that if a peer sends an Eth69 status, we decode it accordingly. Our current `eth_handshake` function in `handshake.rs` still accepts and sends a legacy status.

## Possible Improvements
- We could refactor https://github.com/paradigmxyz/reth/blob/5ff46e8e1ac7e0f36fbbe3ddfcebe70a58e70a8b/crates/net/eth-wire/src/ethstream.rs#L67-L73 to accept `status: StatusPayload` enum instead of the legacy Status.  The enum variant could then be passed here: https://github.com/paradigmxyz/reth/blob/19f8070565bd4bedc4b06d113b4fbc249410c875/crates/net/eth-wire/src/handshake.rs#L82-L86

and we could update the logic to have match arms for legacy + `Status69` versions, i.e.
```
 match msg.message {
            EthMessage::Status(their_status_payload) => {
                trace!("Validating incoming ETH status from peer");
                match (status, their_status_payload) {
                    (StatusPayload::Legacy(local), StatusPayload::Legacy(remote)) => {
                        if local.genesis != remote.genesis {
                            unauth.disconnect(DisconnectReason::ProtocolBreach)
                                .await
                                ---> return `Ok(StatusPayload::Legacy(remote))` 
                    , 
                               ---> implement similar for StatusPayload::Eth69 variant
 }
```
where the `eth_handshake` then returns `Ok(StatusPayload::Legacy(remote))` or `Ok(StatusPayload::Eth69(remote))` depending upon the input

Let me know if we want an implementation like this or some other direction 🤠 