### PR TITLE
ci: check `dry_run` against `true` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - dry_run*
   workflow_dispatch:
     inputs:
       dry_run:
@@ -29,7 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "Dry run: ${{ github.event.inputs.dry_run }}"
+          echo "Dry run value: ${{ github.event.inputs.dry_run }}"
+          echo "Dry run enabled: ${{ github.event.inputs.dry_run == 'true'}}"
 
   extract-version:
     name: extract version
@@ -110,14 +113,14 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        if: ${{ github.event.inputs.dry_run == 'false' }}
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
           path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
 
       - name: Upload signature
-        if: ${{ github.event.inputs.dry_run == 'false' }}
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.asc
@@ -127,7 +130,7 @@ jobs:
     name: draft release
     needs: [build, extract-version]
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.dry_run == 'false' }}
+    if: ${{ github.event.inputs.dry_run != 'true' }}
     env:
       VERSION: ${{ needs.extract-version.outputs.VERSION }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
       - run: |
           echo "Dry run value: ${{ github.event.inputs.dry_run }}"
           echo "Dry run enabled: ${{ github.event.inputs.dry_run == 'true'}}"
+          echo "Dry run disabled: ${{ github.event.inputs.dry_run != 'true'}}"
 
   extract-version:
     name: extract version


### PR DESCRIPTION
If workflow is triggered from `push`, the values of `inputs` will be empty, not default.

---

This https://github.com/paradigmxyz/reth/blob/608f4a8c5f6560e0d84107697d5cc8b923955e58/.github/workflows/release.yml#L10-L11 will be reverted after we test that this workflow works as expected 