### PR TITLE
fix: use correct sender_id_or_create as intended

### DIFF
--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -43,7 +43,7 @@ impl SenderIdentifiers {
         &mut self,
         addrs: impl IntoIterator<Item = Address>,
     ) -> Vec<SenderId> {
-        addrs.into_iter().filter_map(|addr| self.sender_id(&addr)).collect()
+        addrs.into_iter().map(|addr| self.sender_id_or_create(addr)).collect()
     }
 
     /// Returns the current identifier and increments the counter.


### PR DESCRIPTION
this batch create fn is used for 7702 auths which must create entries if missing.

this never assigned a new id and instead just filtered them out which should be fine because then the pool has never seen a tx from that authority yet, but it would exempt this authority from all the rules, once a tx from that comes in