### PR TITLE
feat(engine): allow configuring tree to always use state root fallback

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -768,8 +768,8 @@ Engine:
       --engine.precompile-cache
           Enable precompile cache
 
-      --engine.test-state-root-fallback
-          Enable state root fallback testing
+      --engine.state-root-fallback
+          Enable state root fallback, useful for testing
 
 Ress:
       --ress.enable

--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -768,6 +768,9 @@ Engine:
       --engine.precompile-cache
           Enable precompile cache
 
+      --engine.test-state-root-fallback
+          Enable state root fallback testing
+
 Ress:
       --ress.enable
           Enable support for `ress` subprotocol

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -78,7 +78,7 @@ pub struct TreeConfig {
     /// Whether to enable the precompile cache
     precompile_cache_enabled: bool,
     /// Whether to use state root fallback for testing
-    test_state_root_fallback: bool,
+    state_root_fallback: bool,
 }
 
 impl Default for TreeConfig {
@@ -98,7 +98,7 @@ impl Default for TreeConfig {
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_enabled: false,
-            test_state_root_fallback: false,
+            state_root_fallback: false,
         }
     }
 }
@@ -121,7 +121,7 @@ impl TreeConfig {
         max_proof_task_concurrency: u64,
         reserved_cpu_cores: usize,
         precompile_cache_enabled: bool,
-        test_state_root_fallback: bool,
+        state_root_fallback: bool,
     ) -> Self {
         Self {
             persistence_threshold,
@@ -138,7 +138,7 @@ impl TreeConfig {
             max_proof_task_concurrency,
             reserved_cpu_cores,
             precompile_cache_enabled,
-            test_state_root_fallback,
+            state_root_fallback,
         }
     }
 
@@ -209,9 +209,9 @@ impl TreeConfig {
         self.precompile_cache_enabled
     }
 
-    /// Returns whether to use state root fallback for testing.
-    pub const fn test_state_root_fallback(&self) -> bool {
-        self.test_state_root_fallback
+    /// Returns whether to use state root fallback.
+    pub const fn state_root_fallback(&self) -> bool {
+        self.state_root_fallback
     }
 
     /// Setter for persistence threshold.
@@ -317,9 +317,9 @@ impl TreeConfig {
         self
     }
 
-    /// Setter for whether to use state root fallback for testing.
-    pub const fn with_test_state_root_fallback(mut self, test_state_root_fallback: bool) -> Self {
-        self.test_state_root_fallback = test_state_root_fallback;
+    /// Setter for whether to use state root fallback, useful for testing.
+    pub const fn with_state_root_fallback(mut self, state_root_fallback: bool) -> Self {
+        self.state_root_fallback = state_root_fallback;
         self
     }
 

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -77,6 +77,8 @@ pub struct TreeConfig {
     reserved_cpu_cores: usize,
     /// Whether to enable the precompile cache
     precompile_cache_enabled: bool,
+    /// Whether to use state root fallback for testing
+    test_state_root_fallback: bool,
 }
 
 impl Default for TreeConfig {
@@ -96,6 +98,7 @@ impl Default for TreeConfig {
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_enabled: false,
+            test_state_root_fallback: false,
         }
     }
 }
@@ -118,6 +121,7 @@ impl TreeConfig {
         max_proof_task_concurrency: u64,
         reserved_cpu_cores: usize,
         precompile_cache_enabled: bool,
+        test_state_root_fallback: bool,
     ) -> Self {
         Self {
             persistence_threshold,
@@ -134,6 +138,7 @@ impl TreeConfig {
             max_proof_task_concurrency,
             reserved_cpu_cores,
             precompile_cache_enabled,
+            test_state_root_fallback,
         }
     }
 
@@ -202,6 +207,11 @@ impl TreeConfig {
     /// Returns whether precompile cache is enabled.
     pub const fn precompile_cache_enabled(&self) -> bool {
         self.precompile_cache_enabled
+    }
+
+    /// Returns whether to use state root fallback for testing.
+    pub const fn test_state_root_fallback(&self) -> bool {
+        self.test_state_root_fallback
     }
 
     /// Setter for persistence threshold.
@@ -304,6 +314,12 @@ impl TreeConfig {
     /// Setter for whether to use the precompile cache.
     pub const fn with_precompile_cache_enabled(mut self, precompile_cache_enabled: bool) -> Self {
         self.precompile_cache_enabled = precompile_cache_enabled;
+        self
+    }
+
+    /// Setter for whether to use state root fallback for testing.
+    pub const fn with_test_state_root_fallback(mut self, test_state_root_fallback: bool) -> Self {
+        self.test_state_root_fallback = test_state_root_fallback;
         self
     }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2161,7 +2161,8 @@ where
         //
         // See https://github.com/paradigmxyz/reth/issues/12688 for more details
         let persisting_kind = self.persisting_kind_for(block.header());
-        let run_parallel_state_root = persisting_kind.can_run_parallel_state_root();
+        let run_parallel_state_root = persisting_kind.can_run_parallel_state_root() &&
+            !self.config.test_state_root_fallback(); // don't run parallel if testing fallback
 
         // use prewarming background task
         let header = block.clone_sealed_header();
@@ -2299,8 +2300,13 @@ where
             maybe_state_root
         } else {
             // fallback is to compute the state root regularly in sync
-            warn!(target: "engine::tree", block=?block_num_hash, ?persisting_kind, "Failed to compute state root in parallel");
-            self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
+            if self.config.test_state_root_fallback() {
+                debug!(target: "engine::tree", block=?block_num_hash, "Using state root fallback for testing");
+            } else {
+                warn!(target: "engine::tree", block=?block_num_hash, ?persisting_kind, "Failed to compute state root in parallel");
+                self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
+            }
+
             let (root, updates) =
                 ensure_ok!(state_provider.state_root_with_updates(hashed_state.clone()));
             (root, updates, root_time.elapsed())

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2161,8 +2161,9 @@ where
         //
         // See https://github.com/paradigmxyz/reth/issues/12688 for more details
         let persisting_kind = self.persisting_kind_for(block.header());
-        let run_parallel_state_root = persisting_kind.can_run_parallel_state_root() &&
-            !self.config.test_state_root_fallback(); // don't run parallel if testing fallback
+        // don't run parallel if state root fallback is set
+        let run_parallel_state_root =
+            persisting_kind.can_run_parallel_state_root() && !self.config.state_root_fallback();
 
         // use prewarming background task
         let header = block.clone_sealed_header();
@@ -2300,7 +2301,7 @@ where
             maybe_state_root
         } else {
             // fallback is to compute the state root regularly in sync
-            if self.config.test_state_root_fallback() {
+            if self.config.state_root_fallback() {
                 debug!(target: "engine::tree", block=?block_num_hash, "Using state root fallback for testing");
             } else {
                 warn!(target: "engine::tree", block=?block_num_hash, ?persisting_kind, "Failed to compute state root in parallel");

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -63,6 +63,10 @@ pub struct EngineArgs {
     /// Enable precompile cache
     #[arg(long = "engine.precompile-cache", default_value = "false")]
     pub precompile_cache_enabled: bool,
+
+    /// Enable state root fallback testing
+    #[arg(long = "engine.test-state-root-fallback", default_value = "false")]
+    pub test_state_root_fallback: bool,
 }
 
 impl Default for EngineArgs {
@@ -80,6 +84,7 @@ impl Default for EngineArgs {
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_enabled: false,
+            test_state_root_fallback: false,
         }
     }
 }
@@ -98,6 +103,7 @@ impl EngineArgs {
             .with_max_proof_task_concurrency(self.max_proof_task_concurrency)
             .with_reserved_cpu_cores(self.reserved_cpu_cores)
             .with_precompile_cache_enabled(self.precompile_cache_enabled)
+            .with_test_state_root_fallback(self.test_state_root_fallback)
     }
 }
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -64,9 +64,9 @@ pub struct EngineArgs {
     #[arg(long = "engine.precompile-cache", default_value = "false")]
     pub precompile_cache_enabled: bool,
 
-    /// Enable state root fallback testing
-    #[arg(long = "engine.test-state-root-fallback", default_value = "false")]
-    pub test_state_root_fallback: bool,
+    /// Enable state root fallback, useful for testing
+    #[arg(long = "engine.state-root-fallback", default_value = "false")]
+    pub state_root_fallback: bool,
 }
 
 impl Default for EngineArgs {
@@ -84,7 +84,7 @@ impl Default for EngineArgs {
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_enabled: false,
-            test_state_root_fallback: false,
+            state_root_fallback: false,
         }
     }
 }
@@ -103,7 +103,7 @@ impl EngineArgs {
             .with_max_proof_task_concurrency(self.max_proof_task_concurrency)
             .with_reserved_cpu_cores(self.reserved_cpu_cores)
             .with_precompile_cache_enabled(self.precompile_cache_enabled)
-            .with_test_state_root_fallback(self.test_state_root_fallback)
+            .with_state_root_fallback(self.state_root_fallback)
     }
 }
 


### PR DESCRIPTION
towards #16545

adds cli flag `--engine.state-root-fallback` and changes in `EngineApiTreeHandler` to always run state root fallback when it is set.