### PR TITLE
chore: bump docker lighthouse version for electra

### DIFF
--- a/etc/lighthouse.yml
+++ b/etc/lighthouse.yml
@@ -3,7 +3,7 @@ name: reth
 services:
   lighthouse:
     restart: unless-stopped
-    image: sigp/lighthouse:v7.0.0-beta.5
+    image: sigp/lighthouse:v7.0.1
     depends_on:
       - reth
     ports:


### PR DESCRIPTION
Lighthouse support for electra begins at `v7.0.0` onwards (non-beta tags)