### PR TITLE
docs: Fix typos and grammar in documentation comments

### DIFF
--- a/crates/engine/primitives/src/error.rs
+++ b/crates/engine/primitives/src/error.rs
@@ -3,7 +3,7 @@ use alloy_rpc_types_engine::ForkchoiceUpdateError;
 
 /// Represents all error cases when handling a new payload.
 ///
-/// This represents all possible error cases that must be returned as JSON RCP errors back to the
+/// This represents all possible error cases that must be returned as JSON RPC errors back to the
 /// beacon node.
 #[derive(Debug, thiserror::Error)]
 pub enum BeaconOnNewPayloadError {

--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -1,4 +1,4 @@
-//! Example for how hook into the bsc p2p network
+//! Example for how to hook into the bsc p2p network
 //!
 //! Run with
 //!

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -6,7 +6,7 @@
 //! cargo run -p rpc-db
 //! ```
 //!
-//! This installs an additional RPC method `myrpcExt_customMethod` that can queried via [cast](https://github.com/foundry-rs/foundry)
+//! This installs an additional RPC method `myrpcExt_customMethod` that can be queried via [cast](https://github.com/foundry-rs/foundry)
 //!
 //! ```sh
 //! cast rpc myrpcExt_customMethod


### PR DESCRIPTION
## Description:

**This PR addresses several documentation issues:**
- Corrects `RCP` to `RPC` in `error.rs` documentation
- Adds missing `to` in `bsc-p2p` example documentation (`how hook` -> `how to hook`)
- Adds missing `be` in `rpc-db` example documentation (`can queried` -> `can be queried`)

These changes improve readability and correctness of the documentation without affecting any functionality.