### PR TITLE
feat(trie): decode proofs in multiproof task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10210,6 +10210,7 @@ version = "1.3.12"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "arbitrary",
  "assert_matches",
  "auto_impl",

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -32,9 +32,6 @@ use std::{
 };
 use tracing::{debug, error, trace};
 
-#[cfg(test)]
-use reth_trie::MultiProof;
-
 /// The size of proof targets chunk to spawn in one calculation.
 const MULTIPROOF_TARGETS_CHUNK_SIZE: usize = 10;
 
@@ -56,7 +53,7 @@ impl SparseTrieUpdate {
 
     /// Construct update from multiproof.
     #[cfg(test)]
-    pub(super) fn from_multiproof(multiproof: MultiProof) -> Self {
+    pub(super) fn from_multiproof(multiproof: reth_trie::MultiProof) -> Self {
         Self { multiproof: multiproof.try_into().unwrap(), ..Default::default() }
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1242,7 +1242,8 @@ mod tests {
         sequencer.add_proof(1, SparseTrieUpdate::from_multiproof(proofs[1].clone()).unwrap());
         sequencer.add_proof(3, SparseTrieUpdate::from_multiproof(proofs[3].clone()).unwrap());
 
-        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proofs[0].clone()).unwrap());
+        let ready =
+            sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proofs[0].clone()).unwrap());
         assert_eq!(ready.len(), 5);
         assert!(!sequencer.has_pending());
     }

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -53,8 +53,8 @@ impl SparseTrieUpdate {
 
     /// Construct update from multiproof.
     #[cfg(test)]
-    pub(super) fn from_multiproof(multiproof: reth_trie::MultiProof) -> Self {
-        Self { multiproof: multiproof.try_into().unwrap(), ..Default::default() }
+    pub(super) fn from_multiproof(multiproof: reth_trie::MultiProof) -> alloy_rlp::Result<Self> {
+        Ok(Self { multiproof: multiproof.try_into()?, ..Default::default() })
     }
 
     /// Extend update with contents of the other.
@@ -1172,11 +1172,11 @@ mod tests {
         let proof2 = MultiProof::default();
         sequencer.next_sequence = 2;
 
-        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1));
+        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1).unwrap());
         assert_eq!(ready.len(), 1);
         assert!(!sequencer.has_pending());
 
-        let ready = sequencer.add_proof(1, SparseTrieUpdate::from_multiproof(proof2));
+        let ready = sequencer.add_proof(1, SparseTrieUpdate::from_multiproof(proof2).unwrap());
         assert_eq!(ready.len(), 1);
         assert!(!sequencer.has_pending());
     }
@@ -1189,15 +1189,15 @@ mod tests {
         let proof3 = MultiProof::default();
         sequencer.next_sequence = 3;
 
-        let ready = sequencer.add_proof(2, SparseTrieUpdate::from_multiproof(proof3));
+        let ready = sequencer.add_proof(2, SparseTrieUpdate::from_multiproof(proof3).unwrap());
         assert_eq!(ready.len(), 0);
         assert!(sequencer.has_pending());
 
-        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1));
+        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1).unwrap());
         assert_eq!(ready.len(), 1);
         assert!(sequencer.has_pending());
 
-        let ready = sequencer.add_proof(1, SparseTrieUpdate::from_multiproof(proof2));
+        let ready = sequencer.add_proof(1, SparseTrieUpdate::from_multiproof(proof2).unwrap());
         assert_eq!(ready.len(), 2);
         assert!(!sequencer.has_pending());
     }
@@ -1209,10 +1209,10 @@ mod tests {
         let proof3 = MultiProof::default();
         sequencer.next_sequence = 3;
 
-        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1));
+        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1).unwrap());
         assert_eq!(ready.len(), 1);
 
-        let ready = sequencer.add_proof(2, SparseTrieUpdate::from_multiproof(proof3));
+        let ready = sequencer.add_proof(2, SparseTrieUpdate::from_multiproof(proof3).unwrap());
         assert_eq!(ready.len(), 0);
         assert!(sequencer.has_pending());
     }
@@ -1223,10 +1223,10 @@ mod tests {
         let proof1 = MultiProof::default();
         let proof2 = MultiProof::default();
 
-        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1));
+        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof1).unwrap());
         assert_eq!(ready.len(), 1);
 
