### PR TITLE
minor docstring fixups

### DIFF
--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -174,7 +174,7 @@ where
         let output = executor.execute_with_state_closure(&block, |state| {
             if !self.disallow.is_empty() {
                 // Check whether the submission interacted with any blacklisted account by scanning
-                // the `State`'s cache that records everything read form database during execution.
+                // the `State`'s cache that records everything read from database during execution.
                 for account in state.cache.accounts.keys() {
                     if self.disallow.contains(account) {
                         accessed_blacklisted = Some(*account);

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -74,7 +74,7 @@ where
     executor_provider: E,
     /// The consensus instance for validating blocks.
     consensus: Arc<dyn FullConsensus<E::Primitives, Error = ConsensusError>>,
-    /// The consensu
+    /// The consensus
     /// The commit thresholds of the execution stage.
     thresholds: ExecutionStageThresholds,
     /// The highest threshold (in number of blocks) for switching between incremental

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -607,7 +607,7 @@ mod tests {
                         result.insert(
                             ShardedKey::new(
                                 address,
-                                *list.last().expect("Chuck does not return empty list")
+                                *list.last().expect("Chunk does not return empty list")
                                     as BlockNumber,
                             ),
                             list,

--- a/crates/stages/stages/src/stages/s3/downloader/worker.rs
+++ b/crates/stages/stages/src/stages/s3/downloader/worker.rs
@@ -28,7 +28,7 @@ pub(crate) enum WorkerRequest {
     Finish,
 }
 
-/// Spawns the requested number of workers and returns a `UnboundedReceiver` that all of them will
+/// Spawns the requested number of workers and returns an `UnboundedReceiver` that all of them will
 /// respond to.
 pub(crate) fn spawn_workers(
     url: &str,


### PR DESCRIPTION
crates/rpc/rpc/src/validation.rs
`form` - `from` -- **fix error**

crates/stages/stages/src/stages/execution.rs
`consensu` - `consensus` -- **correction**

crates/stages/stages/src/stages/index_account_history.rs
`Chuck` - `Chunk` -- **fix error**

crates/stages/stages/src/stages/s3/downloader/worker.rs
a `UnboundedReceiver`  - an `UnboundedReceiver` -- **correction**

Hi! If there is anything else I can do for you, I would be very happy