### PR TITLE
perf(trie): optimize TrieNodeIter by skipping redundant seek

### DIFF
--- a/crates/trie/trie/src/metrics.rs
+++ b/crates/trie/trie/src/metrics.rs
@@ -76,8 +76,6 @@ pub struct TrieNodeIterMetrics {
     /// iterator. It does not mean mean the database seek was actually done, as the trie node
     /// iterator caches the last hashed cursor seek.
     leaf_nodes_same_seeked_total: Counter,
-    /// The number of times the same leaf node as we just advanced to was seeked by the iterator.
-    leaf_nodes_same_seeked_as_advanced_total: Counter,
     /// The number of leaf nodes seeked by the iterator.
     leaf_nodes_seeked_total: Counter,
     /// The number of leaf nodes advanced by the iterator.
@@ -100,11 +98,6 @@ impl TrieNodeIterMetrics {
     /// Increment `leaf_nodes_same_seeked_total`.
     pub fn inc_leaf_nodes_same_seeked(&self) {
         self.leaf_nodes_same_seeked_total.increment(1);
-    }
-
-    /// Increment `leaf_nodes_same_seeked_as_advanced_total`.
-    pub fn inc_leaf_nodes_same_seeked_as_advanced(&self) {
-        self.leaf_nodes_same_seeked_as_advanced_total.increment(1);
     }
 
     /// Increment `leaf_nodes_seeked_total`.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -138,8 +138,6 @@ where
             }
         }
 
-        self.last_next_result = None;
-
         if let Some(entry) = self
             .last_seeked_hashed_entry
             .as_ref()

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -69,7 +69,7 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
     previously_advanced_to_key: Option<B256>,
     /// Stores the result of the last successful [`Self::next_hashed_entry`], used to avoid a
     /// redundant [`Self::seek_hashed_entry`] call if the walker points to the same key that
-    /// was just return by `next()`.
+    /// was just returned by `next()`.
     last_next_result: Option<(B256, H::Value)>,
 }
 

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -64,9 +64,6 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
 
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::TrieNodeIterMetrics,
-    /// The key that the [`HashedCursor`] previously advanced to using [`HashedCursor::next`].
-    #[cfg(feature = "metrics")]
-    previously_advanced_to_key: Option<B256>,
     /// Stores the result of the last successful [`Self::next_hashed_entry`], used to avoid a
     /// redundant [`Self::seek_hashed_entry`] call if the walker points to the same key that
     /// was just returned by `next()`.
@@ -112,8 +109,6 @@ where
             last_seeked_hashed_entry: None,
             #[cfg(feature = "metrics")]
             metrics: crate::metrics::TrieNodeIterMetrics::new(trie_type),
-            #[cfg(feature = "metrics")]
-            previously_advanced_to_key: None,
             last_next_result: None,
         }
     }
@@ -178,7 +173,6 @@ where
         #[cfg(feature = "metrics")]
         {
             self.metrics.inc_leaf_nodes_advanced();
-            self.previously_advanced_to_key = self.last_next_result.as_ref().map(|(k, _)| *k);
         }
         result
     }

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -67,9 +67,9 @@ pub struct TrieNodeIter<C, H: HashedCursor> {
     /// The key that the [`HashedCursor`] previously advanced to using [`HashedCursor::next`].
     #[cfg(feature = "metrics")]
     previously_advanced_to_key: Option<B256>,
-    /// Stores the result of the last successful `next_hashed_entry`, used to avoid a redundant
-    /// `seek_hashed_entry` call if the walker points to the same key that was just return by
-    /// `next()`.
+    /// Stores the result of the last successful [`Self::next_hashed_entry`], used to avoid a
+    /// redundant [`Self::seek_hashed_entry`] call if the walker points to the same key that
+    /// was just return by `next()`.
     last_next_result: Option<(B256, H::Value)>,
 }
 
@@ -139,13 +139,6 @@ where
                 let result = Some((last_key, last_value));
                 self.last_seeked_hashed_entry = Some(SeekedHashedEntry { seeked_key: key, result });
 
-                #[cfg(feature = "metrics")]
-                {
-                    self.metrics.inc_leaf_nodes_seeked();
-                    if Some(key) == self.previously_advanced_to_key {
-                        self.metrics.inc_leaf_nodes_same_seeked_as_advanced();
-                    }
-                }
                 return Ok(result);
             }
         }
@@ -303,7 +296,6 @@ where
                         );
 
                         self.should_check_walker_key = false;
-                        self.last_next_result = None;
                         continue
                     }
 


### PR DESCRIPTION
Fixes: #15329 

Avoids the unnecessary `hashed_cursor.seek(key)` operation within TrieNodeIter that could occur if the immediately preceding `hashed_cursor.next()` call had already positioned the cursor at the `key`. It checks the `last_next_result` field (tracking the key and value from the last `next()` call) against the intended `seek_key`. If the keys match, the redundant `seek()` is skipped and the cached result is used. Added the `last_next_result` field to store the needed state, it is cleared during `seek` operations.

Also updated the assertion for visited keys in the existing `test_trie_node_iter` unit test to reflect the new optimised sequence of cursor operations (omitting the redundant seek).