### PR TITLE
chore: parse supervisor rpc error

### DIFF
--- a/crates/optimism/txpool/src/supervisor/client.rs
+++ b/crates/optimism/txpool/src/supervisor/client.rs
@@ -173,7 +173,7 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
 
             result
                 .map_err(|_| InteropTxValidatorError::Timeout(timeout.as_secs()))?
-                .map_err(InteropTxValidatorError::other)
+                .map_err(InteropTxValidatorError::from_json_rpc)
         })
     }
 }


### PR DESCRIPTION
Parses supervisor RPC error in `CheckAccessListRequest`