### PR TITLE
feat(test): rewrite test_engine_tree_fcu_reorg_with_all_blocks using e2e framework

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -36,13 +36,15 @@ impl NodeClient {
     }
 }
 
-/// Represents the latest block information.
-#[derive(Debug, Clone)]
-pub struct LatestBlockInfo {
-    /// Hash of the latest block
+/// Represents complete block information.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockInfo {
+    /// Hash of the block
     pub hash: B256,
-    /// Number of the latest block
+    /// Number of the block
     pub number: u64,
+    /// Timestamp of the block
+    pub timestamp: u64,
 }
 /// Represents a test environment.
 #[derive(Debug)]
@@ -54,8 +56,8 @@ where
     pub node_clients: Vec<NodeClient>,
     /// Tracks instance generic.
     _phantom: PhantomData<I>,
-    /// Latest block information
-    pub latest_block_info: Option<LatestBlockInfo>,
+    /// Current block information
+    pub current_block_info: Option<BlockInfo>,
     /// Last producer index
     pub last_producer_idx: Option<usize>,
     /// Stores payload attributes indexed by block number
@@ -80,8 +82,10 @@ where
     pub slots_to_safe: u64,
     /// Number of slots until a block is considered finalized
     pub slots_to_finalized: u64,
-    /// Registry for tagged blocks, mapping tag names to block hashes
-    pub block_registry: HashMap<String, B256>,
+    /// Registry for tagged blocks, mapping tag names to complete block info
+    pub block_registry: HashMap<String, BlockInfo>,
+    /// Fork base block number for validation (if we're currently on a fork)
+    pub current_fork_base: Option<u64>,
 }
 
 impl<I> Default for Environment<I>
@@ -92,7 +96,7 @@ where
         Self {
             node_clients: vec![],
             _phantom: Default::default(),
-            latest_block_info: None,
+            current_block_info: None,
             last_producer_idx: None,
             payload_attributes: Default::default(),
             latest_header_time: 0,
@@ -106,6 +110,7 @@ where
             slots_to_safe: 0,
             slots_to_finalized: 0,
             block_registry: HashMap::new(),
+            current_fork_base: None,
         }
     }
 }

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -245,9 +245,10 @@ where
             .await?
             .ok_or_else(|| eyre!("Genesis block not found"))?;
 
-        env.latest_block_info = Some(crate::testsuite::LatestBlockInfo {
+        env.current_block_info = Some(crate::testsuite::BlockInfo {
             hash: genesis_block.header.hash,
             number: genesis_block.header.number,
+            timestamp: genesis_block.header.timestamp,
         });
 
         env.latest_header_time = genesis_block.header.timestamp;

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -912,36 +912,6 @@ async fn test_engine_tree_fcu_missing_head() {
 }
 
 #[tokio::test]
-async fn test_engine_tree_fcu_reorg_with_all_blocks() {
-    let chain_spec = MAINNET.clone();
-    let mut test_harness = TestHarness::new(chain_spec.clone());
-
-    let main_chain: Vec<_> = test_harness.block_builder.get_executed_blocks(0..5).collect();
-    test_harness = test_harness.with_blocks(main_chain.clone());
-
-    let fork_chain = test_harness.block_builder.create_fork(main_chain[2].recovered_block(), 3);
-    let fork_chain_last_hash = fork_chain.last().unwrap().hash();
-
-    // add fork blocks to the tree
-    for block in &fork_chain {
-        test_harness.insert_block(block.clone()).unwrap();
-    }
-
-    test_harness.send_fcu(fork_chain_last_hash, ForkchoiceStatus::Valid).await;
-
-    // check for ForkBlockAdded events, we expect fork_chain.len() blocks added
-    test_harness.check_fork_chain_insertion(fork_chain.clone()).await;
-
-    // check for CanonicalChainCommitted event
-    test_harness.check_canon_commit(fork_chain_last_hash).await;
-
-    test_harness.check_fcu(fork_chain_last_hash, ForkchoiceStatus::Valid).await;
-
-    // new head is the tip of the fork chain
-    test_harness.check_canon_head(fork_chain_last_hash);
-}
-
-#[tokio::test]
 async fn test_engine_tree_live_sync_transition_required_blocks_requested() {
     reth_tracing::init_test_tracing();
 


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/14376

Replaces one of the tests that fail with state root task enabled with an e2e test that exercises the same functionality.

It required some fixes for the e2e framework, mainly related to using locally stored info for blocks in a non-canonical fork (not available through rpc). This was not a problem in the engine unit tests where we were able to access the tree's internal data structures.