### PR TITLE
Experiment: Pull `ChainInit` functionality outside of `EthChainSpec`

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -64,12 +64,12 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     fn final_paris_total_difficulty(&self) -> Option<U256>;
 }
 
-/// Trait representing a type for initializing the genesis state
+/// Trait representing a type for initializing the chain
 ///
 /// Note: This is not a part of `EthChainSpec` because it is only needed
-/// to initialize the genesis state and not for block validation.
+/// to initialize the chain and not for block validation.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait EthGenesis {
+pub trait EthChainInitSpec {
     /// The genesis block specification.
     fn genesis(&self) -> &Genesis;
 }
@@ -136,7 +136,7 @@ impl EthChainSpec for ChainSpec {
     }
 }
 
-impl EthGenesis for ChainSpec {
+impl EthChainInitSpec for ChainSpec {
     fn genesis(&self) -> &Genesis {
         self.genesis()
     }

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -47,9 +47,6 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     /// The genesis header.
     fn genesis_header(&self) -> &Self::Header;
 
-    /// The genesis block specification.
-    fn genesis(&self) -> &Genesis;
-
     /// The bootnodes for the chain, if any.
     fn bootnodes(&self) -> Option<Vec<NodeRecord>>;
 
@@ -65,6 +62,16 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
 
     /// Returns the final total difficulty if the Paris hardfork is known.
     fn final_paris_total_difficulty(&self) -> Option<U256>;
+}
+
+/// Trait representing a type for initializing the genesis state
+///
+/// Note: This is not a part of `EthChainSpec` because it is only needed
+/// to initialize the genesis state and not for block validation.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait EthGenesis {
+    /// The genesis block specification.
+    fn genesis(&self) -> &Genesis;
 }
 
 impl EthChainSpec for ChainSpec {
@@ -116,10 +123,6 @@ impl EthChainSpec for ChainSpec {
         self.genesis_header()
     }
 
-    fn genesis(&self) -> &Genesis {
-        self.genesis()
-    }
-
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
         self.bootnodes()
     }
@@ -130,5 +133,11 @@ impl EthChainSpec for ChainSpec {
 
     fn final_paris_total_difficulty(&self) -> Option<U256> {
         self.paris_block_and_final_difficulty.map(|(_, final_difficulty)| final_difficulty)
+    }
+}
+
+impl EthGenesis for ChainSpec {
+    fn genesis(&self) -> &Genesis {
+        self.genesis()
     }
 }

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -12,9 +12,6 @@ use reth_network_peers::NodeRecord;
 /// Trait representing type configuring a chain spec.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait EthChainSpec: Send + Sync + Unpin + Debug {
-    /// The header type of the network.
-    type Header;
-
     /// Returns the [`Chain`] object this spec targets.
     fn chain(&self) -> Chain;
 
@@ -44,9 +41,6 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     /// Returns a string representation of the hardforks.
     fn display_hardforks(&self) -> Box<dyn Display>;
 
