### PR TITLE
chore(storage): fix docs overindent

### DIFF
--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -406,7 +406,7 @@ tables! {
     /// * For N=50 we would get first shard.
     /// * for N=150 we would get second shard.
     /// * If max block number is 200 and we ask for N=250 we would fetch last shard and
-    ///     know that needed entry is in `AccountPlainState`.
+    ///   know that needed entry is in `AccountPlainState`.
     /// * If there were no shard we would get `None` entry or entry of different storage key.
     ///
     /// Code example can be found in `reth_provider::HistoricalStateProviderRef`
@@ -429,7 +429,7 @@ tables! {
     /// * For N=50 we would get first shard.
     /// * for N=150 we would get second shard.
     /// * If max block number is 200 and we ask for N=250 we would fetch last shard and
-    ///     know that needed entry is in `StoragePlainState`.
+    ///   know that needed entry is in `StoragePlainState`.
     /// * If there were no shard we would get `None` entry or entry of different storage key.
     ///
     /// Code example can be found in `reth_provider::HistoricalStateProviderRef`


### PR DESCRIPTION
```
error: doc list item overindented
   --> crates/storage/db-api/src/tables/mod.rs:409:8
    |
409 |     ///     know that needed entry is in `AccountPlainState`.
    |        ^^^^^ help: try using `   ` (3 spaces)
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
    = note: `-D clippy::doc-overindented-list-items` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::doc_overindented_list_items)]`
    = note: this error originates in the macro `tables` (in Nightly builds, run with -Z macro-backtrace for more info)

error: doc list item overindented
   --> crates/storage/db-api/src/tables/mod.rs:432:8
    |
432 |     ///     know that needed entry is in `StoragePlainState`.
    |        ^^^^^ help: try using `   ` (3 spaces)
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
    = note: this error originates in the macro `tables` (in Nightly builds, run with -Z macro-backtrace for more info)
```