### PR TITLE
chore(metrics): summable reth_info value

### DIFF
--- a/crates/node/metrics/src/version.rs
+++ b/crates/node/metrics/src/version.rs
@@ -30,6 +30,7 @@ impl VersionInfo {
             ("build_profile", self.build_profile),
         ];
 
-        let _gauge = gauge!("info", &labels);
+        let gauge = gauge!("info", &labels);
+        gauge.set(1);
     }
 }


### PR DESCRIPTION
### Description
We run multiple clusters of Reth/Geth nodes. We want to be able to sum the number of `reth_info` metrics by version to have a count of nodes that are on each version, e.g. compare our Geth devnet vs. Reth

<img width="876" alt="Screenshot 2025-04-23 at 11 14 56 AM" src="https://github.com/user-attachments/assets/e71b9551-51c5-4d7c-8d61-07c75a16b0ab" />

For historical context, this was previously set in https://github.com/paradigmxyz/reth/pull/9679, but it was removed in https://github.com/paradigmxyz/reth/pull/9691. If there's an issue with setting this metric to 1, happy to find a workaround.