### PR TITLE
feat(optimism): Remove bounds on `EthChainSpec` and `Hardforks` for `ChainSpec` in the `evm` crate

### DIFF
--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -27,6 +27,7 @@ op-alloy-consensus.workspace = true
 alloy-consensus.workspace = true
 
 # Optimism
+reth-optimism-chainspec.workspace = true
 reth-optimism-consensus.workspace = true
 reth-optimism-forks.workspace = true
 reth-optimism-primitives.workspace = true
@@ -41,7 +42,6 @@ thiserror.workspace = true
 [dev-dependencies]
 reth-evm = { workspace = true, features = ["test-utils"] }
 reth-revm = { workspace = true, features = ["test-utils"] }
-reth-optimism-chainspec.workspace = true
 alloy-genesis.workspace = true
 alloy-consensus.workspace = true
 reth-optimism-primitives = { workspace = true, features = ["arbitrary"] }

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -28,7 +28,6 @@ alloy-consensus.workspace = true
 
 # Optimism
 reth-optimism-consensus.workspace = true
-reth-optimism-chainspec.workspace = true
 reth-optimism-forks.workspace = true
 reth-optimism-primitives.workspace = true
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -1,11 +1,11 @@
 //! Optimism block execution strategy.
 
 /// Helper type with backwards compatible methods to obtain executor providers.
