### PR TITLE
chore(trie): make `RevealedNode` usable externally

### DIFF
--- a/crates/trie/sparse/src/blinded.rs
+++ b/crates/trie/sparse/src/blinded.rs
@@ -20,7 +20,7 @@ pub trait BlindedProviderFactory {
 }
 
 /// Revealed blinded trie node.
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct RevealedNode {
     /// Raw trie node.
     pub node: Bytes,


### PR DESCRIPTION
## Description

Make `RevealedNode` type usable externally: e.g. for comparison in tests or storing in cache.