### PR TITLE
chore: Add configuration option to enable/disable HTTP response compression

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -247,6 +247,9 @@ RPC:
 
           [default: 8545]
 
+      --http.disable-compression
+          Http server should compress responses or not
+
       --http.api <HTTP_API>
           Rpc Modules to be configured for the HTTP server
 

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -248,7 +248,7 @@ RPC:
           [default: 8545]
 
       --http.disable-compression
-          Http server should compress responses or not
+          Disable compression for HTTP responses
 
       --http.api <HTTP_API>
           Rpc Modules to be configured for the HTTP server

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -55,7 +55,7 @@ pub struct RpcServerArgs {
     pub http_port: u16,
 
     /// Http server should compress responses or not
-    #[arg(long = "http.disable_compression", default_value_t = false)]
+    #[arg(long = "http.disable-compression", default_value_t = false)]
     pub http_disable_compression: bool,
 
     /// Rpc Modules to be configured for the HTTP server

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -54,7 +54,7 @@ pub struct RpcServerArgs {
     #[arg(long = "http.port", default_value_t = constants::DEFAULT_HTTP_RPC_PORT)]
     pub http_port: u16,
 
-    /// Http server should compress responses or not
+    /// Disable compression for HTTP responses
     #[arg(long = "http.disable-compression", default_value_t = false)]
     pub http_disable_compression: bool,
 

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -54,6 +54,10 @@ pub struct RpcServerArgs {
     #[arg(long = "http.port", default_value_t = constants::DEFAULT_HTTP_RPC_PORT)]
     pub http_port: u16,
 
+    /// Http server should compress responses or not
+    #[arg(long = "http.disable_compression", default_value_t = false)]
+    pub http_disable_compression: bool,
+
     /// Rpc Modules to be configured for the HTTP server
     #[arg(long = "http.api", value_parser = RpcModuleSelectionValueParser::default())]
     pub http_api: Option<RpcModuleSelection>,
@@ -316,6 +320,7 @@ impl Default for RpcServerArgs {
             http: false,
             http_addr: Ipv4Addr::LOCALHOST.into(),
             http_port: constants::DEFAULT_HTTP_RPC_PORT,
+            http_disable_compression: false,
             http_api: None,
             http_corsdomain: None,
             ws: false,

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -192,6 +192,7 @@ impl RethRpcServerConfig for RpcServerArgs {
                 .with_http_address(socket_address)
                 .with_http(self.http_ws_server_builder())
                 .with_http_cors(self.http_corsdomain.clone())
+                .with_http_compression(!self.http_disable_compression)
                 .with_ws_cors(self.ws_allowed_origins.clone());
         }
 

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -192,7 +192,7 @@ impl RethRpcServerConfig for RpcServerArgs {
                 .with_http_address(socket_address)
                 .with_http(self.http_ws_server_builder())
                 .with_http_cors(self.http_corsdomain.clone())
-                .with_http_disable_compression(!self.http_disable_compression)
+                .with_http_disable_compression(self.http_disable_compression)
                 .with_ws_cors(self.ws_allowed_origins.clone());
         }
 

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -192,7 +192,7 @@ impl RethRpcServerConfig for RpcServerArgs {
                 .with_http_address(socket_address)
                 .with_http(self.http_ws_server_builder())
                 .with_http_cors(self.http_corsdomain.clone())
-                .with_http_compression(!self.http_disable_compression)
+                .with_http_disable_compression(!self.http_disable_compression)
                 .with_ws_cors(self.ws_allowed_origins.clone());
         }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1173,7 +1173,7 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
         self
     }
 
-    /// Configure the http response woule be compressed or not
+    /// Configure whether HTTP responses should be compressed
     pub fn with_http_disable_compression(mut self, http_disable_compression: bool) -> Self {
         self.http_disable_compression = http_disable_compression;
         self
@@ -1274,9 +1274,10 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
     /// Returns a [`CompressionLayer`] that adds compression support (gzip, deflate, brotli, zstd)
     /// based on the client's `Accept-Encoding` header
     fn maybe_compression_layer(disable_compression: bool) -> Option<CompressionLayer> {
-        match disable_compression {
-            true => None,
-            false => Some(CompressionLayer::new()),
+        if disable_compression {
+            None
+        } else {
+            Some(CompressionLayer::new())
         }
     }
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1060,6 +1060,8 @@ pub struct RpcServerConfig<RpcMiddleware = Identity> {
     http_cors_domains: Option<String>,
     /// Address where to bind the http server to
     http_addr: Option<SocketAddr>,
+    /// Control whether http responses should be compressed
+    http_disable_compression: bool,
     /// Configs for WS server
     ws_server_config: Option<ServerConfigBuilder>,
     /// Allowed CORS Domains for ws.
@@ -1085,6 +1087,7 @@ impl Default for RpcServerConfig<Identity> {
             http_server_config: None,
             http_cors_domains: None,
             http_addr: None,
+            http_disable_compression: false,
             ws_server_config: None,
             ws_cors_domains: None,
             ws_addr: None,
@@ -1148,6 +1151,7 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
             http_server_config: self.http_server_config,
             http_cors_domains: self.http_cors_domains,
             http_addr: self.http_addr,
+            http_disable_compression: self.http_disable_compression,
             ws_server_config: self.ws_server_config,
             ws_cors_domains: self.ws_cors_domains,
             ws_addr: self.ws_addr,
@@ -1166,6 +1170,12 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
     /// Configure the cors domains for WS
     pub fn with_ws_cors(mut self, cors_domain: Option<String>) -> Self {
         self.ws_cors_domains = cors_domain;
+        self
+    }
+
+    /// Configure the http response woule be compressed or not
+    pub fn with_http_disable_compression(mut self, http_disable_compression: bool) -> Self {
+        self.http_disable_compression = http_disable_compression;
         self
     }
 
@@ -1263,8 +1273,11 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
 
     /// Returns a [`CompressionLayer`] that adds compression support (gzip, deflate, brotli, zstd)
     /// based on the client's `Accept-Encoding` header
-    fn maybe_compression_layer() -> Option<CompressionLayer> {
-        Some(CompressionLayer::new())
+    fn maybe_compression_layer(disable_compression: bool) -> Option<CompressionLayer> {
+        match disable_compression {
+            true => None,
+            false => Some(CompressionLayer::new()),
+        }
     }
 
     /// Builds and starts the configured server(s): http, ws, ipc.
@@ -1339,7 +1352,7 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                         tower::ServiceBuilder::new()
                             .option_layer(Self::maybe_cors_layer(cors)?)
                             .option_layer(Self::maybe_jwt_layer(self.jwt_secret))
-                            .option_layer(Self::maybe_compression_layer()),
+                            .option_layer(Self::maybe_compression_layer(self.http_disable_compression)),
                     )
                     .set_rpc_middleware(
                         self.rpc_middleware.clone().layer(
@@ -1414,7 +1427,7 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                     tower::ServiceBuilder::new()
                         .option_layer(Self::maybe_cors_layer(self.http_cors_domains.clone())?)
                         .option_layer(Self::maybe_jwt_layer(self.jwt_secret))
-                        .option_layer(Self::maybe_compression_layer()),
+                        .option_layer(Self::maybe_compression_layer(self.http_disable_compression)),
                 )
                 .set_rpc_middleware(
                     self.rpc_middleware.clone().layer(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1174,7 +1174,7 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
     }
 
     /// Configure whether HTTP responses should be compressed
-    pub fn with_http_disable_compression(mut self, http_disable_compression: bool) -> Self {
+    pub const fn with_http_disable_compression(mut self, http_disable_compression: bool) -> Self {
         self.http_disable_compression = http_disable_compression;
         self
     }
@@ -1353,7 +1353,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                         tower::ServiceBuilder::new()
                             .option_layer(Self::maybe_cors_layer(cors)?)
                             .option_layer(Self::maybe_jwt_layer(self.jwt_secret))
-                            .option_layer(Self::maybe_compression_layer(self.http_disable_compression)),
+                            .option_layer(Self::maybe_compression_layer(
+                                self.http_disable_compression,
+                            )),
                     )
                     .set_rpc_middleware(
                         self.rpc_middleware.clone().layer(


### PR DESCRIPTION
In #15832 we described the CPU consuming problem due to the http response compression logic tonic would process. This pr we tried to add one clap option to let user to control whether disable this compression logic or not. 
For the reason why the flag is named `disable_compression` is that clap would not allow user to set one value for bool flag which means it's not allowed to do `--http.disable_compression false` or `--http.disable_compression true`. The program would fail to launch and reports something like `error: unexpected argument 'true' found`.
User now can launch their reth process using `--http.disable_compression` to skip the http response compression logic to save their validator node's CPU resource. For those who care about how to save network bandwidth using response compression logic, we suggest that you can place one LB before the validator to do so.