### PR TITLE
docs: Update installation.md hardware requirements

### DIFF
--- a/book/installation/installation.md
+++ b/book/installation/installation.md
@@ -21,8 +21,8 @@ The most important requirement is by far the disk, whereas CPU and RAM requireme
 
 |           | Archive Node                          | Full Node                             |
 |-----------|---------------------------------------|---------------------------------------|
-| Disk      | At least 2.2TB (TLC NVMe recommended) | At least 1.2TB (TLC NVMe recommended) |
-| Memory    | 8GB+                                  | 8GB+                                  |
+| Disk      | At least 2.8TB (TLC NVMe recommended) | At least 1.8TB (TLC NVMe recommended) |
+| Memory    | 16GB+                                 | 8GB+                                  |
 | CPU       | Higher clock speed over core count    | Higher clock speeds over core count   |
 | Bandwidth | Stable 24Mbps+                        | Stable 24Mbps+                        |
 
@@ -39,10 +39,10 @@ Prior to purchasing an NVMe drive, it is advisable to research and determine whe
 ### Disk
 
 There are multiple types of disks to sync Reth, with varying size requirements, depending on the syncing mode.
-As of April 2024 at block number 19.6M:
+As of April 2025 at block number 22.1M:
 
-* Archive Node: At least 2.14TB is required
-* Full Node: At least 1.13TB is required
+* Archive Node: At least 2.8TB is required
+* Full Node: At least 1.8TB is required
 
 NVMe based SSD drives are recommended for the best performance, with SATA SSDs being a cheaper alternative. HDDs are the cheapest option, but they will take the longest to sync, and are not recommended.
 


### PR DESCRIPTION
I downloaded and extracted archive from `https://snapshots.merkle.io/`

This is the disk that reth volume is using at block `22187646`
```sh
root@reth-ubuntu-s-4vcpu-8gb-240gb-intel-nyc3-01:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda        3.2T  2.6T  396G  87% /mnt/volume_nyc3_01
```

I would recommend 2.8TB as the minimum starting point for `Archive`. I also increased the same amount for `Full node`, but I think it might be less.


I also added 8GB to memory requirements. I got a random crash like in this [issue](https://github.com/paradigmxyz/reth/issues/7282) with 8GB. Therefore, I think 16GB is reasonable due to docker/lighthouse/grafana and others overhead.

---

Issue nr 2

🚨 Actually, it seems that lighthouse crashed at some point with OOM. It's memory goes  goes to 10GB+ and then it crashes
As you can see from docker stats, it's memory use is quite high. It crashed a shortwhile later

```sh
$ docker stats
CONTAINER ID   NAME                      CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O         PIDS
7746b0cd187b   reth-grafana-1            0.22%     153.6MiB / 15.62GiB   0.96%     714kB / 1.95MB   505MB / 1.01MB    17
0e46dca970e9   reth-metrics-exporter-1   0.10%     25.48MiB / 15.62GiB   0.16%     1.84MB / 1MB     43.6MB / 0B       10
2a71ba211b3a   reth-prometheus-1         0.20%     67.2MiB / 15.62GiB    0.42%     116MB / 536kB    324MB / 6.15MB    10
78022ffdbce2   reth-lighthouse-1         335.21%   5.72GiB / 15.62GiB    36.62%    379MB / 7.27MB   2.18GB / 2.55GB   53
0bea243aa254   reth-reth-1               29.31%    3.835GiB / 15.62GiB   24.55%    40.3MB / 133MB   4.65GB / 2.24MB   24
```


