### PR TITLE
chore: Remove unused `write_to_db` method in `ef-tests`

### DIFF
--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -6,12 +6,8 @@ use alloy_eips::eip4895::Withdrawals;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{keccak256, Address, Bloom, Bytes, B256, B64, U256};
 use reth_chainspec::{ChainSpec, ChainSpecBuilder};
-use reth_db_api::{
-    cursor::DbDupCursorRO,
-    tables,
-    transaction::{DbTx, DbTxMut},
-};
-use reth_primitives_traits::{Account as RethAccount, Bytecode, SealedHeader, StorageEntry};
+use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
+use reth_primitives_traits::SealedHeader;
 use serde::Deserialize;
 use std::{collections::BTreeMap, ops::Deref};
 
@@ -157,42 +153,6 @@ pub struct TransactionSequence {
 pub struct State(BTreeMap<Address, Account>);
 
 impl State {
-    /// Write the state to the database.
-    pub fn write_to_db(&self, tx: &impl DbTxMut) -> Result<(), Error> {
-        for (&address, account) in &self.0 {
-            let hashed_address = keccak256(address);
-            let has_code = !account.code.is_empty();
-            let code_hash = has_code.then(|| keccak256(&account.code));
-            let reth_account = RethAccount {
-                balance: account.balance,
-                nonce: account.nonce.to::<u64>(),
-                bytecode_hash: code_hash,
-            };
-            tx.put::<tables::PlainAccountState>(address, reth_account)?;
-            tx.put::<tables::HashedAccounts>(hashed_address, reth_account)?;
-
-            if let Some(code_hash) = code_hash {
-                tx.put::<tables::Bytecodes>(code_hash, Bytecode::new_raw(account.code.clone()))?;
-            }
-
-            for (k, v) in &account.storage {
-                if v.is_zero() {
-                    continue
-                }
-                let storage_key = B256::from_slice(&k.to_be_bytes::<32>());
-                tx.put::<tables::PlainStorageState>(
-                    address,
-                    StorageEntry { key: storage_key, value: *v },
-                )?;
-                tx.put::<tables::HashedStorages>(
-                    hashed_address,
-                    StorageEntry { key: keccak256(storage_key), value: *v },
-                )?;
-            }
-        }
-        Ok(())
-    }
-
     /// Return state as genesis state.
     pub fn into_genesis_state(self) -> BTreeMap<Address, GenesisAccount> {
         self.0


### PR DESCRIPTION
This method was previously used to write the pre-state from the execution spec tests into the database, however we now convert that pre-state into `GenesisAccount`s and re-use the `insert_genesis` logic already in the codebase.