### PR TITLE
refactor: move FullRpcProvider trait to storage-api crate

### DIFF
--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -2,11 +2,9 @@
 
 use crate::{
     AccountReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader, DatabaseProviderFactory,
-    HeaderProvider, StageCheckpointReader, StateProviderFactory, StaticFileProviderFactory,
-    TransactionsProvider,
+    StageCheckpointReader, StateProviderFactory, StaticFileProviderFactory,
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
-use reth_chainspec::EthereumHardforks;
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_storage_api::NodePrimitivesProvider;
 use std::fmt::Debug;
@@ -53,34 +51,6 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
         + StageCheckpointReader
         + Clone
         + Debug
-        + Unpin
-        + 'static
-{
-}
-
-/// Helper trait to unify all provider traits required to support `eth` RPC server behaviour, for
-/// simplicity.
-pub trait FullRpcProvider:
-    StateProviderFactory
-    + ChainSpecProvider<ChainSpec: EthereumHardforks>
-    + BlockReaderIdExt
-    + HeaderProvider
-    + TransactionsProvider
-    + StageCheckpointReader
-    + Clone
-    + Unpin
-    + 'static
-{
-}
-
-impl<T> FullRpcProvider for T where
-    T: StateProviderFactory
-        + ChainSpecProvider<ChainSpec: EthereumHardforks>
-        + BlockReaderIdExt
-        + HeaderProvider
-        + TransactionsProvider
-        + StageCheckpointReader
-        + Clone
         + Unpin
         + 'static
 {

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -9,4 +9,4 @@ mod static_file_provider;
 pub use static_file_provider::StaticFileProviderFactory;
 
 mod full;
-pub use full::{FullProvider, FullRpcProvider};
+pub use full::FullProvider;

--- a/crates/storage/storage-api/src/full.rs
+++ b/crates/storage/storage-api/src/full.rs
@@ -1,0 +1,36 @@
+//! Helper trait for full rpc provider
+
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+
+use crate::{
+    BlockReaderIdExt, HeaderProvider, StageCheckpointReader, StateProviderFactory,
+    TransactionsProvider,
+};
+
+/// Helper trait to unify all provider traits required to support `eth` RPC server behaviour, for
+/// simplicity.
+pub trait FullRpcProvider:
+    StateProviderFactory
+    + ChainSpecProvider<ChainSpec: EthereumHardforks>
+    + BlockReaderIdExt
+    + HeaderProvider
+    + TransactionsProvider
+    + StageCheckpointReader
+    + Clone
+    + Unpin
+    + 'static
+{
+}
+
+impl<T> FullRpcProvider for T where
+    T: StateProviderFactory
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
+        + BlockReaderIdExt
+        + HeaderProvider
+        + TransactionsProvider
+        + StageCheckpointReader
+        + Clone
+        + Unpin
+        + 'static
+{
+}

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -102,3 +102,6 @@ pub use state_writer::*;
 
 mod header_sync_gap;
 pub use header_sync_gap::HeaderSyncGapProvider;
+
+mod full;
+pub use full::*;


### PR DESCRIPTION
This PR moves the `FullRpcProvider` trait to the storage-api crate

resolves <https://github.com/paradigmxyz/reth/issues/16043>