### PR TITLE
fix: activate Prague in custom-evm example

### DIFF
--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -217,6 +217,7 @@ async fn main() -> eyre::Result<()> {
         .paris_activated()
         .shanghai_activated()
         .cancun_activated()
+        .prague_activated()
         .build();
 
     let node_config =


### PR DESCRIPTION
Closes #15729.

In the example the additional precompile is extending [Prague](https://github.com/paradigmxyz/reth/blob/a7589ea265153f45af947bcd37cfe47a6d156f6c/examples/custom-evm/src/main.rs#L160) precompiles and the node is instantiated with [Cancun](https://github.com/paradigmxyz/reth/blob/a7589ea265153f45af947bcd37cfe47a6d156f6c/examples/custom-evm/src/main.rs#L219) being its last active fork.

Precompile will get included if Prague is activated.