### PR TITLE
chore: fix non-const receivers in const fn

### DIFF
--- a/crates/engine/tree/benches/channel_perf.rs
+++ b/crates/engine/tree/benches/channel_perf.rs
@@ -44,7 +44,7 @@ struct StdStateRootTask {
 }
 
 impl StdStateRootTask {
-    const fn new(rx: std::sync::mpsc::Receiver<EvmState>) -> Self {
+    fn new(rx: std::sync::mpsc::Receiver<EvmState>) -> Self {
         Self { rx }
     }
 
@@ -61,7 +61,7 @@ struct CrossbeamStateRootTask {
 }
 
 impl CrossbeamStateRootTask {
-    const fn new(rx: crossbeam_channel::Receiver<EvmState>) -> Self {
+    fn new(rx: crossbeam_channel::Receiver<EvmState>) -> Self {
         Self { rx }
     }
 


### PR DESCRIPTION
fixed an issue where `Receiver<EvmState>` from `std::sync::mpsc` and `crossbeam_channel` were incorrectly passed to a `const fn`, which requires compile-time computation.