### PR TITLE
feat(txpool): add authorization list setter to mock transaction

### DIFF
--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -482,6 +482,18 @@ impl MockTransaction {
         self
     }
 
+    /// Sets the authorization list for EIP-7702 transactions.
+    pub fn set_authorization_list(&mut self, list: Vec<SignedAuthorization>) -> &mut Self {
+        match self {
+            Self::Eip7702 { authorization_list, .. } => {
+                *authorization_list = list;
+            }
+            _ => {}
+        }
+
+        self
+    }
+
     /// Sets the gas price for the transaction.
     pub const fn set_gas_price(&mut self, val: u128) -> &mut Self {
         match self {

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -484,11 +484,8 @@ impl MockTransaction {
 
     /// Sets the authorization list for EIP-7702 transactions.
     pub fn set_authorization_list(&mut self, list: Vec<SignedAuthorization>) -> &mut Self {
-        match self {
-            Self::Eip7702 { authorization_list, .. } => {
-                *authorization_list = list;
-            }
-            _ => {}
+        if let Self::Eip7702 { authorization_list, .. } = self {
+            *authorization_list = list;
         }
 
         self


### PR DESCRIPTION
Would be a useful addition in some of our tests, and in accordance with the other setters.