### PR TITLE
chore(op-sdk): Relax trait bounds on `TraceApi` methods not accessing mempool

### DIFF
--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -13,7 +13,8 @@ use reth_rpc_eth_api::{
     types::RpcTypes,
     RpcReceipt,
 };
-use reth_storage_api::{BlockReader, HeaderProvider};
+use reth_storage_api::{BlockReader, HeaderProvider, ProviderTx};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 use crate::{eth::OpNodeCore, OpEthApi, OpEthApiError, OpReceiptBuilder};
 
@@ -84,7 +85,11 @@ where
 
 impl<N> LoadBlock for OpEthApi<N>
 where
-    Self: LoadPendingBlock + SpawnBlocking,
+    Self: LoadPendingBlock<
+            Pool: TransactionPool<
+                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
+            >,
+        > + SpawnBlocking,
     N: OpNodeCore,
 {
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -45,7 +45,6 @@ pub trait LoadPendingBlock:
         Provider: BlockReaderIdExt<Receipt: Receipt>
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
-        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
         Evm: ConfigureEvm<
             Primitives: NodePrimitives<
                 BlockHeader = ProviderHeader<Self::Provider>,
@@ -136,6 +135,8 @@ pub trait LoadPendingBlock:
     > + Send
     where
         Self: SpawnBlocking,
+        Self::Pool:
+            TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
     {
         async move {
             let pending = self.pending_block_env_and_cfg()?;
@@ -203,6 +204,8 @@ pub trait LoadPendingBlock:
         Self::Error,
     >
     where
+        Self::Pool:
+            TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
         EthApiError: From<ProviderError>,
     {
         let state_provider = self

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -10,7 +10,8 @@ use reth_rpc_eth_api::{
     RpcNodeCoreExt, RpcReceipt,
 };
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
-use reth_storage_api::BlockReader;
+use reth_storage_api::{BlockReader, ProviderTx};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 use crate::EthApi;
 
@@ -70,7 +71,13 @@ where
 
 impl<Provider, Pool, Network, EvmConfig> LoadBlock for EthApi<Provider, Pool, Network, EvmConfig>
 where
-    Self: LoadPendingBlock + SpawnBlocking + RpcNodeCoreExt,
+    Self: LoadPendingBlock
+        + SpawnBlocking
+        + RpcNodeCoreExt<
+            Pool: TransactionPool<
+                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
+            >,
+        >,
     Provider: BlockReader,
 {
 }


### PR DESCRIPTION
Ref https://github.com/paradigmxyz/reth/issues/15729

Separates methods of `TraceApi` based on if they require accessing tx pool or not. This makes it clearer, when reading the code, how sdk can be used with just a db provider component and no pool component, as in example in linked issue.