### PR TITLE
chore: pin revm deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,13 +446,13 @@ reth-ress-provider = { path = "crates/ress/provider" }
 # revm
 revm = { version = "22.0.1", default-features = false }
 revm-bytecode = { version = "3.0.0", default-features = false }
-revm-database = { version = "=3.0.0", default-features = false }
 revm-state = { version = "3.0.0", default-features = false }
 revm-primitives = { version = "18.0.0", default-features = false }
 revm-interpreter = { version = "18.0.0", default-features = false }
 revm-inspector = { version = "3.0.0", default-features = false }
 revm-context = { version = "3.0.0", default-features = false }
 revm-context-interface = { version = "3.0.0", default-features = false }
+revm-database = { version = "=3.0.0", default-features = false }
 revm-database-interface = { version = "=3.0.0", default-features = false }
 op-revm = { version = "=3.0.2", default-features = false }
 revm-inspectors = "0.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,8 +453,8 @@ revm-interpreter = { version = "18.0.0", default-features = false }
 revm-inspector = { version = "3.0.0", default-features = false }
 revm-context = { version = "3.0.0", default-features = false }
 revm-context-interface = { version = "3.0.0", default-features = false }
-revm-database-interface = { version = "3.0.0", default-features = false }
-op-revm = { version = "3.0.2", default-features = false }
+revm-database-interface = { version = "=3.0.0", default-features = false }
+op-revm = { version = "=3.0.2", default-features = false }
 revm-inspectors = "0.20.0"
 
 # eth

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,7 +446,7 @@ reth-ress-provider = { path = "crates/ress/provider" }
 # revm
 revm = { version = "22.0.1", default-features = false }
 revm-bytecode = { version = "3.0.0", default-features = false }
-revm-database = { version = "3.0.0", default-features = false }
+revm-database = { version = "=3.0.0", default-features = false }
 revm-state = { version = "3.0.0", default-features = false }
 revm-primitives = { version = "18.0.0", default-features = false }
 revm-interpreter = { version = "18.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,7 +446,7 @@ reth-ress-provider = { path = "crates/ress/provider" }
 # revm
 revm = { version = "22.0.1", default-features = false }
 revm-bytecode = { version = "3.0.0", default-features = false }
-revm-state = { version = "3.0.0", default-features = false }
+revm-state = { version = "=3.0.0", default-features = false }
 revm-primitives = { version = "18.0.0", default-features = false }
 revm-interpreter = { version = "18.0.0", default-features = false }
 revm-inspector = { version = "3.0.0", default-features = false }


### PR DESCRIPTION
need to pin because recent release wasn't semver compliant