### PR TITLE
fix: Make DatabaseTrieWitness stateful

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -26,7 +26,7 @@ use reth_trie::{
 };
 use reth_trie_db::{
     DatabaseHashedPostState, DatabaseHashedStorage, DatabaseProof, DatabaseStateRoot,
-    DatabaseStorageProof, DatabaseStorageRoot, DatabaseTrieWitness, StateCommitment,
+    DatabaseStorageProof, DatabaseStorageRoot, DatabaseTrieWitness, StateCommitment,DatabaseTrieCursorFactory,DatabaseHashedCursorFactory
 };
 use std::fmt::Debug;
 
@@ -385,7 +385,7 @@ impl<Provider: DBProvider + BlockNumReader + StateCommitmentProvider> StateProof
 
     fn witness(&self, mut input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
         input.prepend(self.revert_state()?);
-        TrieWitness::overlay_witness(self.tx(), input, target)
+        TrieWitness::overlay_witness(&TrieWitness::new(DatabaseTrieCursorFactory::new(self.tx()),DatabaseHashedCursorFactory::new(self.tx())), input, target)
             .map_err(ProviderError::from)
             .map(|hm| hm.into_values().collect())
     }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -18,7 +18,7 @@ use reth_trie::{
 };
 use reth_trie_db::{
     DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot,
-    DatabaseTrieWitness, StateCommitment,
+    DatabaseTrieWitness, StateCommitment,DatabaseTrieCursorFactory,DatabaseHashedCursorFactory
 };
 
 /// State provider over latest state that takes tx reference.
@@ -144,7 +144,7 @@ impl<Provider: DBProvider + StateCommitmentProvider> StateProofProvider
     }
 
     fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
-        TrieWitness::overlay_witness(self.tx(), input, target)
+        TrieWitness::overlay_witness(&TrieWitness::new(DatabaseTrieCursorFactory::new(self.tx()),DatabaseHashedCursorFactory::new(self.tx())),input, target)
             .map_err(ProviderError::from)
             .map(|hm| hm.into_values().collect())
     }

--- a/crates/trie/db/src/commitment.rs
+++ b/crates/trie/db/src/commitment.rs
@@ -16,7 +16,7 @@ pub trait StateCommitment: std::fmt::Debug + Clone + Send + Sync + Unpin + 'stat
     /// The state proof type.
     type StateProof<'a, TX: DbTx + 'a>: DatabaseProof<'a, TX>;
     /// The state witness type.
-    type StateWitness<'a, TX: DbTx + 'a>: DatabaseTrieWitness<'a, TX>;
+    type StateWitness<'a, TX: DbTx + 'a>: DatabaseTrieWitness;
     /// The key hasher type.
     type KeyHasher: KeyHasher;
 }

--- a/crates/trie/db/src/witness.rs
+++ b/crates/trie/db/src/witness.rs
@@ -8,39 +8,39 @@ use reth_trie::{
 };
 
 /// Extends [`TrieWitness`] with operations specific for working with a database transaction.
-pub trait DatabaseTrieWitness<'a, TX> {
+pub trait DatabaseTrieWitness {
     /// Create a new [`TrieWitness`] from database transaction.
-    fn from_tx(tx: &'a TX) -> Self;
+    fn from_tx(&self) -> Self;
 
     /// Generates trie witness for target state based on [`TrieInput`].
     fn overlay_witness(
-        tx: &'a TX,
+        &self,
         input: TrieInput,
         target: HashedPostState,
     ) -> Result<B256Map<Bytes>, TrieWitnessError>;
 }
 
-impl<'a, TX: DbTx> DatabaseTrieWitness<'a, TX>
+impl<'a, TX: DbTx> DatabaseTrieWitness
     for TrieWitness<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
 {
-    fn from_tx(tx: &'a TX) -> Self {
-        Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx))
+    fn from_tx(&self) -> Self {
+        Self::new(self.trie_cursor_factory.clone(), self.hashed_cursor_factory.clone())
     }
 
     fn overlay_witness(
-        tx: &'a TX,
+        &self,
         input: TrieInput,
         target: HashedPostState,
     ) -> Result<B256Map<Bytes>, TrieWitnessError> {
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
-        Self::from_tx(tx)
+        Self::from_tx(&self)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                DatabaseTrieCursorFactory::new(tx),
+                self.trie_cursor_factory.clone(),
                 &nodes_sorted,
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                DatabaseHashedCursorFactory::new(tx),
+                self.hashed_cursor_factory.clone(),
                 &state_sorted,
             ))
             .with_prefix_sets_mut(input.prefix_sets)

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -27,9 +27,9 @@ use std::sync::{mpsc, Arc};
 #[derive(Debug)]
 pub struct TrieWitness<T, H> {
     /// The cursor factory for traversing trie nodes.
-    trie_cursor_factory: T,
+    pub trie_cursor_factory: T,
     /// The factory for hashed cursors.
-    hashed_cursor_factory: H,
+    pub hashed_cursor_factory: H,
     /// A set of prefix sets that have changes.
     prefix_sets: TriePrefixSetsMut,
     /// Recorded witness.


### PR DESCRIPTION
- Refactored DatabaseTrieWitness trait to be stateful, removing the associated TX type and lifetime parameters.
- Simplified methods to use &self instead of taking &'a TX for every method
Closes #15481