### PR TITLE
fix(db): correct ClientVersion serialization size tracking

### DIFF
--- a/crates/storage/db-models/src/client_version.rs
+++ b/crates/storage/db-models/src/client_version.rs
@@ -29,9 +29,10 @@ impl reth_codecs::Compact for ClientVersion {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        self.version.to_compact(buf);
-        self.git_sha.to_compact(buf);
-        self.build_timestamp.to_compact(buf)
+        let version_size = self.version.to_compact(buf);
+        let git_sha_size = self.git_sha.to_compact(buf);
+        let build_timestamp_size = self.build_timestamp.to_compact(buf);
+        version_size + git_sha_size + build_timestamp_size
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {


### PR DESCRIPTION
The `to_compact` implementation for `ClientVersion` now properly calculates and returns the total size of all serialized fields. Previously, it was only returning the size of the last field, which could lead to incorrect buffer management and data corruption during deserialization.