### PR TITLE
feat(engine): add instrumented state provider

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -740,6 +740,9 @@ Engine:
       --engine.disable-caching-and-prewarming
           Disable cross-block caching and parallel prewarming
 
+      --engine.state-provider-metrics
+          Enable state provider latency metrics. This allows the engine to collect and report stats about how long state provider calls took during execution, but this does introduce slight overhead to state provider calls
+
       --engine.cross-block-cache-size <CROSS_BLOCK_CACHE_SIZE>
           Configure the size of cross-block cache in megabytes
 

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -65,6 +65,8 @@ pub struct TreeConfig {
     always_compare_trie_updates: bool,
     /// Whether to disable cross-block caching and parallel prewarming.
     disable_caching_and_prewarming: bool,
+    /// Whether to enable state provider metrics.
+    state_provider_metrics: bool,
     /// Cross-block cache size in bytes.
     cross_block_cache_size: u64,
     /// Whether the host has enough parallelism to run state root task.
@@ -86,6 +88,7 @@ impl Default for TreeConfig {
             legacy_state_root: false,
             always_compare_trie_updates: false,
             disable_caching_and_prewarming: false,
+            state_provider_metrics: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE,
             has_enough_parallelism: has_enough_parallelism(),
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
@@ -106,6 +109,7 @@ impl TreeConfig {
         legacy_state_root: bool,
         always_compare_trie_updates: bool,
         disable_caching_and_prewarming: bool,
+        state_provider_metrics: bool,
         cross_block_cache_size: u64,
         has_enough_parallelism: bool,
         max_proof_task_concurrency: u64,
@@ -120,6 +124,7 @@ impl TreeConfig {
             legacy_state_root,
             always_compare_trie_updates,
             disable_caching_and_prewarming,
+            state_provider_metrics,
             cross_block_cache_size,
             has_enough_parallelism,
             max_proof_task_concurrency,
@@ -166,6 +171,11 @@ impl TreeConfig {
     /// of the new state root task
     pub const fn legacy_state_root(&self) -> bool {
         self.legacy_state_root
+    }
+
+    /// Returns whether or not state provider metrics are enabled.
+    pub const fn state_provider_metrics(&self) -> bool {
+        self.state_provider_metrics
     }
 
     /// Returns whether or not cross-block caching and parallel prewarming should be used.
@@ -257,6 +267,12 @@ impl TreeConfig {
     /// Setter for has enough parallelism.
     pub const fn with_has_enough_parallelism(mut self, has_enough_parallelism: bool) -> Self {
         self.has_enough_parallelism = has_enough_parallelism;
+        self
+    }
+
+    /// Setter for state provider metrics.
+    pub const fn with_state_provider_metrics(mut self, state_provider_metrics: bool) -> Self {
+        self.state_provider_metrics = state_provider_metrics;
         self
     }
 

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -125,7 +125,7 @@ impl<S> InstrumentedStateProvider<S> {
     }
 
     /// Records the total latencies into their respective gauges and histograms.
-    fn record_total_latency(&self) {
+    pub(crate) fn record_total_latency(&self) {
         let total_storage_fetch_latency = self.total_storage_fetch_latency.duration();
         self.metrics.total_storage_fetch_latency.record(total_storage_fetch_latency);
         self.metrics

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -1,0 +1,310 @@
+//! Implements a state provider that tracks latency metrics.
+use alloy_primitives::{Address, StorageKey, StorageValue, B256};
+use metrics::{Gauge, Histogram};
+use reth_errors::ProviderResult;
+use reth_metrics::Metrics;
+use reth_primitives_traits::{Account, Bytecode};
+use reth_provider::{
+    AccountReader, BlockHashReader, HashedPostStateProvider, StateProofProvider, StateProvider,
+    StateRootProvider, StorageRootProvider,
+};
+use reth_trie::{
+    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
+    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+};
+use std::{
+    sync::atomic::{AtomicU32, AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+/// Nanoseconds per second
+const NANOS_PER_SEC: u32 = 1_000_000_000;
+
+/// An atomic version of [`Duration`], using an [`AtomicU64`] to store the seconds part of the
+/// duration, and an [`AtomicU32`] for the nanoseconds part.
+#[derive(Default)]
+pub(crate) struct AtomicDuration {
+    /// The seconds part of the duration
+    seconds: AtomicU64,
+
+    /// The nanoseconds part of the duration
+    nanos: AtomicU32,
+}
+
+impl AtomicDuration {
+    /// The zero duration.
+    const ZERO: Self = Self { seconds: AtomicU64::new(0), nanos: AtomicU32::new(0) };
+
+    /// Creates a new [`AtomicDuration`] from a [`Duration`]
+    pub(crate) fn new(duration: Duration) -> Self {
+        Self {
+            seconds: AtomicU64::new(duration.as_secs()),
+            nanos: AtomicU32::new(duration.subsec_nanos()),
+        }
+    }
+
+    /// Returns the duration as a [`Duration`]
+    pub(crate) fn duration(&self) -> Duration {
+        Duration::new(self.seconds.load(Ordering::Relaxed), self.nanos.load(Ordering::Relaxed))
+    }
+
+    /// Adds a [`Duration`] to the atomic duration.
+    pub(crate) fn add_duration(&self, duration: Duration) {
+        // add the seconds part of the duration
+        self.seconds.fetch_add(duration.as_secs(), Ordering::Relaxed);
+        // add the nanoseconds part of the duration
+        self.nanos.fetch_add(duration.subsec_nanos(), Ordering::Relaxed);
+
+        // carry over the nanoseconds to the seconds part if the nanoseconds part is greater than 1
+        // second
+        if self.nanos.load(Ordering::Relaxed) >= NANOS_PER_SEC {
+            // get the number of seconds to carry over
+            let carry_over = self.nanos.load(Ordering::Relaxed) / NANOS_PER_SEC;
+            // set the nanoseconds part to the remainder
+            self.nanos.fetch_sub(carry_over * NANOS_PER_SEC, Ordering::Relaxed);
+            // add the carry over to the seconds part
+            self.seconds.fetch_add(carry_over as u64, Ordering::Relaxed);
+        }
+    }
+}
+
+/// A wrapper of a state provider and latency metrics.
+pub(crate) struct InstrumentedStateProvider<S> {
+    /// The state provider
+    state_provider: S,
+
+    /// Metrics for the instrumented state provider
+    metrics: StateProviderMetrics,
+
+    /// The total time we spend fetching storage over the lifetime of this state provider
+    total_storage_fetch_latency: AtomicDuration,
+
+    /// The total time we spend fetching code over the lifetime of this state provider
+    total_code_fetch_latency: AtomicDuration,
+
+    /// The total time we spend fetching accounts over the lifetime of this state provider
+    total_account_fetch_latency: AtomicDuration,
+}
+
+impl<S> InstrumentedStateProvider<S>
+where
+    S: StateProvider,
+{
+    /// Creates a new [`InstrumentedStateProvider`] from a state provider
+    pub(crate) fn from_state_provider(state_provider: S) -> Self {
+        Self {
+            state_provider,
+            metrics: StateProviderMetrics::default(),
+            total_storage_fetch_latency: AtomicDuration::ZERO,
+            total_code_fetch_latency: AtomicDuration::ZERO,
+            total_account_fetch_latency: AtomicDuration::ZERO,
+        }
+    }
+}
+
+impl<S> InstrumentedStateProvider<S> {
+    /// Records the latency for a storage fetch, and increments the duration counter for the storage
+    /// fetch.
+    fn record_storage_fetch(&self, latency: Duration) {
+        self.metrics.storage_fetch_latency.record(latency);
+        self.total_storage_fetch_latency.add_duration(latency);
+    }
+
+    /// Records the latency for a code fetch, and increments the duration counter for the code
+    /// fetch.
+    fn record_code_fetch(&self, latency: Duration) {
+        self.metrics.code_fetch_latency.record(latency);
+        self.total_code_fetch_latency.add_duration(latency);
+    }
+
+    /// Records the latency for an account fetch, and increments the duration counter for the
+    /// account fetch.
+    fn record_account_fetch(&self, latency: Duration) {
+        self.metrics.account_fetch_latency.record(latency);
+        self.total_account_fetch_latency.add_duration(latency);
+    }
+
+    /// Records the total latencies into their respective gauges and histograms.
+    fn record_total_latency(&self) {
+        let total_storage_fetch_latency = self.total_storage_fetch_latency.duration();
+        self.metrics.total_storage_fetch_latency.record(total_storage_fetch_latency);
+        self.metrics
+            .total_storage_fetch_latency_gauge
+            .set(total_storage_fetch_latency.as_secs_f64());
+
+        let total_code_fetch_latency = self.total_code_fetch_latency.duration();
+        self.metrics.total_code_fetch_latency.record(total_code_fetch_latency);
+        self.metrics.total_code_fetch_latency_gauge.set(total_code_fetch_latency.as_secs_f64());
+
+        let total_account_fetch_latency = self.total_account_fetch_latency.duration();
+        self.metrics.total_account_fetch_latency.record(total_account_fetch_latency);
+        self.metrics
+            .total_account_fetch_latency_gauge
+            .set(total_account_fetch_latency.as_secs_f64());
+    }
+}
+
+/// Metrics for the instrumented state provider
+#[derive(Metrics, Clone)]
+#[metrics(scope = "sync.state_provider")]
+pub(crate) struct StateProviderMetrics {
+    /// A histogram of the time it takes to get a storage value
+    storage_fetch_latency: Histogram,
+
+    /// A histogram of the time it takes to get a code value
+    code_fetch_latency: Histogram,
+
+    /// A histogram of the time it takes to get an account value
+    account_fetch_latency: Histogram,
+
+    /// A histogram of the total time we spend fetching storage over the lifetime of this state
+    /// provider
+    total_storage_fetch_latency: Histogram,
+
+    /// A gauge of the total time we spend fetching storage over the lifetime of this state
+    /// provider
+    total_storage_fetch_latency_gauge: Gauge,
+
+    /// A histogram of the total time we spend fetching code over the lifetime of this state
+    /// provider
+    total_code_fetch_latency: Histogram,
+
+    /// A gauge of the total time we spend fetching code over the lifetime of this state provider
+    total_code_fetch_latency_gauge: Gauge,
+
+    /// A histogram of the total time we spend fetching accounts over the lifetime of this state
+    /// provider
+    total_account_fetch_latency: Histogram,
+
+    /// A gauge of the total time we spend fetching accounts over the lifetime of this state
+    /// provider
+    total_account_fetch_latency_gauge: Gauge,
+}
+
+impl<S: AccountReader> AccountReader for InstrumentedStateProvider<S> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        let start = Instant::now();
+        let res = self.state_provider.basic_account(address);
+        self.record_account_fetch(start.elapsed());
+        res
+    }
+}
+
+impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let start = Instant::now();
+        let res = self.state_provider.storage(account, storage_key);
+        self.record_storage_fetch(start.elapsed());
+        res
+    }
+
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        let start = Instant::now();
+        let res = self.state_provider.bytecode_by_hash(code_hash);
+        self.record_code_fetch(start.elapsed());
+        res
+    }
+}
+
+impl<S: StateRootProvider> StateRootProvider for InstrumentedStateProvider<S> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        self.state_provider.state_root(hashed_state)
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        self.state_provider.state_root_from_nodes(input)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.state_provider.state_root_with_updates(hashed_state)
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.state_provider.state_root_from_nodes_with_updates(input)
+    }
+}
+
+impl<S: StateProofProvider> StateProofProvider for InstrumentedStateProvider<S> {
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        self.state_provider.proof(input, address, slots)
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        self.state_provider.multiproof(input, targets)
+    }
+
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+    ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
+        self.state_provider.witness(input, target)
+    }
+}
+
+impl<S: StorageRootProvider> StorageRootProvider for InstrumentedStateProvider<S> {
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        self.state_provider.storage_root(address, hashed_storage)
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        self.state_provider.storage_proof(address, slot, hashed_storage)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        self.state_provider.storage_multiproof(address, slots, hashed_storage)
+    }
+}
+
+impl<S: BlockHashReader> BlockHashReader for InstrumentedStateProvider<S> {
+    fn block_hash(&self, number: alloy_primitives::BlockNumber) -> ProviderResult<Option<B256>> {
+        self.state_provider.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: alloy_primitives::BlockNumber,
+        end: alloy_primitives::BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.state_provider.canonical_hashes_range(start, end)
+    }
+}
+
+impl<S: HashedPostStateProvider> HashedPostStateProvider for InstrumentedStateProvider<S> {
+    fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
+        self.state_provider.hashed_post_state(bundle_state)
+    }
+}

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -32,15 +32,9 @@ pub(crate) struct AtomicDuration {
 }
 
 impl AtomicDuration {
-    /// The zero duration.
-    const ZERO: Self = Self { seconds: AtomicU64::new(0), nanos: AtomicU32::new(0) };
-
-    /// Creates a new [`AtomicDuration`] from a [`Duration`]
-    pub(crate) fn new(duration: Duration) -> Self {
-        Self {
-            seconds: AtomicU64::new(duration.as_secs()),
-            nanos: AtomicU32::new(duration.subsec_nanos()),
-        }
+    /// Returns a zero duration.
+    pub(crate) const fn zero() -> Self {
+        Self { seconds: AtomicU64::new(0), nanos: AtomicU32::new(0) }
     }
 
     /// Returns the duration as a [`Duration`]
@@ -95,9 +89,9 @@ where
         Self {
             state_provider,
             metrics: StateProviderMetrics::default(),
-            total_storage_fetch_latency: AtomicDuration::ZERO,
-            total_code_fetch_latency: AtomicDuration::ZERO,
-            total_account_fetch_latency: AtomicDuration::ZERO,
+            total_storage_fetch_latency: AtomicDuration::zero(),
+            total_code_fetch_latency: AtomicDuration::zero(),
+            total_account_fetch_latency: AtomicDuration::zero(),
         }
     }
 }

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -13,52 +13,48 @@ use reth_trie::{
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 use std::{
-    sync::atomic::{AtomicU32, AtomicU64, Ordering},
+    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, Instant},
 };
 
 /// Nanoseconds per second
 const NANOS_PER_SEC: u32 = 1_000_000_000;
 
