### PR TITLE
chore: update broken link

### DIFF
--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -8,7 +8,7 @@
 //!
 //! This launches a regular reth node overriding the engine api payload builder with our custom.
 //!
-//! Credits to: <https://blog.merkle.io/blog/fastest-transaction-network-eth-polygon-bsc>
+//! Credits to: <https://merkle.io/blog/modifying-reth-to-build-the-fastest-transaction-network-on-bsc-and-polygon>
 
 use chainspec::{boot_nodes, bsc_chain_spec, head};
 use handshake::BscHandshake;

--- a/examples/polygon-p2p/src/main.rs
+++ b/examples/polygon-p2p/src/main.rs
@@ -8,7 +8,7 @@
 //!
 //! This launches a regular reth node overriding the engine api payload builder with our custom.
 //!
-//! Credits to: <https://blog.merkle.io/blog/fastest-transaction-network-eth-polygon-bsc>
+//! Credits to: <https://merkle.io/blog/modifying-reth-to-build-the-fastest-transaction-network-on-bsc-and-polygon>
 
 #![warn(unused_crate_dependencies)]
 


### PR DESCRIPTION
Hey! I found dead link to blog.merkle.io Updated the link to the current version
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/ce5f1f18-f893-4c3f-8c3d-c8b904cb1048" />
[webArchive - jan 18, 2024](https://web.archive.org/web/20240227234540/https://blog.merkle.io/)