### PR TITLE
docs: added parent_beacon_block_root requirement and corrected build-block

### DIFF
--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -296,7 +296,7 @@ pub(crate) async fn call_new_payload<N, P: EngineApiValidWaitExt<N>>(
 ) -> TransportResult<EngineApiMessageVersion> {
     match payload {
         ExecutionPayload::V3(payload) => {
-            // We expect the caller
+            // We expect the caller to provide `parent_beacon_block_root` for V3 payloads.
             let parent_beacon_block_root = parent_beacon_block_root
                 .expect("parent_beacon_block_root is required for V3 payloads and higher");
 

--- a/crates/ethereum/cli/src/debug_cmd/build_block.rs
+++ b/crates/ethereum/cli/src/debug_cmd/build_block.rs
@@ -100,7 +100,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
         Ok(EnvKzgSettings::Default)
     }
 
-    /// Execute `debug in-memory-merkle` command
+    /// Execute `debug build-block` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = EthPrimitives>>(
         self,
         ctx: CliContext,


### PR DESCRIPTION
Hey devs! Description commits:

bin/reth-bench/src/valid_payload.rs
We expect the caller `to provide parent_beacon_block_root for V3 payloads`

crates/ethereum/cli/src/debug_cmd/build_block.rs
`debug in-memory-merkle `- `debug build-block`