### PR TITLE
chore: bump default gas limit for holesky

### DIFF
--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -42,7 +42,7 @@ pub trait PayloadBuilderConfig {
         }
 
         match chain.kind() {
-            ChainKind::Named(NamedChain::Sepolia | NamedChain::Hoodi) => {
+            ChainKind::Named(NamedChain::Sepolia | NamedChain::Holesky) => {
                 ETHEREUM_BLOCK_GAS_LIMIT_60M
             }
             _ => ETHEREUM_BLOCK_GAS_LIMIT_36M,


### PR DESCRIPTION
should be holesky not hoodi