### PR TITLE
feat(examples): Implement `BlockAssembler` and `BlockExecutor` for custom blocks in `custom_node` example

### DIFF
--- a/examples/custom-node/src/evm/alloy.rs
+++ b/examples/custom-node/src/evm/alloy.rs
@@ -99,7 +99,8 @@ where
     }
 }
 
-pub struct CustomEvmFactory(OpEvmFactory);
+#[derive(Debug, Clone)]
+pub struct CustomEvmFactory(pub OpEvmFactory);
 
 impl EvmFactory for CustomEvmFactory {
     type Evm<DB: Database, I: Inspector<OpContext<DB>>> = CustomEvm<DB, I, Self::Precompiles>;

--- a/examples/custom-node/src/evm/assembler.rs
+++ b/examples/custom-node/src/evm/assembler.rs
@@ -1,35 +1,118 @@
-use crate::chainspec::CustomChainSpec;
-use alloy_consensus::Block;
-use alloy_evm::block::{BlockExecutionError, BlockExecutorFactory};
+use crate::{
+    chainspec::CustomChainSpec,
+    primitives::{Block, BlockBody, CustomHeader, CustomTransaction},
+};
+use alloy_consensus::{
+    constants::EMPTY_WITHDRAWALS, proofs, Header, TxReceipt, EMPTY_OMMER_ROOT_HASH,
+};
+use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
+use alloy_evm::block::{BlockExecutionError, BlockExecutionResult, BlockExecutorFactory};
 use alloy_op_evm::OpBlockExecutionCtx;
+use alloy_primitives::logs_bloom;
 use reth_ethereum::{
     evm::primitives::execute::{BlockAssembler, BlockAssemblerInput},
     primitives::Receipt,
 };
-use reth_op::{node::OpBlockAssembler, DepositReceipt, OpTransactionSigned};
+use reth_op::DepositReceipt;
+use reth_optimism_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
+use reth_optimism_forks::OpHardforks;
 
 #[derive(Clone, Debug)]
 pub struct CustomBlockAssembler {
-    inner: OpBlockAssembler<CustomChainSpec>,
+    chain_spec: CustomChainSpec,
 }
 
 impl<F> BlockAssembler<F> for CustomBlockAssembler
 where
     F: for<'a> BlockExecutorFactory<
         ExecutionCtx<'a> = OpBlockExecutionCtx,
-        Transaction = OpTransactionSigned,
+        Transaction = CustomTransaction,
         Receipt: Receipt + DepositReceipt,
     >,
 {
-    // TODO: use custom block here
-    type Block = Block<OpTransactionSigned>;
+    type Block = Block;
 
     fn assemble_block(
         &self,
-        input: BlockAssemblerInput<'_, '_, F>,
+        input: BlockAssemblerInput<'_, '_, F, CustomHeader>,
     ) -> Result<Self::Block, BlockExecutionError> {
-        let block = self.inner.assemble_block(input)?;
+        let BlockAssemblerInput {
+            evm_env,
+            execution_ctx: ctx,
+            transactions,
+            output: BlockExecutionResult { receipts, gas_used, .. },
+            bundle_state,
+            state_root,
+            state_provider,
+            ..
+        } = input;
 
-        Ok(block)
+        let timestamp = evm_env.block_env.timestamp;
+
+        let transactions_root = proofs::calculate_transaction_root(&transactions);
+        let receipts_root =
+            calculate_receipt_root_no_memo_optimism(receipts, &self.chain_spec, timestamp);
+        let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| r.logs()));
+
+        let mut requests_hash = None;
+
+        let withdrawals_root = if self.chain_spec.is_isthmus_active_at_timestamp(timestamp) {
+            // always empty requests hash post isthmus
+            requests_hash = Some(EMPTY_REQUESTS_HASH);
+
+            // withdrawals root field in block header is used for storage root of L2 predeploy
+            // `l2tol1-message-passer`
+            Some(
+                isthmus::withdrawals_root(bundle_state, state_provider)
+                    .map_err(BlockExecutionError::other)?,
+            )
+        } else if self.chain_spec.is_canyon_active_at_timestamp(timestamp) {
+            Some(EMPTY_WITHDRAWALS)
+        } else {
+            None
+        };
+
+        let (excess_blob_gas, blob_gas_used) =
+            if self.chain_spec.is_ecotone_active_at_timestamp(timestamp) {
+                (Some(0), Some(0))
+            } else {
+                (None, None)
+            };
+
+        let header = Header {
+            parent_hash: ctx.parent_hash,
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: evm_env.block_env.beneficiary,
+            state_root,
+            transactions_root,
+            receipts_root,
+            withdrawals_root,
+            logs_bloom,
+            timestamp,
+            mix_hash: evm_env.block_env.prevrandao.unwrap_or_default(),
+            nonce: BEACON_NONCE.into(),
+            base_fee_per_gas: Some(evm_env.block_env.basefee),
+            number: evm_env.block_env.number,
+            gas_limit: evm_env.block_env.gas_limit,
+            difficulty: evm_env.block_env.difficulty,
+            gas_used: *gas_used,
+            extra_data: ctx.extra_data,
+            parent_beacon_block_root: ctx.parent_beacon_block_root,
+            blob_gas_used,
+            excess_blob_gas,
+            requests_hash,
+        };
+
+        Ok(Block::new(
+            header.into(),
+            BlockBody {
+                transactions,
+                ommers: Default::default(),
+                withdrawals: self
+                    .chain_spec
+                    .is_canyon_active_at_timestamp(timestamp)
+                    .then(Default::default),
+            },
+        ))
     }
 }

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -2,6 +2,7 @@ use crate::{
     evm::{alloy::CustomEvmFactory, CustomBlockAssembler},
     primitives::{Block, CustomHeader, CustomNodePrimitives},
 };
