### PR TITLE
feat(rpc): Export Validation Blocklist Hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9716,6 +9716,7 @@ dependencies = [
  "revm-primitives",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -85,6 +85,7 @@ tracing.workspace = true
 tracing-futures.workspace = true
 futures.workspace = true
 serde.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 derive_more.workspace = true
 

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -55,10 +55,10 @@ fn hash_disallow_list(disallow: &HashSet<Address>) -> String {
 
     let mut hasher = Sha256::new();
     for addr in sorted {
-        hasher.update(addr.as_slice()); // Use as_slice() for Address bytes
+        hasher.update(addr.as_slice());
     }
 
-    format!("{:x}", hasher.finalize()) // lowercase hex string
+    format!("{:x}", hasher.finalize())
 }
 
 impl<Provider, E> ValidationApi<Provider, E>

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -674,53 +674,12 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_blocklist_hash() {
-        let empty = HashSet::new();
-        let hash = hash_disallow_list(&empty);
-
-        // SHA256 of empty input
-        assert_eq!(hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    }
-
-    #[test]
-    fn test_hash_format_and_length() {
-        let mut addresses = HashSet::new();
-        addresses.insert(Address::from([42u8; 20]));
-
-        let hash = hash_disallow_list(&addresses);
-
-        // SHA256 produces 64-character hex string
-        assert_eq!(hash.len(), 64);
-
-        // Should be valid lowercase hex
-        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
-        assert_eq!(hash, hash.to_lowercase());
-    }
-
-    #[test]
-    fn test_hash_matches_metrics_output() {
-        // Test that our hash function produces the same results we saw in metrics
-        let empty = HashSet::new();
-        let empty_hash = hash_disallow_list(&empty);
-
-        let mut single = HashSet::new();
-        single.insert(Address::from([0x11u8; 20]));
-        let single_hash = hash_disallow_list(&single);
-
-        // These should be different
-        assert_ne!(empty_hash, single_hash);
-
-        // Empty hash should match what we observed in the metrics test
-        assert_eq!(empty_hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    }
-
-    #[test]
     //ensures parity with rbuilder hashing https://github.com/flashbots/rbuilder/blob/962c8444cdd490a216beda22c7eec164db9fc3ac/crates/rbuilder/src/live_builder/block_list_provider.rs#L248
     fn test_disallow_list_hash_rbuilder_parity() {
         let json = r#"["0x05E0b5B40B7b66098C2161A5EE11C5740A3A7C45","0x01e2919679362dFBC9ee1644Ba9C6da6D6245BB1","0x03893a7c7463AE47D46bc7f091665f1893656003","0x04DBA1194ee10112fE6C3207C0687DEf0e78baCf"]"#;
         let blocklist: Vec<Address> = serde_json::from_str(json).unwrap();
         let blocklist: HashSet<Address> = blocklist.into_iter().collect();
-        let expected_hash = "ee14e9d115e182f61871a5a385ab2f32ecf434f3b17bdbacc71044810d89e608"; 
+        let expected_hash = "ee14e9d115e182f61871a5a385ab2f32ecf434f3b17bdbacc71044810d89e608";
         let hash = hash_disallow_list(&blocklist);
         assert_eq!(expected_hash, hash);
     }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -83,7 +83,6 @@ where
 
         inner.metrics.disallow_size.set(inner.disallow.len() as f64);
 
-        //hash metric with label using the gauge macro
         let disallow_hash = hash_disallow_list(&inner.disallow);
         let hash_gauge = gauge!("builder_validation_disallow_hash", "hash" => disallow_hash);
         hash_gauge.set(1.0);

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -713,4 +713,15 @@ mod tests {
         // Empty hash should match what we observed in the metrics test
         assert_eq!(empty_hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
     }
+
+    #[test]
+    //ensures parity with rbuilder hashing https://github.com/flashbots/rbuilder/blob/962c8444cdd490a216beda22c7eec164db9fc3ac/crates/rbuilder/src/live_builder/block_list_provider.rs#L248
+    fn test_disallow_list_hash_rbuilder_parity() {
+        let json = r#"["0x05E0b5B40B7b66098C2161A5EE11C5740A3A7C45","0x01e2919679362dFBC9ee1644Ba9C6da6D6245BB1","0x03893a7c7463AE47D46bc7f091665f1893656003","0x04DBA1194ee10112fE6C3207C0687DEf0e78baCf"]"#;
+        let blocklist: Vec<Address> = serde_json::from_str(json).unwrap();
+        let blocklist: HashSet<Address> = blocklist.into_iter().collect();
+        let expected_hash = "ee14e9d115e182f61871a5a385ab2f32ecf434f3b17bdbacc71044810d89e608"; 
+        let hash = hash_disallow_list(&blocklist);
+        assert_eq!(expected_hash, hash);
+    }
 }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -49,18 +49,6 @@ pub struct ValidationApi<Provider, E: ConfigureEvm> {
     inner: Arc<ValidationApiInner<Provider, E>>,
 }
 
-fn hash_disallow_list(disallow: &HashSet<Address>) -> String {
-    let mut sorted: Vec<_> = disallow.iter().collect();
-    sorted.sort(); // sort for deterministic hashing
-
-    let mut hasher = Sha256::new();
-    for addr in sorted {
-        hasher.update(addr.as_slice());
-    }
-
-    format!("{:x}", hasher.finalize())
-}
-
 impl<Provider, E> ValidationApi<Provider, E>
 where
     E: ConfigureEvm,
@@ -520,6 +508,22 @@ pub struct ValidationApiInner<Provider, E: ConfigureEvm> {
     task_spawner: Box<dyn TaskSpawner>,
     /// Validation metrics
     metrics: ValidationMetrics,
+}
+
+/// Calculates a deterministic hash of the blocklist for change detection.
+///
+/// This function sorts addresses to ensure deterministic output regardless of
+/// insertion order, then computes a SHA256 hash of the concatenated addresses.
+fn hash_disallow_list(disallow: &HashSet<Address>) -> String {
+    let mut sorted: Vec<_> = disallow.iter().collect();
+    sorted.sort(); // sort for deterministic hashing
+
+    let mut hasher = Sha256::new();
+    for addr in sorted {
+        hasher.update(addr.as_slice());
+    }
+
+    format!("{:x}", hasher.finalize())
 }
 
 impl<Provider, E: ConfigureEvm> fmt::Debug for ValidationApiInner<Provider, E> {

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -85,8 +85,7 @@ where
 
         //hash metric with label using the gauge macro
         let disallow_hash = hash_disallow_list(&inner.disallow);
-        let hash_gauge =
-            gauge!("builder_validation_disallow_hash", "disallow_hash" => disallow_hash);
+        let hash_gauge = gauge!("builder_validation_disallow_hash", "hash" => disallow_hash);
         hash_gauge.set(1.0);
 
         Self { inner }


### PR DESCRIPTION
- Add new  metric as requested in #16482
- Metric uses static value (1) with blocklist hash as label
- Hash calculated using sort + SHA256 approach matching rbuilder implementation
- Enables detection of blocklist content changes even when size stays same
- Includes unit tests

Fixes #16482

<img width="950" alt="Screenshot 2025-05-27 at 7 00 43 PM" src="https://github.com/user-attachments/assets/2fdb843b-57c6-445a-91cb-9cf318d97c25" />


Test Case | Size | Hash (first 16 chars) | Full Hash
-- | -- | -- | --
Empty | 0 | e3b0c44298fc1c14... | e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
Single addr (0x111...) | 1 | 7c854a55ff3b6a65... | 7c854a55ff3b6a65ccb68b366a6b39756d8f2994aa41c45f94627209da86806f
Different addr (0x222...) | 1 | cec72f26f7325b41... | cec72f26f7325b41f0688a5152f9f9430ac607e010aba5be0e2984ad1531690d
Two addresses | 2 | e727e3d8b40368fb... | e727e3d8b40368fba98aa802a3f2fcd59c6aaad75ad8be725287a29f2537deff

