### PR TITLE
feat: add era import persistence commit

### DIFF
--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -69,12 +69,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
         let Environment { provider_factory, config, .. } = self.env.init::<N>(AccessRights::RW)?;
 
         let hash_collector = Collector::new(config.stages.etl.file_size, config.stages.etl.dir);
-        let provider_factory = &provider_factory.provider_rw()?.0;
 
         if let Some(path) = self.import.path {
             let stream = read_dir(path)?;
 
-            era::import(stream, provider_factory, hash_collector)?;
+            era::import(stream, &provider_factory, hash_collector)?;
         } else {
             let url = match self.import.url {
                 Some(url) => url,
@@ -85,7 +84,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
             let client = EraClient::new(Client::new(), url, folder);
             let stream = EraStream::new(client, EraStreamConfig::default());
 
-            era::import(stream, provider_factory, hash_collector)?;
+            era::import(stream, &provider_factory, hash_collector)?;
         }
 
         Ok(())

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -123,7 +123,8 @@ where
         meta.mark_as_processed()?;
     }
 
-    let db_writer: <PF as DatabaseProviderFactory>::ProviderRW = provider_factory.database_provider_rw()?;
+    let db_writer: <PF as DatabaseProviderFactory>::ProviderRW =
+        provider_factory.database_provider_rw()?;
 
     let total_headers = hash_collector.len();
     info!(target: "era::history::import", total = total_headers, "Writing headers hash index");

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -100,6 +100,8 @@ where
             hash_collector.insert(hash, number)?;
         }
 
+        writer.commit()?;
+
         info!(target: "era::history::import", "Processed {}", meta.as_ref().to_string_lossy());
 
         meta.mark_as_processed()?;

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -2,7 +2,10 @@ use reqwest::{Client, Url};
 use reth_db_common::init::init_genesis;
 use reth_era_downloader::{EraClient, EraStream, EraStreamConfig};
 use reth_etl::Collector;
-use reth_provider::test_utils::create_test_provider_factory;
+use reth_provider::{
+    test_utils::create_test_provider_factory, BlockReader, HeaderProvider,
+    StaticFileProviderFactory,
+};
 use std::{fs, str::FromStr};
 use tempfile::tempdir;
 
@@ -25,9 +28,9 @@ async fn test_history_imports_from_fresh_state_successfully() {
     let config = EraStreamConfig::default().with_max_files(1).with_max_concurrent_downloads(1);
 
     let stream = EraStream::new(client, config);
-    let pf = create_test_provider_factory();
+    let provider_factory = create_test_provider_factory();
 
-    init_genesis(&pf).unwrap();
+    init_genesis(&provider_factory).unwrap();
 
     let folder = tempdir().unwrap();
     let folder = Some(folder.path().to_owned());
@@ -35,7 +38,26 @@ async fn test_history_imports_from_fresh_state_successfully() {
 
     let expected_block_number = 8191;
     let actual_block_number =
-        reth_era_utils::import(stream, &pf.provider_rw().unwrap().0, hash_collector).unwrap();
+        reth_era_utils::import(stream, &provider_factory.provider_rw().unwrap().0, hash_collector)
+            .unwrap();
 
+    let static_file_provider = provider_factory.static_file_provider();
+
+    let checkpoint_blocks = [0, 100, 1000, 8191];
+
+    for block_num in checkpoint_blocks {
+        let block_db = provider_factory.provider_rw().unwrap().block_by_number(block_num).unwrap();
+        let header_static = static_file_provider.header_by_number(block_num);
+        let static_header_exists = header_static.is_ok() && header_static.unwrap().is_some();
+
+        assert!(static_header_exists, "Block {block_num} should exist in static files");
+
+        // Only genesis block is in the db, others should be in static files
+        if block_num == 0 {
+            assert!(block_db.is_some(), "Genesis block should exist in the db");
+        } else {
+            assert!(block_db.is_none(), "Block {block_num} should not exist in db");
+        }
+    }
     assert_eq!(actual_block_number, expected_block_number);
 }

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -38,8 +38,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
 
     let expected_block_number = 8191;
     let actual_block_number =
-        reth_era_utils::import(stream, &provider_factory.provider_rw().unwrap().0, hash_collector)
-            .unwrap();
+        reth_era_utils::import(stream, &provider_factory, hash_collector).unwrap();
 
     let static_file_provider = provider_factory.static_file_provider();
 
@@ -51,13 +50,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
         let static_header_exists = header_static.is_ok() && header_static.unwrap().is_some();
 
         assert!(static_header_exists, "Block {block_num} should exist in static files");
-
-        // Only genesis block is in the db, others should be in static files
-        if block_num == 0 {
-            assert!(block_db.is_some(), "Genesis block should exist in the db");
-        } else {
-            assert!(block_db.is_none(), "Block {block_num} should not exist in db");
-        }
+        assert!(block_db.is_some(), "Block should exist in the db");
     }
     assert_eq!(actual_block_number, expected_block_number);
 }

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -47,7 +47,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
     for block_num in checkpoint_blocks {
         let block_db = provider_factory.provider_rw().unwrap().block_by_number(block_num).unwrap();
         let header_static = static_file_provider.header_by_number(block_num);
-        let static_header_exists =  header_static.is_ok_and(|h| h.is_some());
+        let static_header_exists = header_static.is_ok_and(|h| h.is_some());
 
         assert!(static_header_exists, "Block {block_num} should exist in static files");
         assert!(block_db.is_some(), "Block should exist in the db");

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -47,7 +47,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
     for block_num in checkpoint_blocks {
         let block_db = provider_factory.provider_rw().unwrap().block_by_number(block_num).unwrap();
         let header_static = static_file_provider.header_by_number(block_num);
-        let static_header_exists = header_static.map_or(false, |h| h.is_some());
+        let static_header_exists =  header_static.is_ok_and(|h| h.is_some());
 
         assert!(static_header_exists, "Block {block_num} should exist in static files");
         assert!(block_db.is_some(), "Block should exist in the db");

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -47,7 +47,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
     for block_num in checkpoint_blocks {
         let block_db = provider_factory.provider_rw().unwrap().block_by_number(block_num).unwrap();
         let header_static = static_file_provider.header_by_number(block_num);
-        let static_header_exists = header_static.is_ok() && header_static.unwrap().is_some();
+        let static_header_exists = header_static.map_or(false, |h| h.is_some());
 
         assert!(static_header_exists, "Block {block_num} should exist in static files");
         assert!(block_db.is_some(), "Block should exist in the db");


### PR DESCRIPTION
Continuing https://github.com/paradigmxyz/reth/pull/15982 that was wrongly open from `main` branch. 

Prep for https://github.com/paradigmxyz/reth/pull/15909.

It adds file storage/db persistence per file, ~~and then a global db commit at the end of the import~~.

cc @RomanHodulak, @mattsse.