### PR TITLE
chore: enable `clippy::iter_over_hash_type` lints to check where non-determinstic iteration is happening

### DIFF
--- a/crates/chain-state/src/lib.rs
+++ b/crates/chain-state/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::iter_over_hash_type)]
+
 //! Reth state related types and functionality.
 
 #![doc(

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -1,5 +1,6 @@
 //! The spec of an Ethereum network
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -1,5 +1,6 @@
 //! Cli abstraction for reth based nodes.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/cli/commands/src/lib.rs
+++ b/crates/cli/commands/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used reth CLI commands.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -1,5 +1,6 @@
 //! A tokio based CLI runner.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate defines a set of commonly used cli utils.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,5 +1,6 @@
 //! Standalone crate for Reth configuration types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/consensus/common/src/lib.rs
+++ b/crates/consensus/common/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used consensus methods.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(clippy::iter_over_hash_type)]
 
 extern crate alloc;
 

--- a/crates/consensus/debug-client/src/lib.rs
+++ b/crates/consensus/debug-client/src/lib.rs
@@ -4,6 +4,7 @@
 //! provider like Etherscan or an RPC endpoint. This allows to quickly test the execution client
 //! without running a consensus node.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! Utilities for end-to-end tests.
 
 use node::NodeTestContext;

--- a/crates/engine/invalid-block-hooks/src/lib.rs
+++ b/crates/engine/invalid-block-hooks/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::iter_over_hash_type)]
+
 //! Invalid block hook implementations.
 
 mod witness;

--- a/crates/engine/local/src/lib.rs
+++ b/crates/engine/local/src/lib.rs
@@ -1,5 +1,6 @@
 //! A local engine service that can be used to drive a dev chain.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -1,5 +1,6 @@
 //! Traits, validation methods, and helper types used to abstract over engine types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/engine/service/src/lib.rs
+++ b/crates/engine/service/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 /// Engine Service
 pub mod service;

--- a/crates/engine/tree/src/lib.rs
+++ b/crates/engine/tree/src/lib.rs
@@ -91,6 +91,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 /// Support for backfill sync mode.
 pub mod backfill;

--- a/crates/engine/util/src/lib.rs
+++ b/crates/engine/util/src/lib.rs
@@ -1,5 +1,6 @@
 //! Collection of various stream utilities for consensus engine.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/era/src/lib.rs
+++ b/crates/era/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! Era and Era1 files support for Ethereum history expiry.
 //!
 //!

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `test-utils`: Export utilities for testing
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ethereum-forks/src/lib.rs
+++ b/crates/ethereum-forks/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! - `arbitrary`: Adds `arbitrary` support for primitive types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ethereum/cli/src/lib.rs
+++ b/crates/ethereum/cli/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! Reth CLI implementation.
 
 #![doc(

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -1,5 +1,6 @@
 //! Beacon consensus implementation.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -1,5 +1,6 @@
 //! Ethereum specific engine API types and impls.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -6,6 +6,7 @@
 //! critical for revm's evm internals, it is the responsibility of the implementer to ensure the
 //! proper features are selected.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ethereum/node/src/lib.rs
+++ b/crates/ethereum/node/src/lib.rs
@@ -3,6 +3,7 @@
 //! # features
 //! - `js-tracer`: Enable the `JavaScript` tracer for the `debug_trace` endpoints
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![allow(clippy::useless_let_if_seq)]
+#![warn(clippy::iter_over_hash_type)]
 
 pub mod validator;
 pub use validator::EthereumExecutionPayloadValidator;

--- a/crates/ethereum/primitives/src/lib.rs
+++ b/crates/ethereum/primitives/src/lib.rs
@@ -1,5 +1,6 @@
 //! Standalone crate for ethereum-specific Reth primitive types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ethereum/reth/src/lib.rs
+++ b/crates/ethereum/reth/src/lib.rs
@@ -1,5 +1,6 @@
 //! Ethereum meta crate that provides access to commonly used reth dependencies.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -13,6 +13,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 use std::{
     cmp::Reverse,

