### PR TITLE
refactor: improve trait bounds

### DIFF
--- a/crates/optimism/consensus/src/validation/isthmus.rs
+++ b/crates/optimism/consensus/src/validation/isthmus.rs
@@ -102,7 +102,7 @@ pub fn verify_withdrawals_root_prehashed<DB, H>(
 ) -> Result<(), OpConsensusError>
 where
     DB: StorageRootProvider,
-    H: BlockHeader + core::fmt::Debug,
+    H: BlockHeader + Debug,
 {
     let header_storage_root =
         header.withdrawals_root().ok_or(OpConsensusError::L2WithdrawalsRootMissing)?;

--- a/crates/optimism/payload/src/traits.rs
+++ b/crates/optimism/payload/src/traits.rs
@@ -6,24 +6,19 @@ use reth_primitives_traits::{NodePrimitives, SignedTransaction};
 pub trait OpPayloadPrimitives:
     NodePrimitives<
     Receipt: DepositReceipt,
-    SignedTx = Self::_TX,
+    SignedTx: SignedTransaction + OpTransaction,
     BlockHeader = Header,
-    BlockBody = BlockBody<Self::_TX>,
+    BlockBody = BlockBody<Self::SignedTx>,
 >
 {
-    /// Helper AT to bound [`NodePrimitives::Block`] type without causing bound cycle.
-    type _TX: SignedTransaction + OpTransaction;
 }
 
-impl<Tx, T> OpPayloadPrimitives for T
-where
-    Tx: SignedTransaction + OpTransaction,
+impl<T> OpPayloadPrimitives for T where
     T: NodePrimitives<
-        SignedTx = Tx,
         Receipt: DepositReceipt,
+        SignedTx: SignedTransaction + OpTransaction,
         BlockHeader = Header,
-        BlockBody = BlockBody<Tx>,
-    >,
+        BlockBody = BlockBody<Self::SignedTx>,
+    >
 {
-    type _TX = Tx;
 }

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -196,10 +196,10 @@ impl From<Sealed<TxDeposit>> for OpTransactionSigned {
     }
 }
 
-/// A trait that represents an optimism transaction, mainly used to indicate whether or not the
+/// A trait that represents an optimism transaction, mainly used to indicate whether the
 /// transaction is a deposit transaction.
 pub trait OpTransaction {
-    /// Whether or not the transaction is a dpeosit transaction.
+    /// Whether the transaction is a deposit transaction.
     fn is_deposit(&self) -> bool;
 }
 


### PR DESCRIPTION
- Updated trait bounds in `OpPayloadPrimitives` for clarity and consistency.
- Corrected typos in comments within `OpTransaction` to enhance documentation clarity.
- Adjusted type parameters in `verify_withdrawals_root_prehashed` for better readability.