### PR TITLE
fix: `InvalidTimestamp` display

### DIFF
--- a/crates/payload/primitives/src/error.rs
+++ b/crates/payload/primitives/src/error.rs
@@ -175,7 +175,7 @@ impl EngineObjectValidationError {
 #[derive(thiserror::Error, Debug)]
 pub enum InvalidPayloadAttributesError {
     /// Thrown if the timestamp of the payload attributes is invalid according to the engine specs.
-    #[error("parent beacon block root not supported before V3")]
+    #[error("invalid timestamp")]
     InvalidTimestamp,
     /// Another type of error that is not covered by the above variants.
     #[error("Invalid params: {0}")]


### PR DESCRIPTION
Fixes the display implementation for `InvalidTimestamp`.