### PR TITLE
fix: ensure that downloader sync gap is only set once

### DIFF
--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -187,7 +187,7 @@ async fn test_reorg_through_backfill() -> eyre::Result<()> {
 
     // Produce an unfinalized fork chain with 5 blocks
     second_node.payload.timestamp = head.header.timestamp;
-    advance_with_random_transactions(&mut second_node, 5, &mut rng, false).await?;
+    advance_with_random_transactions(&mut second_node, 10, &mut rng, false).await?;
 
     // Now reorg second node to the finalized canonical head
     let head = first_provider.get_block_by_number(100.into()).await?.unwrap();

--- a/crates/net/p2p/src/headers/downloader.rs
+++ b/crates/net/p2p/src/headers/downloader.rs
@@ -80,8 +80,8 @@ impl SyncTarget {
 }
 
 /// Represents a gap to sync: from `local_head` to `target`
-#[derive(Clone, Debug)]
-pub struct HeaderSyncGap<H = Header> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HeaderSyncGap<H: Sealable = Header> {
     /// The local head block. Represents lower bound of sync range.
     pub local_head: SealedHeader<H>,
 

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -214,7 +214,6 @@ where
         let target = SyncTarget::Tip(*self.tip.borrow());
         let gap = HeaderSyncGap { local_head, target };
         let tip = gap.target.tip();
-        self.sync_gap = Some(gap.clone());
 
         // Nothing to sync
         if gap.is_closed() {
@@ -232,7 +231,10 @@ where
         let local_head_number = gap.local_head.number();
 
         // let the downloader know what to sync
-        self.downloader.update_sync_gap(gap.local_head, gap.target);
+        if self.sync_gap != Some(gap.clone()) {
+            self.sync_gap = Some(gap.clone());
+            self.downloader.update_sync_gap(gap.local_head, gap.target);
+        }
 
         // We only want to stop once we have all the headers on ETL filespace (disk).
         loop {
@@ -263,13 +265,17 @@ where
                 }
                 Some(Err(HeadersDownloaderError::DetachedHead { local_head, header, error })) => {
                     error!(target: "sync::stages::headers", %error, "Cannot attach header to head");
+                    self.sync_gap = None;
                     return Poll::Ready(Err(StageError::DetachedHead {
                         local_head: Box::new(local_head.block_with_parent()),
                         header: Box::new(header.block_with_parent()),
                         error,
                     }))
                 }
-                None => return Poll::Ready(Err(StageError::ChannelClosed)),
+                None => {
+                    self.sync_gap = None;
+                    return Poll::Ready(Err(StageError::ChannelClosed))
+                }
             }
         }
     }
@@ -279,7 +285,7 @@ where
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         let current_checkpoint = input.checkpoint();
 
