### PR TITLE
docs(net): replace 404 link message.rs

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -4,7 +4,7 @@
 //!
 //! Examples include creating, encoding, and decoding protocol messages.
 //!
-//! Reference: [Ethereum Wire Protocol](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol).
+//! Reference: [Ethereum Wire Protocol](https://github.com/ethereum/devp2p/blob/master/caps/eth.md).
 
 use super::{
     broadcast::NewBlockHashes, BlockBodies, BlockHeaders, GetBlockBodies, GetBlockHeaders,


### PR DESCRIPTION
hey team! fix reference:

https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol - 404 link
https://github.com/ethereum/devp2p/blob/master/caps/eth.md - new link