### PR TITLE
POC: simplify SDK

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -61,7 +61,7 @@ pub(crate) struct InMemoryState<N: NodePrimitives = EthPrimitives> {
     metrics: InMemoryStateMetrics,
 }
 
-impl<N: NodePrimitives> InMemoryState<N> {
+impl<N: NodePrimitives + Clone> InMemoryState<N> {
     pub(crate) fn new(
         blocks: HashMap<B256, Arc<BlockState<N>>>,
         numbers: BTreeMap<u64, B256>,
@@ -141,7 +141,7 @@ pub(crate) struct CanonicalInMemoryStateInner<N: NodePrimitives> {
     pub(crate) canon_state_notification_sender: CanonStateNotificationSender<N>,
 }
 
-impl<N: NodePrimitives> CanonicalInMemoryStateInner<N> {
+impl<N: NodePrimitives + Clone> CanonicalInMemoryStateInner<N> {
     /// Clears all entries in the in memory state.
     fn clear(&self) {
         {
@@ -169,7 +169,7 @@ pub struct CanonicalInMemoryState<N: NodePrimitives = EthPrimitives> {
     pub(crate) inner: Arc<CanonicalInMemoryStateInner<N>>,
 }
 
-impl<N: NodePrimitives> CanonicalInMemoryState<N> {
+impl<N: NodePrimitives + Clone + Default> CanonicalInMemoryState<N> {
     /// Create a new in-memory state with the given blocks, numbers, pending state, and optional
     /// finalized header.
     pub fn new(
@@ -598,7 +598,10 @@ pub struct BlockState<N: NodePrimitives = EthPrimitives> {
 }
 
 #[allow(dead_code)]
-impl<N: NodePrimitives> BlockState<N> {
+impl<N> BlockState<N>
+where
+    N: NodePrimitives + Clone,
+{
     /// [`BlockState`] constructor.
     pub const fn new(block: ExecutedBlockWithTrieUpdates<N>) -> Self {
         Self { block, parent: None }

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -19,7 +19,7 @@ use std::sync::OnceLock;
 #[expect(missing_debug_implementations)]
 pub struct MemoryOverlayStateProviderRef<
     'a,
-    N: NodePrimitives = reth_ethereum_primitives::EthPrimitives,
+    N: NodePrimitives + 'static = reth_ethereum_primitives::EthPrimitives,
 > {
     /// Historical state provider for state lookups that are not found in in-memory blocks.
     pub(crate) historical: Box<dyn StateProvider + 'a>,

--- a/crates/chain-state/src/noop.rs
+++ b/crates/chain-state/src/noop.rs
@@ -8,7 +8,11 @@ use reth_primitives_traits::NodePrimitives;
 use reth_storage_api::noop::NoopProvider;
 use tokio::sync::{broadcast, watch};
 
-impl<C: Send + Sync, N: NodePrimitives> CanonStateSubscriptions for NoopProvider<C, N> {
+impl<C, N> CanonStateSubscriptions for NoopProvider<C, N>
+where
+    C: Send + Sync,
+    N: NodePrimitives + Default + Clone + 'static,
+{
     fn subscribe_to_canonical_state(&self) -> CanonStateNotifications<N> {
         broadcast::channel(1).1
     }

--- a/crates/chain-state/src/noop.rs
+++ b/crates/chain-state/src/noop.rs
@@ -11,7 +11,7 @@ use tokio::sync::{broadcast, watch};
 impl<C, N> CanonStateSubscriptions for NoopProvider<C, N>
 where
     C: Send + Sync,
-    N: NodePrimitives + Default + Clone + 'static,
+    N: NodePrimitives + Unpin + Default + Clone + 'static,
 {
     fn subscribe_to_canonical_state(&self) -> CanonStateNotifications<N> {
         broadcast::channel(1).1

--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -53,13 +53,17 @@ impl<T: CanonStateSubscriptions> CanonStateSubscriptions for &T {
 /// A Stream of [`CanonStateNotification`].
 #[derive(Debug)]
 #[pin_project::pin_project]
-pub struct CanonStateNotificationStream<N: NodePrimitives = reth_ethereum_primitives::EthPrimitives>
-{
+pub struct CanonStateNotificationStream<
+    N: NodePrimitives + 'static = reth_ethereum_primitives::EthPrimitives,
+> {
     #[pin]
     st: BroadcastStream<CanonStateNotification<N>>,
 }
 
-impl<N: NodePrimitives> Stream for CanonStateNotificationStream<N> {
+impl<N> Stream for CanonStateNotificationStream<N>
+where
+    N: NodePrimitives + Clone + 'static,
+{
     type Item = CanonStateNotification<N>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -637,7 +637,7 @@ where
 
 impl<N, P, E, T, V, C> EngineApiTreeHandler<N, P, E, T, V, C>
 where
-    N: NodePrimitives,
+    N: NodePrimitives + Clone + Default + 'static,
     P: DatabaseProviderFactory
         + BlockReader<Block = N::Block, Header = N::BlockHeader>
         + StateProviderFactory

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -98,7 +98,7 @@ pub(crate) const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = EPOCH_SLOTS;
 /// - This only stores blocks that are connected to the canonical chain.
 /// - All executed blocks are valid and have been executed.
 #[derive(Debug, Default)]
-pub struct TreeState<N: NodePrimitives = EthPrimitives> {
+pub struct TreeState<N: NodePrimitives + Clone = EthPrimitives> {
     /// __All__ unique executed blocks by block hash that are connected to the canonical chain.
     ///
     /// This includes blocks of all forks.
@@ -119,7 +119,7 @@ pub struct TreeState<N: NodePrimitives = EthPrimitives> {
     current_canonical_head: BlockNumHash,
 }
 
-impl<N: NodePrimitives> TreeState<N> {
+impl<N> TreeState<N> where N: NodePrimitives + Clone {
     /// Returns a new, empty tree state that points to the given canonical head.
     fn new(current_canonical_head: BlockNumHash) -> Self {
         Self {
@@ -639,7 +639,7 @@ impl<N, P, E, T, V, C> EngineApiTreeHandler<N, P, E, T, V, C>
 where
     N: NodePrimitives + Clone + Default + 'static,
     P: DatabaseProviderFactory
-        + BlockReader<Block = N::Block, Header = N::BlockHeader>
+        + BlockReader<Block = N::Block, BlockHeader = N::BlockHeader>
         + StateProviderFactory
         + StateReader<Receipt = N::Receipt>
         + StateCommitmentProvider
@@ -647,7 +647,7 @@ where
         + Clone
         + 'static,
     <P as DatabaseProviderFactory>::Provider:
-        BlockReader<Block = N::Block, Header = N::BlockHeader>,
+        BlockReader<Block = N::Block, BlockHeader = N::BlockHeader>,
     E: BlockExecutorProvider<Primitives = N>,
     C: ConfigureEvm<Primitives = N> + 'static,
     T: PayloadTypes,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -98,7 +98,7 @@ pub(crate) const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = EPOCH_SLOTS;
 /// - This only stores blocks that are connected to the canonical chain.
 /// - All executed blocks are valid and have been executed.
 #[derive(Debug, Default)]
-pub struct TreeState<N: NodePrimitives + Clone = EthPrimitives> {
+pub struct TreeState<N: NodePrimitives = EthPrimitives> {
     /// __All__ unique executed blocks by block hash that are connected to the canonical chain.
     ///
     /// This includes blocks of all forks.
@@ -119,7 +119,10 @@ pub struct TreeState<N: NodePrimitives + Clone = EthPrimitives> {
     current_canonical_head: BlockNumHash,
 }
 
-impl<N> TreeState<N> where N: NodePrimitives + Clone {
+impl<N> TreeState<N>
+where
+    N: NodePrimitives + Clone,
+{
     /// Returns a new, empty tree state that points to the given canonical head.
     fn new(current_canonical_head: BlockNumHash) -> Self {
         Self {
@@ -460,8 +463,9 @@ impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
     }
 }
 
-impl<N: NodePrimitives, P> StateProviderBuilder<N, P>
+impl<N, P> StateProviderBuilder<N, P>
 where
+    N: NodePrimitives + Clone + 'static,
     P: BlockReader + StateProviderFactory + StateReader + StateCommitmentProvider + Clone,
 {
     /// Creates a new state provider from this builder.
@@ -490,7 +494,10 @@ pub struct EngineApiTreeState<N: NodePrimitives> {
     invalid_headers: InvalidHeaderCache,
 }
 
-impl<N: NodePrimitives> EngineApiTreeState<N> {
+impl<N> EngineApiTreeState<N>
+where
+    N: NodePrimitives + Clone,
+{
     fn new(
         block_buffer_limit: u32,
         max_invalid_header_cache_length: u32,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -77,7 +77,7 @@ impl<N, Evm> PayloadProcessor<N, Evm> {
 
 impl<N, Evm> PayloadProcessor<N, Evm>
 where
-    N: NodePrimitives + 'static,
+    N: NodePrimitives + Clone + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Spawns all background tasks and returns a handle connected to the tasks.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -77,7 +77,7 @@ impl<N, Evm> PayloadProcessor<N, Evm> {
 
 impl<N, Evm> PayloadProcessor<N, Evm>
 where
-    N: NodePrimitives,
+    N: NodePrimitives + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Spawns all background tasks and returns a handle connected to the tasks.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -51,7 +51,7 @@ pub(super) struct PrewarmCacheTask<N: NodePrimitives, P, Evm> {
 
 impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
 where
-    N: NodePrimitives,
+    N: NodePrimitives + Clone + 'static,
     P: BlockReader + StateProviderFactory + StateReader + StateCommitmentProvider + Clone + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -204,7 +204,7 @@ pub(super) struct PrewarmContext<N: NodePrimitives, P, Evm> {
 
 impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
-    N: NodePrimitives,
+    N: NodePrimitives + Clone + 'static,
     P: BlockReader + StateProviderFactory + StateReader + StateCommitmentProvider + Clone + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -99,7 +99,7 @@ impl<S, T, Provider, Evm, Validator> Stream for EngineReorg<S, T, Provider, Evm,
 where
     S: Stream<Item = BeaconEngineMessage<T>>,
     T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = Evm::Primitives>>,
-    Provider: BlockReader<Header = HeaderTy<Evm::Primitives>, Block = BlockTy<Evm::Primitives>>
+    Provider: BlockReader<BlockHeader = HeaderTy<Evm::Primitives>, Block = BlockTy<Evm::Primitives>>
         + StateProviderFactory
         + ChainSpecProvider,
     Evm: ConfigureEvm,
@@ -244,7 +244,7 @@ fn create_reorg_head<Provider, Evm, Validator>(
     next_payload: Validator::ExecutionData,
 ) -> RethResult<SealedBlock<BlockTy<Evm::Primitives>>>
 where
-    Provider: BlockReader<Header = HeaderTy<Evm::Primitives>, Block = BlockTy<Evm::Primitives>>
+    Provider: BlockReader<BlockHeader = HeaderTy<Evm::Primitives>, Block = BlockTy<Evm::Primitives>>
         + StateProviderFactory
         + ChainSpecProvider<ChainSpec: EthChainSpec>,
     Evm: ConfigureEvm,

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -132,7 +132,7 @@ pub trait Executor<DB: Database>: Sized {
 /// A type that can create a new executor for block execution.
 pub trait BlockExecutorProvider: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Receipt type.
-    type Primitives: NodePrimitives;
+    type Primitives: NodePrimitives + Clone;
 
     /// An executor that can execute a single block given a database.
     ///
@@ -405,7 +405,7 @@ impl<F> BasicBlockExecutorProvider<F> {
 
 impl<F> BlockExecutorProvider for BasicBlockExecutorProvider<F>
 where
-    F: ConfigureEvm + 'static,
+    F: ConfigureEvm<Primitives: Clone> + 'static,
 {
     type Primitives = F::Primitives;
 

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -305,7 +305,7 @@ where
     >,
     DB: Database + 'a,
     Builder: BlockAssembler<F, Block = N::Block>,
-    N: NodePrimitives,
+    N: NodePrimitives + Default + 'static,
 {
     type Primitives = N;
     type Executor = Executor;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -91,7 +91,7 @@ pub use alloy_evm::block::state_changes as state_change;
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// The primitives type used by the EVM.
-    type Primitives: NodePrimitives;
+    type Primitives: NodePrimitives + Default + 'static;
 
     /// The error type that is returned by [`Self::next_evm_env`].
     type Error: Error + Send + Sync + 'static;

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -15,7 +15,9 @@ const UNAVAILABLE_FOR_NOOP: &str = "execution unavailable for noop";
 #[non_exhaustive]
 pub struct NoopBlockExecutorProvider<P>(core::marker::PhantomData<P>);
 
-impl<P: NodePrimitives> BlockExecutorProvider for NoopBlockExecutorProvider<P> {
+impl<P: NodePrimitives + Default + Clone + 'static> BlockExecutorProvider
+    for NoopBlockExecutorProvider<P>
+{
     type Primitives = P;
 
     type Executor<DB: Database> = Self;

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -15,8 +15,9 @@ const UNAVAILABLE_FOR_NOOP: &str = "execution unavailable for noop";
 #[non_exhaustive]
 pub struct NoopBlockExecutorProvider<P>(core::marker::PhantomData<P>);
 
-impl<P: NodePrimitives + Default + Clone + 'static> BlockExecutorProvider
-    for NoopBlockExecutorProvider<P>
+impl<P> BlockExecutorProvider for NoopBlockExecutorProvider<P>
+where
+    P: NodePrimitives + Unpin + Default + Clone + 'static,
 {
     type Primitives = P;
 

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -41,7 +41,7 @@ pub struct BackfillJob<E, P> {
 impl<E, P> Iterator for BackfillJob<E, P>
 where
     E: BlockExecutorProvider<Primitives: NodePrimitives<Block = P::Block>>,
-    P: HeaderProvider + BlockReader<Transaction: SignedTransaction> + StateProviderFactory,
+    P: HeaderProvider + BlockReader<SignedTx: SignedTransaction> + StateProviderFactory,
 {
     type Item = BackfillJobResult<Chain<E::Primitives>>;
 
@@ -57,7 +57,7 @@ where
 impl<E, P> BackfillJob<E, P>
 where
     E: BlockExecutorProvider<Primitives: NodePrimitives<Block = P::Block>>,
-    P: BlockReader<Transaction: SignedTransaction> + HeaderProvider + StateProviderFactory,
+    P: BlockReader<SignedTx: SignedTransaction> + HeaderProvider + StateProviderFactory,
 {
     /// Converts the backfill job into a single block backfill job.
     pub fn into_single_blocks(self) -> SingleBlockBackfillJob<E, P> {

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -426,7 +426,7 @@ where
 impl<P, N> Future for ExExManager<P, N>
 where
     P: HeaderProvider + Unpin + 'static,
-    N: NodePrimitives + Clone,
+    N: NodePrimitives + Clone + 'static,
 {
     type Output = eyre::Result<()>;
 

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -89,7 +89,10 @@ pub struct ExExHandle<N: NodePrimitives = EthPrimitives> {
     finished_height: Option<BlockNumHash>,
 }
 
-impl<N: NodePrimitives> ExExHandle<N> {
+impl<N> ExExHandle<N>
+where
+    N: NodePrimitives + Clone,
+{
     /// Create a new handle for the given `ExEx`.
     ///
     /// Returns the handle, as well as a [`UnboundedSender`] for [`ExExEvent`]s and a
@@ -423,7 +426,7 @@ where
 impl<P, N> Future for ExExManager<P, N>
 where
     P: HeaderProvider + Unpin + 'static,
-    N: NodePrimitives,
+    N: NodePrimitives + Clone,
 {
     type Output = eyre::Result<()>;
 
@@ -553,7 +556,10 @@ pub struct ExExManagerHandle<N: NodePrimitives = EthPrimitives> {
     finished_height: watch::Receiver<FinishedExExHeight>,
 }
 
-impl<N: NodePrimitives> ExExManagerHandle<N> {
+impl<N> ExExManagerHandle<N>
+where
+    N: NodePrimitives + Clone,
+{
     /// Creates an empty manager handle.
     ///
     /// Use this if there is no manager present.

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -37,7 +37,7 @@ use tracing::info;
 pub struct BodiesDownloader<
     B: Block,
     C: BodiesClient<Body = B::Body>,
-    Provider: HeaderProvider<Header = B::Header>,
+    Provider: HeaderProvider<BlockHeader = B::Header>,
 > {
     /// The bodies client
     client: Arc<C>,
@@ -73,10 +73,12 @@ impl<B, C, Provider> BodiesDownloader<B, C, Provider>
 where
     B: Block,
     C: BodiesClient<Body = B::Body> + 'static,
-    Provider: HeaderProvider<Header = B::Header> + Unpin + 'static,
+    Provider: HeaderProvider<BlockHeader = B::Header> + Unpin + 'static,
 {
     /// Returns the next contiguous request.
-    fn next_headers_request(&self) -> DownloadResult<Option<Vec<SealedHeader<Provider::Header>>>> {
+    fn next_headers_request(
+        &self,
+    ) -> DownloadResult<Option<Vec<SealedHeader<Provider::BlockHeader>>>> {
         let start_at = match self.in_progress_queue.last_requested_block_number {
             Some(num) => num + 1,
             None => *self.download_range.start(),
@@ -286,7 +288,7 @@ impl<B, C, Provider> BodiesDownloader<B, C, Provider>
 where
     B: Block + 'static,
     C: BodiesClient<Body = B::Body> + 'static,
-    Provider: HeaderProvider<Header = B::Header> + Unpin + 'static,
+    Provider: HeaderProvider<BlockHeader = B::Header> + Unpin + 'static,
 {
     /// Spawns the downloader task via [`tokio::task::spawn`]
     pub fn into_task(self) -> TaskDownloader<B> {
@@ -306,7 +308,7 @@ impl<B, C, Provider> BodyDownloader for BodiesDownloader<B, C, Provider>
 where
     B: Block + 'static,
     C: BodiesClient<Body = B::Body> + 'static,
-    Provider: HeaderProvider<Header = B::Header> + Unpin + 'static,
+    Provider: HeaderProvider<BlockHeader = B::Header> + Unpin + 'static,
 {
     type Block = B;
 
@@ -357,7 +359,7 @@ impl<B, C, Provider> Stream for BodiesDownloader<B, C, Provider>
 where
     B: Block + 'static,
     C: BodiesClient<Body = B::Body> + 'static,
-    Provider: HeaderProvider<Header = B::Header> + Unpin + 'static,
+    Provider: HeaderProvider<BlockHeader = B::Header> + Unpin + 'static,
 {
     type Item = BodyDownloaderResult<B>;
 
@@ -580,7 +582,7 @@ impl BodiesDownloaderBuilder {
     where
         B: Block,
         C: BodiesClient<Body = B::Body> + 'static,
-        Provider: HeaderProvider<Header = B::Header>,
+        Provider: HeaderProvider<BlockHeader = B::Header>,
     {
         let Self {
             request_limit,

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -52,7 +52,7 @@ impl<B: Block + 'static> TaskDownloader<B> {
     /// fn t<
     ///     B: Block + 'static,
     ///     C: BodiesClient<Body = B::Body> + 'static,
-    ///     Provider: HeaderProvider<Header = B::Header> + Unpin + 'static,
+    ///     Provider: HeaderProvider<BlockHeader = B::Header> + Unpin + 'static,
     /// >(
     ///     client: Arc<C>,
     ///     consensus: Arc<dyn Consensus<B, Error = ConsensusError>>,

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -154,7 +154,7 @@ where
 impl<C, N> NetworkConfig<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
+    C: BlockReader<Block = N::Block, Receipt = N::Receipt, BlockHeader = N::BlockHeader>
         + HeaderProvider
         + Clone
         + Unpin

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -84,7 +84,7 @@ where
     C: BlockReader,
 {
     /// Returns the list of requested headers
-    fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<C::Header> {
+    fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<C::BlockHeader> {
         let GetBlockHeaders { start_block, limit, skip, direction } = request;
 
         let mut headers = Vec::new();
@@ -147,7 +147,7 @@ where
         &self,
         _peer_id: PeerId,
         request: GetBlockHeaders,
-        response: oneshot::Sender<RequestResult<BlockHeaders<C::Header>>>,
+        response: oneshot::Sender<RequestResult<BlockHeaders<C::BlockHeader>>>,
     ) {
         self.metrics.eth_headers_requests_received_total.increment(1);
         let headers = self.get_headers_response(request);
@@ -223,7 +223,7 @@ impl<C, N> Future for EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
     C: BlockReader<Block = N::Block, Receipt = N::Receipt>
-        + HeaderProvider<Header = N::BlockHeader>
+        + HeaderProvider<BlockHeader = N::BlockHeader>
         + Unpin,
 {
     type Output = ();

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -9,7 +9,7 @@ use reth_engine_primitives::{BeaconConsensusEngineEvent, BeaconConsensusEngineHa
 use reth_evm::{execute::BlockExecutorProvider, ConfigureEvm};
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
-use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter, TxTy};
+use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDBAdapter, TxTy};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_provider::FullProvider;
 use reth_tasks::TaskExecutor;
@@ -23,7 +23,7 @@ use std::{fmt::Debug, future::Future, marker::PhantomData};
 /// Its types are configured by node internally and are not intended to be user configurable.
 pub trait FullNodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Node's types with the database.
-    type Types: NodeTypes;
+    type Types: NodeTypes<Primitives: FullNodePrimitives>;
     /// Underlying database type used by the node to store and retrieve data.
     type DB: Database + DatabaseMetrics + Clone + Unpin + 'static;
     /// The provider type used to interact with the node.
@@ -36,7 +36,7 @@ pub struct FullNodeTypesAdapter<Types, DB, Provider>(PhantomData<(Types, DB, Pro
 
 impl<Types, DB, Provider> FullNodeTypes for FullNodeTypesAdapter<Types, DB, Provider>
 where
-    Types: NodeTypes,
+    Types: NodeTypes<Primitives: FullNodePrimitives>,
     DB: Database + DatabaseMetrics + Clone + Unpin + 'static,
     Provider: FullProvider<NodeTypesWithDBAdapter<Types, DB>>,
 {

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -27,7 +27,7 @@ use reth_trie_db::StateCommitment;
 /// This trait is intended to be stateless and only define the types of the node.
 pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// The node's primitive types, defining basic operations and structures.
-    type Primitives: NodePrimitives + Clone + Default + 'static;
+    type Primitives: NodePrimitives + Unpin + Clone + Default + PartialEq + Eq + 'static;
     /// The type used for configuration of the EVM.
     type ChainSpec: EthChainSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>;
     /// The type used to perform state commitment operations.

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -42,7 +42,7 @@ pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
 /// node.
 ///
 /// Its types are configured by node internally and are not intended to be user configurable.
-pub trait NodeTypesWithDB: NodeTypes {
+pub trait NodeTypesWithDB: NodeTypes<Primitives: FullNodePrimitives> {
     /// Underlying database type used by the node to store and retrieve data.
     type DB: Database + DatabaseMetrics + Clone + Unpin + 'static;
 }
@@ -75,7 +75,7 @@ where
 
 impl<Types, DB> NodeTypesWithDB for NodeTypesWithDBAdapter<Types, DB>
 where
-    Types: NodeTypes,
+    Types: NodeTypes<Primitives: FullNodePrimitives>,
     DB: Database + DatabaseMetrics + Clone + Unpin + 'static,
 {
     type DB = DB;

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -27,7 +27,7 @@ use reth_trie_db::StateCommitment;
 /// This trait is intended to be stateless and only define the types of the node.
 pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// The node's primitive types, defining basic operations and structures.
-    type Primitives: NodePrimitives + PartialEq + Eq + Clone + Default + 'static;
+    type Primitives: NodePrimitives + Clone + Default + 'static;
     /// The type used for configuration of the EVM.
     type ChainSpec: EthChainSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>;
     /// The type used to perform state commitment operations.

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -27,7 +27,7 @@ use reth_trie_db::StateCommitment;
 /// This trait is intended to be stateless and only define the types of the node.
 pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// The node's primitive types, defining basic operations and structures.
-    type Primitives: NodePrimitives;
+    type Primitives: NodePrimitives + PartialEq + Eq + Clone + Default + 'static;
     /// The type used for configuration of the EVM.
     type ChainSpec: EthChainSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>;
     /// The type used to perform state commitment operations.
@@ -125,7 +125,7 @@ impl<P, C, SC, S, PL> AnyNodeTypes<P, C, SC, S, PL> {
 
 impl<P, C, SC, S, PL> NodeTypes for AnyNodeTypes<P, C, SC, S, PL>
 where
-    P: NodePrimitives + Send + Sync + Unpin + 'static,
+    P: NodePrimitives + Send + Sync + Unpin + Clone + Default + PartialEq + Eq + 'static,
     C: EthChainSpec<Header = P::BlockHeader> + Clone + 'static,
     SC: StateCommitment,
     S: Default + Clone + Send + Sync + Unpin + Debug + 'static,
@@ -186,7 +186,7 @@ impl<P, E, C, SC, S, PL> AnyNodeTypesWithEngine<P, E, C, SC, S, PL> {
 
 impl<P, E, C, SC, S, PL> NodeTypes for AnyNodeTypesWithEngine<P, E, C, SC, S, PL>
 where
-    P: NodePrimitives + Send + Sync + Unpin + 'static,
+    P: NodePrimitives + Send + Sync + Unpin + Clone + Default + PartialEq + Eq + 'static,
     E: EngineTypes + Send + Sync + Unpin,
     C: EthChainSpec<Header = P::BlockHeader> + Clone + 'static,
     SC: StateCommitment,

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -103,12 +103,12 @@ impl<ChainSpec, N, R> ConfigureEvm for OpEvmConfig<ChainSpec, N, R>
 where
     ChainSpec: EthChainSpec + OpHardforks,
     N: NodePrimitives<
-        Receipt = R::Receipt,
-        SignedTx = R::Transaction,
-        BlockHeader = Header,
-        BlockBody = alloy_consensus::BlockBody<R::Transaction>,
-        Block = alloy_consensus::Block<R::Transaction>,
-    >,
+            Receipt = R::Receipt,
+            SignedTx = R::Transaction,
+            BlockHeader = Header,
+            BlockBody = alloy_consensus::BlockBody<R::Transaction>,
+            Block = alloy_consensus::Block<R::Transaction>,
+        > + 'static,
     OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx> + FromTxWithEncoded<N::SignedTx>,
     R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
     Self: Send + Sync + Unpin + Clone + 'static,

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -129,7 +129,7 @@ impl<Client, Tasks, Builder> PayloadJobGenerator
     for BasicPayloadJobGenerator<Client, Tasks, Builder>
 where
     Client: StateProviderFactory
-        + BlockReaderIdExt<Header = HeaderForPayload<Builder::BuiltPayload>>
+        + BlockReaderIdExt<BlockHeader = HeaderForPayload<Builder::BuiltPayload>>
         + Clone
         + Unpin
         + 'static,

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -6,7 +6,7 @@ use alloc::sync::Arc;
 use core::fmt;
 
 /// Configures all the primitive types of the node.
-pub trait NodePrimitives: Send + Sync + Unpin + Sized + fmt::Debug + PartialEq + Eq {
+pub trait NodePrimitives: Send + Sync + Sized + fmt::Debug {
     /// Block primitive.
     type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody>
         + MaybeSerdeBincodeCompat
@@ -47,8 +47,11 @@ where
             BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
-        > + Default
+        > + Unpin
+        + Default
         + Clone
+        + PartialEq
+        + Eq
         + 'static,
 {
 }
@@ -60,8 +63,11 @@ impl<T> FullNodePrimitives for T where
             BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
-        > + Default
+        > + Unpin
+        + Default
         + Clone
+        + PartialEq
+        + Eq
         + 'static
 {
 }

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -49,8 +49,6 @@ where
             Receipt: FullReceipt,
         > + Default
         + Clone
-        + PartialEq
-        + Eq
         + 'static,
 {
 }
@@ -64,8 +62,6 @@ impl<T> FullNodePrimitives for T where
             Receipt: FullReceipt,
         > + Default
         + Clone
-        + PartialEq
-        + Eq
         + 'static
 {
 }

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -6,17 +6,20 @@ use alloc::sync::Arc;
 use core::fmt;
 
 /// Configures all the primitive types of the node.
-pub trait NodePrimitives: Send + Sync + Unpin + Clone + fmt::Debug + PartialEq + Eq {
+pub trait NodePrimitives: Send + Sync + Unpin + Sized + fmt::Debug + PartialEq + Eq {
     /// Block primitive.
-    type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody> + MaybeSerdeBincodeCompat;
+    type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody>
+        + MaybeSerdeBincodeCompat
+        + 'static;
     /// Block header primitive.
-    type BlockHeader: FullBlockHeader;
+    type BlockHeader: FullBlockHeader + 'static;
     /// Block body primitive.
-    type BlockBody: FullBlockBody<Transaction = Self::SignedTx, OmmerHeader = Self::BlockHeader>;
+    type BlockBody: FullBlockBody<Transaction = Self::SignedTx, OmmerHeader = Self::BlockHeader>
+        + 'static;
     /// Signed version of the transaction type.
-    type SignedTx: FullSignedTx;
+    type SignedTx: FullSignedTx + 'static;
     /// A receipt.
-    type Receipt: Receipt;
+    type Receipt: Receipt + 'static;
 }
 
 impl<T: NodePrimitives> NodePrimitives for &T {
@@ -45,6 +48,9 @@ where
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
         > + Default
+        + Clone
+        + PartialEq
+        + Eq
         + 'static,
 {
 }
@@ -57,6 +63,9 @@ impl<T> FullNodePrimitives for T where
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
         > + Default
+        + Clone
+        + PartialEq
+        + Eq
         + 'static
 {
 }

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -2,12 +2,11 @@ use crate::{
     Block, FullBlock, FullBlockBody, FullBlockHeader, FullReceipt, FullSignedTx,
     MaybeSerdeBincodeCompat, Receipt,
 };
+use alloc::sync::Arc;
 use core::fmt;
 
 /// Configures all the primitive types of the node.
-pub trait NodePrimitives:
-    Send + Sync + Unpin + Clone + Default + fmt::Debug + PartialEq + Eq + 'static
-{
+pub trait NodePrimitives: Send + Sync + Unpin + Clone + fmt::Debug + PartialEq + Eq {
     /// Block primitive.
     type Block: Block<Header = Self::BlockHeader, Body = Self::BlockBody> + MaybeSerdeBincodeCompat;
     /// Block header primitive.
@@ -19,6 +18,23 @@ pub trait NodePrimitives:
     /// A receipt.
     type Receipt: Receipt;
 }
+
+impl<T: NodePrimitives> NodePrimitives for &T {
+    type Block = T::Block;
+    type BlockHeader = T::BlockHeader;
+    type BlockBody = T::BlockBody;
+    type SignedTx = T::SignedTx;
+    type Receipt = T::Receipt;
+}
+
+impl<T: NodePrimitives> NodePrimitives for Arc<T> {
+    type Block = T::Block;
+    type BlockHeader = T::BlockHeader;
+    type BlockBody = T::BlockBody;
+    type SignedTx = T::SignedTx;
+    type Receipt = T::Receipt;
+}
+
 /// Helper trait that sets trait bounds on [`NodePrimitives`].
 pub trait FullNodePrimitives
 where
@@ -28,14 +44,7 @@ where
             BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
-        > + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
+        > + Default
         + 'static,
 {
 }
@@ -47,14 +56,7 @@ impl<T> FullNodePrimitives for T where
             BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
-        > + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
+        > + Default
         + 'static
 {
 }

--- a/crates/primitives-traits/src/serde_bincode_compat.rs
+++ b/crates/primitives-traits/src/serde_bincode_compat.rs
@@ -11,7 +11,7 @@ pub use block_bincode::{Block, BlockBody};
 ///
 /// The recommended way to add bincode compatible serialization is via the
 /// [`serde_with`] crate and the `serde_as` macro that. See for reference [`header`].
-pub trait SerdeBincodeCompat: Sized + 'static {
+pub trait SerdeBincodeCompat: Sized {
     /// Serde representation of the type for bincode serialization.
     ///
     /// This type defines the bincode compatible serde format for the type.

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -104,16 +104,9 @@ impl PrunerBuilder {
         static_file_provider: StaticFileProvider<Provider>,
     ) -> Pruner<Provider, ()>
     where
-        Provider: StaticFileProviderFactory<
-                Primitives: NodePrimitives<
-                    SignedTx = Provider::SignedTx,
-                    Receipt = Provider::Receipt,
-                    Block = Provider::Block,
-                    BlockHeader = Provider::BlockHeader,
-                    BlockBody = Provider::BlockBody,
-                >,
-            > + DBProvider<Tx: DbTxMut>
-            + BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>
+        Provider: BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>
+            + StaticFileProviderFactory<Primitives = Provider>
+            + DBProvider<Tx: DbTxMut>
             + PruneCheckpointWriter,
     {
         let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -81,13 +81,9 @@ impl PrunerBuilder {
     where
         PF: DatabaseProviderFactory<
                 ProviderRW: PruneCheckpointWriter
-                                + BlockReader<SignedTx: Encodable2718 + Value, Receipt  : Value>
-                                + StaticFileProviderFactory<
-                    Primitives = PF::ProviderRW,
-                >,
-            > + StaticFileProviderFactory<
-                Primitives = PF::ProviderRW,
-            >,
+                                + BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>
+                                + StaticFileProviderFactory<Primitives = PF::ProviderRW>,
+            > + StaticFileProviderFactory<Primitives = PF::ProviderRW>,
     {
         let segments =
             SegmentSet::from_components(provider_factory.static_file_provider(), self.segments);
@@ -108,9 +104,16 @@ impl PrunerBuilder {
         static_file_provider: StaticFileProvider<Provider>,
     ) -> Pruner<Provider, ()>
     where
-        Provider: StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>>
-            + DBProvider<Tx: DbTxMut>
-            + BlockReader<SignedTx: Encodable2718>
+        Provider: StaticFileProviderFactory<
+                Primitives: NodePrimitives<
+                    SignedTx = Provider::SignedTx,
+                    Receipt = Provider::Receipt,
+                    Block = Provider::Block,
+                    BlockHeader = Provider::BlockHeader,
+                    BlockBody = Provider::BlockBody,
+                >,
+            > + DBProvider<Tx: DbTxMut>
+            + BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>
             + PruneCheckpointWriter,
     {
         let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -48,15 +48,8 @@ impl<Provider> SegmentSet<Provider> {
 impl<Provider> SegmentSet<Provider>
 where
     Provider: BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>
-        + StaticFileProviderFactory<
-            Primitives: NodePrimitives<
-                SignedTx = Provider::SignedTx,
-                Receipt = Provider::Receipt,
-                Block = Provider::Block,
-                BlockHeader = Provider::BlockHeader,
-                BlockBody = Provider::BlockBody,
-            >,
-        > + DBProvider<Tx: DbTxMut>
+        + StaticFileProviderFactory<Primitives = Provider>
+        + DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -47,15 +47,22 @@ impl<Provider> SegmentSet<Provider> {
 
 impl<Provider> SegmentSet<Provider>
 where
-    Provider: StaticFileProviderFactory<Primitives = Provider>
-        + DBProvider<Tx: DbTxMut>
-        + PruneCheckpointWriter
-        + BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>,
+    Provider: BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>
+        + StaticFileProviderFactory<
+            Primitives: NodePrimitives<
+                SignedTx = Provider::SignedTx,
+                Receipt = Provider::Receipt,
+                Block = Provider::Block,
+                BlockHeader = Provider::BlockHeader,
+                BlockBody = Provider::BlockBody,
+            >,
+        > + DBProvider<Tx: DbTxMut>
+        + PruneCheckpointWriter,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and
     /// [`PruneModes`].
     pub fn from_components(
-        static_file_provider: StaticFileProvider<Provider::Primitives>,
+        static_file_provider: StaticFileProvider<Provider>,
         prune_modes: PruneModes,
     ) -> Self {
         let PruneModes {

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -47,15 +47,15 @@ impl<Provider> SegmentSet<Provider> {
 
 impl<Provider> SegmentSet<Provider>
 where
-    Provider: BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>
-        + StaticFileProviderFactory<Primitives = Provider>
+    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>>
         + DBProvider<Tx: DbTxMut>
-        + PruneCheckpointWriter,
+        + PruneCheckpointWriter
+        + BlockReader<SignedTx: Encodable2718>,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and
     /// [`PruneModes`].
     pub fn from_components(
-        static_file_provider: StaticFileProvider<Provider>,
+        static_file_provider: StaticFileProvider<Provider::Primitives>,
         prune_modes: PruneModes,
     ) -> Self {
         let PruneModes {

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -47,10 +47,10 @@ impl<Provider> SegmentSet<Provider> {
 
 impl<Provider> SegmentSet<Provider>
 where
-    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>>
+    Provider: StaticFileProviderFactory<Primitives = Provider>
         + DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter
-        + BlockReader<Transaction: Encodable2718>,
+        + BlockReader<SignedTx: Encodable2718 + Value, Receipt: Value>,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and
     /// [`PruneModes`].

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -23,7 +23,7 @@ impl TransactionLookup {
 
 impl<Provider> Segment<Provider> for TransactionLookup
 where
-    Provider: DBProvider<Tx: DbTxMut> + BlockReader<Transaction: Encodable2718>,
+    Provider: DBProvider<Tx: DbTxMut> + BlockReader<SignedTx: Encodable2718>,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::TransactionLookup

--- a/crates/ress/provider/src/pending_state.rs
+++ b/crates/ress/provider/src/pending_state.rs
@@ -25,7 +25,10 @@ struct PendingStateInner<N: NodePrimitives> {
     block_hashes_by_number: BTreeMap<BlockNumber, B256HashSet>,
 }
 
-impl<N> PendingState<N>  where N: NodePrimitives + Clone{
+impl<N> PendingState<N>
+where
+    N: NodePrimitives + Clone,
+{
     /// Insert executed block with trie updates.
     pub fn insert_block(&self, block: ExecutedBlockWithTrieUpdates<N>) {
         let mut this = self.0.write();

--- a/crates/ress/provider/src/pending_state.rs
+++ b/crates/ress/provider/src/pending_state.rs
@@ -25,7 +25,7 @@ struct PendingStateInner<N: NodePrimitives> {
     block_hashes_by_number: BTreeMap<BlockNumber, B256HashSet>,
 }
 
-impl<N: NodePrimitives> PendingState<N> {
+impl<N> PendingState<N>  where N: NodePrimitives + Clone{
     /// Insert executed block with trie updates.
     pub fn insert_block(&self, block: ExecutedBlockWithTrieUpdates<N>) {
         let mut this = self.0.write();

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -204,7 +204,7 @@ where
         provider: P,
     ) -> RpcModuleBuilder<N, P, Pool, Network, Tasks, EvmConfig, BlockExecutor, Consensus>
     where
-        P: BlockReader<Block = N::Block, Header = N::BlockHeader, Receipt = N::Receipt>
+        P: BlockReader<Block = N::Block, BlockHeader = N::BlockHeader, Receipt = N::Receipt>
             + StateProviderFactory
             + 'static,
     {
@@ -516,7 +516,7 @@ where
     /// See also [`EthApiBuilder`].
     pub fn bootstrap_eth_api(&self) -> EthApi<Provider, Pool, Network, EvmConfig>
     where
-        Provider: BlockReaderIdExt<Block = N::Block, Header = N::BlockHeader, Receipt = N::Receipt>
+        Provider: BlockReaderIdExt<Block = N::Block, BlockHeader = N::BlockHeader, Receipt = N::Receipt>
             + StateProviderFactory
             + CanonStateSubscriptions<Primitives = N>
             + ChainSpecProvider

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -11,7 +11,7 @@ use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{Block, BlockTransactions, Header, Index};
 use futures::Future;
 use reth_node_api::BlockBody;
-use reth_primitives_traits::{RecoveredBlock, SealedBlock};
+use reth_primitives_traits::{BlockTy, ReceiptTy, RecoveredBlock, SealedBlock};
 use reth_provider::{
     BlockIdReader, BlockReader, BlockReaderIdExt, ProviderHeader, ProviderReceipt,
 };

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -208,10 +208,7 @@ pub trait LoadBlock: LoadPendingBlock + SpawnBlocking + RpcNodeCoreExt {
         &self,
         block_id: BlockId,
     ) -> impl Future<
-        Output = Result<
-            Option<Arc<RecoveredBlock<<Self::Provider as BlockReader>::Block>>>,
-            Self::Error,
-        >,
+        Output = Result<Option<Arc<RecoveredBlock<BlockTy<Self::Primitives>>>>, Self::Error>,
     > + Send {
         async move {
             if block_id.is_pending() {

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -23,8 +23,8 @@ pub type BlockReceiptsResult<N, E> = Result<Option<Vec<RpcReceipt<N>>>, E>;
 /// Result type of the fetched block and its receipts.
 pub type BlockAndReceiptsResult<Eth> = Result<
     Option<(
-        SealedBlock<<<Eth as RpcNodeCore>::Provider as BlockReader>::Block>,
-        Arc<Vec<ProviderReceipt<<Eth as RpcNodeCore>::Provider>>>,
+        SealedBlock<BlockTy<<Eth as RpcNodeCore>::Primitives>>,
+        Arc<Vec<ReceiptTy<<Eth as RpcNodeCore>::Primitives>>>,
     )>,
     <Eth as EthApiTypes>::Error,
 >;

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -12,9 +12,7 @@ use alloy_rpc_types_eth::{Block, BlockTransactions, Header, Index};
 use futures::Future;
 use reth_node_api::BlockBody;
 use reth_primitives_traits::{BlockTy, ReceiptTy, RecoveredBlock, SealedBlock};
-use reth_provider::{
-    BlockIdReader, BlockReader, BlockReaderIdExt, ProviderHeader, ProviderReceipt,
-};
+use reth_provider::{BlockIdReader, BlockReader, BlockReaderIdExt, ProviderHeader};
 use reth_rpc_types_compat::block::from_block;
 use std::sync::Arc;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -128,7 +128,10 @@ pub trait LoadPendingBlock:
         &self,
     ) -> impl Future<
         Output = Result<
-            Option<(RecoveredBlock<BlockTy<Self::Primitives>>, Vec<ReceiptTy<Self::Primitives>>)>,
+            Option<(
+                RecoveredBlock<<Self::Provider as NodePrimitives>::Block>,
+                Vec<ProviderReceipt<Self::Provider>>,
+            )>,
             Self::Error,
         >,
     > + Send

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -15,7 +15,8 @@ use reth_evm::{
 };
 use reth_node_api::NodePrimitives;
 use reth_primitives_traits::{
-    transaction::error::InvalidTransactionError, Receipt, RecoveredBlock, SealedHeader,
+    transaction::error::InvalidTransactionError, BlockTy, Receipt, ReceiptTy, RecoveredBlock,
+    SealedHeader, TxTy,
 };
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, ProviderBlock, ProviderError, ProviderHeader,
@@ -127,10 +128,7 @@ pub trait LoadPendingBlock:
         &self,
     ) -> impl Future<
         Output = Result<
-            Option<(
-                RecoveredBlock<<Self::Provider as BlockReader>::Block>,
-                Vec<ProviderReceipt<Self::Provider>>,
-            )>,
+            Option<(RecoveredBlock<BlockTy<Self::Primitives>>, Vec<ReceiptTy<Self::Primitives>>)>,
             Self::Error,
         >,
     > + Send

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -15,8 +15,7 @@ use reth_evm::{
 };
 use reth_node_api::NodePrimitives;
 use reth_primitives_traits::{
-    transaction::error::InvalidTransactionError, BlockTy, Receipt, ReceiptTy, RecoveredBlock,
-    SealedHeader, TxTy,
+    transaction::error::InvalidTransactionError, Receipt, RecoveredBlock, SealedHeader,
 };
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, ProviderBlock, ProviderError, ProviderHeader,

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -81,7 +81,18 @@ where
 
 /// Additional components, asides the core node components, needed to run `eth_` namespace API
 /// server.
-pub trait RpcNodeCoreExt: RpcNodeCore<Provider: BlockReader> {
+pub trait RpcNodeCoreExt:
+    RpcNodeCore<
+    Primitives: NodePrimitives,
+    Provider: BlockReader<
+        Block = BlockTy<Self::Primitives>,
+        BlockHeader = HeaderTy<Self::Primitives>,
+        BlockBody = BodyTy<Self::Primitives>,
+        SignedTx = TxTy<Self::Primitives>,
+        Receipt = ReceiptTy<Self::Primitives>,
+    >,
+>
+{
     /// Returns handle to RPC cache service.
     fn cache(
         &self,

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -2,6 +2,7 @@
 
 use reth_node_api::{FullNodeComponents, NodeTypes, PrimitivesTy};
 use reth_payload_builder::PayloadBuilderHandle;
+use reth_primitives_traits::{BlockTy, BodyTy, HeaderTy, NodePrimitives, ReceiptTy, TxTy};
 use reth_provider::{BlockReader, ProviderBlock, ProviderReceipt};
 use reth_rpc_eth_types::EthStateCache;
 

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -4,6 +4,7 @@ use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
 use alloy_json_rpc::RpcObject;
 use alloy_network::{Network, ReceiptResponse, TransactionResponse};
 use alloy_rpc_types_eth::Block;
+use reth_primitives_traits::{ReceiptTy, TxTy};
 use reth_provider::{ProviderTx, ReceiptProvider, TransactionsProvider};
 use reth_rpc_types_compat::TransactionCompat;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -78,12 +79,10 @@ pub trait FullEthApiTypes
 where
     Self: RpcNodeCore<
             Provider: TransactionsProvider + ReceiptProvider,
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
+            Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Provider>>>,
         > + EthApiTypes<
             TransactionCompat: TransactionCompat<
-                <Self::Provider as TransactionsProvider>::Transaction,
+                TxTy<Self::Provider>,
                 Transaction = RpcTransaction<Self::NetworkTypes>,
                 Error = RpcError<Self>,
             >,
@@ -94,12 +93,10 @@ where
 impl<T> FullEthApiTypes for T where
     T: RpcNodeCore<
             Provider: TransactionsProvider + ReceiptProvider,
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
+            Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Provider>>>,
         > + EthApiTypes<
             TransactionCompat: TransactionCompat<
-                <Self::Provider as TransactionsProvider>::Transaction,
+                TxTy<Self::Provider>,
                 Transaction = RpcTransaction<T::NetworkTypes>,
                 Error = RpcError<T>,
             >,

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -4,8 +4,8 @@ use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
 use alloy_json_rpc::RpcObject;
 use alloy_network::{Network, ReceiptResponse, TransactionResponse};
 use alloy_rpc_types_eth::Block;
-use reth_primitives_traits::{ReceiptTy, TxTy};
-use reth_provider::{ProviderTx, ReceiptProvider, TransactionsProvider};
+use reth_primitives_traits::TxTy;
+use reth_provider::{ReceiptProvider, TransactionsProvider};
 use reth_rpc_types_compat::TransactionCompat;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -230,7 +230,7 @@ pub(crate) struct EthStateCacheService<
     Provider: BlockReader,
     LimitBlocks: Limiter<B256, Arc<RecoveredBlock<Provider::Block>>>,
     LimitReceipts: Limiter<B256, Arc<Vec<Provider::Receipt>>>,
-    LimitHeaders: Limiter<B256, Provider::Header>,
+    LimitHeaders: Limiter<B256, Provider::BlockHeader>,
 {
     /// The type used to lookup data from disk
     provider: Provider,
@@ -242,7 +242,7 @@ pub(crate) struct EthStateCacheService<
     ///
     /// Headers are cached because they are required to populate the environment for execution
     /// (evm).
-    headers_cache: HeaderLruCache<Provider::Header, LimitHeaders>,
+    headers_cache: HeaderLruCache<Provider::BlockHeader, LimitHeaders>,
     /// Sender half of the action channel.
     action_tx: UnboundedSender<CacheAction<Provider::Block, Provider::Receipt>>,
     /// Receiver half of the action channel.

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{B256, U256};
 use alloy_rpc_types_eth::BlockId;
 use derive_more::{Deref, DerefMut, From, Into};
 use itertools::Itertools;
-use reth_primitives_traits::{BlockBody, SignedTransaction};
+use reth_primitives_traits::{BlockBody, NodePrimitives, SignedTransaction};
 use reth_rpc_server_types::{
     constants,
     constants::gas_oracle::{
@@ -16,7 +16,7 @@ use reth_rpc_server_types::{
         DEFAULT_MAX_GAS_PRICE, MAX_HEADER_HISTORY, MAX_REWARD_PERCENTILE_COUNT, SAMPLE_NUMBER,
     },
 };
-use reth_storage_api::{BlockReader, BlockReaderIdExt};
+use reth_storage_api::BlockReaderIdExt;
 use schnellru::{ByLength, LruMap};
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
@@ -78,7 +78,7 @@ impl Default for GasPriceOracleConfig {
 #[derive(Debug)]
 pub struct GasPriceOracle<Provider>
 where
-    Provider: BlockReader,
+    Provider: NodePrimitives,
 {
     /// The type used to subscribe to block events and get block info
     provider: Provider,

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -70,7 +70,7 @@ pub fn append_matching_block_logs<P>(
     block_timestamp: u64,
 ) -> Result<(), ProviderError>
 where
-    P: BlockReader<Transaction: SignedTransaction>,
+    P: BlockReader<SignedTx: SignedTransaction>,
 {
     // Tracks the index of a log in the entire block.
     let mut log_index: u64 = 0;

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -101,7 +101,7 @@ where
 
 impl<Provider, E> ValidationApi<Provider, E>
 where
-    Provider: BlockReaderIdExt<Header = <E::Primitives as NodePrimitives>::BlockHeader>
+    Provider: BlockReaderIdExt<BlockHeader = <E::Primitives as NodePrimitives>::BlockHeader>
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + 'static,
@@ -406,7 +406,7 @@ where
 #[async_trait]
 impl<Provider, E> BlockSubmissionValidationApiServer for ValidationApi<Provider, E>
 where
-    Provider: BlockReaderIdExt<Header = <E::Primitives as NodePrimitives>::BlockHeader>
+    Provider: BlockReaderIdExt<BlockHeader = <E::Primitives as NodePrimitives>::BlockHeader>
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + Clone

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -259,7 +259,7 @@ where
     Provider: DBProvider
         + BlockReader<
             Block = <E::Primitives as NodePrimitives>::Block,
-            Header = <E::Primitives as NodePrimitives>::BlockHeader,
+            BlockHeader = <E::Primitives as NodePrimitives>::BlockHeader,
         > + StaticFileProviderFactory
         + StatsReader
         + BlockHashReader
@@ -564,7 +564,7 @@ where
     }
 }
 
-fn execution_checkpoint<N: NodePrimitives>(
+fn execution_checkpoint<N: NodePrimitives + 'static>(
     provider: &StaticFileProvider<N>,
     start_block: BlockNumber,
     max_block: BlockNumber,
@@ -631,7 +631,7 @@ fn execution_checkpoint<N: NodePrimitives>(
     })
 }
 
-fn calculate_gas_used_from_headers<N: NodePrimitives>(
+fn calculate_gas_used_from_headers<N: NodePrimitives + 'static>(
     provider: &StaticFileProvider<N>,
     range: RangeInclusive<BlockNumber>,
 ) -> Result<u64, ProviderError> {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -29,7 +29,7 @@ use reth_db_api::{
 use reth_ethereum_primitives::{Block, EthPrimitives, Receipt, TransactionSigned};
 use reth_evm::{ConfigureEvm, EvmEnv};
 use reth_execution_types::ExecutionOutcome;
-use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
+use reth_node_types::{BlockTy, BodyTy, HeaderTy, NodeTypes, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{
     Account, BlockBody, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader, StorageEntry,
 };
@@ -361,25 +361,22 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
         self.consistent_provider()?.transaction_id(tx_hash)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::SignedTx>> {
         self.consistent_provider()?.transaction_by_id(id)
     }
 
-    fn transaction_by_id_unhashed(
-        &self,
-        id: TxNumber,
-    ) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_id_unhashed(&self, id: TxNumber) -> ProviderResult<Option<Self::SignedTx>> {
         self.consistent_provider()?.transaction_by_id_unhashed(id)
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::SignedTx>> {
         self.consistent_provider()?.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(Self::SignedTx, TransactionMeta)>> {
         self.consistent_provider()?.transaction_by_hash_with_meta(tx_hash)
     }
 
@@ -390,21 +387,21 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+    ) -> ProviderResult<Option<Vec<Self::SignedTx>>> {
         self.consistent_provider()?.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+    ) -> ProviderResult<Vec<Vec<Self::SignedTx>>> {
         self.consistent_provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Self::Transaction>> {
+    ) -> ProviderResult<Vec<Self::SignedTx>> {
         self.consistent_provider()?.transactions_by_tx_range(range)
     }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -357,8 +357,6 @@ impl<N: ProviderNodeTypes> BlockReader for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
-    type Transaction = TxTy<N>;
-
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.consistent_provider()?.transaction_id(tx_hash)
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -157,7 +157,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     }
 }
 
-impl<N: NodeTypes> NodePrimitives for BlockchainProvider<N> {
+impl<N: NodeTypesWithDB> NodePrimitives for BlockchainProvider<N> {
     type Block = BlockTy<N>;
     type BlockHeader = HeaderTy<N>;
     type BlockBody = BodyTy<N>;
@@ -666,7 +666,7 @@ impl<N: ProviderNodeTypes> CanonChainTracker for BlockchainProvider<N> {
 
 impl<N: ProviderNodeTypes> BlockReaderIdExt for BlockchainProvider<N>
 where
-    Self: ReceiptProviderIdExt,
+    Self: ReceiptProviderIdExt<Block = BlockTy<N>>,
 {
     fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Block>> {
         self.consistent_provider()?.block_by_id(id)

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -157,6 +157,14 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     }
 }
 
+impl<N: NodeTypes> NodePrimitives for BlockchainProvider<N> {
+    type Block = BlockTy<N>;
+    type BlockHeader = HeaderTy<N>;
+    type BlockBody = BodyTy<N>;
+    type SignedTx = TxTy<N>;
+    type Receipt = ReceiptTy<N>;
+}
+
 impl<N: NodeTypesWithDB> NodePrimitivesProvider for BlockchainProvider<N> {
     type Primitives = N::Primitives;
 }
@@ -281,8 +289,6 @@ impl<N: ProviderNodeTypes> BlockIdReader for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> BlockReader for BlockchainProvider<N> {
-    type Block = BlockTy<N>;
-
     fn find_block_by_hash(
         &self,
         hash: B256,
@@ -417,8 +423,6 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> ReceiptProvider for BlockchainProvider<N> {
-    type Receipt = ReceiptTy<N>;
-
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.consistent_provider()?.receipt(id)
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -194,13 +194,11 @@ impl<N: ProviderNodeTypes> StaticFileProviderFactory for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider<N> {
-    type Header = HeaderTy<N>;
-
-    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::BlockHeader>> {
         self.consistent_provider()?.header(block_hash)
     }
 
-    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::BlockHeader>> {
         self.consistent_provider()?.header_by_number(num)
     }
 
@@ -215,29 +213,29 @@ impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider<N> {
     fn headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Self::Header>> {
+    ) -> ProviderResult<Vec<Self::BlockHeader>> {
         self.consistent_provider()?.headers_range(range)
     }
 
     fn sealed_header(
         &self,
         number: BlockNumber,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.consistent_provider()?.sealed_header(number)
     }
 
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
         self.consistent_provider()?.sealed_headers_range(range)
     }
 
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
-    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        predicate: impl FnMut(&SealedHeader<Self::BlockHeader>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
         self.consistent_provider()?.sealed_headers_while(range, predicate)
     }
 }
@@ -458,7 +456,7 @@ impl<N: ProviderNodeTypes> WithdrawalsProvider for BlockchainProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> OmmersProvider for BlockchainProvider<N> {
-    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::BlockHeader>>> {
         self.consistent_provider()?.ommers(id)
     }
 }
@@ -666,7 +664,7 @@ impl<N: ProviderNodeTypes> CanonChainTracker for BlockchainProvider<N> {
 
 impl<N: ProviderNodeTypes> BlockReaderIdExt for BlockchainProvider<N>
 where
-    Self: ReceiptProviderIdExt<Block = BlockTy<N>>,
+    Self: ReceiptProviderIdExt<Block = BlockTy<N>, BlockHeader = HeaderTy<N>>,
 {
     fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Block>> {
         self.consistent_provider()?.block_by_id(id)
@@ -675,29 +673,29 @@ where
     fn header_by_number_or_tag(
         &self,
         id: BlockNumberOrTag,
-    ) -> ProviderResult<Option<Self::Header>> {
+    ) -> ProviderResult<Option<Self::BlockHeader>> {
         self.consistent_provider()?.header_by_number_or_tag(id)
     }
 
     fn sealed_header_by_number_or_tag(
         &self,
         id: BlockNumberOrTag,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.consistent_provider()?.sealed_header_by_number_or_tag(id)
     }
 
     fn sealed_header_by_id(
         &self,
         id: BlockId,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.consistent_provider()?.sealed_header_by_id(id)
     }
 
-    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Header>> {
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::BlockHeader>> {
         self.consistent_provider()?.header_by_id(id)
     }
 
-    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Self::Header>>> {
+    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Self::BlockHeader>>> {
         self.consistent_provider()?.ommers_by_id(id)
     }
 }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -613,7 +613,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     }
 }
 
-impl<N: NodeTypes> NodePrimitives for ConsistentProvider<N> {
+impl<N: NodeTypesWithDB> NodePrimitives for ConsistentProvider<N> {
     type Block = BlockTy<N>;
     type BlockHeader = HeaderTy<N>;
     type BlockBody = BodyTy<N>;

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -20,7 +20,7 @@ use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::{BundleStateInit, ExecutionOutcome, RevertsInit};
 use reth_node_types::{
-    BlockTy, BodyTy, HeaderTy, NodePrimitives, NodeTypesWithDB, ReceiptTy, TxTy,
+    BlockTy, BodyTy, HeaderTy, NodePrimitives, ReceiptTy, TxTy,
 };
 use reth_primitives_traits::{
     Account, BlockBody, RecoveredBlock, SealedBlock, SealedHeader, StorageEntry,
@@ -615,7 +615,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     }
 }
 
-impl<N: NodeTypesWithDB> NodePrimitives for ConsistentProvider<N> {
+impl<N: ProviderNodeTypes> NodePrimitives for ConsistentProvider<N> {
     type Block = BlockTy<N>;
     type BlockHeader = HeaderTy<N>;
     type BlockBody = BodyTy<N>;

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -19,7 +19,7 @@ use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStatePro
 use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::{BundleStateInit, ExecutionOutcome, RevertsInit};
-use reth_node_types::{BlockTy, HeaderTy, ReceiptTy, TxTy};
+use reth_node_types::{BlockTy, HeaderTy, NodePrimitives, ReceiptTy, TxTy};
 use reth_primitives_traits::{
     Account, BlockBody, RecoveredBlock, SealedBlock, SealedHeader, StorageEntry,
 };
@@ -613,6 +613,14 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     }
 }
 
+impl<N: NodeTypes> NodePrimitives for ConsistentProvider<N> {
+    type Block = BlockTy<N>;
+    type BlockHeader = HeaderTy<N>;
+    type BlockBody = BodyTy<N>;
+    type SignedTx = TxTy<N>;
+    type Receipt = ReceiptTy<N>;
+}
+
 impl<N: ProviderNodeTypes> NodePrimitivesProvider for ConsistentProvider<N> {
     type Primitives = N::Primitives;
 }
@@ -1044,8 +1052,6 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> ReceiptProvider for ConsistentProvider<N> {
-    type Receipt = ReceiptTy<N>;
-
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.get_in_memory_or_storage_by_tx(
             id.into(),

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -912,8 +912,6 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
-    type Transaction = TxTy<N>;
-
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.get_in_memory_or_storage_by_tx(
             tx_hash.into(),

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -797,8 +797,6 @@ impl<N: ProviderNodeTypes> BlockIdReader for ConsistentProvider<N> {
 }
 
 impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
-    type Block = BlockTy<N>;
-
     fn find_block_by_hash(
         &self,
         hash: B256,

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -19,9 +19,7 @@ use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStatePro
 use reth_chainspec::{ChainInfo, EthereumHardforks};
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::{BundleStateInit, ExecutionOutcome, RevertsInit};
-use reth_node_types::{
-    BlockTy, BodyTy, HeaderTy, NodePrimitives, ReceiptTy, TxTy,
-};
+use reth_node_types::{BlockTy, BodyTy, HeaderTy, NodePrimitives, ReceiptTy, TxTy};
 use reth_primitives_traits::{
     Account, BlockBody, RecoveredBlock, SealedBlock, SealedHeader, StorageEntry,
 };

--- a/crates/storage/provider/src/providers/database/builder.rs
+++ b/crates/storage/provider/src/providers/database/builder.rs
@@ -6,7 +6,7 @@
 use crate::{providers::StaticFileProvider, ProviderFactory};
 use reth_db::{mdbx::DatabaseArguments, open_db_read_only, DatabaseEnv};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
-use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter};
+use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDBAdapter};
 use std::{
     marker::PhantomData,
     path::{Path, PathBuf},
@@ -77,7 +77,7 @@ impl<N> ProviderFactoryBuilder<N> {
         config: impl Into<ReadOnlyConfig>,
     ) -> eyre::Result<ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>>
     where
-        N: NodeTypes,
+        N: NodeTypes<Primitives: FullNodePrimitives>,
     {
         let ReadOnlyConfig { db_dir, db_args, static_files_dir, watch_static_files } =
             config.into();
@@ -285,7 +285,7 @@ impl<N, Val1, Val2, Val3> TypesAnd3<N, Val1, Val2, Val3> {
 
 impl<N, DB> TypesAnd3<N, DB, Arc<N::ChainSpec>, StaticFileProvider<N::Primitives>>
 where
-    N: NodeTypes,
+    N: NodeTypes<Primitives: FullNodePrimitives>,
     DB: Database + DatabaseMetrics + Clone + Unpin + 'static,
 {
     /// Creates the [`ProviderFactory`].

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -424,8 +424,6 @@ impl<N: ProviderNodeTypes> BlockReader for ProviderFactory<N> {
 }
 
 impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
-    type Transaction = TxTy<N>;
-
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.provider()?.transaction_id(tx_hash)
     }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -16,8 +16,8 @@ use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
 use reth_node_types::{
-    BlockTy, BodyTy, HeaderTy, NodePrimitives, NodeTypes, NodeTypesWithDB, NodeTypesWithDBAdapter,
-    ReceiptTy, TxTy,
+    BlockTy, BodyTy, FullNodePrimitives, HeaderTy, NodePrimitives, NodeTypes, NodeTypesWithDB,
+    NodeTypesWithDBAdapter, ReceiptTy, TxTy,
 };
 use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
@@ -68,7 +68,10 @@ pub struct ProviderFactory<N: NodeTypesWithDB> {
     storage: Arc<N::Storage>,
 }
 
-impl<N: NodeTypes> ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>> {
+impl<N> ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>
+where
+    N: NodeTypes<Primitives: FullNodePrimitives>,
+{
     /// Instantiates the builder for this type
     pub fn builder() -> ProviderFactoryBuilder<N> {
         ProviderFactoryBuilder::default()

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -360,8 +360,6 @@ impl<N: ProviderNodeTypes> BlockNumReader for ProviderFactory<N> {
 }
 
 impl<N: ProviderNodeTypes> BlockReader for ProviderFactory<N> {
-    type Block = BlockTy<N>;
-
     fn find_block_by_hash(
         &self,
         hash: B256,

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -16,7 +16,7 @@ use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
 use reth_node_types::{
-    BlockTy, HeaderTy, NodePrimitives, NodeTypes, NodeTypesWithDB, NodeTypesWithDBAdapter,
+    BlockTy, BodyTy, HeaderTy, NodePrimitives, NodeTypes, NodeTypesWithDB, NodeTypesWithDBAdapter,
     ReceiptTy, TxTy,
 };
 use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
@@ -426,7 +426,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
         self.provider()?.transaction_id(tx_hash)
     }
 
-    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::SignedTx>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Transactions,
             id,
@@ -435,10 +435,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
         )
     }
 
-    fn transaction_by_id_unhashed(
-        &self,
-        id: TxNumber,
-    ) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_id_unhashed(&self, id: TxNumber) -> ProviderResult<Option<Self::SignedTx>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Transactions,
             id,
@@ -447,14 +444,14 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
         )
     }
 
-    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::SignedTx>> {
         self.provider()?.transaction_by_hash(hash)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         tx_hash: TxHash,
-    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(Self::SignedTx, TransactionMeta)>> {
         self.provider()?.transaction_by_hash_with_meta(tx_hash)
     }
 
@@ -465,21 +462,21 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+    ) -> ProviderResult<Option<Vec<Self::SignedTx>>> {
         self.provider()?.transactions_by_block(id)
     }
 
     fn transactions_by_block_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+    ) -> ProviderResult<Vec<Vec<Self::SignedTx>>> {
         self.provider()?.transactions_by_block_range(range)
     }
 
     fn transactions_by_tx_range(
         &self,
         range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Self::Transaction>> {
+    ) -> ProviderResult<Vec<Self::SignedTx>> {
         self.provider()?.transactions_by_tx_range(range)
     }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -16,7 +16,8 @@ use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
 use reth_node_types::{
-    BlockTy, HeaderTy, NodeTypes, NodeTypesWithDB, NodeTypesWithDBAdapter, ReceiptTy, TxTy,
+    BlockTy, HeaderTy, NodePrimitives, NodeTypes, NodeTypesWithDB, NodeTypesWithDBAdapter,
+    ReceiptTy, TxTy,
 };
 use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
@@ -197,6 +198,13 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     }
 }
 
+impl<N: NodeTypes> NodePrimitives for ProviderFactory<N> {
+    type Block = BlockTy<N>;
+    type BlockHeader = HeaderTy<N>;
+    type BlockBody = BodyTy<N>;
+    type SignedTx = TxTy<N>;
+    type Receipt = ReceiptTy<N>;
+}
 impl<N: NodeTypesWithDB> NodePrimitivesProvider for ProviderFactory<N> {
     type Primitives = N::Primitives;
 }
@@ -492,7 +500,6 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
 }
 
 impl<N: ProviderNodeTypes> ReceiptProvider for ProviderFactory<N> {
-    type Receipt = ReceiptTy<N>;
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Receipts,

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -198,7 +198,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     }
 }
 
-impl<N: NodeTypes> NodePrimitives for ProviderFactory<N> {
+impl<N: NodeTypesWithDB> NodePrimitives for ProviderFactory<N> {
     type Block = BlockTy<N>;
     type BlockHeader = HeaderTy<N>;
     type BlockBody = BodyTy<N>;
@@ -236,6 +236,7 @@ impl<N: NodeTypesWithDB> StaticFileProviderFactory for ProviderFactory<N> {
 
 impl<N: ProviderNodeTypes> HeaderSyncGapProvider for ProviderFactory<N> {
     type Header = HeaderTy<N>;
+
     fn sync_gap(
         &self,
         tip: watch::Receiver<B256>,
@@ -246,13 +247,11 @@ impl<N: ProviderNodeTypes> HeaderSyncGapProvider for ProviderFactory<N> {
 }
 
 impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
-    type Header = HeaderTy<N>;
-
-    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::BlockHeader>> {
         self.provider()?.header(block_hash)
     }
 
-    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+    fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::BlockHeader>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             num,
@@ -272,7 +271,7 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     fn headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Self::Header>> {
+    ) -> ProviderResult<Vec<Self::BlockHeader>> {
         self.static_file_provider.get_range_with_static_file_or_database(
             StaticFileSegment::Headers,
             to_range(range),
@@ -285,7 +284,7 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     fn sealed_header(
         &self,
         number: BlockNumber,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,
@@ -297,15 +296,15 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
         self.sealed_headers_while(range, |_| true)
     }
 
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
-    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        predicate: impl FnMut(&SealedHeader<Self::BlockHeader>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
         self.static_file_provider.get_range_with_static_file_or_database(
             StaticFileSegment::Headers,
             to_range(range),
@@ -538,7 +537,7 @@ impl<N: ProviderNodeTypes> WithdrawalsProvider for ProviderFactory<N> {
 }
 
 impl<N: ProviderNodeTypes> OmmersProvider for ProviderFactory<N> {
-    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::BlockHeader>>> {
         self.provider()?.ommers(id)
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1380,8 +1380,6 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProviderExt
 
 // Calculates the hash of the given transaction
 impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for DatabaseProvider<TX, N> {
-    type Transaction = TxTy<N>;
-
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         Ok(self.tx.get::<tables::TransactionHashNumbers>(tx_hash)?)
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1159,8 +1159,6 @@ impl<TX: DbTx + 'static, N: NodeTypes> BlockNumReader for DatabaseProvider<TX, N
 }
 
 impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvider<TX, N> {
-    type Block = BlockTy<N>;
-
     fn find_block_by_hash(
         &self,
         hash: B256,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -211,6 +211,14 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     }
 }
 
+impl<TX, N: NodeTypes> NodePrimitives for DatabaseProvider<TX, N> {
+    type Block = BlockTy<N>;
+    type BlockHeader = HeaderTy<N>;
+    type BlockBody = BodyTy<N>;
+    type SignedTx = TxTy<N>;
+    type Receipt = ReceiptTy<N>;
+}
+
 impl<TX, N: NodeTypes> NodePrimitivesProvider for DatabaseProvider<TX, N> {
     type Primitives = N::Primitives;
 }
@@ -1516,8 +1524,6 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
 }
 
 impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabaseProvider<TX, N> {
-    type Receipt = ReceiptTy<N>;
-
     fn receipt(&self, id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Receipts,

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -228,8 +228,6 @@ impl<N: NodePrimitives> BlockNumReader for StaticFileJarProvider<'_, N> {
 impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsProvider
     for StaticFileJarProvider<'_, N>
 {
-    type Transaction = N::SignedTx;
-
     fn transaction_id(&self, hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         let mut cursor = self.cursor()?;
 

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -90,6 +90,14 @@ impl<'a, N: NodePrimitives> StaticFileJarProvider<'a, N> {
     }
 }
 
+impl<'a, N: NodePrimitives> NodePrimitives for StaticFileJarProvider<'a, N> {
+    type Block = N::Block;
+    type BlockHeader = N::BlockHeader;
+    type BlockBody = N::BlockBody;
+    type SignedTx = N::SignedTx;
+    type Receipt = N::Receipt;
+}
+
 impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileJarProvider<'_, N> {
     type Header = N::BlockHeader;
 
@@ -311,8 +319,6 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsPr
 impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction, Receipt: Decompress>>
     ReceiptProvider for StaticFileJarProvider<'_, N>
 {
-    type Receipt = N::Receipt;
-
     fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.cursor()?.get_one::<ReceiptMask<Self::Receipt>>(num.into())
     }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -314,8 +314,8 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsPr
     }
 }
 
-impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction, Receipt: Decompress>>
-    ReceiptProvider for StaticFileJarProvider<'_, N>
+impl<N>
+    ReceiptProvider for StaticFileJarProvider<'_, N> where N: NodePrimitives<SignedTx: Decompress + SignedTransaction, Receipt: Decompress>
 {
     fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.cursor()?.get_one::<ReceiptMask<Self::Receipt>>(num.into())

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1237,7 +1237,7 @@ pub trait StaticFileWriter {
     fn commit(&self) -> ProviderResult<()>;
 }
 
-impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
+impl<N: NodePrimitives + 'static> StaticFileWriter for StaticFileProvider<N> {
     type Primitives = N;
 
     fn get_writer(

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -221,6 +221,14 @@ impl<N: NodePrimitives> Deref for StaticFileProvider<N> {
     }
 }
 
+impl<N: NodePrimitives> NodePrimitives for StaticFileProvider<N> {
+    type Block = N::Block;
+    type BlockHeader = N::BlockHeader;
+    type BlockBody = N::BlockBody;
+    type SignedTx = N::SignedTx;
+    type Receipt = N::Receipt;
+}
+
 /// [`StaticFileProviderInner`] manages all existing [`StaticFileJarProvider`].
 #[derive(Debug)]
 pub struct StaticFileProviderInner<N> {
@@ -1376,8 +1384,6 @@ impl<N: NodePrimitives> BlockHashReader for StaticFileProvider<N> {
 impl<N: NodePrimitives<SignedTx: Value + SignedTransaction, Receipt: Value>> ReceiptProvider
     for StaticFileProvider<N>
 {
-    type Receipt = N::Receipt;
-
     fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.get_segment_provider_from_transaction(StaticFileSegment::Receipts, num, None)
             .and_then(|provider| provider.receipt(num))

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1489,8 +1489,6 @@ impl<N: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>>
 impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsProvider
     for StaticFileProvider<N>
 {
-    type Transaction = N::SignedTx;
-
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         self.find_static_file(StaticFileSegment::Transactions, |jar_provider| {
             let mut cursor = jar_provider.cursor()?;

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1267,7 +1267,10 @@ impl<N: NodePrimitives + 'static> StaticFileWriter for StaticFileProvider<N> {
     }
 }
 
-impl<N> HeaderProvider for StaticFileProvider<N> where N: NodePrimitives<BlockHeader: Value> + 'static {
+impl<N> HeaderProvider for StaticFileProvider<N>
+where
+    N: NodePrimitives<BlockHeader: Value> + 'static,
+{
     type Header = N::BlockHeader;
 
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::Header>> {
@@ -1381,8 +1384,9 @@ impl<N: NodePrimitives + 'static> BlockHashReader for StaticFileProvider<N> {
     }
 }
 
-impl<N> ReceiptProvider
-    for StaticFileProvider<N> where N: NodePrimitives<SignedTx: Value + SignedTransaction, Receipt: Value> + 'static
+impl<N> ReceiptProvider for StaticFileProvider<N>
+where
+    N: NodePrimitives<SignedTx: Value + SignedTransaction, Receipt: Value> + 'static,
 {
     fn receipt(&self, num: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         self.get_segment_provider_from_transaction(StaticFileSegment::Receipts, num, None)
@@ -1423,8 +1427,9 @@ impl<N> ReceiptProvider
     }
 }
 
-impl<N>
-    TransactionsProviderExt for StaticFileProvider<N> where N: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>
+impl<N> TransactionsProviderExt for StaticFileProvider<N>
+where
+    N: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
 {
     fn transaction_hashes_by_range(
         &self,
@@ -1459,13 +1464,13 @@ impl<N>
                     StaticFileSegment::Transactions,
                     chunk_range,
                     |cursor, number| {
-                        Ok(cursor
-                            .get_one::<TransactionMask<Self::SignedTx>>(number.into())?
-                            .map(|transaction| {
+                        Ok(cursor.get_one::<TransactionMask<Self::SignedTx>>(number.into())?.map(
+                            |transaction| {
                                 rlp_buf.clear();
                                 let _ = channel_tx
                                     .send(calculate_hash((number, transaction), &mut rlp_buf));
-                            }))
+                            },
+                        ))
                     },
                     |_| true,
                 );
@@ -1516,10 +1521,7 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction> + 'static> Tran
             })
     }
 
-    fn transaction_by_id_unhashed(
-        &self,
-        num: TxNumber,
-    ) -> ProviderResult<Option<Self::SignedTx>> {
+    fn transaction_by_id_unhashed(&self, num: TxNumber) -> ProviderResult<Option<Self::SignedTx>> {
         self.get_segment_provider_from_transaction(StaticFileSegment::Transactions, num, None)
             .and_then(|provider| provider.transaction_by_id_unhashed(num))
             .or_else(|err| {

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1624,8 +1624,6 @@ impl<N: NodePrimitives> BlockNumReader for StaticFileProvider<N> {
 impl<N: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>> BlockReader
     for StaticFileProvider<N>
 {
-    type Block = N::Block;
-
     fn find_block_by_hash(
         &self,
         _hash: B256,

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -45,7 +45,7 @@ impl<N> Default for StaticFileWriters<N> {
     }
 }
 
-impl<N: NodePrimitives> StaticFileWriters<N> {
+impl<N: NodePrimitives + 'static> StaticFileWriters<N> {
     pub(crate) fn get_or_create(
         &self,
         segment: StaticFileSegment,
@@ -118,7 +118,7 @@ pub struct StaticFileProviderRW<N> {
     prune_on_commit: Option<(u64, Option<BlockNumber>)>,
 }
 
-impl<N: NodePrimitives> StaticFileProviderRW<N> {
+impl<N: NodePrimitives + 'static> StaticFileProviderRW<N> {
     /// Creates a new [`StaticFileProviderRW`] for a [`StaticFileSegment`].
     ///
     /// Before use, transaction based segments should ensure the block end range is the expected

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -558,8 +558,6 @@ impl<ChainSpec: EthChainSpec> BlockIdReader for MockEthProvider<ChainSpec> {
 }
 
 impl<ChainSpec: EthChainSpec> BlockReader for MockEthProvider<ChainSpec> {
-    type Block = reth_ethereum_primitives::Block;
-
     fn find_block_by_hash(
         &self,
         hash: B256,

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -5,6 +5,7 @@ use crate::{
     StateProvider, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
     TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
+use core::fmt;
 use alloy_consensus::{constants::EMPTY_ROOT_HASH, transaction::TransactionMeta, Header};
 use alloy_eips::{eip4895::Withdrawals, BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{
@@ -158,7 +159,7 @@ impl Default for MockEthProvider {
     }
 }
 
-impl<ChainSpec> NodePrimitives for MockEthProvider {
+impl<ChainSpec: Send + Sync + fmt::Debug> NodePrimitives for MockEthProvider<ChainSpec> {
     type Block = <EthPrimitives as NodePrimitives>::Block;
     type BlockHeader = <EthPrimitives as NodePrimitives>::BlockHeader;
     type BlockBody = <EthPrimitives as NodePrimitives>::BlockBody;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -262,8 +262,6 @@ impl<ChainSpec: EthChainSpec + 'static> DBProvider for MockEthProvider<ChainSpec
 }
 
 impl<ChainSpec: EthChainSpec> HeaderProvider for MockEthProvider<ChainSpec> {
-    type Header = Header;
-
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         let lock = self.headers.lock();
         Ok(lock.get(block_hash).cloned())

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -5,13 +5,13 @@ use crate::{
     StateProvider, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
     TransactionVariant, TransactionsProvider, WithdrawalsProvider,
 };
-use core::fmt;
 use alloy_consensus::{constants::EMPTY_ROOT_HASH, transaction::TransactionMeta, Header};
 use alloy_eips::{eip4895::Withdrawals, BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{
     keccak256, map::HashMap, Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue,
     TxHash, TxNumber, B256, U256,
 };
+use core::fmt;
 use parking_lot::Mutex;
 use reth_chain_state::{CanonStateNotifications, CanonStateSubscriptions};
 use reth_chainspec::{ChainInfo, EthChainSpec};

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -21,7 +21,7 @@ use reth_db_api::{
 use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_ethereum_primitives::{EthPrimitives, Receipt};
 use reth_execution_types::ExecutionOutcome;
-use reth_node_types::NodeTypes;
+use reth_node_types::{NodePrimitives, NodeTypes};
 use reth_primitives_traits::{
     Account, Bytecode, GotExpected, RecoveredBlock, SealedBlock, SealedHeader, SignedTransaction,
 };
@@ -90,6 +90,7 @@ impl MockEthProvider {
         }
     }
 }
+
 impl<ChainSpec> MockEthProvider<ChainSpec> {
     /// Add block to local block store
     pub fn add_block(&self, hash: B256, block: reth_ethereum_primitives::Block) {
@@ -155,6 +156,14 @@ impl Default for MockEthProvider {
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl<ChainSpec> NodePrimitives for MockEthProvider {
+    type Block = <EthPrimitives as NodePrimitives>::Block;
+    type BlockHeader = <EthPrimitives as NodePrimitives>::BlockHeader;
+    type BlockBody = <EthPrimitives as NodePrimitives>::BlockBody;
+    type SignedTx = <EthPrimitives as NodePrimitives>::SignedTx;
+    type Receipt = <EthPrimitives as NodePrimitives>::Receipt;
 }
 
 /// An extended account for local store
@@ -459,8 +468,6 @@ impl<ChainSpec: EthChainSpec> TransactionsProvider for MockEthProvider<ChainSpec
 }
 
 impl<ChainSpec: EthChainSpec> ReceiptProvider for MockEthProvider<ChainSpec> {
-    type Receipt = Receipt;
-
     fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
         Ok(None)
     }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -329,8 +329,6 @@ impl<ChainSpec: EthChainSpec + 'static> ChainSpecProvider for MockEthProvider<Ch
 }
 
 impl<ChainSpec: EthChainSpec> TransactionsProvider for MockEthProvider<ChainSpec> {
-    type Transaction = reth_ethereum_primitives::TransactionSigned;
-
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         let lock = self.blocks.lock();
         let tx_number = lock

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -17,10 +17,10 @@ pub trait FullProvider<N: NodeTypesWithDB>:
     + NodePrimitivesProvider<Primitives = N::Primitives>
     + StaticFileProviderFactory<Primitives = N::Primitives>
     + BlockReaderIdExt<
-        Transaction = TxTy<N>,
+        SignedTx = TxTy<N>,
         Block = BlockTy<N>,
         Receipt = ReceiptTy<N>,
-        Header = HeaderTy<N>,
+        BlockHeader = HeaderTy<N>,
     > + AccountReader
     + StateProviderFactory
     + ChainSpecProvider<ChainSpec = N::ChainSpec>
@@ -40,10 +40,10 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
         + NodePrimitivesProvider<Primitives = N::Primitives>
         + StaticFileProviderFactory<Primitives = N::Primitives>
         + BlockReaderIdExt<
-            Transaction = TxTy<N>,
+            SignedTx = TxTy<N>,
             Block = BlockTy<N>,
             Receipt = ReceiptTy<N>,
-            Header = HeaderTy<N>,
+            BlockHeader = HeaderTy<N>,
         > + AccountReader
         + StateProviderFactory
         + ChainSpecProvider<ChainSpec = N::ChainSpec>

--- a/crates/storage/storage-api/src/block.rs
+++ b/crates/storage/storage-api/src/block.rs
@@ -6,7 +6,7 @@ use alloc::{sync::Arc, vec::Vec};
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{BlockNumber, B256};
 use core::ops::RangeInclusive;
-use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
+use reth_primitives_traits::{NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
 use reth_storage_errors::provider::ProviderResult;
 
 /// A helper enum that represents the origin of the requested block.
@@ -41,7 +41,7 @@ impl BlockSource {
 }
 
 /// A helper type alias to access [`BlockReader::Block`].
-pub type ProviderBlock<P> = <P as BlockReader>::Block;
+pub type ProviderBlock<P> = <P as NodePrimitives>::Block;
 
 /// Api trait for fetching `Block` related data.
 ///
@@ -58,12 +58,6 @@ pub trait BlockReader:
     + Send
     + Sync
 {
-    /// The block type this provider reads.
-    type Block: reth_primitives_traits::Block<
-        Body: reth_primitives_traits::BlockBody<Transaction = Self::Transaction>,
-        Header = Self::Header,
-    >;
-
     /// Tries to find in the given block source.
     ///
     /// Note: this only operates on the hash because the number might be ambiguous.
@@ -155,8 +149,6 @@ pub trait BlockReader:
 }
 
 impl<T: BlockReader> BlockReader for Arc<T> {
-    type Block = T::Block;
-
     fn find_block_by_hash(
         &self,
         hash: B256,
@@ -216,8 +208,6 @@ impl<T: BlockReader> BlockReader for Arc<T> {
 }
 
 impl<T: BlockReader> BlockReader for &T {
-    type Block = T::Block;
-
     fn find_block_by_hash(
         &self,
         hash: B256,

--- a/crates/storage/storage-api/src/block.rs
+++ b/crates/storage/storage-api/src/block.rs
@@ -288,7 +288,7 @@ pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [`SealedHeader`] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn pending_header(&self) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    fn pending_header(&self) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.sealed_header_by_id(BlockNumberOrTag::Pending.into())
     }
 
@@ -296,7 +296,7 @@ pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [`SealedHeader`] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn latest_header(&self) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    fn latest_header(&self) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.sealed_header_by_id(BlockNumberOrTag::Latest.into())
     }
 
@@ -304,7 +304,7 @@ pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [`SealedHeader`] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn safe_header(&self) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    fn safe_header(&self) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.sealed_header_by_id(BlockNumberOrTag::Safe.into())
     }
 
@@ -312,7 +312,7 @@ pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     ///
     /// Note: This returns a [`SealedHeader`] because it's expected that this is sealed by the
     /// provider and the caller does not know the hash.
-    fn finalized_header(&self) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    fn finalized_header(&self) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.sealed_header_by_id(BlockNumberOrTag::Finalized.into())
     }
 
@@ -345,7 +345,7 @@ pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     fn header_by_number_or_tag(
         &self,
         id: BlockNumberOrTag,
-    ) -> ProviderResult<Option<Self::Header>> {
+    ) -> ProviderResult<Option<Self::BlockHeader>> {
         self.convert_block_number(id)?
             .map_or_else(|| Ok(None), |num| self.header_by_hash_or_number(num.into()))
     }
@@ -356,7 +356,7 @@ pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     fn sealed_header_by_number_or_tag(
         &self,
         id: BlockNumberOrTag,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         self.convert_block_number(id)?
             .map_or_else(|| Ok(None), |num| self.header_by_hash_or_number(num.into()))?
             .map_or_else(|| Ok(None), |h| Ok(Some(SealedHeader::seal_slow(h))))
@@ -368,25 +368,25 @@ pub trait BlockReaderIdExt: BlockReader + ReceiptProviderIdExt {
     fn sealed_header_by_id(
         &self,
         id: BlockId,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>>;
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>>;
 
     /// Returns the header with the matching `BlockId` from the database.
     ///
     /// Returns `None` if header is not found.
-    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::Header>>;
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Self::BlockHeader>>;
 
     /// Returns the ommers with the matching tag from the database.
     fn ommers_by_number_or_tag(
         &self,
         id: BlockNumberOrTag,
-    ) -> ProviderResult<Option<Vec<Self::Header>>> {
+    ) -> ProviderResult<Option<Vec<Self::BlockHeader>>> {
         self.convert_block_number(id)?.map_or_else(|| Ok(None), |num| self.ommers(num.into()))
     }
 
     /// Returns the ommers with the matching `BlockId` from the database.
     ///
     /// Returns `None` if block is not found.
-    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Self::Header>>>;
+    fn ommers_by_id(&self, id: BlockId) -> ProviderResult<Option<Vec<Self::BlockHeader>>>;
 }
 
 /// Functionality to read the last known chain blocks from the database.

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -146,8 +146,9 @@ where
 
 impl<Provider, T, H> BlockBodyReader<Provider> for EthStorage<T, H>
 where
-    Provider:
-        DBProvider + ChainSpecProvider<ChainSpec: EthereumHardforks> + OmmersProvider<Header = H>,
+    Provider: DBProvider
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
+        + OmmersProvider<BlockHeader = H>,
     T: SignedTransaction,
     H: FullBlockHeader,
 {

--- a/crates/storage/storage-api/src/header.rs
+++ b/crates/storage/storage-api/src/header.rs
@@ -1,43 +1,39 @@
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{BlockHash, BlockNumber, U256};
 use core::ops::RangeBounds;
-use reth_primitives_traits::{BlockHeader, SealedHeader};
+use reth_primitives_traits::{NodePrimitives, SealedHeader};
 use reth_storage_errors::provider::ProviderResult;
 
 /// A helper type alias to access [`HeaderProvider::Header`].
-pub type ProviderHeader<P> = <P as HeaderProvider>::Header;
+pub type ProviderHeader<P> = <P as NodePrimitives>::BlockHeader;
 
 /// Client trait for fetching `Header` related data.
-#[auto_impl::auto_impl(&, Arc)]
-pub trait HeaderProvider: Send + Sync {
-    /// The header type this provider supports.
-    type Header: BlockHeader;
-
+pub trait HeaderProvider: NodePrimitives + Send + Sync {
     /// Check if block is known
     fn is_known(&self, block_hash: &BlockHash) -> ProviderResult<bool> {
         self.header(block_hash).map(|header| header.is_some())
     }
 
     /// Get header by block hash
-    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::Header>>;
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::BlockHeader>>;
 
     /// Retrieves the header sealed by the given block hash.
     fn sealed_header_by_hash(
         &self,
         block_hash: BlockHash,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         Ok(self.header(&block_hash)?.map(|header| SealedHeader::new(header, block_hash)))
     }
 
     /// Get header by block number
-    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::Header>>;
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::BlockHeader>>;
 
     /// Get header by block number or hash
     fn header_by_hash_or_number(
         &self,
         hash_or_num: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Self::Header>> {
+    ) -> ProviderResult<Option<Self::BlockHeader>> {
         match hash_or_num {
             BlockHashOrNumber::Hash(hash) => self.header(&hash),
             BlockHashOrNumber::Number(num) => self.header_by_number(num),
@@ -54,19 +50,19 @@ pub trait HeaderProvider: Send + Sync {
     fn headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Self::Header>>;
+    ) -> ProviderResult<Vec<Self::BlockHeader>>;
 
     /// Get a single sealed header by block number.
     fn sealed_header(
         &self,
         number: BlockNumber,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>>;
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>>;
 
     /// Get headers in range of block numbers.
     fn sealed_headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
         self.sealed_headers_while(range, |_| true)
     }
 
@@ -74,6 +70,122 @@ pub trait HeaderProvider: Send + Sync {
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
-    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>>;
+        predicate: impl FnMut(&SealedHeader<Self::BlockHeader>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>>;
+}
+
+impl<T: HeaderProvider> HeaderProvider for &T {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::BlockHeader>> {
+        T::header(self, block_hash)
+    }
+
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::BlockHeader>> {
+        T::header_by_number(self, num)
+    }
+
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        T::header_td(self, hash)
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        T::header_td_by_number(self, number)
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::BlockHeader>> {
+        T::headers_range(self, range)
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
+        T::sealed_header(self, number)
+    }
+
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
+        T::sealed_headers_range(self, range)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader<Self::BlockHeader>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
+        T::sealed_headers_while(self, range, predicate)
+    }
+
+    fn is_known(&self, block_hash: &BlockHash) -> ProviderResult<bool> {
+        T::is_known(self, block_hash)
+    }
+
+    fn header_by_hash_or_number(
+        &self,
+        hash_or_num: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Self::BlockHeader>> {
+        T::header_by_hash_or_number(self, hash_or_num)
+    }
+}
+
+impl<T: HeaderProvider> HeaderProvider for Arc<T> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::BlockHeader>> {
+        T::header(self, block_hash)
+    }
+
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::BlockHeader>> {
+        T::header_by_number(self, num)
+    }
+
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        T::header_td(self, hash)
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        T::header_td_by_number(self, number)
+    }
+
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::BlockHeader>> {
+        T::headers_range(self, range)
+    }
+
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
+        T::sealed_header(self, number)
+    }
+
+    fn sealed_headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
+        T::sealed_headers_range(self, range)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader<Self::BlockHeader>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
+        T::sealed_headers_while(self, range, predicate)
+    }
+
+    fn is_known(&self, block_hash: &BlockHash) -> ProviderResult<bool> {
+        T::is_known(self, block_hash)
+    }
+
+    fn header_by_hash_or_number(
+        &self,
+        hash_or_num: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Self::BlockHeader>> {
+        T::header_by_hash_or_number(self, hash_or_num)
+    }
 }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -225,8 +225,6 @@ impl<C: Send + Sync, N: NodePrimitives> BlockReader for NoopProvider<C, N> {
 }
 
 impl<C: Send + Sync, N: NodePrimitives> TransactionsProvider for NoopProvider<C, N> {
-    type Transaction = N::SignedTx;
-
     fn transaction_id(&self, _tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         Ok(None)
     }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -34,7 +34,7 @@ use reth_trie_common::{
 };
 
 /// Supports various api interfaces for testing purposes.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct NoopProvider<ChainSpec = reth_chainspec::ChainSpec, N = EthPrimitives> {
     chain_spec: Arc<ChainSpec>,
@@ -76,7 +76,7 @@ impl<ChainSpec, N> Clone for NoopProvider<ChainSpec, N> {
 
 impl<ChainSpec, N> NodePrimitives for NoopProvider<ChainSpec, N>
 where
-    ChainSpec: Send + Sync + PartialEq + Eq + Debug,
+    ChainSpec: Send + Sync + Debug,
     N: NodePrimitives,
 {
     type Block = N::Block;
@@ -334,14 +334,12 @@ where
 {
 }
 
-impl<C: Send + Sync, N: NodePrimitives> HeaderProvider for NoopProvider<C, N> {
-    type Header = N::BlockHeader;
-
-    fn header(&self, _block_hash: &BlockHash) -> ProviderResult<Option<Self::Header>> {
+impl<C: Send + Sync + Debug, N: NodePrimitives> HeaderProvider for NoopProvider<C, N> {
+    fn header(&self, _block_hash: &BlockHash) -> ProviderResult<Option<Self::BlockHeader>> {
         Ok(None)
     }
 
-    fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Self::Header>> {
+    fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Self::BlockHeader>> {
         Ok(None)
     }
 
@@ -356,22 +354,22 @@ impl<C: Send + Sync, N: NodePrimitives> HeaderProvider for NoopProvider<C, N> {
     fn headers_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Self::Header>> {
+    ) -> ProviderResult<Vec<Self::BlockHeader>> {
         Ok(Vec::new())
     }
 
     fn sealed_header(
         &self,
         _number: BlockNumber,
-    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+    ) -> ProviderResult<Option<SealedHeader<Self::BlockHeader>>> {
         Ok(None)
     }
 
     fn sealed_headers_while(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-        _predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
-    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+        _predicate: impl FnMut(&SealedHeader<Self::BlockHeader>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::BlockHeader>>> {
         Ok(Vec::new())
     }
 }
@@ -566,8 +564,8 @@ impl<C: Send + Sync, N: NodePrimitives> WithdrawalsProvider for NoopProvider<C, 
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> OmmersProvider for NoopProvider<C, N> {
-    fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
+impl<C: Send + Sync + Debug, N: NodePrimitives> OmmersProvider for NoopProvider<C, N> {
+    fn ommers(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::BlockHeader>>> {
         Ok(None)
     }
 }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -243,25 +243,22 @@ where
         Ok(None)
     }
 
-    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<Self::SignedTx>> {
         Ok(None)
     }
 
-    fn transaction_by_id_unhashed(
-        &self,
-        _id: TxNumber,
-    ) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_id_unhashed(&self, _id: TxNumber) -> ProviderResult<Option<Self::SignedTx>> {
         Ok(None)
     }
 
-    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Self::SignedTx>> {
         Ok(None)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         _hash: TxHash,
-    ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(Self::SignedTx, TransactionMeta)>> {
         Ok(None)
     }
 
@@ -272,21 +269,21 @@ where
     fn transactions_by_block(
         &self,
         _block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+    ) -> ProviderResult<Option<Vec<Self::SignedTx>>> {
         Ok(None)
     }
 
     fn transactions_by_block_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+    ) -> ProviderResult<Vec<Vec<Self::SignedTx>>> {
         Ok(Vec::default())
     }
 
     fn transactions_by_tx_range(
         &self,
         _range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Self::Transaction>> {
+    ) -> ProviderResult<Vec<Self::SignedTx>> {
         Ok(Vec::default())
     }
 
@@ -588,7 +585,11 @@ impl<C: Send + Sync, N: NodePrimitives> PruneCheckpointReader for NoopProvider<C
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> NodePrimitivesProvider for NoopProvider<C, N> {
+impl<C, N> NodePrimitivesProvider for NoopProvider<C, N>
+where
+    C: Send + Sync,
+    N: NodePrimitives + Clone + Default + 'static,
+{
     type Primitives = N;
 }
 

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -74,6 +74,14 @@ impl<ChainSpec, N> Clone for NoopProvider<ChainSpec, N> {
     }
 }
 
+impl<ChainSpec: Send + Sync, N: NodePrimitives> NodePrimitives for NoopProvider<ChainSpec, N> {
+    type Block = N::Block;
+    type BlockHeader = N::BlockHeader;
+    type BlockBody = N::BlockBody;
+    type SignedTx = N::SignedTx;
+    type Receipt = N::Receipt;
+}
+
 /// Noop implementation for testing purposes
 impl<ChainSpec: Send + Sync, N: Send + Sync> BlockHashReader for NoopProvider<ChainSpec, N> {
     fn block_hash(&self, _number: u64) -> ProviderResult<Option<B256>> {
@@ -283,8 +291,6 @@ impl<C: Send + Sync, N: NodePrimitives> TransactionsProvider for NoopProvider<C,
 }
 
 impl<C: Send + Sync, N: NodePrimitives> ReceiptProvider for NoopProvider<C, N> {
-    type Receipt = N::Receipt;
-
     fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         Ok(None)
     }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -586,7 +586,7 @@ impl<C: Send + Sync, N: NodePrimitives> PruneCheckpointReader for NoopProvider<C
 impl<C, N> NodePrimitivesProvider for NoopProvider<C, N>
 where
     C: Send + Sync,
-    N: NodePrimitives + Clone + Default + 'static,
+    N: NodePrimitives + Unpin + Clone + Default + 'static,
 {
     type Primitives = N;
 }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -34,7 +34,7 @@ use reth_trie_common::{
 };
 
 /// Supports various api interfaces for testing purposes.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct NoopProvider<ChainSpec = reth_chainspec::ChainSpec, N = EthPrimitives> {
     chain_spec: Arc<ChainSpec>,
@@ -74,7 +74,11 @@ impl<ChainSpec, N> Clone for NoopProvider<ChainSpec, N> {
     }
 }
 
-impl<ChainSpec: Send + Sync, N: NodePrimitives> NodePrimitives for NoopProvider<ChainSpec, N> {
+impl<ChainSpec, N> NodePrimitives for NoopProvider<ChainSpec, N>
+where
+    ChainSpec: Send + Sync + PartialEq + Eq + Debug,
+    N: NodePrimitives,
+{
     type Block = N::Block;
     type BlockHeader = N::BlockHeader;
     type BlockBody = N::BlockBody;
@@ -139,7 +143,11 @@ impl<C: Send + Sync, N: NodePrimitives> BlockIdReader for NoopProvider<C, N> {
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> BlockReaderIdExt for NoopProvider<C, N> {
+impl<C, N> BlockReaderIdExt for NoopProvider<C, N>
+where
+    C: Send + Sync + PartialEq + Eq + Debug,
+    N: NodePrimitives,
+{
     fn block_by_id(&self, _id: BlockId) -> ProviderResult<Option<N::Block>> {
         Ok(None)
     }
@@ -160,9 +168,11 @@ impl<C: Send + Sync, N: NodePrimitives> BlockReaderIdExt for NoopProvider<C, N> 
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> BlockReader for NoopProvider<C, N> {
-    type Block = N::Block;
-
+impl<C, N> BlockReader for NoopProvider<C, N>
+where
+    C: Send + Sync + Eq + PartialEq + Debug,
+    N: NodePrimitives,
+{
     fn find_block_by_hash(
         &self,
         _hash: B256,
@@ -224,7 +234,11 @@ impl<C: Send + Sync, N: NodePrimitives> BlockReader for NoopProvider<C, N> {
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> TransactionsProvider for NoopProvider<C, N> {
+impl<C, N> TransactionsProvider for NoopProvider<C, N>
+where
+    C: Send + Sync + PartialEq + Eq + Debug,
+    N: NodePrimitives,
+{
     fn transaction_id(&self, _tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         Ok(None)
     }
@@ -288,7 +302,11 @@ impl<C: Send + Sync, N: NodePrimitives> TransactionsProvider for NoopProvider<C,
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> ReceiptProvider for NoopProvider<C, N> {
+impl<C, N> ReceiptProvider for NoopProvider<C, N>
+where
+    C: Send + Sync + PartialEq + Eq + Debug,
+    N: NodePrimitives,
+{
     fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         Ok(None)
     }
@@ -312,7 +330,12 @@ impl<C: Send + Sync, N: NodePrimitives> ReceiptProvider for NoopProvider<C, N> {
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> ReceiptProviderIdExt for NoopProvider<C, N> {}
+impl<C, N> ReceiptProviderIdExt for NoopProvider<C, N>
+where
+    C: Send + Sync + PartialEq + Eq + Debug,
+    N: NodePrimitives,
+{
+}
 
 impl<C: Send + Sync, N: NodePrimitives> HeaderProvider for NoopProvider<C, N> {
     type Header = N::BlockHeader;
@@ -466,7 +489,11 @@ impl<C: Send + Sync, N: NodePrimitives> StateProvider for NoopProvider<C, N> {
     }
 }
 
-impl<C: Send + Sync + 'static, N: NodePrimitives> StateProviderFactory for NoopProvider<C, N> {
+impl<C, N> StateProviderFactory for NoopProvider<C, N>
+where
+    C: Send + Sync + PartialEq + Eq + Debug + 'static,
+    N: NodePrimitives + 'static,
+{
     fn latest(&self) -> ProviderResult<StateProviderBox> {
         Ok(Box::new(self.clone()))
     }

--- a/crates/storage/storage-api/src/ommers.rs
+++ b/crates/storage/storage-api/src/ommers.rs
@@ -8,17 +8,17 @@ pub trait OmmersProvider: HeaderProvider + Send + Sync {
     /// Returns the ommers/uncle headers of the given block from the database.
     ///
     /// Returns `None` if block is not found.
-    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>>;
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::BlockHeader>>>;
 }
 
 impl<T: OmmersProvider> OmmersProvider for Arc<T> {
-    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::BlockHeader>>> {
         T::ommers(self, id)
     }
 }
 
 impl<T: OmmersProvider> OmmersProvider for &T {
-    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::Header>>> {
+    fn ommers(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Vec<Self::BlockHeader>>> {
         T::ommers(self, id)
     }
 }

--- a/crates/storage/storage-api/src/primitives.rs
+++ b/crates/storage/storage-api/src/primitives.rs
@@ -4,5 +4,5 @@ use reth_primitives_traits::NodePrimitives;
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait NodePrimitivesProvider {
     /// The node primitive types.
-    type Primitives: NodePrimitives;
+    type Primitives: NodePrimitives + Clone + Default + 'static;
 }

--- a/crates/storage/storage-api/src/primitives.rs
+++ b/crates/storage/storage-api/src/primitives.rs
@@ -4,5 +4,5 @@ use reth_primitives_traits::NodePrimitives;
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait NodePrimitivesProvider {
     /// The node primitive types.
-    type Primitives: NodePrimitives + Clone + Default + 'static;
+    type Primitives: NodePrimitives + Unpin + Clone + Default + 'static;
 }

--- a/crates/storage/storage-api/src/receipts.rs
+++ b/crates/storage/storage-api/src/receipts.rs
@@ -3,18 +3,15 @@ use alloc::vec::Vec;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{TxHash, TxNumber};
 use core::ops::RangeBounds;
-use reth_primitives_traits::Receipt;
+use reth_primitives_traits::NodePrimitives;
 use reth_storage_errors::provider::ProviderResult;
 
 /// A helper type alias to access [`ReceiptProvider::Receipt`].
-pub type ProviderReceipt<P> = <P as ReceiptProvider>::Receipt;
+pub type ProviderReceipt<P> = <P as NodePrimitives>::Receipt;
 
 /// Client trait for fetching receipt data.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait ReceiptProvider: Send + Sync {
-    /// The receipt type.
-    type Receipt: Receipt;
-
+pub trait ReceiptProvider: NodePrimitives + Send + Sync {
     /// Get receipt by transaction number
     ///
     /// Returns `None` if the transaction is not found.

--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -4,7 +4,7 @@ use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockNumber, TxHash, TxNumber};
 use core::ops::{Range, RangeBounds, RangeInclusive};
-use reth_primitives_traits::SignedTransaction;
+use reth_primitives_traits::NodePrimitives;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 
 /// Enum to control transaction hash inclusion.
@@ -22,10 +22,7 @@ pub enum TransactionVariant {
 
 ///  Client trait for fetching transactions related data.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait TransactionsProvider: BlockNumReader + Send + Sync {
-    /// The transaction type this provider reads.
-    type Transaction: Send + Sync + SignedTransaction;
-
+pub trait TransactionsProvider: NodePrimitives + BlockNumReader + Send + Sync {
     /// Get internal transaction identifier by transaction hash.
     ///
     /// This is the inverse of [TransactionsProvider::transaction_by_id].


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/13951

`BlockReader` is trait aggregating a lot of stateful behaviour, however it's used as trait bound in type definitions just in order to access the associated data primitive types. A more intentional way to do this, is to make use of the stateless base trait `NodePrimitives` in the type definition. 
https://github.com/paradigmxyz/reth/blob/6ae48f8d95cd71698e9c61d83683ff1160f1a059/crates/rpc/rpc/src/eth/core.rs#L249-L288
Since `NodePrimitives` is stateless, it can effortlessly become supertrait of any provider trait and removes the need for adding the same associated types again explicitly to the provider traits.

All provider traits read to and from the same database so there is no need to separately configure and therefore to define new associated types `TransactionProvider::Transaction`, `HeaderProvider::Header`, etc. creating overhead as we need to link them to the rest of the node, e.g. `TransactionProvider::Transaction == <N as NodePrimitives>::SignedTx`. It also saves the need for the trait `NodePrimitivesProvider`, hereby removing an extra complexity layer.
https://github.com/paradigmxyz/reth/blob/6ae48f8d95cd71698e9c61d83683ff1160f1a059/crates/storage/storage-api/src/header.rs#L11-L15

Alt approaches: creating a new trait `NodePrimitivesBase`, identical associated types as `NodePrimitives` but without trait bounds on the associated types and using this as super trait instead and in type defs, similar as `RpcNodeCore`. This approach was out-ruled because it adds more code, whereas the PR aims to remove redundancy and create stronger cohesion in the SDK abstraction to its origin in `NodePrimitives`.