### PR TITLE
chore: fixed broken link

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -243,7 +243,7 @@ pub trait EngineApi<Engine: EngineTypes> {
     ) -> RpcResult<Option<Vec<BlobAndProofV2>>>;
 }
 
-/// A subset of the ETH rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
+/// A subset of the ETH rpc interface: <https://ethereum.github.io/execution-apis/docs/reference/json-rpc-api>
 ///
 /// This also includes additional eth functions required by optimism.
 ///

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -45,7 +45,7 @@ impl<T> FullEthApiServer for T where
 {
 }
 
-/// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation/>
+/// Eth rpc interface: <https://ethereum.github.io/execution-apis/docs/reference/json-rpc-api>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 pub trait EthApi<T: RpcObject, B: RpcObject, R: RpcObject, H: RpcObject> {


### PR DESCRIPTION
Hi! Updated outdated links to the Ethereum JSON-RPC API spec. The previous URLs were broken and have been replaced with the correct ones.