### PR TITLE
fix: use correct params for kurtosis-op

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -5,13 +5,24 @@ ethereum_package:
         - "--rpc.eth-proof-window=100"
       cl_type: teku
       cl_image: "consensys/teku:25.4.0"
+  network_params:
+    preset: minimal
+    genesis_delay: 5
+    additional_preloaded_contracts: '
+      {
+        "0x4e59b44847b379578588920cA78FbF26c0B4956C": {
+          "balance": "0ETH",
+          "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3",
+          "storage": {},
+          "nonce": "1"
+        }
+      }'
 optimism_package:
   chains:
     - participants:
       - el_type: op-geth
         cl_type: op-node
       - el_type: op-reth
-        el_image: "ghcr.io/paradigmxyz/op-reth:kurtosis-ci"
         cl_type: op-node
       network_params:
         holocene_time_offset: 0


### PR DESCRIPTION
#15805 didn't help because it turns out that unless we specify `ethereum_package.network_params`, the optimism-package is always using the default teku-geth configuration by default

ref https://github.com/ethpandaops/optimism-package/issues/222