### PR TITLE
fix: Remove redundant article and add missing apostrophe

### DIFF
--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -439,7 +439,7 @@ struct NetworkInner<N: NetworkPrimitives = EthNetworkPrimitives> {
     secret_key: SecretKey,
     /// The identifier used by this node.
     local_peer_id: PeerId,
-    /// Access to the all the nodes.
+    /// Access to all the nodes.
     peers: PeersHandle,
     /// The mode of the network
     network_mode: NetworkMode,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -116,7 +116,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     let SimBlock { block_overrides, state_overrides, calls } = block;
 
                     if let Some(block_overrides) = block_overrides {
-                        // ensure we dont allow uncapped gas limit per block
+                        // ensure we don't allow uncapped gas limit per block
                         if let Some(gas_limit_override) = block_overrides.gas_limit {
                             if gas_limit_override > evm_env.block_env.gas_limit &&
                                 gas_limit_override > this.call_gas_limit()

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -131,7 +131,7 @@ fn arbitrary_storage_root() {
 }
 
 #[test]
-// This ensures we dont add empty accounts to the trie
+// This ensures we don't add empty accounts to the trie
 fn test_empty_account() {
     let state: State = BTreeMap::from([
         (


### PR DESCRIPTION
This PR fixes two minor grammar issues:

1. Removes redundant "the" article in the comment "Access to the all the nodes"
2. Adds missing apostrophe in "dont" -> "don't" in the gas limit check comment

These changes improve code documentation readability without affecting functionality.