### PR TITLE
ci: use HTTPS for APT in Dockerfiles

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,8 @@
 [build]
 pre-build = [
+    # Use HTTPS for package sources
+    "sed -i 's|http://|https://|g' /etc/apt/sources.list &&  find /etc/apt/sources.list.d/ -name '*.list' -exec sed -i 's|http://|https://|g' {} +",
+
     # rust-bindgen dependencies: llvm-dev libclang-dev (>= 10) clang (>= 10)
     # See: https://github.com/cross-rs/cross/wiki/FAQ#using-clang--bindgen for
     # recommended clang versions for the given cross and bindgen version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
+# Use HTTPS for package sources
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
+    find /etc/apt/sources.list.d/ -name '*.list' -exec sed -i 's|http://|https://|g' {} +
+
 # Install system dependencies
 RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,6 +1,10 @@
 # Use the Rust 1.86 image based on Debian Bookworm
 FROM rust:1.86-bookworm AS builder
 
+# Use HTTPS for package sources
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
+    find /etc/apt/sources.list.d/ -name '*.list' -exec sed -i 's|http://|https://|g' {} +
+
 # Install specific version of libclang-dev
 RUN apt-get update && apt-get install -y libclang-dev=1:14.0-55.7~deb12u1
 

--- a/Dockerfile.x86_64-pc-windows-gnu
+++ b/Dockerfile.x86_64-pc-windows-gnu
@@ -1,6 +1,9 @@
 FROM ubuntu:24.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Use HTTPS for package sources
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
+    find /etc/apt/sources.list.d/ -name '*.list' -exec sed -i 's|http://|https://|g' {} +
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends git ca-certificates
 
 RUN git clone https://github.com/cross-rs/cross /cross
@@ -12,6 +15,10 @@ RUN cp cmake.sh / && /cmake.sh
 RUN cp xargo.sh / && /xargo.sh
 
 FROM cross-base AS build
+
+# Use HTTPS for package sources
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
+    find /etc/apt/sources.list.d/ -name '*.list' -exec sed -i 's|http://|https://|g' {} +
 
 RUN apt-get install --assume-yes --no-install-recommends libz-mingw-w64-dev g++-mingw-w64-x86-64 gfortran-mingw-w64-x86-64
 


### PR DESCRIPTION
Ubuntu is having an [outage](https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQGnu9-UhZcQUtDmIVRYTQMx6Vt0EjSxe6Bz4_D89gPRLg==) affecting APT repositories. For some reason, HTTPS still works.

```console
~/Downloads via 🦀 v1.86.0 took 2s
❯ curl -I --max-time 2 http://security.archive.ubuntu.com/ubuntu/pool/main/p/python3.8/libpython3.8-minimal_3.8.10-0ubuntu1\~20.04.18_amd64.deb
curl: (28) Connection timed out after 2004 milliseconds

~/Downloads via 🦀 v1.86.0 took 2s
❯ curl -I --max-time 2 https://security.archive.ubuntu.com/ubuntu/pool/main/p/python3.8/libpython3.8-minimal_3.8.10-0ubuntu1\~20.04.18_amd64.deb
HTTP/1.1 200 OK
Date: Thu, 29 May 2025 11:20:31 GMT
Server: Apache/2.4.52 (Ubuntu)
Last-Modified: Mon, 24 Mar 2025 20:51:29 GMT
ETag: "afec0-6311cc4b6e374"
Accept-Ranges: bytes
Content-Length: 720576
Cache-Control: max-age=86400
Content-Type: application/vnd.debian.binary-package
```