### PR TITLE
perf(engine): enable precompile cache by default

### DIFF
--- a/book/cli/reth/node.md
+++ b/book/cli/reth/node.md
@@ -735,9 +735,6 @@ Engine:
       --engine.legacy-state-root
           Enable legacy state root
 
-      --engine.caching-and-prewarming
-          CAUTION: This CLI flag has no effect anymore, use --engine.disable-caching-and-prewarming if you want to disable caching and prewarming
-
       --engine.disable-caching-and-prewarming
           Disable cross-block caching and parallel prewarming
 
@@ -765,8 +762,8 @@ Engine:
 
           [default: 1]
 
-      --engine.precompile-cache
-          Enable precompile cache
+      --engine.disable-precompile-cache
+          Disable precompile cache
 
       --engine.state-root-fallback
           Enable state root fallback, useful for testing

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -75,8 +75,8 @@ pub struct TreeConfig {
     max_proof_task_concurrency: u64,
     /// Number of reserved CPU cores for non-reth processes
     reserved_cpu_cores: usize,
-    /// Whether to enable the precompile cache
-    precompile_cache_enabled: bool,
+    /// Whether to disable the precompile cache
+    precompile_cache_disabled: bool,
     /// Whether to use state root fallback for testing
     state_root_fallback: bool,
 }
@@ -97,7 +97,7 @@ impl Default for TreeConfig {
             has_enough_parallelism: has_enough_parallelism(),
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
-            precompile_cache_enabled: false,
+            precompile_cache_disabled: false,
             state_root_fallback: false,
         }
     }
