### PR TITLE
feat: add always-process-payload-attributes-on-canonical-head config

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -771,6 +771,11 @@ Engine:
       --engine.state-root-fallback
           Enable state root fallback, useful for testing
 
+      --engine.always-process-payload-attributes-on-canonical-head
+          Always process payload attributes and begin a payload build process even if `forkchoiceState.headBlockHash` is already the canonical head or an ancestor. See `TreeConfig::always_process_payload_attributes_on_canonical_head` for more details.
+
+          Note: This is a no-op on OP Stack.
+
 Ress:
       --ress.enable
           Enable support for `ress` subprotocol

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -79,6 +79,20 @@ pub struct TreeConfig {
     precompile_cache_enabled: bool,
     /// Whether to use state root fallback for testing
     state_root_fallback: bool,
+    /// Whether to always process payload attributes and begin a payload build process
+    /// even if `forkchoiceState.headBlockHash` is already the canonical head or an ancestor.
+    ///
+    /// The Engine API specification generally states that client software "MUST NOT begin a
+    /// payload build process if `forkchoiceState.headBlockHash` references a `VALID`
+    /// ancestor of the head of canonical chain".
+    /// See: <https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_forkchoiceupdatedv1> (Rule 2)
+    ///
+    /// This flag allows overriding that behavior.
+    /// This is useful for specific chain configurations (e.g., OP Stack where proposers
+    /// can reorg their own chain), various custom chains, or for development/testing purposes
+    /// where immediate payload regeneration is desired despite the head not changing or moving to
+    /// an ancestor.
+    always_process_payload_attributes_on_canonical_head: bool,
 }
 
 impl Default for TreeConfig {
@@ -99,6 +113,7 @@ impl Default for TreeConfig {
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_enabled: false,
             state_root_fallback: false,
+            always_process_payload_attributes_on_canonical_head: false,
         }
     }
 }
@@ -122,6 +137,7 @@ impl TreeConfig {
         reserved_cpu_cores: usize,
         precompile_cache_enabled: bool,
         state_root_fallback: bool,
+        always_process_payload_attributes_on_canonical_head: bool,
     ) -> Self {
         Self {
             persistence_threshold,
@@ -139,6 +155,7 @@ impl TreeConfig {
             reserved_cpu_cores,
             precompile_cache_enabled,
             state_root_fallback,
+            always_process_payload_attributes_on_canonical_head,
         }
     }
 
@@ -212,6 +229,22 @@ impl TreeConfig {
     /// Returns whether to use state root fallback.
     pub const fn state_root_fallback(&self) -> bool {
         self.state_root_fallback
+    }
+
+    /// Sets whether to always process payload attributes when the FCU head is already canonical.
+    pub const fn with_always_process_payload_attributes_on_canonical_head(
+        mut self,
+        always_process_payload_attributes_on_canonical_head: bool,
+    ) -> Self {
+        self.always_process_payload_attributes_on_canonical_head =
+            always_process_payload_attributes_on_canonical_head;
+        self
+    }
+
+    /// Returns true if payload attributes should always be processed even when the FCU head is
+    /// canonical.
+    pub const fn always_process_payload_attributes_on_canonical_head(&self) -> bool {
+        self.always_process_payload_attributes_on_canonical_head
     }
 
     /// Setter for persistence threshold.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -884,7 +884,10 @@ where
 
             // For OpStack the proposers are allowed to reorg their own chain at will, so we need to
             // always trigger a new payload job if requested.
-            if self.engine_kind.is_opstack() {
+            // Also allow forcing this behavior via a config flag.
+            if self.engine_kind.is_opstack() ||
+                self.config.always_process_payload_attributes_on_canonical_head()
+            {
                 if let Some(attr) = attrs {
                     debug!(target: "engine::tree", head = canonical_header.number(), "handling payload attributes for canonical head");
                     let updated =

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -67,6 +67,17 @@ pub struct EngineArgs {
     /// Enable state root fallback, useful for testing
     #[arg(long = "engine.state-root-fallback", default_value = "false")]
     pub state_root_fallback: bool,
+
+    /// Always process payload attributes and begin a payload build process even if
+    /// `forkchoiceState.headBlockHash` is already the canonical head or an ancestor. See
+    /// `TreeConfig::always_process_payload_attributes_on_canonical_head` for more details.
+    ///
+    /// Note: This is a no-op on OP Stack.
+    #[arg(
+        long = "engine.always-process-payload-attributes-on-canonical-head",
+        default_value = "false"
+    )]
+    pub always_process_payload_attributes_on_canonical_head: bool,
 }
 
 impl Default for EngineArgs {
@@ -85,6 +96,7 @@ impl Default for EngineArgs {
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_enabled: false,
             state_root_fallback: false,
+            always_process_payload_attributes_on_canonical_head: false,
         }
     }
 }
@@ -104,6 +116,9 @@ impl EngineArgs {
             .with_reserved_cpu_cores(self.reserved_cpu_cores)
             .with_precompile_cache_enabled(self.precompile_cache_enabled)
             .with_state_root_fallback(self.state_root_fallback)
+            .with_always_process_payload_attributes_on_canonical_head(
+                self.always_process_payload_attributes_on_canonical_head,
+            )
     }
 }
 


### PR DESCRIPTION
Adds a new configuration flag,
`--engine.always-process-payload-attributes-on-canonical-head`.

This flag allows overriding the standard Engine API behavior which
normally prevents starting a new payload build process if the
`forkchoiceState.headBlockHash` is already the canonical head or one of
its ancestors.

The Engine API specification (Rule 2 under `engine_forkchoiceUpdatedV1`:
> Client software MAY skip an update of the forkchoice state and MUST
> NOT begin a payload build process if `forkchoiceState.headBlockHash`
> references a `VALID` ancestor of the head of canonical chain... In the
> case of such an event, client software MUST return `{payloadStatus:
> {status: VALID, latestValidHash: forkchoiceState.headBlockHash,
> validationError: null}, payloadId: null}`

This new setting provides flexibility for scenarios such as:
- Various custom chains that may have unique block production or reorg
  handling logic requiring more direct control over payload building.
- Development or testing environments requiring immediate payload
  regeneration even if the head hasn't advanced to a new block.

When this flag is enabled, or when `engine_kind.is_opstack()` is true,
Reth will proceed with processing payload attributes and initiating a
payload build process, regardless of the canonical status of the
forkchoice head.

Closes: https://github.com/paradigmxyz/reth/issues/16629