### PR TITLE
chore: fix typo and remove redundant article in comments

### DIFF
--- a/crates/optimism/txpool/src/supervisor/client.rs
+++ b/crates/optimism/txpool/src/supervisor/client.rs
@@ -24,7 +24,7 @@ use tracing::trace;
 pub const DEFAULT_SUPERVISOR_URL: &str = "http://localhost:1337/";
 
 /// The default request timeout to use
-const DEFAULT_REQUEST_TIMOUT: Duration = Duration::from_millis(100);
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Implementation of the supervisor trait for the interop.
 #[derive(Debug, Clone)]
@@ -48,7 +48,7 @@ impl SupervisorClient {
         Self {
             client,
             safety,
-            timeout: DEFAULT_REQUEST_TIMOUT,
+            timeout: DEFAULT_REQUEST_TIMEOUT,
             metrics: SupervisorMetrics::default(),
         }
     }

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -76,7 +76,7 @@ impl BlockchainTestCase {
         name.contains("UncleFromSideChain")
     }
 
-    /// If the test expects an exception, return the the block number
+    /// If the test expects an exception, return the block number
     /// at which it must occur together with the original message.
     ///
     /// Note: There is a +1 here because the genesis block is not included


### PR DESCRIPTION


This pull request includes two improvements to the codebase:

1. Corrects the spelling of `DEFAULT_REQUEST_TIMEOUT` constant (previously misspelled as `DEFAULT_REQUEST_TIMOUT`) in both its definition and usage in the SupervisorClient struct.

2. Removes the redundant article "the" from the comment in blockchain_test.rs, improving the clarity of the documentation. The comment now reads more concisely while maintaining its meaning.

These changes enhance code readability and maintain consistent naming conventions throughout the project.
