### PR TITLE
feat: trigger resolution task when multiple connection failures occur for a trusted peer

### DIFF
--- a/crates/net/network-types/src/lib.rs
+++ b/crates/net/network-types/src/lib.rs
@@ -25,7 +25,10 @@ pub use backoff::BackoffKind;
 pub use peers::{
     addr::PeerAddr,
     kind::PeerKind,
-    reputation::{is_banned_reputation, ReputationChangeOutcome, DEFAULT_REPUTATION},
+    reputation::{
+        is_banned_reputation, is_connection_failed_reputation, ReputationChangeOutcome,
+        DEFAULT_REPUTATION,
+    },
     state::PeerConnectionState,
     ConnectionsConfig, Peer, PeersConfig,
 };

--- a/crates/net/network-types/src/peers/reputation.rs
+++ b/crates/net/network-types/src/peers/reputation.rs
@@ -48,6 +48,13 @@ pub const fn is_banned_reputation(reputation: i32) -> bool {
     reputation < BANNED_REPUTATION
 }
 
+/// Returns `true` if the given reputation is below the [`FAILED_TO_CONNECT_REPUTATION_CHANGE`]
+/// threshold
+#[inline]
+pub const fn is_connection_failed_reputation(reputation: i32) -> bool {
+    reputation < FAILED_TO_CONNECT_REPUTATION_CHANGE
+}
+
 /// The type that tracks the reputation score.
 pub type Reputation = i32;
 

--- a/crates/net/network-types/src/peers/reputation.rs
+++ b/crates/net/network-types/src/peers/reputation.rs
@@ -13,7 +13,7 @@ pub const BANNED_REPUTATION: i32 = 50 * REPUTATION_UNIT;
 const REMOTE_DISCONNECT_REPUTATION_CHANGE: i32 = 4 * REPUTATION_UNIT;
 
 /// The reputation change to apply to a peer that we failed to connect to.
-const FAILED_TO_CONNECT_REPUTATION_CHANGE: i32 = 25 * REPUTATION_UNIT;
+pub const FAILED_TO_CONNECT_REPUTATION_CHANGE: i32 = 25 * REPUTATION_UNIT;
 
 /// The reputation change to apply to a peer that failed to respond in time.
 const TIMEOUT_REPUTATION_CHANGE: i32 = 4 * REPUTATION_UNIT;

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -586,7 +586,8 @@ impl PeersManager {
             }
 
             if peer.is_trusted() && is_connection_failed_reputation(peer.reputation) {
-                // trigger resolution task for trusted peer since multiple connection failures occurred
+                // trigger resolution task for trusted peer since multiple connection failures
+                // occurred
                 self.trusted_peers_resolver.interval.reset_immediately();
             }
         }

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -14,6 +14,7 @@ use reth_net_banlist::BanList;
 use reth_network_api::test_utils::{PeerCommand, PeersHandle};
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_network_types::{
+    is_connection_failed_reputation,
     peers::{
         config::PeerBackoffDurations,
         reputation::{DEFAULT_REPUTATION, MAX_TRUSTED_PEER_REPUTATION_CHANGE},
@@ -582,6 +583,11 @@ impl PeersManager {
             if peer.state.is_incoming() {
                 // we already have an active connection to the peer, so we can ignore this error
                 return
+            }
+
+            if peer.is_trusted() && is_connection_failed_reputation(peer.reputation) {
+                // trigger resolution task for trusted peer since multiple connection failures occurred
+                self.trusted_peers_resolver.interval.reset_immediately();
             }
         }
 


### PR DESCRIPTION
Based on #16647 

Here I am considering a way for Trusted Peers' DNS resolution, even time becomes configurable with #16647, trusted peers should trigger resolution immediately when multiple disconnections occur since this is probably showing an old record

this is just an idea to consider; simple interval configuration with low interval would be cleaner and enough approach as well