### PR TITLE
feat(examples): Add `CustomEvm` for the execution of `CustomTransaction` in the `custom_node` example

### DIFF
--- a/examples/custom-node/src/evm/alloy.rs
+++ b/examples/custom-node/src/evm/alloy.rs
@@ -1,0 +1,159 @@
+use crate::evm::{CustomEvmTransaction, CustomTxEnv};
+use alloy_evm::{Database, Evm, EvmEnv};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use op_alloy_consensus::OpTxType;
+use op_revm::{
+    precompiles::OpPrecompiles, L1BlockInfo, OpHaltReason, OpSpecId, OpTransactionError,
+};
+use reth_ethereum::evm::revm::{
+    context::{result::ResultAndState, BlockEnv, CfgEnv, TxEnv},
+    handler::{instructions::EthInstructions, PrecompileProvider},
+    interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    Context, Inspector, Journal,
+};
+use revm::{context_interface::result::EVMError, handler::EvmTr, ExecuteEvm, InspectEvm};
+
+/// EVM context contains data that EVM needs for execution of [`CustomEvmTransaction`].
+pub type CustomContext<DB> =
+    Context<BlockEnv, CustomEvmTransaction, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
+
+pub struct CustomEvm<DB: Database, I, P = OpPrecompiles> {
+    inner:
+        op_revm::OpEvm<CustomContext<DB>, I, EthInstructions<EthInterpreter, CustomContext<DB>>, P>,
+    inspect: bool,
+}
+
+impl<DB, I, P> Evm for CustomEvm<DB, I, P>
+where
+    DB: Database,
+    I: Inspector<CustomContext<DB>>,
+    P: PrecompileProvider<CustomContext<DB>, Output = InterpreterResult>,
+{
+    type DB = DB;
+    type Tx = CustomEvmTransaction;
+    type Error = EVMError<DB::Error, OpTransactionError>;
+    type HaltReason = OpHaltReason;
+    type Spec = OpSpecId;
+    type Precompiles = P;
+    type Inspector = I;
+
+    fn block(&self) -> &BlockEnv {
+        &self.inner.ctx_ref().block
+    }
+
+    fn chain_id(&self) -> u64 {
+        self.inner.ctx_ref().cfg.chain_id
+    }
+
+    fn transact_raw(
+        &mut self,
+        tx: Self::Tx,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        if self.inspect {
+            self.inner.set_tx(tx);
+            self.inner.inspect_replay()
+        } else {
+            self.inner.transact(tx)
+        }
+    }
+
+    fn transact_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        let tx = CustomEvmTransaction {
+            base: CustomTxEnv(TxEnv {
+                caller,
+                kind: TxKind::Call(contract),
+                // Explicitly set nonce to 0 so revm does not do any nonce checks
+                nonce: 0,
+                gas_limit: 30_000_000,
+                value: U256::ZERO,
+                data,
+                // Setting the gas price to zero enforces that no value is transferred as part of
+                // the call, and that the call will not count against the block's
+                // gas limit
+                gas_price: 0,
+                // The chain ID check is not relevant here and is disabled if set to None
+                chain_id: None,
+                // Setting the gas priority fee to None ensures the effective gas price is derived
+                // from the `gas_price` field, which we need to be zero
+                gas_priority_fee: None,
+                access_list: Default::default(),
+                // blob fields can be None for this tx
+                blob_hashes: Vec::new(),
+                max_fee_per_blob_gas: 0,
+                tx_type: OpTxType::Deposit as u8,
+                authorization_list: Default::default(),
+            }),
+            // The L1 fee is not charged for the EIP-4788 transaction, submit zero bytes for the
+            // enveloped tx size.
+            enveloped_tx: Some(Bytes::default()),
+            deposit: Default::default(),
+        };
+
+        let mut gas_limit = tx.base.0.gas_limit;
+        let mut basefee = 0;
+        let mut disable_nonce_check = true;
+
+        // ensure the block gas limit is >= the tx
+        core::mem::swap(&mut self.inner.ctx().block.gas_limit, &mut gas_limit);
+        // disable the base fee check for this call by setting the base fee to zero
+        core::mem::swap(&mut self.inner.ctx().block.basefee, &mut basefee);
+        // disable the nonce check
+        core::mem::swap(&mut self.inner.ctx().cfg.disable_nonce_check, &mut disable_nonce_check);
+
+        let mut res = self.transact(tx);
+
+        // swap back to the previous gas limit
+        core::mem::swap(&mut self.inner.ctx().block.gas_limit, &mut gas_limit);
+        // swap back to the previous base fee
+        core::mem::swap(&mut self.inner.ctx().block.basefee, &mut basefee);
+        // swap back to the previous nonce check flag
+        core::mem::swap(&mut self.inner.ctx().cfg.disable_nonce_check, &mut disable_nonce_check);
+
+        // NOTE: We assume that only the contract storage is modified. Revm currently marks the
+        // caller and block beneficiary accounts as "touched" when we do the above transact calls,
+        // and includes them in the result.
+        //
+        // We're doing this state cleanup to make sure that changeset only includes the changed
+        // contract storage.
+        if let Ok(res) = &mut res {
+            res.state.retain(|addr, _| *addr == contract);
+        }
+
+        res
+    }
+
+    fn db_mut(&mut self) -> &mut Self::DB {
+        &mut self.inner.ctx().journaled_state.database
+    }
+
+    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
+        let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = self.inner.0.ctx;
+
+        (journaled_state.database, EvmEnv { block_env, cfg_env })
+    }
+
+    fn set_inspector_enabled(&mut self, enabled: bool) {
+        self.inspect = enabled;
+    }
+
+    fn precompiles(&self) -> &Self::Precompiles {
+        &self.inner.0.precompiles
+    }
+
+    fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
+        &mut self.inner.0.precompiles
+    }
+
+    fn inspector(&self) -> &Self::Inspector {
+        &self.inner.0.inspector
+    }
+
+    fn inspector_mut(&mut self) -> &mut Self::Inspector {
+        &mut self.inner.0.inspector
+    }
+}

