### PR TITLE
test: benchmark for fetch pending hashes

### DIFF
--- a/crates/net/network/benches/tx_manager_hash_fetching.rs
+++ b/crates/net/network/benches/tx_manager_hash_fetching.rs
@@ -1,23 +1,104 @@
 #![allow(missing_docs)]
 
-use alloy_primitives::U256;
-use criterion::*;
-use rand::SeedableRng;
+use alloy_primitives::{
+    private::proptest::test_runner::{RngAlgorithm, TestRng},
+    B256, U256,
+};
+use criterion::{measurement::WallTime, *};
+use pprof::criterion::{Output, PProfProfiler};
+use reth_eth_wire::EthVersion;
+use reth_eth_wire_types::EthNetworkPrimitives;
 use reth_network::{
+    cache::LruCache,
     test_utils::Testnet,
     transactions::{
-        TransactionFetcherConfig, TransactionPropagationMode::Max, TransactionsManagerConfig,
+        constants::{
+            tx_fetcher::DEFAULT_MAX_COUNT_FALLBACK_PEERS,
+            tx_manager::DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+        },
+        fetcher::{TransactionFetcher, TxFetchMetadata},
+        PeerMetadata, TransactionFetcherConfig,
+        TransactionPropagationMode::Max,
+        TransactionsManagerConfig,
     },
 };
+use reth_network_api::{PeerRequest, PeerRequestSender};
+use reth_network_peers::PeerId;
 use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 use reth_transaction_pool::{test_utils::TransactionGenerator, PoolTransaction, TransactionPool};
-use tokio::runtime::Runtime as TokioRuntime;
+use std::{collections::HashMap, fmt, hash, sync::Arc};
+use tokio::{runtime::Runtime as TokioRuntime, sync::mpsc};
 
 criterion_group!(
     name = tx_fetch_benches;
     config = Criterion::default();
-    targets = tx_fetch_bench
+    targets = tx_fetch_bench, fetch_pending_hashes,
 );
