### PR TITLE
perf(engine): do not use state root task for non-empty revert state

### DIFF
--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -15,6 +15,13 @@ pub struct TriePrefixSetsMut {
 }
 
 impl TriePrefixSetsMut {
+    /// Returns `true` if all prefix sets are empty.
+    pub fn is_empty(&self) -> bool {
+        self.account_prefix_set.is_empty() &&
+            self.storage_prefix_sets.is_empty() &&
+            self.destroyed_accounts.is_empty()
+    }
+
     /// Extends prefix sets with contents of another prefix set.
     pub fn extend(&mut self, other: Self) {
         self.account_prefix_set.extend(other.account_prefix_set);


### PR DESCRIPTION
## Problem

Sometimes we need to generate a revert state for `TrieInput` that will be used in the state root calculation, because database tip is higher than the parent block that we're calculating the state root on top of. This can happen during reorgs, and especially with `--engine.persistence-threshold 0 --engine.memory-block-buffer-target 0` settings, because we persist to the database after every block.

Generating a revert state also means invalidating a lot of paths in the trie by updating the prefix set, and it increases the time it takes to walk the trie tables.
- When using the state root task, we need to generate N proofs, and every time we walk invalidates paths.
- When using the parallel state root, we just need to walk over the invalidated paths once and insert everything in the hash builder.

<img width="1652" alt="image" src="https://github.com/user-attachments/assets/eff5cd96-fc02-471f-ae4b-ea5b3e161bd1" />

## Solution

This PR makes the state root calculation to switch to `ParallelStateRoot` if we detect non-empty prefix sets, meaning that we generated a revert state from the database, and have invalidated paths.