### PR TITLE
feat(examples): Add `CustomExecutorBuilder` and implement `ExecutorBuilder` for it in `custom_node` example

### DIFF
--- a/examples/custom-node/src/chainspec.rs
+++ b/examples/custom-node/src/chainspec.rs
@@ -14,6 +14,12 @@ pub struct CustomChainSpec {
     genesis_header: SealedHeader<CustomHeader>,
 }
 
+impl CustomChainSpec {
+    pub const fn inner(&self) -> &OpChainSpec {
+        &self.inner
+    }
+}
+
 impl Hardforks for CustomChainSpec {
     fn fork<H: Hardfork>(&self, fork: H) -> reth_ethereum::chainspec::ForkCondition {
         self.inner.fork(fork)

--- a/examples/custom-node/src/evm/alloy.rs
+++ b/examples/custom-node/src/evm/alloy.rs
@@ -102,6 +102,12 @@ where
 #[derive(Debug, Clone)]
 pub struct CustomEvmFactory(pub OpEvmFactory);
 
+impl CustomEvmFactory {
+    pub const fn new(op_factory: OpEvmFactory) -> Self {
+        Self(op_factory)
+    }
+}
+
 impl EvmFactory for CustomEvmFactory {
     type Evm<DB: Database, I: Inspector<OpContext<DB>>> = CustomEvm<DB, I, Self::Precompiles>;
     type Context<DB: Database> = OpContext<DB>;

--- a/examples/custom-node/src/evm/alloy.rs
+++ b/examples/custom-node/src/evm/alloy.rs
@@ -99,12 +99,12 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct CustomEvmFactory(pub OpEvmFactory);
 
 impl CustomEvmFactory {
-    pub const fn new(op_factory: OpEvmFactory) -> Self {
-        Self(op_factory)
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/examples/custom-node/src/evm/assembler.rs
+++ b/examples/custom-node/src/evm/assembler.rs
@@ -9,6 +9,7 @@ use reth_ethereum::{
     primitives::Receipt,
 };
 use reth_op::{node::OpBlockAssembler, DepositReceipt};
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct CustomBlockAssembler {
@@ -16,8 +17,8 @@ pub struct CustomBlockAssembler {
 }
 
 impl CustomBlockAssembler {
-    pub const fn new(block_assembler: OpBlockAssembler<CustomChainSpec>) -> Self {
-        Self { block_assembler }
+    pub const fn new(chain_spec: Arc<CustomChainSpec>) -> Self {
+        Self { block_assembler: OpBlockAssembler::new(chain_spec) }
     }
 }
 

--- a/examples/custom-node/src/evm/assembler.rs
+++ b/examples/custom-node/src/evm/assembler.rs
@@ -15,6 +15,12 @@ pub struct CustomBlockAssembler {
     block_assembler: OpBlockAssembler<CustomChainSpec>,
 }
 
+impl CustomBlockAssembler {
+    pub const fn new(block_assembler: OpBlockAssembler<CustomChainSpec>) -> Self {
+        Self { block_assembler }
+    }
+}
+
 impl<F> BlockAssembler<F> for CustomBlockAssembler
 where
     F: for<'a> BlockExecutorFactory<

--- a/examples/custom-node/src/evm/builder.rs
+++ b/examples/custom-node/src/evm/builder.rs
@@ -1,0 +1,33 @@
+use crate::{
+    chainspec::CustomChainSpec,
+    evm::{alloy::CustomEvmFactory, CustomBlockAssembler, CustomEvmConfig},
+    primitives::CustomNodePrimitives,
+};
+use alloy_op_evm::OpEvmFactory;
+use reth_ethereum::node::api::FullNodeTypes;
+use reth_node_builder::{components::ExecutorBuilder, BuilderContext, NodeTypes};
+use reth_op::node::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
+use std::{future, future::Future, sync::Arc};
+
+pub struct CustomExecutorBuilder;
+
+impl<Node: FullNodeTypes> ExecutorBuilder<Node> for CustomExecutorBuilder
+where
+    Node::Types: NodeTypes<ChainSpec = CustomChainSpec, Primitives = CustomNodePrimitives>,
+{
+    type EVM = CustomEvmConfig;
+
+    fn build_evm(
+        self,
+        ctx: &BuilderContext<Node>,
+    ) -> impl Future<Output = eyre::Result<Self::EVM>> + Send {
+        future::ready(Ok(CustomEvmConfig::new(
+            OpEvmConfig::new(
+                Arc::new(ctx.chain_spec().inner().clone()),
+                OpRethReceiptBuilder::default(),
+            ),
+            CustomBlockAssembler::new(OpBlockAssembler::new(ctx.chain_spec())),
+            CustomEvmFactory::new(OpEvmFactory::default()),
+        )))
+    }
+}

--- a/examples/custom-node/src/evm/builder.rs
+++ b/examples/custom-node/src/evm/builder.rs
@@ -1,13 +1,7 @@
-use crate::{
-    chainspec::CustomChainSpec,
-    evm::{alloy::CustomEvmFactory, CustomBlockAssembler, CustomEvmConfig},
-    primitives::CustomNodePrimitives,
-};
-use alloy_op_evm::OpEvmFactory;
+use crate::{chainspec::CustomChainSpec, evm::CustomEvmConfig, primitives::CustomNodePrimitives};
 use reth_ethereum::node::api::FullNodeTypes;
 use reth_node_builder::{components::ExecutorBuilder, BuilderContext, NodeTypes};
-use reth_op::node::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
-use std::{future, future::Future, sync::Arc};
+use std::{future, future::Future};
 
 pub struct CustomExecutorBuilder;
 
@@ -21,13 +15,6 @@ where
         self,
         ctx: &BuilderContext<Node>,
     ) -> impl Future<Output = eyre::Result<Self::EVM>> + Send {
-        future::ready(Ok(CustomEvmConfig::new(
-            OpEvmConfig::new(
-                Arc::new(ctx.chain_spec().inner().clone()),
-                OpRethReceiptBuilder::default(),
-            ),
-            CustomBlockAssembler::new(OpBlockAssembler::new(ctx.chain_spec())),
-            CustomEvmFactory::new(OpEvmFactory::default()),
-        )))
+        future::ready(Ok(CustomEvmConfig::new(ctx.chain_spec())))
     }
 }

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -1,4 +1,5 @@
 use crate::{
+    chainspec::CustomChainSpec,
     evm::{alloy::CustomEvmFactory, CustomBlockAssembler},
     primitives::{Block, CustomHeader, CustomNodePrimitives},
 };
@@ -10,7 +11,8 @@ use reth_ethereum::{
     node::api::ConfigureEvm,
     primitives::{SealedBlock, SealedHeader},
 };
-use reth_op::node::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_op::node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct CustomEvmConfig {
@@ -20,12 +22,15 @@ pub struct CustomEvmConfig {
 }
 
 impl CustomEvmConfig {
-    pub const fn new(
-        inner: OpEvmConfig,
-        block_assembler: CustomBlockAssembler,
-        custom_evm_factory: CustomEvmFactory,
-    ) -> Self {
-        Self { inner, block_assembler, custom_evm_factory }
+    pub fn new(chain_spec: Arc<CustomChainSpec>) -> Self {
+        Self {
+            inner: OpEvmConfig::new(
+                Arc::new(chain_spec.inner().clone()),
+                OpRethReceiptBuilder::default(),
+            ),
+            block_assembler: CustomBlockAssembler::new(chain_spec),
+            custom_evm_factory: CustomEvmFactory::new(),
+        }
     }
 }
 

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -19,6 +19,16 @@ pub struct CustomEvmConfig {
     pub(super) custom_evm_factory: CustomEvmFactory,
 }
 
+impl CustomEvmConfig {
+    pub const fn new(
+        inner: OpEvmConfig,
+        block_assembler: CustomBlockAssembler,
+        custom_evm_factory: CustomEvmFactory,
+    ) -> Self {
+        Self { inner, block_assembler, custom_evm_factory }
+    }
+}
+
 impl ConfigureEvm for CustomEvmConfig {
     type Primitives = CustomNodePrimitives;
     type Error = <OpEvmConfig as ConfigureEvm>::Error;

--- a/examples/custom-node/src/evm/mod.rs
+++ b/examples/custom-node/src/evm/mod.rs
@@ -1,5 +1,6 @@
 mod alloy;
 mod assembler;
+mod builder;
 mod config;
 mod env;
 mod executor;


### PR DESCRIPTION
Adds the service responsible for creating `CustomEvmConfig` for the custom node.