### PR TITLE
feat: relax OpEthApiBuilder type constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9172,6 +9172,7 @@ dependencies = [
  "eyre",
  "futures",
  "op-alloy-consensus",
+ "op-alloy-network",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "reth-chainspec",

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -50,6 +50,7 @@ op-revm.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 op-alloy-consensus.workspace = true
+op-alloy-network.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-eth.workspace = true

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -99,7 +99,7 @@ where
     }
 
     /// Build a [`OpEthApi`] using [`OpEthApiBuilder`].
-    pub const fn builder() -> OpEthApiBuilder {
+    pub const fn builder() -> OpEthApiBuilder<NetworkT> {
         OpEthApiBuilder::new()
     }
 }
@@ -119,9 +119,10 @@ where
     }
 }
 
-impl<N> RpcNodeCore for OpEthApi<N>
+impl<N, NetworkT> RpcNodeCore for OpEthApi<N, NetworkT>
 where
     N: OpNodeCore,
+    NetworkT: op_alloy_network::Network,
 {
     type Primitives = N::Primitives;
     type Provider = N::Provider;
@@ -156,9 +157,10 @@ where
     }
 }
 
-impl<N> RpcNodeCoreExt for OpEthApi<N>
+impl<N, NetworkT> RpcNodeCoreExt for OpEthApi<N, NetworkT>
 where
     N: OpNodeCore,
+    NetworkT: op_alloy_network::Network,
 {
     #[inline]
     fn cache(&self) -> &EthStateCache<ProviderBlock<N::Provider>, ProviderReceipt<N::Provider>> {
@@ -166,7 +168,7 @@ where
     }
 }
 
-impl<N> EthApiSpec for OpEthApi<N>
+impl<N, NetworkT> EthApiSpec for OpEthApi<N, NetworkT>
 where
     N: OpNodeCore<
         Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
@@ -174,6 +176,7 @@ where
                       + StageCheckpointReader,
         Network: NetworkInfo,
     >,
+    NetworkT: op_alloy_network::Network,
 {
     type Transaction = ProviderTx<Self::Provider>;
 
@@ -188,10 +191,11 @@ where
     }
 }
 
-impl<N> SpawnBlocking for OpEthApi<N>
+impl<N, NetworkT> SpawnBlocking for OpEthApi<N, NetworkT>
 where
     Self: Send + Sync + Clone + 'static,
     N: OpNodeCore,
+    NetworkT: op_alloy_network::Network,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {
@@ -209,7 +213,7 @@ where
     }
 }
 
-impl<N> LoadFee for OpEthApi<N>
+impl<N, NetworkT> LoadFee for OpEthApi<N, NetworkT>
 where
     Self: LoadBlock<Provider = N::Provider>,
     N: OpNodeCore<
@@ -229,15 +233,17 @@ where
     }
 }
 
-impl<N> LoadState for OpEthApi<N> where
+impl<N, NetworkT> LoadState for OpEthApi<N, NetworkT>
+where
     N: OpNodeCore<
         Provider: StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks>,
         Pool: TransactionPool,
-    >
+    >,
+    NetworkT: op_alloy_network::Network,
 {
 }
 
-impl<N> EthState for OpEthApi<N>
+impl<N, NetworkT> EthState for OpEthApi<N, NetworkT>
 where
     Self: LoadState + SpawnBlocking,
     N: OpNodeCore,
@@ -248,14 +254,14 @@ where
     }
 }
 
-impl<N> EthFees for OpEthApi<N>
+impl<N, NetworkT> EthFees for OpEthApi<N, NetworkT>
 where
     Self: LoadFee,
     N: OpNodeCore,
 {
 }
 
-impl<N> Trace for OpEthApi<N>
+impl<N, NetworkT> Trace for OpEthApi<N, NetworkT>
 where
     Self: RpcNodeCore<Provider: BlockReader>
         + LoadState<
@@ -271,7 +277,7 @@ where
 {
 }
 
-impl<N> AddDevSigners for OpEthApi<N>
+impl<N, NetworkT> AddDevSigners for OpEthApi<N, NetworkT>
 where
     N: OpNodeCore,
 {
@@ -280,7 +286,7 @@ where
     }
 }
 
-impl<N: OpNodeCore> fmt::Debug for OpEthApi<N> {
+impl<N: OpNodeCore, NetworkT> fmt::Debug for OpEthApi<N, NetworkT> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpEthApi").finish_non_exhaustive()
     }
@@ -308,17 +314,25 @@ impl<N: OpNodeCore> OpEthApiInner<N> {
 }
 
 /// Builds [`OpEthApi`] for Optimism.
-#[derive(Debug, Default)]
-pub struct OpEthApiBuilder {
+#[derive(Debug)]
+pub struct OpEthApiBuilder<NetworkT = Optimism> {
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
     /// network.
     sequencer_url: Option<String>,
+    /// Marker for network types.
+    _nt: PhantomData<NetworkT>,
 }
 
-impl OpEthApiBuilder {
+impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
+    fn default() -> Self {
+        Self { sequencer_url: None, _nt: PhantomData }
+    }
+}
+
+impl<NetworkT> OpEthApiBuilder<NetworkT> {
     /// Creates a [`OpEthApiBuilder`] instance from core components.
     pub const fn new() -> Self {
-        Self { sequencer_url: None }
+        Self { sequencer_url: None, _nt: PhantomData }
     }
 
     /// With a [`SequencerClient`].
@@ -328,15 +342,16 @@ impl OpEthApiBuilder {
     }
 }
 
-impl<N> EthApiBuilder<N> for OpEthApiBuilder
+impl<N, NetworkT> EthApiBuilder<N> for OpEthApiBuilder<NetworkT>
 where
     N: FullNodeComponents,
-    OpEthApi<N>: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>,
+    OpEthApi<N, NetworkT>: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>,
+    NetworkT: op_alloy_network::Network + Unpin,
 {
-    type EthApi = OpEthApi<N>;
+    type EthApi = OpEthApi<N, NetworkT>;
 
     async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
-        let Self { sequencer_url } = self;
+        let Self { sequencer_url, .. } = self;
         let eth_api = reth_rpc::EthApiBuilder::new(
             ctx.components.provider().clone(),
             ctx.components.pool().clone(),


### PR DESCRIPTION
followup of #16398, add network types generic to `OpEthApiBuilder`