### PR TITLE
ci: bump base image for reproducible builds

### DIFF
--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,8 +1,8 @@
-# Use the Rust 1.86 image based on Debian Bullseye
-FROM rust:1.86-bullseye AS builder
+# Use the Rust 1.86 image based on Debian Bookworm
+FROM rust:1.86-bookworm AS builder
 
 # Install specific version of libclang-dev
-RUN apt-get update && apt-get install -y libclang-dev=1:11.0-51+nmu5
+RUN apt-get update && apt-get install -y libclang-dev=1:14.0-55.7~deb12u1
 
 # Copy the project to the container
 COPY ./ /app

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ RUST_BUILD_FLAGS =
 # Enable static linking to ensure reproducibility across builds
 RUST_BUILD_FLAGS += --C target-feature=+crt-static
 # Set the linker to use static libgcc to ensure reproducibility across builds
-RUST_BUILD_FLAGS += -Clink-arg=-static-libgcc
+RUST_BUILD_FLAGS += -C link-arg=-static-libgcc
 # Remove build ID from the binary to ensure reproducibility across builds
 RUST_BUILD_FLAGS += -C link-arg=-Wl,--build-id=none
 # Remove metadata hash from symbol names to ensure reproducible builds


### PR DESCRIPTION
Doesn't fail anymore
```console
❯ docker buildx build -f Dockerfile.reproducible --platform=linux/amd64 .
[+] Building 312.1s (16/16) FINISHED                                                                                                                            docker:orbstack
 => [internal] load build definition from Dockerfile.reproducible                                                                                                          0.0s
 => => transferring dockerfile: 794B                                                                                                                                       0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1.7-labs                                                                                           0.8s
 => CACHED docker-image://docker.io/docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894                                     0.0s
 => [internal] load metadata for gcr.io/distroless/cc-debian12:nonroot-6755e21ccd99ddead6edc8106ba03888cbeed41a                                                            0.4s
 => [internal] load metadata for docker.io/library/rust:1.86-bookworm                                                                                                      0.5s
 => [internal] load .dockerignore                                                                                                                                          0.0s
 => => transferring context: 373B                                                                                                                                          0.0s
 => [builder 1/6] FROM docker.io/library/rust:1.86-bookworm@sha256:300ec56abce8cc9448ddea2172747d048ed902a3090e6b57babb2bf19f754081                                        0.0s
 => CACHED [stage-1 1/2] FROM gcr.io/distroless/cc-debian12:nonroot-6755e21ccd99ddead6edc8106ba03888cbeed41a@sha256:ce79e1448516ef8909ccdc7f09b7e9186c53e5c964394580f92d9  0.0s
 => [internal] load build context                                                                                                                                         22.2s
 => => transferring context: 2.83MB                                                                                                                                       22.2s
 => CACHED [builder 2/6] RUN apt-get update && apt-get install -y libclang-dev=1:14.0-55.7~deb12u1                                                                         0.0s
 => CACHED [builder 3/6] COPY --exclude=target ./ /app                                                                                                                     0.0s
 => CACHED [builder 4/6] WORKDIR /app                                                                                                                                      0.0s
 => [builder 5/6] RUN make build-reproducible                                                                                                                            287.0s
 => [builder 6/6] RUN mv /app/target/x86_64-unknown-linux-gnu/release/reth /reth                                                                                           0.1s
 => [stage-1 2/2] COPY --from=builder /reth /reth                                                                                                                          0.0s
 => exporting to image                                                                                                                                                     0.1s
 => => exporting layers                                                                                                                                                    0.1s
 => => writing image sha256:46e0b081966bace34994155c5a9e4a3646190e2db92c03a43267b4e7eb95e42a     
```