### PR TITLE
fix: avoid cloning receipts on verification for op

### DIFF
--- a/crates/optimism/consensus/src/validation/mod.rs
+++ b/crates/optimism/consensus/src/validation/mod.rs
@@ -126,7 +126,7 @@ fn verify_receipts_optimism<R: DepositReceipt>(
     timestamp: u64,
 ) -> Result<(), ConsensusError> {
     // Calculate receipts root.
-    let receipts_with_bloom = receipts.iter().cloned().map(Into::into).collect::<Vec<_>>();
+    let receipts_with_bloom = receipts.iter().map(TxReceipt::with_bloom_ref).collect::<Vec<_>>();
     let receipts_root =
         calculate_receipt_root_optimism(&receipts_with_bloom, chain_spec, timestamp);
 


### PR DESCRIPTION
Changes `calculate_receipt_root_optimism` to accept references to receipts. Changed tests a bit as it's tricky to make it work for both owned and borrowed receipt generic