### PR TITLE
feat(trie): add native packed nibbles representation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ book/sources/Cargo.lock
 
 # Cargo chef recipe file
 recipe.json
+
+**/.claude/settings.local.json


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/15594

Minimal methods for a packed nibbles representation, will close and add to `alloy-rs/nybbles` if successful

TODO:
* Integrate into only sparse trie
* bench