### PR TITLE
chore(ci): unpin teku image for kurtosis-op ethereum-package

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -4,7 +4,6 @@ ethereum_package:
       el_extra_params:
         - "--rpc.eth-proof-window=100"
       cl_type: teku
-      cl_image: "consensys/teku:25.4.0"
   network_params:
     preset: minimal
     genesis_delay: 5


### PR DESCRIPTION
we no longer need to pin teku image for l1 in kurtosis-op, successful execution from this branch here https://github.com/paradigmxyz/reth/actions/runs/15461802870