### PR TITLE
chore: Add `reth-primitives` to `no-std` CI checks

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -4,6 +4,7 @@ set +e  # Disable immediate exit on error
 # Array of crates to check
 crates_to_check=(
     reth-codecs-derive
+    reth-primitives
     reth-primitives-traits
     reth-network-peers
     reth-trie-common


### PR DESCRIPTION
This follows the convention of adding no-std crates into the CI to ensure that CI fails if they are no longer no-std or no longer compile under riscv