### PR TITLE
fix: :bug: Fix gas_limit handle in eth_simulate

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -89,9 +89,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into())
             }
 
-            // Gas cap for entire operation
-            let total_gas_limit = self.call_gas_limit();
-
             let base_block =
                 self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
             let mut parent = base_block.sealed_header().clone();
@@ -100,7 +97,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             self.spawn_with_state_at_block(block, move |state| {
                 let mut db =
                     State::builder().with_database(StateProviderDatabase::new(state)).build();
-                let mut gas_used = 0;
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
                 for block in block_state_calls {
@@ -120,7 +116,17 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     let SimBlock { block_overrides, state_overrides, calls } = block;
 
+                    evm_env.block_env.gas_limit = this.call_gas_limit();
                     if let Some(block_overrides) = block_overrides {
+                        if let Some(gas_limit) = block_overrides.gas_limit {
+                            if gas_limit > evm_env.block_env.gas_limit {
+                                return Err(EthApiError::InvalidTransaction(
+                                    RpcInvalidTransactionError::GasTooHigh,
+                                )
+                                .into());
+                            }
+                            evm_env.block_env.gas_limit = gas_limit;
+                        }
                         apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
                     }
                     if let Some(state_overrides) = state_overrides {
@@ -129,12 +135,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     let block_env = evm_env.block_env.clone();
                     let chain_id = evm_env.cfg_env.chain_id;
-
-                    if (total_gas_limit - gas_used) < evm_env.block_env.gas_limit {
-                        return Err(
-                            EthApiError::Other(Box::new(EthSimulateError::GasLimitReached)).into()
-                        )
-                    }
 
                     let default_gas_limit = {
                         let total_specified_gas = calls.iter().filter_map(|tx| tx.gas).sum::<u64>();
@@ -199,7 +199,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         block.inner.header.inner.clone(),
                         block.inner.header.hash,
                     );
-                    gas_used += block.inner.header.gas_used();
 
                     blocks.push(block);
                 }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -116,16 +116,17 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     let SimBlock { block_overrides, state_overrides, calls } = block;
 
-                    evm_env.block_env.gas_limit = this.call_gas_limit();
                     if let Some(block_overrides) = block_overrides {
-                        if let Some(gas_limit) = block_overrides.gas_limit {
-                            if gas_limit > evm_env.block_env.gas_limit {
-                                return Err(EthApiError::InvalidTransaction(
-                                    RpcInvalidTransactionError::GasTooHigh,
+                        // ensure we dont allow uncapped gas limit per block
+                        if let Some(gas_limit_override) = block_overrides.gas_limit {
+                            if gas_limit_override > evm_env.block_env.gas_limit &&
+                                gas_limit_override > this.call_gas_limit()
+                            {
+                                return Err(
+                                    EthApiError::other(EthSimulateError::GasLimitReached).into()
                                 )
-                                .into());
                             }
-                            evm_env.block_env.gas_limit = gas_limit;
+                            evm_env.block_env.gas_limit = gas_limit_override;
                         }
                         apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
                     }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -126,7 +126,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                                     EthApiError::other(EthSimulateError::GasLimitReached).into()
                                 )
                             }
-                            evm_env.block_env.gas_limit = gas_limit_override;
                         }
                         apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
                     }


### PR DESCRIPTION
Resolve the issue where the global gas limit was being applied across multiple simulated blocks in the eth_simulateV1 method. Instead of using global cap, we now use the block gas_limit itself.

Close #15490 

Note : since the variable gas_used was no longer used, I took the liberty of removing it. Do we need to keep track of it ?