### PR TITLE
ci: remove concurrency from bench

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,10 +12,6 @@ env:
   BASELINE: base
   SEED: reth
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 name: bench
 jobs:
   codspeed:


### PR DESCRIPTION
Codspeed handles runs per commit so we can allow concurrency.