### PR TITLE
feat(net): Add update_block_range to NetworkSyncUpdater

### DIFF
--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -179,6 +179,8 @@ where
     fn update_status(&self, _head: reth_ethereum_forks::Head) {}
 
     fn update_sync_state(&self, _state: reth_network_p2p::sync::SyncState) {}
+
+    fn update_block_range(&self, _: reth_eth_wire_types::BlockRangeUpdate) {}
 }
 
 impl<Net> NetworkEventListenerProvider for NoopNetwork<Net>

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -713,6 +713,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     let _ = tx.send(None);
                 }
             }
+            NetworkHandleMessage::InternalBlockRangeUpdate(block_range_update) => {
+                self.swarm.sessions_mut().update_advertised_block_range(block_range_update);
+            }
             NetworkHandleMessage::EthMessage { peer_id, message } => {
                 self.swarm.sessions_mut().send_message(&peer_id, message)
             }

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 use reth_discv4::{Discv4, NatResolver};
 use reth_discv5::Discv5;
 use reth_eth_wire::{
-    DisconnectReason, EthNetworkPrimitives, NetworkPrimitives, NewBlock,
+    BlockRangeUpdate, DisconnectReason, EthNetworkPrimitives, NetworkPrimitives, NewBlock,
     NewPooledTransactionHashes, SharedTransactions,
 };
 use reth_ethereum_forks::Head;
@@ -415,6 +415,11 @@ impl<N: NetworkPrimitives> NetworkSyncUpdater for NetworkHandle<N> {
     fn update_status(&self, head: Head) {
         self.send_message(NetworkHandleMessage::StatusUpdate { head });
     }
+
+    /// Updates the advertised block range.
+    fn update_block_range(&self, update: reth_eth_wire::BlockRangeUpdate) {
+        self.send_message(NetworkHandleMessage::InternalBlockRangeUpdate(update));
+    }
 }
 
 impl<N: NetworkPrimitives> BlockDownloaderProvider for NetworkHandle<N> {
@@ -541,4 +546,6 @@ pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives
     AddRlpxSubProtocol(RlpxSubProtocol),
     /// Connect to the given peer.
     ConnectPeer(PeerId, PeerKind, PeerAddr),
+    /// Message to update the node's advertised block range information.
+    InternalBlockRangeUpdate(BlockRangeUpdate),
 }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -651,7 +651,10 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         }
     }
 
-    pub(crate) const fn update_advertised_block_range(&mut self, block_range_update: BlockRangeUpdate) {
+    pub(crate) const fn update_advertised_block_range(
+        &mut self,
+        block_range_update: BlockRangeUpdate,
+    ) {
         self.status.earliest_block = Some(block_range_update.earliest);
         self.status.latest_block = Some(block_range_update.latest);
         self.status.blockhash = block_range_update.latest_hash;

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -651,7 +651,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         }
     }
 
-    pub(crate) fn update_advertised_block_range(&mut self, block_range_update: BlockRangeUpdate) {
+    pub(crate) const fn update_advertised_block_range(&mut self, block_range_update: BlockRangeUpdate) {
         self.status.earliest_block = Some(block_range_update.earliest);
         self.status.latest_block = Some(block_range_update.latest);
         self.status.blockhash = block_range_update.latest_hash;

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -34,8 +34,9 @@ use futures::{future::Either, io, FutureExt, StreamExt};
 use reth_ecies::{stream::ECIESStream, ECIESError};
 use reth_eth_wire::{
     errors::EthStreamError, handshake::EthRlpxHandshake, multiplex::RlpxProtocolMultiplexer,
-    Capabilities, DisconnectReason, EthStream, EthVersion, HelloMessageWithProtocols,
-    NetworkPrimitives, UnauthedP2PStream, UnifiedStatus, HANDSHAKE_TIMEOUT,
+    BlockRangeUpdate, Capabilities, DisconnectReason, EthStream, EthVersion,
+    HelloMessageWithProtocols, NetworkPrimitives, UnauthedP2PStream, UnifiedStatus,
+    HANDSHAKE_TIMEOUT,
 };
 use reth_ethereum_forks::{ForkFilter, ForkId, ForkTransition, Head};
 use reth_metrics::common::mpsc::MeteredPollSender;
@@ -648,6 +649,12 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 }
             }
         }
+    }
+
+    pub(crate) fn update_advertised_block_range(&mut self, block_range_update: BlockRangeUpdate) {
+        self.status.earliest_block = Some(block_range_update.earliest);
+        self.status.latest_block = Some(block_range_update.latest);
+        self.status.blockhash = block_range_update.latest_hash;
     }
 }
 

--- a/crates/net/p2p/src/sync.rs
+++ b/crates/net/p2p/src/sync.rs
@@ -1,6 +1,7 @@
 //! Traits used when interacting with the sync status of the network.
 
 use alloy_eips::eip2124::Head;
+use reth_eth_wire_types::BlockRangeUpdate;
 
 /// A type that provides information about whether the node is currently syncing and the network is
 /// currently serving syncing related requests.
@@ -25,8 +26,11 @@ pub trait NetworkSyncUpdater: std::fmt::Debug + Send + Sync + 'static {
     /// Notifies about a [SyncState] update.
     fn update_sync_state(&self, state: SyncState);
 
-    /// Updates the status of the p2p node
+    /// Updates the status of the p2p node.
     fn update_status(&self, head: Head);
+
+    /// Updates the advertised block range.
+    fn update_block_range(&self, update: BlockRangeUpdate);
 }
 
 /// The state the network is currently in when it comes to synchronization.
@@ -66,4 +70,5 @@ impl SyncStateProvider for NoopSyncStateUpdater {
 impl NetworkSyncUpdater for NoopSyncStateUpdater {
     fn update_sync_state(&self, _state: SyncState) {}
     fn update_status(&self, _: Head) {}
+    fn update_block_range(&self, _update: BlockRangeUpdate) {}
 }


### PR DESCRIPTION
Closes - #16412 

Implements a new method `update_block_range` on the `NetworkSyncUpdater` trait. This allows the network stack to be informed of changes to the node's advertised block range.