### PR TITLE
docs: Replace GitFlic URL with official GitHub repository for libmdbx

### DIFF
--- a/crates/storage/libmdbx-rs/README.md
+++ b/crates/storage/libmdbx-rs/README.md
@@ -13,7 +13,7 @@ Make sure to follow the [building steps](https://libmdbx.dqdkfa.ru/usage.html#ge
 
 ```bash
 # clone libmmdbx to a repository outside at specific tag
-git clone https://gitflic.ru/project/erthink/libmdbx.git ../libmdbx --branch v0.7.0
+git clone https://github.com/erthink/libmdbx.git ../libmdbx --branch v0.7.0
 make -C ../libmdbx dist
 
 # copy the `libmdbx/dist/` folder just created into `mdbx-sys/libmdbx`


### PR DESCRIPTION
I replaced the outdated/inactive GitFlic URL (`https://gitflic.ru/project/erthink/libmdbx.git`) with the official GitHub mirror (`https://github.com/erthink/libmdbx.git`) in the update instructions.

Both repositories belong to the same author (`erthink`), but the GitHub version is actively maintained and more accessible to contributors. This change ensures better reliability and developer experience.







