### PR TITLE
fix(cli): drop ExEx WAL only if it exists

### DIFF
--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -146,9 +146,11 @@ impl<N: ProviderNodeTypes> DbTool<N> {
         fs::remove_dir_all(static_files_path)?;
         fs::create_dir_all(static_files_path)?;
 
-        let exex_wal_path = exex_wal_path.as_ref();
-        info!(target: "reth::cli", "Dropping ExEx WAL at {:?}", exex_wal_path);
-        fs::remove_dir_all(exex_wal_path)?;
+        if exex_wal_path.as_ref().exists() {
+            let exex_wal_path = exex_wal_path.as_ref();
+            info!(target: "reth::cli", "Dropping ExEx WAL at {:?}", exex_wal_path);
+            fs::remove_dir_all(exex_wal_path)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Otherwise this happens
```console
❯ reth db drop --chain hoodi
2025-04-23T09:06:08.860608Z  INFO Initialized tracing, debug log directory: /Users/shekhirin/Library/Caches/reth/logs/hoodi
Are you sure you want to drop the database at /Users/shekhirin/Library/Application Support/reth/hoodi? This cannot be undone. (y/N): y
2025-04-23T09:06:10.359305Z  INFO Opening storage db_path="/Users/shekhirin/Library/Application Support/reth/hoodi/db" sf_path="/Users/shekhirin/Library/Application Support/reth/hoodi/static_files"
2025-04-23T09:06:10.379905Z  INFO Verifying storage consistency.
2025-04-23T09:06:10.487872Z  INFO Dropping database at "/Users/shekhirin/Library/Application Support/reth/hoodi/db"
2025-04-23T09:06:10.489387Z  INFO Dropping static files at "/Users/shekhirin/Library/Application Support/reth/hoodi/static_files"
2025-04-23T09:06:10.490993Z  INFO Dropping ExEx WAL at "/Users/shekhirin/Library/Application Support/reth/hoodi/exex/wal"
Error: failed to remove dir "/Users/shekhirin/Library/Application Support/reth/hoodi/exex/wal": No such file or directory (os error 2)

Caused by:
    No such file or directory (os error 2)

Location:
    /Users/shekhirin/Projects/reth/crates/storage/db-common/src/db_tool/mod.rs:151:9
```