-        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof2));
+        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proof2).unwrap());
         assert_eq!(ready.len(), 0);
         assert!(!sequencer.has_pending());
     }
@@ -1237,12 +1237,12 @@ mod tests {
         let proofs: Vec<_> = (0..5).map(|_| MultiProof::default()).collect();
         sequencer.next_sequence = 5;
 
-        sequencer.add_proof(4, SparseTrieUpdate::from_multiproof(proofs[4].clone()));
-        sequencer.add_proof(2, SparseTrieUpdate::from_multiproof(proofs[2].clone()));
-        sequencer.add_proof(1, SparseTrieUpdate::from_multiproof(proofs[1].clone()));
-        sequencer.add_proof(3, SparseTrieUpdate::from_multiproof(proofs[3].clone()));
+        sequencer.add_proof(4, SparseTrieUpdate::from_multiproof(proofs[4].clone()).unwrap());
+        sequencer.add_proof(2, SparseTrieUpdate::from_multiproof(proofs[2].clone()).unwrap());
+        sequencer.add_proof(1, SparseTrieUpdate::from_multiproof(proofs[1].clone()).unwrap());
+        sequencer.add_proof(3, SparseTrieUpdate::from_multiproof(proofs[3].clone()).unwrap());
 
-        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proofs[0].clone()));
+        let ready = sequencer.add_proof(0, SparseTrieUpdate::from_multiproof(proofs[0].clone()).unwrap());
         assert_eq!(ready.len(), 5);
         assert!(!sequencer.has_pending());
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -137,7 +137,7 @@ where
     let started_at = Instant::now();
 
     // Reveal new accounts and storage slots.
-    trie.reveal_multiproof(multiproof)?;
+    trie.reveal_decoded_multiproof(multiproof)?;
     let reveal_multiproof_elapsed = started_at.elapsed();
     trace!(
         target: "engine::root::sparse",

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -413,7 +413,7 @@ impl DecodedMultiProof {
         }
     }
 
-    /// Create a [`MultiProof`] from a [`DecodedStorageMultiProof`].
+    /// Create a [`DecodedMultiProof`] from a [`DecodedStorageMultiProof`].
     pub fn from_storage_proof(
         hashed_address: B256,
         storage_proof: DecodedStorageMultiProof,

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -308,6 +308,14 @@ pub struct DecodedMultiProof {
 }
 
 impl DecodedMultiProof {
+    /// Returns true if the multiproof is empty.
+    pub fn is_empty(&self) -> bool {
+        self.account_subtree.is_empty() &&
+            self.branch_node_hash_masks.is_empty() &&
+            self.branch_node_tree_masks.is_empty() &&
+            self.storages.is_empty()
+    }
+
     /// Return the account proof nodes for the given account path.
     pub fn account_proof_nodes(&self, path: &Nibbles) -> Vec<(Nibbles, TrieNode)> {
         self.account_subtree.matching_nodes_sorted(path)
@@ -403,6 +411,36 @@ impl DecodedMultiProof {
                 }
             }
         }
+    }
+
+    /// Create a [`MultiProof`] from a [`DecodedStorageMultiProof`].
+    pub fn from_storage_proof(
+        hashed_address: B256,
+        storage_proof: DecodedStorageMultiProof,
+    ) -> Self {
+        Self {
+            storages: B256Map::from_iter([(hashed_address, storage_proof)]),
+            ..Default::default()
+        }
+    }
+}
+
+impl TryFrom<MultiProof> for DecodedMultiProof {
+    type Error = alloy_rlp::Error;
+
+    fn try_from(multi_proof: MultiProof) -> Result<Self, Self::Error> {
+        let account_subtree = DecodedProofNodes::try_from(multi_proof.account_subtree)?;
+        let storages = multi_proof
+            .storages
+            .into_iter()
+            .map(|(address, storage)| Ok((address, storage.try_into()?)))
+            .collect::<Result<B256Map<_>, alloy_rlp::Error>>()?;
+        Ok(Self {
+            account_subtree,
+            branch_node_hash_masks: multi_proof.branch_node_hash_masks,
+            branch_node_tree_masks: multi_proof.branch_node_tree_masks,
+            storages,
+        })
     }
 }
 
