### PR TITLE
feat(`OpEngineValidator`): `pub` `chain_spec`

### DIFF
--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -107,7 +107,7 @@ where
 {
     /// Returns the chain spec used by the validator.
     #[inline]
-    fn chain_spec(&self) -> &ChainSpec {
+    pub fn chain_spec(&self) -> &ChainSpec {
         self.inner.chain_spec()
     }
 }


### PR DESCRIPTION
Make life easier for `CustomEngineValidator`s that use an inner `OpEngineValidator` :pray:. 