### PR TITLE
fix(RPC): Ensure `eth_getTransactionCount` returns correct nonce for 'pending' tag

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -323,7 +323,7 @@ pub trait LoadState:
                 .unwrap_or_default();
 
             if block_id == Some(BlockId::pending()) {
-                // for pending tag we need to find the highest nonce in the pool
+                // for pending tag we need to find the highest nonce of txn in the pending state.
                 if let Some(highest_pool_tx) =
                     this.pool().get_highest_consecutive_transaction_by_sender(address, on_chain_account_nonce)
                 {

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -324,9 +324,9 @@ pub trait LoadState:
 
             if block_id == Some(BlockId::pending()) {
                 // for pending tag we need to find the highest nonce of txn in the pending state.
-                if let Some(highest_pool_tx) =
-                    this.pool().get_highest_consecutive_transaction_by_sender(address, on_chain_account_nonce)
-                {
+                if let Some(highest_pool_tx) = this
+                    .pool()
+                    .get_highest_consecutive_transaction_by_sender(address, on_chain_account_nonce){
                     {
                         // and the corresponding txcount is nonce + 1 of the highest tx in the pool
                         // (on chain nonce is increased after tx)

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -326,7 +326,8 @@ pub trait LoadState:
                 // for pending tag we need to find the highest nonce of txn in the pending state.
                 if let Some(highest_pool_tx) = this
                     .pool()
-                    .get_highest_consecutive_transaction_by_sender(address, on_chain_account_nonce){
+                    .get_highest_consecutive_transaction_by_sender(address, on_chain_account_nonce)
+                {
                     {
                         // and the corresponding txcount is nonce + 1 of the highest tx in the pool
                         // (on chain nonce is increased after tx)

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -325,7 +325,7 @@ pub trait LoadState:
             if block_id == Some(BlockId::pending()) {
                 // for pending tag we need to find the highest nonce in the pool
                 if let Some(highest_pool_tx) =
-                    this.pool().get_highest_transaction_by_sender(address)
+                    this.pool().get_highest_consecutive_transaction_by_sender(address, on_chain_account_nonce)
                 {
                     {
                         // and the corresponding txcount is nonce + 1 of the highest tx in the pool


### PR DESCRIPTION
## Description

This PR addresses an issue with the `eth_getTransactionCount` RPC method, specifically when called with the `'pending'` block tag (i.e., `eth_getTransactionCount(address, "pending")`). The goal is to ensure it returns the correct next sequential nonce for an account, accurately reflecting pending transactions currently in the transaction pool.

