### PR TITLE
docs: improve documentation clarity in pool.rs

### DIFF
--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -66,7 +66,7 @@ pub(crate) struct MockTransactionSimulator<R: Rng> {
     balances: HashMap<Address, U256>,
     /// represents the on chain nonce of a sender.
     nonces: HashMap<Address, u64>,
-    /// A set of addresses to as senders.
+    /// A set of addresses to use as senders.
     senders: Vec<Address>,
     /// What scenarios to execute.
     scenarios: Vec<ScenarioType>,
@@ -166,7 +166,7 @@ impl MockSimulatorConfig {
     }
 }
 
-/// Represents
+/// Represents the different types of test scenarios.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) enum ScenarioType {


### PR DESCRIPTION
- Add missing word in "A set of addresses to use as senders"
- Complete the partial comment for ScenarioType enum to "Represents the different types of test scenarios"

These changes make the documentation more precise and informative without modifying functionality.