--- a/examples/custom-node/src/evm/env.rs
+++ b/examples/custom-node/src/evm/env.rs
@@ -5,7 +5,17 @@ use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use op_revm::OpTransaction;
 use reth_ethereum::evm::revm::context::TxEnv;
 
-pub struct CustomTxEnv(TxEnv);
+/// An Optimism extended Ethereum transaction that can be fed to [`Evm`] because it contains
+/// [`CustomTxEnv`].
+///
+/// [`Evm`]: alloy_evm::Evm
+pub type CustomEvmTransaction = OpTransaction<CustomTxEnv>;
+
+/// A transaction environment is a set of information related to an Ethereum transaction that can be
+/// fed to [`Evm`] for execution.
+///
+/// [`Evm`]: alloy_evm::Evm
+pub struct CustomTxEnv(pub TxEnv);
 
 impl revm::context::Transaction for CustomTxEnv {
     type AccessListItem<'a>

--- a/examples/custom-node/src/evm/mod.rs
+++ b/examples/custom-node/src/evm/mod.rs
@@ -1,9 +1,11 @@
+mod alloy;
 mod assembler;
 mod config;
 mod env;
 mod executor;
 
+pub use alloy::{CustomContext, CustomEvm};
 pub use assembler::CustomBlockAssembler;
 pub use config::CustomEvmConfig;
-pub use env::CustomTxEnv;
+pub use env::{CustomEvmTransaction, CustomTxEnv};
 pub use executor::CustomBlockExecutor;


### PR DESCRIPTION
Adds `CustomEvm` tied to `CustomTransaction = OpTransaction<CustomTxEnv>`

Following the path of supporting custom transaction where we need at least:
- `CustomTxEnv`
- `CustomEvm`
- `CustomBlockExecutor`