### PR TITLE
docs: fix typos in doc comments across stages & stateless modules

### DIFF
--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -599,7 +599,7 @@ mod tests {
         ///
         /// 1. If there are any entries in the [`tables::TransactionSenders`] table above a given
         ///    block number.
-        /// 2. If the is no requested block entry in the bodies table, but
+        /// 2. If there is no requested block entry in the bodies table, but
         ///    [`tables::TransactionSenders`] is not empty.
         fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -460,7 +460,7 @@ mod tests {
         ///
         /// 1. If there are any entries in the [`tables::TransactionHashNumbers`] table above a
         ///    given block number.
-        /// 2. If the is no requested block entry in the bodies table, but
+        /// 2. If there is no requested block entry in the bodies table, but
         ///    [`tables::TransactionHashNumbers`] is    not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -461,7 +461,7 @@ mod tests {
         /// 1. If there are any entries in the [`tables::TransactionHashNumbers`] table above a
         ///    given block number.
         /// 2. If there is no requested block entry in the bodies table, but
-        ///    [`tables::TransactionHashNumbers`] is    not empty.
+        ///    [`tables::TransactionHashNumbers`] is not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self
                 .db

--- a/crates/stateless/src/execution_witness.rs
+++ b/crates/stateless/src/execution_witness.rs
@@ -32,7 +32,7 @@ pub struct ExecutionWitness {
     pub keys: Vec<Bytes>,
     /// Block headers required for proving correctness of stateless execution.
     ///
-    /// This collection stores ancestor(parent) block headers needed to verify:
+    /// This collection stores ancestor (parent) block headers needed to verify:
     /// - State reads are correct (ie the code and accounts are correct wrt the pre-state root)
     /// - BLOCKHASH opcode execution results are correct
     ///


### PR DESCRIPTION

- replace “the is” with “there is” in:
  * crates/stages/src/stages/sender_recovery.rs
  * crates/stages/src/stages/tx_lookup.rs
- rephrase line in crates/stateless/src/execution_witness.rs:
  `ancestor(parent)` → `ancestor (parent)`

