### PR TITLE
Rename metrics for getBlobsV2

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -938,10 +938,17 @@ where
 
         if let Ok(blobs) = &res {
             let blobs_found = blobs.iter().flatten().count();
-            let blobs_missed = hashes_len - blobs_found;
 
-            self.inner.metrics.blob_metrics.blob_count.increment(blobs_found as u64);
-            self.inner.metrics.blob_metrics.blob_misses.increment(blobs_missed as u64);
+            self.inner.metrics.blob_metrics.get_blobs_requests_blobs_total.increment(hashes_len as u64);
+            self.inner.metrics.blob_metrics.get_blobs_requests_blobs_in_blobpool_total.increment(blobs_found as u64);
+
+            if blobs_found == hashes_len {
+                self.inner.metrics.blob_metrics.get_blobs_requests_success_total.increment(1);
+            } else {
+                self.inner.metrics.blob_metrics.get_blobs_requests_failure_total.increment(1);
+            }
+        } else {
+            self.inner.metrics.blob_metrics.get_blobs_requests_failure_total.increment(1);
         }
 
         res

--- a/crates/rpc/rpc-engine-api/src/metrics.rs
+++ b/crates/rpc/rpc-engine-api/src/metrics.rs
@@ -119,6 +119,15 @@ pub(crate) struct BlobMetrics {
     pub(crate) blob_count: Counter,
     /// Count of blob misses
     pub(crate) blob_misses: Counter,
+
+    /// Number of blobs requested via getBlobsV2
+    pub(crate) get_blobs_requests_blobs_total: Counter,
+    /// Number of blobs requested via getBlobsV2 that are present in the blobpool
+    pub(crate) get_blobs_requests_blobs_in_blobpool_total : Counter,
+    /// Number of times getBlobsV2 responded with “hit”
+    pub(crate) get_blobs_requests_success_total: Counter,
+    /// Number of times getBlobsV2 responded with “miss”
+    pub(crate) get_blobs_requests_failure_total : Counter,
 }
 
 impl NewPayloadStatusResponseMetrics {


### PR DESCRIPTION
This PR renames execution metrics for the new `engine_getBlobsV2` rpc for peerdas. 
This rename is for unifying the execution metric naming, shown in [this proposal](https://testinprod.notion.site/Proposal-for-Unified-EL-metrics-for-PeerDAS-1d28fc57f54680f2a3cbfe408d7db4b8?pvs=4).

Since reth has metric prefix like `engine.rpc.blobs`, the exact metric naming won't be identical, but it will be easier for searching and indexing across different ELs.