### PR TITLE
chore: remove_auths doc

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1618,6 +1618,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
         result
     }
 
+    /// Removes any pending auths for the given transaction.
+    ///
+    /// This is a noop for non EIP-7702 transactions.
     fn remove_auths(&mut self, tx: &PoolInternalTransaction<T>) {
         let Some(auths) = &tx.transaction.authority_ids else { return };
 
@@ -1977,6 +1980,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn assert_invariants(&self) {
         assert_eq!(self.by_hash.len(), self.txs.len(), "by_hash.len() != txs.len()");
+        assert!(self.auths.len() <= self.txs.len(), "auths > txs.len()");
     }
 }
 


### PR DESCRIPTION
smol https://github.com/paradigmxyz/reth/pull/15312 followup

document fn and add an invariant check that auths by sender <= total txs