### PR TITLE
perf: perform contains check without alloc

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -812,10 +812,7 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         if let Some(authority_list) = &transaction.authority_ids {
             for sender_id in authority_list {
-                if !self.pending_pool.get_txs_by_sender(*sender_id).is_empty() ||
-                    !self.queued_pool.get_txs_by_sender(*sender_id).is_empty() ||
-                    !self.basefee_pool.get_txs_by_sender(*sender_id).is_empty()
-                {
+                if self.all_transactions.txs_iter(*sender_id).next().is_some() {
                     return Err(PoolError::new(
                         *transaction.hash(),
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(


### PR DESCRIPTION
smol https://github.com/paradigmxyz/reth/pull/15312 followup

this check is equivalent and doesn't require multiple lookups and potential allocs