### PR TITLE
fix: `latest_state` returning `last_valid` instead of latest received

### DIFF
--- a/crates/engine/primitives/src/forkchoice.rs
+++ b/crates/engine/primitives/src/forkchoice.rs
@@ -75,8 +75,8 @@ impl ForkchoiceStateTracker {
     /// Returns the latest received [`ForkchoiceState`].
     ///
     /// Caution: this can be invalid.
-    pub const fn latest_state(&self) -> Option<ForkchoiceState> {
-        self.last_valid
+    pub fn latest_state(&self) -> Option<ForkchoiceState> {
+        self.latest.as_ref().map(|s| s.state.clone())
     }
 
     /// Returns the last valid [`ForkchoiceState`].

--- a/crates/engine/primitives/src/forkchoice.rs
+++ b/crates/engine/primitives/src/forkchoice.rs
@@ -76,7 +76,7 @@ impl ForkchoiceStateTracker {
     ///
     /// Caution: this can be invalid.
     pub fn latest_state(&self) -> Option<ForkchoiceState> {
-        self.latest.as_ref().map(|s| s.state.clone())
+        self.latest.as_ref().map(|s| s.state)
     }
 
     /// Returns the last valid [`ForkchoiceState`].

--- a/crates/engine/primitives/src/forkchoice.rs
+++ b/crates/engine/primitives/src/forkchoice.rs
@@ -122,7 +122,6 @@ impl ForkchoiceStateTracker {
 /// Represents a forkchoice update and tracks the status we assigned to it.
 #[derive(Debug, Clone)]
 pub(crate) struct ReceivedForkchoiceState {
-    #[cfg_attr(not(test), expect(dead_code))]
     state: ForkchoiceState,
     status: ForkchoiceStatus,
 }


### PR DESCRIPTION
While looking through `ForkchoiceStateTracker`, I noticed that `latest_state()` was returning `last_valid` instead of the actual latest received forkchoice state.

The method's comment, name, and intended purpose all point to returning the most recently received state (even if it's invalid), but the implementation returned only the last valid one. This caused a subtle mismatch between the API's behavior and what it claims to provide.

This updates the method to correctly return `self.latest.as_ref().map(|s| s.state.clone())`.