### PR TITLE
chore: remove `NoopBlockExecutorProvider`

### DIFF
--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -184,7 +184,7 @@ pub fn build_import_pipeline<N, C, E>(
     executor: E,
 ) -> eyre::Result<(Pipeline<N>, impl Stream<Item = NodeEvent<N::Primitives>>)>
 where
-    N: ProviderNodeTypes + CliNodeTypes,
+    N: ProviderNodeTypes,
     C: FullConsensus<N::Primitives, Error = ConsensusError> + 'static,
     E: BlockExecutorProvider<Primitives = N::Primitives>,
 {

--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -97,17 +97,19 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
     {
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
         let tool = DbTool::new(provider_factory)?;
+        let components = components(tool.chain());
+        let executor = components.executor().clone();
+        let consensus = components.consensus().clone();
 
         match &self.command {
             Stages::Execution(cmd) => {
-                let components = components(tool.chain());
-                let executor = components.executor().clone();
-                let consensus = components.consensus().clone();
                 handle_stage!(dump_execution_stage, &tool, cmd, executor, consensus)
             }
             Stages::StorageHashing(cmd) => handle_stage!(dump_hashing_storage_stage, &tool, cmd),
             Stages::AccountHashing(cmd) => handle_stage!(dump_hashing_account_stage, &tool, cmd),
-            Stages::Merkle(cmd) => handle_stage!(dump_merkle_stage, &tool, cmd),
+            Stages::Merkle(cmd) => {
+                handle_stage!(dump_merkle_stage, &tool, cmd, executor, consensus)
+            }
         }
 
         Ok(())

--- a/crates/cli/commands/src/stage/mod.rs
+++ b/crates/cli/commands/src/stage/mod.rs
@@ -52,7 +52,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             Subcommands::Run(command) => command.execute::<N, _, _, P>(ctx, components).await,
             Subcommands::Drop(command) => command.execute::<N>().await,
             Subcommands::Dump(command) => command.execute::<N, _, _>(components).await,
-            Subcommands::Unwind(command) => command.execute::<N>().await,
+            Subcommands::Unwind(command) => command.execute::<N, _, _>(components).await,
         }
     }
 }

--- a/crates/ethereum/cli/src/debug_cmd/execution.rs
+++ b/crates/ethereum/cli/src/debug_cmd/execution.rs
@@ -70,7 +70,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         static_file_producer: StaticFileProducer<ProviderFactory<N>>,
     ) -> eyre::Result<Pipeline<N>>
     where
-        N: ProviderNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives> + CliNodeTypes,
+        N: ProviderNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives>,
         Client: EthBlockClient + 'static,
     {
         // building network downloaders using the fetch client

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -17,7 +17,7 @@ use reth_db_common::init::{init_genesis, InitStorageError};
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_engine_local::MiningMode;
 use reth_engine_tree::tree::{InvalidBlockHook, InvalidBlockHooks, NoopInvalidBlockHook};
-use reth_evm::noop::NoopBlockExecutorProvider;
+use reth_evm::{execute::BasicBlockExecutorProvider, noop::NoopEvmConfig, ConfigureEvm};
 use reth_fs_util as fs;
 use reth_invalid_block_hooks::InvalidBlockWitnessHook;
 use reth_network_p2p::headers::client::HeadersClient;
@@ -381,9 +381,10 @@ where
     /// Returns the [`ProviderFactory`] for the attached storage after executing a consistent check
     /// between the database and static files. **It may execute a pipeline unwind if it fails this
     /// check.**
-    pub async fn create_provider_factory<N>(&self) -> eyre::Result<ProviderFactory<N>>
+    pub async fn create_provider_factory<N, Evm>(&self) -> eyre::Result<ProviderFactory<N>>
     where
         N: ProviderNodeTypes<DB = DB, ChainSpec = ChainSpec>,
+        Evm: ConfigureEvm<Primitives = N::Primitives> + 'static,
     {
         let factory = ProviderFactory::new(
             self.right().clone(),
@@ -422,7 +423,7 @@ where
                     Arc::new(NoopConsensus::default()),
                     NoopHeaderDownloader::default(),
                     NoopBodiesDownloader::default(),
-                    NoopBlockExecutorProvider::<N::Primitives>::default(),
+                    BasicBlockExecutorProvider::new(NoopEvmConfig::<Evm>::default()),
                     self.toml_config().stages.clone(),
                     self.prune_modes(),
                 ))
@@ -449,13 +450,14 @@ where
     }
 
     /// Creates a new [`ProviderFactory`] and attaches it to the launch context.
-    pub async fn with_provider_factory<N>(
+    pub async fn with_provider_factory<N, Evm>(
         self,
     ) -> eyre::Result<LaunchContextWith<Attached<WithConfigs<ChainSpec>, ProviderFactory<N>>>>
     where
         N: ProviderNodeTypes<DB = DB, ChainSpec = ChainSpec>,
+        Evm: ConfigureEvm<Primitives = N::Primitives> + 'static,
     {
-        let factory = self.create_provider_factory().await?;
+        let factory = self.create_provider_factory::<N, Evm>().await?;
         let ctx = LaunchContextWith {
             inner: self.inner,
             attachment: self.attachment.map_right(|_| factory),

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -106,7 +106,7 @@ where
             // ensure certain settings take effect
             .with_adjusted_configs()
             // Create the provider factory
-            .with_provider_factory().await?
+            .with_provider_factory::<_, <CB::Components as NodeComponents<T>>::Evm>().await?
             .inspect(|_| {
                 info!(target: "reth::cli", "Database opened");
             })


### PR DESCRIPTION
To unblock #15989 we need to firstly find a replacement for noop block executor.

This PR removes all instances of `NoopBlockExecutorProvider` usage. Some of them are replaced with actual valid executors (mostly in CLI)

Others are replaced with `BasicBlockExecutorProvider` wrapping new `NoopEvmConfig` which is basically a wrapper that knows the type of a user-configured EVM config allowing it to satisfy all of the bounds while panicking on every call.