+
+// Returns (peer, channel-to-send-get-pooled-tx-response-on).
+pub fn new_mock_session(
+    peer_id: PeerId,
+    version: EthVersion,
+) -> (PeerMetadata<EthNetworkPrimitives>, mpsc::Receiver<PeerRequest>) {
+    let (to_mock_session_tx, to_mock_session_rx) = mpsc::channel(1);
+
+    (
+        PeerMetadata::new(
+            PeerRequestSender::new(peer_id, to_mock_session_tx),
+            version,
+            Arc::from(""),
+            DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+        ),
+        to_mock_session_rx,
+    )
+}
+
+pub fn default_cache<T: hash::Hash + Eq + fmt::Debug>() -> LruCache<T> {
+    LruCache::new(DEFAULT_MAX_COUNT_FALLBACK_PEERS as u32)
+}
+
+pub fn benchmark_fetch_pending_hashes(group: &mut BenchmarkGroup<'_, WallTime>, peers_num: usize) {
+    let setup = || {
+        let mut tx_fetcher = TransactionFetcher::<EthNetworkPrimitives>::default();
+        let mut peers = HashMap::default();
+
+        for i in 0..peers_num {
+            // NOTE: the worst case, each tx in the cache belongs to a differenct peer.
+            let peer = PeerId::random();
+            let hash = B256::random();
+
+            let (mut peer_data, _) = new_mock_session(peer, EthVersion::Eth66);
+            peer_data.seen_transactions.insert(hash);
+            peers.insert(peer, peer_data);
+
+            let mut backups = default_cache();
+            backups.insert(peer);
+            let meta = TxFetchMetadata::new(0, backups, None);
+            tx_fetcher.hashes_fetch_inflight_and_pending_fetch.insert(hash, meta);
+            tx_fetcher.hashes_pending_fetch.insert(hash);
+        }
+
+        (tx_fetcher, peers)
+    };
+
+    let group_id = format!("fetch pending hashes, peers num: {}", peers_num);
+
+    group.bench_function(group_id, |b| {
+        b.iter_with_setup(setup, |(mut tx_fetcher, peers)| {
+            tx_fetcher.on_fetch_pending_hashes(&peers, |_| true);
+        });
+    });
+}
+
+pub fn fetch_pending_hashes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Fetch Pending Hashes");
+
+    for peers in [5, 10, 20, 100, 1000, 10000, 100000] {
+        benchmark_fetch_pending_hashes(&mut group, peers);
+    }
+
+    group.finish();
+}
 
 pub fn tx_fetch_bench(c: &mut Criterion) {
     let rt = TokioRuntime::new().unwrap();

--- a/crates/net/network/src/test_utils/mod.rs
+++ b/crates/net/network/src/test_utils/mod.rs
@@ -2,9 +2,11 @@
 
 mod init;
 mod testnet;
+pub mod transactions;
 
 pub use init::{
     enr_to_peer_id, unused_port, unused_tcp_addr, unused_tcp_and_udp_port, unused_tcp_udp,
     unused_udp_addr, unused_udp_port, GETH_TIMEOUT,
 };
 pub use testnet::{NetworkEventStream, Peer, PeerConfig, PeerHandle, Testnet, TestnetHandle};
+pub use transactions::{buffer_hash_to_tx_fetcher, new_mock_session, new_tx_manager};

--- a/crates/net/network/src/test_utils/transactions.rs
+++ b/crates/net/network/src/test_utils/transactions.rs
@@ -1,0 +1,101 @@
+//! Test helper impls for transactions
+
+#![allow(dead_code)]
+
+use crate::{
+    cache::LruCache,
+    transactions::{
+        constants::{
+            tx_fetcher::DEFAULT_MAX_COUNT_FALLBACK_PEERS,
+            tx_manager::DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+        },
+        fetcher::{TransactionFetcher, TxFetchMetadata},
+        PeerMetadata, TransactionsManager,
+    },
+    NetworkConfigBuilder, NetworkManager,
+};
+use alloy_primitives::TxHash;
+use reth_eth_wire::EthVersion;
+use reth_eth_wire_types::EthNetworkPrimitives;
+use reth_network_api::{PeerKind, PeerRequest, PeerRequestSender};
+use reth_network_peers::PeerId;
+use reth_storage_api::noop::NoopProvider;
+use reth_transaction_pool::test_utils::{testing_pool, TestPool};
+use secp256k1::SecretKey;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::trace;
+
+/// A new tx manager for testing.
+pub async fn new_tx_manager(
+) -> (TransactionsManager<TestPool, EthNetworkPrimitives>, NetworkManager<EthNetworkPrimitives>) {
+    let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+    let client = NoopProvider::default();
+
+    let config = NetworkConfigBuilder::new(secret_key)
+        // let OS choose port
+        .listener_port(0)
+        .disable_discovery()
+        .build(client);
+
+    let pool = testing_pool();
+
+    let transactions_manager_config = config.transactions_manager_config.clone();
+    let (_network_handle, network, transactions, _) = NetworkManager::new(config)
+        .await
+        .unwrap()
+        .into_builder()
+        .transactions(pool.clone(), transactions_manager_config)
+        .split_with_handle();
+
+    (transactions, network)
+}
+
+/// Directly buffer hahs into tx fetcher for testing.
+pub fn buffer_hash_to_tx_fetcher(
+    tx_fetcher: &mut TransactionFetcher,
+    hash: TxHash,
+    peer_id: PeerId,
+    retries: u8,
+    tx_encoded_length: Option<usize>,
+) {
+    match tx_fetcher.hashes_fetch_inflight_and_pending_fetch.get_or_insert(hash, || {
+        TxFetchMetadata::new(
+            retries,
+            LruCache::new(DEFAULT_MAX_COUNT_FALLBACK_PEERS as u32),
+            tx_encoded_length,
+        )
+    }) {
+        Some(metadata) => {
+            metadata.fallback_peers_mut().insert(peer_id);
+        }
+        None => {
+            trace!(target: "net::tx",
+                    peer_id=format!("{peer_id:#}"),
+                    %hash,
+                    "failed to insert hash from peer in schnellru::LruMap, dropping hash"
+            )
+        }
+    }
+
+    tx_fetcher.hashes_pending_fetch.insert(hash);
+}
+
+/// Mock a new session, returns (peer, channel-to-send-get-pooled-tx-response-on).
+pub fn new_mock_session(
+    peer_id: PeerId,
+    version: EthVersion,
+) -> (PeerMetadata<EthNetworkPrimitives>, mpsc::Receiver<PeerRequest>) {
+    let (to_mock_session_tx, to_mock_session_rx) = mpsc::channel(1);
+
+    (
+        PeerMetadata::new(
+            PeerRequestSender::new(peer_id, to_mock_session_tx),
+            version,
+            Arc::from(""),
+            DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+            PeerKind::Trusted,
+        ),
+        to_mock_session_rx,
+    )
+}

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -84,7 +84,7 @@ pub struct TransactionFetcher<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// which a [`GetPooledTransactions`] request is inflight.
     pub hashes_pending_fetch: LruCache<TxHash>,
     /// Tracks all hashes in the transaction fetcher.
-    pub(super) hashes_fetch_inflight_and_pending_fetch: LruMap<TxHash, TxFetchMetadata, ByLength>,
+    pub hashes_fetch_inflight_and_pending_fetch: LruMap<TxHash, TxFetchMetadata, ByLength>,
     /// Filter for valid announcement and response data.
     pub(super) filter_valid_message: MessageFilter,
     /// Info on capacity of the transaction fetcher.

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -1301,7 +1301,7 @@ struct TxFetcherSearchDurations {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::transactions::tests::{buffer_hash_to_tx_fetcher, new_mock_session};
+    use crate::test_utils::transactions::{buffer_hash_to_tx_fetcher, new_mock_session};
     use alloy_primitives::{hex, B256};
     use alloy_rlp::Decodable;
     use derive_more::IntoIterator;

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1833,7 +1833,7 @@ pub struct PeerMetadata<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Optimistically keeps track of transactions that we know the peer has seen. Optimistic, in
     /// the sense that transactions are preemptively marked as seen by peer when they are sent to
     /// the peer.
-    pub seen_transactions: LruCache<TxHash>,
+    seen_transactions: LruCache<TxHash>,
     /// A communication channel directly to the peer's session task.
     request_tx: PeerRequestSender<PeerRequest<N>>,
     /// negotiated version of the session.
@@ -1865,6 +1865,11 @@ impl<N: NetworkPrimitives> PeerMetadata<N> {
     /// Returns a reference to the peer's request sender channel.
     pub fn request_tx(&self) -> &PeerRequestSender<PeerRequest<N>> {
         &self.request_tx
+    }
+
+    /// Return a
+    pub fn seen_transactions_mut(&mut self) -> &mut LruCache<TxHash> {
+        &mut self.seen_transactions
     }
 
     /// Returns the negotiated `EthVersion` of the session.
@@ -1983,11 +1988,16 @@ struct TxManagerPollDurations {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::Testnet, NetworkConfigBuilder, NetworkManager};
+    use crate::{
+        test_utils::{
+            transactions::{buffer_hash_to_tx_fetcher, new_mock_session, new_tx_manager},
+            Testnet,
+        },
+        NetworkConfigBuilder, NetworkManager,
+    };
     use alloy_consensus::{transaction::PooledTransaction, TxEip1559, TxLegacy};
     use alloy_primitives::{hex, Signature, TxKind, U256};
     use alloy_rlp::Decodable;
-    use constants::tx_fetcher::DEFAULT_MAX_COUNT_FALLBACK_PEERS;
     use futures::FutureExt;
     use reth_chainspec::MIN_TRANSACTION_GAS;
     use reth_ethereum_primitives::{Transaction, TransactionSigned};
@@ -1998,7 +2008,7 @@ mod tests {
     };
     use reth_storage_api::noop::NoopProvider;
     use reth_transaction_pool::test_utils::{
-        testing_pool, MockTransaction, MockTransactionFactory, TestPool,
+        testing_pool, MockTransaction, MockTransactionFactory,
     };
     use secp256k1::SecretKey;
     use std::{
@@ -2006,81 +2016,7 @@ mod tests {
         net::{IpAddr, Ipv4Addr, SocketAddr},
         str::FromStr,
     };
-    use tests::fetcher::TxFetchMetadata;
     use tracing::error;
-
-    async fn new_tx_manager(
-    ) -> (TransactionsManager<TestPool, EthNetworkPrimitives>, NetworkManager<EthNetworkPrimitives>)
-    {
-        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
-        let client = NoopProvider::default();
-
-        let config = NetworkConfigBuilder::new(secret_key)
-            // let OS choose port
-            .listener_port(0)
-            .disable_discovery()
-            .build(client);
-
-        let pool = testing_pool();
-
-        let transactions_manager_config = config.transactions_manager_config.clone();
-        let (_network_handle, network, transactions, _) = NetworkManager::new(config)
-            .await
-            .unwrap()
-            .into_builder()
-            .transactions(pool.clone(), transactions_manager_config)
-            .split_with_handle();
-
-        (transactions, network)
-    }
-
-    pub(super) fn buffer_hash_to_tx_fetcher(
-        tx_fetcher: &mut TransactionFetcher,
-        hash: TxHash,
-        peer_id: PeerId,
-        retries: u8,
-        tx_encoded_length: Option<usize>,
-    ) {
-        match tx_fetcher.hashes_fetch_inflight_and_pending_fetch.get_or_insert(hash, || {
-            TxFetchMetadata::new(
-                retries,
-                LruCache::new(DEFAULT_MAX_COUNT_FALLBACK_PEERS as u32),
-                tx_encoded_length,
-            )
-        }) {
-            Some(metadata) => {
-                metadata.fallback_peers_mut().insert(peer_id);
-            }
-            None => {
-                trace!(target: "net::tx",
-                        peer_id=format!("{peer_id:#}"),
-                        %hash,
-                        "failed to insert hash from peer in schnellru::LruMap, dropping hash"
-                )
-            }
-        }
-
-        tx_fetcher.hashes_pending_fetch.insert(hash);
-    }
-
-    // Returns (peer, channel-to-send-get-pooled-tx-response-on).
-    pub(super) fn new_mock_session(
-        peer_id: PeerId,
-        version: EthVersion,
-    ) -> (PeerMetadata<EthNetworkPrimitives>, mpsc::Receiver<PeerRequest>) {
-        let (to_mock_session_tx, to_mock_session_rx) = mpsc::channel(1);
-
-        (
-            PeerMetadata::new(
-                PeerRequestSender::new(peer_id, to_mock_session_tx),
-                version,
-                Arc::from(""),
-                DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
-                PeerKind::Trusted,
-            ),
-            to_mock_session_rx,
-        )
-    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_ignored_tx_broadcasts_while_initially_syncing() {

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1833,7 +1833,7 @@ pub struct PeerMetadata<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Optimistically keeps track of transactions that we know the peer has seen. Optimistic, in
     /// the sense that transactions are preemptively marked as seen by peer when they are sent to
     /// the peer.
-    seen_transactions: LruCache<TxHash>,
+    pub seen_transactions: LruCache<TxHash>,
     /// A communication channel directly to the peer's session task.
     request_tx: PeerRequestSender<PeerRequest<N>>,
     /// negotiated version of the session.
@@ -1846,7 +1846,7 @@ pub struct PeerMetadata<N: NetworkPrimitives = EthNetworkPrimitives> {
 
 impl<N: NetworkPrimitives> PeerMetadata<N> {
     /// Returns a new instance of [`PeerMetadata`].
-    fn new(
+    pub fn new(
         request_tx: PeerRequestSender<PeerRequest<N>>,
         version: EthVersion,
         client_version: Arc<str>,


### PR DESCRIPTION
Just a quick benchmark for `fetch pending hashes` in the worst case that each tx in the cache belongs to a different peer.

And this is the result:

```bash
Fetch Pending Hashes/fetch pending hashes, peers num: 5
                        time:   [1.1113 µs 1.1257 µs 1.1413 µs]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Fetch Pending Hashes/fetch pending hashes, peers num: 10
                        time:   [1.8548 µs 1.8734 µs 1.8936 µs]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
Fetch Pending Hashes/fetch pending hashes, peers num: 20
                        time:   [3.4596 µs 3.4865 µs 3.5164 µs]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
Fetch Pending Hashes/fetch pending hashes, peers num: 100
                        time:   [17.052 µs 17.259 µs 17.488 µs]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Benchmarking Fetch Pending Hashes/fetch pending hashes, peers num: 1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.5s, enable flat sampling, or reduce sample count to 50.
Fetch Pending Hashes/fetch pending hashes, peers num: 1000
                        time:   [336.12 µs 362.97 µs 398.35 µs]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
Fetch Pending Hashes/fetch pending hashes, peers num: 10000
                        time:   [18.844 ms 19.183 ms 19.527 ms]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
Benchmarking Fetch Pending Hashes/fetch pending hashes, peers num: 100000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 54.6s, or reduce sample count to 10.
Fetch Pending Hashes/fetch pending hashes, peers num: 100000
                        time:   [218.21 ms 221.80 ms 225.39 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
```

The maximum capacity of hashes_pending_fetch is 25 600. Therefore, so ms-level times are expected in mainnet.

@mattsse WDYT?
