### PR TITLE
fix: skip nonce check in simulate v1 if no validation

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -109,7 +109,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     evm_env.cfg_env.disable_eip3607 = true;
 
                     if !validation {
-                        evm_env.cfg_env.disable_base_fee = !validation;
+                        // If not explicitly required, we disable nonce check <https://github.com/paradigmxyz/reth/issues/16108>
+                        evm_env.cfg_env.disable_nonce_check = true;
+                        evm_env.cfg_env.disable_base_fee = true;
                         evm_env.block_env.basefee = 0;
                     }
 


### PR DESCRIPTION
closes #16108

mirrors geth and only enforces nonce if validation is requested via the request