### PR TITLE
chore: bump inspectors 0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10325,9 +10325,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af7323cc83064900505770032be483b314f08cfd05d3c625d32d6b94f4f197b"
+checksum = "859fdfb2ef545140a68f44d02cfe5524964f9478896cd0c793f5948959818640"
 dependencies = [
  "alloy-primitives 1.0.0",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,7 +451,7 @@ revm-context = { version = "3.0.0", default-features = false }
 revm-context-interface = { version = "3.0.0", default-features = false }
 revm-database-interface = { version = "3.0.0", default-features = false }
 op-revm = { version = "3.0.2", default-features = false }
-revm-inspectors = "0.19.0"
+revm-inspectors = "0.19.1"
 
 # eth
 alloy-chains = { version = "0.2.0", default-features = false }


### PR DESCRIPTION
includes fix for 7702 accesslist tracing