### PR TITLE
fix(exex): Remove unneeded `mut` from exex manager variable

### DIFF
--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -1045,7 +1045,7 @@ mod tests {
 
         // Create an ExExManager with a small max capacity
         let max_capacity = 2;
-        let mut exex_manager = ExExManager::new(
+        let exex_manager = ExExManager::new(
             provider_factory,
             vec![exex_handle_1],
             max_capacity,


### PR DESCRIPTION
After recent update of `nightly`, this variable no longer needs to be mutable.

Thanks to this fact, the strict clippy prevents all pull request from passing CI checks.