-/// An atomic version of [`Duration`], using an [`AtomicU64`] to store the seconds part of the
-/// duration, and an [`AtomicU32`] for the nanoseconds part.
+/// An atomic version of [`Duration`], using an [`AtomicU64`] to store the total nanoseconds in the
+/// duration.
 #[derive(Default)]
 pub(crate) struct AtomicDuration {
-    /// The seconds part of the duration
-    seconds: AtomicU64,
-
     /// The nanoseconds part of the duration
-    nanos: AtomicU32,
+    ///
+    /// We would have to accumulate 584 years of nanoseconds to overflow a u64, so this is
+    /// sufficiently large for our use case. We don't expect to be adding arbitrary durations to
+    /// this value.
+    nanos: AtomicU64,
 }
 
 impl AtomicDuration {
     /// Returns a zero duration.
     pub(crate) const fn zero() -> Self {
-        Self { seconds: AtomicU64::new(0), nanos: AtomicU32::new(0) }
+        Self { nanos: AtomicU64::new(0) }
     }
 
     /// Returns the duration as a [`Duration`]
     pub(crate) fn duration(&self) -> Duration {
-        Duration::new(self.seconds.load(Ordering::Relaxed), self.nanos.load(Ordering::Relaxed))
+        let nanos = self.nanos.load(Ordering::Relaxed);
+        let seconds = nanos / NANOS_PER_SEC as u64;
+        let nanos = nanos % NANOS_PER_SEC as u64;
+        // `as u32` is ok because we did a mod by u32 const
+        Duration::new(seconds, nanos as u32)
     }
 
     /// Adds a [`Duration`] to the atomic duration.
     pub(crate) fn add_duration(&self, duration: Duration) {
-        // add the seconds part of the duration
-        self.seconds.fetch_add(duration.as_secs(), Ordering::Relaxed);
+        // this is `as_nanos` but without the `as u128` - we do not expect durations over 584 years
+        // as input here
+        let total_nanos =
+            duration.as_secs() * NANOS_PER_SEC as u64 + duration.subsec_nanos() as u64;
         // add the nanoseconds part of the duration
-        self.nanos.fetch_add(duration.subsec_nanos(), Ordering::Relaxed);
-
-        // carry over the nanoseconds to the seconds part if the nanoseconds part is greater than 1
-        // second
-        if self.nanos.load(Ordering::Relaxed) >= NANOS_PER_SEC {
-            // get the number of seconds to carry over
-            let carry_over = self.nanos.load(Ordering::Relaxed) / NANOS_PER_SEC;
-            // set the nanoseconds part to the remainder
-            self.nanos.fetch_sub(carry_over * NANOS_PER_SEC, Ordering::Relaxed);
-            // add the carry over to the seconds part
-            self.seconds.fetch_add(carry_over as u64, Ordering::Relaxed);
-        }
+        self.nanos.fetch_add(total_nanos, Ordering::Relaxed);
     }
 }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -66,6 +66,7 @@ use tracing::*;
 mod block_buffer;
 mod cached_state;
 pub mod error;
