### PR TITLE
chore: Move execution witness checks outside of `WitnessDB`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10021,6 +10021,7 @@ name = "reth-stateless"
 version = "1.4.1"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips 1.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",

--- a/crates/stateless/Cargo.toml
+++ b/crates/stateless/Cargo.toml
@@ -18,6 +18,7 @@ alloy-rlp.workspace = true
 alloy-trie.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-debug.workspace = true
+alloy-eips.workspace = true
 
 # reth
 reth-ethereum-consensus.workspace = true

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -350,6 +350,9 @@ fn fetch_all_accounts_and_storage_slots(
     let mut accounts: BTreeMap<Address, Option<TrieAccount>> = BTreeMap::new();
     let mut storage_slots: BTreeMap<(Address, U256), U256> = BTreeMap::new();
 
+    // Add the system contract caller
+    accounts.insert(alloy_eips::eip4788::SYSTEM_ADDRESS, None);
+
     // TODO: We could remove the need of this by having the ExecutionWitness
     // TODO: have a map of keys instead of a vector. ie address -> {storage_slots}
     let mut current_address: Option<Address> = None;

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -364,6 +364,6 @@ fn fetch_storage_slot(
     address: Address,
     slot: U256,
     trie: &SparseStateTrie,
-) -> Result<Option<U256>, ProviderError> {
+) -> Result<U256, ProviderError> {
     todo!()
 }

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -129,9 +129,13 @@ pub enum StatelessValidationError {
 /// `current_block`.
 pub fn stateless_validation(
     current_block: RecoveredBlock<Block<TransactionSigned>>,
-    witness: ExecutionWitness,
+    mut witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
 ) -> Result<B256, StatelessValidationError> {
+    // Add coinbase account to keys that should be checked
+    let coinbase = current_block.header().beneficiary;
+    witness.keys.push(coinbase.0.into());
+
     let mut ancestor_headers: Vec<Header> = witness
         .headers
         .iter()

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -245,6 +245,7 @@ fn validate_block_consensus(
 /// for the given `pre_state_root`.
 // Note: This approach might be inefficient for ZKVMs requiring minimal memory operations, which
 // would explain why they have for the most part re-implemented this function.
+#[allow(clippy::type_complexity)] // TODO: use a struct
 pub fn verify_execution_witness(
     witness: &ExecutionWitness,
     pre_state_root: B256,
@@ -340,6 +341,7 @@ fn compute_ancestor_hashes(
     Ok(ancestor_hashes)
 }
 
+#[allow(clippy::type_complexity)] // TODO: use a struct
 fn fetch_all_accounts_and_storage_slots(
     keys: &[Bytes],
     trie: &SparseStateTrie,

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -358,6 +358,19 @@ fn fetch_account(
     address: Address,
     trie: &SparseStateTrie,
 ) -> Result<Option<TrieAccount>, ProviderError> {
+    let hashed_address = keccak256(address);
+
+    if let Some(bytes) = trie.get_account_value(&hashed_address) {
+        let account = TrieAccount::decode(&mut bytes.as_slice())?;
+        return Ok(Some(account));
+    }
+
+    if !trie.check_valid_account_witness(hashed_address) {
+        return Err(ProviderError::TrieWitnessError(format!(
+            "incomplete account witness for {hashed_address:?}"
+        )));
+    }
+
     Ok(None)
 }
 fn fetch_storage_slot(

--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -31,10 +31,12 @@ pub(crate) struct WitnessDatabase<'a> {
     bytecode: B256Map<Bytecode>,
     /// The sparse Merkle Patricia Trie containing account and storage state.
     /// This is used to provide account/storage values during EVM execution.
-    /// TODO: Ideally we do not have this trie and instead a simple map.
-    /// TODO: Then as a corollary we can avoid unnecessary hashing in `Database::storage`
-    /// TODO: and `Database::basic` without needing to cache the hashed Addresses and Keys
+    /// TODO: This will be removed, once `accounts` and `storage_slots`
+    /// TODO: properly implemented
     trie: &'a SparseStateTrie,
+
+    accounts: BTreeMap<Address, Option<TrieAccount>>,
+    storage_slots: BTreeMap<(Address, U256), U256>,
 }
 
 impl<'a> WitnessDatabase<'a> {
@@ -53,10 +55,18 @@ impl<'a> WitnessDatabase<'a> {
     ///    the block limit.
     pub(crate) const fn new(
         trie: &'a SparseStateTrie,
+        accounts: BTreeMap<Address, Option<TrieAccount>>,
+        storage_slots: BTreeMap<(Address, U256), U256>,
         bytecode: B256Map<Bytecode>,
         ancestor_hashes: BTreeMap<u64, B256>,
     ) -> Self {
-        Self { trie, block_hashes_by_block_number: ancestor_hashes, bytecode }
+        Self {
+            trie,
+            block_hashes_by_block_number: ancestor_hashes,
+            bytecode,
+            accounts,
+            storage_slots,
+        }
     }
 }
 


### PR DESCRIPTION
This separates the checks that are currently in WitnessDB for ensuring that the ExecutionWitness is complete.