### PR TITLE
fix: pick 1559 fees correctly for dynamic fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e158fd08c4be4fafe8c9fb7cb661f3b9585038446df0cd20b3d99e71f4166748"
+checksum = "b71b0b181c956dca015b4c08b36668736013787c9dc9e743fd39a23b8b130c14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f49ab23b828db185eea248540f997cb5196ba0d76d5af10d0d5450eb19fab4"
+checksum = "324cf0b3b08b4c3354460dee8208384a59245da8b0eaefe9e962d3942d919d58"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2253,7 +2253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3182,7 +3182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4815,7 +4815,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5169,7 +5169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6559,7 +6559,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10599,7 +10599,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10612,7 +10612,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10678,7 +10678,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11441,7 +11441,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12015,7 +12015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12529,7 +12529,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -455,7 +455,7 @@ revm-inspectors = "0.18.0"
 alloy-chains = { version = "0.1.68", default-features = false }
 alloy-dyn-abi = "0.8.25"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { version = "0.3.1", default-features = false }
+alloy-evm = { version = "0.3.2", default-features = false }
 alloy-primitives = { version = "0.8.25", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.25", default-features = false }
@@ -493,7 +493,7 @@ alloy-transport-ipc = { version = "0.13.0", default-features = false }
 alloy-transport-ws = { version = "0.13.0", default-features = false }
 
 # op
-alloy-op-evm = { version = "0.3.1", default-features = false }
+alloy-op-evm = { version = "0.3.2", default-features = false }
 alloy-op-hardforks = "0.1.2"
 op-alloy-rpc-types = { version = "0.12.0", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.12.0", default-features = false }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -263,9 +263,14 @@ pub trait BlockBuilder {
     /// Provides mutable access to the inner [`BlockExecutor`].
     fn executor_mut(&mut self) -> &mut Self::Executor;
 
-    /// Helper to access inner [`BlockExecutor::Evm`].
+    /// Helper to access inner [`BlockExecutor::Evm`] mutably.
     fn evm_mut(&mut self) -> &mut <Self::Executor as BlockExecutor>::Evm {
         self.executor_mut().evm_mut()
+    }
+
+    /// Helper to access inner [`BlockExecutor::Evm`].
+    fn evm(&self) -> &<Self::Executor as BlockExecutor>::Evm {
+        self.executor_mut().evm()
     }
 
     /// Consumes the type and returns the underlying [`BlockExecutor`].

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -263,6 +263,9 @@ pub trait BlockBuilder {
     /// Provides mutable access to the inner [`BlockExecutor`].
     fn executor_mut(&mut self) -> &mut Self::Executor;
 
+    /// Provides access to the inner [`BlockExecutor`].
+    fn executor(&self) -> &Self::Executor;
+
     /// Helper to access inner [`BlockExecutor::Evm`] mutably.
     fn evm_mut(&mut self) -> &mut <Self::Executor as BlockExecutor>::Evm {
         self.executor_mut().evm_mut()
@@ -270,7 +273,7 @@ pub trait BlockBuilder {
 
     /// Helper to access inner [`BlockExecutor::Evm`].
     fn evm(&self) -> &<Self::Executor as BlockExecutor>::Evm {
-        self.executor_mut().evm()
+        self.executor().evm()
     }
 
     /// Consumes the type and returns the underlying [`BlockExecutor`].
@@ -391,6 +394,10 @@ where
 
     fn executor_mut(&mut self) -> &mut Self::Executor {
         &mut self.executor
+    }
+
+    fn executor(&self) -> &Self::Executor {
+        &self.executor
     }
 
     fn into_executor(self) -> Self::Executor {

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -96,7 +96,7 @@ mod tests {
         let builder = EthTxBuilder::default();
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
         let tx = TransactionRequest::default();
-        let result = resolve_transaction(tx, 21000, 1, &mut db, &builder).unwrap();
+        let result = resolve_transaction(tx, 21000, 0, 1, &mut db, &builder).unwrap();
 
         // For an empty request, we should get a valid transaction with defaults
         let tx = result.into_inner();
@@ -112,7 +112,7 @@ mod tests {
 
         let tx = TransactionRequest { gas_price: Some(100), ..Default::default() };
 
-        let tx = resolve_transaction(tx, 21000, 1, &mut db, &builder).unwrap();
+        let tx = resolve_transaction(tx, 21000, 0, 1, &mut db, &builder).unwrap();
 
         assert_eq!(tx.tx_type(), TxType::Legacy);
 
@@ -132,7 +132,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = resolve_transaction(tx, 21000, 1, &mut db, &builder).unwrap();
+        let result = resolve_transaction(tx, 21000, 0, 1, &mut db, &builder).unwrap();
 
         assert_eq!(result.tx_type(), TxType::Eip1559);
         let tx = result.into_inner();

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -206,6 +206,10 @@ where
     fn evm_mut(&mut self) -> &mut Self::Evm {
         self.inner.evm_mut()
     }
+
+    fn evm(&self) -> &Self::Evm {
+        self.inner.evm()
+    }
 }
 
 sol!(

--- a/examples/custom-node/src/evm.rs
+++ b/examples/custom-node/src/evm.rs
@@ -62,6 +62,10 @@ where
     fn evm_mut(&mut self) -> &mut Self::Evm {
         self.inner.evm_mut()
     }
+
+    fn evm(&self) -> &Self::Evm {
+        self.inner.evm()
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
closes #15604

closes #15602

In order to prevent malformed tx filling we need to:
* use the block's base fee
* ensure that the tx's max fee per gas isn't lower than the prio fee if provided