### PR TITLE
fix: config defaults for eth components

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -145,6 +145,7 @@ where
         .eth_proof_window(ctx.config.eth_proof_window)
         .fee_history_cache_config(ctx.config.fee_history_cache)
         .proof_permits(ctx.config.proof_permits)
+        .gas_oracle_config(ctx.config.gas_oracle)
         .build()
     }
 }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -340,6 +340,7 @@ where
         .eth_proof_window(ctx.config.eth_proof_window)
         .fee_history_cache_config(ctx.config.fee_history_cache)
         .proof_permits(ctx.config.proof_permits)
+        .gas_oracle_config(ctx.config.gas_oracle)
         .build_inner();
 
         OpEthApi { inner: Arc::new(OpEthApiInner { eth_api, sequencer_client }) }


### PR DESCRIPTION
closes #15551

the issue here was that we always used the defaults if no oracle was configured in the builder.

this adds the missing setters and uses those configs