### PR TITLE
chore: bump inspectors 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10500,9 +10500,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8854cd409c50e98f74a15ec5e971d81d10c825754ab55ec9b9135fff45571a66"
+checksum = "6745857d9a4fcb03821e899a7072f9faca0eca5113f544ebcdf1b2c70b7d1fd1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -455,7 +455,7 @@ revm-context = { version = "4.0.0", default-features = false }
 revm-context-interface = { version = "4.0.0", default-features = false }
 revm-database-interface = { version = "4.0.0", default-features = false }
 op-revm = { version = "4.0.2", default-features = false }
-revm-inspectors = "0.22.0"
+revm-inspectors = "0.22.1"
 
 # eth
 alloy-chains = { version = "0.2.0", default-features = false }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -287,7 +287,7 @@ where
                                 Ok(inspector)
                             })
                             .await?;
-                        return Ok(FourByteFrame::from(&inspector).into())
+                        Ok(FourByteFrame::from(&inspector).into())
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
                         let call_config = tracer_config
@@ -310,7 +310,7 @@ where
                                 Ok(frame.into())
                             })
                             .await?;
-                        return Ok(frame)
+                        Ok(frame)
                     }
                     GethDebugBuiltInTracerType::PreStateTracer => {
                         let prestate_config = tracer_config
@@ -341,7 +341,7 @@ where
                                 Ok(frame)
                             })
                             .await?;
-                        return Ok(frame.into())
+                        Ok(frame.into())
                     }
                     GethDebugBuiltInTracerType::NoopTracer => Ok(NoopFrame::default().into()),
                     GethDebugBuiltInTracerType::MuxTracer => {
@@ -380,7 +380,7 @@ where
                                 Ok(frame.into())
                             })
                             .await?;
-                        return Ok(frame)
+                        Ok(frame)
                     }
                     GethDebugBuiltInTracerType::FlatCallTracer => {
                         let flat_call_config = tracer_config
@@ -406,7 +406,7 @@ where
                             })
                             .await?;
 
-                        return Ok(frame.into());
+                        Ok(frame.into())
                     }
                 },
                 #[cfg(not(feature = "js-tracer"))]


### PR DESCRIPTION
first smol bug fix for #16289

drive by: remove redundant returns