### PR TITLE
ci: deduplicate changelog in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,12 +158,6 @@ jobs:
           fetch-depth: 0
       - name: Download artifacts
         uses: actions/download-artifact@v4
-      - name: Generate full changelog
-        id: changelog
-        run: |
-          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - name: Create release draft
         env:
           GITHUB_USER: ${{ github.repository_owner }}
@@ -206,10 +200,6 @@ jobs:
           | Non-Payload Builders | <TODO>    |
 
           *See [Update Priorities](https://paradigmxyz.github.io/reth/installation/priorities.html) for more information about this table.*
-
-          ## All Changes
-
-          ${{ steps.changelog.outputs.CHANGELOG }}
 
           ## Binaries
 


### PR DESCRIPTION
`gh release create --draft` already creates a changelog that looks exactly the same as ours. See "All Changes" and "What's Changed" here https://github.com/paradigmxyz/reth/releases/tag/v1.3.12 as an example.

This PR removes custom changelog that we generate.