### PR TITLE
chore: simplify `NetworkPrimitives`

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -11,7 +11,7 @@ use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor};
 use reth_network::{
-    primitives::NetPrimitivesFor, NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives,
+    types::BasicNetworkPrimitives, NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives,
     PeersInfo,
 };
 use reth_node_api::{
@@ -39,7 +39,7 @@ use reth_optimism_payload_builder::{
     config::{OpBuilderConfig, OpDAConfig},
     OpBuiltPayload, OpPayloadBuilderAttributes, OpPayloadPrimitives,
 };
-use reth_optimism_primitives::{DepositReceipt, OpPrimitives, OpReceipt, OpTransactionSigned};
+use reth_optimism_primitives::{DepositReceipt, OpPrimitives, OpTransactionSigned};
 use reth_optimism_rpc::{
     eth::{ext::OpEthExtApi, OpEthApiBuilder},
     miner::{MinerApiExtServer, OpMinerExtApi},
@@ -57,8 +57,8 @@ use reth_rpc_eth_types::error::FromEvmError;
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
-    blobstore::DiskFileBlobStore, CoinbaseTipOrdering, EthPoolTransaction, PoolTransaction,
-    TransactionPool, TransactionValidationTaskExecutor,
+    blobstore::DiskFileBlobStore, CoinbaseTipOrdering, EthPoolTransaction, PoolPooledTx,
+    PoolTransaction, TransactionPool, TransactionValidationTaskExecutor,
 };
 use reth_trie_db::MerklePatriciaTrie;
 use revm::context::TxEnv;
@@ -818,40 +818,37 @@ where
 
 /// A basic optimism network builder.
 #[derive(Debug, Default)]
-pub struct OpNetworkBuilder<NetworkP = OpNetworkPrimitives, PooledTx = OpPooledTransaction> {
+pub struct OpNetworkBuilder {
     /// Disable transaction pool gossip
     pub disable_txpool_gossip: bool,
     /// Disable discovery v4
     pub disable_discovery_v4: bool,
-    /// Marker for the network primitives type
-    _np: PhantomData<NetworkP>,
-    /// Marker for the pooled transaction type
-    _pt: PhantomData<PooledTx>,
 }
 
-impl<NetworkP, PooledTx> Clone for OpNetworkBuilder<NetworkP, PooledTx> {
+impl Clone for OpNetworkBuilder {
     fn clone(&self) -> Self {
         Self::new(self.disable_txpool_gossip, self.disable_discovery_v4)
     }
 }
 
-impl<NetworkP, PooledTx> OpNetworkBuilder<NetworkP, PooledTx> {
+impl OpNetworkBuilder {
     /// Creates a new `OpNetworkBuilder`.
     pub const fn new(disable_txpool_gossip: bool, disable_discovery_v4: bool) -> Self {
-        Self { disable_txpool_gossip, disable_discovery_v4, _np: PhantomData, _pt: PhantomData }
+        Self { disable_txpool_gossip, disable_discovery_v4 }
     }
 }
 
-impl<NetworkP: NetworkPrimitives, PooledTx> OpNetworkBuilder<NetworkP, PooledTx> {
+impl OpNetworkBuilder {
     /// Returns the [`NetworkConfig`] that contains the settings to launch the p2p network.
     ///
     /// This applies the configured [`OpNetworkBuilder`] settings.
-    pub fn network_config<Node>(
+    pub fn network_config<Node, NetworkP>(
         &self,
         ctx: &BuilderContext<Node>,
-    ) -> eyre::Result<NetworkConfig<<Node as FullNodeTypes>::Provider, NetworkP>>
+    ) -> eyre::Result<NetworkConfig<Node::Provider, NetworkP>>
     where
         Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
+        NetworkP: NetworkPrimitives,
     {
         let Self { disable_txpool_gossip, disable_discovery_v4, .. } = self.clone();
         let args = &ctx.config().network;
@@ -890,22 +887,15 @@ impl<NetworkP: NetworkPrimitives, PooledTx> OpNetworkBuilder<NetworkP, PooledTx>
     }
 }
 
-impl<Node, Pool, NetworkP, PooledTx> NetworkBuilder<Node, Pool>
-    for OpNetworkBuilder<NetworkP, PooledTx>
+impl<Node, Pool> NetworkBuilder<Node, Pool> for OpNetworkBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
-    Pool: TransactionPool<
-            Transaction: PoolTransaction<Consensus = TxTy<Node::Types>, Pooled = PooledTx>,
-        > + Unpin
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
         + 'static,
-    NetworkP: NetworkPrimitives<
-            PooledTransaction = PooledTx,
-            BroadcastedTransaction = <<Node::Types as NodeTypes>::Primitives as NodePrimitives>::SignedTx
-        >
-        + NetPrimitivesFor<PrimitivesTy<Node::Types>>,
-    PooledTx: Send,
 {
-    type Network = NetworkHandle<NetworkP>;
+    type Network =
+        NetworkHandle<BasicNetworkPrimitives<PrimitivesTy<Node::Types>, PoolPooledTx<Pool>>>;
 
     async fn build_network(
         self,
@@ -967,15 +957,4 @@ where
 }
 
 /// Network primitive types used by Optimism networks.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub struct OpNetworkPrimitives;
-
-impl NetworkPrimitives for OpNetworkPrimitives {
-    type BlockHeader = alloy_consensus::Header;
-    type BlockBody = alloy_consensus::BlockBody<OpTransactionSigned>;
-    type Block = alloy_consensus::Block<OpTransactionSigned>;
-    type BroadcastedTransaction = OpTransactionSigned;
-    type PooledTransaction = OpPooledTransaction;
-    type Receipt = OpReceipt;
-}
+pub type OpNetworkPrimitives = BasicNetworkPrimitives<OpPrimitives, OpPooledTransaction>;

--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -5,6 +5,7 @@ use alloc::vec::Vec;
 use alloy_consensus::{
     Eip2718EncodableReceipt, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt, Typed2718,
 };
+use alloy_rlp::{Decodable, Encodable};
 use core::fmt;
 
 /// Helper trait that unifies all behaviour required by receipt to support full node operations.
@@ -23,6 +24,8 @@ pub trait Receipt:
     + TxReceipt<Log = alloy_primitives::Log>
     + RlpEncodableReceipt
     + RlpDecodableReceipt
+    + Encodable
+    + Decodable
     + Eip2718EncodableReceipt
     + Typed2718
     + MaybeSerde

--- a/examples/custom-node/src/lib.rs
+++ b/examples/custom-node/src/lib.rs
@@ -8,8 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use crate::{
-    evm::CustomExecutorBuilder, network::CustomNetworkPrimitives, pool::CustomPooledTransaction,
-    primitives::CustomTransaction,
+    evm::CustomExecutorBuilder, pool::CustomPooledTransaction, primitives::CustomTransaction,
 };
 use chainspec::CustomChainSpec;
 use consensus::CustomConsensusBuilder;
@@ -52,7 +51,7 @@ where
         N,
         OpPoolBuilder<txpool::OpPooledTransaction<CustomTransaction, CustomPooledTransaction>>,
         BasicPayloadServiceBuilder<OpPayloadBuilder>,
-        OpNetworkBuilder<CustomNetworkPrimitives, CustomPooledTransaction>,
+        OpNetworkBuilder,
         CustomExecutorBuilder,
         CustomConsensusBuilder,
     >;


### PR DESCRIPTION
Right now users are always forced to manually define `NetworkPrimitives` impl while it can always be derived from `NodePrimitives` and pool transaction

This PR introduces `BasicNetworkPrimitives` which are basically adapter to combine these and allows us to simplify custom network setup a bit by having `OpNetworkBuilder` attach primitives with pooled tx