### PR TITLE
refactor(era): Replace known host URL for ERA files with Ithaca

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7779,6 +7779,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "snap",
  "tempfile",
+ "test-case",
  "thiserror 2.0.12",
  "tokio",
 ]

--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -48,10 +48,10 @@ impl TryFromChain for ChainKind {
     fn try_to_url(&self) -> eyre::Result<Url> {
         Ok(match self {
             ChainKind::Named(NamedChain::Mainnet) => {
-                Url::parse("https://mainnet.era1.nimbus.team/").expect("URL should be valid")
+                Url::parse("https://era.ithaca.xyz/era1/").expect("URL should be valid")
             }
             ChainKind::Named(NamedChain::Sepolia) => {
-                Url::parse("https://sepolia.era1.nimbus.team/").expect("URL should be valid")
+                Url::parse("https://era.ithaca.xyz/sepolia-era1/").expect("URL should be valid")
             }
             chain => return Err(eyre!("No known host for ERA files on chain {chain:?}")),
         })

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -9,7 +9,7 @@ use tempfile::tempdir;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_history_imports_from_fresh_state_successfully() {
     // URL where the ERA1 files are hosted
-    let url = Url::from_str("https://mainnet.era1.nimbus.team/").unwrap();
+    let url = Url::from_str("https://era.ithaca.xyz/era1/").unwrap();
 
     // Directory where the ERA1 files will be downloaded to
     let folder = tempdir().unwrap();

--- a/crates/era/Cargo.toml
+++ b/crates/era/Cargo.toml
@@ -33,6 +33,7 @@ reqwest.workspace = true
 reth-era-downloader.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
+test-case.workspace = true
 
 [lints]
 workspace = true

--- a/crates/era/src/era1_types.rs
+++ b/crates/era/src/era1_types.rs
@@ -328,30 +328,38 @@ mod tests {
         assert_eq!(era1_group.block_index.starting_number, 2000);
     }
 
-    #[test]
-    fn test_era1id_file_naming() {
-        // Test with real mainnet examples
-        // See <https://era1.ethportal.net/> or <https://mainnet.era1.nimbus.team/>
-        let mainnet_00000 = Era1Id::new("mainnet", 0, 8192).with_hash([0x5e, 0xc1, 0xff, 0xb8]);
-        assert_eq!(mainnet_00000.to_file_name(), "mainnet-00000-5ec1ffb8.era1");
-
-        let mainnet_00012 = Era1Id::new("mainnet", 12, 8192).with_hash([0x5e, 0xcb, 0x9b, 0xf9]);
-        assert_eq!(mainnet_00012.to_file_name(), "mainnet-00012-5ecb9bf9.era1");
-
-        // Test with real sepolia examples
-        // See <https://sepolia.era1.nimbus.team/>
-        let sepolia_00005 = Era1Id::new("sepolia", 5, 8192).with_hash([0x90, 0x91, 0x84, 0x72]);
-        assert_eq!(sepolia_00005.to_file_name(), "sepolia-00005-90918472.era1");
-
-        let sepolia_00019 = Era1Id::new("sepolia", 19, 8192).with_hash([0xfa, 0x77, 0x00, 0x19]);
-        assert_eq!(sepolia_00019.to_file_name(), "sepolia-00019-fa770019.era1");
-
-        // Test fallback to original format when no hash is provided
-        let id_without_hash = Era1Id::new("mainnet", 1000, 100);
-        assert_eq!(id_without_hash.to_file_name(), "mainnet-1000-100.era1");
-
-        // Test with larger era numbers to ensure proper zero-padding
-        let large_era = Era1Id::new("sepolia", 12345, 8192).with_hash([0xab, 0xcd, 0xef, 0x12]);
-        assert_eq!(large_era.to_file_name(), "sepolia-12345-abcdef12.era1");
+    #[test_case::test_case(
+        Era1Id::new("mainnet", 0, 8192).with_hash([0x5e, 0xc1, 0xff, 0xb8]),
+        "mainnet-00000-5ec1ffb8.era1";
+        "Mainnet 00000"
+    )]
+    #[test_case::test_case(
+        Era1Id::new("mainnet", 12, 8192).with_hash([0x5e, 0xcb, 0x9b, 0xf9]),
+        "mainnet-00012-5ecb9bf9.era1";
+        "Mainnet 00012"
+    )]
+    #[test_case::test_case(
+        Era1Id::new("sepolia", 5, 8192).with_hash([0x90, 0x91, 0x84, 0x72]),
+        "sepolia-00005-90918472.era1";
+        "Sepolia 00005"
+    )]
+    #[test_case::test_case(
+        Era1Id::new("sepolia", 19, 8192).with_hash([0xfa, 0x77, 0x00, 0x19]),
+        "sepolia-00019-fa770019.era1";
+        "Sepolia 00019"
+    )]
+    #[test_case::test_case(
+        Era1Id::new("mainnet", 1000, 100),
+        "mainnet-1000-100.era1";
+        "ID without hash"
+    )]
+    #[test_case::test_case(
+        Era1Id::new("sepolia", 12345, 8192).with_hash([0xab, 0xcd, 0xef, 0x12]),
+        "sepolia-12345-abcdef12.era1";
+        "Large block number"
+    )]
+    fn test_era1id_file_naming(id: Era1Id, expected_file_name: &str) {
+        let actual_file_name = id.to_file_name();
+        assert_eq!(actual_file_name, expected_file_name);
     }
 }

