### PR TITLE
Fix: Add missing assertion

### DIFF
--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -285,6 +285,7 @@ impl<S> P2PStream<S> {
     ///
     /// If the provided capacity is `0`.
     pub const fn set_outgoing_message_buffer_capacity(&mut self, capacity: usize) {
+        assert_ne!(capacity, 0);
         self.outgoing_message_buffer_capacity = capacity;
     }
 

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -636,6 +636,7 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
     ///
     /// Panics if the buffer capacity is 0.
     pub const fn set_message_buffer_capacity(mut self, c: u32) -> Self {
+        assert_ne!(c, 0);
         self.settings.message_buffer_capacity = c;
         self
     }


### PR DESCRIPTION
In reth/crates/net/eth-wire/src/p2pstream.rs, the comment indicate that this function will panic when capacity is 0 while it doesn't check it.
```rust
 /// # Panics
    ///
    /// If the provided capacity is `0`.
    pub const fn set_outgoing_message_buffer_capacity(&mut self, capacity: usize) {
        self.outgoing_message_buffer_capacity = capacity;
    }
``` 
In reth/crates/rpc/ipc/src/server/mod.rs, there is a similar problem.
```rust
 /// # Panics
    ///
    /// Panics if the buffer capacity is 0.
    pub const fn set_message_buffer_capacity(mut self, c: u32) -> Self {
        self.settings.message_buffer_capacity = c;
        self
    }
```