### PR TITLE
fix(era): Use the `url` as the index page for HTTP hosts

### DIFF
--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -48,10 +48,11 @@ impl TryFromChain for ChainKind {
     fn try_to_url(&self) -> eyre::Result<Url> {
         Ok(match self {
             ChainKind::Named(NamedChain::Mainnet) => {
-                Url::parse("https://era.ithaca.xyz/era1/").expect("URL should be valid")
+                Url::parse("https://era.ithaca.xyz/era1/index.html").expect("URL should be valid")
             }
             ChainKind::Named(NamedChain::Sepolia) => {
-                Url::parse("https://era.ithaca.xyz/sepolia-era1/").expect("URL should be valid")
+                Url::parse("https://era.ithaca.xyz/sepolia-era1/index.html")
+                    .expect("URL should be valid")
             }
             chain => return Err(eyre!("No known host for ERA files on chain {chain:?}")),
         })

--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -142,7 +142,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     /// Fetches the list of ERA1 files from `url` and stores it in a file located within `folder`.
     pub async fn fetch_file_list(&self) -> eyre::Result<()> {
         let (mut index, mut checksums) = try_join!(
-            self.client.get(self.url.clone().join("index.html")?),
+            self.client.get(self.url.clone()),
             self.client.get(self.url.clone().join(Self::CHECKSUMS)?),
         )?;
 

--- a/crates/era-downloader/tests/it/checksums.rs
+++ b/crates/era-downloader/tests/it/checksums.rs
@@ -9,7 +9,7 @@ use test_case::test_case;
 
 #[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
-#[test_case("https://era.ithaca.xyz/era1/"; "ithaca")]
+#[test_case("https://era.ithaca.xyz/era1/index.html"; "ithaca")]
 #[tokio::test]
 async fn test_invalid_checksum_returns_error(url: &str) {
     let base_url = Url::from_str(url).unwrap();
@@ -57,13 +57,13 @@ impl HttpClient for FailingClient {
 
         async move {
             match url.to_string().as_str() {
-                "https://mainnet.era1.nimbus.team/index.html" => {
+                "https://mainnet.era1.nimbus.team/" => {
                     Ok(Box::new(futures::stream::once(Box::pin(async move {
                         Ok(bytes::Bytes::from(crate::NIMBUS))
                     })))
                         as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
                 }
-                "https://era1.ethportal.net/index.html" => {
+                "https://era1.ethportal.net/" => {
                     Ok(Box::new(futures::stream::once(Box::pin(async move {
                         Ok(bytes::Bytes::from(crate::ETH_PORTAL))
                     })))

--- a/crates/era-downloader/tests/it/download.rs
+++ b/crates/era-downloader/tests/it/download.rs
@@ -8,17 +8,17 @@ use test_case::test_case;
 
 #[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
-#[test_case("https://era.ithaca.xyz/era1/"; "ithaca")]
+#[test_case("https://era.ithaca.xyz/era1/index.html"; "ithaca")]
 #[tokio::test]
 async fn test_getting_file_url_after_fetching_file_list(url: &str) {
     let base_url = Url::from_str(url).unwrap();
     let folder = tempdir().unwrap();
     let folder = folder.path().to_owned().into_boxed_path();
-    let client = EraClient::new(StubClient, base_url, folder);
+    let client = EraClient::new(StubClient, base_url.clone(), folder);
 
     client.fetch_file_list().await.unwrap();
 
-    let expected_url = Some(Url::from_str(&format!("{url}mainnet-00000-5ec1ffb8.era1")).unwrap());
+    let expected_url = Some(base_url.join("mainnet-00000-5ec1ffb8.era1").unwrap());
     let actual_url = client.url(0).await.unwrap();
 
     assert_eq!(actual_url, expected_url);
@@ -26,7 +26,7 @@ async fn test_getting_file_url_after_fetching_file_list(url: &str) {
 
 #[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
-#[test_case("https://era.ithaca.xyz/era1/"; "ithaca")]
+#[test_case("https://era.ithaca.xyz/era1/index.html"; "ithaca")]
 #[tokio::test]
 async fn test_getting_file_after_fetching_file_list(url: &str) {
     let base_url = Url::from_str(url).unwrap();

--- a/crates/era-downloader/tests/it/list.rs
+++ b/crates/era-downloader/tests/it/list.rs
@@ -8,7 +8,7 @@ use test_case::test_case;
 
 #[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
-#[test_case("https://era.ithaca.xyz/era1/"; "ithaca")]
+#[test_case("https://era.ithaca.xyz/era1/index.html"; "ithaca")]
 #[tokio::test]
 async fn test_getting_file_name_after_fetching_file_list(url: &str) {
     let url = Url::from_str(url).unwrap();

--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -38,13 +38,13 @@ impl HttpClient for StubClient {
 
         async move {
             match url.to_string().as_str() {
-                "https://mainnet.era1.nimbus.team/index.html" => {
+                "https://mainnet.era1.nimbus.team/" => {
                     Ok(Box::new(futures::stream::once(Box::pin(async move {
                         Ok(bytes::Bytes::from(NIMBUS))
                     })))
                         as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
                 }
-                "https://era1.ethportal.net/index.html" => {
+                "https://era1.ethportal.net/" => {
                     Ok(Box::new(futures::stream::once(Box::pin(async move {
                         Ok(bytes::Bytes::from(ETH_PORTAL))
                     })))

--- a/crates/era-downloader/tests/it/stream.rs
+++ b/crates/era-downloader/tests/it/stream.rs
@@ -9,7 +9,7 @@ use test_case::test_case;
 
 #[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
-#[test_case("https://era.ithaca.xyz/era1/"; "ithaca")]
+#[test_case("https://era.ithaca.xyz/era1/index.html"; "ithaca")]
 #[tokio::test]
 async fn test_streaming_files_after_fetching_file_list(url: &str) {
     let base_url = Url::from_str(url).unwrap();

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -11,7 +11,7 @@ use tempfile::tempdir;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_history_imports_from_fresh_state_successfully() {
     // URL where the ERA1 files are hosted
-    let url = Url::from_str("https://era.ithaca.xyz/era1/").unwrap();
+    let url = Url::from_str("https://era.ithaca.xyz/era1/index.html").unwrap();
 
     // Directory where the ERA1 files will be downloaded to
     let folder = tempdir().unwrap();

--- a/crates/era/tests/it/main.rs
+++ b/crates/era/tests/it/main.rs
@@ -32,7 +32,7 @@ const fn main() {}
 const MAINNET: &str = "mainnet";
 /// Default mainnet url
 /// for downloading mainnet `.era1` files
-const MAINNET_URL: &str = "https://era.ithaca.xyz/era1/";
+const MAINNET_URL: &str = "https://era.ithaca.xyz/era1/index.html";
 
 /// Succinct list of mainnet files we want to download
 /// from <https://era.ithaca.xyz/era1/>


### PR DESCRIPTION
Part of #13186

Removes the assumption that the `url` contains file called `index.html` and instead require `url` to be the index page.

Fixes downloading era file index for such hosts such as "hoodi".
