### PR TITLE
docs: Update witness.rs

### DIFF
--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -15,7 +15,7 @@ pub struct ExecutionWitnessRecord {
     pub codes: Vec<Bytes>,
     /// Map of all hashed account and storage keys (addresses and slots) to their preimages
     /// (unhashed account addresses and storage slots, respectively) that were required during
-    /// the execution of the block. during the execution of the block.
+    /// the execution of the block.
     ///
     /// `keccak(address|slot) => address|slot`
     pub keys: Vec<Bytes>,


### PR DESCRIPTION


This pull request removes a redundant phrase in the documentation comment for the `ExecutionWitnessRecord` struct. The phrase "during the execution of the block" was accidentally duplicated in the comment, making it read awkwardly. This simple fix improves code readability and documentation quality.
