### PR TITLE
feat(examples): Replace `CustomNetworkBuilder` using `OpNetworkBuilder` with custom generics

### DIFF
--- a/examples/custom-node/src/lib.rs
+++ b/examples/custom-node/src/lib.rs
@@ -7,17 +7,27 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use crate::{evm::CustomExecutorBuilder, network::CustomNetworkBuilder};
+use crate::{
+    evm::CustomExecutorBuilder, network::CustomNetworkPrimitives,
+    primitives::CustomTransactionEnvelope,
+};
 use chainspec::CustomChainSpec;
 use consensus::CustomConsensusBuilder;
+use op_alloy_consensus::OpPooledTransaction;
 use pool::CustomPoolBuilder;
 use primitives::CustomNodePrimitives;
-use reth_ethereum::node::api::{FullNodeTypes, NodeTypes};
+use reth_ethereum::{
+    node::api::{FullNodeTypes, NodeTypes},
+    primitives::Extended,
+};
 use reth_node_builder::{
     components::{BasicPayloadServiceBuilder, ComponentsBuilder},
     Node,
 };
-use reth_op::node::{node::OpPayloadBuilder, OpNode, OpPayloadTypes};
+use reth_op::node::{
+    node::{OpNetworkBuilder, OpPayloadBuilder},
+    OpNode, OpPayloadTypes,
+};
 
 pub mod chainspec;
 pub mod consensus;
@@ -47,7 +57,10 @@ where
         N,
         CustomPoolBuilder,
         BasicPayloadServiceBuilder<OpPayloadBuilder>,
-        CustomNetworkBuilder,
+        OpNetworkBuilder<
+            CustomNetworkPrimitives,
+            Extended<OpPooledTransaction, CustomTransactionEnvelope>,
+        >,
         CustomExecutorBuilder,
         CustomConsensusBuilder,
     >;
@@ -60,7 +73,7 @@ where
             .pool(CustomPoolBuilder::default())
             .executor(CustomExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(OpPayloadBuilder::new(false)))
-            .network(CustomNetworkBuilder::default())
+            .network(OpNetworkBuilder::new(false, false))
             .consensus(CustomConsensusBuilder)
     }
 

--- a/examples/custom-node/src/network.rs
+++ b/examples/custom-node/src/network.rs
@@ -1,19 +1,7 @@
-use crate::{
-    chainspec::CustomChainSpec,
-    primitives::{
-        CustomHeader, CustomNodePrimitives, CustomTransaction, CustomTransactionEnvelope,
-    },
-};
+use crate::primitives::{CustomHeader, CustomTransaction, CustomTransactionEnvelope};
 use alloy_consensus::{Block, BlockBody};
-use eyre::Result;
 use op_alloy_consensus::OpPooledTransaction;
-use reth_ethereum::{
-    chainspec::{EthChainSpec, Hardforks},
-    network::{NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives},
-    node::api::{FullNodeTypes, NodeTypes, TxTy},
-    pool::{PoolTransaction, TransactionPool},
-};
-use reth_node_builder::{components::NetworkBuilder, BuilderContext};
+use reth_ethereum::network::NetworkPrimitives;
 use reth_op::{primitives::Extended, OpReceipt};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
@@ -27,70 +15,4 @@ impl NetworkPrimitives for CustomNetworkPrimitives {
     type BroadcastedTransaction = CustomTransaction;
     type PooledTransaction = Extended<OpPooledTransaction, CustomTransactionEnvelope>;
     type Receipt = OpReceipt;
-}
-
-#[derive(Default)]
-pub struct CustomNetworkBuilder {}
-
-impl CustomNetworkBuilder {
-    fn network_config<Node>(
-        &self,
-        ctx: &BuilderContext<Node>,
-    ) -> eyre::Result<NetworkConfig<<Node as FullNodeTypes>::Provider, CustomNetworkPrimitives>>
-    where
-        Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
-    {
-        let args = &ctx.config().network;
-        let network_builder = ctx
-            .network_config_builder()?
-            // apply discovery settings
-            .apply(|mut builder| {
-                let rlpx_socket = (args.addr, args.port).into();
-                if args.discovery.disable_discovery {
-                    builder = builder.disable_discv4_discovery();
-                }
-                if !args.discovery.disable_discovery {
-                    builder = builder.discovery_v5(
-                        args.discovery.discovery_v5_builder(
-                            rlpx_socket,
-                            ctx.config()
-                                .network
-                                .resolved_bootnodes()
-                                .or_else(|| ctx.chain_spec().bootnodes())
-                                .unwrap_or_default(),
-                        ),
-                    );
-                }
-
-                builder
-            });
-
-        let network_config = ctx.build_network_config(network_builder);
-
-        Ok(network_config)
-    }
-}
-
-impl<Node, Pool> NetworkBuilder<Node, Pool> for CustomNetworkBuilder
-where
-    Node: FullNodeTypes<
-        Types: NodeTypes<ChainSpec = CustomChainSpec, Primitives = CustomNodePrimitives>,
-    >,
-    Pool: TransactionPool<
-            Transaction: PoolTransaction<
-                Consensus = TxTy<Node::Types>,
-                Pooled = Extended<OpPooledTransaction, CustomTransactionEnvelope>,
-            >,
-        > + Unpin
-        + 'static,
-{
-    type Network = NetworkHandle<CustomNetworkPrimitives>;
-
-    async fn build_network(self, ctx: &BuilderContext<Node>, pool: Pool) -> Result<Self::Network> {
-        let network_config = self.network_config(ctx)?;
-        let network = NetworkManager::builder(network_config).await?;
-        let handle = ctx.start_network(network, pool);
-
-        Ok(handle)
-    }
 }


### PR DESCRIPTION
Part of #16194

In an effort to reduce the amount of bloat in the custom node example, this PR cuts down on having to define custom network builder and instead reuses the Optimism one with custom generics.