### PR TITLE
feat(txpool): track osaka activation

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -642,8 +642,10 @@ pub struct EthTransactionValidatorBuilder<Client> {
     shanghai: bool,
     /// Fork indicator whether we are in the Cancun hardfork.
     cancun: bool,
-    /// Fork indicator whether we are in the Cancun hardfork.
+    /// Fork indicator whether we are in the Prague hardfork.
     prague: bool,
+    /// Fork indicator whether we are in the Osaka hardfork.
+    osaka: bool,
     /// Max blob count at the block's timestamp.
     max_blob_count: u64,
     /// Whether using EIP-2718 type transactions is allowed
@@ -707,6 +709,9 @@ impl<Client> EthTransactionValidatorBuilder<Client> {
             // prague not yet activated
             prague: false,
 
+            // osaka not yet activated
+            osaka: false,
+
             // max blob count is cancun by default
             max_blob_count: BlobParams::cancun().max_blob_count,
         }
@@ -751,6 +756,17 @@ impl<Client> EthTransactionValidatorBuilder<Client> {
     /// Set the Prague fork.
     pub const fn set_prague(mut self, prague: bool) -> Self {
         self.prague = prague;
+        self
+    }
+
+    /// Disables the Osaka fork.
+    pub const fn no_osaka(self) -> Self {
+        self.set_osaka(false)
+    }
+
+    /// Set the Osaka fork.
+    pub const fn set_osaka(mut self, osaka: bool) -> Self {
+        self.osaka = osaka;
         self
     }
 
@@ -812,9 +828,10 @@ impl<Client> EthTransactionValidatorBuilder<Client> {
     where
         Client: ChainSpecProvider<ChainSpec: EthereumHardforks>,
     {
-        self.cancun = self.client.chain_spec().is_cancun_active_at_timestamp(timestamp);
         self.shanghai = self.client.chain_spec().is_shanghai_active_at_timestamp(timestamp);
+        self.cancun = self.client.chain_spec().is_cancun_active_at_timestamp(timestamp);
         self.prague = self.client.chain_spec().is_prague_active_at_timestamp(timestamp);
+        self.osaka = self.client.chain_spec().is_osaka_active_at_timestamp(timestamp);
         self.max_blob_count = self
             .client
             .chain_spec()
@@ -856,6 +873,7 @@ impl<Client> EthTransactionValidatorBuilder<Client> {
             shanghai,
             cancun,
             prague,
+            osaka,
             eip2718,
             eip1559,
             eip4844,
@@ -869,6 +887,7 @@ impl<Client> EthTransactionValidatorBuilder<Client> {
             ..
         } = self;
 
+        // TODO: use osaka max blob count once <https://github.com/alloy-rs/alloy/pull/2427> is released
         let max_blob_count = if prague {
             BlobParams::prague().max_blob_count
         } else {
@@ -879,6 +898,7 @@ impl<Client> EthTransactionValidatorBuilder<Client> {
             shanghai: AtomicBool::new(shanghai),
             cancun: AtomicBool::new(cancun),
             prague: AtomicBool::new(prague),
+            osaka: AtomicBool::new(osaka),
             max_blob_count: AtomicU64::new(max_blob_count),
         };
 
@@ -955,6 +975,8 @@ pub struct ForkTracker {
     pub cancun: AtomicBool,
     /// Tracks if prague is activated at the block's timestamp.
     pub prague: AtomicBool,
+    /// Tracks if osaka is activated at the block's timestamp.
+    pub osaka: AtomicBool,
     /// Tracks max blob count at the block's timestamp.
     pub max_blob_count: AtomicU64,
 }
@@ -972,6 +994,11 @@ impl ForkTracker {
 
     /// Returns `true` if Prague fork is activated.
     pub fn is_prague_activated(&self) -> bool {
+        self.prague.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns `true` if Osaka fork is activated.
+    pub fn is_osaka_activated(&self) -> bool {
         self.prague.load(std::sync::atomic::Ordering::Relaxed)
     }
 
@@ -1047,6 +1074,7 @@ mod tests {
             shanghai: false.into(),
             cancun: false.into(),
             prague: false.into(),
+            osaka: false.into(),
             max_blob_count: 0.into(),
         };
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -999,7 +999,7 @@ impl ForkTracker {
 
     /// Returns `true` if Osaka fork is activated.
     pub fn is_osaka_activated(&self) -> bool {
-        self.prague.load(std::sync::atomic::Ordering::Relaxed)
+        self.osaka.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Returns the max blob count.


### PR DESCRIPTION
## Description

Extracted from https://github.com/paradigmxyz/reth/pull/15534

Track Osaka activation in eth txpool validator.