### PR TITLE
chore: add `reth-errors` to no-std checks

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -14,6 +14,7 @@ crates_to_check=(
     reth-static-file-types
     reth-storage-errors
     reth-execution-errors
+    reth-errors
     reth-execution-types
     reth-db-models
     reth-evm


### PR DESCRIPTION
I saw that there is already a riscv lint in the CI for various other crates.

Adding reth-errors since we just made it no-std compatible