### PR TITLE
refactor(rpc-builder): Use Box<dyn TaskSpawner> for RPC task handling

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -25,7 +25,6 @@ use reth_rpc_builder::{
 };
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_rpc_eth_types::{cache::cache_new_blocks_task, EthConfig, EthStateCache};
-use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
 use reth_tracing::tracing::{debug, info};
 use std::{
@@ -194,7 +193,6 @@ pub struct RpcRegistry<Node: FullNodeComponents, EthApi: EthApiTypes> {
         Node::Provider,
         Node::Pool,
         Node::Network,
-        TaskExecutor,
         EthApi,
         Node::Evm,
         Node::Consensus,
@@ -210,7 +208,6 @@ where
         Node::Provider,
         Node::Pool,
         Node::Network,
-        TaskExecutor,
         EthApi,
         Node::Evm,
         Node::Consensus,
@@ -511,7 +508,7 @@ where
             .with_provider(node.provider().clone())
             .with_pool(node.pool().clone())
             .with_network(node.network().clone())
-            .with_executor(node.task_executor().clone())
+            .with_executor(Box::new(node.task_executor().clone()))
             .with_evm_config(node.evm_config().clone())
             .with_consensus(node.consensus().clone())
             .build_with_auth_server(module_config, engine_api, eth_api);

--- a/crates/rpc/rpc-builder/src/eth.rs
+++ b/crates/rpc/rpc-builder/src/eth.rs
@@ -21,14 +21,14 @@ where
     /// Returns a new instance with the additional handlers for the `eth` namespace.
     ///
     /// This will spawn all necessary tasks for the additional handlers.
-    pub fn bootstrap<Tasks>(config: EthConfig, executor: Tasks, eth_api: EthApi) -> Self
-    where
-        Tasks: TaskSpawner + Clone + 'static,
-    {
-        let filter =
-            EthFilter::new(eth_api.clone(), config.filter_config(), Box::new(executor.clone()));
+    pub fn bootstrap(
+        config: EthConfig,
+        executor: Box<dyn TaskSpawner + 'static>,
+        eth_api: EthApi,
+    ) -> Self {
+        let filter = EthFilter::new(eth_api.clone(), config.filter_config(), executor.clone());
 
-        let pubsub = EthPubSub::with_spawner(eth_api.clone(), Box::new(executor));
+        let pubsub = EthPubSub::with_spawner(eth_api.clone(), executor);
 
         Self { api: eth_api, filter, pubsub }
     }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -209,8 +209,7 @@ where
     /// [`EthApi`] which requires a [`TransactionPool`] implementation.
     pub fn with_noop_pool(
         self,
-    ) -> RpcModuleBuilder<N, Provider, NoopTransactionPool, Network, EvmConfig, Consensus>
-    {
+    ) -> RpcModuleBuilder<N, Provider, NoopTransactionPool, Network, EvmConfig, Consensus> {
         let Self { provider, executor, network, evm_config, consensus, _primitives, .. } = self;
         RpcModuleBuilder {
             provider,
@@ -259,8 +258,7 @@ where
     pub fn with_executor(
         self,
         executor: Box<dyn TaskSpawner + 'static>,
-    ) -> RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus>
-    {
+    ) -> RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus> {
         let Self { pool, network, provider, evm_config, consensus, _primitives, .. } = self;
         RpcModuleBuilder { provider, network, pool, executor, evm_config, consensus, _primitives }
     }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -34,7 +34,7 @@ use jsonrpsee::{
 };
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::{op_revm::api::exec, ConfigureEvm};
+use reth_evm::{ConfigureEvm};
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc::{

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -103,13 +103,13 @@ pub mod rate_limiter;
 
 /// Convenience function for starting a server in one step.
 #[expect(clippy::too_many_arguments)]
-pub async fn launch<N, Provider, Pool, Network, Tasks, EvmConfig, EthApi>(
+pub async fn launch<N, Provider, Pool, Network, EvmConfig, EthApi>(
     provider: Provider,
     pool: Pool,
     network: Network,
     module_config: impl Into<TransportRpcModuleConfig>,
     server_config: impl Into<RpcServerConfig>,
-    executor: Tasks,
+    executor: Box<dyn TaskSpawner + 'static>,
     evm_config: EvmConfig,
     eth: EthApi,
     consensus: Arc<dyn FullConsensus<N, Error = ConsensusError>>,
@@ -122,7 +122,6 @@ where
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
-    Tasks: TaskSpawner + Clone + 'static,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
     EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
 {
@@ -140,7 +139,7 @@ where
 ///
 /// This is the main entrypoint and the easiest way to configure an RPC server.
 #[derive(Debug, Clone)]
-pub struct RpcModuleBuilder<N, Provider, Pool, Network, Tasks, EvmConfig, Consensus> {
+pub struct RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus> {
     /// The Provider type to when creating all rpc handlers
     provider: Provider,
     /// The Pool type to when creating all rpc handlers
@@ -148,7 +147,7 @@ pub struct RpcModuleBuilder<N, Provider, Pool, Network, Tasks, EvmConfig, Consen
     /// The Network type to when creating all rpc handlers
     network: Network,
     /// How additional tasks are spawned, for example in the eth pubsub namespace
-    executor: Tasks,
+    executor: Box<dyn TaskSpawner + 'static>,
     /// Defines how the EVM should be configured before execution.
     evm_config: EvmConfig,
     /// The consensus implementation.
@@ -159,8 +158,8 @@ pub struct RpcModuleBuilder<N, Provider, Pool, Network, Tasks, EvmConfig, Consen
 
 // === impl RpcBuilder ===
 
-impl<N, Provider, Pool, Network, Tasks, EvmConfig, Consensus>
-    RpcModuleBuilder<N, Provider, Pool, Network, Tasks, EvmConfig, Consensus>
+impl<N, Provider, Pool, Network, EvmConfig, Consensus>
+    RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus>
 where
     N: NodePrimitives,
     EvmConfig: Clone,
@@ -170,7 +169,7 @@ where
         provider: Provider,
         pool: Pool,
         network: Network,
-        executor: Tasks,
+        executor: Box<dyn TaskSpawner + 'static>,
         evm_config: EvmConfig,
         consensus: Consensus,
     ) -> Self {
@@ -181,7 +180,7 @@ where
     pub fn with_provider<P>(
         self,
         provider: P,
-    ) -> RpcModuleBuilder<N, P, Pool, Network, Tasks, EvmConfig, Consensus>
+    ) -> RpcModuleBuilder<N, P, Pool, Network, EvmConfig, Consensus>
     where
         P: BlockReader<Block = N::Block, Header = N::BlockHeader, Receipt = N::Receipt>
             + StateProviderFactory
@@ -195,7 +194,7 @@ where
     pub fn with_pool<P>(
         self,
         pool: P,
-    ) -> RpcModuleBuilder<N, Provider, P, Network, Tasks, EvmConfig, Consensus>
+    ) -> RpcModuleBuilder<N, Provider, P, Network, EvmConfig, Consensus>
     where
         P: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>> + 'static,
     {
@@ -210,7 +209,7 @@ where
     /// [`EthApi`] which requires a [`TransactionPool`] implementation.
     pub fn with_noop_pool(
         self,
-    ) -> RpcModuleBuilder<N, Provider, NoopTransactionPool, Network, Tasks, EvmConfig, Consensus>
+    ) -> RpcModuleBuilder<N, Provider, NoopTransactionPool, Network, EvmConfig, Consensus>
     {
         let Self { provider, executor, network, evm_config, consensus, _primitives, .. } = self;
         RpcModuleBuilder {
@@ -228,7 +227,7 @@ where
     pub fn with_network<Net>(
         self,
         network: Net,
-    ) -> RpcModuleBuilder<N, Provider, Pool, Net, Tasks, EvmConfig, Consensus>
+    ) -> RpcModuleBuilder<N, Provider, Pool, Net, EvmConfig, Consensus>
     where
         Net: NetworkInfo + Peers + 'static,
     {
@@ -243,7 +242,7 @@ where
     /// [`EthApi`] which requires a [`NetworkInfo`] implementation.
     pub fn with_noop_network(
         self,
-    ) -> RpcModuleBuilder<N, Provider, Pool, NoopNetwork, Tasks, EvmConfig, Consensus> {
+    ) -> RpcModuleBuilder<N, Provider, Pool, NoopNetwork, EvmConfig, Consensus> {
         let Self { provider, pool, executor, evm_config, consensus, _primitives, .. } = self;
         RpcModuleBuilder {
             provider,
@@ -257,12 +256,10 @@ where
     }
 
     /// Configure the task executor to use for additional tasks.
-    pub fn with_executor<T>(
+    pub fn with_executor(
         self,
-        executor: T,
-    ) -> RpcModuleBuilder<N, Provider, Pool, Network, T, EvmConfig, Consensus>
-    where
-        T: TaskSpawner + 'static,
+        executor: Box<dyn TaskSpawner + 'static>,
+    ) -> RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus>
     {
         let Self { pool, network, provider, evm_config, consensus, _primitives, .. } = self;
         RpcModuleBuilder { provider, network, pool, executor, evm_config, consensus, _primitives }
@@ -274,13 +271,13 @@ where
     /// [`TokioTaskExecutor`].
     pub fn with_tokio_executor(
         self,
-    ) -> RpcModuleBuilder<N, Provider, Pool, Network, TokioTaskExecutor, EvmConfig, Consensus> {
+    ) -> RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus> {
         let Self { pool, network, provider, evm_config, consensus, _primitives, .. } = self;
         RpcModuleBuilder {
             provider,
             network,
             pool,
-            executor: TokioTaskExecutor::default(),
+            executor: Box::new(TokioTaskExecutor::default()),
             evm_config,
             consensus,
             _primitives,
@@ -291,7 +288,7 @@ where
     pub fn with_evm_config<E>(
         self,
         evm_config: E,
-    ) -> RpcModuleBuilder<N, Provider, Pool, Network, Tasks, E, Consensus>
+    ) -> RpcModuleBuilder<N, Provider, Pool, Network, E, Consensus>
     where
         EvmConfig: 'static,
         E: ConfigureEvm + Clone,
@@ -304,7 +301,7 @@ where
     pub fn with_consensus<C>(
         self,
         consensus: C,
-    ) -> RpcModuleBuilder<N, Provider, Pool, Network, Tasks, EvmConfig, C> {
+    ) -> RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, C> {
         let Self { provider, network, pool, executor, evm_config, _primitives, .. } = self;
         RpcModuleBuilder { provider, network, pool, executor, evm_config, consensus, _primitives }
     }
@@ -347,8 +344,8 @@ where
     }
 }
 
-impl<N, Provider, Pool, Network, Tasks, EvmConfig, Consensus>
-    RpcModuleBuilder<N, Provider, Pool, Network, Tasks, EvmConfig, Consensus>
+impl<N, Provider, Pool, Network, EvmConfig, Consensus>
+    RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus>
 where
     N: NodePrimitives,
     Provider: FullRpcProvider<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
@@ -357,7 +354,6 @@ where
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
-    Tasks: TaskSpawner + Clone + 'static,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
     Consensus: FullConsensus<N, Error = ConsensusError> + Clone + 'static,
 {
@@ -376,7 +372,7 @@ where
     ) -> (
         TransportRpcModules,
         AuthRpcModule,
-        RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>,
+        RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>,
     )
     where
         EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
@@ -404,7 +400,7 @@ where
         self,
         config: RpcModuleConfig,
         eth: EthApi,
-    ) -> RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
+    ) -> RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>
     where
         EthApi: EthApiTypes + 'static,
     {
@@ -450,9 +446,9 @@ where
     }
 }
 
-impl<N: NodePrimitives> Default for RpcModuleBuilder<N, (), (), (), (), (), ()> {
+impl<N: NodePrimitives> Default for RpcModuleBuilder<N, (), (), (), (), ()> {
     fn default() -> Self {
-        Self::new((), (), (), (), (), ())
+        Self::new((), (), (), Box::new(TokioTaskExecutor::default()), (), ())
     }
 }
 
@@ -540,7 +536,6 @@ pub struct RpcRegistryInner<
     Provider: BlockReader,
     Pool,
     Network,
-    Tasks,
     EthApi: EthApiTypes,
     EvmConfig,
     Consensus,
@@ -548,7 +543,7 @@ pub struct RpcRegistryInner<
     provider: Provider,
     pool: Pool,
     network: Network,
-    executor: Tasks,
+    executor: Box<dyn TaskSpawner + 'static>,
     evm_config: EvmConfig,
     consensus: Consensus,
     /// Holds a all `eth_` namespace handlers
@@ -563,8 +558,8 @@ pub struct RpcRegistryInner<
 
 // === impl RpcRegistryInner ===
 
-impl<N, Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
+impl<N, Provider, Pool, Network, EthApi, EvmConfig, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>
 where
     N: NodePrimitives,
     Provider: StateProviderFactory
@@ -575,7 +570,6 @@ where
         + 'static,
     Pool: Send + Sync + Clone + 'static,
     Network: Clone + 'static,
-    Tasks: TaskSpawner + Clone + 'static,
     EthApi: EthApiTypes + 'static,
     EvmConfig: ConfigureEvm<Primitives = N>,
 {
@@ -585,7 +579,7 @@ where
         provider: Provider,
         pool: Pool,
         network: Network,
-        executor: Tasks,
+        executor: Box<dyn TaskSpawner + 'static>,
         consensus: Consensus,
         config: RpcModuleConfig,
         evm_config: EvmConfig,
@@ -596,7 +590,8 @@ where
     {
         let blocking_pool_guard = BlockingTaskGuard::new(config.eth.max_tracing_requests);
 
-        let eth = EthHandlers::bootstrap(config.eth, executor.clone(), eth_api);
+        let arc_executor: Arc<dyn TaskSpawner + 'static> = Arc::from(executor.clone());
+        let eth = EthHandlers::bootstrap(config.eth, arc_executor, eth_api);
 
         Self {
             provider,
@@ -613,8 +608,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, BlockExecutor, Consensus>
+impl<Provider, Pool, Network, EthApi, BlockExecutor, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, EthApi, BlockExecutor, Consensus>
 where
     Provider: BlockReader,
     EthApi: EthApiTypes,
@@ -635,8 +630,8 @@ where
     }
 
     /// Returns a reference to the tasks type
-    pub const fn tasks(&self) -> &Tasks {
-        &self.executor
+    pub const fn tasks(&self) -> &(dyn TaskSpawner + 'static) {
+        &*self.executor
     }
 
     /// Returns a reference to the provider
@@ -659,8 +654,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
+impl<Provider, Pool, Network, EthApi, EvmConfig, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>
 where
     Network: NetworkInfo + Clone + 'static,
     EthApi: EthApiTypes,
@@ -698,8 +693,8 @@ where
     }
 }
 
-impl<N, Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
+impl<N, Provider, Pool, Network, EthApi, EvmConfig, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>
 where
     N: NodePrimitives,
     Provider: FullRpcProvider<
@@ -710,7 +705,6 @@ where
         > + AccountReader
         + ChangeSetReader,
     Network: NetworkInfo + Peers + Clone + 'static,
-    Tasks: TaskSpawner + Clone + 'static,
     EthApi: EthApiServer<
             RpcTransaction<EthApi::NetworkTypes>,
             RpcBlock<EthApi::NetworkTypes>,
@@ -813,8 +807,8 @@ where
     }
 }
 
-impl<N, Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
+impl<N, Provider, Pool, Network, EthApi, EvmConfig, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>
 where
     N: NodePrimitives,
     Provider: FullRpcProvider<
@@ -825,7 +819,6 @@ where
         > + AccountReader
         + ChangeSetReader,
     Network: NetworkInfo + Peers + Clone + 'static,
-    Tasks: TaskSpawner + Clone + 'static,
     EthApi: EthApiTypes,
     EvmConfig: ConfigureEvm<Primitives = N>,
 {
@@ -886,12 +879,12 @@ where
 
     /// Instantiates `RethApi`
     pub fn reth_api(&self) -> RethApi<Provider> {
-        RethApi::new(self.provider.clone(), Box::new(self.executor.clone()))
+        RethApi::new(self.provider.clone(), self.executor.clone())
     }
 }
 
-impl<N, Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
-    RpcRegistryInner<Provider, Pool, Network, Tasks, EthApi, EvmConfig, Consensus>
+impl<N, Provider, Pool, Network, EthApi, EvmConfig, Consensus>
+    RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>
 where
     N: NodePrimitives,
     Provider: FullRpcProvider<Block = N::Block>
@@ -900,7 +893,6 @@ where
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
-    Tasks: TaskSpawner + Clone + 'static,
     EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
     Consensus: FullConsensus<N, Error = ConsensusError> + Clone + 'static,
@@ -1037,7 +1029,7 @@ where
                         .into(),
                         RethRpcModule::Ots => OtterscanApi::new(eth_api.clone()).into_rpc().into(),
                         RethRpcModule::Reth => {
-                            RethApi::new(self.provider.clone(), Box::new(self.executor.clone()))
+                            RethApi::new(self.provider.clone(), self.executor.clone())
                                 .into_rpc()
                                 .into()
                         }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -34,7 +34,7 @@ use jsonrpsee::{
 };
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_evm::{ConfigureEvm};
+use reth_evm::ConfigureEvm;
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc::{

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -123,7 +123,6 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
     NoopProvider,
     TestPool,
     NoopNetwork,
-    TokioTaskExecutor,
     EthEvmConfig,
     NoopConsensus,
 > {
@@ -131,7 +130,7 @@ pub fn test_rpc_builder() -> RpcModuleBuilder<
         .with_provider(NoopProvider::default())
         .with_pool(TestPoolBuilder::default().into())
         .with_network(NoopNetwork::default())
-        .with_executor(TokioTaskExecutor::default())
+        .with_executor(Box::new(TokioTaskExecutor::default()))
         .with_evm_config(EthEvmConfig::mainnet())
         .with_consensus(NoopConsensus::default())
 }

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -118,14 +118,9 @@ pub async fn launch_http_ws_same_port(modules: impl Into<RpcModuleSelection>) ->
 }
 
 /// Returns an [`RpcModuleBuilder`] with testing components.
-pub fn test_rpc_builder() -> RpcModuleBuilder<
-    EthPrimitives,
-    NoopProvider,
-    TestPool,
-    NoopNetwork,
-    EthEvmConfig,
-    NoopConsensus,
-> {
+pub fn test_rpc_builder(
+) -> RpcModuleBuilder<EthPrimitives, NoopProvider, TestPool, NoopNetwork, EthEvmConfig, NoopConsensus>
+{
     RpcModuleBuilder::default()
         .with_provider(NoopProvider::default())
         .with_pool(TestPoolBuilder::default().into())

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> eyre::Result<()> {
         // Rest is just noops that do nothing
         .with_noop_pool()
         .with_noop_network()
-        .with_executor(TokioTaskExecutor::default())
+        .with_executor(Box::new(TokioTaskExecutor::default()))
         .with_evm_config(EthEvmConfig::new(spec.clone()))
         .with_consensus(EthBeaconConsensus::new(spec.clone()));
 


### PR DESCRIPTION
Closes: #15261 

Replace the generic "Tasks" parameter throughout the RPC builder stack (RpcModuleBuilder, RpcRegistryInner, and associated functions) with the trait object type `Box<dyn TaskSpawner + 'static>`.