### PR TITLE
feat: add executor fn

### DIFF
--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -273,6 +273,12 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
 
     /// Returns a new [`BasicBlockExecutor`].
     #[auto_impl(keep_default_for(&, Arc))]
+    fn executor<DB: Database>(&self, db: DB) -> BasicBlockExecutor<&Self, DB> {
+        BasicBlockExecutor::new(self, db)
+    }
+
+    /// Returns a new [`BasicBlockExecutor`].
+    #[auto_impl(keep_default_for(&, Arc))]
     fn batch_executor<DB: Database>(&self, db: DB) -> BasicBlockExecutor<&Self, DB> {
         BasicBlockExecutor::new(self, db)
     }


### PR DESCRIPTION
since the BasicBlockExecutor can also be used to execute a single block, and we used to have this as part of the executorProvider, we should add this so that this doesn't break for users and `executor` is more intuitive for executing single blocks.

ref https://github.com/paradigmxyz/reth/pull/15591 with this pr the executor change would have even went unoticed there