+mod instrumented_state;
 mod invalid_block_hook;
 mod invalid_headers;
 mod metrics;

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2464,6 +2464,7 @@ where
         ));
         let execution_finish = Instant::now();
         let execution_time = execution_finish.duration_since(execution_start);
+        state_provider.record_total_latency();
         debug!(target: "engine::tree", elapsed = ?execution_time, number=?block_num_hash.number, "Executed block");
 
         // after executing the block we can stop executing transactions

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -17,6 +17,7 @@ use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
 use error::{InsertBlockError, InsertBlockErrorKind, InsertBlockFatalError};
+use instrumented_state::InstrumentedStateProvider;
 use payload_processor::sparse_trie::StateRootComputeOutcome;
 use persistence_state::CurrentPersistenceAction;
 use reth_chain_state::{
@@ -2440,11 +2441,12 @@ where
 
         // Use cached state provider before executing, used in execution after prewarming threads
         // complete
-        let state_provider = CachedStateProvider::new_with_caches(
-            state_provider,
-            handle.caches(),
-            handle.cache_metrics(),
-        );
+        let state_provider =
+            InstrumentedStateProvider::from_state_provider(CachedStateProvider::new_with_caches(
+                state_provider,
+                handle.caches(),
+                handle.cache_metrics(),
+            ));
 
         debug!(target: "engine::tree", block=?block_num_hash, "Executing block");
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -33,6 +33,12 @@ pub struct EngineArgs {
     #[arg(long = "engine.disable-caching-and-prewarming")]
     pub caching_and_prewarming_disabled: bool,
 
+    /// Enable state provider latency metrics. This allows the engine to collect and report stats
+    /// about how long state provider calls took during execution, but this does introduce slight
+    /// overhead to state provider calls.
+    #[arg(long = "engine.state-provider-metrics", default_value = "false")]
+    pub state_provider_metrics: bool,
+
     /// Configure the size of cross-block cache in megabytes
     #[arg(long = "engine.cross-block-cache-size", default_value_t = DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB)]
     pub cross_block_cache_size: u64,
@@ -64,6 +70,7 @@ impl Default for EngineArgs {
             state_root_task_compare_updates: false,
             caching_and_prewarming_enabled: true,
             caching_and_prewarming_disabled: false,
+            state_provider_metrics: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB,
             accept_execution_requests_hash: false,
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
@@ -80,6 +87,7 @@ impl EngineArgs {
             .with_memory_block_buffer_target(self.memory_block_buffer_target)
             .with_legacy_state_root(self.legacy_state_root_task_enabled)
             .without_caching_and_prewarming(self.caching_and_prewarming_disabled)
+            .with_state_provider_metrics(self.state_provider_metrics)
             .with_always_compare_trie_updates(self.state_root_task_compare_updates)
             .with_cross_block_cache_size(self.cross_block_cache_size * 1024 * 1024)
             .with_max_proof_task_concurrency(self.max_proof_task_concurrency)


### PR DESCRIPTION
This adds a state provider that tracks metrics for:
* How long it takes to fetch storage
* How long it takes to fetch an account
* How long it takes to fetch code
* How long total, we spent in accounts during execution
* How long total, we spent in storage fetching during execution
* How long total, we spent in code fetching during execution