--- a/crates/evm/execution-errors/src/lib.rs
+++ b/crates/evm/execution-errors/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used error types used when doing block execution.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/evm/execution-types/src/lib.rs
+++ b/crates/evm/execution-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used types for (EVM) block execution.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -6,6 +6,7 @@
 //! critical for revm's evm internals, it is the responsibility of the implementer to ensure the
 //! proper features are selected.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/exex/exex/src/lib.rs
+++ b/crates/exex/exex/src/lib.rs
@@ -87,6 +87,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 mod backfill;
 pub use backfill::*;

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -1,5 +1,6 @@
 //! Test helpers for `reth-exex`
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/exex/types/src/lib.rs
+++ b/crates/exex/types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used ExEx types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -6,6 +6,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fs::{self, File, OpenOptions, ReadDir},

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -5,6 +5,7 @@
 //! - `common`: Common metrics utilities, such as wrappers around tokio senders and receivers. Pulls
 //!   in `tokio`.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/net/banlist/src/lib.rs
+++ b/crates/net/banlist/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 type PeerId = alloy_primitives::B512;
 

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -23,6 +23,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 use crate::{
     error::{DecodePacketError, Discv4Error},

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 use std::{
     collections::HashSet,

--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -12,6 +12,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 pub use crate::resolver::{DnsResolver, MapResolver, Resolver};
 use crate::{

--- a/crates/net/downloaders/src/lib.rs
+++ b/crates/net/downloaders/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `test-utils`: Export utilities for testing
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/net/ecies/src/lib.rs
+++ b/crates/net/ecies/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 pub mod algorithm;
 pub mod mac;

--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Types for the eth wire protocol: <https://github.com/ethereum/devp2p/blob/master/caps/eth.md>
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -5,6 +5,7 @@
 //! - `serde` (default): Enable serde support
 //! - `arbitrary`: Adds `proptest` and `arbitrary` support for wire types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -11,6 +11,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 pub mod net_if;
 

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! - `serde` (default): Enable serde support
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/net/network-types/src/lib.rs
+++ b/crates/net/network-types/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `serde` (default): Enable serde support
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -117,6 +117,7 @@
 #![allow(unreachable_pub)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 #[cfg(any(test, feature = "test-utils"))]
 /// Common helpers for network testing.

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -3,6 +3,7 @@
 //! ## Feature Flags
 //!
 //! - `test-utils`: Export utilities for testing
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -53,6 +53,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(clippy::iter_over_hash_type)]
 
 extern crate alloc;
 

--- a/crates/node/api/src/lib.rs
+++ b/crates/node/api/src/lib.rs
@@ -1,5 +1,6 @@
 //! Standalone crate for Reth configuration traits and builder types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/node/builder/src/lib.rs
+++ b/crates/node/builder/src/lib.rs
@@ -3,6 +3,7 @@
 //! # features
 //! - `js-tracer`: Enable the `JavaScript` tracer for the `debug_trace` endpoints
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/node/core/src/lib.rs
+++ b/crates/node/core/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 pub mod args;
 pub mod cli;

--- a/crates/node/events/src/lib.rs
+++ b/crates/node/events/src/lib.rs
@@ -1,5 +1,6 @@
 //! Various event handlers for the node.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/node/metrics/src/lib.rs
+++ b/crates/node/metrics/src/lib.rs
@@ -1,4 +1,5 @@
 //! Metrics utilities for the node.
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Standalone crate for Reth configuration traits and builder types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/bin/src/lib.rs
+++ b/crates/optimism/bin/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! Rust Optimism (op-reth) binary executable.
 //!
 //! ## Feature Flags

--- a/crates/optimism/chain-registry/src/lib.rs
+++ b/crates/optimism/chain-registry/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! Utilities for interacting the optimism superchain registry
 
 #![doc(

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(clippy::iter_over_hash_type)]
 
 extern crate alloc;
 

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 /// Optimism chain specification parser.
 pub mod chainspec;

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -1,5 +1,6 @@
 //! Optimism Consensus implementation.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 extern crate alloc;
 

--- a/crates/optimism/hardforks/src/lib.rs
+++ b/crates/optimism/hardforks/src/lib.rs
@@ -1,5 +1,6 @@
 //! OP-Reth hard forks.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/node/src/lib.rs
+++ b/crates/optimism/node/src/lib.rs
@@ -3,6 +3,7 @@
 //! # features
 //! - `js-tracer`: Enable the `JavaScript` tracer for the `debug_trace` endpoints
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -1,5 +1,6 @@
 //! Optimism's payload builder implementation.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -1,5 +1,6 @@
 //! Standalone crate for Optimism-specific Reth primitive types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/reth/src/lib.rs
+++ b/crates/optimism/reth/src/lib.rs
@@ -1,5 +1,6 @@
 //! Optimism meta crate that provides access to commonly used reth dependencies.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/rpc/src/lib.rs
+++ b/crates/optimism/rpc/src/lib.rs
@@ -1,5 +1,6 @@
 //! OP-Reth RPC support.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/optimism/storage/src/lib.rs
+++ b/crates/optimism/storage/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 extern crate alloc;
 

--- a/crates/optimism/txpool/src/lib.rs
+++ b/crates/optimism/txpool/src/lib.rs
@@ -1,5 +1,6 @@
 //! OP-Reth Transaction pool.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -1,5 +1,6 @@
 //! A basic payload generator for reth.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/payload/builder-primitives/src/lib.rs
+++ b/crates/payload/builder-primitives/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate defines abstractions to create and update payloads (blocks)
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! This crate defines abstractions to create and update payloads (blocks):
 //! - [`PayloadJobGenerator`]: a type that knows how to create new jobs for creating payloads based
 //!   on [`PayloadAttributes`](alloy_rpc_types::engine::PayloadAttributes).

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate defines abstractions to create and update payloads (blocks)
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/payload/util/src/lib.rs
+++ b/crates/payload/util/src/lib.rs
@@ -1,5 +1,6 @@
 //! payload utils.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -1,5 +1,6 @@
 //! Payload Validation support.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -70,6 +70,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(clippy::iter_over_hash_type)]
 
 #[macro_use]
 extern crate alloc;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `reth-codec`: Enables db codec support for reth types including zstd compression for certain
 //!   types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/prune/prune/src/lib.rs
+++ b/crates/prune/prune/src/lib.rs
@@ -1,5 +1,6 @@
 //! Pruning implementation.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used types for prune usage.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ress/protocol/src/lib.rs
+++ b/crates/ress/protocol/src/lib.rs
@@ -1,6 +1,7 @@
 //! `ress` protocol is an `RLPx` subprotocol for stateless nodes.
 //! following [RLPx specs](https://github.com/ethereum/devp2p/blob/master/rlpx.md)
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/ress/provider/src/lib.rs
+++ b/crates/ress/provider/src/lib.rs
@@ -1,6 +1,7 @@
 //! Reth implementation of [`reth_ress_protocol::RessProtocolProvider`].
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 use alloy_consensus::BlockHeader as _;
 use alloy_primitives::{Bytes, B256};

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -1,5 +1,6 @@
 //! Revm utils and implementations specific to reth.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/ipc/src/lib.rs
+++ b/crates/rpc/ipc/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `client`: Enables JSON-RPC client support.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! - `client`: Enables JSON-RPC client support.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -18,6 +18,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 use crate::{auth::AuthRpcModule, error::WsHttpSamePortError, metrics::RpcRequestMetrics};
 use alloy_provider::{fillers::RecommendedFillers, Provider, ProviderBuilder};

--- a/crates/rpc/rpc-engine-api/src/lib.rs
+++ b/crates/rpc/rpc-engine-api/src/lib.rs
@@ -1,6 +1,7 @@
 //! The implementation of Engine API.
 //! [Read more](https://github.com/ethereum/execution-apis/tree/main/src/engine).
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `client`: Enables JSON-RPC client support.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Reth RPC server types, used in server implementation of `eth` namespace API.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc-layer/src/lib.rs
+++ b/crates/rpc/rpc-layer/src/lib.rs
@@ -1,5 +1,6 @@
 //! Layer implementations used in RPC
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc-server-types/src/lib.rs
+++ b/crates/rpc/rpc-server-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Reth RPC server types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc-testing-util/src/lib.rs
+++ b/crates/rpc/rpc-testing-util/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! Reth RPC testing utilities.
 
 #![doc(

--- a/crates/rpc/rpc-types-compat/src/lib.rs
+++ b/crates/rpc/rpc-types-compat/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This crate various helper functions to convert between reth primitive types and rpc types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -24,6 +24,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 use http as _;
 use http_body as _;

--- a/crates/stages/api/src/lib.rs
+++ b/crates/stages/api/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `test-utils`: Utilities for testing
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/stages/stages/src/lib.rs
+++ b/crates/stages/stages/src/lib.rs
@@ -80,6 +80,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 #[expect(missing_docs)]
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/stages/types/src/lib.rs
+++ b/crates/stages/types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used types for staged sync usage.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/static-file/static-file/src/lib.rs
+++ b/crates/static-file/static-file/src/lib.rs
@@ -1,5 +1,6 @@
 //! Static file producer implementation.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used types for static file usage.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -1,5 +1,6 @@
 //! Derive macros for the Compact codec traits.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(clippy::iter_over_hash_type)]
 
 extern crate alloc;
 

--- a/crates/storage/db-api/src/lib.rs
+++ b/crates/storage/db-api/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! reth's database abstraction layer.
 //!
 //! The database abstraction assumes that the underlying store is a KV store subdivided into tables.

--- a/crates/storage/db-common/src/lib.rs
+++ b/crates/storage/db-common/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::iter_over_hash_type)]
 //! Common db operations
 
 #![doc(