@@ -510,6 +548,20 @@ impl DecodedStorageMultiProof {
         };
 
         Ok(DecodedStorageProof { key: slot, nibbles, value, proof })
+    }
+}
+
+impl TryFrom<StorageMultiProof> for DecodedStorageMultiProof {
+    type Error = alloy_rlp::Error;
+
+    fn try_from(multi_proof: StorageMultiProof) -> Result<Self, Self::Error> {
+        let subtree = DecodedProofNodes::try_from(multi_proof.subtree)?;
+        Ok(Self {
+            root: multi_proof.root,
+            subtree,
+            branch_node_hash_masks: multi_proof.branch_node_hash_masks,
+            branch_node_tree_masks: multi_proof.branch_node_tree_masks,
+        })
     }
 }
 

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -156,8 +156,7 @@ where
 
         // Now decode the nodes of the proof
         let proof = proof
-            .try_into()
-            .map_err(|err: alloy_rlp::Error| ParallelStateRootError::Other(err.to_string()))?;
+            .try_into()?;
 
         Ok(proof)
     }
@@ -346,8 +345,7 @@ where
 
         // Now decode the nodes of the multiproof
         let multiproof = multiproof
-            .try_into()
-            .map_err(|err: alloy_rlp::Error| ParallelStateRootError::Other(err.to_string()))?;
+            .try_into()?;
 
         Ok(multiproof)
     }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -155,8 +155,7 @@ where
         let proof = self.storage_proof(hashed_address, target_slots)?;
 
         // Now decode the nodes of the proof
-        let proof = proof
-            .try_into()?;
+        let proof = proof.try_into()?;
 
         Ok(proof)
     }
@@ -344,8 +343,7 @@ where
         let multiproof = self.multiproof(targets)?;
 
         // Now decode the nodes of the multiproof
-        let multiproof = multiproof
-            .try_into()?;
+        let multiproof = multiproof.try_into()?;
 
         Ok(multiproof)
     }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -25,8 +25,8 @@ use reth_trie::{
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
     updates::TrieUpdatesSorted,
     walker::TrieWalker,
-    HashBuilder, HashedPostStateSorted, MultiProof, MultiProofTargets, Nibbles, StorageMultiProof,
-    TRIE_ACCOUNT_RLP_MAX_SIZE,
+    DecodedMultiProof, DecodedStorageMultiProof, HashBuilder, HashedPostStateSorted, MultiProof,
+    MultiProofTargets, Nibbles, StorageMultiProof, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use reth_trie_common::proof::ProofRetainer;
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
@@ -143,6 +143,23 @@ where
         );
 
         proof_result
+    }
+
+    /// Generate a [`DecodedStorageMultiProof`] for the given proof by first calling
+    /// `storage_proof`, then decoding the proof nodes.
+    pub fn decoded_storage_proof(
+        self,
+        hashed_address: B256,
+        target_slots: B256Set,
+    ) -> Result<DecodedStorageMultiProof, ParallelStateRootError> {
+        let proof = self.storage_proof(hashed_address, target_slots)?;
+
+        // Now decode the nodes of the proof
+        let proof = proof
+            .try_into()
+            .map_err(|err: alloy_rlp::Error| ParallelStateRootError::Other(err.to_string()))?;
+
+        Ok(proof)
     }
 
     /// Generate a state multiproof according to specified targets.
@@ -316,6 +333,23 @@ where
         );
 
         Ok(MultiProof { account_subtree, branch_node_hash_masks, branch_node_tree_masks, storages })
+    }
+
+    /// Returns a [`DecodedMultiProof`] for the given proof.
+    ///
+    /// Uses `multiproof` first to get the proof, and then decodes the nodes of the multiproof.
+    pub fn decoded_multiproof(
+        self,
+        targets: MultiProofTargets,
+    ) -> Result<DecodedMultiProof, ParallelStateRootError> {
+        let multiproof = self.multiproof(targets)?;
+
+        // Now decode the nodes of the multiproof
+        let multiproof = multiproof
+            .try_into()
+            .map_err(|err: alloy_rlp::Error| ParallelStateRootError::Other(err.to_string()))?;
+
+        Ok(multiproof)
     }
 }
 

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -250,6 +250,12 @@ impl From<ParallelStateRootError> for ProviderError {
     }
 }
 
