### PR TITLE
feat(stages): reduce index history progress logging frequency

### DIFF
--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -124,14 +124,14 @@ where
 
     // observability
     let total_entries = collector.len();
-    let interval = (total_entries / 100).max(1);
+    let interval = (total_entries / 1000).max(1);
 
     for (index, element) in collector.iter()?.enumerate() {
         let (k, v) = element?;
         let sharded_key = decode_key(k)?;
         let new_list = BlockNumberList::decompress_owned(v)?;
 
-        if index > 0 && index % interval == 0 && total_entries > 100 {
+        if index > 0 && index % interval == 0 && total_entries > 1000 {
             info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing indices");
         }
 

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -131,7 +131,7 @@ where
         let sharded_key = decode_key(k)?;
         let new_list = BlockNumberList::decompress_owned(v)?;
 
-        if index > 0 && index % interval == 0 && total_entries > 1000 {
+        if index > 0 && index % interval == 0 && total_entries > 10 {
             info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing indices");
         }
 

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -124,7 +124,7 @@ where
 
     // observability
     let total_entries = collector.len();
-    let interval = (total_entries / 1000).max(1);
+    let interval = (total_entries / 10).max(1);
 
     for (index, element) in collector.iter()?.enumerate() {
         let (k, v) = element?;


### PR DESCRIPTION
In our running node, I found there's too much logs for the index history progress, about 15 logs in 1 second, which is too much.

```
2025-05-16T02:40:53.776686Z  INFO Writing indices progress=45.71%
2025-05-16T02:40:53.791592Z  INFO Writing indices progress=46.71%
2025-05-16T02:40:53.808306Z  INFO Writing indices progress=47.70%
2025-05-16T02:40:53.821290Z  INFO Writing indices progress=48.69%
2025-05-16T02:40:53.837545Z  INFO Writing indices progress=49.69%
2025-05-16T02:40:53.852716Z  INFO Writing indices progress=50.68%
2025-05-16T02:40:53.870144Z  INFO Writing indices progress=51.68%
2025-05-16T02:40:53.883455Z  INFO Writing indices progress=52.67%
2025-05-16T02:40:53.896637Z  INFO Writing indices progress=53.66%
2025-05-16T02:40:53.912344Z  INFO Writing indices progress=54.66%
2025-05-16T02:40:53.924329Z  INFO Writing indices progress=55.65%
2025-05-16T02:40:53.936311Z  INFO Writing indices progress=56.64%
2025-05-16T02:40:53.949874Z  INFO Writing indices progress=57.64%
2025-05-16T02:40:53.963764Z  INFO Writing indices progress=58.63%
2025-05-16T02:40:53.977196Z  INFO Writing indices progress=59.63%
2025-05-16T02:40:53.989558Z  INFO Writing indices progress=60.62%
```

So propose to increase the interval from `total_entries / 100` to `total_entries /1000`, which is similar to `collect_history_indices`