### PR TITLE
feat: add split_ref method to SealedHeader (#15917)

### DIFF
--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -99,6 +99,11 @@ impl<H: Sealable> SealedHeader<H> {
         let hash = self.hash();
         (self.header, hash)
     }
+
+    /// Returns references to both the header and hash without taking ownership.
+    pub fn split_ref(&self) -> (&H, &BlockHash) {
+        (self.header(), self.hash_ref())
+    }
 }
 
 impl<H: Sealable> SealedHeader<&H> {


### PR DESCRIPTION
This is in response to #15917
