### PR TITLE
perf(trie): reserve space for new proof nodes ahead of time

### DIFF
--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -24,6 +24,7 @@ alloy-rlp.workspace = true
 
 # misc
 auto_impl.workspace = true
+itertools.workspace = true
 smallvec = { workspace = true, features = ["const_new"] }
 
 # metrics

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -24,7 +24,6 @@ alloy-rlp.workspace = true
 
 # misc
 auto_impl.workspace = true
-itertools.workspace = true
 smallvec = { workspace = true, features = ["const_new"] }
 
 # metrics

--- a/crates/trie/sparse/src/metrics.rs
+++ b/crates/trie/sparse/src/metrics.rs
@@ -36,23 +36,23 @@ impl SparseStateTrieMetrics {
             .record(self.multiproof_total_storage_nodes as f64);
     }
 
-    /// Increment the skipped account nodes counter
-    pub(crate) fn increment_skipped_account_nodes(&mut self) {
+    /// Increment the skipped account nodes counter by the given count
+    pub(crate) fn increment_skipped_account_nodes(&mut self, count: u64) {
         self.multiproof_skipped_account_nodes += 1;
     }
 
-    /// Increment the total account nodes counter
-    pub(crate) fn increment_total_account_nodes(&mut self) {
+    /// Increment the total account nodes counter by the given count
+    pub(crate) fn increment_total_account_nodes(&mut self, count: u64) {
         self.multiproof_total_account_nodes += 1;
     }
 
-    /// Increment the skipped storage nodes counter
-    pub(crate) fn increment_skipped_storage_nodes(&mut self) {
+    /// Increment the skipped storage nodes counter by the given count
+    pub(crate) fn increment_skipped_storage_nodes(&mut self, count: u64) {
         self.multiproof_skipped_storage_nodes += 1;
     }
 
-    /// Increment the total storage nodes counter
-    pub(crate) fn increment_total_storage_nodes(&mut self) {
+    /// Increment the total storage nodes counter by the given count
+    pub(crate) fn increment_total_storage_nodes(&mut self, count: u64) {
         self.multiproof_total_storage_nodes += 1;
     }
 }

--- a/crates/trie/sparse/src/metrics.rs
+++ b/crates/trie/sparse/src/metrics.rs
@@ -38,22 +38,22 @@ impl SparseStateTrieMetrics {
 
     /// Increment the skipped account nodes counter by the given count
     pub(crate) fn increment_skipped_account_nodes(&mut self, count: u64) {
-        self.multiproof_skipped_account_nodes += 1;
+        self.multiproof_skipped_account_nodes += count;
     }
 
     /// Increment the total account nodes counter by the given count
     pub(crate) fn increment_total_account_nodes(&mut self, count: u64) {
-        self.multiproof_total_account_nodes += 1;
+        self.multiproof_total_account_nodes += count;
     }
 
     /// Increment the skipped storage nodes counter by the given count
     pub(crate) fn increment_skipped_storage_nodes(&mut self, count: u64) {
-        self.multiproof_skipped_storage_nodes += 1;
+        self.multiproof_skipped_storage_nodes += count;
     }
 
     /// Increment the total storage nodes counter by the given count
     pub(crate) fn increment_total_storage_nodes(&mut self, count: u64) {
-        self.multiproof_total_storage_nodes += 1;
+        self.multiproof_total_storage_nodes += count;
     }
 }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -299,6 +299,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                 self.retain_updates,
             )?;
 
+            // Reserve the capacity for new nodes ahead of time.
             trie.reserve_nodes(new_nodes);
 
             // Reveal the remaining proof nodes.
@@ -355,6 +356,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                 self.retain_updates,
             )?;
 
+            // Reserve the capacity for new nodes ahead of time.
             trie.reserve_nodes(new_nodes);
 
             // Reveal the remaining proof nodes.

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -781,7 +781,8 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     }
 }
 
