### PR TITLE
chore: add empty line to display hardforks

### DIFF
--- a/crates/ethereum-forks/src/display.rs
+++ b/crates/ethereum-forks/src/display.rs
@@ -123,11 +123,11 @@ impl core::fmt::Display for DisplayHardforks {
             f,
         )?;
 
-        if !self.with_merge.is_empty() {
-            format("Merge hard forks", &self.with_merge, self.post_merge.is_empty(), f)?;
-        } else {
+        if self.with_merge.is_empty() {
             // need an extra line here in case we don't have a merge block (optimism)
             writeln!(f)?;
+        } else {
+            format("Merge hard forks", &self.with_merge, self.post_merge.is_empty(), f)?;
         }
 
         if !self.post_merge.is_empty() {

--- a/crates/ethereum-forks/src/display.rs
+++ b/crates/ethereum-forks/src/display.rs
@@ -125,6 +125,9 @@ impl core::fmt::Display for DisplayHardforks {
 
         if !self.with_merge.is_empty() {
             format("Merge hard forks", &self.with_merge, self.post_merge.is_empty(), f)?;
+        } else {
+            // need an extra line here in case we don't have a merge block (optimism)
+            writeln!(f)?;
         }
 
         if !self.post_merge.is_empty() {

--- a/crates/ethereum-forks/src/display.rs
+++ b/crates/ethereum-forks/src/display.rs
@@ -124,8 +124,10 @@ impl core::fmt::Display for DisplayHardforks {
         )?;
 
         if self.with_merge.is_empty() {
-            // need an extra line here in case we don't have a merge block (optimism)
-            writeln!(f)?;
+            if !self.post_merge.is_empty() {
+                // need an extra line here in case we don't have a merge block (optimism)
+                writeln!(f)?;
+            }
         } else {
             format("Merge hard forks", &self.with_merge, self.post_merge.is_empty(), f)?;
         }


### PR DESCRIPTION
smol formatting issue if we dont have a merge block:

```
Pre-merge hard forks (block based):
- Bedrock                          @0Post-merge hard forks (timestamp based):
- Regolith                         @0
- Canyon                           @0
- Ecotone                          @0
- Fjord                            @0
- Granite                          @0
- Holocene                         @1736445601
- Isthmus                          @1746806401
```