### PR TITLE
feat(tasks): enable graceful shutdown request via TaskExecutor

### DIFF
--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -175,14 +175,10 @@ where
         let fut = pin!(fut);
         tokio::select! {
             task_manager_result = tasks => {
-                match task_manager_result {
-                    Ok(()) => {
-                        return Ok(());
-                    }
-                    Err(panicked_error) => {
-                        error!(target: "reth::cli", ?panicked_error, "Critical task panicked");
-                        return Err(panicked_error.into());
-                    }
+                if let Err(panicked_error) = task_manager_result {
+                    return Err(panicked_error.into());
+                } else {
+                    debug!(target: "reth::cli", "TaskManager resolved without error.")
                 }
             },
             res = fut => res?,

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -174,8 +174,16 @@ where
     {
         let fut = pin!(fut);
         tokio::select! {
-            err = tasks => {
-                return Err(err.into())
+            task_manager_result = tasks => {
+                match task_manager_result {
+                    Ok(()) => {
+                        return Ok(());
+                    }
+                    Err(panicked_error) => {
+                        error!(target: "reth::cli", ?panicked_error, "Critical task panicked");
+                        return Err(panicked_error.into());
+                    }
+                }
             },
             res = fut => res?,
         }

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -177,8 +177,6 @@ where
             task_manager_result = tasks => {
                 if let Err(panicked_error) = task_manager_result {
                     return Err(panicked_error.into());
-                } else {
-                    debug!(target: "reth::cli", "TaskManager resolved without error.")
                 }
             },
             res = fut => res?,

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -175,9 +175,7 @@ where
         let fut = pin!(fut);
         tokio::select! {
             task_manager_result = tasks => {
-                if let Err(panicked_error) = task_manager_result {
-                    return Err(panicked_error.into());
-                }
+                task_manager_result.map_err(|panicked_error| panicked_error.into())?;
             },
             res = fut => res?,
         }

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -175,7 +175,9 @@ where
         let fut = pin!(fut);
         tokio::select! {
             task_manager_result = tasks => {
-                task_manager_result.map_err(|panicked_error| panicked_error.into())?;
+                if let Err(panicked_error) = task_manager_result {
+                    return Err(panicked_error.into());
+                }
             },
             res = fut => res?,
         }

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -616,7 +616,7 @@ impl TaskExecutor {
     ///
     /// The [`TaskManager`] upon receiving this event, will terminate and initiate the shutdown that
     /// can be handled via the returned [`GracefulShutdown`].
-    pub fn request_graceful_shutdown(
+    pub fn initiate_graceful_shutdown(
         &self,
     ) -> Result<GracefulShutdown, tokio::sync::mpsc::error::SendError<()>> {
         self.task_events_tx
@@ -884,7 +884,7 @@ mod tests {
 
         let manager_future_handle = runtime.spawn(task_manager);
 
-        let send_result = executor.request_graceful_shutdown();
+        let send_result = executor.initiate_graceful_shutdown();
         assert!(send_result.is_ok(), "Sending the graceful shutdown signal should succeed and return a GracefulShutdown future");
 
         let manager_final_result = runtime.block_on(manager_future_handle);


### PR DESCRIPTION
Closes #16377 

Introduces a mechanism to request a graceful shutdown of the TaskManager via the TaskExecutor. Previously, the TaskManager future would only resolve due to a critical task panic.