### PR TITLE
Fix invalid ERA1 link: remove “index.html” suffix

### DIFF
--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -38,7 +38,7 @@ impl HttpClient for StubClient {
 
         async move {
             match url.to_string().as_str() {
-                "https://mainnet.era1.nimbus.team/index.html" => {
+                "https://mainnet.era1.nimbus.team/" => {
                     Ok(Box::new(futures::stream::once(Box::pin(async move {
                         Ok(bytes::Bytes::from(NIMBUS))
                     })))


### PR DESCRIPTION
Updates occurrence of  
`https://mainnet.era1.nimbus.team/index.html` → `https://mainnet.era1.nimbus.team/`.

*Rationale*: the `/index.html` path returns 404, while the root URL serves the expected ERA1 resources.