### PR TITLE
fix: typos in comments

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions.rs
@@ -379,7 +379,7 @@ impl<I: Sync + Send + 'static> Action<I> for Sequence<I> {
     }
 }
 
-/// Action that braodcasts the next new payload
+/// Action that broadcasts the next new payload
 #[derive(Debug, Default)]
 pub struct BroadcastNextNewPayload {}
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1708,7 +1708,7 @@ where
     ///
     /// Assumes that `finish` has been called on the `persistence_state` at least once
     fn on_new_persisted_block(&mut self) -> ProviderResult<()> {
-        // If we have an on-disk reorg, we need to handle it firsrt before touching the in-memory
+        // If we have an on-disk reorg, we need to handle it first before touching the in-memory
         // state.
         if let Some(remove_above) = self.find_disk_reorg()? {
             self.remove_blocks(remove_above);


### PR DESCRIPTION
This PR fixes two minor typos in comments:
- Corrects "braodcasts" to "broadcasts" in the test utils actions file
- Corrects "firsrt" to "first" in the engine tree module

These changes only affect comments and have no functional impact on the code.