### PR TITLE
chore: pin crunchy by including it in one of the member crates

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,39 +18,3 @@ jobs:
     uses: ithacaxyz/ci/.github/workflows/cargo-update-pr.yml@main
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
-
-  # re‑pin `crunchy` to version 0.2.2 since 0.2.3 is broken.
-  # The Cargo.toml file states we want `=0.2.2` however cargo update
-  # is not respecting this.
-  # For underlying issue, See: https://github.com/eira-fransham/crunchy/issues/13
-  repin-crunchy:
-    needs: update
-    runs-on: ubuntu-latest
-
-    steps:
-      # The ithaca re-usable workflow will create a PR on
-      # branch `cargo-update`. So we re-check that branch out.
-      - uses: actions/checkout@v4
-        with:
-          ref: cargo-update
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-
-      - name: Re-pin crunchy to 0.2.2
-        run: cargo update -p crunchy --precise 0.2.2
-
-      - name: Commit & push if Cargo.lock changed
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if ! git diff --quiet -- Cargo.lock; then
-            git config user.name  "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add Cargo.lock
-            git commit -m "ci: re‑pin crunchy to 0.2.2"
-            git push origin cargo-update
-          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives 1.0.0",
  "alloy-rlp",
+ "crunchy",
  "rayon",
  "reth-chainspec",
  "reth-db",

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -43,3 +43,8 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 rayon.workspace = true
+# TODO: When we build for a windows target on an ubuntu runner, crunchy tries to
+# get the wrong path, update this when the workflow has been updated
+#
+# See: https://github.com/eira-fransham/crunchy/issues/13
+crunchy = "=0.2.2"


### PR DESCRIPTION
We were previously ensuring that we always ended up with crunchy 0.2.2 after doing a weekly `cargo update` by re-pinning this crunchy version to 0.2.2 after the update.

@DaniPopes noted that cargo was not respecting `=0.2.2` because it was only present in the virtual manifest and not in any of the crates in the workspace.