### PR TITLE
feat(trie): make create_factories a const function

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -208,7 +208,7 @@ impl<Tx> ProofTaskTx<Tx>
 where
     Tx: DbTx,
 {
-    fn create_factories(
+    const fn create_factories(
         &self,
     ) -> (
         InMemoryTrieCursorFactory<'_, DatabaseTrieCursorFactory<'_, Tx>>,


### PR DESCRIPTION
The create_factories function in ProofTaskTx can be marked as const since it:
- Has no side effects
- Uses only immutable references
- Performs no dynamic memory allocation

This change allows the function to be evaluated at compile time,
potentially improving runtime performance.