--- a/crates/era/tests/it/main.rs
+++ b/crates/era/tests/it/main.rs
@@ -4,11 +4,7 @@
 //! These tests use the `reth-era-downloader` client to download `.era1` files temporarily
 //! and verify that we can correctly read and decompress their data.
 //!
-//! Files are downloaded from the Nimbus mainnet server:
-//! <https://mainnet.era1.nimbus.team/>
-//! and
-//! from the Sepolia testnet server:
-//! <https://sepolia.era1.nimbus.team/>
+//! Files are downloaded from [`MAINNET_URL`] and [`SEPOLIA_URL`].
 
 use reqwest::{Client, Url};
 use reth_era::{
@@ -34,12 +30,12 @@ const fn main() {}
 
 /// Mainnet network name
 const MAINNET: &str = "mainnet";
-/// Default nimbus mainnet url
+/// Default mainnet url
 /// for downloading mainnet `.era1` files
-const MAINNET_URL: &str = "https://mainnet.era1.nimbus.team/";
+const MAINNET_URL: &str = "https://era.ithaca.xyz/era1/";
 
 /// Succinct list of mainnet files we want to download
-/// from <https://mainnet.era1.nimbus.team/>
+/// from <https://era.ithaca.xyz/era1/>
 /// for testing purposes
 const ERA1_MAINNET_FILES_NAMES: [&str; 6] = [
     "mainnet-00000-5ec1ffb8.era1",
@@ -53,12 +49,12 @@ const ERA1_MAINNET_FILES_NAMES: [&str; 6] = [
 /// Sepolia network name
 const SEPOLIA: &str = "sepolia";
 
-/// Default sepolia nimbus mainnet url
+/// Default sepolia mainnet url
 /// for downloading sepolia `.era1` files
-const SEPOLIA_URL: &str = "https://sepolia.era1.nimbus.team/";
+const SEPOLIA_URL: &str = "https://era.ithaca.xyz/sepolia-era1/";
 
 /// Succinct list of sepolia files we want to download
-/// from <https://sepolia.era1.nimbus.team/>
+/// from <https://era.ithaca.xyz/sepolia-era1/>
 /// for testing purposes
 const ERA1_SEPOLIA_FILES_NAMES: [&str; 3] =
     ["sepolia-00000-643a00f7.era1", "sepolia-00074-0e81003c.era1", "sepolia-00173-b6924da5.era1"];


### PR DESCRIPTION
With the rollout of Ithaca's own ERA files host, this PR replaces the usages of other hosts with it.
