### PR TITLE
feat(optimism): Replace `OpTransactionSigned` bound on the `Block` associated to `OpEngineValidator` with a generic

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -406,7 +406,10 @@ where
     >,
     OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
 {
-    type Validator = OpEngineValidator<N::Provider>;
+    type Validator = OpEngineValidator<
+        N::Provider,
+        <<N::Types as NodeTypes>::Primitives as NodePrimitives>::SignedTx,
+    >;
 
     async fn engine_validator(&self, ctx: &AddOnsContext<'_, N>) -> eyre::Result<Self::Validator> {
         OpEngineValidatorBuilder::default().build(ctx).await
@@ -951,7 +954,10 @@ where
     Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives, Payload = OpEngineTypes>,
     Node: FullNodeComponents<Types = Types>,
 {
-    type Validator = OpEngineValidator<Node::Provider>;
+    type Validator = OpEngineValidator<
+        Node::Provider,
+        <<Node::Types as NodeTypes>::Primitives as NodePrimitives>::SignedTx,
+    >;
 
     async fn build(self, ctx: &AddOnsContext<'_, Node>) -> eyre::Result<Self::Validator> {
         Ok(OpEngineValidator::new::<KeyHasherTy<Types>>(


### PR DESCRIPTION
Closes #16476

Removes the fixation on `OpBlock` which implies `OpTransactionSigned`.

Uses a generic type passed down from `NodePrimitives` instead.

Reduces the amount of changes needed for a custom op node with a custom transaction type.