### PR TITLE
test: add ReorgTo e2e action

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/examples.rs
+++ b/crates/e2e-test-utils/src/testsuite/examples.rs
@@ -1,7 +1,7 @@
 //! Example tests using the test suite framework.
 
 use crate::testsuite::{
-    actions::{AssertMineBlock, CreateFork, ProduceBlocks},
+    actions::{AssertMineBlock, CaptureBlock, CreateFork, ProduceBlocks, ReorgTo},
     setup::{NetworkSetup, Setup},
     TestBuilder,
 };
@@ -88,7 +88,33 @@ async fn test_testsuite_create_fork() -> Result<()> {
     let test = TestBuilder::new()
         .with_setup(setup)
         .with_action(ProduceBlocks::<EthEngineTypes>::new(2))
-        .with_action(CreateFork::<EthEngineTypes>::new(0, 3));
+        .with_action(CreateFork::<EthEngineTypes>::new(1, 3));
+
+    test.run::<EthereumNode>().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_testsuite_reorg_with_tagging() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = Setup::default()
+        .with_chain_spec(Arc::new(
+            ChainSpecBuilder::default()
+                .chain(MAINNET.chain)
+                .genesis(serde_json::from_str(include_str!("assets/genesis.json")).unwrap())
+                .cancun_activated()
+                .build(),
+        ))
+        .with_network(NetworkSetup::single_node());
+
+    let test = TestBuilder::new()
+        .with_setup(setup)
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(3)) // produce blocks 1, 2, 3
+        .with_action(CaptureBlock::new("main_chain_tip")) // tag block 3 as "main_chain_tip"
+        .with_action(CreateFork::<EthEngineTypes>::new(1, 2)) // fork from block 1, produce blocks 2', 3'
+        .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("main_chain_tip")); // reorg back to tagged block 3
 
     test.run::<EthereumNode>().await?;
 

--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -74,10 +74,14 @@ where
     pub latest_payload_built: Option<PayloadAttributes>,
     /// Stores the most recent executed payload
     pub latest_payload_executed: Option<PayloadAttributes>,
+    /// Stores the most recent built execution payload envelope
+    pub latest_payload_envelope: Option<I::ExecutionPayloadEnvelopeV3>,
     /// Number of slots until a block is considered safe
     pub slots_to_safe: u64,
     /// Number of slots until a block is considered finalized
     pub slots_to_finalized: u64,
+    /// Registry for tagged blocks, mapping tag names to block hashes
+    pub block_registry: HashMap<String, B256>,
 }
 
 impl<I> Default for Environment<I>
@@ -98,8 +102,10 @@ where
             latest_fork_choice_state: ForkchoiceState::default(),
             latest_payload_built: None,
             latest_payload_executed: None,
+            latest_payload_envelope: None,
             slots_to_safe: 0,
             slots_to_finalized: 0,
+            block_registry: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
Closes #15745
towards #16480

* `ReorgTo` is basically `SetReorgTarget` + `BroadcastLatestForkchoice` + `UpdateBlockInfo`
* Adds a new `CaptureBlock` action to tag blocks and refer to them later.
* Includes fixes to `ProduceBlocks` to build on top of previous canonical blocks properly.