### PR TITLE
refactor(examples): Replace redundant type definitions with a `CustomTransaction` alias in the `custom_node` example

### DIFF
--- a/examples/custom-node/src/network.rs
+++ b/examples/custom-node/src/network.rs
@@ -1,7 +1,7 @@
 use crate::{
     chainspec::CustomChainSpec,
     primitives::{
-        CustomHeader, CustomNodePrimitives, CustomTransactionEnvelope, ExtendedOpTxEnvelope,
+        CustomHeader, CustomNodePrimitives, CustomTransaction, CustomTransactionEnvelope,
     },
 };
 use alloy_consensus::{Block, BlockBody};
@@ -22,9 +22,9 @@ pub struct CustomNetworkPrimitives;
 
 impl NetworkPrimitives for CustomNetworkPrimitives {
     type BlockHeader = CustomHeader;
-    type BlockBody = BlockBody<ExtendedOpTxEnvelope<CustomTransactionEnvelope>, CustomHeader>;
-    type Block = Block<ExtendedOpTxEnvelope<CustomTransactionEnvelope>, CustomHeader>;
-    type BroadcastedTransaction = ExtendedOpTxEnvelope<CustomTransactionEnvelope>;
+    type BlockBody = BlockBody<CustomTransaction, CustomHeader>;
+    type Block = Block<CustomTransaction, CustomHeader>;
+    type BroadcastedTransaction = CustomTransaction;
     type PooledTransaction = Extended<OpPooledTransaction, CustomTransactionEnvelope>;
     type Receipt = OpReceipt;
 }

--- a/examples/custom-node/src/primitives/block.rs
+++ b/examples/custom-node/src/primitives/block.rs
@@ -1,9 +1,7 @@
-use crate::primitives::{CustomHeader, CustomTransactionEnvelope, ExtendedOpTxEnvelope};
+use crate::primitives::{CustomHeader, CustomTransaction};
 
 /// The Block type of this node
-pub type Block =
-    alloy_consensus::Block<ExtendedOpTxEnvelope<CustomTransactionEnvelope>, CustomHeader>;
+pub type Block = alloy_consensus::Block<CustomTransaction, CustomHeader>;
 
 /// The body type of this node
-pub type BlockBody =
-    alloy_consensus::BlockBody<ExtendedOpTxEnvelope<CustomTransactionEnvelope>, CustomHeader>;
+pub type BlockBody = alloy_consensus::BlockBody<CustomTransaction, CustomHeader>;

--- a/examples/custom-node/src/primitives/mod.rs
+++ b/examples/custom-node/src/primitives/mod.rs
@@ -22,6 +22,6 @@ impl NodePrimitives for CustomNodePrimitives {
     type Block = Block;
     type BlockHeader = CustomHeader;
     type BlockBody = BlockBody;
-    type SignedTx = ExtendedOpTxEnvelope<CustomTransactionEnvelope>;
+    type SignedTx = CustomTransaction;
     type Receipt = OpReceipt;
 }

--- a/examples/custom-node/src/primitives/tx.rs
+++ b/examples/custom-node/src/primitives/tx.rs
@@ -20,6 +20,9 @@ use reth_op::primitives::{Extended, SignedTransaction};
 use revm_primitives::{Address, Bytes};
 use serde::{Deserialize, Serialize};
 
+/// An [`OpTxEnvelope`] that is [`Extended`] by one more variant of [`CustomTransactionEnvelope`].
+pub type CustomTransaction = ExtendedOpTxEnvelope<CustomTransactionEnvelope>;
+
 /// A [`SignedTransaction`] implementation that combines the [`OpTxEnvelope`] and another
 /// transaction type.
 pub type ExtendedOpTxEnvelope<T> = Extended<OpTxEnvelope, T>;


### PR DESCRIPTION
Purpose of this is to remove the redundant composite type definition and unify it under a single alias called `CustomTransaction`.

An alternative to this would be to have a newtype declaration. This would have the benefit of `CustomTransaction` being local to the crate where it is defined, allowing for foreign trait implementations which might be very useful, making it ready for potential unforeseen real world use-cases. However, that would require to also have a mechanism to easily inherit all the trait implementations that the wrapped type has, like using `derive` macros like so:

```rust
#[derive(Transaction, IsTyped2718, InMemorySize, SignerRecoverable, SignedTransaction, Typed2718, Decodable2718, Encodable2718, Encodable, Decodable)]
pub struct CustomTransaction(ExtendedOpTxEnvelope<CustomTransactionEnvelope>);
```

Apart from being local declaration, this also makes thing nicely explicit and defined at one place. Currently, we don't have these macros, but should be relatively easy to implement.