### PR TITLE
docs: fix JWT token link

### DIFF
--- a/etc/generate-jwt.sh
+++ b/etc/generate-jwt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Borrowed from EthStaker's prepare for the merge guide
-# See https://github.com/remyroy/ethstaker/blob/main/prepare-for-the-merge.md#configuring-a-jwt-token-file
+# See https://github.com/eth-educators/ethstaker-guides/blob/main/docs/prepare-for-the-merge.md#configuring-a-jwt-token-file
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 mkdir -p "${SCRIPT_DIR}/jwttoken"


### PR DESCRIPTION
Hi, I replaced the broken “Configuring a JWT token file” link with a working one from eth-educators, so readers don’t hit a 404 anymore.