### PR TITLE
fix(discv5): Use 30303 as default port if v4 disabled

### DIFF
--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -39,8 +39,8 @@ pub mod network_stack_id;
 pub use discv5::{self, IpMode};
 
 pub use config::{
-    BootNode, Config, ConfigBuilder, DEFAULT_COUNT_BOOTSTRAP_LOOKUPS, DEFAULT_DISCOVERY_V5_ADDR,
-    DEFAULT_DISCOVERY_V5_ADDR_IPV6, DEFAULT_DISCOVERY_V5_LISTEN_CONFIG, DEFAULT_DISCOVERY_V5_PORT,
+    default_discovery_v5_listen_config, default_discovery_v5_port, BootNode, Config, ConfigBuilder,
+    DEFAULT_COUNT_BOOTSTRAP_LOOKUPS, DEFAULT_DISCOVERY_V5_ADDR, DEFAULT_DISCOVERY_V5_ADDR_IPV6,
     DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL, DEFAULT_SECONDS_LOOKUP_INTERVAL,
 };
 pub use enr::enr_to_discv4_id;
@@ -666,7 +666,7 @@ mod test {
                 discv5::Discv5::new(
                     Enr::empty(&sk).unwrap(),
                     sk,
-                    discv5::ConfigBuilder::new(DEFAULT_DISCOVERY_V5_LISTEN_CONFIG).build(),
+                    discv5::ConfigBuilder::new(default_discovery_v5_listen_config(false)).build(),
                 )
                 .unwrap(),
             ),

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -599,6 +599,9 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
         } = self;
 
         discovery_v5_builder = discovery_v5_builder.map(|mut builder| {
+            if discovery_v4_builder.is_none() {
+                builder = builder.discv4_disabled();
+            }
             if let Some(network_stack_id) = NetworkStackId::id(&chain_spec) {
                 let fork_id = chain_spec.latest_fork_id();
                 builder = builder.fork(network_stack_id, fork_id)

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -11,7 +11,7 @@ use reth_chainspec::EthChainSpec;
 use reth_config::Config;
 use reth_discv4::{NodeRecord, DEFAULT_DISCOVERY_ADDR, DEFAULT_DISCOVERY_PORT};
 use reth_discv5::{
-    discv5::ListenConfig, DEFAULT_COUNT_BOOTSTRAP_LOOKUPS, DEFAULT_DISCOVERY_V5_PORT,
+    config::DEFAULT_DISCOVERY_V5_PORT, discv5::ListenConfig, DEFAULT_COUNT_BOOTSTRAP_LOOKUPS,
     DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL, DEFAULT_SECONDS_LOOKUP_INTERVAL,
 };
 use reth_net_nat::{NatResolver, DEFAULT_NET_IF_NAME};


### PR DESCRIPTION
Sets discv5 default port to 30303 for nodes which don't run discv4, ~~like op-reth by default~~