-    /// The genesis header.
-    fn genesis_header(&self) -> &Self::Header;
-
     /// Returns `true` if this chain contains Optimism configuration.
     fn is_optimism(&self) -> bool {
         self.chain().is_optimism()
@@ -67,16 +61,23 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
 /// to initialize the chain and not for block validation.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait EthChainInitSpec {
+    /// The header type of the network.
+    type Header;
+
     /// The genesis block specification.
     fn genesis(&self) -> &Genesis;
+
+    /// The genesis header.
+    fn genesis_header(&self) -> &Self::Header;
+
+    /// The genesis hash.
+    fn genesis_hash(&self) -> B256;
 
     /// The bootnodes for the chain, if any.
     fn bootnodes(&self) -> Option<Vec<NodeRecord>>;
 }
 
 impl EthChainSpec for ChainSpec {
-    type Header = Header;
-
     fn chain(&self) -> Chain {
         self.chain
     }
@@ -119,10 +120,6 @@ impl EthChainSpec for ChainSpec {
         Box::new(Self::display_hardforks(self))
     }
 
-    fn genesis_header(&self) -> &Self::Header {
-        self.genesis_header()
-    }
-
     fn is_optimism(&self) -> bool {
         false
     }
@@ -133,8 +130,18 @@ impl EthChainSpec for ChainSpec {
 }
 
 impl EthChainInitSpec for ChainSpec {
+    type Header = Header;
+
     fn genesis(&self) -> &Genesis {
         self.genesis()
+    }
+
+    fn genesis_hash(&self) -> B256 {
+        self.genesis_hash()
+    }
+
+    fn genesis_header(&self) -> &Self::Header {
+        self.genesis_header()
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -47,9 +47,6 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     /// The genesis header.
     fn genesis_header(&self) -> &Self::Header;
 
-    /// The bootnodes for the chain, if any.
-    fn bootnodes(&self) -> Option<Vec<NodeRecord>>;
-
     /// Returns `true` if this chain contains Optimism configuration.
     fn is_optimism(&self) -> bool {
         self.chain().is_optimism()
@@ -72,6 +69,9 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
 pub trait EthChainInitSpec {
     /// The genesis block specification.
     fn genesis(&self) -> &Genesis;
+
+    /// The bootnodes for the chain, if any.
+    fn bootnodes(&self) -> Option<Vec<NodeRecord>>;
 }
 
 impl EthChainSpec for ChainSpec {
@@ -123,10 +123,6 @@ impl EthChainSpec for ChainSpec {
         self.genesis_header()
     }
 
-    fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.bootnodes()
-    }
-
     fn is_optimism(&self) -> bool {
         false
     }
@@ -139,5 +135,9 @@ impl EthChainSpec for ChainSpec {
 impl EthChainInitSpec for ChainSpec {
     fn genesis(&self) -> &Genesis {
         self.genesis()
+    }
+
+    fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
+        self.bootnodes()
     }
 }

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,7 +25,7 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 /// Re-export for convenience
 pub use reth_ethereum_forks::*;
 
-pub use api::{EthChainSpec, EthChainInitSpec};
+pub use api::{EthChainInitSpec, EthChainSpec};
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,7 +25,7 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 /// Re-export for convenience
 pub use reth_ethereum_forks::*;
 
-pub use api::{EthChainSpec, EthGenesis};
+pub use api::{EthChainSpec, EthChainInitSpec};
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,7 +25,7 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 /// Re-export for convenience
 pub use reth_ethereum_forks::*;
 
-pub use api::EthChainSpec;
+pub use api::{EthChainSpec, EthGenesis};
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -3,7 +3,7 @@ use alloy_evm::eth::spec::EthExecutorSpec;
 
 use crate::{
     constants::{MAINNET_DEPOSIT_CONTRACT, MAINNET_PRUNE_DELETE_LIMIT},
-    EthChainSpec,
+    EthChainSpec, EthGenesis,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_chains::{Chain, NamedChain};
@@ -772,7 +772,7 @@ impl EthereumHardforks for ChainSpec {
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ChainSpecProvider: Debug + Send + Sync {
     /// The chain spec type.
-    type ChainSpec: EthChainSpec + 'static;
+    type ChainSpec: EthChainSpec + EthGenesis + 'static;
 
     /// Get an [`Arc`] to the chainspec.
     fn chain_spec(&self) -> Arc<Self::ChainSpec>;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -3,7 +3,7 @@ use alloy_evm::eth::spec::EthExecutorSpec;
 
 use crate::{
     constants::{MAINNET_DEPOSIT_CONTRACT, MAINNET_PRUNE_DELETE_LIMIT},
-    EthChainSpec, EthChainInitSpec,
+    EthChainInitSpec, EthChainSpec,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_chains::{Chain, NamedChain};

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -3,7 +3,7 @@ use alloy_evm::eth::spec::EthExecutorSpec;
 
 use crate::{
     constants::{MAINNET_DEPOSIT_CONTRACT, MAINNET_PRUNE_DELETE_LIMIT},
-    EthChainSpec, EthGenesis,
+    EthChainSpec, EthChainInitSpec,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_chains::{Chain, NamedChain};
@@ -772,7 +772,7 @@ impl EthereumHardforks for ChainSpec {
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ChainSpecProvider: Debug + Send + Sync {
     /// The chain spec type.
-    type ChainSpec: EthChainSpec + EthGenesis + 'static;
+    type ChainSpec: EthChainSpec + EthChainInitSpec + 'static;
 
     /// Get an [`Arc`] to the chainspec.
     fn chain_spec(&self) -> Arc<Self::ChainSpec>;

--- a/crates/cli/commands/src/dump_genesis.rs
+++ b/crates/cli/commands/src/dump_genesis.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use clap::Parser;
-use reth_chainspec::{EthChainSpec, EthChainInitSpec};
+use reth_chainspec::{EthChainInitSpec, EthChainSpec};
 use reth_cli::chainspec::ChainSpecParser;
 
 /// Dumps genesis block JSON configuration to stdout

--- a/crates/cli/commands/src/dump_genesis.rs
+++ b/crates/cli/commands/src/dump_genesis.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use clap::Parser;
-use reth_chainspec::{EthChainSpec, EthGenesis};
+use reth_chainspec::{EthChainSpec, EthChainInitSpec};
 use reth_cli::chainspec::ChainSpecParser;
 
 /// Dumps genesis block JSON configuration to stdout
@@ -21,7 +21,7 @@ pub struct DumpGenesisCommand<C: ChainSpecParser> {
     chain: Arc<C::ChainSpec>,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis>> DumpGenesisCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec>> DumpGenesisCommand<C> {
     /// Execute the `dump-genesis` command
     pub async fn execute(self) -> eyre::Result<()> {
         println!("{}", serde_json::to_string_pretty(self.chain.genesis())?);

--- a/crates/cli/commands/src/dump_genesis.rs
+++ b/crates/cli/commands/src/dump_genesis.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use clap::Parser;
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::{EthChainSpec, EthGenesis};
 use reth_cli::chainspec::ChainSpecParser;
 
 /// Dumps genesis block JSON configuration to stdout
@@ -21,7 +21,7 @@ pub struct DumpGenesisCommand<C: ChainSpecParser> {
     chain: Arc<C::ChainSpec>,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> DumpGenesisCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis>> DumpGenesisCommand<C> {
     /// Execute the `dump-genesis` command
     pub async fn execute(self) -> eyre::Result<()> {
         println!("{}", serde_json::to_string_pretty(self.chain.genesis())?);

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use alloy_eips::BlockHashOrNumber;
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::{get_secret_key, hash_or_num_value_parser};
 use reth_config::Config;
@@ -74,7 +74,9 @@ pub enum Subcommands {
     Rlpx(rlpx::Command),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis + Hardforks + EthereumHardforks>>
+    Command<C>
+{
     /// Execute `p2p` command
     pub async fn execute<N: NetworkPrimitives>(self) -> eyre::Result<()> {
         let data_dir = self.datadir.clone().resolve_datadir(self.chain.chain());

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use alloy_eips::BlockHashOrNumber;
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthChainInitSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::{get_secret_key, hash_or_num_value_parser};
 use reth_config::Config;
@@ -74,7 +74,7 @@ pub enum Subcommands {
     Rlpx(rlpx::Command),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis + Hardforks + EthereumHardforks>>
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>>
     Command<C>
 {
     /// Execute `p2p` command

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use alloy_eips::BlockHashOrNumber;
 use backon::{ConstantBuilder, Retryable};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthChainInitSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainInitSpec, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::{get_secret_key, hash_or_num_value_parser};
 use reth_config::Config;
@@ -74,8 +74,9 @@ pub enum Subcommands {
     Rlpx(rlpx::Command),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>>
-    Command<C>
+impl<
+        C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>,
+    > Command<C>
 {
     /// Execute `p2p` command
     pub async fn execute<N: NetworkPrimitives>(self) -> eyre::Result<()> {

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -2,7 +2,7 @@
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use clap::Parser;
 use itertools::Itertools;
-use reth_chainspec::EthGenesis;
+use reth_chainspec::EthChainInitSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_db::{mdbx::tx::Tx, static_file::iter_static_files, DatabaseError};
 use reth_db_api::{

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -2,7 +2,7 @@
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use clap::Parser;
 use itertools::Itertools;
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::EthGenesis;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_db::{mdbx::tx::Tx, static_file::iter_static_files, DatabaseError};
 use reth_db_api::{

--- a/crates/cli/commands/src/stage/mod.rs
+++ b/crates/cli/commands/src/stage/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::common::{CliNodeComponents, CliNodeTypes};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthChainInitSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainInitSpec, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_eth_wire::NetPrimitivesFor;
@@ -39,8 +39,9 @@ pub enum Subcommands<C: ChainSpecParser> {
     Unwind(unwind::Command<C>),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>>
-    Command<C>
+impl<
+        C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>,
+    > Command<C>
 {
     /// Execute `stage` command
     pub async fn execute<N, Comp, F, P>(self, ctx: CliContext, components: F) -> eyre::Result<()>

--- a/crates/cli/commands/src/stage/mod.rs
+++ b/crates/cli/commands/src/stage/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::common::{CliNodeComponents, CliNodeTypes};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_eth_wire::NetPrimitivesFor;
@@ -39,7 +39,9 @@ pub enum Subcommands<C: ChainSpecParser> {
     Unwind(unwind::Command<C>),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis + Hardforks + EthereumHardforks>>
+    Command<C>
+{
     /// Execute `stage` command
     pub async fn execute<N, Comp, F, P>(self, ctx: CliContext, components: F) -> eyre::Result<()>
     where

--- a/crates/cli/commands/src/stage/mod.rs
+++ b/crates/cli/commands/src/stage/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::common::{CliNodeComponents, CliNodeTypes};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthChainInitSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_eth_wire::NetPrimitivesFor;
@@ -39,7 +39,7 @@ pub enum Subcommands<C: ChainSpecParser> {
     Unwind(unwind::Command<C>),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis + Hardforks + EthereumHardforks>>
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>>
     Command<C>
 {
     /// Execute `stage` command

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -6,7 +6,7 @@ use crate::common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, 
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::Sealable;
 use clap::Parser;
-use reth_chainspec::{EthChainSpec, EthChainInitSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainInitSpec, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::get_secret_key;
@@ -101,8 +101,9 @@ pub struct Command<C: ChainSpecParser> {
     network: NetworkArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>>
-    Command<C>
+impl<
+        C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>,
+    > Command<C>
 {
     /// Execute `stage` command
     pub async fn execute<N, Comp, F, P>(self, ctx: CliContext, components: F) -> eyre::Result<()>

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -6,7 +6,7 @@ use crate::common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, 
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::Sealable;
 use clap::Parser;
-use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::get_secret_key;
@@ -101,7 +101,9 @@ pub struct Command<C: ChainSpecParser> {
     network: NetworkArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis + Hardforks + EthereumHardforks>>
+    Command<C>
+{
     /// Execute `stage` command
     pub async fn execute<N, Comp, F, P>(self, ctx: CliContext, components: F) -> eyre::Result<()>
     where

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -6,7 +6,7 @@ use crate::common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, 
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::Sealable;
 use clap::Parser;
-use reth_chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthChainInitSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::get_secret_key;
@@ -101,7 +101,7 @@ pub struct Command<C: ChainSpecParser> {
     network: NetworkArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthGenesis + Hardforks + EthereumHardforks>>
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + EthereumHardforks>>
     Command<C>
 {
     /// Execute `stage` command

--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -4,7 +4,7 @@
 use alloy_eips::BlockNumHash;
 use reth_chainspec::EthChainSpec;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_node_api::{FullNodeComponents, HeaderTy, NodePrimitives, NodeTypes, PrimitivesTy};
+use reth_node_api::{FullNodeComponents, NodePrimitives, NodeTypes, PrimitivesTy};
 use reth_node_core::node_config::NodeConfig;
 use reth_provider::BlockReader;
 use std::fmt::Debug;
@@ -18,7 +18,7 @@ pub struct ExExContextDyn<N: NodePrimitives = EthPrimitives> {
     /// The current head of the blockchain at launch.
     pub head: BlockNumHash,
     /// The config of the node
-    pub config: NodeConfig<Box<dyn EthChainSpec<Header = N::BlockHeader> + 'static>>,
+    pub config: NodeConfig<Box<dyn EthChainSpec + 'static>>,
     /// The loaded node config
     pub reth_config: reth_config::Config,
     /// Channel used to send [`ExExEvent`]s to the rest of the node.
@@ -56,9 +56,8 @@ where
     Node::Provider: Debug + BlockReader,
 {
     fn from(ctx: ExExContext<Node>) -> Self {
-        let config = ctx.config.map_chainspec(|chainspec| {
-            Box::new(chainspec) as Box<dyn EthChainSpec<Header = HeaderTy<Node::Types>>>
-        });
+        let config =
+            ctx.config.map_chainspec(|chainspec| Box::new(chainspec) as Box<dyn EthChainSpec>);
         let notifications = Box::new(ctx.notifications) as Box<_>;
 
         Self {

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -599,7 +599,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
         } = self;
 
         let head = head.unwrap_or_else(|| Head {
-            hash: chain_spec.genesis_hash(),
+            hash: EthChainInitSpec::genesis_hash(&chain_spec),
             number: 0,
             timestamp: chain_spec.genesis().timestamp,
             difficulty: chain_spec.genesis().difficulty,
@@ -731,7 +731,7 @@ mod tests {
         Arc::make_mut(&mut chain_spec).hardforks = Default::default();
 
         // check that the forkid is initialized with the genesis and no other forks
-        let genesis_fork_hash = ForkHash::from(chain_spec.genesis_hash());
+        let genesis_fork_hash = ForkHash::from(EthChainInitSpec::genesis_hash(&chain_spec));
 
         // enforce that the fork_id set in the status is consistent with the generated fork filter
         let config = builder().build_with_noop_provider(chain_spec);

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -6,7 +6,7 @@ use crate::{
     transactions::TransactionsManagerConfig,
     NetworkHandle, NetworkManager,
 };
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthChainInitSpec, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainInitSpec, EthChainSpec, Hardforks};
 use reth_discv4::{Discv4Config, Discv4ConfigBuilder, NatResolver, DEFAULT_DISCOVERY_ADDRESS};
 use reth_discv5::NetworkStackId;
 use reth_dns_discovery::DnsDiscoveryConfig;

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -6,7 +6,7 @@ use crate::{
     transactions::TransactionsManagerConfig,
     NetworkHandle, NetworkManager,
 };
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthGenesis, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthChainInitSpec, Hardforks};
 use reth_discv4::{Discv4Config, Discv4ConfigBuilder, NatResolver, DEFAULT_DISCOVERY_ADDRESS};
 use reth_discv5::NetworkStackId;
 use reth_dns_discovery::DnsDiscoveryConfig;
@@ -547,7 +547,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
         chain_spec: Arc<ChainSpec>,
     ) -> NetworkConfig<NoopProvider<ChainSpec>, N>
     where
-        ChainSpec: EthChainSpec + EthGenesis + Hardforks + 'static,
+        ChainSpec: EthChainSpec + EthChainInitSpec + Hardforks + 'static,
     {
         self.build(NoopProvider::eth(chain_spec))
     }
@@ -572,7 +572,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
     /// establishing a connection.
     pub fn build<C>(self, client: C) -> NetworkConfig<C, N>
     where
-        C: ChainSpecProvider<ChainSpec: Hardforks + EthGenesis>,
+        C: ChainSpecProvider<ChainSpec: Hardforks + EthChainInitSpec>,
     {
         let peer_id = self.get_peer_id();
         let chain_spec = client.chain_spec();

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -6,7 +6,7 @@ use crate::{
     transactions::TransactionsManagerConfig,
     NetworkHandle, NetworkManager,
 };
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthGenesis, Hardforks};
 use reth_discv4::{Discv4Config, Discv4ConfigBuilder, NatResolver, DEFAULT_DISCOVERY_ADDRESS};
 use reth_discv5::NetworkStackId;
 use reth_dns_discovery::DnsDiscoveryConfig;
@@ -547,7 +547,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
         chain_spec: Arc<ChainSpec>,
     ) -> NetworkConfig<NoopProvider<ChainSpec>, N>
     where
-        ChainSpec: EthChainSpec + Hardforks + 'static,
+        ChainSpec: EthChainSpec + EthGenesis + Hardforks + 'static,
     {
         self.build(NoopProvider::eth(chain_spec))
     }
@@ -572,7 +572,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
     /// establishing a connection.
     pub fn build<C>(self, client: C) -> NetworkConfig<C, N>
     where
-        C: ChainSpecProvider<ChainSpec: Hardforks>,
+        C: ChainSpecProvider<ChainSpec: Hardforks + EthGenesis>,
     {
         let peer_id = self.get_peer_id();
         let chain_spec = client.chain_spec();

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -206,8 +206,8 @@ impl NetworkArgs {
         }
     }
 
-    /// Build a [`NetworkConfigBuilder`] from a [`Config`] and a [`EthChainSpec`], in addition to
-    /// the values in this option struct.
+    /// Build a [`NetworkConfigBuilder`] from a [`Config`] and a [`EthChainInitSpec`], in addition
+    /// to the values in this option struct.
     ///
     /// The `default_peers_file` will be used as the default location to store the persistent peers
     /// file if `no_persist_peers` is false, and there is no provided `peers_file`.

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::Args;
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::EthChainInitSpec;
 use reth_config::Config;
 use reth_discv4::{NodeRecord, DEFAULT_DISCOVERY_ADDR, DEFAULT_DISCOVERY_PORT};
 use reth_discv5::{
@@ -220,7 +220,7 @@ impl NetworkArgs {
     pub fn network_config<N: NetworkPrimitives>(
         &self,
         config: &Config,
-        chain_spec: impl EthChainSpec,
+        chain_spec: impl EthChainInitSpec,
         secret_key: SecretKey,
         default_peers_file: PathBuf,
     ) -> NetworkConfigBuilder<N> {

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -14,7 +14,7 @@ pub use reth_primitives_traits::{
     Block, BlockBody, FullBlock, FullNodePrimitives, FullReceipt, FullSignedTx, NodePrimitives,
 };
 
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::{EthChainSpec, EthGenesis};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
 use reth_engine_primitives::EngineTypes;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};
@@ -29,7 +29,8 @@ pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// The node's primitive types, defining basic operations and structures.
     type Primitives: NodePrimitives;
     /// The type used for configuration of the EVM.
-    type ChainSpec: EthChainSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>;
+    type ChainSpec: EthChainSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>
+        + EthGenesis;
     /// The type used to perform state commitment operations.
     type StateCommitment: StateCommitment;
     /// The type responsible for writing chain primitives to storage.
@@ -126,7 +127,7 @@ impl<P, C, SC, S, PL> AnyNodeTypes<P, C, SC, S, PL> {
 impl<P, C, SC, S, PL> NodeTypes for AnyNodeTypes<P, C, SC, S, PL>
 where
     P: NodePrimitives + Send + Sync + Unpin + 'static,
-    C: EthChainSpec<Header = P::BlockHeader> + Clone + 'static,
+    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthGenesis + 'static,
     SC: StateCommitment,
     S: Default + Clone + Send + Sync + Unpin + Debug + 'static,
     PL: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = P>> + Send + Sync + Unpin + 'static,
@@ -188,7 +189,7 @@ impl<P, E, C, SC, S, PL> NodeTypes for AnyNodeTypesWithEngine<P, E, C, SC, S, PL
 where
     P: NodePrimitives + Send + Sync + Unpin + 'static,
     E: EngineTypes + Send + Sync + Unpin,
-    C: EthChainSpec<Header = P::BlockHeader> + Clone + 'static,
+    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthGenesis + 'static,
     SC: StateCommitment,
     S: Default + Clone + Send + Sync + Unpin + Debug + 'static,
     PL: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = P>> + Send + Sync + Unpin + 'static,

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -14,7 +14,7 @@ pub use reth_primitives_traits::{
     Block, BlockBody, FullBlock, FullNodePrimitives, FullReceipt, FullSignedTx, NodePrimitives,
 };
 
-use reth_chainspec::{EthChainSpec, EthChainInitSpec};
+use reth_chainspec::{EthChainInitSpec, EthChainSpec};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
 use reth_engine_primitives::EngineTypes;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -29,8 +29,8 @@ pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     /// The node's primitive types, defining basic operations and structures.
     type Primitives: NodePrimitives;
     /// The type used for configuration of the EVM.
-    type ChainSpec: EthChainSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>
-        + EthChainInitSpec;
+    type ChainSpec: EthChainSpec
+        + EthChainInitSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>;
     /// The type used to perform state commitment operations.
     type StateCommitment: StateCommitment;
     /// The type responsible for writing chain primitives to storage.
@@ -127,7 +127,7 @@ impl<P, C, SC, S, PL> AnyNodeTypes<P, C, SC, S, PL> {
 impl<P, C, SC, S, PL> NodeTypes for AnyNodeTypes<P, C, SC, S, PL>
 where
     P: NodePrimitives + Send + Sync + Unpin + 'static,
-    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthChainInitSpec + 'static,
+    C: EthChainSpec + Clone + EthChainInitSpec<Header = P::BlockHeader> + 'static,
     SC: StateCommitment,
     S: Default + Clone + Send + Sync + Unpin + Debug + 'static,
     PL: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = P>> + Send + Sync + Unpin + 'static,
@@ -189,7 +189,7 @@ impl<P, E, C, SC, S, PL> NodeTypes for AnyNodeTypesWithEngine<P, E, C, SC, S, PL
 where
     P: NodePrimitives + Send + Sync + Unpin + 'static,
     E: EngineTypes + Send + Sync + Unpin,
-    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthChainInitSpec + 'static,
+    C: EthChainSpec + Clone + EthChainInitSpec<Header = P::BlockHeader> + 'static,
     SC: StateCommitment,
     S: Default + Clone + Send + Sync + Unpin + Debug + 'static,
     PL: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = P>> + Send + Sync + Unpin + 'static,

--- a/crates/node/types/src/lib.rs
+++ b/crates/node/types/src/lib.rs
@@ -14,7 +14,7 @@ pub use reth_primitives_traits::{
     Block, BlockBody, FullBlock, FullNodePrimitives, FullReceipt, FullSignedTx, NodePrimitives,
 };
 
-use reth_chainspec::{EthChainSpec, EthGenesis};
+use reth_chainspec::{EthChainSpec, EthChainInitSpec};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
 use reth_engine_primitives::EngineTypes;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};
@@ -30,7 +30,7 @@ pub trait NodeTypes: Clone + Debug + Send + Sync + Unpin + 'static {
     type Primitives: NodePrimitives;
     /// The type used for configuration of the EVM.
     type ChainSpec: EthChainSpec<Header = <Self::Primitives as NodePrimitives>::BlockHeader>
-        + EthGenesis;
+        + EthChainInitSpec;
     /// The type used to perform state commitment operations.
     type StateCommitment: StateCommitment;
     /// The type responsible for writing chain primitives to storage.
@@ -127,7 +127,7 @@ impl<P, C, SC, S, PL> AnyNodeTypes<P, C, SC, S, PL> {
 impl<P, C, SC, S, PL> NodeTypes for AnyNodeTypes<P, C, SC, S, PL>
 where
     P: NodePrimitives + Send + Sync + Unpin + 'static,
-    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthGenesis + 'static,
+    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthChainInitSpec + 'static,
     SC: StateCommitment,
     S: Default + Clone + Send + Sync + Unpin + Debug + 'static,
     PL: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = P>> + Send + Sync + Unpin + 'static,
@@ -189,7 +189,7 @@ impl<P, E, C, SC, S, PL> NodeTypes for AnyNodeTypesWithEngine<P, E, C, SC, S, PL
 where
     P: NodePrimitives + Send + Sync + Unpin + 'static,
     E: EngineTypes + Send + Sync + Unpin,
-    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthGenesis + 'static,
+    C: EthChainSpec<Header = P::BlockHeader> + Clone + EthChainInitSpec + 'static,
     SC: StateCommitment,
     S: Default + Clone + Send + Sync + Unpin + Debug + 'static,
     PL: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = P>> + Send + Sync + Unpin + 'static,

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -270,10 +270,6 @@ impl EthChainSpec for OpChainSpec {
         self.inner.genesis_header()
     }
 
-    fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.inner.bootnodes()
-    }
-
     fn is_optimism(&self) -> bool {
         true
     }
@@ -426,6 +422,10 @@ impl From<ChainSpec> for OpChainSpec {
 impl EthChainInitSpec for OpChainSpec {
     fn genesis(&self) -> &Genesis {
         self.inner.genesis()
+    }
+
+    fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
+        self.inner.bootnodes()
     }
 }
 

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -61,7 +61,8 @@ pub use base_sepolia::BASE_SEPOLIA;
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, DepositContract,
-    DisplayHardforks, EthChainSpec, EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
+    DisplayHardforks, EthChainSpec, EthGenesis, EthereumHardforks, ForkFilter, ForkId, Hardforks,
+    Head,
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
 use reth_network_peers::NodeRecord;
@@ -269,10 +270,6 @@ impl EthChainSpec for OpChainSpec {
         self.inner.genesis_header()
     }
 
-    fn genesis(&self) -> &Genesis {
-        self.inner.genesis()
-    }
-
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
         self.inner.bootnodes()
     }
@@ -423,6 +420,12 @@ impl From<Genesis> for OpChainSpec {
 impl From<ChainSpec> for OpChainSpec {
     fn from(value: ChainSpec) -> Self {
         Self { inner: value }
+    }
+}
+
+impl EthGenesis for OpChainSpec {
+    fn genesis(&self) -> &Genesis {
+        self.inner.genesis()
     }
 }
 

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -227,8 +227,6 @@ impl OpChainSpec {
 }
 
 impl EthChainSpec for OpChainSpec {
-    type Header = Header;
-
     fn chain(&self) -> Chain {
         self.inner.chain()
     }
@@ -264,10 +262,6 @@ impl EthChainSpec for OpChainSpec {
         });
 
         Box::new(DisplayHardforks::new(op_forks))
-    }
-
-    fn genesis_header(&self) -> &Self::Header {
-        self.inner.genesis_header()
     }
 
     fn is_optimism(&self) -> bool {
@@ -420,8 +414,18 @@ impl From<ChainSpec> for OpChainSpec {
 }
 
 impl EthChainInitSpec for OpChainSpec {
+    type Header = Header;
+
     fn genesis(&self) -> &Genesis {
         self.inner.genesis()
+    }
+
+    fn genesis_hash(&self) -> B256 {
+        self.inner.genesis_hash()
+    }
+
+    fn genesis_header(&self) -> &Self::Header {
+        self.inner.genesis_header()
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
@@ -509,7 +513,7 @@ mod tests {
     #[test]
     fn base_mainnet_forkids() {
         let mut base_mainnet = OpChainSpecBuilder::base_mainnet().build();
-        base_mainnet.inner.genesis_header.set_hash(BASE_MAINNET.genesis_hash());
+        base_mainnet.inner.genesis_header.set_hash(EthChainInitSpec::genesis_hash(&*BASE_MAINNET));
         test_fork_ids(
             &BASE_MAINNET,
             &[
@@ -617,7 +621,7 @@ mod tests {
         let mut op_mainnet = OpChainSpecBuilder::optimism_mainnet().build();
         // for OP mainnet we have to do this because the genesis header can't be properly computed
         // from the genesis.json file
-        op_mainnet.inner.genesis_header.set_hash(OP_MAINNET.genesis_hash());
+        op_mainnet.inner.genesis_header.set_hash(EthChainInitSpec::genesis_hash(&*OP_MAINNET));
         test_fork_ids(
             &op_mainnet,
             &[

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -61,8 +61,8 @@ pub use base_sepolia::BASE_SEPOLIA;
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, DepositContract,
-    DisplayHardforks, EthChainSpec, EthGenesis, EthereumHardforks, ForkFilter, ForkId, Hardforks,
-    Head,
+    DisplayHardforks, EthChainInitSpec, EthChainSpec, EthereumHardforks, ForkFilter, ForkId,
+    Hardforks, Head,
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
 use reth_network_peers::NodeRecord;
@@ -423,7 +423,7 @@ impl From<ChainSpec> for OpChainSpec {
     }
 }
 
-impl EthGenesis for OpChainSpec {
+impl EthChainInitSpec for OpChainSpec {
     fn genesis(&self) -> &Genesis {
         self.inner.genesis()
     }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -7,7 +7,7 @@ use crate::{
     OpEngineApiBuilder, OpEngineTypes,
 };
 use op_alloy_consensus::{interop::SafetyLevel, OpPooledTransaction};
-use reth_chainspec::{EthChainSpec, Hardforks};
+use reth_chainspec::{EthChainInitSpec, Hardforks};
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor};
 use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo};
 use reth_node_api::{
@@ -767,7 +767,7 @@ impl OpNetworkBuilder {
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<NetworkConfig<<Node as FullNodeTypes>::Provider, OpNetworkPrimitives>>
     where
-        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
+        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks + EthChainInitSpec>>,
     {
         let Self { disable_txpool_gossip, disable_discovery_v4 } = self.clone();
         let args = &ctx.config().network;

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -7,7 +7,9 @@ use alloy_rpc_types_admin::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition};
+use reth_chainspec::{
+    EthChainSpec, EthGenesis, EthereumHardfork, EthereumHardforks, ForkCondition,
+};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::{id2pk, AnyNode, NodeRecord};
 use reth_network_types::PeerKind;
@@ -35,7 +37,7 @@ impl<N, ChainSpec> AdminApi<N, ChainSpec> {
 impl<N, ChainSpec> AdminApiServer for AdminApi<N, ChainSpec>
 where
     N: NetworkInfo + Peers + 'static,
-    ChainSpec: EthChainSpec + EthereumHardforks + Send + Sync + 'static,
+    ChainSpec: EthChainSpec + EthGenesis + EthereumHardforks + Send + Sync + 'static,
 {
     /// Handler for `admin_addPeer`
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool> {

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_admin::{
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{
-    EthChainSpec, EthGenesis, EthereumHardfork, EthereumHardforks, ForkCondition,
+    EthChainSpec, EthChainInitSpec, EthereumHardfork, EthereumHardforks, ForkCondition,
 };
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::{id2pk, AnyNode, NodeRecord};
@@ -37,7 +37,7 @@ impl<N, ChainSpec> AdminApi<N, ChainSpec> {
 impl<N, ChainSpec> AdminApiServer for AdminApi<N, ChainSpec>
 where
     N: NetworkInfo + Peers + 'static,
-    ChainSpec: EthChainSpec + EthGenesis + EthereumHardforks + Send + Sync + 'static,
+    ChainSpec: EthChainSpec + EthChainInitSpec + EthereumHardforks + Send + Sync + 'static,
 {
     /// Handler for `admin_addPeer`
     fn add_peer(&self, record: NodeRecord) -> RpcResult<bool> {

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_admin::{
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{
-    EthChainSpec, EthChainInitSpec, EthereumHardfork, EthereumHardforks, ForkCondition,
+    EthChainInitSpec, EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition,
 };
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::{id2pk, AnyNode, NodeRecord};

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_trace::geth::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::{ChainSpecProvider, EthGenesis, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainInitSpec, EthereumHardforks};
 use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor, TxEnvFor};
 use reth_primitives_traits::{
     Block as _, BlockBody, NodePrimitives, ReceiptWithBloom, RecoveredBlock, SignedTransaction,

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_trace::geth::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthGenesis, EthereumHardforks};
 use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor, TxEnvFor};
 use reth_primitives_traits::{
     Block as _, BlockBody, NodePrimitives, ReceiptWithBloom, RecoveredBlock, SignedTransaction,

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -89,13 +89,12 @@ where
         + HashingWriter
         + StateWriter
         + AsRef<PF::ProviderRW>,
-    PF::ChainSpec:
-        EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader> + EthChainInitSpec,
+    PF::ChainSpec: EthChainInitSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader>,
 {
     let chain = factory.chain_spec();
 
     let genesis = chain.genesis();
-    let hash = chain.genesis_hash();
+    let hash = EthChainInitSpec::genesis_hash(&chain);
 
     // Check if we already have the genesis header or if we have the wrong one.
     match factory.block_hash(0) {
@@ -335,7 +334,7 @@ pub fn insert_genesis_header<Provider, Spec>(
 where
     Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Compact>>
         + DBProvider<Tx: DbTxMut>,
-    Spec: EthChainSpec<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>,
+    Spec: EthChainInitSpec<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>,
 {
     let (header, block_hash) = (chain.genesis_header(), chain.genesis_hash());
     let static_file_provider = provider.static_file_provider();

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{map::HashMap, Address, B256, U256};
-use reth_chainspec::{EthChainSpec, EthGenesis};
+use reth_chainspec::{EthChainSpec, EthChainInitSpec};
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
 use reth_db_api::{tables, transaction::DbTxMut, DatabaseError};
@@ -90,7 +90,7 @@ where
         + StateWriter
         + AsRef<PF::ProviderRW>,
     PF::ChainSpec:
-        EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader> + EthGenesis,
+        EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader> + EthChainInitSpec,
 {
     let chain = factory.chain_spec();
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{map::HashMap, Address, B256, U256};
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::{EthChainSpec, EthGenesis};
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
 use reth_db_api::{tables, transaction::DbTxMut, DatabaseError};
@@ -89,7 +89,8 @@ where
         + HashingWriter
         + StateWriter
         + AsRef<PF::ProviderRW>,
-    PF::ChainSpec: EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader>,
+    PF::ChainSpec:
+        EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader> + EthGenesis,
 {
     let chain = factory.chain_spec();
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{map::HashMap, Address, B256, U256};
-use reth_chainspec::{EthChainSpec, EthChainInitSpec};
+use reth_chainspec::{EthChainInitSpec, EthChainSpec};
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
 use reth_db_api::{tables, transaction::DbTxMut, DatabaseError};

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -91,7 +91,7 @@ mod tests {
     };
     use alloy_primitives::Bytes;
     use assert_matches::assert_matches;
-    use reth_chainspec::{EthChainSpec, MAINNET};
+    use reth_chainspec::MAINNET;
     use reth_ethereum_primitives::{Block, BlockBody};
     use reth_primitives_traits::{block::TestBlock, RecoveredBlock, SealedBlock};
     use reth_static_file_types::StaticFileSegment;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{
 };
 use parking_lot::Mutex;
 use reth_chain_state::{CanonStateNotifications, CanonStateSubscriptions};
-use reth_chainspec::{ChainInfo, EthChainSpec, EthGenesis};
+use reth_chainspec::{ChainInfo, EthChainSpec, EthChainInitSpec};
 use reth_db_api::{
     mock::{DatabaseMock, TxMock},
     models::{AccountBeforeTx, StoredBlockBodyIndices},
@@ -333,7 +333,7 @@ impl<ChainSpec: EthChainSpec + Send + Sync + 'static> HeaderProvider
 impl<T, ChainSpec> ChainSpecProvider for MockEthProvider<T, ChainSpec>
 where
     T: NodePrimitives,
-    ChainSpec: EthChainSpec + EthGenesis + 'static + Debug + Send + Sync,
+    ChainSpec: EthChainSpec + EthChainInitSpec + 'static + Debug + Send + Sync,
 {
     type ChainSpec = ChainSpec;
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{
 };
 use parking_lot::Mutex;
 use reth_chain_state::{CanonStateNotifications, CanonStateSubscriptions};
-use reth_chainspec::{ChainInfo, EthChainSpec};
+use reth_chainspec::{ChainInfo, EthChainSpec, EthGenesis};
 use reth_db_api::{
     mock::{DatabaseMock, TxMock},
     models::{AccountBeforeTx, StoredBlockBodyIndices},
@@ -333,7 +333,7 @@ impl<ChainSpec: EthChainSpec + Send + Sync + 'static> HeaderProvider
 impl<T, ChainSpec> ChainSpecProvider for MockEthProvider<T, ChainSpec>
 where
     T: NodePrimitives,
-    ChainSpec: EthChainSpec + 'static + Debug + Send + Sync,
+    ChainSpec: EthChainSpec + EthGenesis + 'static + Debug + Send + Sync,
 {
     type ChainSpec = ChainSpec;
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{
 };
 use parking_lot::Mutex;
 use reth_chain_state::{CanonStateNotifications, CanonStateSubscriptions};
-use reth_chainspec::{ChainInfo, EthChainSpec, EthChainInitSpec};
+use reth_chainspec::{ChainInfo, EthChainInitSpec, EthChainSpec};
 use reth_db_api::{
     mock::{DatabaseMock, TxMock},
     models::{AccountBeforeTx, StoredBlockBodyIndices},

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -19,7 +19,7 @@ use core::{
     marker::PhantomData,
     ops::{RangeBounds, RangeInclusive},
 };
-use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, EthChainInitSpec, MAINNET};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainInitSpec, EthChainSpec, MAINNET};
 use reth_db_models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -19,7 +19,7 @@ use core::{
     marker::PhantomData,
     ops::{RangeBounds, RangeInclusive},
 };
-use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, EthGenesis, MAINNET};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, EthChainInitSpec, MAINNET};
 use reth_db_models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{
@@ -107,7 +107,7 @@ impl<ChainSpec: Send + Sync, N: Send + Sync> BlockNumReader for NoopProvider<Cha
     }
 }
 
-impl<ChainSpec: EthChainSpec + EthGenesis + 'static, N: Debug + Send + Sync + 'static>
+impl<ChainSpec: EthChainSpec + EthChainInitSpec + 'static, N: Debug + Send + Sync + 'static>
     ChainSpecProvider for NoopProvider<ChainSpec, N>
 {
     type ChainSpec = ChainSpec;

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -19,7 +19,7 @@ use core::{
     marker::PhantomData,
     ops::{RangeBounds, RangeInclusive},
 };
-use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, MAINNET};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, EthGenesis, MAINNET};
 use reth_db_models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{
@@ -107,8 +107,8 @@ impl<ChainSpec: Send + Sync, N: Send + Sync> BlockNumReader for NoopProvider<Cha
     }
 }
 
-impl<ChainSpec: EthChainSpec + 'static, N: Debug + Send + Sync + 'static> ChainSpecProvider
-    for NoopProvider<ChainSpec, N>
+impl<ChainSpec: EthChainSpec + EthGenesis + 'static, N: Debug + Send + Sync + 'static>
+    ChainSpecProvider for NoopProvider<ChainSpec, N>
 {
     type ChainSpec = ChainSpec;
 

--- a/examples/custom-node/src/chainspec.rs
+++ b/examples/custom-node/src/chainspec.rs
@@ -1,7 +1,7 @@
 use crate::primitives::CustomHeader;
 use alloy_genesis::Genesis;
 use reth_ethereum::{
-    chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardfork, Hardforks},
+    chainspec::{EthChainInitSpec, EthChainSpec, EthereumHardforks, Hardfork, Hardforks},
     primitives::SealedHeader,
 };
 use reth_network_peers::NodeRecord;
@@ -104,7 +104,7 @@ impl EthereumHardforks for CustomChainSpec {
     }
 }
 
-impl EthGenesis for CustomChainSpec {
+impl EthChainInitSpec for CustomChainSpec {
     fn genesis(&self) -> &Genesis {
         self.inner.genesis()
     }

--- a/examples/custom-node/src/chainspec.rs
+++ b/examples/custom-node/src/chainspec.rs
@@ -42,8 +42,6 @@ impl Hardforks for CustomChainSpec {
 }
 
 impl EthChainSpec for CustomChainSpec {
-    type Header = CustomHeader;
-
     fn base_fee_params_at_block(
         &self,
         block_number: u64,
@@ -82,10 +80,6 @@ impl EthChainSpec for CustomChainSpec {
         self.genesis_header.hash()
     }
 
-    fn genesis_header(&self) -> &Self::Header {
-        &self.genesis_header
-    }
-
     fn final_paris_total_difficulty(&self) -> Option<revm_primitives::U256> {
         self.inner.get_final_paris_total_difficulty()
     }
@@ -101,8 +95,18 @@ impl EthereumHardforks for CustomChainSpec {
 }
 
 impl EthChainInitSpec for CustomChainSpec {
+    type Header = CustomHeader;
+
     fn genesis(&self) -> &Genesis {
         self.inner.genesis()
+    }
+
+    fn genesis_header(&self) -> &Self::Header {
+        &self.genesis_header
+    }
+
+    fn genesis_hash(&self) -> revm_primitives::B256 {
+        self.genesis_header.hash()
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {

--- a/examples/custom-node/src/chainspec.rs
+++ b/examples/custom-node/src/chainspec.rs
@@ -62,10 +62,6 @@ impl EthChainSpec for CustomChainSpec {
         self.inner.base_fee_params_at_timestamp(timestamp)
     }
 
-    fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.inner.bootnodes()
-    }
-
     fn chain(&self) -> reth_ethereum::chainspec::Chain {
         self.inner.chain()
     }
@@ -107,6 +103,10 @@ impl EthereumHardforks for CustomChainSpec {
 impl EthChainInitSpec for CustomChainSpec {
     fn genesis(&self) -> &Genesis {
         self.inner.genesis()
+    }
+
+    fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
+        self.inner.bootnodes()
     }
 }
 

--- a/examples/custom-node/src/chainspec.rs
+++ b/examples/custom-node/src/chainspec.rs
@@ -1,7 +1,7 @@
 use crate::primitives::CustomHeader;
 use alloy_genesis::Genesis;
 use reth_ethereum::{
-    chainspec::{EthChainSpec, EthereumHardforks, Hardfork, Hardforks},
+    chainspec::{EthChainSpec, EthGenesis, EthereumHardforks, Hardfork, Hardforks},
     primitives::SealedHeader,
 };
 use reth_network_peers::NodeRecord;
@@ -82,10 +82,6 @@ impl EthChainSpec for CustomChainSpec {
         self.inner.prune_delete_limit()
     }
 
-    fn genesis(&self) -> &Genesis {
-        self.inner.genesis()
-    }
-
     fn genesis_hash(&self) -> revm_primitives::B256 {
         self.genesis_header.hash()
     }
@@ -105,6 +101,12 @@ impl EthereumHardforks for CustomChainSpec {
         fork: reth_ethereum::chainspec::EthereumHardfork,
     ) -> reth_ethereum::chainspec::ForkCondition {
         self.inner.ethereum_fork_activation(fork)
+    }
+}
+
+impl EthGenesis for CustomChainSpec {
+    fn genesis(&self) -> &Genesis {
+        self.inner.genesis()
     }
 }
 

--- a/examples/custom-node/src/network.rs
+++ b/examples/custom-node/src/network.rs
@@ -38,7 +38,7 @@ impl CustomNetworkBuilder {
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<NetworkConfig<<Node as FullNodeTypes>::Provider, CustomNetworkPrimitives>>
     where
-        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks + EthChainInitSpec>>,
+        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
     {
         let args = &ctx.config().network;
         let network_builder = ctx

--- a/examples/custom-node/src/network.rs
+++ b/examples/custom-node/src/network.rs
@@ -8,7 +8,7 @@ use alloy_consensus::{Block, BlockBody};
 use eyre::Result;
 use op_alloy_consensus::OpPooledTransaction;
 use reth_ethereum::{
-    chainspec::{EthChainSpec, Hardforks},
+    chainspec::{EthChainInitSpec, Hardforks},
     network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives},
     node::api::{FullNodeTypes, NodeTypes, TxTy},
     pool::{PoolTransaction, TransactionPool},
@@ -38,7 +38,7 @@ impl CustomNetworkBuilder {
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<NetworkConfig<<Node as FullNodeTypes>::Provider, CustomNetworkPrimitives>>
     where
-        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
+        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks + EthChainInitSpec>>,
     {
         let args = &ctx.config().network;
         let network_builder = ctx


### PR DESCRIPTION
The underlying motivation being that some fields are only needed upon startup, while others are needed in order to validate every block. 
Matthias noted that the genesis block is only needed for initialization, so opening this PR to see how pulling it out of the ChainSpec trait affects the rest of the code.

Note: that the same could possibly apply to `bootnodes()` -- did the same for bootnodes and renamed it to EthChainInitSpec