### PR TITLE
fix: to_compact for CompactEnvelope

### DIFF
--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -127,6 +127,17 @@ impl Transaction {
             Self::Eip7702(tx) => tx.nonce = nonce,
         }
     }
+
+    #[cfg(test)]
+    fn input_mut(&mut self) -> &mut Bytes {
+        match self {
+            Self::Legacy(tx) => &mut tx.input,
+            Self::Eip2930(tx) => &mut tx.input,
+            Self::Eip1559(tx) => &mut tx.input,
+            Self::Eip4844(tx) => &mut tx.input,
+            Self::Eip7702(tx) =>  &mut tx.input,
+        }
+    }
 }
 
 impl Typed2718 for Transaction {
@@ -1127,6 +1138,36 @@ mod tests {
 
         #[test]
         fn test_roundtrip_compact_decode_envelope(reth_tx in arb::<TransactionSigned>()) {
+            let mut buf = Vec::<u8>::new();
+            let len = reth_tx.to_compact(&mut buf);
+
+            let (actual_tx, _) = EthereumTxEnvelope::<TxEip4844>::from_compact(&buf, len);
+            let expected_tx = EthereumTxEnvelope::<TxEip4844>::from(reth_tx);
+
+            assert_eq!(actual_tx, expected_tx);
+        }
+
+        #[test]
+        fn test_roundtrip_compact_encode_envelope_zstd(mut reth_tx in arb::<TransactionSigned>()) {
+               // zstd only kicks in if the input is large enough
+            *reth_tx.transaction.input_mut() = vec![0;33].into();
+
+            let mut expected_buf = Vec::<u8>::new();
+            let expected_len = reth_tx.to_compact(&mut expected_buf);
+
+            let mut actual_but  = Vec::<u8>::new();
+            let alloy_tx = EthereumTxEnvelope::<TxEip4844>::from(reth_tx);
+            let actual_len = alloy_tx.to_compact(&mut actual_but);
+
+            assert_eq!(actual_but, expected_buf);
+            assert_eq!(actual_len, expected_len);
+        }
+
+        #[test]
+        fn test_roundtrip_compact_decode_envelope_zstd(mut reth_tx in arb::<TransactionSigned>()) {
+            // zstd only kicks in if the input is large enough
+            *reth_tx.transaction.input_mut() = vec![0;33].into();
+
             let mut buf = Vec::<u8>::new();
             let len = reth_tx.to_compact(&mut buf);
 

--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -135,7 +135,7 @@ impl Transaction {
             Self::Eip2930(tx) => &mut tx.input,
             Self::Eip1559(tx) => &mut tx.input,
             Self::Eip4844(tx) => &mut tx.input,
-            Self::Eip7702(tx) =>  &mut tx.input,
+            Self::Eip7702(tx) => &mut tx.input,
         }
     }
 }

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -61,8 +61,8 @@ impl OpTransactionSigned {
             OpTypedTransaction::Legacy(tx) => &mut tx.input,
             OpTypedTransaction::Eip2930(tx) => &mut tx.input,
             OpTypedTransaction::Eip1559(tx) => &mut tx.input,
-            OpTypedTransaction::Eip7702(tx) =>  &mut tx.input,
-            OpTypedTransaction::Deposit(tx) =>  &mut tx.input,
+            OpTypedTransaction::Eip7702(tx) => &mut tx.input,
+            OpTypedTransaction::Deposit(tx) => &mut tx.input,
         }
     }
 

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -55,6 +55,17 @@ impl OpTransactionSigned {
         Self { hash: hash.into(), signature, transaction }
     }
 
+    #[cfg(test)]
+    fn input_mut(&mut self) -> &mut Bytes {
+        match &mut self.transaction {
+            OpTypedTransaction::Legacy(tx) => &mut tx.input,
+            OpTypedTransaction::Eip2930(tx) => &mut tx.input,
+            OpTypedTransaction::Eip1559(tx) => &mut tx.input,
+            OpTypedTransaction::Eip7702(tx) =>  &mut tx.input,
+            OpTypedTransaction::Deposit(tx) =>  &mut tx.input,
+        }
+    }
+
     /// Consumes the type and returns the transaction.
     #[inline]
     pub fn into_transaction(self) -> OpTypedTransaction {
@@ -819,6 +830,34 @@ mod tests {
     proptest! {
         #[test]
         fn test_roundtrip_compact_encode_envelope(reth_tx in arb::<OpTransactionSigned>()) {
+            let mut expected_buf = Vec::<u8>::new();
+            let expected_len = reth_tx.to_compact(&mut expected_buf);
+
+            let mut actual_but  = Vec::<u8>::new();
+            let alloy_tx = OpTxEnvelope::from(reth_tx);
+            let actual_len = alloy_tx.to_compact(&mut actual_but);
+
+            assert_eq!(actual_but, expected_buf);
+            assert_eq!(actual_len, expected_len);
+        }
+
+        #[test]
+        fn test_roundtrip_compact_decode_envelope_zstd(mut reth_tx in arb::<OpTransactionSigned>()) {
+                 // zstd only kicks in if the input is large enough
+            *reth_tx.input_mut() = vec![0;33].into();
+            let mut buf = Vec::<u8>::new();
+            let len = reth_tx.to_compact(&mut buf);
+
+            let (actual_tx, _) = OpTxEnvelope::from_compact(&buf, len);
+            let expected_tx = OpTxEnvelope::from(reth_tx);
+
+            assert_eq!(actual_tx, expected_tx);
+        }
+
+        #[test]
+        fn test_roundtrip_compact_encode_envelope_zstd(mut reth_tx in arb::<OpTransactionSigned>()) {
+                 // zstd only kicks in if the input is large enough
+            *reth_tx.input_mut() = vec![0;33].into();
             let mut expected_buf = Vec::<u8>::new();
             let expected_len = reth_tx.to_compact(&mut expected_buf);
 

--- a/crates/storage/codecs/src/alloy/transaction/ethereum.rs
+++ b/crates/storage/codecs/src/alloy/transaction/ethereum.rs
@@ -143,14 +143,11 @@ impl<T: Envelope + ToTxCompact + Transaction + Send + Sync> CompactEnvelope for 
 
         let sig_bit = self.signature().to_compact(buf) as u8;
         let zstd_bit = self.input().len() >= 32;
-        let tx_bits = self.tx_type().to_compact(buf) as u8;
-        let flags = sig_bit | (tx_bits << 1) | ((zstd_bit as u8) << 3);
 
-        buf.as_mut()[start] = flags;
-
-        if zstd_bit {
+       let tx_bits =  if zstd_bit {
+            // compress the tx prefixed with txtype
             let mut tx_buf = Vec::with_capacity(256);
-
+            let tx_bits = self.tx_type().to_compact(&mut tx_buf) as u8;
             self.to_tx_compact(&mut tx_buf);
 
             buf.put_slice(
@@ -170,9 +167,15 @@ impl<T: Envelope + ToTxCompact + Transaction + Send + Sync> CompactEnvelope for 
                 }
                 .expect("Failed to compress"),
             );
+           tx_bits
         } else {
+           let tx_bits = self.tx_type().to_compact(buf) as u8;
             self.to_tx_compact(buf);
+           tx_bits
         };
+
+        let flags = sig_bit | (tx_bits << 1) | ((zstd_bit as u8) << 3);
+        buf.as_mut()[start] = flags;
 
         buf.as_mut().len() - start
     }


### PR DESCRIPTION
fixes a similar issue where the txtype wasn't encoded into the buffer that we compress.

added more rountrip tests that go through zstd, by increasing the input size, this wasn't the case previously so we never entered the zstd branch