### PR TITLE
chore: add a method on SparseTrie to check whether a leaf exists

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1107,9 +1107,9 @@ impl<P: BlindedProvider> RevealedSparseTrie<P> {
     ///
     /// # Returns
     ///
-    /// - `Ok(FindLeafResult::Found)` if the leaf exists with the expected value.
-    /// - `Ok(FindLeafResult::NotFound)` if the leaf definitely does not exist (exclusion proof).
-    /// - `Err(FindLeafError)` if the search encountered a blinded node or found a different value.
+    /// - `Ok(LeafLookup::Found)` if the leaf exists with the expected value.
+    /// - `Ok(LeafLookup::NonExistent)` if the leaf definitely does not exist (exclusion proof).
+    /// - `Err(LeafLookupError)` if the search encountered a blinded node or found a different value.
     pub fn find_leaf(
         &self,
         path: &Nibbles,

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1057,7 +1057,7 @@ impl<P> RevealedSparseTrie<P> {
     }
 }
 
-/// Error type for leaf finding operations.
+/// Error type for a leaf lookup operation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LeafLookupError {
     /// The path leads to a blinded node, cannot determine if leaf exists.
@@ -1081,7 +1081,7 @@ pub enum LeafLookupError {
     },
 }
 
-/// Result of a leaf finding operation.
+/// Success value for a leaf lookup operation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LeafLookup {
     /// Leaf exists with expected value.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1169,8 +1169,7 @@ impl<P: BlindedProvider> RevealedSparseTrie<P> {
                     full_path.extend_from_slice_unchecked(key);
 
                     if &full_path == path {
-                        // TODO: This should be handled by the values map check above
-                        // TODO: But it's here for consistency
+                        // This should have been handled by our initial values map check
                         if let Some(value) = self.values.get(path) {
                             check_value_match(value, expected_value, path)?;
                             return Ok(LeafLookup::Found);

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1070,7 +1070,6 @@ pub enum LeafLookupError {
     },
     /// The path leads to a leaf with a different value than expected.
     /// This means the witness is malformed.
-    /// TODO: double check the code to see if this can happen
     ValueMismatch {
         /// Path to the leaf.
         path: Nibbles,


### PR DESCRIPTION
This PR adds a new method called find_leaf that will allow you to prove that a particular leaf:

- Exists in the trie
- Does not Exist in the trie
- Cannot be proven to exist in the trie

The last point being an error.

This is useful for stateless where an account may be missing and we want to know whether the account was missing due to the witness being incomplete or the account not existing in the trie.