### PR TITLE
docs: update docs

### DIFF
--- a/book/jsonrpc/intro.md
+++ b/book/jsonrpc/intro.md
@@ -58,7 +58,7 @@ To enable JSON-RPC namespaces on the HTTP server, pass each namespace separated 
 reth node --http --http.api eth,net,trace
 ```
 
-You can pass the `all` option, which is a convenient wrapper for the all the JSON-RPC namespaces `admin,debug,eth,net,trace,txpool,web3,rpc` on the HTTP server:
+You can pass the `all` option, which is a convenient wrapper for all the JSON-RPC namespaces `admin,debug,eth,net,trace,txpool,web3,rpc` on the HTTP server:
 
 ```bash
 reth node --http --http.api all

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -188,7 +188,7 @@ impl<Payload: PayloadTypes> Display for BeaconEngineMessage<Payload> {
     }
 }
 
-/// A clonable sender type that can be used to send engine API messages.
+/// A cloneable sender type that can be used to send engine API messages.
 ///
 /// This type mirrors consensus related functions of the engine API.
 #[derive(Debug, Clone)]

--- a/testing/ef-tests/src/suite.rs
+++ b/testing/ef-tests/src/suite.rs
@@ -21,7 +21,7 @@ pub trait Suite {
     /// - `BlockchainTests/TransitionTests`
     fn suite_name(&self) -> String;
 
-    /// Load an run each contained test case.
+    /// Load and run each contained test case.
     ///
     /// # Note
     ///


### PR DESCRIPTION
This PR fixes several typos and grammar issues in the documentation:

1. Removes duplicate "the" in book/jsonrpc/intro.md:
- Before: "wrapper for the all the JSON-RPC namespaces"
- After: "wrapper for all the JSON-RPC namespaces"

2. Fixes typo in testing/ef-tests/src/suite.rs:
- Before: "Load an run each contained test case"
- After: "Load and run each contained test case"

3. Fixes typo in crates/engine/primitives/src/message.rs:
- Before: "clonable"
- After: "cloneable"

These changes improve readability and correctness of the documentation.