@@ -120,7 +120,7 @@ impl TreeConfig {
         has_enough_parallelism: bool,
         max_proof_task_concurrency: u64,
         reserved_cpu_cores: usize,
-        precompile_cache_enabled: bool,
+        precompile_cache_disabled: bool,
         state_root_fallback: bool,
     ) -> Self {
         Self {
@@ -137,7 +137,7 @@ impl TreeConfig {
             has_enough_parallelism,
             max_proof_task_concurrency,
             reserved_cpu_cores,
-            precompile_cache_enabled,
+            precompile_cache_disabled,
             state_root_fallback,
         }
     }
@@ -204,9 +204,9 @@ impl TreeConfig {
         self.cross_block_cache_size
     }
 
-    /// Returns whether precompile cache is enabled.
-    pub const fn precompile_cache_enabled(&self) -> bool {
-        self.precompile_cache_enabled
+    /// Returns whether precompile cache is disabled.
+    pub const fn precompile_cache_disabled(&self) -> bool {
+        self.precompile_cache_disabled
     }
 
     /// Returns whether to use state root fallback.
@@ -311,9 +311,9 @@ impl TreeConfig {
         self
     }
 
-    /// Setter for whether to use the precompile cache.
-    pub const fn with_precompile_cache_enabled(mut self, precompile_cache_enabled: bool) -> Self {
-        self.precompile_cache_enabled = precompile_cache_enabled;
+    /// Setter for whether to disable the precompile cache.
+    pub const fn without_precompile_cache(mut self, precompile_cache_disabled: bool) -> Self {
+        self.precompile_cache_disabled = precompile_cache_disabled;
         self
     }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2411,7 +2411,7 @@ where
             .build();
         let mut executor = self.evm_config.executor_for_block(&mut db, block);
 
-        if self.config.precompile_cache_enabled() {
+        if !self.config.precompile_cache_disabled() {
             executor.evm_mut().precompiles_mut().map_precompiles(|address, precompile| {
                 CachedPrecompile::wrap(
                     precompile,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -63,7 +63,7 @@ where
     disable_transaction_prewarming: bool,
     /// Determines how to configure the evm for execution.
     evm_config: Evm,
-    /// whether precompile cache should be enabled.
+    /// Whether precompile cache should be disabled.
     precompile_cache_disabled: bool,
     /// Precompile cache map.
     precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -64,7 +64,7 @@ where
     /// Determines how to configure the evm for execution.
     evm_config: Evm,
     /// whether precompile cache should be enabled.
-    precompile_cache_enabled: bool,
+    precompile_cache_disabled: bool,
     /// Precompile cache map.
     precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
     _marker: std::marker::PhantomData<N>,
@@ -89,7 +89,7 @@ where
             cross_block_cache_size: config.cross_block_cache_size(),
             disable_transaction_prewarming: config.disable_caching_and_prewarming(),
             evm_config,
-            precompile_cache_enabled: config.precompile_cache_enabled(),
+            precompile_cache_disabled: config.precompile_cache_disabled(),
             precompile_cache_map,
             _marker: Default::default(),
         }
@@ -273,7 +273,7 @@ where
             provider: provider_builder,
             metrics: PrewarmMetrics::default(),
             terminate_execution: Arc::new(AtomicBool::new(false)),
-            precompile_cache_enabled: self.precompile_cache_enabled,
+            precompile_cache_disabled: self.precompile_cache_disabled,
             precompile_cache_map: self.precompile_cache_map.clone(),
         };
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -214,7 +214,7 @@ where
     pub(super) metrics: PrewarmMetrics,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
     pub(super) terminate_execution: Arc<AtomicBool>,
-    pub(super) precompile_cache_enabled: bool,
+    pub(super) precompile_cache_disabled: bool,
     pub(super) precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
 }
 
@@ -237,7 +237,7 @@ where
             provider,
             metrics,
             terminate_execution,
-            precompile_cache_enabled,
+            precompile_cache_disabled,
             mut precompile_cache_map,
         } = self;
 
@@ -269,7 +269,7 @@ where
         let spec_id = *evm_env.spec_id();
         let mut evm = evm_config.evm_with_env(state_provider, evm_env);
 
-        if precompile_cache_enabled {
+        if !precompile_cache_disabled {
             evm.precompiles_mut().map_precompiles(|address, precompile| {
                 CachedPrecompile::wrap(
                     precompile,

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -25,8 +25,9 @@ pub struct EngineArgs {
     pub legacy_state_root_task_enabled: bool,
 
     /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-caching-and-prewarming
-    /// if you want to disable caching and prewarming.
+    /// if you want to disable caching and prewarming
     #[arg(long = "engine.caching-and-prewarming", default_value = "true", hide = true)]
+    #[deprecated]
     pub caching_and_prewarming_enabled: bool,
 
     /// Disable cross-block caching and parallel prewarming
@@ -60,8 +61,10 @@ pub struct EngineArgs {
     #[arg(long = "engine.reserved-cpu-cores", default_value_t = DEFAULT_RESERVED_CPU_CORES)]
     pub reserved_cpu_cores: usize,
 
-    /// Enable precompile cache
+    /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-precompile-cache
+    /// if you want to disable precompile cache
     #[arg(long = "engine.precompile-cache", default_value = "true", hide = true)]
+    #[deprecated]
     pub precompile_cache_enabled: bool,
 
     /// Disable precompile cache
@@ -80,6 +83,7 @@ impl Default for EngineArgs {
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             legacy_state_root_task_enabled: false,
             state_root_task_compare_updates: false,
+            #[allow(deprecated)]
             caching_and_prewarming_enabled: true,
             caching_and_prewarming_disabled: false,
             state_provider_metrics: false,
@@ -87,6 +91,7 @@ impl Default for EngineArgs {
             accept_execution_requests_hash: false,
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
+            #[allow(deprecated)]
             precompile_cache_enabled: true,
             precompile_cache_disabled: false,
             state_root_fallback: false,

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -64,7 +64,7 @@ pub struct EngineArgs {
     #[arg(long = "engine.precompile-cache", default_value = "true", hide = true)]
     pub precompile_cache_enabled: bool,
 
-    /// Enable precompile cache
+    /// Disable precompile cache
     #[arg(long = "engine.disable-precompile-cache", default_value = "false")]
     pub precompile_cache_disabled: bool,
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -76,6 +76,7 @@ pub struct EngineArgs {
     pub state_root_fallback: bool,
 }
 
+#[allow(deprecated)]
 impl Default for EngineArgs {
     fn default() -> Self {
         Self {
@@ -83,7 +84,6 @@ impl Default for EngineArgs {
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             legacy_state_root_task_enabled: false,
             state_root_task_compare_updates: false,
-            #[allow(deprecated)]
             caching_and_prewarming_enabled: true,
             caching_and_prewarming_disabled: false,
             state_provider_metrics: false,
@@ -91,7 +91,6 @@ impl Default for EngineArgs {
             accept_execution_requests_hash: false,
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
-            #[allow(deprecated)]
             precompile_cache_enabled: true,
             precompile_cache_disabled: false,
             state_root_fallback: false,

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -26,7 +26,7 @@ pub struct EngineArgs {
 
     /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-caching-and-prewarming
     /// if you want to disable caching and prewarming.
-    #[arg(long = "engine.caching-and-prewarming", default_value = "true")]
+    #[arg(long = "engine.caching-and-prewarming", default_value = "true", hide = true)]
     pub caching_and_prewarming_enabled: bool,
 
     /// Disable cross-block caching and parallel prewarming
@@ -61,8 +61,12 @@ pub struct EngineArgs {
     pub reserved_cpu_cores: usize,
 
     /// Enable precompile cache
-    #[arg(long = "engine.precompile-cache", default_value = "false")]
+    #[arg(long = "engine.precompile-cache", default_value = "true", hide = true)]
     pub precompile_cache_enabled: bool,
+
+    /// Enable precompile cache
+    #[arg(long = "engine.disable-precompile-cache", default_value = "false")]
+    pub precompile_cache_disabled: bool,
 
     /// Enable state root fallback, useful for testing
     #[arg(long = "engine.state-root-fallback", default_value = "false")]
@@ -83,7 +87,8 @@ impl Default for EngineArgs {
             accept_execution_requests_hash: false,
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
-            precompile_cache_enabled: false,
+            precompile_cache_enabled: true,
+            precompile_cache_disabled: false,
             state_root_fallback: false,
         }
     }
@@ -102,7 +107,7 @@ impl EngineArgs {
             .with_cross_block_cache_size(self.cross_block_cache_size * 1024 * 1024)
             .with_max_proof_task_concurrency(self.max_proof_task_concurrency)
             .with_reserved_cpu_cores(self.reserved_cpu_cores)
-            .with_precompile_cache_enabled(self.precompile_cache_enabled)
+            .without_precompile_cache(self.precompile_cache_disabled)
             .with_state_root_fallback(self.state_root_fallback)
     }
 }


### PR DESCRIPTION
Enables the precompile cache by default, and adds a new flag `--engine.disable-precompile-cache` to disable it.