### PR TITLE
fix(ipc): Improve server code correctness, logging, and doc comments

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -256,7 +256,7 @@ pub struct IpcServerStartError {
 
 /// Data required by the server to handle requests received via an IPC connection
 #[derive(Debug, Clone)]
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub(crate) struct ServiceData {
     /// Registered server methods.
     pub(crate) methods: Methods,
@@ -612,7 +612,7 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
         self
     }
 
-    /// Set the maximum number of connections allowed. Default is 1024.
+    /// Set the maximum number of subscriptions per connection. Default is 1024.
     pub const fn max_subscriptions_per_connection(mut self, max: u32) -> Self {
         self.settings.max_subscriptions_per_connection = max;
         self
@@ -620,7 +620,7 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
 
     /// The server enforces backpressure which means that
     /// `n` messages can be buffered and if the client
-    /// can't keep with up the server.
+    /// can't keep up with the server.
     ///
     /// This `capacity` is applied per connection and
     /// applies globally on the connection which implies

--- a/crates/rpc/ipc/src/server/rpc_service.rs
+++ b/crates/rpc/ipc/src/server/rpc_service.rs
@@ -25,7 +25,7 @@ pub struct RpcService {
 }
 
 /// Configuration of the `RpcService`.
-#[expect(dead_code)]
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) enum RpcServiceCfg {
     /// The server supports only calls.
@@ -88,7 +88,7 @@ impl RpcServiceT for RpcService {
                         id_provider,
                     } = &self.cfg
                     else {
-                        tracing::warn!("Subscriptions not supported");
+                        tracing::warn!(id = ?id, method = %name, "Attempted subscription on a service not configured for subscriptions.");
                         let rp =
                             MethodResponse::error(id, ErrorObject::from(ErrorCode::InternalError));
                         return ResponseFuture::ready(rp);
@@ -115,7 +115,7 @@ impl RpcServiceT for RpcService {
                     // happen!
 
                     let RpcServiceCfg::CallsAndSubscriptions { .. } = self.cfg else {
-                        tracing::warn!("Subscriptions not supported");
+                        tracing::warn!(id = ?id, method = %name, "Attempted unsubscription on a service not configured for subscriptions.");
                         let rp =
                             MethodResponse::error(id, ErrorObject::from(ErrorCode::InternalError));
                         return ResponseFuture::ready(rp);


### PR DESCRIPTION
1.  **Correct attribute usage (`crates/rpc/ipc/src/server/mod.rs`, `crates/rpc/ipc/src/server/rpc_service.rs`):**
    Replaced `#[expect(dead_code)]` with `#[allow(dead_code)]` on the `ServiceData` struct and `RpcServiceCfg` enum. The `#[allow(dead_code)]` attribute is semantically more appropriate for these cases than `#[expect(dead_code)]`.

2.  **Enhanced logging context in `RpcService` (`crates/rpc/ipc/src/server/rpc_service.rs`):**
    Added request ID and method name to `tracing::warn!` messages when subscription or unsubscription operations are attempted on an `RpcService` instance not configured for such operations. This provides more context for debugging.
