### PR TITLE
chore: migrate from `reth_transaction_pool` to `reth_ethereum::pool` namespace

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -385,14 +385,14 @@ where
                     .unwrap_or_else(|| data_dir.txpool_transactions());
 
                 let transactions_backup_config =
-                    reth_ethereum::pool::maintain::LocalTransactionBackupConfig::with_local_txs_backup(
+                    reth_transaction_pool::maintain::LocalTransactionBackupConfig::with_local_txs_backup(
                         transactions_path,
                     );
 
                 ctx.task_executor().spawn_critical_with_graceful_shutdown_signal(
                     "local transactions backup task",
                     |shutdown| {
-                        reth_ethereum::pool::maintain::backup_local_transactions_task(
+                        reth_transaction_pool::maintain::backup_local_transactions_task(
                             shutdown,
                             pool.clone(),
                             transactions_backup_config,
@@ -404,12 +404,12 @@ where
             // spawn the maintenance task
             ctx.task_executor().spawn_critical(
                 "txpool maintenance task",
-                reth_ethereum::pool::maintain::maintain_transaction_pool_future(
+                reth_transaction_pool::maintain::maintain_transaction_pool_future(
                     client,
                     pool,
                     chain_events,
                     ctx.task_executor().clone(),
-                    reth_ethereum::pool::maintain::MaintainPoolConfig {
+                    reth_transaction_pool::maintain::MaintainPoolConfig {
                         max_tx_lifetime: transaction_pool.config().max_queued_lifetime,
                         ..Default::default()
                     },

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -385,12 +385,14 @@ where
                     .unwrap_or_else(|| data_dir.txpool_transactions());
 
                 let transactions_backup_config =
-                    reth_transaction_pool::maintain::LocalTransactionBackupConfig::with_local_txs_backup(transactions_path);
+                    reth_ethereum::pool::maintain::LocalTransactionBackupConfig::with_local_txs_backup(
+                        transactions_path,
+                    );
 
                 ctx.task_executor().spawn_critical_with_graceful_shutdown_signal(
                     "local transactions backup task",
                     |shutdown| {
-                        reth_transaction_pool::maintain::backup_local_transactions_task(
+                        reth_ethereum::pool::maintain::backup_local_transactions_task(
                             shutdown,
                             pool.clone(),
                             transactions_backup_config,
@@ -402,12 +404,12 @@ where
             // spawn the maintenance task
             ctx.task_executor().spawn_critical(
                 "txpool maintenance task",
-                reth_transaction_pool::maintain::maintain_transaction_pool_future(
+                reth_ethereum::pool::maintain::maintain_transaction_pool_future(
                     client,
                     pool,
                     chain_events,
                     ctx.task_executor().clone(),
-                    reth_transaction_pool::maintain::MaintainPoolConfig {
+                    reth_ethereum::pool::maintain::MaintainPoolConfig {
                         max_tx_lifetime: transaction_pool.config().max_queued_lifetime,
                         ..Default::default()
                     },


### PR DESCRIPTION


**Description:**
This PR updates the transaction pool namespace references from `reth_transaction_pool` to `reth_ethereum::pool`. The change maintains the same functionality while aligning with the new module structure, improving code organization and namespace consistency.

Changes include:
- Updated import paths for transaction pool components
- Replaced all occurrences of the old namespace with the new one
- Maintained identical functionality while improving code structure
