### PR TITLE
perf(engine): drop sparse trie after task returned result

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -170,7 +170,7 @@ where
             multi_proof_task.run();
         });
 
-        let sparse_trie_task = SparseTrieTask::new(
+        let mut sparse_trie_task = SparseTrieTask::new(
             self.executor.clone(),
             sparse_trie_rx,
             proof_task.handle(),


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/pull/15092 didn't actually solve it, because we initialized the `SparseStateTrie` inside the `run` method body, so it got dropped when we returned.