### PR TITLE
docs: add engine API builder docs

### DIFF
--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -42,10 +42,16 @@ pub use invalid_block_hook::InvalidBlockHook;
 pub mod config;
 pub use config::*;
 
-/// This type defines the versioned types of the engine API.
+/// This type defines the versioned types of the engine API based on the [ethereum engine API](https://github.com/ethereum/execution-apis/tree/main/src/engine).
 ///
 /// This includes the execution payload types and payload attributes that are used to trigger a
 /// payload job. Hence this trait is also [`PayloadTypes`].
+///
+/// Implementations of this type are intended to be stateless and just define the types as
+/// associated types.
+/// This type is intended for non-ethereum chains that closely mirror the ethereum engine API spec,
+/// but may have different payload, for example opstack, but structurally equivalent otherwise (same
+/// engine API RPC endpoints for example).
 pub trait EngineTypes:
     PayloadTypes<
         BuiltPayload: TryInto<Self::ExecutionPayloadEnvelopeV1>

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -688,11 +688,19 @@ where
 }
 
 /// Builder for engine API RPC module.
+///
+/// This builder type is responsible for providing an instance of [`IntoEngineApiRpcModule`], which
+/// is effectively a helper trait that provides the type erased [`jsonrpsee::RpcModule`] instance
+/// that contains the method handlers for the engine API. See [`EngineApi`] for an implementation of
+/// [`IntoEngineApiRpcModule`].
 pub trait EngineApiBuilder<Node: FullNodeComponents>: Send + Sync {
-    /// The engine API RPC module. Only required to be convertible to an [`jsonrpsee`] module.
+    /// The engine API RPC module. Only required to be convertible to an [`jsonrpsee::RpcModule`].
     type EngineApi: IntoEngineApiRpcModule + Send + Sync;
 
-    /// Builds the engine API.
+    /// Builds the engine API instance given the provided context.
+    ///
+    /// [`Self::EngineApi`] will be converted into the method handlers of the authenticated RPC
+    /// server (engine API).
     fn build_engine_api(
         self,
         ctx: &AddOnsContext<'_, Node>,
@@ -700,6 +708,10 @@ pub trait EngineApiBuilder<Node: FullNodeComponents>: Send + Sync {
 }
 
 /// Builder for basic [`EngineApi`] implementation.
+///
+/// This provides a basic default implementation for opstack and ethereum engine API via
+/// [`EngineTypes`] and uses the general purpose [`EngineApi`] implementation as the builder's
+/// output.
 #[derive(Debug, Default)]
 pub struct BasicEngineApiBuilder<EV> {
     engine_validator_builder: EV,

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -697,7 +697,7 @@ pub trait EngineApiBuilder<Node: FullNodeComponents>: Send + Sync {
     /// The engine API RPC module. Only required to be convertible to an [`jsonrpsee::RpcModule`].
     type EngineApi: IntoEngineApiRpcModule + Send + Sync;
 
-    /// Builds the engine API instance given the provided context.
+    /// Builds the engine API instance given the provided [`AddOnsContext`].
     ///
     /// [`Self::EngineApi`] will be converted into the method handlers of the authenticated RPC
     /// server (engine API).

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -53,8 +53,10 @@ const MAX_BLOB_LIMIT: usize = 128;
 /// ## Implementers
 ///
 /// Implementing support for an engine API jsonrpsee RPC handler is done by defining the engine API
-/// server trait and implementing it on a type that can wrap this [`EngineApi`] type.
-/// See also [`EngineApiServer`] implementation for this type which is the L1 implementation.
+/// server trait and implementing it on a type that can either wrap this [`EngineApi`] type or
+/// provide an [`EngineTypes`] implementation if it mirrors ethereum's versioned engine API
+/// endpoints (e.g. opstack). See also [`EngineApiServer`] implementation for this type which is the
+/// L1 implementation.
 pub struct EngineApi<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSpec> {
     inner: Arc<EngineApiInner<Provider, PayloadT, Pool, Validator, ChainSpec>>,
 }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -54,8 +54,9 @@ const MAX_BLOB_LIMIT: usize = 128;
 ///
 /// Implementing support for an engine API jsonrpsee RPC handler is done by defining the engine API
 /// server trait and implementing it on a type that can either wrap this [`EngineApi`] type or
-/// provide an [`EngineTypes`] implementation if it mirrors ethereum's versioned engine API
-/// endpoints (e.g. opstack). See also [`EngineApiServer`] implementation for this type which is the
+/// use a custom [`EngineTypes`] implementation if it mirrors ethereum's versioned engine API
+/// endpoints (e.g. opstack).
+/// See also [`EngineApiServer`] implementation for this type which is the
 /// L1 implementation.
 pub struct EngineApi<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSpec> {
     inner: Arc<EngineApiInner<Provider, PayloadT, Pool, Validator, ChainSpec>>,


### PR DESCRIPTION
adds docs that describe what this is used for