### PR TITLE
ci: use different names for latest and RC Docker jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-rc:
     if: contains(github.ref, '-rc')
-    name: build and push
+    name: build and push as release candidate
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -54,7 +54,7 @@ jobs:
 
   build:
     if: ${{ !contains(github.ref, '-rc') }}
-    name: build and push
+    name: build and push as latest
     runs-on: ubuntu-24.04
     permissions:
       packages: write


### PR DESCRIPTION
Easier to distinguish in the UI, see https://github.com/paradigmxyz/reth/actions/runs/15441033847 for example.