### PR TITLE
feat: fix tx da scaling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5919,9 +5919,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-flz"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef71f23a8caf6f2a2d5cafbdc44956d44e6014dcb9aa58abf7e4e6481c6ec34"
+checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,7 +507,7 @@ op-alloy-rpc-types-engine = { version = "0.17.2", default-features = false }
 op-alloy-network = { version = "0.17.2", default-features = false }
 op-alloy-consensus = { version = "0.17.2", default-features = false }
 op-alloy-rpc-jsonrpsee = { version = "0.17.2", default-features = false }
-op-alloy-flz = { version = "0.13.0", default-features = false }
+op-alloy-flz = { version = "0.13.1", default-features = false }
 
 # misc
 aquamarine = "0.6"

--- a/crates/optimism/txpool/src/transaction.rs
+++ b/crates/optimism/txpool/src/transaction.rs
@@ -76,7 +76,7 @@ impl<Cons: SignedTransaction, Pooled> OpPooledTransaction<Cons, Pooled> {
     pub fn estimated_compressed_size(&self) -> u64 {
         *self
             .estimated_tx_compressed_size
-            .get_or_init(|| op_alloy_flz::data_gas_fjord(self.encoded_2718()))
+            .get_or_init(|| op_alloy_flz::tx_estimated_size_fjord_bytes(self.encoded_2718()))
     }
 
     /// Returns lazily computed EIP-2718 encoded bytes of the transaction.

--- a/crates/optimism/txpool/src/transaction.rs
+++ b/crates/optimism/txpool/src/transaction.rs
@@ -69,14 +69,14 @@ impl<Cons: SignedTransaction, Pooled> OpPooledTransaction<Cons, Pooled> {
         }
     }
 
-    /// Returns the estimated compressed size of a transaction in bytes scaled by 1e6.
+    /// Returns the estimated compressed size of a transaction in bytes.
     /// This value is computed based on the following formula:
-    /// `max(minTransactionSize, intercept + fastlzCoef*fastlzSize)`
+    /// `max(minTransactionSize, intercept + fastlzCoef*fastlzSize) / 1e6`
     /// Uses cached EIP-2718 encoded bytes to avoid recomputing the encoding for each estimation.
     pub fn estimated_compressed_size(&self) -> u64 {
         *self
             .estimated_tx_compressed_size
-            .get_or_init(|| op_alloy_flz::tx_estimated_size_fjord(self.encoded_2718()))
+            .get_or_init(|| op_alloy_flz::data_gas_fjord(self.encoded_2718()))
     }
 
     /// Returns lazily computed EIP-2718 encoded bytes of the transaction.


### PR DESCRIPTION
We used compressed size to track DA size of tx https://github.com/paradigmxyz/reth/issues/16110
We must use downscaled size (like op-geth does) https://github.com/ethereum-optimism/op-geth/blob/optimism/core/types/rollup_cost.go#L563
Example of DA size sent by op-batcher:
```
"jsonrpc":"2.0", "method":"miner_setMaxDASize", "params":["0x0", "0x1fbd0"]
```