### PR TITLE
ci: special treatment for release candidate tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,10 +30,10 @@ jobs:
         build:
           - name: "Build and push reth image"
             id: reth_image
-            command: "make PROFILE=maxperf docker-build-push"
+            command: "make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push"
           - name: "Build and push reth image, tag as latest"
             id: reth_image_latest
-            command: "make PROFILE=maxperf docker-build-push-latest"
+            command: "make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest"
           - name: "Build and push op-reth image"
             id: op_reth_image
             command: "make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,12 +16,8 @@ env:
   DOCKER_USERNAME: ${{ github.actor }}
 
 jobs:
-  build:
-    name: build and push
+  setup:
     runs-on: ubuntu-24.04
-    permissions:
-      packages: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -41,18 +37,38 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
 
-      # Build and tag the release candidate under the Git tag
-      - name: Build and push reth image
-        if: ${{ contains(github.ref, '-rc') }}
+  reth:
+    needs: setup
+    runs-on: ubuntu-24.04
+    if: ${{ contains(github.ref, '-rc') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and push reth
         run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push
-      - name: Build and push op-reth image
-        if: ${{ contains(github.ref, '-rc') }}
+
+  op-reth:
+    needs: setup
+    runs-on: ubuntu-24.04
+    if: ${{ contains(github.ref, '-rc') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and push op-reth
         run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push
 
-      # Build and tag the release under the Git tag and "latest" tag
-      - name: Build and push reth image
-        if: ${{ !contains(github.ref, '-rc') }}
+  reth-latest:
+    needs: setup
+    runs-on: ubuntu-24.04
+    if: ${{ !contains(github.ref, '-rc') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and push reth
         run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest
-      - name: Build and push op-reth image
-        if: ${{ !contains(github.ref, '-rc') }}
+
+  op-reth-latest:
+    needs: setup
+    runs-on: ubuntu-24.04
+    if: ${{ !contains(github.ref, '-rc') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and push op-reth
         run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,8 @@ env:
   DOCKER_USERNAME: ${{ github.actor }}
 
 jobs:
-  build:
+  build-rc:
+    if: contains(github.ref, '-rc')
     name: build and push
     runs-on: ubuntu-24.04
     permissions:
@@ -25,32 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        isRC:
-          - ${{ contains(github.ref, '-rc') }}
         build:
           - name: "Build and push reth image"
-            id: reth_image
             command: "make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push"
-          - name: "Build and push reth image, tag as latest"
-            id: reth_image_latest
-            command: "make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest"
           - name: "Build and push op-reth image"
-            id: op_reth_image
             command: "make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push"
-          - name: "Build and push op-reth image, tag as latest"
-            id: op_reth_image_latest
-            command: "make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest"
-        exclude:
-          # For non release candidate runs, exclude items that do not tag as "latest"
-          - isRC: false
-            build: { id: reth_image }
-          - isRC: false
-            build: { id: op_reth_image }
-          # For release candidate runs, exclude items that tag as "latest"
-          - isRC: true
-            build: { id: reth_image_latest }
-          - isRC: true
-            build: { id: op_reth_image_latest }
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -69,5 +49,41 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
-      - name: ${{ matrix.build.name }}
+      - name: Build and push ${{ matrix.build.name }}
+        run: ${{ matrix.build.command }}
+
+  build:
+    if: ${{ !contains(github.ref, '-rc') }}
+    name: build and push
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          - name: "Build and push reth image"
+            command: "make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest"
+          - name: "Build and push op-reth image"
+            command: "make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Install cross main
+        id: cross_main
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+      - name: Log in to Docker
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
+      - name: Set up Docker builder
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
+          docker buildx create --use --name cross-builder
+      - name: Build and push ${{ matrix.build.name }}
         run: ${{ matrix.build.command }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,14 +43,14 @@ jobs:
         exclude:
           # For non release candidate runs, exclude items that do not tag as "latest"
           - isRC: false
-            id: reth_image
+            build: { id: reth_image }
           - isRC: false
-            id: op_reth_image
+            build: { id: op_reth_image }
           # For release candidate runs, exclude items that tag as "latest"
           - isRC: true
-            id: reth_image_latest
+            build: { id: reth_image_latest }
           - isRC: true
-            id: op_reth_image_latest
+            build: { id: op_reth_image_latest }
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,6 @@ on:
       - v*
 
 env:
-  REPO_NAME: ${{ github.repository_owner }}/reth
   IMAGE_NAME: ${{ github.repository_owner }}/reth
   OP_IMAGE_NAME: ${{ github.repository_owner }}/op-reth
   CARGO_TERM_COLOR: always
@@ -23,18 +22,6 @@ jobs:
     permissions:
       packages: write
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        build:
-          - name: 'Build and push reth image'
-            command: 'make PROFILE=maxperf docker-build-push'
-          - name: 'Build and push reth image, tag as "latest"'
-            command: 'make PROFILE=maxperf docker-build-push-latest'
-          - name: 'Build and push op-reth image'
-            command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push'
-          - name: 'Build and push op-reth image, tag as "latest"'
-            command: 'make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest'
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -53,5 +40,19 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
-      - name: Build and push ${{ matrix.build.name }}
-        run: ${{ matrix.build.command }}
+
+      # Build and tag the release candidate under the Git tag
+      - name: Build and push reth image
+        if: ${{ contains(github.ref, '-rc') }}
+        run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push
+      - name: Build and push op-reth image
+        if: ${{ contains(github.ref, '-rc') }}
+        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push
+
+      # Build and tag the release under the Git tag and "latest" tag
+      - name: Build and push reth image
+        if: ${{ !contains(github.ref, '-rc') }}
+        run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest
+      - name: Build and push op-reth image
+        if: ${{ !contains(github.ref, '-rc') }}
+        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,12 @@ env:
   DOCKER_USERNAME: ${{ github.actor }}
 
 jobs:
-  setup:
+  build:
+    name: build and push
     runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -37,38 +41,18 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
 
-  reth:
-    needs: setup
-    runs-on: ubuntu-24.04
-    if: ${{ contains(github.ref, '-rc') }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build and push reth
+      # Build and tag the release candidate under the Git tag
+      - name: Build and push reth image
+        if: ${{ contains(github.ref, '-rc') }}
         run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push
-
-  op-reth:
-    needs: setup
-    runs-on: ubuntu-24.04
-    if: ${{ contains(github.ref, '-rc') }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build and push op-reth
+      - name: Build and push op-reth image
+        if: ${{ contains(github.ref, '-rc') }}
         run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push
 
-  reth-latest:
-    needs: setup
-    runs-on: ubuntu-24.04
-    if: ${{ !contains(github.ref, '-rc') }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build and push reth
+      # Build and tag the release under the Git tag and "latest" tag
+      - name: Build and push reth image
+        if: ${{ !contains(github.ref, '-rc') }}
         run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest
-
-  op-reth-latest:
-    needs: setup
-    runs-on: ubuntu-24.04
-    if: ${{ !contains(github.ref, '-rc') }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build and push op-reth
+      - name: Build and push op-reth image
+        if: ${{ !contains(github.ref, '-rc') }}
         run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,35 @@ jobs:
     permissions:
       packages: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        isRC:
+          - ${{ contains(github.ref, '-rc') }}
+        build:
+          - name: "Build and push reth image"
+            id: reth_image
+            command: "make PROFILE=maxperf docker-build-push"
+          - name: "Build and push reth image, tag as latest"
+            id: reth_image_latest
+            command: "make PROFILE=maxperf docker-build-push-latest"
+          - name: "Build and push op-reth image"
+            id: op_reth_image
+            command: "make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push"
+          - name: "Build and push op-reth image, tag as latest"
+            id: op_reth_image_latest
+            command: "make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest"
+        exclude:
+          # For non release candidate runs, exclude items that do not tag as "latest"
+          - isRC: false
+            id: reth_image
+          - isRC: false
+            id: op_reth_image
+          # For release candidate runs, exclude items that tag as "latest"
+          - isRC: true
+            id: reth_image_latest
+          - isRC: true
+            id: op_reth_image_latest
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -40,19 +69,5 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
-
-      # Build and tag the release candidate under the Git tag
-      - name: Build and push reth image
-        if: ${{ contains(github.ref, '-rc') }}
-        run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push
-      - name: Build and push op-reth image
-        if: ${{ contains(github.ref, '-rc') }}
-        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push
-
-      # Build and tag the release under the Git tag and "latest" tag
-      - name: Build and push reth image
-        if: ${{ !contains(github.ref, '-rc') }}
-        run: make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest
-      - name: Build and push op-reth image
-        if: ${{ !contains(github.ref, '-rc') }}
-        run: make IMAGE_NAME=$OP_IMAGE_NAME DOCKER_IMAGE_NAME=$OP_DOCKER_IMAGE_NAME PROFILE=maxperf op-docker-build-push-latest
+      - name: ${{ matrix.build.name }}
+        run: ${{ matrix.build.command }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,11 @@ jobs:
         # The formatting here is borrowed from Lighthouse (which is borrowed from OpenEthereum):
         # https://github.com/openethereum/openethereum/blob/6c2d392d867b058ff867c4373e40850ca3f96969/.github/workflows/build.yml
         run: |
+          prerelease_flag=""
+          if [[ "${GITHUB_REF}" == *-rc ]]; then
+            prerelease_flag="--prerelease"
+          fi
+
           body=$(cat <<- "ENDBODY"
           ![image](https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-prod.png)
 
@@ -230,7 +235,7 @@ jobs:
               assets+=("$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
-          echo "$body" | gh release create --draft -t "Reth $tag_name" -F "-" "$tag_name" "${assets[@]}"
+          echo "$body" | gh release create --draft $prerelease_flag -t "Reth $tag_name" -F "-" "$tag_name" "${assets[@]}"
 
   dry-run-summary:
     name: dry run summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         # https://github.com/openethereum/openethereum/blob/6c2d392d867b058ff867c4373e40850ca3f96969/.github/workflows/build.yml
         run: |
           prerelease_flag=""
-          if [[ "${GITHUB_REF}" == *-rc ]]; then
+          if [[ "${GITHUB_REF}" == *-rc* ]]; then
             prerelease_flag="--prerelease"
           fi
 


### PR DESCRIPTION
If the tag contains `-rc`, then:
1. Docker images will be built and tagged under the git tag, but not tagged as `latest`.
2. GitHub release artifacts will be built and uploaded, but the draft will be created as a pre-release.

For tags not containing `-rc`, nothing changes.