### PR TITLE
docs: Fix typos in documentation and README

### DIFF
--- a/crates/storage/libmdbx-rs/README.md
+++ b/crates/storage/libmdbx-rs/README.md
@@ -12,7 +12,7 @@ To update the libmdbx version you must clone it and copy the `dist/` folder in `
 Make sure to follow the [building steps](https://libmdbx.dqdkfa.ru/usage.html#getting).
 
 ```bash
-# clone libmmdbx to a repository outside at specific tag
+# clone libmdbx to a repository outside at specific tag
 git clone https://github.com/erthink/libmdbx.git ../libmdbx --branch v0.7.0
 make -C ../libmdbx dist
 

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -43,7 +43,7 @@ mod test_utils {
     use tempfile::tempdir;
 
     /// Regression test for <https://github.com/danburkert/lmdb-rs/issues/21>.
-    /// This test reliably segfaults when run against lmbdb compiled with opt level -O3 and newer
+    /// This test reliably segfaults when run against lmdb compiled with opt level -O3 and newer
     /// GCC compilers.
     #[test]
     fn issue_21_regression() {


### PR DESCRIPTION
Description:
Fixes two typos in the codebase:
1. Corrected "lmbdb" to "lmdb" in the regression test comment in lib.rs
2. Fixed "libmmdbx" to "libmdbx" in the README.md installation instructions

