### PR TITLE
chore: move HeaderSyncGap type 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9390,7 +9390,6 @@ dependencies = [
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
- "reth-network-p2p",
  "reth-nippy-jar",
  "reth-node-types",
  "reth-primitives-traits",

--- a/crates/net/p2p/src/headers/downloader.rs
+++ b/crates/net/p2p/src/headers/downloader.rs
@@ -4,7 +4,7 @@ use alloy_eips::{eip1898::BlockWithParent, BlockHashOrNumber};
 use alloy_primitives::{Sealable, B256};
 use futures::Stream;
 use reth_consensus::HeaderValidator;
-use reth_primitives_traits::{BlockHeader, SealedHeader, Header};
+use reth_primitives_traits::{BlockHeader, Header, SealedHeader};
 use std::fmt::Debug;
 
 /// A downloader capable of fetching and yielding block headers.

--- a/crates/net/p2p/src/headers/downloader.rs
+++ b/crates/net/p2p/src/headers/downloader.rs
@@ -4,7 +4,7 @@ use alloy_eips::{eip1898::BlockWithParent, BlockHashOrNumber};
 use alloy_primitives::{Sealable, B256};
 use futures::Stream;
 use reth_consensus::HeaderValidator;
-use reth_primitives_traits::{BlockHeader, SealedHeader};
+use reth_primitives_traits::{BlockHeader, SealedHeader, Header};
 use std::fmt::Debug;
 
 /// A downloader capable of fetching and yielding block headers.
@@ -75,6 +75,27 @@ impl SyncTarget {
             Self::Tip(tip) => (*tip).into(),
             Self::Gap(gap) => gap.parent.into(),
             Self::TipNum(num) => (*num).into(),
+        }
+    }
+}
+
+/// Represents a gap to sync: from `local_head` to `target`
+#[derive(Clone, Debug)]
+pub struct HeaderSyncGap<H = Header> {
+    /// The local head block. Represents lower bound of sync range.
+    pub local_head: SealedHeader<H>,
+
+    /// The sync target. Represents upper bound of sync range.
+    pub target: SyncTarget,
+}
+
+impl<H: BlockHeader + Sealable> HeaderSyncGap<H> {
+    /// Returns `true` if the gap from the head to the target was closed
+    #[inline]
+    pub fn is_closed(&self) -> bool {
+        match self.target.tip() {
+            BlockHashOrNumber::Hash(hash) => self.local_head.hash() == hash,
+            BlockHashOrNumber::Number(num) => self.local_head.number() == num,
         }
     }
 }

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -13,7 +13,7 @@ use reth_db_api::{
 };
 use reth_etl::Collector;
 use reth_network_p2p::headers::{
-    downloader::{HeaderDownloader, SyncTarget, HeaderSyncGap},
+    downloader::{HeaderDownloader, HeaderSyncGap, SyncTarget},
     error::HeadersDownloaderError,
 };
 use reth_primitives_traits::{serde_bincode_compat, FullBlockHeader, NodePrimitives, SealedHeader};

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -13,12 +13,12 @@ use reth_db_api::{
 };
 use reth_etl::Collector;
 use reth_network_p2p::headers::{
-    downloader::{HeaderDownloader, SyncTarget},
+    downloader::{HeaderDownloader, SyncTarget, HeaderSyncGap},
     error::HeadersDownloaderError,
 };
 use reth_primitives_traits::{serde_bincode_compat, FullBlockHeader, NodePrimitives, SealedHeader};
 use reth_provider::{
-    providers::StaticFileWriter, BlockHashReader, DBProvider, HeaderProvider, HeaderSyncGap,
+    providers::StaticFileWriter, BlockHashReader, DBProvider, HeaderProvider,
     HeaderSyncGapProvider, StaticFileProviderFactory,
 };
 use reth_stages_api::{

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -21,7 +21,6 @@ reth-fs-util.workspace = true
 reth-errors.workspace = true
 reth-storage-errors.workspace = true
 reth-storage-api = { workspace = true, features = ["std", "db-api"] }
-reth-network-p2p.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true
 reth-prune-types.workspace = true
@@ -95,7 +94,6 @@ test-utils = [
     "reth-ethereum-primitives/test-utils",
     "reth-chainspec/test-utils",
     "reth-evm/test-utils",
-    "reth-network-p2p/test-utils",
     "reth-primitives-traits/test-utils",
     "reth-codecs/test-utils",
     "reth-db-api/test-utils",

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -649,25 +649,22 @@ mod tests {
     use crate::{
         providers::{StaticFileProvider, StaticFileWriter},
         test_utils::{blocks::TEST_BLOCK, create_test_provider_factory, MockNodeTypesWithDB},
-        BlockHashReader, BlockNumReader, BlockWriter, DBProvider, HeaderSyncGap,
-        HeaderSyncGapProvider, StorageLocation, TransactionsProvider,
+        BlockHashReader, BlockNumReader, BlockWriter, DBProvider, HeaderSyncGapProvider,
+        StorageLocation, TransactionsProvider,
     };
     use alloy_primitives::{TxNumber, B256, U256};
     use assert_matches::assert_matches;
-    use rand::Rng;
     use reth_chainspec::ChainSpecBuilder;
     use reth_db::{
         mdbx::DatabaseArguments,
         test_utils::{create_test_static_files_dir, ERROR_TEMPDIR},
     };
     use reth_db_api::tables;
-    use reth_network_p2p::headers::downloader::SyncTarget;
     use reth_primitives_traits::SignedTransaction;
     use reth_prune_types::{PruneMode, PruneModes};
     use reth_storage_errors::provider::ProviderError;
     use reth_testing_utils::generators::{self, random_block, random_header, BlockParams};
     use std::{ops::RangeInclusive, sync::Arc};
-    use tokio::sync::watch;
 
     #[test]
     fn common_history_provider() {
@@ -797,8 +794,6 @@ mod tests {
         let provider = factory.provider_rw().unwrap();
 
         let mut rng = generators::rng();
-        let consensus_tip = rng.random();
-        let (_tip_tx, tip_rx) = watch::channel(consensus_tip);
 
         // Genesis
         let checkpoint = 0;
@@ -820,9 +815,7 @@ mod tests {
         drop(static_file_writer);
 
         let local_head = provider.local_tip_header(checkpoint).unwrap();
-        let gap = HeaderSyncGap { local_head, target: SyncTarget::Tip(*tip_rx.borrow()) };
 
-        assert_eq!(gap.local_head, head);
-        assert_eq!(gap.target.tip(), consensus_tip.into());
+        assert_eq!(local_head, head);
     }
 }

--- a/crates/storage/provider/src/traits/header_sync_gap.rs
+++ b/crates/storage/provider/src/traits/header_sync_gap.rs
@@ -1,43 +1,15 @@
-use alloy_consensus::{BlockHeader, Header};
-use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{BlockNumber, Sealable};
-use reth_network_p2p::headers::downloader::SyncTarget;
-use reth_primitives_traits::SealedHeader;
+use reth_primitives_traits::{BlockHeader, SealedHeader};
+use alloy_primitives::BlockNumber;
 use reth_storage_errors::provider::ProviderResult;
 
-/// Represents a gap to sync: from `local_head` to `target`
-#[derive(Clone, Debug)]
-pub struct HeaderSyncGap<H = Header> {
-    /// The local head block. Represents lower bound of sync range.
-    pub local_head: SealedHeader<H>,
-
-    /// The sync target. Represents upper bound of sync range.
-    pub target: SyncTarget,
-}
-
-impl<H: BlockHeader + Sealable> HeaderSyncGap<H> {
-    /// Returns `true` if the gap from the head to the target was closed
-    #[inline]
-    pub fn is_closed(&self) -> bool {
-        match self.target.tip() {
-            BlockHashOrNumber::Hash(hash) => self.local_head.hash() == hash,
-            BlockHashOrNumber::Number(num) => self.local_head.number() == num,
-        }
-    }
-}
-
-/// Client trait for determining the current headers sync gap.
-#[auto_impl::auto_impl(&, Arc)]
+/// Provider for getting the local tip header for sync gap calculation.
 pub trait HeaderSyncGapProvider: Send + Sync {
     /// The header type.
-    type Header: Send + Sync;
+    type Header: BlockHeader;
 
-    /// Find a current sync gap for the headers depending on the last
-    /// uninterrupted block number. Last uninterrupted block represents the block number before
-    /// which there are no gaps. It's up to the caller to ensure that last uninterrupted block is
-    /// determined correctly.
+    /// Returns the local tip header for the given highest uninterrupted block.
     fn local_tip_header(
         &self,
         highest_uninterrupted_block: BlockNumber,
     ) -> ProviderResult<SealedHeader<Self::Header>>;
-}
+} 

--- a/crates/storage/provider/src/traits/header_sync_gap.rs
+++ b/crates/storage/provider/src/traits/header_sync_gap.rs
@@ -1,5 +1,5 @@
-use reth_primitives_traits::{BlockHeader, SealedHeader};
 use alloy_primitives::BlockNumber;
+use reth_primitives_traits::{BlockHeader, SealedHeader};
 use reth_storage_errors::provider::ProviderResult;
 
 /// Provider for getting the local tip header for sync gap calculation.
@@ -12,4 +12,4 @@ pub trait HeaderSyncGapProvider: Send + Sync {
         &self,
         highest_uninterrupted_block: BlockNumber,
     ) -> ProviderResult<SealedHeader<Self::Header>>;
-} 
+}

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -7,7 +7,7 @@ mod block;
 pub use block::*;
 
 mod header_sync_gap;
-pub use header_sync_gap::{HeaderSyncGap, HeaderSyncGapProvider};
+pub use header_sync_gap::HeaderSyncGapProvider;
 
 mod state;
 pub use state::StateWriter;


### PR DESCRIPTION
HeaderSyncGap type has been moved to an appropriate location with all imports reflecting the change. All unit tests and doc tests are passing. There is one warning about an unused import, but for the sake of keeping PRs as discrete as possible I have left it as is. Also made a slight improvement, in that the change from `Send + Sync` to `BlockHeader` trait bound is better because it specifically states what functionality a header type must provide for sync gap calculations rather than just requiring thread-safety traits. 

If anyone has questions or wants to provide feedback, this is always appreciated!