### PR TITLE
refactor: use `impl IntoIterator` for transaction batches and streamline validation calls

### DIFF
--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -238,7 +238,7 @@ where
     pub async fn validate_all_with_origin(
         &self,
         origin: TransactionOrigin,
-        transactions: Vec<Tx>,
+        transactions: impl IntoIterator<Item = Tx> + Send,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
         futures_util::future::join_all(
             transactions.into_iter().map(|tx| self.validate_one(origin, tx)),
@@ -347,7 +347,7 @@ where
     async fn validate_transactions_with_origin(
         &self,
         origin: TransactionOrigin,
-        transactions: Vec<Self::Transaction>,
+        transactions: impl IntoIterator<Item = Self::Transaction> + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
         self.validate_all_with_origin(origin, transactions).await
     }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -248,11 +248,11 @@ where
     async fn validate_all(
         &self,
         origin: TransactionOrigin,
-        transactions: impl IntoIterator<Item = V::Transaction>,
+        transactions: impl IntoIterator<Item = V::Transaction> + Send,
     ) -> Vec<(TxHash, TransactionValidationOutcome<V::Transaction>)> {
         self.pool
             .validator()
-            .validate_transactions(transactions.into_iter().map(|tx| (origin, tx)).collect())
+            .validate_transactions_with_origin(origin, transactions)
             .await
             .into_iter()
             .map(|tx| (tx.tx_hash(), tx))

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -113,7 +113,7 @@ where
     pub fn validate_all_with_origin(
         &self,
         origin: TransactionOrigin,
-        transactions: Vec<Tx>,
+        transactions: impl IntoIterator<Item = Tx> + Send,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
         self.inner.validate_batch_with_origin(origin, transactions)
     }
@@ -144,7 +144,7 @@ where
     async fn validate_transactions_with_origin(
         &self,
         origin: TransactionOrigin,
-        transactions: Vec<Self::Transaction>,
+        transactions: impl IntoIterator<Item = Self::Transaction> + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
         self.validate_all_with_origin(origin, transactions)
     }
@@ -648,7 +648,7 @@ where
     fn validate_batch_with_origin(
         &self,
         origin: TransactionOrigin,
-        transactions: Vec<Tx>,
+        transactions: impl IntoIterator<Item = Tx> + Send,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
         let mut provider = None;
         transactions

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -214,7 +214,7 @@ pub trait TransactionValidator: Debug + Send + Sync {
     fn validate_transactions_with_origin(
         &self,
         origin: TransactionOrigin,
-        transactions: Vec<Self::Transaction>,
+        transactions: impl IntoIterator<Item = Self::Transaction> + Send,
     ) -> impl Future<Output = Vec<TransactionValidationOutcome<Self::Transaction>>> + Send {
         let futures = transactions.into_iter().map(|tx| self.validate_transaction(origin, tx));
         futures_util::future::join_all(futures)
@@ -261,7 +261,7 @@ where
     async fn validate_transactions_with_origin(
         &self,
         origin: TransactionOrigin,
-        transactions: Vec<Self::Transaction>,
+        transactions: impl IntoIterator<Item = Self::Transaction> + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
         match self {
             Self::Left(v) => v.validate_transactions_with_origin(origin, transactions).await,


### PR DESCRIPTION
Updates various transaction validation methods (including in `TransactionValidator` trait, `EthTransactionValidator`, `OpTransactionValidator`, and `Pool`) to accept `impl IntoIterator<Item = Transaction> + Send` for transaction batches, replacing `Vec<Transaction>`. This change offers greater flexibility to callers and can reduce intermediate collections.

Additionally, `Pool::validate_all` now directly invokes `validator.validate_transactions_with_origin`, simplifying its implementation and leveraging the more specific batch validation logic.