### PR TITLE
chore(transaction-pool): make `price_bump` fn public

### DIFF
--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -150,7 +150,7 @@ pub struct PriceBumpConfig {
 impl PriceBumpConfig {
     /// Returns the price bump required to replace the given transaction type.
     #[inline]
-    pub(crate) const fn price_bump(&self, tx_type: u8) -> u128 {
+    pub const fn price_bump(&self, tx_type: u8) -> u128 {
         if tx_type == EIP4844_TX_TYPE_ID {
             return self.replace_blob_tx_price_bump
         }


### PR DESCRIPTION
To implement a custom validation it is helpful if this is public.