### PR TITLE
feat(optimism): Add generic `Header` into `OpPayloadPrimitives`

### DIFF
--- a/crates/optimism/payload/src/traits.rs
+++ b/crates/optimism/payload/src/traits.rs
@@ -1,19 +1,33 @@
 use alloy_consensus::BlockBody;
 use reth_optimism_primitives::{transaction::OpTransaction, DepositReceipt};
-use reth_primitives_traits::{NodePrimitives, SignedTransaction};
+use reth_primitives_traits::{FullBlockHeader, NodePrimitives, SignedTransaction};
 
 /// Helper trait to encapsulate common bounds on [`NodePrimitives`] for OP payload builder.
 pub trait OpPayloadPrimitives:
-    NodePrimitives<Receipt: DepositReceipt, SignedTx = Self::_TX, BlockBody = BlockBody<Self::_TX>>
+    NodePrimitives<
+    Receipt: DepositReceipt,
+    SignedTx = Self::_TX,
+    BlockBody = BlockBody<Self::_TX, Self::_Header>,
+    BlockHeader = Self::_Header,
+>
 {
     /// Helper AT to bound [`NodePrimitives::Block`] type without causing bound cycle.
     type _TX: SignedTransaction + OpTransaction;
+    /// Helper AT to bound [`NodePrimitives::Block`] type without causing bound cycle.
+    type _Header: FullBlockHeader;
 }
 
-impl<Tx, T> OpPayloadPrimitives for T
+impl<Tx, T, Header> OpPayloadPrimitives for T
 where
     Tx: SignedTransaction + OpTransaction,
-    T: NodePrimitives<SignedTx = Tx, Receipt: DepositReceipt, BlockBody = BlockBody<Tx>>,
+    T: NodePrimitives<
+        SignedTx = Tx,
+        Receipt: DepositReceipt,
+        BlockBody = BlockBody<Tx, Header>,
+        BlockHeader = Header,
+    >,
+    Header: FullBlockHeader,
 {
     type _TX = Tx;
+    type _Header = Header;
 }

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -66,10 +66,9 @@ where
     Pool: TransactionPool<
             Transaction: OpPooledTx<Consensus = <Provider::Primitives as NodePrimitives>::SignedTx>,
         > + 'static,
-    Provider: BlockReaderIdExt
-        + NodePrimitivesProvider<
-            Primitives: OpPayloadPrimitives + NodePrimitives<BlockHeader = Provider::Header>,
-        > + StateProviderFactory
+    Provider: BlockReaderIdExt<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>
+        + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>
+        + StateProviderFactory
         + ChainSpecProvider<ChainSpec = OpChainSpec>
         + Clone
         + 'static,


### PR DESCRIPTION
Closes #16524

Propagates generic header type from `NodePrimitives` into `OpPayloadPrimitives`. The `BlockBody` was bound to `alloy_consensus::Header` which is its generic header type default.

Reduces the amount of changes needed for custom nodes with different headers.
