### PR TITLE
fix!(rpc): wrap call many response in vec

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -235,7 +235,7 @@ pub trait EthApi<T: RpcObject, B: RpcObject, R: RpcObject, H: RpcObject> {
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
         state_override: Option<StateOverride>,
-    ) -> RpcResult<Vec<EthCallResponse>>;
+    ) -> RpcResult<Vec<Vec<EthCallResponse>>>;
 
     /// Generates an access list for a transaction.
     ///
@@ -659,7 +659,7 @@ where
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
         state_override: Option<StateOverride>,
-    ) -> RpcResult<Vec<EthCallResponse>> {
+    ) -> RpcResult<Vec<Vec<EthCallResponse>>> {
         trace!(target: "rpc::eth", ?bundles, ?state_context, ?state_override, "Serving eth_callMany");
         Ok(EthCall::call_many(self, bundles, state_context, state_override).await?)
     }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -73,7 +73,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send {
         async move {
             if payload.block_state_calls.len() > self.max_simulate_blocks() as usize {
-                return Err(EthApiError::InvalidParams("too many blocks.".to_string()).into());
+                return Err(EthApiError::InvalidParams("too many blocks.".to_string()).into())
             }
 
             let block = block.unwrap_or_default();
@@ -86,7 +86,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             } = payload;
 
             if block_state_calls.is_empty() {
-                return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into());
+                return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into())
             }
 
             let base_block =
@@ -119,12 +119,12 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     if let Some(block_overrides) = block_overrides {
                         // ensure we dont allow uncapped gas limit per block
                         if let Some(gas_limit_override) = block_overrides.gas_limit {
-                            if gas_limit_override > evm_env.block_env.gas_limit
-                                && gas_limit_override > this.call_gas_limit()
+                            if gas_limit_override > evm_env.block_env.gas_limit &&
+                                gas_limit_override > this.call_gas_limit()
                             {
                                 return Err(
                                     EthApiError::other(EthSimulateError::GasLimitReached).into()
-                                );
+                                )
                             }
                         }
                         apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
@@ -149,8 +149,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         }
 
                         if txs_without_gas_limit > 0 {
-                            (block_env.gas_limit - total_specified_gas)
-                                / txs_without_gas_limit as u64
+                            (block_env.gas_limit - total_specified_gas) /
+                                txs_without_gas_limit as u64
                         } else {
                             0
                         }
@@ -405,11 +405,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             ExecutionResult::Halt { reason, gas_used } => {
                 let error =
                     Some(Self::Error::from_evm_halt(reason, tx_env.gas_limit()).to_string());
-                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error });
+                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
             }
             ExecutionResult::Revert { output, gas_used } => {
                 let error = Some(RevertError::new(output).to_string());
-                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error });
+                return Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
             }
             ExecutionResult::Success { .. } => {}
         };
@@ -675,7 +675,7 @@ pub trait Call:
         for tx in transactions {
             if *tx.tx_hash() == target_tx_hash {
                 // reached the target transaction
-                break;
+                break
             }
 
             let tx_env = self.evm_config().tx_env(tx);
@@ -725,7 +725,7 @@ pub trait Call:
             // configured gas exceeds limit
             return Err(
                 EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
-            );
+            )
         }
 
         // apply configured gas cap

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -229,7 +229,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
         mut state_override: Option<StateOverride>,
-    ) -> impl Future<Output = Result<Vec<EthCallResponse>, Self::Error>> + Send {
+    ) -> impl Future<Output = Result<Vec<Vec<EthCallResponse>>, Self::Error>> + Send {
         async move {
             // Check if the vector of bundles is empty
             if bundles.is_empty() {
@@ -332,7 +332,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     }
                 }
 
-                Ok(results)
+                Ok(vec![results])
             })
             .await
         }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -145,7 +145,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             return Err(EthApiError::Other(Box::new(
                                 EthSimulateError::BlockGasLimitExceeded,
                             ))
-                            .into());
+                            .into())
                         }
 
                         if txs_without_gas_limit > 0 {


### PR DESCRIPTION
resolves missing fix in issue: https://github.com/paradigmxyz/reth/issues/15584 

call_many now returns a vec similar to:
```vec![vec![tx1_res, tx2_res]]```

reference: https://github.com/alloy-rs/alloy/blob/a8d7df28046db5dc0589a8f5d36c679096c951ef/crates/provider/src/provider/trait.rs#L189

sample quicknode response: 

```
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": [ <- We need this extra [] for bundles
    [ <- A bundle with 2 transactions
      {
        "value": "0000000000000000000000000000000000000000000000000000000000000001"
      },
      {
        "value": ""
      }
    ],
    [ <- Another bundle with 1 transaction
      {
        "value": ""
      }
    ]
  ]
}
```