### PR TITLE
feat(examples): Implement `EvmFactory` for `CustomEvm` in `custom_node` example

### DIFF
--- a/examples/custom-node/src/evm/env.rs
+++ b/examples/custom-node/src/evm/env.rs
@@ -15,6 +15,7 @@ pub type CustomEvmTransaction = OpTransaction<CustomTxEnv>;
 /// fed to [`Evm`] for execution.
 ///
 /// [`Evm`]: alloy_evm::Evm
+#[derive(Default)]
 pub struct CustomTxEnv(pub TxEnv);
 
 impl revm::context::Transaction for CustomTxEnv {


### PR DESCRIPTION
An `EvmFactory` accompanying `CustomEvm` introduced in #16394 