+impl From<alloy_rlp::Error> for ParallelStateRootError {
+    fn from(error: alloy_rlp::Error) -> Self {
+        Self::Provider(ProviderError::Rlp(error))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -73,9 +73,10 @@ test-utils = [
 ]
 arbitrary = [
     "std",
+    "alloy-primitives/arbitrary",
+    "alloy-trie/arbitrary",
     "reth-primitives-traits/arbitrary",
     "reth-trie-common/arbitrary",
-    "alloy-primitives/arbitrary",
     "smallvec/arbitrary",
 ]
 

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -54,12 +54,13 @@ rand_08.workspace = true
 [features]
 default = ["std", "metrics"]
 std = [
-    "reth-storage-api/std",
-    "reth-primitives-traits/std",
-    "reth-execution-errors/std",
-    "reth-trie-common/std",
     "alloy-primitives/std",
     "alloy-rlp/std",
+    "alloy-trie/std",
+    "reth-execution-errors/std",
+    "reth-primitives-traits/std",
+    "reth-storage-api/std",
+    "reth-trie-common/std",
     "tracing/std",
 ]
 metrics = ["dep:reth-metrics", "dep:metrics", "std"]

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -17,6 +17,7 @@ reth-primitives-traits.workspace = true
 reth-execution-errors.workspace = true
 reth-trie-common.workspace = true
 tracing.workspace = true
+alloy-trie.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -310,7 +310,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     /// Reveals an account multiproof.
     pub fn reveal_account_multiproof(
         &mut self,
-        account_subtree: alloy_trie::proof::DecodedProofNodes,
+        account_subtree: DecodedProofNodes,
         branch_node_hash_masks: HashMap<Nibbles, TrieMask>,
         branch_node_tree_masks: HashMap<Nibbles, TrieMask>,
     ) -> SparseStateTrieResult<()> {

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -831,7 +831,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     }
 }
 
-/// Result of [`decode_proof_nodes`].
+/// Result of [`skip_revealed_nodes`].
 #[derive(Debug, PartialEq, Eq)]
 struct DecodedProofNodes {
     /// Filtered, decoded and sorted proof nodes.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -69,7 +69,7 @@ pub enum SparseTrie<P = DefaultBlindedProvider> {
     /// The trie is blind -- no nodes have been revealed
     ///
     /// This is the default state. In this state,
-    /// the trie cannot be directly queried or modified until nodes are revealed.    
+    /// the trie cannot be directly queried or modified until nodes are revealed.
     #[default]
     Blind,
     /// Some nodes in the Trie have been revealed.

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -154,7 +154,7 @@ where
             tx,
         );
         let mut sparse_trie = SparseStateTrie::new(blinded_provider_factory);
-        sparse_trie.reveal_multiproof(multiproof.try_into()?)?;
+        sparse_trie.reveal_multiproof(multiproof)?;
 
         // Attempt to update state trie to gather additional information for the witness.
         for (hashed_address, hashed_slots) in

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -154,7 +154,7 @@ where
             tx,
         );
         let mut sparse_trie = SparseStateTrie::new(blinded_provider_factory);
-        sparse_trie.reveal_multiproof(multiproof)?;
+        sparse_trie.reveal_multiproof(multiproof.try_into()?)?;
 
         // Attempt to update state trie to gather additional information for the witness.
         for (hashed_address, hashed_slots) in


### PR DESCRIPTION
Offloads the decoding from the critical path by doing it in the proof task

In the previous code it would take up about 20% of time in the critical path
<img width="672" alt="Screenshot 2025-05-12 at 1 31 30 PM" src="https://github.com/user-attachments/assets/d8051dda-10fd-4434-94b3-02bb25eed687" />
<img width="672" alt="Screenshot 2025-05-12 at 1 31 42 PM" src="https://github.com/user-attachments/assets/61c39b43-8746-459b-8477-2d7e7a770e17" />

Now this takes 0% of time in the critical path:
<img width="2560" alt="Screenshot 2025-05-12 at 1 33 39 PM" src="https://github.com/user-attachments/assets/4f542bf8-d668-4f0b-b1a1-6f23a8b13555" />
