### PR TITLE
feat: configure tracing layers

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -73,6 +73,7 @@ exclude_crates=(
   reth-optimism-txpool # reth-transaction-pool
   reth-era-downloader # tokio
   reth-era-utils # tokio
+  reth-tracing-otlp
 )
 
 # Array to hold the results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7172,7 +7172,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "async-trait",
  "backon",
  "clap",
  "comfy-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7172,6 +7172,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
+ "async-trait",
  "backon",
  "clap",
  "comfy-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6075,6 +6075,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "opentelemetry"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+dependencies = [
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.1",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,6 +6622,29 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -10173,6 +10272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-tracing-otlp"
+version = "1.3.12"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.19",
+]
+
+[[package]]
 name = "reth-transaction-pool"
 version = "1.4.3"
 dependencies = [
@@ -12029,6 +12140,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12180,6 +12312,24 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.19",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.19",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10279,7 +10279,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.4.1"
+version = "1.4.3"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6133,6 +6133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10277,6 +10283,7 @@ version = "1.4.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "tracing",
  "tracing-opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10273,7 +10273,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.3.12"
+version = "1.4.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ members = [
     "examples/txpool-tracing/",
     "examples/custom-beacon-withdrawals",
     "testing/ef-tests/",
-    "testing/testing-utils",
+    "testing/testing-utils", "crates/tracing-otlp",
 ]
 default-members = ["bin/reth"]
 exclude = ["book/sources", "book/cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,8 @@ members = [
     "examples/txpool-tracing/",
     "examples/custom-beacon-withdrawals",
     "testing/ef-tests/",
-    "testing/testing-utils", "crates/tracing-otlp",
+    "testing/testing-utils",
+    "crates/tracing-otlp",
 ]
 default-members = ["bin/reth"]
 exclude = ["book/sources", "book/cli"]

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -66,7 +66,6 @@ futures.workspace = true
 tokio.workspace = true
 
 # misc
-async-trait.workspace = true
 ahash.workspace = true
 human_bytes.workspace = true
 eyre.workspace = true

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -66,6 +66,7 @@ futures.workspace = true
 tokio.workspace = true
 
 # misc
+async-trait.workspace = true
 ahash.workspace = true
 human_bytes.workspace = true
 eyre.workspace = true

--- a/crates/cli/commands/src/launcher.rs
+++ b/crates/cli/commands/src/launcher.rs
@@ -24,7 +24,11 @@ pub struct FnLauncher<F, Fut> {
 }
 
 impl<F, Fut> FnLauncher<F, Fut> {
-    pub fn new(func: F) -> Self {
+    pub fn new<C, Ext>(func: F) -> Self
+    where
+        C: ChainSpecParser,
+        F: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>, Ext) -> Fut,
+    {
         Self { func, _result: PhantomData }
     }
 }

--- a/crates/cli/commands/src/launcher.rs
+++ b/crates/cli/commands/src/launcher.rs
@@ -1,0 +1,52 @@
+use async_trait::async_trait;
+use futures::Future;
+use reth_cli::chainspec::ChainSpecParser;
+use reth_db::DatabaseEnv;
+use reth_node_builder::{NodeBuilder, WithLaunchContext};
+use std::{fmt, marker::PhantomData, sync::Arc};
+
+#[async_trait(?Send)]
+pub trait Launcher<C, Ext>
+where
+    C: ChainSpecParser,
+    Ext: clap::Args + fmt::Debug,
+{
+    async fn entrypoint<'a>(
+        self,
+        builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>,
+        builder_args: Ext,
+    ) -> eyre::Result<()>
+    where
+        Ext: 'a;
+}
+
+pub struct FnLauncher<F, Fut> {
+    func: F,
+    _result: PhantomData<Fut>,
+}
+
+impl<F, Fut> FnLauncher<F, Fut> {
+    pub fn new(func: F) -> Self {
+        Self { func, _result: PhantomData }
+    }
+}
+
+#[async_trait(?Send)]
+impl<C, Ext, F, Fut> Launcher<C, Ext> for FnLauncher<F, Fut>
+where
+    C: ChainSpecParser,
+    Ext: clap::Args + fmt::Debug,
+    F: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>, Ext) -> Fut,
+    Fut: Future<Output = eyre::Result<()>>,
+{
+    async fn entrypoint<'a>(
+        self,
+        builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>,
+        builder_args: Ext,
+    ) -> eyre::Result<()>
+    where
+        Ext: 'a,
+    {
+        (self.func)(builder, builder_args).await
+    }
+}

