### PR TITLE
fix: Make `reth-evm-ethereum` turn off default-features in top level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,7 +357,7 @@ reth-ethereum-primitives = { path = "crates/ethereum/primitives", default-featur
 reth-ethereum = { path = "crates/ethereum/reth" }
 reth-etl = { path = "crates/etl" }
 reth-evm = { path = "crates/evm", default-features = false }
-reth-evm-ethereum = { path = "crates/ethereum/evm" }
+reth-evm-ethereum = { path = "crates/ethereum/evm", default-features = false }
 reth-optimism-evm = { path = "crates/optimism/evm", default-features = false }
 reth-execution-errors = { path = "crates/evm/execution-errors", default-features = false }
 reth-execution-types = { path = "crates/evm/execution-types", default-features = false }

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -55,6 +55,7 @@ std = [
     "alloy-rpc-types-eth?/std",
     "reth-storage-api?/std",
     "reth-evm?/std",
+    "reth-evm-ethereum?/std",
     "reth-revm?/std",
 ]
 arbitrary = [


### PR DESCRIPTION
Due to the way feature flags work with workspaces, If a crate pulls in `reth-evm-ethereum` and we compile that workspace member using `no-default-features`, it will have no effect on `reth-evm-ethereum` because we did not put no-default-features in the top level Cargo.toml