### PR TITLE
chore: `RecoveredBlock` -> `Block`

### DIFF
--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -13,10 +13,10 @@ use reth_chainspec::ChainSpec;
 use reth_consensus::{Consensus, HeaderValidator};
 use reth_errors::ConsensusError;
 use reth_ethereum_consensus::{validate_block_post_execution, EthBeaconConsensus};
-use reth_ethereum_primitives::Block as EthereumBlock;
+use reth_ethereum_primitives::Block;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_evm_ethereum::execute::EthExecutorProvider;
-use reth_primitives_traits::{block::error::BlockRecoveryError, Block, RecoveredBlock};
+use reth_primitives_traits::{block::error::BlockRecoveryError, Block as _, RecoveredBlock};
 use reth_revm::state::Bytecode;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher};
 use reth_trie_sparse::{blinded::DefaultBlindedProviderFactory, SparseStateTrie};
@@ -88,7 +88,7 @@ pub enum StatelessValidationError {
 
     /// Error when recovering signers
     #[error("error recovering the signers in the block")]
-    SignerRecovery(#[from] Box<BlockRecoveryError<EthereumBlock>>),
+    SignerRecovery(#[from] Box<BlockRecoveryError<Block>>),
 }
 
 /// Performs stateless validation of a block using the provided witness data.
@@ -127,7 +127,7 @@ pub enum StatelessValidationError {
 /// If all steps succeed the function returns `Some` containing the hash of the validated
 /// `current_block`.
 pub fn stateless_validation(
-    current_block: EthereumBlock,
+    current_block: Block,
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
 ) -> Result<B256, StatelessValidationError> {
@@ -218,7 +218,7 @@ pub fn stateless_validation(
 /// transition function.
 fn validate_block_consensus(
     chain_spec: Arc<ChainSpec>,
-    block: &RecoveredBlock<EthereumBlock>,
+    block: &RecoveredBlock<Block>,
 ) -> Result<(), StatelessValidationError> {
     let consensus = EthBeaconConsensus::new(chain_spec);
 
@@ -304,7 +304,7 @@ pub fn verify_execution_witness(
 /// If both checks pass, it returns a [`BTreeMap`] mapping the block number of each
 /// ancestor header to its corresponding block hash.
 fn compute_ancestor_hashes(
-    current_block: &RecoveredBlock<EthereumBlock>,
+    current_block: &RecoveredBlock<Block>,
     ancestor_headers: &[Header],
 ) -> Result<BTreeMap<u64, B256>, StatelessValidationError> {
     let mut ancestor_hashes = BTreeMap::new();

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -5,17 +5,17 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use alloy_consensus::{Block, BlockHeader, Header};
+use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::{keccak256, map::B256Map, B256};
 use alloy_rlp::Decodable;
 use reth_chainspec::ChainSpec;
 use reth_consensus::{Consensus, HeaderValidator};
 use reth_errors::ConsensusError;
 use reth_ethereum_consensus::{validate_block_post_execution, EthBeaconConsensus};
-use reth_ethereum_primitives::TransactionSigned;
+use reth_ethereum_primitives::Block as EthereumBlock;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_evm_ethereum::execute::EthExecutorProvider;
-use reth_primitives_traits::RecoveredBlock;
+use reth_primitives_traits::{block::error::BlockRecoveryError, Block, RecoveredBlock};
 use reth_revm::state::Bytecode;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher};
 use reth_trie_sparse::{blinded::DefaultBlindedProviderFactory, SparseStateTrie};
@@ -84,6 +84,10 @@ pub enum StatelessValidationError {
         /// The expected pre-state root from the previous block
         expected: B256,
     },
+
+    /// Error when recovering signers
+    #[error("error recovering the signers in the block")]
+    SignerRecovery(#[from] BlockRecoveryError<EthereumBlock>),
 }
 
 /// Performs stateless validation of a block using the provided witness data.
@@ -122,10 +126,13 @@ pub enum StatelessValidationError {
 /// If all steps succeed the function returns `Some` containing the hash of the validated
 /// `current_block`.
 pub fn stateless_validation(
-    current_block: RecoveredBlock<Block<TransactionSigned>>,
+    current_block: EthereumBlock,
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
 ) -> Result<B256, StatelessValidationError> {
+    let current_block =
+        current_block.try_into_recovered().map_err(StatelessValidationError::from)?;
+
     let mut ancestor_headers: Vec<Header> = witness
         .headers
         .iter()
@@ -209,7 +216,7 @@ pub fn stateless_validation(
 /// transition function.
 fn validate_block_consensus(
     chain_spec: Arc<ChainSpec>,
-    block: &RecoveredBlock<Block<TransactionSigned>>,
+    block: &RecoveredBlock<EthereumBlock>,
 ) -> Result<(), StatelessValidationError> {
     let consensus = EthBeaconConsensus::new(chain_spec);
 
@@ -295,7 +302,7 @@ pub fn verify_execution_witness(
 /// If both checks pass, it returns a [`BTreeMap`] mapping the block number of each
 /// ancestor header to its corresponding block hash.
 fn compute_ancestor_hashes(
-    current_block: &RecoveredBlock<Block<TransactionSigned>>,
+    current_block: &RecoveredBlock<EthereumBlock>,
     ancestor_headers: &[Header],
 ) -> Result<BTreeMap<u64, B256>, StatelessValidationError> {
     let mut ancestor_hashes = BTreeMap::new();

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -319,7 +319,7 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
 
     // Now validate using the stateless client if everything else passes
     for (block, execution_witness) in program_inputs {
-        stateless_validation(block, execution_witness, chain_spec.clone())
+        stateless_validation(block.into_block(), execution_witness, chain_spec.clone())
             .expect("stateless validation failed");
     }
 


### PR DESCRIPTION
Changes `RecoveredBlock` -> `Block` so that the public API of reth-stateless is closer to the types that are exposed by every client