### PR TITLE
Fix random generator usage in transaction test module

### DIFF
--- a/crates/transaction-pool/src/test_utils/tx_gen.rs
+++ b/crates/transaction-pool/src/test_utils/tx_gen.rs
@@ -362,11 +362,11 @@ impl Default for TransactionBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::rng;
+    use rand::thread_rng;
 
     #[test]
     fn test_generate_transaction() {
-        let rng = rng();
+        let rng = thread_rng();
         let mut tx_gen = TransactionGenerator::new(rng);
         let _tx = tx_gen.transaction().into_legacy();
         let _tx = tx_gen.transaction().into_eip1559();


### PR DESCRIPTION
Fixed incorrect random generator import and usage in tx_gen.rs test module by replacing `use rand::rng` with `use rand::thread_rng` and `rng()` with `thread_rng()`.

This change is necessary since the rand crate doesn't contain a `rng` module or function. Without this fix, tests would fail during compilation, preventing proper validation of transaction generation functionality.