### PR TITLE
feat: add RpcStateCacheArgs::set_zero_lengths

### DIFF
--- a/crates/node/core/src/args/rpc_state_cache.rs
+++ b/crates/node/core/src/args/rpc_state_cache.rs
@@ -39,7 +39,7 @@ pub struct RpcStateCacheArgs {
 }
 
 impl RpcStateCacheArgs {
-    /// Sets the Cache sizes to zero, effecitively disabling caching.
+    /// Sets the Cache sizes to zero, effectively disabling caching.
     pub fn set_zero_lengths(&mut self) {
         self.max_blocks = 0;
         self.max_receipts = 0;

--- a/crates/node/core/src/args/rpc_state_cache.rs
+++ b/crates/node/core/src/args/rpc_state_cache.rs
@@ -38,6 +38,15 @@ pub struct RpcStateCacheArgs {
     pub max_concurrent_db_requests: usize,
 }
 
+impl RpcStateCacheArgs {
+    /// Sets the Cache sizes to zero, effecitively disabling caching.
+    pub fn set_zero_lengths(&mut self) {
+        self.max_blocks = 0;
+        self.max_receipts = 0;
+        self.max_headers = 0;
+    }
+}
+
 impl Default for RpcStateCacheArgs {
     fn default() -> Self {
         Self {

--- a/crates/node/core/src/args/rpc_state_cache.rs
+++ b/crates/node/core/src/args/rpc_state_cache.rs
@@ -40,7 +40,7 @@ pub struct RpcStateCacheArgs {
 
 impl RpcStateCacheArgs {
     /// Sets the Cache sizes to zero, effectively disabling caching.
-    pub fn set_zero_lengths(&mut self) {
+    pub const fn set_zero_lengths(&mut self) {
         self.max_blocks = 0;
         self.max_receipts = 0;
         self.max_headers = 0;


### PR DESCRIPTION
helper to programmatically disable rpc caching