### PR TITLE
feat(engine): add conversions for `ExecutionPayloadEnvelopeV5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8097,6 +8097,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -345,7 +345,7 @@ pub(crate) async fn call_forkchoice_updated<N, P: EngineApiValidWaitExt<N>>(
     payload_attributes: Option<PayloadAttributes>,
 ) -> TransportResult<ForkchoiceUpdated> {
     match message_version {
-        EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 => {
+        EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 | EngineApiMessageVersion::V5 => {
             provider.fork_choice_updated_v3_wait(forkchoice_state, payload_attributes).await
         }
         EngineApiMessageVersion::V2 => {

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -57,7 +57,8 @@ pub trait EngineTypes:
         BuiltPayload: TryInto<Self::ExecutionPayloadEnvelopeV1>
                           + TryInto<Self::ExecutionPayloadEnvelopeV2>
                           + TryInto<Self::ExecutionPayloadEnvelopeV3>
-                          + TryInto<Self::ExecutionPayloadEnvelopeV4>,
+                          + TryInto<Self::ExecutionPayloadEnvelopeV4>
+                          + TryInto<Self::ExecutionPayloadEnvelopeV5>,
     > + DeserializeOwned
     + Serialize
 {
@@ -87,6 +88,14 @@ pub trait EngineTypes:
         + 'static;
     /// Execution Payload V4 envelope type.
     type ExecutionPayloadEnvelopeV4: DeserializeOwned
+        + Serialize
+        + Clone
+        + Unpin
+        + Send
+        + Sync
+        + 'static;
+    /// Execution Payload V5 envelope type.
+    type ExecutionPayloadEnvelopeV5: DeserializeOwned
         + Serialize
         + Clone
         + Unpin

--- a/crates/ethereum/engine-primitives/Cargo.toml
+++ b/crates/ethereum/engine-primitives/Cargo.toml
@@ -42,6 +42,7 @@ std = [
     "serde/std",
     "sha2/std",
     "serde_json/std",
+    "thiserror/std",
     "reth-engine-primitives/std",
     "reth-primitives-traits/std",
 ]

--- a/crates/ethereum/engine-primitives/Cargo.toml
+++ b/crates/ethereum/engine-primitives/Cargo.toml
@@ -26,6 +26,7 @@ alloy-rlp.workspace = true
 # misc
 serde.workspace = true
 sha2.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/ethereum/engine-primitives/src/error.rs
+++ b/crates/ethereum/engine-primitives/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+/// Error during [`EthBuiltPayload`](crate::EthBuiltPayload) to execution payload envelope
+/// conversion.
+#[derive(Error, Debug)]
+pub enum BuiltPayloadConversionError {
+    /// Unexpected EIP-4844 sidecars in the built payload.
+    #[error("unexpected EIP-4844 sidecars")]
+    UnexpectedEip4844Sidecars,
+    /// Unexpected EIP-7594 sidecars in the built payload.
+    #[error("unexpected EIP-7594 sidecars")]
+    UnexpectedEip7594Sidecars,
+}

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -14,6 +14,9 @@ extern crate alloc;
 mod payload;
 pub use payload::{EthBuiltPayload, EthPayloadBuilderAttributes};
 
+mod error;
+pub use error::*;
+
 use alloy_rpc_types_engine::{ExecutionData, ExecutionPayload, ExecutionPayloadEnvelopeV5};
 pub use alloy_rpc_types_engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod payload;
-pub use payload::{EthBuiltPayload, EthPayloadBuilderAttributes};
+pub use payload::{BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
 
 mod error;
 pub use error::*;

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -14,7 +14,7 @@ extern crate alloc;
 mod payload;
 pub use payload::{EthBuiltPayload, EthPayloadBuilderAttributes};
 
-use alloy_rpc_types_engine::{ExecutionData, ExecutionPayload};
+use alloy_rpc_types_engine::{ExecutionData, ExecutionPayload, ExecutionPayloadEnvelopeV5};
 pub use alloy_rpc_types_engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,
     ExecutionPayloadV1, PayloadAttributes as EthPayloadAttributes,
@@ -62,12 +62,14 @@ where
         + TryInto<ExecutionPayloadV1>
         + TryInto<ExecutionPayloadEnvelopeV2>
         + TryInto<ExecutionPayloadEnvelopeV3>
-        + TryInto<ExecutionPayloadEnvelopeV4>,
+        + TryInto<ExecutionPayloadEnvelopeV4>
+        + TryInto<ExecutionPayloadEnvelopeV5>,
 {
     type ExecutionPayloadEnvelopeV1 = ExecutionPayloadV1;
     type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadEnvelopeV3 = ExecutionPayloadEnvelopeV3;
     type ExecutionPayloadEnvelopeV4 = ExecutionPayloadEnvelopeV4;
+    type ExecutionPayloadEnvelopeV5 = ExecutionPayloadEnvelopeV5;
 }
 
 /// A default payload type for [`EthEngineTypes`]

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -70,7 +70,7 @@ impl EthBuiltPayload {
     }
 
     /// Returns the blob sidecars.
-    pub fn sidecars(&self) -> &BlobSidecars {
+    pub const fn sidecars(&self) -> &BlobSidecars {
         &self.sidecars
     }
 
@@ -235,12 +235,12 @@ pub enum BlobSidecars {
 
 impl BlobSidecars {
     /// Create new EIP-4844 style sidecars.
-    pub fn eip4844(sidecars: Vec<BlobTransactionSidecar>) -> Self {
+    pub const fn eip4844(sidecars: Vec<BlobTransactionSidecar>) -> Self {
         Self::Eip4844(sidecars)
     }
 
     /// Create new EIP-7549 style sidecars.
-    pub fn eip7549(sidecars: Vec<BlobTransactionSidecarEip7594>) -> Self {
+    pub const fn eip7549(sidecars: Vec<BlobTransactionSidecarEip7594>) -> Self {
         Self::Eip7594(sidecars)
     }
 }

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -74,7 +74,7 @@ impl EthBuiltPayload {
         &self.sidecars
     }
 
-    /// Same as [`Self::extend_sidecars`] but returns the type again.
+    /// Sets blob transactions sidecars on the payload.
     pub fn with_sidecars(mut self, sidecars: impl Into<BlobSidecars>) -> Self {
         self.sidecars = sidecars.into();
         self

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -44,7 +44,7 @@ pub struct EthBuiltPayload {
 impl EthBuiltPayload {
     /// Initializes the payload with the given initial block
     ///
-    /// Caution: This does not set any [`BlobTransactionSidecarVariant`].
+    /// Caution: This does not set any [`BlobSidecars`].
     pub const fn new(
         id: PayloadId,
         block: Arc<SealedBlock<Block>>,
@@ -229,7 +229,7 @@ pub enum BlobSidecars {
     Empty,
     /// EIP-4844 style sidecars.
     Eip4844(Vec<BlobTransactionSidecar>),
-    /// EIP-7549 style sidecars.
+    /// EIP-7594 style sidecars.
     Eip7594(Vec<BlobTransactionSidecarEip7594>),
 }
 
@@ -239,8 +239,8 @@ impl BlobSidecars {
         Self::Eip4844(sidecars)
     }
 
-    /// Create new EIP-7549 style sidecars.
-    pub const fn eip7549(sidecars: Vec<BlobTransactionSidecarEip7594>) -> Self {
+    /// Create new EIP-7594 style sidecars.
+    pub const fn eip7594(sidecars: Vec<BlobTransactionSidecarEip7594>) -> Self {
         Self::Eip7594(sidecars)
     }
 }

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -136,7 +136,7 @@ impl EthBuiltPayload {
 
     /// Try converting built payload into [`ExecutionPayloadEnvelopeV5`].
     pub fn try_into_v5(self) -> Result<ExecutionPayloadEnvelopeV5, String> {
-        let EthBuiltPayload { block, fees, sidecars, requests, .. } = self;
+        let Self { block, fees, sidecars, requests, .. } = self;
 
         let blobs_bundle = BlobsBundleV2::from(
             sidecars

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -253,7 +253,7 @@ impl From<Vec<BlobTransactionSidecar>> for BlobSidecars {
 
 impl From<Vec<BlobTransactionSidecarEip7594>> for BlobSidecars {
     fn from(value: Vec<BlobTransactionSidecarEip7594>) -> Self {
-        Self::eip7549(value)
+        Self::eip7594(value)
     }
 }
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -9,10 +9,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![allow(clippy::useless_let_if_seq)]
 
-pub mod validator;
-use alloy_eips::eip7594::BlobTransactionSidecarVariant;
-pub use validator::EthereumExecutionPayloadValidator;
-
 use alloy_consensus::{Transaction, Typed2718};
 use alloy_primitives::U256;
 use reth_basic_payload_builder::{
@@ -30,11 +26,13 @@ use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{
-    error::InvalidPoolTransactionError, BestTransactions, BestTransactionsAttributes,
-    PoolTransaction, TransactionPool, ValidPoolTransaction,
+    error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
+    BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
+    ValidPoolTransaction,
 };
 use revm::context_interface::Block as _;
 use std::sync::Arc;
@@ -42,8 +40,9 @@ use tracing::{debug, trace, warn};
 
 mod config;
 pub use config::*;
-use reth_primitives_traits::transaction::error::InvalidTransactionError;
-use reth_transaction_pool::error::Eip4844PoolTransactionError;
+
+pub mod validator;
+pub use validator::EthereumExecutionPayloadValidator;
 
 type BestTransactionsIter<Pool> = Box<
     dyn BestTransactions<Item = Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>,
@@ -316,14 +315,9 @@ where
     let sealed_block = Arc::new(block.sealed_block().clone());
     debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
 
-    let mut payload = EthBuiltPayload::new(attributes.id, sealed_block, total_fees, requests);
-
-    // extend the payload with the blob sidecars from the executed txs
-    payload.extend_sidecars(
-        blob_sidecars
-            .into_iter()
-            .map(|sidecar| BlobTransactionSidecarVariant::Eip4844(Arc::unwrap_or_clone(sidecar))),
-    );
+    let payload = EthBuiltPayload::new(attributes.id, sealed_block, total_fees, requests)
+        // add blob sidecars from the executed txs
+        .with_sidecars(blob_sidecars.into_iter().map(Arc::unwrap_or_clone).collect::<Vec<_>>());
 
     Ok(BuildOutcome::Better { payload, cached_reads })
 }

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::useless_let_if_seq)]
 
 pub mod validator;
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 pub use validator::EthereumExecutionPayloadValidator;
 
 use alloy_consensus::{Transaction, Typed2718};
@@ -318,7 +319,11 @@ where
     let mut payload = EthBuiltPayload::new(attributes.id, sealed_block, total_fees, requests);
 
     // extend the payload with the blob sidecars from the executed txs
-    payload.extend_sidecars(blob_sidecars.into_iter().map(Arc::unwrap_or_clone));
+    payload.extend_sidecars(
+        blob_sidecars
+            .into_iter()
+            .map(|sidecar| BlobTransactionSidecarVariant::Eip4844(Arc::unwrap_or_clone(sidecar))),
+    );
 
     Ok(BuildOutcome::Better { payload, cached_reads })
 }

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -234,7 +234,10 @@ pub fn validate_withdrawals_presence(
                     .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))
             }
         }
-        EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 => {
+        EngineApiMessageVersion::V2 |
+        EngineApiMessageVersion::V3 |
+        EngineApiMessageVersion::V4 |
+        EngineApiMessageVersion::V5 => {
             if is_shanghai && !has_withdrawals {
                 return Err(message_validation_kind
                     .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -66,6 +66,7 @@ where
     type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadEnvelopeV3 = OpExecutionPayloadEnvelopeV3;
     type ExecutionPayloadEnvelopeV4 = OpExecutionPayloadEnvelopeV4;
+    type ExecutionPayloadEnvelopeV5 = OpExecutionPayloadEnvelopeV4;
 }
 
 /// Validator for Optimism engine API.

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -155,7 +155,10 @@ pub fn validate_withdrawals_presence<T: EthereumHardforks>(
                     .to_error(VersionSpecificValidationError::WithdrawalsNotSupportedInV1))
             }
         }
-        EngineApiMessageVersion::V2 | EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 => {
+        EngineApiMessageVersion::V2 |
+        EngineApiMessageVersion::V3 |
+        EngineApiMessageVersion::V4 |
+        EngineApiMessageVersion::V5 => {
             if is_shanghai_active && !has_withdrawals {
                 return Err(message_validation_kind
                     .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))
@@ -256,7 +259,7 @@ pub fn validate_parent_beacon_block_root_presence<T: EthereumHardforks>(
                 ))
             }
         }
-        EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 => {
+        EngineApiMessageVersion::V3 | EngineApiMessageVersion::V4 | EngineApiMessageVersion::V5 => {
             if !has_parent_beacon_block_root {
                 return Err(validation_kind
                     .to_error(VersionSpecificValidationError::NoParentBeaconBlockRootPostCancun))
@@ -350,12 +353,16 @@ pub enum EngineApiMessageVersion {
     /// Version 3
     ///
     /// Added in the Cancun hardfork.
-    #[default]
     V3 = 3,
     /// Version 4
     ///
     /// Added in the Prague hardfork.
+    #[default]
     V4 = 4,
+    /// Version 5
+    ///
+    /// Added in the Osaka hardfork.
+    V5 = 5,
 }
 
 impl EngineApiMessageVersion {
@@ -377,6 +384,11 @@ impl EngineApiMessageVersion {
     /// Returns true if the version is V4.
     pub const fn is_v4(&self) -> bool {
         matches!(self, Self::V4)
+    }
+
+    /// Returns true if the version is V5.
+    pub const fn is_v5(&self) -> bool {
+        matches!(self, Self::V5)
     }
 }
 

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -23,8 +23,8 @@ use alloy_primitives::{Address, B256};
 use alloy_rpc_types::{
     engine::{
         ExecutionData, ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3,
-        ExecutionPayloadEnvelopeV4, ExecutionPayloadV1, PayloadAttributes as EthPayloadAttributes,
-        PayloadId,
+        ExecutionPayloadEnvelopeV4, ExecutionPayloadEnvelopeV5, ExecutionPayloadV1,
+        PayloadAttributes as EthPayloadAttributes, PayloadId,
     },
     Withdrawal,
 };
@@ -176,6 +176,7 @@ impl EngineTypes for CustomEngineTypes {
     type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
     type ExecutionPayloadEnvelopeV3 = ExecutionPayloadEnvelopeV3;
     type ExecutionPayloadEnvelopeV4 = ExecutionPayloadEnvelopeV4;
+    type ExecutionPayloadEnvelopeV5 = ExecutionPayloadEnvelopeV5;
 }
 
 /// Custom engine validator


### PR DESCRIPTION
## Description

Extracted from https://github.com/paradigmxyz/reth/pull/15534

Change sidecar type on `EthBuiltPayload` to `BlobTransactionSidecarVariant`. Make built payload conversions to v3 & v4 envelopes fallible. Add conversion to v5.
