### PR TITLE
chore(op-sdk): Move `OpPayloadTypes` to `reth-optimism-payload-builder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9035,6 +9035,7 @@ dependencies = [
  "reth-storage-api",
  "reth-transaction-pool",
  "revm",
+ "serde",
  "sha2 0.10.9",
  "thiserror 2.0.12",
  "tracing",

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -19,10 +19,8 @@ use reth_node_api::{
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::isthmus;
 use reth_optimism_forks::{OpHardfork, OpHardforks};
-use reth_optimism_payload_builder::{
-    OpBuiltPayload, OpExecutionPayloadValidator, OpPayloadBuilderAttributes,
-};
-use reth_optimism_primitives::{OpBlock, OpPrimitives, ADDRESS_L2_TO_L1_MESSAGE_PASSER};
+use reth_optimism_payload_builder::{OpExecutionPayloadValidator, OpPayloadTypes};
+use reth_optimism_primitives::{OpBlock, ADDRESS_L2_TO_L1_MESSAGE_PASSER};
 use reth_primitives_traits::{RecoveredBlock, SealedBlock};
 use reth_provider::StateProviderFactory;
 use reth_trie_common::{HashedPostState, KeyHasher};
@@ -68,29 +66,6 @@ where
     type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadEnvelopeV3 = OpExecutionPayloadEnvelopeV3;
     type ExecutionPayloadEnvelopeV4 = OpExecutionPayloadEnvelopeV4;
-}
-
-/// A default payload type for [`OpEngineTypes`]
-#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
-#[non_exhaustive]
-pub struct OpPayloadTypes<N: NodePrimitives = OpPrimitives>(core::marker::PhantomData<N>);
-
-impl<N: NodePrimitives> PayloadTypes for OpPayloadTypes<N>
-where
-    OpBuiltPayload<N>: BuiltPayload<Primitives: NodePrimitives<Block = OpBlock>>,
-{
-    type ExecutionData = OpExecutionData;
-    type BuiltPayload = OpBuiltPayload<N>;
-    type PayloadAttributes = OpPayloadAttributes;
-    type PayloadBuilderAttributes = OpPayloadBuilderAttributes<N::SignedTx>;
-
-    fn block_to_payload(
-        block: SealedBlock<
-            <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
-        >,
-    ) -> Self::ExecutionData {
-        OpExecutionData::from_block_unchecked(block.hash(), &block.into_block())
-    }
 }
 
 /// Validator for Optimism engine API.

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -50,3 +50,4 @@ derive_more.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 sha2.workspace = true
+serde.workspace = true

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -27,7 +27,7 @@ pub use validator::OpExecutionPayloadValidator;
 
 pub mod config;
 
-/// A default payload type for [`OpEngineTypes`]
+/// ZST that aggregates Optimism [`PayloadTypes`].
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct OpPayloadTypes<N: NodePrimitives = OpPrimitives>(core::marker::PhantomData<N>);

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -15,10 +15,37 @@ pub mod builder;
 pub use builder::OpPayloadBuilder;
 pub mod error;
 pub mod payload;
+use op_alloy_rpc_types_engine::OpExecutionData;
 pub use payload::{OpBuiltPayload, OpPayloadAttributes, OpPayloadBuilderAttributes};
 mod traits;
+use reth_optimism_primitives::{OpBlock, OpPrimitives};
+use reth_payload_primitives::{BuiltPayload, PayloadTypes};
+use reth_primitives_traits::{NodePrimitives, SealedBlock};
 pub use traits::*;
 pub mod validator;
 pub use validator::OpExecutionPayloadValidator;
 
 pub mod config;
+
+/// A default payload type for [`OpEngineTypes`]
+#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
+pub struct OpPayloadTypes<N: NodePrimitives = OpPrimitives>(core::marker::PhantomData<N>);
+
+impl<N: NodePrimitives> PayloadTypes for OpPayloadTypes<N>
+where
+    OpBuiltPayload<N>: BuiltPayload<Primitives: NodePrimitives<Block = OpBlock>>,
+{
+    type ExecutionData = OpExecutionData;
+    type BuiltPayload = OpBuiltPayload<N>;
+    type PayloadAttributes = OpPayloadAttributes;
+    type PayloadBuilderAttributes = OpPayloadBuilderAttributes<N::SignedTx>;
+
+    fn block_to_payload(
+        block: SealedBlock<
+            <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
+        >,
+    ) -> Self::ExecutionData {
+        OpExecutionData::from_block_unchecked(block.hash(), &block.into_block())
+    }
+}


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/pull/15743

Moves `OpPayloadTypes` to `reth-optimism-payload-builder` to avoid cyclical deps in https://github.com/paradigmxyz/reth/pull/16104