### PR TITLE
refactor: move ExtendedTxEnvelope to reth-primitives-traits

### DIFF
--- a/crates/primitives-traits/src/extended.rs
+++ b/crates/primitives-traits/src/extended.rs
@@ -40,10 +40,6 @@ pub enum ExtendedTxEnvelope<BuiltIn, Other> {
     Other(Other),
 }
 
-/// A [`SignedTransaction`] implementation that combines the [`OpTxEnvelope`] and another
-/// transaction type.
-pub type ExtendedOpTxEnvelope<T> = ExtendedTxEnvelope<OpTxEnvelope, T>;
-
 impl<Tx> TryFrom<ExtendedTxEnvelope<OpTxEnvelope, Tx>>
     for ExtendedTxEnvelope<OpPooledTransaction, Tx>
 {

--- a/crates/primitives-traits/src/extended.rs
+++ b/crates/primitives-traits/src/extended.rs
@@ -12,6 +12,7 @@ use alloy_eips::{
 };
 use alloy_primitives::{ChainId, TxHash};
 use alloy_rlp::{BufMut, Decodable, Encodable, Result as RlpResult};
+use core::fmt;
 use revm_primitives::{Address, Bytes, TxKind, B256, U256};
 
 #[cfg(feature = "op")]
@@ -323,8 +324,8 @@ mod serde_bincode_compat {
 
     impl<B, T> SerdeBincodeCompat for ExtendedTxEnvelope<B, T>
     where
-        B: SerdeBincodeCompat + std::fmt::Debug,
-        T: SerdeBincodeCompat + std::fmt::Debug,
+        B: SerdeBincodeCompat + fmt::Debug,
+        T: SerdeBincodeCompat + fmt::Debug,
     {
         type BincodeRepr<'a> = ExtendedTxEnvelopeRepr<'a, B, T>;
 

--- a/crates/primitives-traits/src/extended.rs
+++ b/crates/primitives-traits/src/extended.rs
@@ -12,7 +12,6 @@ use alloy_eips::{
 };
 use alloy_primitives::{ChainId, TxHash};
 use alloy_rlp::{BufMut, Decodable, Encodable, Result as RlpResult};
-use core::fmt;
 use revm_primitives::{Address, Bytes, TxKind, B256, U256};
 
 #[cfg(feature = "op")]
@@ -324,8 +323,8 @@ mod serde_bincode_compat {
 
     impl<B, T> SerdeBincodeCompat for ExtendedTxEnvelope<B, T>
     where
-        B: SerdeBincodeCompat + fmt::Debug,
-        T: SerdeBincodeCompat + fmt::Debug,
+        B: SerdeBincodeCompat + core::fmt::Debug,
+        T: SerdeBincodeCompat + core::fmt::Debug,
     {
         type BincodeRepr<'a> = ExtendedTxEnvelopeRepr<'a, B, T>;
 

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -122,6 +122,8 @@ pub use storage::StorageEntry;
 
 pub mod sync;
 
+mod extended;
+pub use extended::{ExtendedOpTxEnvelope, ExtendedTxEnvelope};
 /// Common header types
 pub mod header;
 pub use header::{Header, HeaderError, SealedHeader, SealedHeaderFor};

--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -123,7 +123,7 @@ pub use storage::StorageEntry;
 pub mod sync;
 
 mod extended;
-pub use extended::{ExtendedOpTxEnvelope, ExtendedTxEnvelope};
+pub use extended::ExtendedTxEnvelope;
 /// Common header types
 pub mod header;
 pub use header::{Header, HeaderError, SealedHeader, SealedHeaderFor};

--- a/examples/custom-node/src/network.rs
+++ b/examples/custom-node/src/network.rs
@@ -1,6 +1,8 @@
 use crate::{
     chainspec::CustomChainSpec,
-    primitives::{CustomHeader, CustomNodePrimitives, CustomTransactionEnvelope},
+    primitives::{
+        CustomHeader, CustomNodePrimitives, CustomTransactionEnvelope, ExtendedOpTxEnvelope,
+    },
 };
 use alloy_consensus::{Block, BlockBody};
 use eyre::Result;
@@ -12,10 +14,7 @@ use reth_ethereum::{
     pool::{PoolTransaction, TransactionPool},
 };
 use reth_node_builder::{components::NetworkBuilder, BuilderContext};
-use reth_op::{
-    primitives::{ExtendedOpTxEnvelope, ExtendedTxEnvelope},
-    OpReceipt,
-};
+use reth_op::{primitives::ExtendedTxEnvelope, OpReceipt};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]

--- a/examples/custom-node/src/network.rs
+++ b/examples/custom-node/src/network.rs
@@ -1,9 +1,6 @@
 use crate::{
     chainspec::CustomChainSpec,
-    primitives::{
-        CustomHeader, CustomNodePrimitives, CustomTransactionEnvelope, ExtendedOpTxEnvelope,
-        ExtendedTxEnvelope,
-    },
+    primitives::{CustomHeader, CustomNodePrimitives, CustomTransactionEnvelope},
 };
 use alloy_consensus::{Block, BlockBody};
 use eyre::Result;
@@ -15,7 +12,10 @@ use reth_ethereum::{
     pool::{PoolTransaction, TransactionPool},
 };
 use reth_node_builder::{components::NetworkBuilder, BuilderContext};
-use reth_op::OpReceipt;
+use reth_op::{
+    primitives::{ExtendedOpTxEnvelope, ExtendedTxEnvelope},
+    OpReceipt,
+};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]

--- a/examples/custom-node/src/pool.rs
+++ b/examples/custom-node/src/pool.rs
@@ -1,4 +1,5 @@
 // use jsonrpsee::tracing::{debug, info};
+use crate::primitives::CustomTransactionEnvelope;
 use op_alloy_consensus::{interop::SafetyLevel, OpTxEnvelope};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_node_builder::{
@@ -17,10 +18,9 @@ use reth_op::{
         blobstore::DiskFileBlobStore, CoinbaseTipOrdering, EthPoolTransaction,
         TransactionValidationTaskExecutor,
     },
+    primitives::ExtendedTxEnvelope,
 };
 use reth_optimism_forks::OpHardforks;
-
-use crate::primitives::{CustomTransactionEnvelope, ExtendedTxEnvelope};
 
 #[derive(Debug, Clone)]
 pub struct CustomPoolBuilder<

--- a/examples/custom-node/src/primitives/block.rs
+++ b/examples/custom-node/src/primitives/block.rs
@@ -1,5 +1,4 @@
-use crate::primitives::{CustomHeader, CustomTransactionEnvelope};
-use reth_op::primitives::ExtendedOpTxEnvelope;
+use crate::primitives::{CustomHeader, CustomTransactionEnvelope, ExtendedOpTxEnvelope};
 
 /// The Block type of this node
 pub type Block =

--- a/examples/custom-node/src/primitives/block.rs
+++ b/examples/custom-node/src/primitives/block.rs
@@ -1,6 +1,5 @@
-use crate::primitives::CustomHeader;
-
-use super::{CustomTransactionEnvelope, ExtendedOpTxEnvelope};
+use crate::primitives::{CustomHeader, CustomTransactionEnvelope};
+use reth_op::primitives::ExtendedOpTxEnvelope;
 
 /// The Block type of this node
 pub type Block =

--- a/examples/custom-node/src/primitives/mod.rs
+++ b/examples/custom-node/src/primitives/mod.rs
@@ -9,8 +9,6 @@ pub use tx::*;
 
 pub mod tx_type;
 pub use tx_type::*;
-pub mod extended_op_tx_envelope;
-pub use extended_op_tx_envelope::*;
 pub mod tx_custom;
 pub use tx_custom::*;
 

--- a/examples/custom-node/src/primitives/mod.rs
+++ b/examples/custom-node/src/primitives/mod.rs
@@ -13,7 +13,7 @@ pub mod tx_custom;
 pub use tx_custom::*;
 
 use reth_ethereum::primitives::NodePrimitives;
-use reth_op::{primitives::ExtendedOpTxEnvelope, OpReceipt};
+use reth_op::OpReceipt;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CustomNodePrimitives;

--- a/examples/custom-node/src/primitives/mod.rs
+++ b/examples/custom-node/src/primitives/mod.rs
@@ -13,7 +13,7 @@ pub mod tx_custom;
 pub use tx_custom::*;
 
 use reth_ethereum::primitives::NodePrimitives;
-use reth_op::OpReceipt;
+use reth_op::{primitives::ExtendedOpTxEnvelope, OpReceipt};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CustomNodePrimitives;

--- a/examples/custom-node/src/primitives/tx.rs
+++ b/examples/custom-node/src/primitives/tx.rs
@@ -9,14 +9,19 @@ use alloy_consensus::{
 use alloy_eips::{eip2718::Eip2718Result, Decodable2718, Encodable2718, Typed2718};
 use alloy_primitives::{keccak256, Signature, TxHash};
 use alloy_rlp::{BufMut, Decodable, Encodable, Result as RlpResult};
+use op_alloy_consensus::OpTxEnvelope;
 use reth_codecs::{
     alloy::transaction::{FromTxCompact, ToTxCompact},
     Compact,
 };
 use reth_ethereum::primitives::{serde_bincode_compat::SerdeBincodeCompat, InMemorySize};
-use reth_op::primitives::SignedTransaction;
+use reth_op::primitives::{ExtendedTxEnvelope, SignedTransaction};
 use revm_primitives::{Address, Bytes};
 use serde::{Deserialize, Serialize};
+
+/// A [`SignedTransaction`] implementation that combines the [`OpTxEnvelope`] and another
+/// transaction type.
+pub type ExtendedOpTxEnvelope<T> = ExtendedTxEnvelope<OpTxEnvelope, T>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 pub struct CustomTransactionEnvelope {


### PR DESCRIPTION
This PR moves `ExtendedTxEnvelope` and its impls to the `reth-primitives-traits` crate

resolves <https://github.com/paradigmxyz/reth/issues/16091>