### PR TITLE
perf(rpc): clone less when building block response

### DIFF
--- a/crates/rpc/rpc-types-compat/src/block.rs
+++ b/crates/rpc/rpc-types-compat/src/block.rs
@@ -1,12 +1,14 @@
 //! Compatibility functions for rpc `Block` type.
 
 use crate::transaction::TransactionCompat;
-use alloy_consensus::{BlockHeader, Sealable};
+use alloy_consensus::{transaction::Recovered, BlockBody, BlockHeader, Sealable};
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::{
     Block, BlockTransactions, BlockTransactionsKind, Header, TransactionInfo,
 };
-use reth_primitives_traits::{Block as BlockTrait, BlockBody, RecoveredBlock, SignedTransaction};
+use reth_primitives_traits::{
+    Block as BlockTrait, BlockBody as BlockBodyTrait, RecoveredBlock, SignedTransaction,
+};
 
 /// Converts the given primitive block into a [`Block`] response with the given
 /// [`BlockTransactionsKind`]
@@ -19,7 +21,7 @@ pub fn from_block<T, B>(
     tx_resp_builder: &T,
 ) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
 where
-    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
+    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBodyTrait>::Transaction>,
     B: BlockTrait,
 {
     match kind {
@@ -40,13 +42,10 @@ where
     let transactions = block.body().transaction_hashes_iter().copied().collect();
     let rlp_length = block.rlp_length();
     let (header, body) = block.into_sealed_block().split_sealed_header_body();
+    let BlockBody { ommers, withdrawals, .. } = body.into_ethereum_body();
 
     let transactions = BlockTransactions::Hashes(transactions);
-    let withdrawals =
-        header.withdrawals_root().is_some().then(|| body.withdrawals().cloned()).flatten();
-
-    let uncles =
-        body.ommers().map(|o| o.iter().map(|h| h.hash_slow()).collect()).unwrap_or_default();
+    let uncles = ommers.into_iter().map(|h| h.hash_slow()).collect();
     let header = Header::from_consensus(header.into(), None, Some(U256::from(rlp_length)));
 
     Block { header, uncles, transactions, withdrawals }
@@ -63,7 +62,7 @@ pub fn from_block_full<T, B>(
     tx_resp_builder: &T,
 ) -> Result<Block<T::Transaction, Header<B::Header>>, T::Error>
 where
-    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBody>::Transaction>,
+    T: TransactionCompat<<<B as BlockTrait>::Body as BlockBodyTrait>::Transaction>,
     B: BlockTrait,
 {
     let block_number = block.header().number();
@@ -71,10 +70,15 @@ where
     let block_length = block.rlp_length();
     let block_hash = Some(block.hash());
 
-    let transactions = block
-        .transactions_recovered()
+    let (block, senders) = block.split_sealed();
+    let (header, body) = block.split_sealed_header_body();
+    let BlockBody { transactions, ommers, withdrawals } = body.into_ethereum_body();
+
+    let transactions = transactions
+        .into_iter()
+        .zip(senders)
         .enumerate()
-        .map(|(idx, tx)| {
+        .map(|(idx, (tx, sender))| {
             let tx_info = TransactionInfo {
                 hash: Some(*tx.tx_hash()),
                 block_hash,
@@ -83,18 +87,12 @@ where
                 index: Some(idx as u64),
             };
 
-            tx_resp_builder.fill(tx.cloned(), tx_info)
+            tx_resp_builder.fill(Recovered::new_unchecked(tx, sender), tx_info)
         })
         .collect::<Result<Vec<_>, T::Error>>()?;
 
-    let (header, body) = block.into_sealed_block().split_sealed_header_body();
-
     let transactions = BlockTransactions::Full(transactions);
-    let withdrawals =
-        header.withdrawals_root().is_some().then(|| body.withdrawals().cloned()).flatten();
-
-    let uncles =
-        body.ommers().map(|o| o.iter().map(|h| h.hash_slow()).collect()).unwrap_or_default();
+    let uncles = ommers.into_iter().map(|h| h.hash_slow()).collect();
     let header = Header::from_consensus(header.into(), None, Some(U256::from(block_length)));
 
     let block = Block { header, uncles, transactions, withdrawals };


### PR DESCRIPTION
`eth_getBlockByNumber` is critical for performance rollups with heavy blocks. This PR is not all the way there, but it reduces some low-hanging cloning here.