### PR TITLE
chore(ci): Add a usage comment on `revert`

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -58,6 +58,7 @@ jobs:
             - `refactor`: Changes to improve code structure
             - `docs`: Documentation updates
             - `ci`: Changes to CI/CD configurations
+            - `revert`: Reverts a previously merged PR
             
             **Breaking Changes**
 


### PR DESCRIPTION
Short line on why one would use `revert` in the PR title