--- a/crates/cli/commands/src/launcher.rs
+++ b/crates/cli/commands/src/launcher.rs
@@ -4,26 +4,58 @@ use reth_db::DatabaseEnv;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use std::{fmt, marker::PhantomData, sync::Arc};
 
+/// A trait for launching a reth node with custom configuration strategies.
+///
+/// This trait allows defining node configuration through various object types rather than just
+/// functions. By implementing this trait on your own structures, you can:
+///
+/// - Create flexible configurations that connect necessary components without creating separate
+///   closures
+/// - Take advantage of decomposition to break complex configurations into a series of methods
+/// - Encapsulate configuration logic in dedicated types with their own state and behavior
+/// - Reuse configuration patterns across different parts of your application
 pub trait Launcher<C, Ext>
 where
     C: ChainSpecParser,
     Ext: clap::Args + fmt::Debug,
 {
-    fn entrypoint<'a>(
+    /// Entry point for launching a node with custom configuration.
+    ///
+    /// Consumes `self` to use pre-configured state, takes a builder and arguments,
+    /// and returns an async future.
+    ///
+    /// # Arguments
+    ///
+    /// * `builder` - Node builder with launch context
+    /// * `builder_args` - Extension arguments for configuration
+    fn entrypoint(
         self,
         builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>,
         builder_args: Ext,
-    ) -> impl Future<Output = eyre::Result<()>>
-    where
-        Ext: 'a;
+    ) -> impl Future<Output = eyre::Result<()>>;
 }
 
+/// A function-based adapter implementation of the [`Launcher`] trait.
+///
+/// This struct adapts existing closures to work with the new [`Launcher`] trait,
+/// maintaining backward compatibility with current node implementations while
+/// enabling the transition to the more flexible trait-based approach.
 pub struct FnLauncher<F, Fut> {
+    /// The function to execute when launching the node
     func: F,
+    /// Phantom data to track the future type
     _result: PhantomData<Fut>,
 }
 
 impl<F, Fut> FnLauncher<F, Fut> {
+    /// Creates a new function launcher adapter.
+    ///
+    /// Type parameters `C` and `Ext` help the compiler infer correct types
+    /// since they're not stored in the struct itself.
+    ///
+    /// # Arguments
+    ///
+    /// * `func` - Function that configures and launches a node
     pub fn new<C, Ext>(func: F) -> Self
     where
         C: ChainSpecParser,
@@ -40,14 +72,11 @@ where
     F: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>, Ext) -> Fut,
     Fut: Future<Output = eyre::Result<()>>,
 {
-    fn entrypoint<'a>(
+    fn entrypoint(
         self,
         builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>,
         builder_args: Ext,
-    ) -> impl Future<Output = eyre::Result<()>>
-    where
-        Ext: 'a,
-    {
+    ) -> impl Future<Output = eyre::Result<()>> {
         (self.func)(builder, builder_args)
     }
 }

--- a/crates/cli/commands/src/lib.rs
+++ b/crates/cli/commands/src/lib.rs
@@ -17,6 +17,7 @@ pub mod import;
 pub mod import_era;
 pub mod init_cmd;
 pub mod init_state;
+pub mod launcher;
 pub mod node;
 pub mod p2p;
 pub mod prune;

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -152,9 +152,9 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
             (EthExecutorProvider::ethereum(spec.clone()), EthBeaconConsensus::new(spec))
         };
         match self.command {
-            Commands::Node(command) => {
-                runner.run_command_until_exit(|ctx| command.execute(ctx, FnLauncher::new(launcher)))
-            }
+            Commands::Node(command) => runner.run_command_until_exit(|ctx| {
+                command.execute(ctx, FnLauncher::new::<C, Ext>(launcher))
+            }),
             Commands::Init(command) => {
                 runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())
             }

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -6,6 +6,7 @@ use reth_chainspec::ChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     config_cmd, db, download, dump_genesis, import, import_era, init_cmd, init_state,
+    launcher::FnLauncher,
     node::{self, NoArgs},
     p2p, prune, recover, stage,
 };
