### PR TITLE
fix: use different cache instance per precompile

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -13,7 +13,7 @@ use reth_chain_state::EthPrimitives;
 use reth_chainspec::ChainSpec;
 use reth_db_common::init::init_genesis;
 use reth_engine_tree::tree::{
-    executor::WorkloadExecutor, precompile_cache::PrecompileCache, PayloadProcessor,
+    executor::WorkloadExecutor, precompile_cache::PrecompileCacheMap, PayloadProcessor,
     StateProviderBuilder, TreeConfig,
 };
 use reth_evm::OnStateHook;
@@ -221,7 +221,7 @@ fn bench_state_root(c: &mut Criterion) {
                             WorkloadExecutor::default(),
                             EthEvmConfig::new(factory.chain_spec()),
                             &TreeConfig::default(),
-                            PrecompileCache::default(),
+                            PrecompileCacheMap::default(),
                         );
                         let provider = BlockchainProvider::new(factory).unwrap();
 

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -2,8 +2,11 @@
 
 use reth_evm::precompiles::{DynPrecompile, Precompile};
 use revm::precompile::{PrecompileOutput, PrecompileResult};
-use revm_primitives::Bytes;
+use revm_primitives::{Address, Bytes, HashMap};
 use std::sync::Arc;
+
+/// Stores caches for each precompile.
+pub type PrecompileCacheMap = HashMap<Address, PrecompileCache>;
 
 /// Cache for precompiles, for each input stores the result.
 #[derive(Debug, Clone)]

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -1,12 +1,20 @@
 //! Contains a precompile cache that is backed by a moka cache.
 
+use alloy_primitives::map::Entry;
 use reth_evm::precompiles::{DynPrecompile, Precompile};
 use revm::precompile::{PrecompileOutput, PrecompileResult};
 use revm_primitives::{Address, Bytes, HashMap};
 use std::sync::Arc;
 
 /// Stores caches for each precompile.
-pub type PrecompileCacheMap = HashMap<Address, PrecompileCache>;
+#[derive(Debug, Clone, Default)]
+pub struct PrecompileCacheMap(HashMap<Address, PrecompileCache>);
+
+impl PrecompileCacheMap {
+    pub(crate) fn entry(&mut self, address: Address) -> Entry<'_, Address, PrecompileCache> {
+        self.0.entry(address)
+    }
+}
 
 /// Cache for precompiles, for each input stores the result.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
We store different caches for each precompile indexed by address. 