### PR TITLE
feat(rpc): add debug_stateRootWithUpdates method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9638,6 +9638,7 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "reth-transaction-pool",
+ "reth-trie-common",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -9674,6 +9675,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-network-peers",
  "reth-rpc-eth-api",
+ "reth-trie-common",
 ]
 
 [[package]]

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 reth-rpc-eth-api.workspace = true
 reth-engine-primitives.workspace = true
 reth-network-peers.workspace = true
+reth-trie-common.workspace = true
 
 # ethereum
 alloy-eips.workspace = true

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -7,6 +7,7 @@ use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 
 /// Debug rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
@@ -358,6 +359,15 @@ pub trait DebugApi {
     /// Starts writing a Go runtime trace to the given file.
     #[method(name = "startGoTrace")]
     async fn debug_start_go_trace(&self, file: String) -> RpcResult<()>;
+
+    /// Returns the state root of the `HashedPostState` on top of the state for the given block with
+    /// trie updates.
+    #[method(name = "stateRootWithUpdates")]
+    async fn debug_state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+        block_id: Option<BlockId>,
+    ) -> RpcResult<(B256, TrieUpdates)>;
 
     /// Stops an ongoing CPU profile.
     #[method(name = "stopCPUProfile")]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -38,6 +38,7 @@ reth-rpc-server-types.workspace = true
 reth-network-types.workspace = true
 reth-consensus.workspace = true
 reth-node-api.workspace = true
+reth-trie-common.workspace = true
 
 # ethereum
 alloy-evm.workspace = true

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -22,6 +22,7 @@ use revm_database::{AccountStatus, BundleAccount};
 
 /// Representation of in-memory hashed state.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HashedPostState {
     /// Mapping of hashed address to account info, `None` if destroyed.
     pub accounts: B256Map<Option<Account>>,
@@ -337,6 +338,7 @@ impl HashedPostState {
 
 /// Representation of in-memory hashed storage.
 #[derive(PartialEq, Eq, Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HashedStorage {
     /// Flag indicating whether the storage was wiped or not.
     pub wiped: bool,


### PR DESCRIPTION
This exposes the `state_root_with_updates` function, allowing calculation of the state root and also returning the corresponding trie updates.

This method is similar to `rbuilder_calculateStateRoot` from https://github.com/NethermindEth/nethermind/pull/7985, but it enables the implementation of `state_root_with_updates` from `StateRootProvider` to be used remotely via RPC while preserving the structs.

This can be used e.g. to use this with a remote provider:
https://github.com/paradigmxyz/reth/blob/3f9268e2d449b923a761abb35b7e98a1edcd4e0d/crates/evm/evm/src/execute.rs#L340-L344


PS: Calculating a state root for old blocks can cause timeouts. This method is intended to be used only with the most recent blocks. Since it is a debug endpoint, no precautions have been implemented to handle such cases. But I am open for suggestions.