### PR TITLE
ci: do not trigger release workflow on `dry_run*` branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - dry_run*
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
It works https://github.com/paradigmxyz/reth/actions/runs/15134550485/job/42543164010, can now be reverted.