### PR TITLE
chore: relax primtives types bound

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -361,7 +361,7 @@ where
     N: FullNodeComponents<
         Types: NodeTypes<
             ChainSpec: OpHardforks,
-            Primitives = OpPrimitives,
+            Primitives: OpPayloadPrimitives,
             Storage = OpStorage,
             Payload: EngineTypes<ExecutionData = OpExecutionData>,
         >,


### PR DESCRIPTION
we dont't need to define the concrete type here