### PR TITLE
chore: Relax the bounds on `DBProvider`

### DIFF
--- a/crates/storage/storage-api/src/account.rs
+++ b/crates/storage/storage-api/src/account.rs
@@ -11,7 +11,7 @@ use reth_storage_errors::provider::ProviderResult;
 
 /// Account reader
 #[auto_impl(&, Arc, Box)]
-pub trait AccountReader: Send + Sync {
+pub trait AccountReader {
     /// Get basic account information.
     ///
     /// Returns `None` if the account doesn't exist.
@@ -20,7 +20,7 @@ pub trait AccountReader: Send + Sync {
 
 /// Account reader
 #[auto_impl(&, Arc, Box)]
-pub trait AccountExtReader: Send + Sync {
+pub trait AccountExtReader {
     /// Iterate over account changesets and return all account address that were changed.
     fn changed_accounts_with_range(
         &self,
@@ -48,7 +48,7 @@ pub trait AccountExtReader: Send + Sync {
 
 /// AccountChange reader
 #[auto_impl(&, Arc, Box)]
-pub trait ChangeSetReader: Send + Sync {
+pub trait ChangeSetReader {
     /// Iterate over account changesets and return the account state from before this block.
     fn account_block_changeset(
         &self,

--- a/crates/storage/storage-api/src/database_provider.rs
+++ b/crates/storage/storage-api/src/database_provider.rs
@@ -12,7 +12,7 @@ use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderResult;
 
 /// Database provider.
-pub trait DBProvider: Send + Sync + Sized + 'static {
+pub trait DBProvider: Sized {
     /// Underlying database transaction held by the provider.
     type Tx: DbTx;
 


### PR DESCRIPTION
No code in this repo uses the `Send + Sync + 'static` bounds of `DBProvider`, thus they can be removed.

Also removed the bounds from the account traits because some of their impls are in part depending on `DBProvider`.

Note that `Sync`, `Send` are compile-only traits (and lifetimes are also a compile-only attribute), so the fact that this code compiles successfully should be enough to prove that these bounds are not actually used.