### PR TITLE
chore: simplify rpc ro primitive block impls

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -275,18 +275,7 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for EthereumNode {
     type RpcBlock = alloy_rpc_types_eth::Block;
 
     fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> reth_ethereum_primitives::Block {
-        let alloy_rpc_types_eth::Block { header, transactions, withdrawals, .. } = rpc_block;
-        reth_ethereum_primitives::Block {
-            header: header.inner,
-            body: reth_ethereum_primitives::BlockBody {
-                transactions: transactions
-                    .into_transactions()
-                    .map(|tx| tx.inner.into_inner().into())
-                    .collect(),
-                ommers: Default::default(),
-                withdrawals,
-            },
-        }
+        rpc_block.into_consensus().map_transactions(|tx| tx.inner.into_inner().into())
     }
 }
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -275,7 +275,7 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for EthereumNode {
     type RpcBlock = alloy_rpc_types_eth::Block;
 
     fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> reth_ethereum_primitives::Block {
-        rpc_block.into_consensus().map_transactions(|tx| tx.inner.into_inner().into())
+        rpc_block.into_consensus().convert_transactions()
     }
 }
 

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -216,14 +216,7 @@ where
     type RpcBlock = alloy_rpc_types_eth::Block<op_alloy_consensus::OpTxEnvelope>;
 
     fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> reth_node_api::BlockTy<Self> {
-        let alloy_rpc_types_eth::Block { header, transactions, .. } = rpc_block;
-        reth_optimism_primitives::OpBlock {
-            header: header.inner,
-            body: reth_optimism_primitives::OpBlockBody {
-                transactions: transactions.into_transactions().collect(),
-                ..Default::default()
-            },
-        }
+        rpc_block.into_consensus()
     }
 }
 


### PR DESCRIPTION
we can even just make this `.into()` after

https://github.com/alloy-rs/alloy/pull/2514