### PR TITLE
refactor(storage-api): move statewriter trait to storage-api crate

### DIFF
--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -9,9 +9,6 @@ pub use block::*;
 mod header_sync_gap;
 pub use header_sync_gap::{HeaderSyncGap, HeaderSyncGapProvider};
 
-mod state;
-pub use state::StateWriter;
-
 pub use reth_chainspec::ChainSpecProvider;
 
 mod static_file_provider;

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -96,3 +96,6 @@ pub use block_indices::*;
 
 mod block_writer;
 pub use block_writer::*;
+
+mod state_writer;
+pub use state_writer::*;

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::BlockNumber;
 use reth_execution_types::ExecutionOutcome;
 use reth_storage_errors::provider::ProviderResult;
-use reth_trie::HashedPostStateSorted;
+use reth_trie_common::HashedPostStateSorted;
 use revm_database::{
     states::{PlainStateReverts, StateChangeset},
     OriginalValuesKnown,


### PR DESCRIPTION
Fixes- #15889 