### PR TITLE
Feature: add `--override.<hardfork>` cli args

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -6,7 +6,7 @@ use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_genesis::Genesis;
 use alloy_primitives::{B256, U256};
 use core::fmt::{Debug, Display};
-use reth_ethereum_forks::EthereumHardforks;
+use reth_ethereum_forks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use reth_network_peers::NodeRecord;
 
 /// Trait representing type configuring a chain spec.
@@ -130,5 +130,17 @@ impl EthChainSpec for ChainSpec {
 
     fn final_paris_total_difficulty(&self) -> Option<U256> {
         self.paris_block_and_final_difficulty.map(|(_, final_difficulty)| final_difficulty)
+    }
+}
+
+/// Trait representing type that can have its hardforks overridden.
+pub trait EthChainSpecHardforksOverrides {
+    /// Override the hardforks of the chain.
+    fn with_hardforks_overrides(&self, overrides: Vec<(EthereumHardfork, ForkCondition)>) -> Self;
+}
+
+impl EthChainSpecHardforksOverrides for ChainSpec {
+    fn with_hardforks_overrides(&self, overrides: Vec<(EthereumHardfork, ForkCondition)>) -> Self {
+        self.with_hardforks_overrides(overrides)
     }
 }

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,7 +25,7 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 /// Re-export for convenience
 pub use reth_ethereum_forks::*;
 
-pub use api::EthChainSpec;
+pub use api::{EthChainSpec, EthChainSpecHardforksOverrides};
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -435,6 +435,18 @@ impl ChainSpec {
         }
     }
 