@@ -152,7 +153,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
         };
         match self.command {
             Commands::Node(command) => {
-                runner.run_command_until_exit(|ctx| command.execute(ctx, launcher))
+                runner.run_command_until_exit(|ctx| command.execute(ctx, FnLauncher::new(launcher)))
             }
             Commands::Init(command) => {
                 runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -3,7 +3,7 @@
 use crate::dirs::{LogsDir, PlatformPath};
 use clap::{ArgAction, Args, ValueEnum};
 use reth_tracing::{
-    tracing_subscriber::filter::Directive, FileInfo, FileWorkerGuard, LayerInfo, LogFormat,
+    tracing_subscriber::filter::Directive, FileInfo, FileWorkerGuard, LayerInfo, Layers, LogFormat,
     RethTracer, Tracer,
 };
 use std::{fmt, fmt::Display};
@@ -73,7 +73,7 @@ pub struct LogArgs {
 
 impl LogArgs {
     /// Creates a [`LayerInfo`] instance.
-    fn layer(&self, format: LogFormat, filter: String, use_color: bool) -> LayerInfo {
+    fn layer_info(&self, format: LogFormat, filter: String, use_color: bool) -> LayerInfo {
         LayerInfo::new(
             format,
             self.verbosity.directive().to_string(),
@@ -93,11 +93,24 @@ impl LogArgs {
 
     /// Initializes tracing with the configured options from cli args.
     ///
-    /// Returns the file worker guard, and the file name, if a file worker was configured.
+    /// Uses default layers for tracing. If you need to include custom layers,
+    /// use `init_tracing_with_layers` instead.
+    ///
+    /// Returns the file worker guard if a file worker was configured.
     pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
+        self.init_tracing_with_layers(Layers::new())
+    }
+
+    /// Initializes tracing with the configured options from cli args.
+    ///
+    /// Returns the file worker guard, and the file name, if a file worker was configured.
+    pub fn init_tracing_with_layers(
+        &self,
+        layers: Layers,
+    ) -> eyre::Result<Option<FileWorkerGuard>> {
         let mut tracer = RethTracer::new();
 
-        let stdout = self.layer(self.log_stdout_format, self.log_stdout_filter.clone(), true);
+        let stdout = self.layer_info(self.log_stdout_format, self.log_stdout_filter.clone(), true);
         tracer = tracer.with_stdout(stdout);
 
         if self.journald {
@@ -106,11 +119,11 @@ impl LogArgs {
 
         if self.log_file_max_files > 0 {
             let info = self.file_info();
-            let file = self.layer(self.log_file_format, self.log_file_filter.clone(), false);
+            let file = self.layer_info(self.log_file_format, self.log_file_filter.clone(), false);
             tracer = tracer.with_file(file, info);
         }
 
-        let guard = tracer.init()?;
+        let guard = tracer.init_with_layers(layers)?;
         Ok(guard)
     }
 }

--- a/crates/optimism/cli/src/app.rs
+++ b/crates/optimism/cli/src/app.rs
@@ -26,7 +26,7 @@ where
     Ext: clap::Args + fmt::Debug,
 {
     pub(crate) fn new(cli: Cli<C, Ext>) -> Self {
-        Self { cli, runner: None, layers: None, guard: None }
+        Self { cli, runner: None, layers: Some(Layers::new()), guard: None }
     }
 
     /// Sets the runner for the CLI commander.

--- a/crates/optimism/cli/src/app.rs
+++ b/crates/optimism/cli/src/app.rs
@@ -1,0 +1,111 @@
+use crate::{Cli, Commands};
+use reth_cli::chainspec::ChainSpecParser;
+use reth_cli_commands::launcher::Launcher;
+use reth_cli_runner::CliRunner;
+use reth_node_metrics::recorder::install_prometheus_recorder;
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_consensus::OpBeaconConsensus;
+use reth_optimism_node::{OpExecutorProvider, OpNetworkPrimitives, OpNode};
+use reth_tracing::{FileWorkerGuard, Layers};
+use std::fmt;
+use tracing::info;
+
+/// A wrapper around a parsed CLI that handles command execution.
+#[derive(Debug)]
+pub struct CliApp<Spec: ChainSpecParser, Ext: clap::Args + fmt::Debug> {
+    cli: Cli<Spec, Ext>,
+    runner: Option<CliRunner>,
+    layers: Option<Layers>,
+    guard: Option<FileWorkerGuard>,
+}
+
+impl<C, Ext> CliApp<C, Ext>
+where
+    C: ChainSpecParser<ChainSpec = OpChainSpec>,
+    Ext: clap::Args + fmt::Debug,
+{
+    pub(crate) fn new(cli: Cli<C, Ext>) -> Self {
+        Self { cli, runner: None, layers: None, guard: None }
+    }
+
+    /// Sets the runner for the CLI commander.
+    ///
+    /// This replaces any existing runner with the provided one.
+    pub fn set_runner(&mut self, runner: CliRunner) {
+        self.runner = Some(runner);
+    }
+
+    /// Assigin extra tracing layers to the runner.
+    pub fn set_layers(&mut self, layers: Layers) {
+        self.layers = Some(layers);
+    }
+
+    /// Execute the configured cli command.
+    ///
+    /// This accepts a closure that is used to launch the node via the
+    /// [`NodeCommand`](reth_cli_commands::node::NodeCommand).
+    pub fn run(mut self, launcher: impl Launcher<C, Ext>) -> eyre::Result<()> {
+        let runner = match self.runner.take() {
+            Some(runner) => runner,
+            None => CliRunner::try_default_runtime()?,
+        };
+
+        // add network name to logs dir
+        // Add network name if available to the logs dir
+        if let Some(chain_spec) = self.cli.command.chain_spec() {
+            self.cli.logs.log_file_directory =
+                self.cli.logs.log_file_directory.join(chain_spec.chain.to_string());
+        }
+        self.init_tracing()?;
+        info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
+
+        // Install the prometheus recorder to be sure to record all metrics
+        let _ = install_prometheus_recorder();
+
+        match self.cli.command {
+            Commands::Node(command) => {
+                runner.run_command_until_exit(|ctx| command.execute(ctx, launcher))
+            }
+            Commands::Init(command) => {
+                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
+            }
+            Commands::InitState(command) => {
+                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
+            }
+            Commands::ImportOp(command) => {
+                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
+            }
+            Commands::ImportReceiptsOp(command) => {
+                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
+            }
+            Commands::DumpGenesis(command) => runner.run_blocking_until_ctrl_c(command.execute()),
+            Commands::Db(command) => runner.run_blocking_until_ctrl_c(command.execute::<OpNode>()),
+            Commands::Stage(command) => runner.run_command_until_exit(|ctx| {
+                command.execute::<OpNode, _, _, OpNetworkPrimitives>(ctx, |spec| {
+                    (OpExecutorProvider::optimism(spec.clone()), OpBeaconConsensus::new(spec))
+                })
+            }),
+            Commands::P2P(command) => {
+                runner.run_until_ctrl_c(command.execute::<OpNetworkPrimitives>())
+            }
+            Commands::Config(command) => runner.run_until_ctrl_c(command.execute()),
+            Commands::Recover(command) => {
+                runner.run_command_until_exit(|ctx| command.execute::<OpNode>(ctx))
+            }
+            Commands::Prune(command) => runner.run_until_ctrl_c(command.execute::<OpNode>()),
+            #[cfg(feature = "dev")]
+            Commands::TestVectors(command) => runner.run_until_ctrl_c(command.execute()),
+        }
+    }
+
+    /// Initializes tracing with the configured options.
+    ///
+    /// If file logging is enabled, this function stores guard to the struct.
+    pub fn init_tracing(&mut self) -> eyre::Result<()> {
+        if self.guard.is_none() {
+            let layers = self.layers.take().unwrap_or_default();
+            self.guard = self.cli.logs.init_tracing_with_layers(layers)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -94,10 +94,10 @@ where
     C: ChainSpecParser<ChainSpec = OpChainSpec>,
     Ext: clap::Args + fmt::Debug,
 {
-    /// Configures the CLI and returns a CliApp instance.
+    /// Configures the CLI and returns a [`CliApp`] instance.
     ///
     /// This method is used to prepare the CLI for execution by wrapping it in a
-    /// CliApp that can be further configured before running.
+    /// [`CliApp`] that can be further configured before running.
     pub fn configure(self) -> CliApp<C, Ext> {
         CliApp::new(self)
     }

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -122,7 +122,7 @@ where
     {
         let mut this = self.configure();
         this.set_runner(runner);
-        this.run(FnLauncher::new(launcher))
+        this.run(FnLauncher::new::<C, Ext>(launcher))
     }
 }
 

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -8,6 +8,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+/// A configurable App on top of the cli parser.
+pub mod app;
 /// Optimism chain specification parser.
 pub mod chainspec;
 /// Optimism CLI commands.
@@ -30,6 +32,7 @@ pub mod receipt_file_codec;
 /// Enables decoding and encoding `Block` types within file contexts.
 pub mod ovm_file_codec;
 
+pub use app::CliApp;
 pub use commands::{import::ImportOpCommand, import_receipts::ImportReceiptsOpCommand};
 use reth_optimism_chainspec::OpChainSpec;
 
@@ -40,6 +43,7 @@ use clap::{command, Parser};
 use commands::Commands;
 use futures_util::Future;
 use reth_cli::chainspec::ChainSpecParser;
+use reth_cli_commands::launcher::FnLauncher;
 use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
@@ -47,16 +51,11 @@ use reth_node_core::{
     args::LogArgs,
     version::{LONG_VERSION, SHORT_VERSION},
 };
-use reth_optimism_consensus::OpBeaconConsensus;
-use reth_optimism_evm::OpExecutorProvider;
-use reth_optimism_node::{args::RollupArgs, OpNetworkPrimitives, OpNode};
-use reth_tracing::FileWorkerGuard;
-use tracing::info;
+use reth_optimism_node::args::RollupArgs;
 
 // This allows us to manually enable node metrics features, required for proper jemalloc metric
 // reporting
 use reth_node_metrics as _;
-use reth_node_metrics::recorder::install_prometheus_recorder;
 
 /// The main op-reth cli interface.
 ///
@@ -95,6 +94,14 @@ where
     C: ChainSpecParser<ChainSpec = OpChainSpec>,
     Ext: clap::Args + fmt::Debug,
 {
+    /// Configures the CLI and returns a CliApp instance.
+    ///
+    /// This method is used to prepare the CLI for execution by wrapping it in a
+    /// CliApp that can be further configured before running.
+    pub fn configure(self) -> CliApp<C, Ext> {
+        CliApp::new(self)
+    }
+
     /// Execute the configured cli command.
     ///
     /// This accepts a closure that is used to launch the node via the
@@ -108,66 +115,14 @@ where
     }
 
     /// Execute the configured cli command with the provided [`CliRunner`].
-    pub fn with_runner<L, Fut>(mut self, runner: CliRunner, launcher: L) -> eyre::Result<()>
+    pub fn with_runner<L, Fut>(self, runner: CliRunner, launcher: L) -> eyre::Result<()>
     where
         L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
-        // add network name to logs dir
-        // Add network name if available to the logs dir
-        if let Some(chain_spec) = self.command.chain_spec() {
-            self.logs.log_file_directory =
-                self.logs.log_file_directory.join(chain_spec.chain.to_string());
-        }
-        let _guard = self.init_tracing()?;
-        info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
-
-        // Install the prometheus recorder to be sure to record all metrics
-        let _ = install_prometheus_recorder();
-
-        match self.command {
-            Commands::Node(command) => {
-                runner.run_command_until_exit(|ctx| command.execute(ctx, launcher))
-            }
-            Commands::Init(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
-            }
-            Commands::InitState(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
-            }
-            Commands::ImportOp(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
-            }
-            Commands::ImportReceiptsOp(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<OpNode>())
-            }
-            Commands::DumpGenesis(command) => runner.run_blocking_until_ctrl_c(command.execute()),
-            Commands::Db(command) => runner.run_blocking_until_ctrl_c(command.execute::<OpNode>()),
-            Commands::Stage(command) => runner.run_command_until_exit(|ctx| {
-                command.execute::<OpNode, _, _, OpNetworkPrimitives>(ctx, |spec| {
-                    (OpExecutorProvider::optimism(spec.clone()), OpBeaconConsensus::new(spec))
-                })
-            }),
-            Commands::P2P(command) => {
-                runner.run_until_ctrl_c(command.execute::<OpNetworkPrimitives>())
-            }
-            Commands::Config(command) => runner.run_until_ctrl_c(command.execute()),
-            Commands::Recover(command) => {
-                runner.run_command_until_exit(|ctx| command.execute::<OpNode>(ctx))
-            }
-            Commands::Prune(command) => runner.run_until_ctrl_c(command.execute::<OpNode>()),
-            #[cfg(feature = "dev")]
-            Commands::TestVectors(command) => runner.run_until_ctrl_c(command.execute()),
-        }
-    }
-
-    /// Initializes tracing with the configured options.
-    ///
-    /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
-    /// that all logs are flushed to disk.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
-        let guard = self.logs.init_tracing()?;
-        Ok(guard)
+        let mut this = self.configure();
+        this.set_runner(runner);
+        this.run(FnLauncher::new(launcher))
     }
 }
 

--- a/crates/tracing-otlp/Cargo.toml
+++ b/crates/tracing-otlp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "reth-tracing-otlp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+opentelemetry_sdk = "0.29.0"
+opentelemetry = "0.29.1"
+opentelemetry-otlp = "0.29.0"
+tracing-opentelemetry = "0.30.0"
+tracing-subscriber.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tracing-otlp/Cargo.toml
+++ b/crates/tracing-otlp/Cargo.toml
@@ -15,6 +15,7 @@ opentelemetry-otlp = "0.29.0"
 tracing-opentelemetry = "0.30.0"
 tracing-subscriber.workspace = true
 tracing.workspace = true
+opentelemetry-semantic-conventions = "0.29.0"
 
 [lints]
 workspace = true

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -4,7 +4,7 @@
 //! applications. It allows for easily capturing and exporting distributed traces to compatible
 //! backends like Jaeger, Zipkin, or any other OpenTelemetry-compatible tracing system.
 
-use opentelemetry::{trace::TracerProvider, KeyValue};
+use opentelemetry::{trace::TracerProvider, KeyValue, Value};
 use opentelemetry_otlp::SpanExporter;
 use opentelemetry_sdk::{
     trace::{SdkTracer, SdkTracerProvider},
@@ -19,24 +19,20 @@ use tracing_subscriber::registry::LookupSpan;
 ///
 /// This layer can be added to a [tracing_subscriber::Registry] to enable OpenTelemetry tracing
 /// with OTLP export.
-pub fn layer<S>() -> OpenTelemetryLayer<S, SdkTracer>
+pub fn layer<S>(service_name: impl Into<Value>) -> OpenTelemetryLayer<S, SdkTracer>
 where
     for<'span> S: Subscriber + LookupSpan<'span>,
 {
     let exporter = SpanExporter::builder().with_http().build().unwrap();
 
-    let provider = SdkTracerProvider::builder()
-        .with_resource(resource())
-        .with_batch_exporter(exporter)
+    let resource = Resource::builder()
+        .with_service_name(service_name)
+        .with_schema_url([KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION"))], SCHEMA_URL)
         .build();
+
+    let provider =
+        SdkTracerProvider::builder().with_resource(resource).with_batch_exporter(exporter).build();
 
     let tracer = provider.tracer("reth-otlp");
     tracing_opentelemetry::layer().with_tracer(tracer)
-}
-
-fn resource() -> Resource {
-    Resource::builder()
-        .with_service_name(env!("CARGO_PKG_NAME"))
-        .with_schema_url([KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION"))], SCHEMA_URL)
-        .build()
 }

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -1,0 +1,28 @@
+//! Provides a tracing layer for OpenTelemetry that exports spans to an OTLP endpoint.
+//!
+//! This module simplifies the integration of OpenTelemetry tracing with OTLP export in Rust
+//! applications. It allows for easily capturing and exporting distributed traces to compatible
+//! backends like Jaeger, Zipkin, or any other OpenTelemetry-compatible tracing system.
+
+use opentelemetry::trace::TracerProvider;
+use opentelemetry_otlp::SpanExporter;
+use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider};
+use tracing::Subscriber;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Creates a tracing [OpenTelemetryLayer] that exports spans to an OTLP endpoint.
+///
+/// This layer can be added to a [tracing_subscriber::Registry] to enable OpenTelemetry tracing
+/// with OTLP export.
+pub fn layer<S>() -> OpenTelemetryLayer<S, SdkTracer>
+where
+    for<'span> S: Subscriber + LookupSpan<'span>,
+{
+    let exporter = SpanExporter::builder().with_http().build().unwrap();
+
+    let provider = SdkTracerProvider::builder().with_batch_exporter(exporter).build();
+
+    let tracer = provider.tracer("reth-otlp");
+    tracing_opentelemetry::layer().with_tracer(tracer)
+}

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -1,6 +1,6 @@
-//! Provides a tracing layer for OpenTelemetry that exports spans to an OTLP endpoint.
+//! Provides a tracing layer for `OpenTelemetry` that exports spans to an OTLP endpoint.
 //!
-//! This module simplifies the integration of OpenTelemetry tracing with OTLP export in Rust
+//! This module simplifies the integration of `OpenTelemetry` tracing with OTLP export in Rust
 //! applications. It allows for easily capturing and exporting distributed traces to compatible
 //! backends like Jaeger, Zipkin, or any other OpenTelemetry-compatible tracing system.
 
@@ -15,9 +15,9 @@ use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
 
-/// Creates a tracing [OpenTelemetryLayer] that exports spans to an OTLP endpoint.
+/// Creates a tracing [`OpenTelemetryLayer`] that exports spans to an OTLP endpoint.
 ///
-/// This layer can be added to a [tracing_subscriber::Registry] to enable OpenTelemetry tracing
+/// This layer can be added to a [`tracing_subscriber::Registry`] to enable `OpenTelemetry` tracing
 /// with OTLP export.
 pub fn layer<S>(service_name: impl Into<Value>) -> OpenTelemetryLayer<S, SdkTracer>
 where

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -50,14 +50,13 @@ pub use tracing_subscriber;
 
 // Re-export our types
 pub use formatter::LogFormat;
-pub use layers::{FileInfo, FileWorkerGuard};
+pub use layers::{FileInfo, FileWorkerGuard, Layers};
 pub use test_tracer::TestTracer;
 
 mod formatter;
 mod layers;
 mod test_tracer;
 
-use crate::layers::Layers;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -171,12 +170,29 @@ impl Default for LayerInfo {
 /// in an application. Implementations of this trait can specify different logging setups,
 /// such as standard output logging, file logging, journald logging, or custom logging
 /// configurations tailored for specific environments (like testing).
-pub trait Tracer {
+pub trait Tracer: Sized {
     /// Initialize the logging configuration.
-    ///  # Returns
-    ///  An `eyre::Result` which is `Ok` with an optional `WorkerGuard` if a file layer is used,
-    ///  or an `Err` in case of an error during initialization.
-    fn init(self) -> eyre::Result<Option<WorkerGuard>>;
+    ///
+    /// By default, this method creates a new `Layers` instance and delegates to `init_with_layers`.
+    ///
+    /// # Returns
+    /// An `eyre::Result` which is `Ok` with an optional `WorkerGuard` if a file layer is used,
+    /// or an `Err` in case of an error during initialization. Initialize the logging configuration.
+    fn init(self) -> eyre::Result<Option<WorkerGuard>> {
+        self.init_with_layers(Layers::new())
+    }
+    /// Initialize the logging configuration with additional custom layers.
+    ///
+    /// This method allows for more customized setup by accepting pre-configured
+    /// `Layers` which can be further customized before initialization.
+    ///
+    /// # Arguments
+    /// * `layers` - Pre-configured `Layers` instance to use for initialization
+    ///
+    /// # Returns
+    /// An `eyre::Result` which is `Ok` with an optional `WorkerGuard` if a file layer is used,
+    /// or an `Err` in case of an error during initialization.
+    fn init_with_layers(self, layers: Layers) -> eyre::Result<Option<WorkerGuard>>;
 }
 
 impl Tracer for RethTracer {
@@ -190,9 +206,7 @@ impl Tracer for RethTracer {
     ///  # Returns
     ///  An `eyre::Result` which is `Ok` with an optional `WorkerGuard` if a file layer is used,
     ///  or an `Err` in case of an error during initialization.
-    fn init(self) -> eyre::Result<Option<WorkerGuard>> {
-        let mut layers = Layers::new();
-
+    fn init_with_layers(self, mut layers: Layers) -> eyre::Result<Option<WorkerGuard>> {
         layers.stdout(
             self.stdout.format,
             self.stdout.default_directive.parse()?,

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -177,7 +177,7 @@ pub trait Tracer: Sized {
     ///
     /// # Returns
     /// An `eyre::Result` which is `Ok` with an optional `WorkerGuard` if a file layer is used,
-    /// or an `Err` in case of an error during initialization. Initialize the logging configuration.
+    /// or an `Err` in case of an error during initialization.
     fn init(self) -> eyre::Result<Option<WorkerGuard>> {
         self.init_with_layers(Layers::new())
     }

--- a/crates/tracing/src/test_tracer.rs
+++ b/crates/tracing/src/test_tracer.rs
@@ -1,7 +1,7 @@
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 
-use crate::Tracer;
+use crate::{Layers, Tracer};
 
 ///  Initializes a tracing subscriber for tests.
 ///
@@ -15,7 +15,7 @@ use crate::Tracer;
 pub struct TestTracer;
 
 impl Tracer for TestTracer {
-    fn init(self) -> eyre::Result<Option<WorkerGuard>> {
+    fn init_with_layers(self, _layers: Layers) -> eyre::Result<Option<WorkerGuard>> {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .with_writer(std::io::stderr)


### PR DESCRIPTION
## Description

This PR adds the ability to configure (add) **custom tracing layers**, such as OpenTelemetry. For now, this extended functionality is available in the Optimism CLI.

Implementation details:

1. The `Layers` type is public and can be modified using the `.add_layer()` method.
2. The `Tracer` trait can now be configured with a custom set of layers via a special method `init_with_layers()`. The original `init()` method is preserved but internally reuses the new one by providing an empty `Layers` list, just like before.
3. A new `configure()` method has been added to the Optimism `Cli`, which provides a builder-wrapper `CliApp`. This allows users to specify their own `CliRunner` or `Layers`. It also stores the tracing guard within the same structure.
4. The Optimism `Cli` now fully relies on `CliRunner`.
5. To avoid duplicating a large number of `launcher` type definitions, a special `Launcher` trait has been introduced. This allows defining a custom launcher using a struct, adding flexibility:
   * All contextual data for launching can be stored in the struct and reused.
   * A launcher can now be constructed even from a `json::Value` (e.g., read from a file).
   * Launchers can be layered, wrapping one another and forwarding the launch method.
   * Different methods can be added for various stages of the launcher's lifecycle.
   * For compatibility, a closure-style launcher wrapper `FnLauncher` is provided. It is also used in the previous `Cli` methods of the Optimism node.   
6. A new `reth-tracing-otlp` crate has been added to provide an OpenTelemetry tracing layer for exporting spans in OTLP format.

## Example

1. Now the parameters allow you to obtain a `CliApp` (via the `configure()` method, which provides access to tracing layers).

```rust
let mut cli_app = Cli::<OpChainSpecParser, OpRbuilderArgs>::parse().configure();
```

2. The OTLP layer is available in a separate crate, `reth_tracing_otlp`. The layer is created using the `layer()` function, which expects a service name as input.

```diff
+ let otlp = reth_tracing_otlp::layer("my-op-node");
+ cli_app.access_tracing_layers()?.add_layer(otlp);
```

3. The only thing is, I added a `Launcher` trait to avoid duplicating the long type parameter definitions from `Cli` in the `CliApp` function. Now a wrapper launcher like `FnLauncher` is required, but in the long run, this paves the way to make `Launcher` configurable and decomposable.

```rust
cli_app.run(FnLauncher::new::<OpChainSpecParser, OpRbuilderArgs>(
    |builder, builder_args| async move {
        let _span = tracing::span!(Level::INFO, "Node");
        tracing::info!("Starting the node");
        let rollup_args = builder_args.rollup_args;
        let op_node = OpNode::new(rollup_args.clone());
        let handle = builder
            .with_types::<OpNode>()
            .with_components(op_node.components())
            .with_add_ons(OpAddOnsBuilder::default().build())
            // .on_node_started(move |_ctx| Ok(()))
            .launch()
            .await?;
        handle.node_exit_future.await
    },
))?;
```