### PR TITLE
fix: Check for the maximum allowed gas limit in the block

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -7,7 +7,8 @@ use alloy_eips::{calc_next_block_base_fee, eip4844::DATA_GAS_PER_BLOB, eip7840::
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{
-    Block, BlockBody, BlockHeader, GotExpected, SealedBlock, SealedHeader,
+    constants::MAXIMUM_GAS_LIMIT_BLOCK, Block, BlockBody, BlockHeader, GotExpected, SealedBlock,
+    SealedHeader,
 };
 
 /// Gas used needs to be less than gas limit. Gas used is going to be checked after execution.
@@ -18,6 +19,10 @@ pub fn validate_header_gas<H: BlockHeader>(header: &H) -> Result<(), ConsensusEr
             gas_used: header.gas_used(),
             gas_limit: header.gas_limit(),
         })
+    }
+    // Check that the gas limit is below the maximum allowed gas limit
+    if header.gas_limit() > MAXIMUM_GAS_LIMIT_BLOCK {
+        return Err(ConsensusError::HeaderGasLimitExceedsMax { gas_limit: header.gas_limit() })
     }
     Ok(())
 }

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -16,8 +16,10 @@ use alloy_consensus::Header;
 use alloy_primitives::{BlockHash, BlockNumber, Bloom, B256, U256};
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
-    constants::MINIMUM_GAS_LIMIT, transaction::error::InvalidTransactionError, Block, GotExpected,
-    GotExpectedBoxed, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
+    constants::{MAXIMUM_GAS_LIMIT_BLOCK, MINIMUM_GAS_LIMIT},
+    transaction::error::InvalidTransactionError,
+    Block, GotExpected, GotExpectedBoxed, NodePrimitives, RecoveredBlock, SealedBlock,
+    SealedHeader,
 };
 
 /// A consensus implementation that does nothing.
@@ -412,6 +414,15 @@ pub enum ConsensusError {
     GasLimitInvalidMinimum {
         /// The child gas limit.
         child_gas_limit: u64,
+    },
+
+    /// Error indicating that the block gas limit is above the allowed maximum.
+    ///
+    /// This error occurs when the gas limit is more than the specified maximum gas limit.
+    #[error("child gas limit {block_gas_limit} is above the maximum allowed limit ({MAXIMUM_GAS_LIMIT_BLOCK})")]
+    GasLimitInvalidBlockMaximum {
+        /// block gas limit.
+        block_gas_limit: u64,
     },
 
     /// Error when the child gas limit exceeds the maximum allowed decrease.

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -182,7 +182,7 @@ pub enum ConsensusError {
     },
     /// Error when the gas the gas limit is more than the maximum allowed.
     #[error(
-        "gas limit ({gas_limit}) exceed the maximum allowed gas limit ({MAXIMUM_GAS_LIMIT_BLOCK})"
+        "header gas limit ({gas_limit}) exceed the maximum allowed gas limit ({MAXIMUM_GAS_LIMIT_BLOCK})"
     )]
     HeaderGasLimitExceedsMax {
         /// The gas limit in the block header.

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -180,6 +180,14 @@ pub enum ConsensusError {
         /// The gas limit in the block header.
         gas_limit: u64,
     },
+    /// Error when the gas the gas limit is more than the maximum allowed.
+    #[error(
+        "gas limit ({gas_limit}) exceed the maximum allowed gas limit ({MAXIMUM_GAS_LIMIT_BLOCK})"
+    )]
+    HeaderGasLimitExceedsMax {
+        /// The gas limit in the block header.
+        gas_limit: u64,
+    },
 
     /// Error when block gas used doesn't match expected value
     #[error("block gas used mismatch: {gas}; gas spent by each transaction: {gas_spent_by_tx:?}")]

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -21,7 +21,7 @@ use reth_consensus_common::validation::{
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
-    constants::{GAS_LIMIT_BOUND_DIVISOR, MAXIMUM_GAS_LIMIT_BLOCK, MINIMUM_GAS_LIMIT},
+    constants::{GAS_LIMIT_BOUND_DIVISOR, MINIMUM_GAS_LIMIT},
     Block, BlockHeader, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 use std::{fmt::Debug, sync::Arc, time::SystemTime};
@@ -53,15 +53,6 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
         header: &SealedHeader<H>,
         parent: &SealedHeader<H>,
     ) -> Result<(), ConsensusError> {
-        // TODO: Maybe put this check in another place, it is not really
-        // TODO: related to the parent gas limit
-        // Check that the gas limit is below the maximum allowed gas limit
-        if header.gas_limit() > MAXIMUM_GAS_LIMIT_BLOCK {
-            return Err(ConsensusError::GasLimitInvalidBlockMaximum {
-                block_gas_limit: header.gas_limit(),
-            })
-        }
-
         // Determine the parent gas limit, considering elasticity multiplier on the London fork.
         let parent_gas_limit = if !self.chain_spec.is_london_active_at_block(parent.number()) &&
             self.chain_spec.is_london_active_at_block(header.number())

--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -10,6 +10,9 @@ pub const RETH_CLIENT_VERSION: &str = concat!("reth/v", env!("CARGO_PKG_VERSION"
 /// Minimum gas limit allowed for transactions.
 pub const MINIMUM_GAS_LIMIT: u64 = 5000;
 
+/// Maximum gas limit allowed for block.
+pub const MAXIMUM_GAS_LIMIT_BLOCK: u64 = 0x7fffffffffffffff;
+
 /// The bound divisor of the gas limit, used in update calculations.
 pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 

--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -11,7 +11,8 @@ pub const RETH_CLIENT_VERSION: &str = concat!("reth/v", env!("CARGO_PKG_VERSION"
 pub const MINIMUM_GAS_LIMIT: u64 = 5000;
 
 /// Maximum gas limit allowed for block.
-pub const MAXIMUM_GAS_LIMIT_BLOCK: u64 = 0x7fffffffffffffff;
+/// In hex this number is `0x7fffffffffffffff`
+pub const MAXIMUM_GAS_LIMIT_BLOCK: u64 = 2u64.pow(63) - 1;
 
 /// The bound divisor of the gas limit, used in update calculations.
 pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;


### PR DESCRIPTION
Pulling this out of the invalid blocks PR.

The execution spec tests have a test that checks that the gas limit is not above [2^63 - 1](https://github.com/ethereum/execution-spec-tests/blob/13fecee8c413dd591d44769a3c3f238cfac5e392/src/ethereum_test_exceptions/exceptions.py#L452C32-L452C50) 

The test that fails is: `reth/testing/ef-tests/ethereum-tests/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest/GasLimitHigherThan2p63m1.json`

In this test, the genesis block has the max gas limit of `0x7fffffffffffffff` and the first child block has `0x8000000000000000`