-/// Decoded proof nodes returned by [`decode_proof_nodes`].
+/// Decoded proof nodes with additional information about the number of total, skipped, and new
+/// nodes.
 #[derive(Debug)]
 struct DecodedProofNodes {
     /// Filtered, decoded and sorted proof nodes.

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -815,6 +815,8 @@ impl DecodedProofNodes {
 
             let node = TrieNode::decode(&mut &bytes[..])?;
             result.new_nodes += 1;
+            // If it's a branch node, increase the number of new nodes by the number of children
+            // according to the state mask.
             if let TrieNode::Branch(branch) = &node {
                 result.new_nodes += branch.state_mask.count_ones() as usize;
             }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -412,8 +412,9 @@ impl<P> RevealedSparseTrie<P> {
                 // Reserve space for children nodes. We may over-reserve here if some of the
                 // children already exist in `nodes`, but it's better than reserving one by one.
                 //
-                // TODO: ideally we do preprocessing of all nodes by decoding them, calculating full
-                // paths, checking if they exist in `nodes`, and then reserving space for them.
+                // TODO: ideally we do preprocessing of all nodes in a caller of `reveal_node` by
+                // decoding them, calculating full paths, checking if they exist in `nodes`, and
+                // then reserving space for them.
                 self.nodes.reserve(set_nibbles.len());
 
                 let mut stack_ptr = branch.as_ref().first_child_index();

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -408,7 +408,7 @@ impl<P> RevealedSparseTrie<P> {
             TrieNode::Branch(branch) => {
                 let set_nibbles = CHILD_INDEX_RANGE
                     .filter(|idx| branch.state_mask.is_bit_set(*idx))
-                    .collect::<Vec<_>>();
+                    .collect::<SmallVec<[u8; 16]>>();
                 // Reserve space for children nodes. We may over-reserve here if some of the
                 // children already exist in `nodes`, but it's better than reserving one by one.
                 //

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -381,6 +381,11 @@ impl<P> RevealedSparseTrie<P> {
         self.updates.take().unwrap_or_default()
     }
 
+    /// Reserves capacity for at least `additional` more nodes to be inserted.
+    pub fn reserve_nodes(&mut self, additional: usize) {
+        self.nodes.reserve(additional);
+    }
+
     /// Reveal the trie node only if it was not known already.
     pub fn reveal_node(
         &mut self,
@@ -406,23 +411,14 @@ impl<P> RevealedSparseTrie<P> {
                 self.nodes.insert(path, SparseNode::Empty);
             }
             TrieNode::Branch(branch) => {
-                let set_nibbles = CHILD_INDEX_RANGE
-                    .filter(|idx| branch.state_mask.is_bit_set(*idx))
-                    .collect::<SmallVec<[u8; 16]>>();
-                // Reserve space for children nodes. We may over-reserve here if some of the
-                // children already exist in `nodes`, but it's better than reserving one by one.
-                //
-                // TODO: ideally we do preprocessing of all nodes in a caller of `reveal_node` by
-                // decoding them, calculating full paths, checking if they exist in `nodes`, and
-                // then reserving space for them.
-                self.nodes.reserve(set_nibbles.len());
-
                 let mut stack_ptr = branch.as_ref().first_child_index();
-                for nibble in set_nibbles {
-                    let mut child_path = path.clone();
-                    child_path.push_unchecked(nibble);
-                    self.reveal_node_or_hash(child_path, &branch.stack[stack_ptr])?;
-                    stack_ptr += 1;
+                for idx in CHILD_INDEX_RANGE {
+                    if branch.state_mask.is_bit_set(idx) {
+                        let mut child_path = path.clone();
+                        child_path.push_unchecked(idx);
+                        self.reveal_node_or_hash(child_path, &branch.stack[stack_ptr])?;
+                        stack_ptr += 1;
+                    }
                 }
 
                 match self.nodes.entry(path) {


### PR DESCRIPTION
## Problem

When revealing multiproofs, we insert new nodes into the `nodes` hashmap of the `RevealedSparseTrie` struct. If there's not enough capacity in the hashmap, it allocates new memory with more space, copies old elements into this memory, and inserts a new element. This can happen multiple times when revealing the proof, because proofs can be large.

## Solution

Iterate over the proof nodes once, count the number of new nodes, reserve the space in the nodes hashmap ahead of time for them, and proceed as before.

### Before

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/6edc7921-b843-48af-b86c-33e3dd0a989c" />

### After

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/a793e672-29c0-45d4-8c92-d7bbe9ed1808" />