--- a/crates/storage/db-models/src/lib.rs
+++ b/crates/storage/db-models/src/lib.rs
@@ -1,5 +1,6 @@
 //! Models used in storage module.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! An overview of the current data model of reth can be found in the [`mod@tables`] module.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/storage/errors/src/lib.rs
+++ b/crates/storage/errors/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used error types used when interacting with storage.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/storage/libmdbx-rs/mdbx-sys/src/lib.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/src/lib.rs
@@ -8,5 +8,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case, clippy::all)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![allow(missing_docs, clippy::needless_pass_by_ref_mut)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 pub extern crate reth_mdbx_sys as ffi;
 

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -11,6 +11,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 use memmap2::Mmap;
 use serde::{Deserialize, Serialize};

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `test-utils`: Export utilities for testing
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/storage/zstd-compressors/src/lib.rs
+++ b/crates/storage/zstd-compressors/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used zstd [`Compressor`] and [`Decompressor`] for reth types.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `rayon`: Enable rayon thread pool for blocking tasks.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/tokio-util/src/lib.rs
+++ b/crates/tokio-util/src/lib.rs
@@ -1,5 +1,6 @@
 //! Event listeners
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -42,6 +42,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(clippy::iter_over_hash_type)]
 
 // Re-export tracing crates
 pub use tracing;

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -151,6 +151,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 pub use crate::{
     blobstore::{BlobStore, BlobStoreError},

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -1,5 +1,6 @@
 //! Commonly used types for trie usage.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -1,5 +1,6 @@
 //! An integration of [`reth-trie`] with [`reth-db`].
 
+#![warn(clippy::iter_over_hash_type)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod commitment;

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -1,5 +1,6 @@
 //! Implementation of exotic state root computation approaches.
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -1,6 +1,7 @@
 //! The implementation of sparse MPT.
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::iter_over_hash_type)]
 
 mod state;
 pub use state::*;

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -7,6 +7,7 @@
 //! - `rayon`: uses rayon for parallel [`HashedPostState`] creation.
 //! - `test-utils`: Export utilities for testing
 
+#![warn(clippy::iter_over_hash_type)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",


### PR DESCRIPTION
Not intended to fix the lint warnings.

Rationale: Iterating over a HashMap/HashSet is non-deterministic and can cause bugs where one expects determinism. This PR enables the lint to just double check where this non-determinism is happening. Likely okay in all of the places it is happening.

EDIT: CI exits early so would need to run it locally to see all of the errors