+use alloy_consensus::BlockHeader;
 use alloy_evm::EvmEnv;
 use alloy_op_evm::OpBlockExecutionCtx;
 use op_revm::OpSpecId;
@@ -46,7 +47,11 @@ impl ConfigureEvm for CustomEvmConfig {
     }
 
     fn context_for_block(&self, block: &SealedBlock<Block>) -> OpBlockExecutionCtx {
-        self.inner.context_for_block(block)
+        OpBlockExecutionCtx {
+            parent_hash: block.header().parent_hash(),
+            parent_beacon_block_root: block.header().parent_beacon_block_root(),
+            extra_data: block.header().extra_data().clone(),
+        }
     }
 
     fn context_for_next_block(
@@ -54,6 +59,10 @@ impl ConfigureEvm for CustomEvmConfig {
         parent: &SealedHeader<CustomHeader>,
         attributes: Self::NextBlockEnvCtx,
     ) -> OpBlockExecutionCtx {
-        self.inner.context_for_next_block(parent, attributes)
+        OpBlockExecutionCtx {
+            parent_hash: parent.hash(),
+            parent_beacon_block_root: attributes.parent_beacon_block_root,
+            extra_data: attributes.extra_data,
+        }
     }
 }

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -1,5 +1,7 @@
-use crate::evm::CustomBlockAssembler;
-use alloy_consensus::{Block, Header};
+use crate::{
+    evm::{alloy::CustomEvmFactory, CustomBlockAssembler},
+    primitives::{Block, CustomHeader, CustomNodePrimitives},
+};
 use alloy_evm::EvmEnv;
 use alloy_op_evm::OpBlockExecutionCtx;
 use op_revm::OpSpecId;
@@ -7,19 +9,17 @@ use reth_ethereum::{
     node::api::ConfigureEvm,
     primitives::{SealedBlock, SealedHeader},
 };
