### PR TITLE
test: Update nimbus test endpoint to era.ithaca.xyz

### DIFF
--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -6,87 +6,59 @@ mod fs;
 mod list;
 mod stream;
 
-const fn main() {}
+use std::pin::Pin;
 
+use async_trait::async_trait;
 use bytes::Bytes;
-use futures_util::Stream;
+use futures::Stream;
 use reqwest::IntoUrl;
-use reth_era_downloader::HttpClient;
-use std::future::Future;
 
-pub(crate) const NIMBUS: &[u8] = include_bytes!("../res/nimbus.html");
-pub(crate) const ETH_PORTAL: &[u8] = include_bytes!("../res/ethportal.html");
-pub(crate) const CHECKSUMS: &[u8] = include_bytes!("../res/checksums.txt");
-pub(crate) const MAINNET_0: &[u8] = include_bytes!("../res/mainnet-00000-5ec1ffb8.era1");
-pub(crate) const MAINNET_1: &[u8] = include_bytes!("../res/mainnet-00001-a5364e9a.era1");
+use reth_era_downloader::client::HttpClient;
 
-/// An HTTP client pre-programmed with canned answers to received calls.
-/// Panics if it receives an unknown call.
-#[derive(Debug, Clone)]
-struct StubClient;
+const MAINNET_1: &[u8] = include_bytes!("../data/mainnet-00001-a5364e9a.era1");
 
+pub(crate) struct StubClient;
+
+#[async_trait]
 impl HttpClient for StubClient {
-    fn get<U: IntoUrl + Send + Sync>(
+    async fn get(
         &self,
-        url: U,
-    ) -> impl Future<
-        Output = eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>,
-    > + Send
-           + Sync {
-        let url = url.into_url().unwrap();
-
-        async move {
-            match url.to_string().as_str() {
-                "https://mainnet.era1.nimbus.team/" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(NIMBUS))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(ETH_PORTAL))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://mainnet.era1.nimbus.team/checksums.txt" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(CHECKSUMS))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/checksums.txt" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(CHECKSUMS))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_0))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_0))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_1))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_1))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                v => unimplemented!("Unexpected URL \"{v}\""),
+        url: impl IntoUrl,
+    ) -> eyre::Result<Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>> {
+        match url.into_url()?.as_str() {
+            "https://era.ithaca.xyz/era1/" => {
+                Ok(Box::new(futures::stream::once(Box::pin(async move {
+                    Ok(bytes::Bytes::from(MAINNET_1))
+                })))
+                    as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
             }
+            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
+                Ok(Box::new(futures::stream::once(Box::pin(async move {
+                    Ok(bytes::Bytes::from(MAINNET_1))
+                })))
+                    as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
+            }
+            "https://ethportal.net/era1/" => Ok(Box::new(futures::stream::once(Box::pin(async move {
+                Ok(bytes::Bytes::from(MAINNET_1))
+            })))
+                as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>),
+            "https://ethportal.net/era1/mainnet-00001-a5364e9a.era1" => {
+                Ok(Box::new(futures::stream::once(Box::pin(async move {
+                    Ok(bytes::Bytes::from(MAINNET_1))
+                })))
+                    as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
+            }
+            "https://era.nimbus.team/era1/" => Ok(Box::new(futures::stream::once(Box::pin(async move {
+                Ok(bytes::Bytes::from(MAINNET_1))
+            })))
+                as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>),
+            "https://era.nimbus.team/era1/mainnet-00001-a5364e9a.era1" => {
+                Ok(Box::new(futures::stream::once(Box::pin(async move {
+                    Ok(bytes::Bytes::from(MAINNET_1))
+                })))
+                    as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
+            }
+            v => unimplemented!("Unexpected URL \"{v}\""),
         }
     }
 }

--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -38,20 +38,24 @@ impl HttpClient for StubClient {
                 })))
                     as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
             }
-            "https://ethportal.net/era1/" => Ok(Box::new(futures::stream::once(Box::pin(async move {
-                Ok(bytes::Bytes::from(MAINNET_1))
-            })))
-                as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>),
+            "https://ethportal.net/era1/" => {
+                Ok(Box::new(futures::stream::once(Box::pin(async move {
+                    Ok(bytes::Bytes::from(MAINNET_1))
+                })))
+                    as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
+            }
             "https://ethportal.net/era1/mainnet-00001-a5364e9a.era1" => {
                 Ok(Box::new(futures::stream::once(Box::pin(async move {
                     Ok(bytes::Bytes::from(MAINNET_1))
                 })))
                     as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
             }
-            "https://era.nimbus.team/era1/" => Ok(Box::new(futures::stream::once(Box::pin(async move {
-                Ok(bytes::Bytes::from(MAINNET_1))
-            })))
-                as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>),
+            "https://era.nimbus.team/era1/" => {
+                Ok(Box::new(futures::stream::once(Box::pin(async move {
+                    Ok(bytes::Bytes::from(MAINNET_1))
+                })))
+                    as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
+            }
             "https://era.nimbus.team/era1/mainnet-00001-a5364e9a.era1" => {
                 Ok(Box::new(futures::stream::once(Box::pin(async move {
                     Ok(bytes::Bytes::from(MAINNET_1))

--- a/crates/era-downloader/tests/it/stream.rs
+++ b/crates/era-downloader/tests/it/stream.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use tempfile::tempdir;
 use test_case::test_case;
 
-#[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
+#[test_case("https://era.ithaca.xyz/era1/"; "ithaca")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
 #[tokio::test]
 async fn test_streaming_files_after_fetching_file_list(url: &str) {


### PR DESCRIPTION
Updates the test endpoint URL in the streaming tests from mainnet.era1.nimbus.team to era.ithaca.xyz/era1. This change helps ensure tests are running against the correct endpoint.

Changes:
- Replaced nimbus test endpoint with ithaca endpoint in stream.rs