+    /// Override the hardforks for the chain.
+    pub fn with_hardforks_overrides(
+        &self,
+        overrides: Vec<(EthereumHardfork, ForkCondition)>,
+    ) -> Self {
+        let mut spec = self.clone();
+        for (fork, condition) in overrides {
+            spec.hardforks.insert(fork, condition);
+        }
+        spec
+    }
+
     /// Returns the hardfork display helper.
     pub fn display_hardforks(&self) -> DisplayHardforks {
         DisplayHardforks::new(self.hardforks.forks_iter())

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -2,7 +2,7 @@
 
 use crate::launcher::Launcher;
 use clap::{value_parser, Args, Parser};
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_chainspec::{EthChainSpec, EthChainSpecHardforksOverrides, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::parse_socket_address;
@@ -10,8 +10,8 @@ use reth_db::init_db;
 use reth_node_builder::NodeBuilder;
 use reth_node_core::{
     args::{
-        DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, EraArgs, NetworkArgs,
-        PayloadBuilderArgs, PruningArgs, RpcServerArgs, TxPoolArgs,
+        DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, EraArgs, HardforkOverrideArgs,
+        NetworkArgs, PayloadBuilderArgs, PruningArgs, RpcServerArgs, TxPoolArgs,
     },
     node_config::NodeConfig,
     version,
@@ -116,6 +116,10 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     /// Additional cli arguments
     #[command(flatten, next_help_heading = "Extension")]
     pub ext: Ext,
+
+    /// All hardfork related arguments
+    #[command(flatten)]
+    pub hardfork: HardforkOverrideArgs,
 }
 
 impl<C: ChainSpecParser> NodeCommand<C> {
@@ -137,7 +141,7 @@ impl<C: ChainSpecParser> NodeCommand<C> {
 impl<C, Ext> NodeCommand<C, Ext>
 where
     C: ChainSpecParser,
-    C::ChainSpec: EthChainSpec + EthereumHardforks,
+    C::ChainSpec: EthChainSpec + EthereumHardforks + EthChainSpecHardforksOverrides,
     Ext: clap::Args + fmt::Debug,
 {
     /// Launches the node
@@ -168,9 +172,16 @@ where
             ext,
             engine,
             era,
+            hardfork,
         } = self;
 
-        // set up node config
+        let hardfork_overrides = hardfork.overrides();
+        let chain = if !hardfork_overrides.is_empty() {
+            Arc::new(chain.with_hardforks_overrides(hardfork_overrides))
+        } else {
+            chain
+        };
+
         let mut node_config = NodeConfig {
             datadir,
             config,

--- a/crates/node/core/src/args/hardfork.rs
+++ b/crates/node/core/src/args/hardfork.rs
@@ -1,0 +1,211 @@
+//! clap [Args](clap::Args) for hardfork activation block overrides
+
+use reth_chainspec::{EthereumHardfork, ForkCondition};
+/// Parameters for hardfork activation block overrides
+#[derive(Default, Debug, Clone, clap::Args, PartialEq)]
+#[command(next_help_heading = "Hardfork activation block overrides")]
+pub struct HardforkOverrideArgs {
+    /// Override the block number after which the Frontier hardfork is activated
+    #[arg(long = "override.frontier")]
+    pub frontier: Option<u64>,
+
+    /// Override the block number after which the Homestead hardfork is activated
+    #[arg(long = "override.homestead")]
+    pub homestead: Option<u64>,
+
+    /// Override the block number after which the Dao hardfork is activated
+    #[arg(long = "override.dao")]
+    pub dao: Option<u64>,
+
+    /// Override the block number after which the Tangerine hardfork is activated
+    #[arg(long = "override.tangerine")]
+    pub tangerine: Option<u64>,
+
+    /// Override the block number after which the SpuriousDragon hardfork is activated
+    #[arg(long = "override.spuriousdragon")]
+    pub spuriousdragon: Option<u64>,
+
+    /// Override the block number after which the Byzantium hardfork is activated
+    #[arg(long = "override.byzantium")]
+    pub byzantium: Option<u64>,
+
+    /// Override the block number after which the Constantinople hardfork is activated
+    #[arg(long = "override.constantinople")]
+    pub constantinople: Option<u64>,
+
+    /// Override the block number after which the Petersburg hardfork is activated
+    #[arg(long = "override.petersburg")]
+    pub petersburg: Option<u64>,
+
+    /// Override the block number after which the Istanbul hardfork is activated
+    #[arg(long = "override.istanbul")]
+    pub istanbul: Option<u64>,
+
+    /// Override the block number after which the MuirGlacier hardfork is activated
+    #[arg(long = "override.muirglacier")]
+    pub muirglacier: Option<u64>,
+
+    /// Override the block number after which the Berlin hardfork is activated
+    #[arg(long = "override.berlin")]
+    pub berlin: Option<u64>,
+
+    /// Override the block number after which the London hardfork is activated
+    #[arg(long = "override.london")]
+    pub london: Option<u64>,
+
+    /// Override the block number after which the ArrowGlacier hardfork is activated
+    #[arg(long = "override.arrowglacier")]
+    pub arrowglacier: Option<u64>,
+
+    /// Override the block number after which the Prague hardfork is activated
+    #[arg(long = "override.prague")]
+    pub prague: Option<u64>,
+
+    /// Override the block number after which the Paris hardfork is activated
+    #[arg(long = "override.paris")]
+    pub paris: Option<u64>,
+
+    /// Override the block number after which the Shanghai hardfork is activated
+    #[arg(long = "override.shanghai")]
+    pub shanghai: Option<u64>,
+
+    /// Override the block number after which the Cancun hardfork is activated
+    #[arg(long = "override.cancun")]
+    pub cancun: Option<u64>,
+}
+
+impl HardforkOverrideArgs {
+    /// Get the hardfork overrides
+    pub fn overrides(&self) -> Vec<(EthereumHardfork, ForkCondition)> {
+        let mut hardforks = Vec::new();
+        if let Some(frontier) = self.frontier {
+            hardforks.push((EthereumHardfork::Frontier, ForkCondition::Block(frontier)));
+        }
+        if let Some(homestead) = self.homestead {
+            hardforks.push((EthereumHardfork::Homestead, ForkCondition::Block(homestead)));
+        }
+        if let Some(dao) = self.dao {
+            hardforks.push((EthereumHardfork::Dao, ForkCondition::Block(dao)));
+        }
+        if let Some(tangerine) = self.tangerine {
+            hardforks.push((EthereumHardfork::Tangerine, ForkCondition::Block(tangerine)));
+        }
+        if let Some(spuriousdragon) = self.spuriousdragon {
+            hardforks
+                .push((EthereumHardfork::SpuriousDragon, ForkCondition::Block(spuriousdragon)));
+        }
+        if let Some(byzantium) = self.byzantium {
+            hardforks.push((EthereumHardfork::Byzantium, ForkCondition::Block(byzantium)));
+        }
+        if let Some(constantinople) = self.constantinople {
+            hardforks
+                .push((EthereumHardfork::Constantinople, ForkCondition::Block(constantinople)));
+        }
+        if let Some(petersburg) = self.petersburg {
+            hardforks.push((EthereumHardfork::Petersburg, ForkCondition::Block(petersburg)));
+        }
+        if let Some(istanbul) = self.istanbul {
+            hardforks.push((EthereumHardfork::Istanbul, ForkCondition::Block(istanbul)));
+        }
+        if let Some(muirglacier) = self.muirglacier {
+            hardforks.push((EthereumHardfork::MuirGlacier, ForkCondition::Block(muirglacier)));
+        }
+        if let Some(berlin) = self.berlin {
+            hardforks.push((EthereumHardfork::Berlin, ForkCondition::Block(berlin)));
+        }
+        if let Some(london) = self.london {
+            hardforks.push((EthereumHardfork::London, ForkCondition::Block(london)));
+        }
+        if let Some(arrowglacier) = self.arrowglacier {
+            hardforks.push((EthereumHardfork::ArrowGlacier, ForkCondition::Block(arrowglacier)));
+        }
+        if let Some(prague) = self.prague {
+            hardforks.push((EthereumHardfork::Prague, ForkCondition::Block(prague)));
+        }
+        if let Some(paris) = self.paris {
+            hardforks.push((EthereumHardfork::Paris, ForkCondition::Block(paris)));
+        }
+        if let Some(shanghai) = self.shanghai {
+            hardforks.push((EthereumHardfork::Shanghai, ForkCondition::Block(shanghai)));
+        }
+        if let Some(cancun) = self.cancun {
+            hardforks.push((EthereumHardfork::Cancun, ForkCondition::Block(cancun)));
+        }
+        hardforks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, Parser};
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_parse_hardfork_overrides() {
+        let expected_args = HardforkOverrideArgs {
+            frontier: Some(1),
+            homestead: Some(2),
+            dao: Some(3),
+            tangerine: Some(4),
+            spuriousdragon: Some(5),
+            byzantium: Some(6),
+            constantinople: Some(7),
+            petersburg: Some(8),
+            istanbul: Some(9),
+            muirglacier: Some(10),
+            berlin: Some(11),
+            london: Some(12),
+            arrowglacier: Some(13),
+            prague: Some(14),
+            paris: Some(15),
+            shanghai: Some(16),
+            cancun: Some(17),
+        };
+        let args = CommandParser::<HardforkOverrideArgs>::parse_from([
+            "reth",
+            "--override.prague",
+            "1",
+            "--override.homestead",
+            "2",
+            "--override.dao",
+            "3",
+            "--override.tangerine",
+            "4",
+            "--override.spuriousdragon",
+            "5",
+            "--override.byzantium",
+            "6",
+            "--override.constantinople",
+            "7",
+            "--override.petersburg",
+            "8",
+            "--override.istanbul",
+            "9",
+            "--override.muirglacier",
+            "10",
+            "--override.berlin",
+            "11",
+            "--override.london",
+            "12",
+            "--override.arrowglacier",
+            "13",
+            "--override.prague",
+            "14",
+            "--override.paris",
+            "15",
+            "--override.shanghai",
+            "16",
+            "--override.cancun",
+            "17",
+        ])
+        .args;
+        assert_eq!(args, expected_args);
+    }
+}

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -68,5 +68,9 @@ pub use ress_args::RessArgs;
 mod era;
 pub use era::{DefaultEraHost, EraArgs, EraSourceArgs};
 
+/// HardforkArgs for configuring hardfork activation block overrides
+mod hardfork;
+pub use hardfork::HardforkOverrideArgs;
+
 mod error;
 pub mod types;


### PR DESCRIPTION
The aim is to resolve #16523.

- Introduced `EthChainSpecHardforksOverrides` trait for overriding hardforks.
- Implemented `with_hardforks_overrides` method in `ChainSpec` to apply hardfork overrides.
- Added `HardforkOverrideArgs` struct for CLI argument parsing related to hardfork activation blocks.
- Updated relevant modules to integrate new hardfork override functionality.

### Implementation status
- [x] Eth hardforks overrides 
- [ ] OP hardforks overrides