-pub type OpExecutorProvider = crate::OpEvmConfig;
+pub type OpExecutorProvider<ChainSpec> = crate::OpEvmConfig<ChainSpec>;
 
 #[cfg(test)]
 mod tests {
-    use crate::{OpChainSpec, OpEvmConfig, OpRethReceiptBuilder};
+    use crate::{OpEvmConfig, OpRethReceiptBuilder};
     use alloc::sync::Arc;
     use alloy_consensus::{Block, BlockBody, Header, SignableTransaction, TxEip1559};
     use alloy_primitives::{b256, Address, Signature, StorageKey, StorageValue, U256};
@@ -13,7 +13,7 @@ mod tests {
     use op_revm::constants::L1_BLOCK_CONTRACT;
     use reth_chainspec::MIN_TRANSACTION_GAS;
     use reth_evm::{execute::Executor, ConfigureEvm};
-    use reth_optimism_chainspec::OpChainSpecBuilder;
+    use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
     use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
     use reth_primitives_traits::{Account, RecoveredBlock};
     use reth_revm::{database::StateProviderDatabase, test_utils::StateProviderTest};
@@ -46,7 +46,7 @@ mod tests {
         db
     }
 
-    fn evm_config(chain_spec: Arc<OpChainSpec>) -> OpEvmConfig {
+    fn evm_config(chain_spec: Arc<OpChainSpec>) -> OpEvmConfig<OpChainSpec> {
         OpEvmConfig::new(chain_spec, OpRethReceiptBuilder::default())
     }
 

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -1,7 +1,7 @@
 //! Optimism block execution strategy.
 
 /// Helper type with backwards compatible methods to obtain executor providers.
-pub type OpExecutorProvider<ChainSpec> = crate::OpEvmConfig<ChainSpec>;
+pub type OpExecutorProvider = crate::OpEvmConfig;
 
 #[cfg(test)]
 mod tests {

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -46,7 +46,7 @@ mod tests {
         db
     }
 
-    fn evm_config(chain_spec: Arc<OpChainSpec>) -> OpEvmConfig<OpChainSpec> {
+    fn evm_config(chain_spec: Arc<OpChainSpec>) -> OpEvmConfig {
         OpEvmConfig::new(chain_spec, OpRethReceiptBuilder::default())
     }
 

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -21,7 +21,6 @@ use op_alloy_consensus::EIP1559ParamError;
 use op_revm::{OpSpecId, OpTransaction};
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, EvmEnv};
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::next_block_base_fee;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
@@ -51,7 +50,7 @@ pub use alloy_op_evm::{OpBlockExecutorFactory, OpEvm, OpEvmFactory};
 /// Optimism-related EVM configuration.
 #[derive(Debug)]
 pub struct OpEvmConfig<
-    ChainSpec = OpChainSpec,
+    ChainSpec: OpHardforks,
     N: NodePrimitives = OpPrimitives,
     R = OpRethReceiptBuilder,
 > {
@@ -62,7 +61,7 @@ pub struct OpEvmConfig<
     _pd: core::marker::PhantomData<N>,
 }
 
-impl<ChainSpec, N: NodePrimitives, R: Clone> Clone for OpEvmConfig<ChainSpec, N, R> {
+impl<ChainSpec: OpHardforks, N: NodePrimitives, R: Clone> Clone for OpEvmConfig<ChainSpec, N, R> {
     fn clone(&self) -> Self {
         Self {
             executor_factory: self.executor_factory.clone(),
@@ -72,14 +71,14 @@ impl<ChainSpec, N: NodePrimitives, R: Clone> Clone for OpEvmConfig<ChainSpec, N,
     }
 }
 
-impl<ChainSpec> OpEvmConfig<ChainSpec> {
+impl<ChainSpec: OpHardforks> OpEvmConfig<ChainSpec> {
     /// Creates a new [`OpEvmConfig`] with the given chain spec for OP chains.
     pub fn optimism(chain_spec: Arc<ChainSpec>) -> Self {
         Self::new(chain_spec, OpRethReceiptBuilder::default())
     }
 }
 
-impl<ChainSpec, N: NodePrimitives, R> OpEvmConfig<ChainSpec, N, R> {
+impl<ChainSpec: OpHardforks, N: NodePrimitives, R> OpEvmConfig<ChainSpec, N, R> {
     /// Creates a new [`OpEvmConfig`] with the given chain spec.
     pub fn new(chain_spec: Arc<ChainSpec>, receipt_builder: R) -> Self {
         Self {
@@ -227,7 +226,7 @@ mod tests {
     use reth_execution_types::{
         AccountRevertInit, BundleStateInit, Chain, ExecutionOutcome, RevertsInit,
     };
-    use reth_optimism_chainspec::BASE_MAINNET;
+    use reth_optimism_chainspec::{OpChainSpec, BASE_MAINNET};
     use reth_optimism_primitives::{OpBlock, OpPrimitives, OpReceipt};
     use reth_primitives_traits::{Account, RecoveredBlock};
     use revm::{
@@ -239,7 +238,7 @@ mod tests {
     };
     use std::sync::Arc;
 
-    fn test_evm_config() -> OpEvmConfig {
+    fn test_evm_config() -> OpEvmConfig<OpChainSpec> {
         OpEvmConfig::optimism(BASE_MAINNET.clone())
     }
 

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -21,6 +21,7 @@ use op_alloy_consensus::EIP1559ParamError;
 use op_revm::{OpSpecId, OpTransaction};
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, EvmEnv};
+use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::next_block_base_fee;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
@@ -50,7 +51,7 @@ pub use alloy_op_evm::{OpBlockExecutorFactory, OpEvm, OpEvmFactory};
 /// Optimism-related EVM configuration.
 #[derive(Debug)]
 pub struct OpEvmConfig<
-    ChainSpec: OpHardforks,
+    ChainSpec = OpChainSpec,
     N: NodePrimitives = OpPrimitives,
     R = OpRethReceiptBuilder,
 > {
@@ -61,7 +62,7 @@ pub struct OpEvmConfig<
     _pd: core::marker::PhantomData<N>,
 }
 
-impl<ChainSpec: OpHardforks, N: NodePrimitives, R: Clone> Clone for OpEvmConfig<ChainSpec, N, R> {
+impl<ChainSpec, N: NodePrimitives, R: Clone> Clone for OpEvmConfig<ChainSpec, N, R> {
     fn clone(&self) -> Self {
         Self {
             executor_factory: self.executor_factory.clone(),
@@ -238,7 +239,7 @@ mod tests {
     };
     use std::sync::Arc;
 
-    fn test_evm_config() -> OpEvmConfig<OpChainSpec> {
+    fn test_evm_config() -> OpEvmConfig {
         OpEvmConfig::optimism(BASE_MAINNET.clone())
     }
 

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -65,7 +65,7 @@ where
 }
 
 /// Validator for Optimism engine API.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct OpEngineValidator<P, Tx, ChainSpec> {
     inner: OpExecutionPayloadValidator<ChainSpec>,
     provider: P,
@@ -82,6 +82,21 @@ impl<P, Tx, ChainSpec> OpEngineValidator<P, Tx, ChainSpec> {
             provider,
             hashed_addr_l2tol1_msg_passer,
             phantom: PhantomData,
+        }
+    }
+}
+
+impl<P, Tx, ChainSpec> Clone for OpEngineValidator<P, Tx, ChainSpec>
+where
+    P: Clone,
+    ChainSpec: OpHardforks,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: OpExecutionPayloadValidator::new(self.inner.clone()),
+            provider: self.provider.clone(),
+            hashed_addr_l2tol1_msg_passer: self.hashed_addr_l2tol1_msg_passer,
+            phantom: Default::default(),
         }
     }
 }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -580,7 +580,7 @@ impl<ChainSpec, Primitives> Default for OpExecutorBuilder<ChainSpec, Primitives>
 impl<Node, ChainSpec, Primitives> ExecutorBuilder<Node> for OpExecutorBuilder<ChainSpec, Primitives>
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = Primitives>>,
-    ChainSpec: EthChainSpec + OpHardforks,
+    ChainSpec: OpHardforks + Send + Sync,
     Primitives: NodePrimitives,
     OpEvmConfig<ChainSpec, Primitives>: ConfigureEvm<Primitives = Primitives> + 'static,
 {

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -66,12 +66,16 @@ use std::{marker::PhantomData, sync::Arc};
 
 /// Marker trait for Optimism node types with standard engine, chain spec, and primitives.
 pub trait OpNodeTypes:
-    NodeTypes<Payload = OpEngineTypes, ChainSpec = OpChainSpec, Primitives = OpPrimitives>
+    NodeTypes<Payload = OpEngineTypes, ChainSpec: OpHardforks + Hardforks, Primitives = OpPrimitives>
 {
 }
 /// Blanket impl for all node types that conform to the Optimism spec.
 impl<N> OpNodeTypes for N where
-    N: NodeTypes<Payload = OpEngineTypes, ChainSpec = OpChainSpec, Primitives = OpPrimitives>
+    N: NodeTypes<
+        Payload = OpEngineTypes,
+        ChainSpec: OpHardforks + Hardforks,
+        Primitives = OpPrimitives,
+    >
 {
 }
 /// Storage implementation for Optimism.
@@ -92,6 +96,16 @@ pub struct OpNode {
     pub da_config: OpDAConfig,
 }
 
+/// A [`ComponentsBuilder`] with its generic arguments set to a stack of Optimism specific builders.
+pub type OpNodeComponentBuilder<Node, Payload = OpPayloadBuilder> = ComponentsBuilder<
+    Node,
+    OpPoolBuilder,
+    BasicPayloadServiceBuilder<Payload>,
+    OpNetworkBuilder,
+    OpExecutorBuilder<<<Node as FullNodeTypes>::Types as NodeTypes>::ChainSpec>,
+    OpConsensusBuilder,
+>;
+
 impl OpNode {
     /// Creates a new instance of the Optimism node type.
     pub fn new(args: RollupArgs) -> Self {
@@ -105,16 +119,7 @@ impl OpNode {
     }
 
     /// Returns the components for the given [`RollupArgs`].
-    pub fn components<Node>(
-        &self,
-    ) -> ComponentsBuilder<
-        Node,
-        OpPoolBuilder,
-        BasicPayloadServiceBuilder<OpPayloadBuilder>,
-        OpNetworkBuilder,
-        OpExecutorBuilder,
-        OpConsensusBuilder,
-    >
+    pub fn components<Node>(&self) -> OpNodeComponentBuilder<Node>
     where
         Node: FullNodeTypes<Types: OpNodeTypes>,
     {
@@ -178,7 +183,7 @@ where
     N: FullNodeTypes<
         Types: NodeTypes<
             Payload = OpEngineTypes,
-            ChainSpec = OpChainSpec,
+            ChainSpec: OpHardforks + Hardforks,
             Primitives = OpPrimitives,
             Storage = OpStorage,
         >,
@@ -189,7 +194,7 @@ where
         OpPoolBuilder,
         BasicPayloadServiceBuilder<OpPayloadBuilder>,
         OpNetworkBuilder,
-        OpExecutorBuilder,
+        OpExecutorBuilder<<N::Types as NodeTypes>::ChainSpec>,
         OpConsensusBuilder,
     >;
 
@@ -340,7 +345,7 @@ impl<N, NetworkT> NodeAddOns<N> for OpAddOns<N, OpEthApiBuilder<NetworkT>>
 where
     N: FullNodeComponents<
         Types: NodeTypes<
-            ChainSpec = OpChainSpec,
+            ChainSpec: OpHardforks,
             Primitives = OpPrimitives,
             Storage = OpStorage,
             Payload = OpEngineTypes,
@@ -433,7 +438,7 @@ impl<N, NetworkT> RethRpcAddOns<N> for OpAddOns<N, OpEthApiBuilder<NetworkT>>
 where
     N: FullNodeComponents<
         Types: NodeTypes<
-            ChainSpec = OpChainSpec,
+            ChainSpec: OpHardforks,
             Primitives = OpPrimitives,
             Storage = OpStorage,
             Payload = OpEngineTypes,
@@ -457,7 +462,7 @@ impl<N, NetworkT> EngineValidatorAddOn<N> for OpAddOns<N, OpEthApiBuilder<Networ
 where
     N: FullNodeComponents<
         Types: NodeTypes<
-            ChainSpec = OpChainSpec,
+            ChainSpec: OpHardforks,
             Primitives = OpPrimitives,
             Payload = OpEngineTypes,
         >,
@@ -1011,7 +1016,7 @@ pub struct OpEngineValidatorBuilder;
 
 impl<Node, Types> EngineValidatorBuilder<Node> for OpEngineValidatorBuilder
 where
-    Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives, Payload = OpEngineTypes>,
+    Types: NodeTypes<ChainSpec: OpHardforks, Primitives = OpPrimitives, Payload = OpEngineTypes>,
     Node: FullNodeComponents<Types = Types>,
 {
     type Validator = OpEngineValidator<

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -19,8 +19,8 @@ use reth_optimism_chainspec::OpChainSpecBuilder;
 use reth_optimism_node::{
     args::RollupArgs,
     node::{
-        OpAddOns, OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder, OpNodeTypes,
-        OpPayloadBuilder, OpPoolBuilder,
+        OpAddOns, OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder, OpNodeComponentBuilder,
+        OpNodeTypes, OpPayloadBuilder, OpPoolBuilder,
     },
     txpool::OpPooledTransaction,
     utils::optimism_payload_attributes,
@@ -88,14 +88,7 @@ impl OpPayloadTransactions<OpPooledTransaction> for CustomTxPriority {
 /// Builds the node with custom transaction priority service within default payload builder.
 fn build_components<Node>(
     chain_id: ChainId,
-) -> ComponentsBuilder<
-    Node,
-    OpPoolBuilder,
-    BasicPayloadServiceBuilder<OpPayloadBuilder<CustomTxPriority>>,
-    OpNetworkBuilder,
-    OpExecutorBuilder,
-    OpConsensusBuilder,
->
+) -> OpNodeComponentBuilder<Node, OpPayloadBuilder<CustomTxPriority>>
 where
     Node: FullNodeTypes<Types: OpNodeTypes>,
 {

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -31,7 +31,6 @@ reth-chainspec.workspace = true
 reth-rpc-engine-api.workspace = true
 
 # op-reth
-reth-optimism-chainspec.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-payload-builder.workspace = true
 reth-optimism-txpool.workspace = true

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_eth::BlockId;
 use op_alloy_rpc_types::OpTransactionReceipt;
 use reth_chainspec::ChainSpecProvider;
 use reth_node_api::BlockBody;
-use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
@@ -24,7 +24,7 @@ where
         NetworkTypes: RpcTypes<Receipt = OpTransactionReceipt>,
         Provider: BlockReader<Receipt = OpReceipt, Transaction = OpTransactionSigned>,
     >,
-    N: OpNodeCore<Provider: ChainSpecProvider<ChainSpec = OpChainSpec> + HeaderProvider>,
+    N: OpNodeCore<Provider: ChainSpecProvider<ChainSpec: OpHardforks> + HeaderProvider>,
 {
     async fn block_receipts(
         &self,

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -7,7 +7,6 @@ use op_alloy_consensus::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptE
 use op_alloy_rpc_types::{L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
 use reth_chainspec::ChainSpecProvider;
 use reth_node_api::{FullNodeComponents, NodeTypes};
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::RethL1BlockInfo;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
@@ -20,7 +19,7 @@ use crate::{OpEthApi, OpEthApiError};
 impl<N> LoadReceipt for OpEthApi<N>
 where
     Self: Send + Sync,
-    N: FullNodeComponents<Types: NodeTypes<ChainSpec = OpChainSpec>>,
+    N: FullNodeComponents<Types: NodeTypes<ChainSpec: OpHardforks>>,
     Self::Provider: TransactionsProvider<Transaction = OpTransactionSigned>
         + ReceiptProvider<Receipt = OpReceipt>,
 {
@@ -115,7 +114,7 @@ impl OpReceiptFieldsBuilder {
     /// Applies [`L1BlockInfo`](op_revm::L1BlockInfo).
     pub fn l1_block_info(
         mut self,
-        chain_spec: &OpChainSpec,
+        chain_spec: &impl OpHardforks,
         tx: &OpTransactionSigned,
         l1_block_info: &mut op_revm::L1BlockInfo,
     ) -> Result<Self, OpEthApiError> {
@@ -223,7 +222,7 @@ pub struct OpReceiptBuilder {
 impl OpReceiptBuilder {
     /// Returns a new builder.
     pub fn new(
-        chain_spec: &OpChainSpec,
+        chain_spec: &impl OpHardforks,
         transaction: &OpTransactionSigned,
         meta: TransactionMeta,
         receipt: &OpReceipt,
@@ -341,7 +340,7 @@ mod test {
         assert!(OP_MAINNET.is_fjord_active_at_timestamp(BLOCK_124665056_TIMESTAMP));
 
         let receipt_meta = OpReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
-            .l1_block_info(&OP_MAINNET, &tx_1, &mut l1_block_info)
+            .l1_block_info(&*OP_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
 
@@ -412,7 +411,7 @@ mod test {
         l1_block_info.operator_fee_constant = Some(U256::from(2));
 
         let receipt_meta = OpReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
-            .l1_block_info(&OP_MAINNET, &tx_1, &mut l1_block_info)
+            .l1_block_info(&*OP_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
 
@@ -435,7 +434,7 @@ mod test {
         l1_block_info.operator_fee_constant = Some(U256::ZERO);
 
         let receipt_meta = OpReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
-            .l1_block_info(&OP_MAINNET, &tx_1, &mut l1_block_info)
+            .l1_block_info(&*OP_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
 
@@ -469,7 +468,7 @@ mod test {
         let tx_1 = OpTransactionSigned::decode_2718(&mut &tx[..]).unwrap();
 
         let receipt_meta = OpReceiptFieldsBuilder::new(1730216981, 21713817)
-            .l1_block_info(&BASE_MAINNET, &tx_1, &mut l1_block_info)
+            .l1_block_info(&*BASE_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
 

--- a/crates/optimism/rpc/src/witness.rs
+++ b/crates/optimism/rpc/src/witness.rs
@@ -7,8 +7,8 @@ use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::ChainSpecProvider;
 use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
+use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{OpPayloadBuilder, OpPayloadPrimitives};
 use reth_optimism_txpool::OpPooledTx;
 use reth_primitives_traits::SealedHeader;
@@ -69,7 +69,7 @@ where
     Provider: BlockReaderIdExt<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>
         + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>
         + StateProviderFactory
-        + ChainSpecProvider<ChainSpec = OpChainSpec>
+        + ChainSpecProvider<ChainSpec: OpHardforks>
         + Clone
         + 'static,
     EvmConfig: ConfigureEvm<Primitives = Provider::Primitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -11,12 +11,15 @@ use reth_ethereum::{
     node::api::ConfigureEvm,
     primitives::{SealedBlock, SealedHeader},
 };
-use reth_op::node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder};
+use reth_op::{
+    chainspec::OpChainSpec,
+    node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder},
+};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct CustomEvmConfig {
-    pub(super) inner: OpEvmConfig,
+    pub(super) inner: OpEvmConfig<OpChainSpec>,
     pub(super) block_assembler: CustomBlockAssembler,
     pub(super) custom_evm_factory: CustomEvmFactory,
 }
@@ -36,8 +39,8 @@ impl CustomEvmConfig {
 
 impl ConfigureEvm for CustomEvmConfig {
     type Primitives = CustomNodePrimitives;
-    type Error = <OpEvmConfig as ConfigureEvm>::Error;
-    type NextBlockEnvCtx = <OpEvmConfig as ConfigureEvm>::NextBlockEnvCtx;
+    type Error = <OpEvmConfig<OpChainSpec> as ConfigureEvm>::Error;
+    type NextBlockEnvCtx = <OpEvmConfig<OpChainSpec> as ConfigureEvm>::NextBlockEnvCtx;
     type BlockExecutorFactory = Self;
     type BlockAssembler = CustomBlockAssembler;
 

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -11,15 +11,12 @@ use reth_ethereum::{
     node::api::ConfigureEvm,
     primitives::{SealedBlock, SealedHeader},
 };
-use reth_op::{
-    chainspec::OpChainSpec,
-    node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder},
-};
+use reth_op::node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct CustomEvmConfig {
-    pub(super) inner: OpEvmConfig<OpChainSpec>,
+    pub(super) inner: OpEvmConfig,
     pub(super) block_assembler: CustomBlockAssembler,
     pub(super) custom_evm_factory: CustomEvmFactory,
 }
@@ -39,8 +36,8 @@ impl CustomEvmConfig {
 
 impl ConfigureEvm for CustomEvmConfig {
     type Primitives = CustomNodePrimitives;
-    type Error = <OpEvmConfig<OpChainSpec> as ConfigureEvm>::Error;
-    type NextBlockEnvCtx = <OpEvmConfig<OpChainSpec> as ConfigureEvm>::NextBlockEnvCtx;
+    type Error = <OpEvmConfig as ConfigureEvm>::Error;
+    type NextBlockEnvCtx = <OpEvmConfig as ConfigureEvm>::NextBlockEnvCtx;
     type BlockExecutorFactory = Self;
     type BlockAssembler = CustomBlockAssembler;
 


### PR DESCRIPTION
Part of #16374 

As part of trait bound audit towards simplification and making Op components reusable for custom types, this code change removes additional bounds on `ChainSpec` that are not needed in the whole `evm` optimism crate.
