### PR TITLE
docs: add docs about CachedReads

### DIFF
--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -11,8 +11,8 @@ use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
 /// This is intended to be used in conjunction with `revm::db::State`
 /// during payload building which repeatedly accesses the same data.
 ///
-/// [`CachedReads::as_db_mut`] transforms this type into a [`Database`] implementation that uses [`CachedReads`] as a caching
-/// layer for operations, and records any cache misses.
+/// [`CachedReads::as_db_mut`] transforms this type into a [`Database`] implementation that uses
+/// [`CachedReads`] as a caching layer for operations, and records any cache misses.
 ///
 /// # Example
 ///

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -11,6 +11,10 @@ use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
 /// This is intended to be used in conjunction with `revm::db::State`
 /// during payload building which repeatedly accesses the same data.
 ///
+/// Given a [`Database`] [`CachedReads::as_db_mut`] transforms this type into a [`Database`]
+/// implementation uses [`CachedReads`] as a caching layer for [`Database`] operations and records
+/// any cache misses.
+///
 /// # Example
 ///
 /// ```

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -11,7 +11,7 @@ use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
 /// This is intended to be used in conjunction with `revm::db::State`
 /// during payload building which repeatedly accesses the same data.
 ///
-/// Transforms this type into a [`Database`] implementation that uses [`CachedReads`] as a caching
+/// [`CachedReads::as_db_mut`] transforms this type into a [`Database`] implementation that uses [`CachedReads`] as a caching
 /// layer for operations, and records any cache misses.
 ///
 /// # Example

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -11,9 +11,8 @@ use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
 /// This is intended to be used in conjunction with `revm::db::State`
 /// during payload building which repeatedly accesses the same data.
 ///
-/// Given a [`Database`] [`CachedReads::as_db_mut`] transforms this type into a [`Database`]
-/// implementation uses [`CachedReads`] as a caching layer for [`Database`] operations and records
-/// any cache misses.
+/// Transforms this type into a [`Database`] implementation that uses [`CachedReads`] as a caching
+/// layer for operations, and records any cache misses.
 ///
 /// # Example
 ///

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -173,6 +173,8 @@ where
         let mut accessed_blacklisted = None;
         let output = executor.execute_with_state_closure(&block, |state| {
             if !self.disallow.is_empty() {
+                // Check whether the submission interacted with any blacklisted account by scanning
+                // the `State`'s cache that records everything read form database during execution.
                 for account in state.cache.accounts.keys() {
                     if self.disallow.contains(account) {
                         accessed_blacklisted = Some(*account);
@@ -181,12 +183,12 @@ where
             }
         })?;
 
-        // update the cached reads
-        self.update_cached_reads(parent_header_hash, request_cache).await;
-
         if let Some(account) = accessed_blacklisted {
             return Err(ValidationApiError::Blacklist(account))
         }
+
+        // update the cached reads
+        self.update_cached_reads(parent_header_hash, request_cache).await;
 
         self.consensus.validate_block_post_execution(&block, &output)?;
 


### PR DESCRIPTION
adds some additional docs to `CachedReads`.

also skips cache update for disallowed blocks in `validate_message_against_block`, even though this was fine before. 