### PR TITLE
refactor(rpc): eliminate unnecessary cloning in `RpcService::call`

### DIFF
--- a/crates/rpc/ipc/src/server/rpc_service.rs
+++ b/crates/rpc/ipc/src/server/rpc_service.rs
@@ -82,7 +82,7 @@ impl<'a> RpcServiceT<'a> for RpcService {
                         bounded_subscriptions,
                         sink,
                         id_provider,
-                    } = self.cfg.clone()
+                    } = &self.cfg
                     else {
                         tracing::warn!("Subscriptions not supported");
                         let rp =
@@ -93,11 +93,11 @@ impl<'a> RpcServiceT<'a> for RpcService {
                     if let Some(p) = bounded_subscriptions.acquire() {
                         let conn_state = SubscriptionState {
                             conn_id,
-                            id_provider: &*id_provider.clone(),
+                            id_provider: &**id_provider,
                             subscription_permit: p,
                         };
 
-                        let fut = callback(id.clone(), params, sink, conn_state, extensions);
+                        let fut = callback(id.clone(), params, sink.clone(), conn_state, extensions);
                         ResponseFuture::future(fut)
                     } else {
                         let max = bounded_subscriptions.max();

--- a/crates/rpc/ipc/src/server/rpc_service.rs
+++ b/crates/rpc/ipc/src/server/rpc_service.rs
@@ -97,7 +97,8 @@ impl<'a> RpcServiceT<'a> for RpcService {
                             subscription_permit: p,
                         };
 
-                        let fut = callback(id.clone(), params, sink.clone(), conn_state, extensions);
+                        let fut =
+                            callback(id.clone(), params, sink.clone(), conn_state, extensions);
                         ResponseFuture::future(fut)
                     } else {
                         let max = bounded_subscriptions.max();


### PR DESCRIPTION
This PR removes unnecessary `.clone()` calls in the `RpcService::call` implementation for better performance and readability.

Changes:
- Replaced `self.cfg.clone()` with a reference `&self.cfg`.
- Simplified `id_provider` access using `&**id_provider`.
- Retained `sink.clone()` to correctly pass an `Arc` without consuming it.

