### PR TITLE
docs: fixed usage of `--http.api` with "all" option

### DIFF
--- a/book/jsonrpc/intro.md
+++ b/book/jsonrpc/intro.md
@@ -65,7 +65,7 @@ reth node --http --http.api all
 ```
 
 ```bash
-reth node --http --http.api All
+reth node --http --http.api all
 ```
 
 You can also restrict who can access the HTTP server by specifying a domain for Cross-Origin requests. This is important, since any application local to your node will be able to access the RPC server:


### PR DESCRIPTION
the documentation mentioned using `--http.api All` with a capital "A".
this can lead to issues in some cases due to case sensitivity.
the correct usage is `--http.api all` **with lowercase letters**, as this is the preconfigured option for enabling all available APIs.