### PR TITLE
feat(engine): add osaka engine methods to capabilities

### DIFF
--- a/crates/rpc/rpc-engine-api/src/capabilities.rs
+++ b/crates/rpc/rpc-engine-api/src/capabilities.rs
@@ -10,6 +10,7 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getPayloadV2",
     "engine_getPayloadV3",
     "engine_getPayloadV4",
+    "engine_getPayloadV5",
     "engine_newPayloadV1",
     "engine_newPayloadV2",
     "engine_newPayloadV3",
@@ -17,6 +18,7 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getPayloadBodiesByHashV1",
     "engine_getPayloadBodiesByRangeV1",
     "engine_getBlobsV1",
+    "engine_getBlobsV2",
 ];
 
 // The list of all supported Engine capabilities available over the engine endpoint.


### PR DESCRIPTION
## Description

Add `engine_getPayloadV5` & `engine_getBlobsV2` to capabilities.