### PR TITLE
chore(meta): restrict mdbx vendored attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 book/cli/**/*.md linguist-vendored
 book/cli/cli.md -linguist-vendored
 
-crates/storage/libmdbx-rs/mdbx-sys/** linguist-vendored
+crates/storage/libmdbx-rs/mdbx-sys/libmdbx/** linguist-vendored


### PR DESCRIPTION
Only the `libmdbx` directory is vendored.