### PR TITLE
docs: fix incorrect web3_sha3 param description

### DIFF
--- a/book/jsonrpc/web3.md
+++ b/book/jsonrpc/web3.md
@@ -22,9 +22,9 @@ Get the web3 client version.
 
 Get the Keccak-256 hash of the given data.
 
-| Client | Method invocation                            |
-|--------|----------------------------------------------|
-| RPC    | `{"method": "web3_sha3", "params": [bytes]}` |
+| Client | Method invocation                              |
+|--------|------------------------------------------------|
+| RPC    | `{"method": "web3_sha3", "params": ["0x..."]}` |
 
 ### Example
 


### PR DESCRIPTION
Hey, just a quick fix — the `web3_sha3` method was previously described as accepting `bytes`, but it actually takes a hex string prefixed with `0x`. JSON-RPC doesn't support raw bytes, so this could be misleading.
Updated the param description and example accordingly.

p.s. soure https://github.com/etclabscore/ethereum-json-rpc-specification/blob/master/openrpc.json or https://openethereum.github.io/JSONRPC-web3-module