### PR TITLE
feat(witness): `always_include_root_node` flag

### DIFF
--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -34,7 +34,9 @@ pub struct TrieWitness<T, H> {
     hashed_cursor_factory: H,
     /// A set of prefix sets that have changes.
     prefix_sets: TriePrefixSetsMut,
-    /// Flag indicating whether the root node.
+    /// Flag indicating whether the root node should always be included (even if the target state
+    /// is empty). This setting is useful if the caller wants to verify the witness against the
+    /// parent state root.
     /// Set to `false` by default.
     always_include_root_node: bool,
     /// Recorded witness.
@@ -82,6 +84,8 @@ impl<T, H> TrieWitness<T, H> {
     }
 
     /// Set `always_include_root_node` to true. Root node will be included even on empty state.
+    /// This setting is useful if the caller wants to verify the witness against the
+    /// parent state root.
     pub fn always_include_root_node(mut self) -> Self {
         self.always_include_root_node = true;
         self

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -86,7 +86,7 @@ impl<T, H> TrieWitness<T, H> {
     /// Set `always_include_root_node` to true. Root node will be included even on empty state.
     /// This setting is useful if the caller wants to verify the witness against the
     /// parent state root.
-    pub fn always_include_root_node(mut self) -> Self {
+    pub const fn always_include_root_node(mut self) -> Self {
         self.always_include_root_node = true;
         self
     }

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -4,6 +4,8 @@ use crate::{
     proof::{Proof, ProofBlindedProviderFactory},
     trie_cursor::TrieCursorFactory,
 };
+use alloy_rlp::EMPTY_STRING_CODE;
+use alloy_trie::EMPTY_ROOT_HASH;
 use reth_trie_common::HashedPostState;
 
 use alloy_primitives::{
@@ -32,6 +34,9 @@ pub struct TrieWitness<T, H> {
     hashed_cursor_factory: H,
     /// A set of prefix sets that have changes.
     prefix_sets: TriePrefixSetsMut,
+    /// Flag indicating whether the root node.
+    /// Set to `false` by default.
+    always_include_root_node: bool,
     /// Recorded witness.
     witness: B256Map<Bytes>,
 }
@@ -43,6 +48,7 @@ impl<T, H> TrieWitness<T, H> {
             trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets: TriePrefixSetsMut::default(),
+            always_include_root_node: false,
             witness: HashMap::default(),
         }
     }
@@ -53,6 +59,7 @@ impl<T, H> TrieWitness<T, H> {
             trie_cursor_factory,
             hashed_cursor_factory: self.hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
+            always_include_root_node: self.always_include_root_node,
             witness: self.witness,
         }
     }
@@ -63,6 +70,7 @@ impl<T, H> TrieWitness<T, H> {
             trie_cursor_factory: self.trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
+            always_include_root_node: self.always_include_root_node,
             witness: self.witness,
         }
     }
@@ -70,6 +78,12 @@ impl<T, H> TrieWitness<T, H> {
     /// Set the prefix sets. They have to be mutable in order to allow extension with proof target.
     pub fn with_prefix_sets_mut(mut self, prefix_sets: TriePrefixSetsMut) -> Self {
         self.prefix_sets = prefix_sets;
+        self
+    }
+
+    /// Set `always_include_root_node` to true. Root node will be included even on empty state.
+    pub fn always_include_root_node(mut self) -> Self {
+        self.always_include_root_node = true;
         self
     }
 }
@@ -86,15 +100,33 @@ where
     ///
     /// `state` - state transition containing both modified and touched accounts and storage slots.
     pub fn compute(mut self, state: HashedPostState) -> Result<B256Map<Bytes>, TrieWitnessError> {
-        if state.is_empty() {
-            return Ok(self.witness)
+        let is_state_empty = state.is_empty();
+        if is_state_empty && !self.always_include_root_node {
+            return Ok(Default::default())
         }
 
-        let proof_targets = self.get_proof_targets(&state)?;
+        let proof_targets = if is_state_empty {
+            MultiProofTargets::account(B256::ZERO)
+        } else {
+            self.get_proof_targets(&state)?
+        };
         let multiproof =
             Proof::new(self.trie_cursor_factory.clone(), self.hashed_cursor_factory.clone())
                 .with_prefix_sets_mut(self.prefix_sets.clone())
                 .multiproof(proof_targets.clone())?;
+
+        // No need to reconstruct the rest of the trie, we just need to include
+        // the root node and return.
+        if is_state_empty {
+            let (root_hash, root_node) = if let Some(root_node) =
+                multiproof.account_subtree.into_inner().remove(&Nibbles::default())
+            {
+                (keccak256(&root_node), root_node)
+            } else {
+                (EMPTY_ROOT_HASH, Bytes::from([EMPTY_STRING_CODE]))
+            };
+            return Ok(B256Map::from_iter([(root_hash, root_node)]))
+        }
 
         // Record all nodes from multiproof in the witness
         for account_node in multiproof.account_subtree.values() {


### PR DESCRIPTION
## Description

Add `always_include_root_node` flag for execution witness that allows the caller to always retrieve at least the root node.