### PR TITLE
docs: fix typos and improve comment formatting

### DIFF
--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -135,7 +135,7 @@ where
 
     /// Update the L1 block info for the given header and system transaction, if any.
     ///
-    /// Note: this supports optional system transaction, in case this is used in a dev setuo
+    /// Note: this supports optional system transaction, in case this is used in a dev setup
     pub fn update_l1_block_info<H, T>(&self, header: &H, tx: Option<&T>)
     where
         H: BlockHeader,

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -116,7 +116,7 @@ pub trait EthFees: LoadFee {
             // Fetch the headers and ensure we got all of them
             //
             // Treat a request for 1 block as a request for `newest_block..=newest_block`,
-            // otherwise `newest_block - 2
+            // otherwise `newest_block - 2`
             // NOTE: We ensured that block count is capped
             let start_block = end_block_plus - block_count;
 

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -164,7 +164,7 @@ pub struct TaskManager {
     handle: Handle,
     /// Sender half for sending panic signals to this type
     panicked_tasks_tx: UnboundedSender<PanickedTaskError>,
-    /// Listens for panicked tasks
+    /// Listens for a panicked tasks
     panicked_tasks_rx: UnboundedReceiver<PanickedTaskError>,
     /// The [Signal] to fire when all tasks should be shutdown.
     ///

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -164,7 +164,7 @@ pub struct TaskManager {
     handle: Handle,
     /// Sender half for sending panic signals to this type
     panicked_tasks_tx: UnboundedSender<PanickedTaskError>,
-    /// Listens for a panicked tasks
+    /// Listens for panicked tasks
     panicked_tasks_rx: UnboundedReceiver<PanickedTaskError>,
     /// The [Signal] to fire when all tasks should be shutdown.
     ///


### PR DESCRIPTION
**This PR includes the following changes:**

1. Fixed typo in comment: `setuo` -> `setup` in `validator.rs`
2. Added missing backtick in comment for `newest_block - 2` in `fee.rs`
3. Improved comment formatting and consistency

These changes improve code readability and fix minor documentation issues.