-        if self.sync_gap.as_ref().ok_or(StageError::MissingSyncGap)?.is_closed() {
+        if self.sync_gap.take().ok_or(StageError::MissingSyncGap)?.is_closed() {
             self.is_etl_ready = false;
             return Ok(ExecOutput::done(current_checkpoint))
         }


### PR DESCRIPTION
This is another followup around #14288 

Here we are polling not the `ReverseHeaderDownloader` but actually spawned downloader:
https://github.com/paradigmxyz/reth/blob/ff404c80e2e30857af8ae495b2162045346eb262/crates/stages/stages/src/stages/headers.rs#L234-L239

which means that if we're about to poll a `DetachedHead` error, we will always end up calling `update_sync_gap` right before it, thus making downloader starting to sync again.

This would result in next stage run getting the same error again, and causing some weird issues like that one:
```
2025-06-05T19:20:15.570995Z  INFO node{idx=0}: reth_node_events::node: Preparing stage pipeline_stages=1/12 stage=Headers checkpoint=28 target=None
2025-06-05T19:20:15.571018Z DEBUG node{idx=0}:ChainOrchestrator::poll: sync::stages::headers: Commencing sync tip=Hash(0x50370fd9a6b5bec077d952f9e065915ecd361904f1dee2e2ecd662b4314e0283) head=0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6
2025-06-05T19:20:15.581718Z ERROR node{idx=0}: downloaders::headers: Header cannot be attached to known canonical chain error=mismatched parent hash: got 0x5e2d7fa3d0610f458b29c1ded089ae9e6192149403f5d3d8741b081841c2e6fb, expected 0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6 number=29 hash=0x33adc1d8563c7e7b63d0591977784a331635fa9e80cbb7458c3b715c55db49ad
2025-06-05T19:20:15.581739Z DEBUG node{idx=0}: downloaders::headers: Resetting headers downloader
2025-06-05T19:20:15.581834Z DEBUG node{idx=0}:ChainOrchestrator::poll: sync::stages::headers: Commencing sync tip=Hash(0x50370fd9a6b5bec077d952f9e065915ecd361904f1dee2e2ecd662b4314e0283) head=0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6
2025-06-05T19:20:15.581856Z ERROR node{idx=0}:ChainOrchestrator::poll: sync::stages::headers: Cannot attach header to head error=mismatched parent hash: got 0x5e2d7fa3d0610f458b29c1ded089ae9e6192149403f5d3d8741b081841c2e6fb, expected 0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6
2025-06-05T19:20:15.581875Z  WARN node{idx=0}:ChainOrchestrator::poll: sync::pipeline: Stage encountered detached head stage=Headers local_head=BlockWithParent { parent: 0x14ac3021d584583ec913cdac45b5284d23998f1be27d8322eadde7ccfb24ab80, block: NumHash { number: 28, hash: 0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6 } } header=BlockWithParent { parent: 0x5e2d7fa3d0610f458b29c1ded089ae9e6192149403f5d3d8741b081841c2e6fb, block: NumHash { number: 29, hash: 0x33adc1d8563c7e7b63d0591977784a331635fa9e80cbb7458c3b715c55db49ad } } error=mismatched parent hash: got 0x5e2d7fa3d0610f458b29c1ded089ae9e6192149403f5d3d8741b081841c2e6fb, expected 0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6
2025-06-05T19:20:15.582040Z  INFO node{idx=0}:ChainOrchestrator::poll:Unwinding{stage=Finish}: sync::pipeline: Starting unwind from=28 to=25 bad_block=Some(28)
...
2025-06-05T19:20:15.748618Z  INFO node{idx=0}: reth_node_events::node: Preparing stage pipeline_stages=1/12 stage=Headers checkpoint=25 target=None
2025-06-05T19:20:15.748626Z ERROR node{idx=0}:ChainOrchestrator::poll: sync::stages::headers: Cannot attach header to head error=mismatched parent hash: got 0x5e2d7fa3d0610f458b29c1ded089ae9e6192149403f5d3d8741b081841c2e6fb, expected 0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6
2025-06-05T19:20:15.748644Z  WARN node{idx=0}:ChainOrchestrator::poll: sync::pipeline: Stage encountered detached head stage=Headers local_head=BlockWithParent { parent: 0x14ac3021d584583ec913cdac45b5284d23998f1be27d8322eadde7ccfb24ab80, block: NumHash { number: 28, hash: 0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6 } } header=BlockWithParent { parent: 0x5e2d7fa3d0610f458b29c1ded089ae9e6192149403f5d3d8741b081841c2e6fb, block: NumHash { number: 29, hash: 0x33adc1d8563c7e7b63d0591977784a331635fa9e80cbb7458c3b715c55db49ad } } error=mismatched parent hash: got 0x5e2d7fa3d0610f458b29c1ded089ae9e6192149403f5d3d8741b081841c2e6fb, expected 0xdca4d1bafe6db46378754f5812403cceab9260f5f417c29b56362c3c4cde2aa6
2025-06-05T19:20:15.748703Z  INFO node{idx=0}:ChainOrchestrator::poll:Unwinding{stage=Finish}: sync::pipeline: Starting unwind from=25 to=25 bad_block=Some(28)
```

here the problematic part is `Starting unwind from=25 to=25 bad_block=Some(28)` which only happened because of `HeaderStage` receiving message only relevant for the previous run