### PR TITLE
feat(optimism): Remove fixed `alloy_consensus::Header` type from `OpPayloadPrimitives`

### DIFF
--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -32,7 +32,9 @@ use reth_optimism_txpool::{
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_payload_util::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
-use reth_primitives_traits::{NodePrimitives, SealedHeader, SignedTransaction, TxTy};
+use reth_primitives_traits::{
+    HeaderTy, NodePrimitives, SealedHeader, SealedHeaderFor, SignedTransaction, TxTy,
+};
 use reth_revm::{
     cancelled::CancelOnDrop, database::StateProviderDatabase, db::State,
     witness::ExecutionWitnessRecord,
@@ -486,10 +488,8 @@ pub struct OpPayloadBuilderCtx<Evm: ConfigureEvm, ChainSpec> {
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
     /// How to build the payload.
-    pub config: PayloadConfig<
-        OpPayloadBuilderAttributes<TxTy<Evm::Primitives>>,
-        <Evm::Primitives as NodePrimitives>::BlockHeader,
-    >,
+    pub config:
+        PayloadConfig<OpPayloadBuilderAttributes<TxTy<Evm::Primitives>>, HeaderTy<Evm::Primitives>>,
     /// Marker to check whether the job has been cancelled.
     pub cancel: CancelOnDrop,
     /// The currently best payload.
@@ -502,7 +502,7 @@ where
     ChainSpec: EthChainSpec + OpHardforks,
 {
     /// Returns the parent block the payload will be build on.
-    pub fn parent(&self) -> &SealedHeader<<Evm::Primitives as NodePrimitives>::BlockHeader> {
+    pub fn parent(&self) -> &SealedHeaderFor<Evm::Primitives> {
         self.config.parent_header.as_ref()
     }
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     payload::{OpBuiltPayload, OpPayloadBuilderAttributes},
     OpPayloadPrimitives,
 };
-use alloy_consensus::{Transaction, Typed2718};
+use alloy_consensus::{BlockHeader, Transaction, Typed2718};
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
@@ -175,7 +175,7 @@ where
     /// Computes the witness for the payload.
     pub fn payload_witness(
         &self,
-        parent: SealedHeader,
+        parent: SealedHeader<N::BlockHeader>,
         attributes: OpPayloadAttributes,
     ) -> Result<ExecutionWitness, PayloadBuilderError> {
         let attributes = OpPayloadBuilderAttributes::try_new(parent.hash(), attributes, 3)
@@ -231,7 +231,7 @@ where
     // system txs, hence on_missing_payload we return [MissingPayloadBehaviour::AwaitInProgress].
     fn build_empty_payload(
         &self,
-        config: PayloadConfig<Self::Attributes>,
+        config: PayloadConfig<Self::Attributes, N::BlockHeader>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         let args = BuildArguments {
             config,
@@ -290,7 +290,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
     {
         let Self { best } = self;
-        debug!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number, "building new payload");
+        debug!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number(), "building new payload");
 
         let mut db = State::builder().with_database(db).with_bundle_update().build();
 
@@ -328,7 +328,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         let execution_outcome = ExecutionOutcome::new(
             db.take_bundle(),
             vec![execution_result.receipts],
-            block.number,
+            block.number(),
             Vec::new(),
         );
 
@@ -486,7 +486,10 @@ pub struct OpPayloadBuilderCtx<Evm: ConfigureEvm, ChainSpec> {
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
     /// How to build the payload.
-    pub config: PayloadConfig<OpPayloadBuilderAttributes<TxTy<Evm::Primitives>>>,
+    pub config: PayloadConfig<
+        OpPayloadBuilderAttributes<TxTy<Evm::Primitives>>,
+        <Evm::Primitives as NodePrimitives>::BlockHeader,
+    >,
     /// Marker to check whether the job has been cancelled.
     pub cancel: CancelOnDrop,
     /// The currently best payload.
@@ -499,8 +502,8 @@ where
     ChainSpec: EthChainSpec + OpHardforks,
 {
     /// Returns the parent block the payload will be build on.
-    pub fn parent(&self) -> &SealedHeader {
-        &self.config.parent_header
+    pub fn parent(&self) -> &SealedHeader<<Evm::Primitives as NodePrimitives>::BlockHeader> {
+        self.config.parent_header.as_ref()
     }
 
     /// Returns the builder attributes.
@@ -561,7 +564,10 @@ where
                     timestamp: self.attributes().timestamp(),
                     suggested_fee_recipient: self.attributes().suggested_fee_recipient(),
                     prev_randao: self.attributes().prev_randao(),
-                    gas_limit: self.attributes().gas_limit.unwrap_or(self.parent().gas_limit),
+                    gas_limit: self
+                        .attributes()
+                        .gas_limit
+                        .unwrap_or_else(|| self.parent().gas_limit()),
                     parent_beacon_block_root: self.attributes().parent_beacon_block_root(),
                     extra_data: self.extra_data()?,
                 },

--- a/crates/optimism/payload/src/traits.rs
+++ b/crates/optimism/payload/src/traits.rs
@@ -1,15 +1,10 @@
-use alloy_consensus::{BlockBody, Header};
+use alloy_consensus::BlockBody;
 use reth_optimism_primitives::{transaction::OpTransaction, DepositReceipt};
 use reth_primitives_traits::{NodePrimitives, SignedTransaction};
 
 /// Helper trait to encapsulate common bounds on [`NodePrimitives`] for OP payload builder.
 pub trait OpPayloadPrimitives:
-    NodePrimitives<
-    Receipt: DepositReceipt,
-    SignedTx = Self::_TX,
-    BlockHeader = Header,
-    BlockBody = BlockBody<Self::_TX>,
->
+    NodePrimitives<Receipt: DepositReceipt, SignedTx = Self::_TX, BlockBody = BlockBody<Self::_TX>>
 {
     /// Helper AT to bound [`NodePrimitives::Block`] type without causing bound cycle.
     type _TX: SignedTransaction + OpTransaction;
@@ -18,12 +13,7 @@ pub trait OpPayloadPrimitives:
 impl<Tx, T> OpPayloadPrimitives for T
 where
     Tx: SignedTransaction + OpTransaction,
-    T: NodePrimitives<
-        SignedTx = Tx,
-        Receipt: DepositReceipt,
-        BlockHeader = Header,
-        BlockBody = BlockBody<Tx>,
-    >,
+    T: NodePrimitives<SignedTx = Tx, Receipt: DepositReceipt, BlockBody = BlockBody<Tx>>,
 {
     type _TX = Tx;
 }

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -16,7 +16,7 @@ pub use reth_rpc_api::DebugExecutionWitnessApiServer;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
     errors::{ProviderError, ProviderResult},
-    BlockReaderIdExt, HeaderProvider, NodePrimitivesProvider, StateProviderFactory,
+    BlockReaderIdExt, NodePrimitivesProvider, StateProviderFactory,
 };
 use reth_tasks::TaskSpawner;
 use reth_transaction_pool::TransactionPool;
@@ -44,15 +44,14 @@ impl<Pool, Provider, EvmConfig> OpDebugWitnessApi<Pool, Provider, EvmConfig> {
 impl<Pool, Provider, EvmConfig> OpDebugWitnessApi<Pool, Provider, EvmConfig>
 where
     EvmConfig: ConfigureEvm,
-    Provider: NodePrimitivesProvider<
-            Primitives: NodePrimitives<BlockHeader = <Provider as HeaderProvider>::Header>,
-        > + BlockReaderIdExt,
+    Provider: NodePrimitivesProvider<Primitives: NodePrimitives<BlockHeader = Provider::Header>>
+        + BlockReaderIdExt,
 {
     /// Fetches the parent header by hash.
     fn parent_header(
         &self,
         parent_block_hash: B256,
-    ) -> ProviderResult<SealedHeader<<Provider as HeaderProvider>::Header>> {
+    ) -> ProviderResult<SealedHeader<Provider::Header>> {
         self.inner
             .provider
             .sealed_header_by_hash(parent_block_hash)?
@@ -69,8 +68,7 @@ where
         > + 'static,
     Provider: BlockReaderIdExt
         + NodePrimitivesProvider<
-            Primitives: OpPayloadPrimitives
-                            + NodePrimitives<BlockHeader = <Provider as HeaderProvider>::Header>,
+            Primitives: OpPayloadPrimitives + NodePrimitives<BlockHeader = Provider::Header>,
         > + StateProviderFactory
         + ChainSpecProvider<ChainSpec = OpChainSpec>
         + Clone


### PR DESCRIPTION
Allows for using generic header type in Optimism components.

Reduces the amount of changes needed for custom node creation.

Related to #16374 