### PR TITLE
refactor: replace generics with Node types for `OpExecutorBuilder`

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -11,8 +11,7 @@ use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor};
 use reth_network::{
-    types::BasicNetworkPrimitives,
-    NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives,
+    types::BasicNetworkPrimitives, NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives,
     PeersInfo,
 };
 use reth_node_api::{

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -562,11 +562,7 @@ pub struct OpExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for OpExecutorBuilder
 where
-    Node: FullNodeTypes<Types: NodeTypes>,
-    <Node::Types as NodeTypes>::ChainSpec: OpHardforks,
-    <Node::Types as NodeTypes>::Primitives: NodePrimitives,
-    OpEvmConfig<<Node::Types as NodeTypes>::ChainSpec, <Node::Types as NodeTypes>::Primitives>:
-        ConfigureEvm<Primitives = <Node::Types as NodeTypes>::Primitives> + 'static,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec: OpHardforks, Primitives = OpPrimitives>>,
 {
     type EVM =
         OpEvmConfig<<Node::Types as NodeTypes>::ChainSpec, <Node::Types as NodeTypes>::Primitives>;

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -556,35 +556,20 @@ impl<NetworkT> OpAddOnsBuilder<NetworkT> {
 }
 
 /// A regular optimism evm and executor builder.
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone, Default)]
 #[non_exhaustive]
-pub struct OpExecutorBuilder<ChainSpec = OpChainSpec, Primitives = OpPrimitives> {
-    /// Marker for chain spec type.
-    _cs: PhantomData<ChainSpec>,
-    /// Marker for primitives type.
-    _p: PhantomData<Primitives>,
-}
+pub struct OpExecutorBuilder;
 
-impl<ChainSpec, Primitives> Clone for OpExecutorBuilder<ChainSpec, Primitives> {
-    fn clone(&self) -> Self {
-        Self::default()
-    }
-}
-
-impl<ChainSpec, Primitives> Default for OpExecutorBuilder<ChainSpec, Primitives> {
-    fn default() -> Self {
-        Self { _cs: PhantomData, _p: PhantomData }
-    }
-}
-
-impl<Node, ChainSpec, Primitives> ExecutorBuilder<Node> for OpExecutorBuilder<ChainSpec, Primitives>
+impl<Node> ExecutorBuilder<Node> for OpExecutorBuilder
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = Primitives>>,
-    ChainSpec: EthChainSpec + OpHardforks,
-    Primitives: NodePrimitives,
-    OpEvmConfig<ChainSpec, Primitives>: ConfigureEvm<Primitives = Primitives> + 'static,
+    Node: FullNodeTypes<Types: NodeTypes>,
+    <Node::Types as NodeTypes>::ChainSpec: EthChainSpec + OpHardforks,
+    <Node::Types as NodeTypes>::Primitives: NodePrimitives,
+    OpEvmConfig<<Node::Types as NodeTypes>::ChainSpec, <Node::Types as NodeTypes>::Primitives>:
+        ConfigureEvm<Primitives = <Node::Types as NodeTypes>::Primitives> + 'static,
 {
-    type EVM = OpEvmConfig<ChainSpec, Primitives>;
+    type EVM =
+        OpEvmConfig<<Node::Types as NodeTypes>::ChainSpec, <Node::Types as NodeTypes>::Primitives>;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
         let evm_config = OpEvmConfig::new(ctx.chain_spec(), OpRethReceiptBuilder::default());

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -563,7 +563,7 @@ pub struct OpExecutorBuilder;
 impl<Node> ExecutorBuilder<Node> for OpExecutorBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes>,
-    <Node::Types as NodeTypes>::ChainSpec: EthChainSpec + OpHardforks,
+    <Node::Types as NodeTypes>::ChainSpec: OpHardforks,
     <Node::Types as NodeTypes>::Primitives: NodePrimitives,
     OpEvmConfig<<Node::Types as NodeTypes>::ChainSpec, <Node::Types as NodeTypes>::Primitives>:
         ConfigureEvm<Primitives = <Node::Types as NodeTypes>::Primitives> + 'static,


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/16599.

cc @klkvr 