### PR TITLE
chore: Remove `ForkSpec::Unknown` and Add `ForkSpec::Prague`

### DIFF
--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -61,8 +61,7 @@ impl BlockchainTestCase {
                 ForkSpec::ConstantinopleFix |
                 ForkSpec::MergeEOF |
                 ForkSpec::MergeMeterInitCode |
-                ForkSpec::MergePush0 |
-                ForkSpec::Unknown
+                ForkSpec::MergePush0
         )
     }
 

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -308,9 +308,8 @@ pub enum ForkSpec {
     MergePush0,
     /// Cancun
     Cancun,
-    /// Fork Spec which is unknown to us
-    #[serde(other)]
-    Unknown,
+    /// Prague
+    Prague,
 }
 
 impl From<ForkSpec> for ChainSpec {
@@ -342,9 +341,7 @@ impl From<ForkSpec> for ChainSpec {
             ForkSpec::ByzantiumToConstantinopleAt5 | ForkSpec::Constantinople => {
                 panic!("Overridden with PETERSBURG")
             }
-            ForkSpec::Unknown => {
-                panic!("Unknown fork");
-            }
+            ForkSpec::Prague => spec_builder.prague_activated(),
         }
         .build()
     }


### PR DESCRIPTION
Removing `ForkSpec::Unknown` because it implicitly skips all new forks, skipping those tests. 

I think its likely better to explicitly skip forks that we don't want and for new forks that are not yet supported, an issue could be created so we don't forget to unskip them before making releases.

This also adds in the `ForkSpec::Prague` -- this were previously being classed under `ForkSpec::Unknown`