### PR TITLE
perf: process chunks in par for get logs in block range `eth_getLogs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9818,6 +9818,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "itertools 0.14.0",
  "jsonrpsee",
  "jsonrpsee-types",
  "jsonwebtoken",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -90,6 +90,7 @@ serde.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 derive_more.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 reth-evm-ethereum.workspace = true


### PR DESCRIPTION
## Description
the current `eth_getLogs` behavior supports two types of block filtering:

`AtBlockHash`: Gets logs for a specific block by hash
`Range`: Gets logs for a range of blocks
For range queries, it processes blocks in chunks of max_headers_range (1000 blocks) and uses bloom filters to quickly skip blocks that can't contain matching logs, then fetches receipts and logs only for blocks that might contain matches.

The current implementation of `get_logs_in_block_range_inner()` processes block ranges sequentially, which can lead to performance bottlenecks when querying logs across large block ranges. This is particularly noticeable in scenarios like:

- Indexers scanning large historical ranges
- Apps that need to fetch logs across many blocks
- Initial data loading for dApps that rely on event logs

## Solution
This PR introduces parallel processing of block ranges while maintaining the correct ordering of results and limit concurrency to a reasonable value (4) to avoid overwhelming system resources.
- Falls back to sequential processing for small ranges (1 chunk or less)
- Preserves all existing optimizations (bloom filter checks, smart block hash retrieval) via `process_block_range()` fn to encapsulate the logic for processing a single block range.
- Maintains all limit checks and error handling behavior.

Please help me review it. Thanks :pray: 