### PR TITLE
feat(examples): Replace redundant type definitions with a `CustomPooledTransaction` alias in the `custom_node` example

### DIFF
--- a/examples/custom-node/src/lib.rs
+++ b/examples/custom-node/src/lib.rs
@@ -8,18 +8,13 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use crate::{
-    evm::CustomExecutorBuilder,
-    network::CustomNetworkPrimitives,
-    primitives::{CustomTransaction, CustomTransactionEnvelope},
+    evm::CustomExecutorBuilder, network::CustomNetworkPrimitives, pool::CustomPooledTransaction,
+    primitives::CustomTransaction,
 };
 use chainspec::CustomChainSpec;
 use consensus::CustomConsensusBuilder;
-use op_alloy_consensus::OpPooledTransaction;
 use primitives::CustomNodePrimitives;
-use reth_ethereum::{
-    node::api::{FullNodeTypes, NodeTypes},
-    primitives::Extended,
-};
+use reth_ethereum::node::api::{FullNodeTypes, NodeTypes};
 use reth_node_builder::{
     components::{BasicPayloadServiceBuilder, ComponentsBuilder},
     Node,
@@ -35,6 +30,7 @@ pub mod engine;
 pub mod engine_api;
 pub mod evm;
 pub mod network;
+pub mod pool;
 pub mod primitives;
 
 #[derive(Debug, Clone)]
@@ -54,17 +50,9 @@ where
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
-        OpPoolBuilder<
-            txpool::OpPooledTransaction<
-                CustomTransaction,
-                Extended<OpPooledTransaction, CustomTransactionEnvelope>,
-            >,
-        >,
+        OpPoolBuilder<txpool::OpPooledTransaction<CustomTransaction, CustomPooledTransaction>>,
         BasicPayloadServiceBuilder<OpPayloadBuilder>,
-        OpNetworkBuilder<
-            CustomNetworkPrimitives,
-            Extended<OpPooledTransaction, CustomTransactionEnvelope>,
-        >,
+        OpNetworkBuilder<CustomNetworkPrimitives, CustomPooledTransaction>,
         CustomExecutorBuilder,
         CustomConsensusBuilder,
     >;

--- a/examples/custom-node/src/network.rs
+++ b/examples/custom-node/src/network.rs
@@ -1,7 +1,9 @@
-use crate::primitives::{CustomHeader, CustomTransaction, CustomTransactionEnvelope};
+use crate::{
+    pool::CustomPooledTransaction,
+    primitives::{CustomHeader, CustomTransaction},
+};
 use alloy_consensus::{Block, BlockBody};
-use op_alloy_consensus::OpPooledTransaction;
-use reth_ethereum::{network::NetworkPrimitives, primitives::Extended};
+use reth_ethereum::network::NetworkPrimitives;
 use reth_op::OpReceipt;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
@@ -13,6 +15,6 @@ impl NetworkPrimitives for CustomNetworkPrimitives {
     type BlockBody = BlockBody<CustomTransaction, CustomHeader>;
     type Block = Block<CustomTransaction, CustomHeader>;
     type BroadcastedTransaction = CustomTransaction;
-    type PooledTransaction = Extended<OpPooledTransaction, CustomTransactionEnvelope>;
+    type PooledTransaction = CustomPooledTransaction;
     type Receipt = OpReceipt;
 }

--- a/examples/custom-node/src/pool.rs
+++ b/examples/custom-node/src/pool.rs
@@ -1,0 +1,5 @@
+use crate::primitives::CustomTransactionEnvelope;
+use op_alloy_consensus::OpPooledTransaction;
+use reth_ethereum::primitives::Extended;
+
+pub type CustomPooledTransaction = Extended<OpPooledTransaction, CustomTransactionEnvelope>;


### PR DESCRIPTION
Part of #16194

Deduplicates the complex type definition using a type alias with a descriptive name that should be easy to look up.