### PR TITLE
ci: do not dry run by default in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       dry_run:
         description: "Enable dry run mode (builds artifacts but skips uploads and release creation)"
         type: boolean
-        default: true
+        default: false
 
 env:
   REPO_NAME: ${{ github.repository_owner }}/reth
@@ -24,6 +24,13 @@ env:
   DOCKER_OP_IMAGE_NAME_URL: ghcr.io/${{ github.repository_owner }}/op-reth
 
 jobs:
+  dry-run:
+    name: check dry run
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Dry run: ${{ github.event.inputs.dry_run }}"
+
   extract-version:
     name: extract version
     runs-on: ubuntu-latest


### PR DESCRIPTION
1. Change the `dry_run` default value to `false`
2. Print `dry_run` value as the first step of release job