-use reth_op::{
-    node::{OpEvmConfig, OpNextBlockEnvAttributes},
-    OpPrimitives, OpTransactionSigned,
-};
+use reth_op::node::{OpEvmConfig, OpNextBlockEnvAttributes};
 
 #[derive(Debug, Clone)]
 pub struct CustomEvmConfig {
     pub(super) inner: OpEvmConfig,
     pub(super) block_assembler: CustomBlockAssembler,
+    pub(super) custom_evm_factory: CustomEvmFactory,
 }
 
 impl ConfigureEvm for CustomEvmConfig {
-    type Primitives = OpPrimitives;
+    type Primitives = CustomNodePrimitives;
     type Error = <OpEvmConfig as ConfigureEvm>::Error;
     type NextBlockEnvCtx = <OpEvmConfig as ConfigureEvm>::NextBlockEnvCtx;
     type BlockExecutorFactory = Self;
@@ -33,28 +33,25 @@ impl ConfigureEvm for CustomEvmConfig {
         &self.block_assembler
     }
 
-    fn evm_env(&self, header: &Header) -> EvmEnv<OpSpecId> {
+    fn evm_env(&self, header: &CustomHeader) -> EvmEnv<OpSpecId> {
         self.inner.evm_env(header)
     }
 
     fn next_evm_env(
         &self,
-        parent: &Header,
+        parent: &CustomHeader,
         attributes: &OpNextBlockEnvAttributes,
     ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
         self.inner.next_evm_env(parent, attributes)
     }
 
-    fn context_for_block(
-        &self,
-        block: &SealedBlock<Block<OpTransactionSigned>>,
-    ) -> OpBlockExecutionCtx {
+    fn context_for_block(&self, block: &SealedBlock<Block>) -> OpBlockExecutionCtx {
         self.inner.context_for_block(block)
     }
 
     fn context_for_next_block(
         &self,
-        parent: &SealedHeader,
+        parent: &SealedHeader<CustomHeader>,
         attributes: Self::NextBlockEnvCtx,
     ) -> OpBlockExecutionCtx {
         self.inner.context_for_next_block(parent, attributes)

--- a/examples/custom-node/src/evm/executor.rs
+++ b/examples/custom-node/src/evm/executor.rs
@@ -1,4 +1,10 @@
-use crate::evm::CustomEvmConfig;
+use crate::{
+    evm::{
+        alloy::{CustomEvm, CustomEvmFactory},
+        CustomEvmConfig, CustomEvmTransaction,
+    },
+    primitives::CustomTransaction,
+};
 use alloy_evm::{
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
@@ -7,18 +13,10 @@ use alloy_evm::{
     precompiles::PrecompilesMap,
     Database, Evm,
 };
-use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpEvm};
-use op_revm::OpTransaction;
-use reth_ethereum::{evm::primitives::InspectorFor, node::api::ConfigureEvm};
-use reth_op::{
-    chainspec::OpChainSpec,
-    node::{OpEvmFactory, OpRethReceiptBuilder},
-    OpReceipt, OpTransactionSigned,
-};
-use revm::{
-    context::{result::ExecutionResult, TxEnv},
-    database::State,
-};
+use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor};
+use reth_ethereum::evm::primitives::InspectorFor;
+use reth_op::{chainspec::OpChainSpec, node::OpRethReceiptBuilder, OpReceipt};
+use revm::{context::result::ExecutionResult, database::State};
 use std::sync::Arc;
 
 pub struct CustomBlockExecutor<Evm> {
@@ -28,9 +26,9 @@ pub struct CustomBlockExecutor<Evm> {
 impl<'db, DB, E> BlockExecutor for CustomBlockExecutor<E>
 where
     DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx = OpTransaction<TxEnv>>,
+    E: Evm<DB = &'db mut State<DB>, Tx = CustomEvmTransaction>,
 {
-    type Transaction = OpTransactionSigned;
+    type Transaction = CustomTransaction;
     type Receipt = OpReceipt;
     type Evm = E;
 
@@ -64,18 +62,18 @@ where
 }
 
 impl BlockExecutorFactory for CustomEvmConfig {
-    type EvmFactory = OpEvmFactory;
+    type EvmFactory = CustomEvmFactory;
     type ExecutionCtx<'a> = OpBlockExecutionCtx;
-    type Transaction = OpTransactionSigned;
+    type Transaction = CustomTransaction;
     type Receipt = OpReceipt;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
-        self.inner.evm_factory()
+        &self.custom_evm_factory
     }
 
     fn create_executor<'a, DB, I>(
         &'a self,
-        evm: OpEvm<&'a mut State<DB>, I, PrecompilesMap>,
+        evm: CustomEvm<&'a mut State<DB>, I, PrecompilesMap>,
         ctx: OpBlockExecutionCtx,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where

--- a/examples/custom-node/src/primitives/header.rs
+++ b/examples/custom-node/src/primitives/header.rs
@@ -36,7 +36,11 @@ pub struct CustomHeader {
     pub extension: u64,
 }
 
-impl CustomHeader {}
+impl From<Header> for CustomHeader {
+    fn from(value: Header) -> Self {
+        CustomHeader { inner: value, extension: 0 }
+    }
+}
 
 impl AsRef<Self> for CustomHeader {
     fn as_ref(&self) -> &Self {


### PR DESCRIPTION
The `BlockAssembler` is very unfriendly.
* It is impossible to construct `BlockAssemblerInput` because it is marked as non-exhaustive and has no public constructor or conversion implementation
* The `parent` in `BlockAssemblerInput` is not used in `OpBlockAssembler` so the difficult reconstruction would yield nothing useful

I think the solution is to add another method to `OpBlockAssembler` with a custom input object that can be created from `BlockAssemblerInput` and does not contain `parent` header. This function can be called inside itself and the `CustomBlockAssembler`.

The `context_for_block` and `context_for_next_block` functions inside `EvmConfig` have somewhat similar situation where it is much better to copy-paste the implementation rather than attempt the maybe impossible type reconstruction that ultimately does not yield anything useful. But over there it is just a simple constructor.