### PR TITLE
chore: Add `reth-revm` to `no_std` CI checks

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -18,6 +18,7 @@ crates_to_check=(
     reth-execution-types
     reth-db-models
     reth-evm
+    reth-revm
     reth-storage-api
 
     ## ethereum


### PR DESCRIPTION
This follows the convention of adding no-std crates into the CI to ensure that CI fails if they are no longer no-std or no longer compile under riscv