### PR TITLE
ci: use `GITHUB_REF_NAME` env var in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract version
-        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
         id: extract_version
     outputs:
       VERSION: ${{ steps.extract_version.outputs.VERSION }}


### PR DESCRIPTION
`GITHUB_REF_NAME` is the branch name like `main` when triggered from a branch, and the tag name like `v1.4.1` when triggered from a tag.

Previous command didn't work for dry runs, because the format of `GITHUB_REF` was `refs/head/main`.