### PR TITLE
chore: fix make-pr lint-codespell errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ clippy:
 	-- -D warnings
 
 lint-codespell: ensure-codespell
-	codespell --skip "*.json" --skip "./testing/ef-tests/ethereum-tests" -L wit
+	codespell --skip "*.json" --skip "./testing/ef-tests/ethereum-tests"
 
 ensure-codespell:
 	@if ! command -v codespell &> /dev/null; then \

--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ clippy:
 	-- -D warnings
 
 lint-codespell: ensure-codespell
-	codespell --skip "*.json" --skip "./testing/ef-tests/ethereum-tests"
+	codespell --skip "*.json" --skip "./testing/ef-tests/ethereum-tests" -L wit
 
 ensure-codespell:
 	@if ! command -v codespell &> /dev/null; then \

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -784,7 +784,7 @@ where
 /// A noop Builder that satisfies the [`EngineApiBuilder`] trait without actually configuring an
 /// engine API module
 ///
-/// This is intended to be used as a workaround for re-using all the existing ethereum node launch
+/// This is intended to be used as a workaround for reusing all the existing ethereum node launch
 /// utilities which require an engine API.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -132,7 +132,7 @@ impl PruningArgs {
             self.receipts_log_filter.as_ref().filter(|c| !c.is_empty()).cloned()
         {
             config.segments.receipts_log_filter = receipt_logs;
-            // need to remove the receipts segment filter entirely because that takes precendence
+            // need to remove the receipts segment filter entirely because that takes precedence
             // over the logs filter
             config.segments.receipts.take();
         }

--- a/crates/ress/provider/src/lib.rs
+++ b/crates/ress/provider/src/lib.rs
@@ -188,8 +188,8 @@ where
         };
 
         // Insert witness into the cache.
-        let wit = Arc::new(witness.clone());
-        self.witness_cache.lock().insert(block_hash, wit);
+        let cached_witness = Arc::new(witness.clone());
+        self.witness_cache.lock().insert(block_hash, cached_witness);
 
         Ok(witness)
     }


### PR DESCRIPTION
This PR fixes some annoying errors that always cause the `make pr` recipe to fail at the `lint-codespell` sub-recipe.

I added a flag to ignore the word `wit`, which gets flagged as a spelling error, but is in fact used as a variable name in `reth-ress-provider` here: 

https://github.com/paradigmxyz/reth/blob/b4f9bec8522ed7e11e98d76fbf986b78964d137a/crates/ress/provider/src/lib.rs#L191-L192