### PR TITLE
feat(rpc): Implement `TransactionCompat` for generic RPC response builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10010,7 +10010,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "jsonrpsee-types",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
+ "reth-storage-api",
  "serde",
  "thiserror 2.0.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10006,11 +10006,13 @@ name = "reth-rpc-types-compat"
 version = "1.4.8"
 dependencies = [
  "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "jsonrpsee-types",
  "reth-primitives-traits",
  "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -70,6 +70,7 @@ serde = [
     "reth-trie/serde",
     "revm-database/serde",
     "revm-state?/serde",
+    "reth-storage-api/serde",
 ]
 test-utils = [
     "alloy-primitives/getrandom",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -124,6 +124,7 @@ serde = [
     "reth-ethereum-primitives/serde",
     "reth-network-api/serde",
     "rand_08/serde",
+    "reth-storage-api/serde",
 ]
 test-utils = [
     "reth-transaction-pool/test-utils",

--- a/crates/optimism/rpc/src/error.rs
+++ b/crates/optimism/rpc/src/error.rs
@@ -5,8 +5,9 @@ use alloy_rpc_types_eth::{error::EthRpcErrorCode, BlockError};
 use alloy_transport::{RpcError, TransportErrorKind};
 use jsonrpsee_types::error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
 use op_revm::{OpHaltReason, OpTransactionError};
+use reth_evm::execute::ProviderError;
 use reth_optimism_evm::OpBlockExecutionError;
-use reth_rpc_eth_api::AsEthApiError;
+use reth_rpc_eth_api::{AsEthApiError, TransactionConversionError};
 use reth_rpc_eth_types::{error::api::FromEvmHalt, EthApiError};
 use reth_rpc_server_types::result::{internal_rpc_err, rpc_err};
 use revm::context_interface::result::{EVMError, InvalidTransaction};
@@ -160,12 +161,6 @@ impl From<SequencerClientError> for jsonrpsee_types::error::ErrorObject<'static>
     }
 }
 
-impl From<BlockError> for OpEthApiError {
-    fn from(error: BlockError) -> Self {
-        Self::Eth(error.into())
-    }
-}
-
 impl<T> From<EVMError<T, OpTransactionError>> for OpEthApiError
 where
     T: Into<EthApiError>,
@@ -191,5 +186,23 @@ impl FromEvmHalt<OpHaltReason> for OpEthApiError {
             }
             OpHaltReason::Base(halt) => EthApiError::from_evm_halt(halt, gas_limit).into(),
         }
+    }
+}
+
+impl From<TransactionConversionError> for OpEthApiError {
+    fn from(value: TransactionConversionError) -> Self {
+        Self::Eth(EthApiError::from(value))
+    }
+}
+
+impl From<ProviderError> for OpEthApiError {
+    fn from(value: ProviderError) -> Self {
+        Self::Eth(EthApiError::from(value))
+    }
+}
+
+impl From<BlockError> for OpEthApiError {
+    fn from(value: BlockError) -> Self {
+        Self::Eth(EthApiError::from(value))
     }
 }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -25,8 +25,7 @@ use reth_rpc_eth_api::{
         AddDevSigners, EthApiSpec, EthFees, EthSigner, EthState, LoadBlock, LoadFee, LoadState,
         SpawnBlocking, Trace,
     },
-    EthApiTypes, FromEvmError, FullEthApiServer, RpcNodeCore, RpcNodeCoreExt,
-    RpcTransactionConverter,
+    EthApiTypes, FromEvmError, FullEthApiServer, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{
@@ -68,8 +67,7 @@ pub struct OpEthApi<N: OpNodeCore, NetworkT = Optimism> {
     inner: Arc<OpEthApiInner<N>>,
     /// Marker for the network types.
     _nt: PhantomData<NetworkT>,
-    tx_resp_builder:
-        RpcTransactionConverter<N::Primitives, NetworkT, OpEthApiError, OpTxInfoMapper<N>>,
+    tx_resp_builder: RpcConverter<N::Primitives, NetworkT, OpEthApiError, OpTxInfoMapper<N>>,
 }
 
 impl<N: OpNodeCore, NetworkT> OpEthApi<N, NetworkT> {
@@ -84,7 +82,7 @@ impl<N: OpNodeCore, NetworkT> OpEthApi<N, NetworkT> {
         Self {
             inner: inner.clone(),
             _nt: PhantomData,
-            tx_resp_builder: RpcTransactionConverter::with_mapper(OpTxInfoMapper::new(inner)),
+            tx_resp_builder: RpcConverter::with_mapper(OpTxInfoMapper::new(inner)),
         }
     }
 }
@@ -121,7 +119,7 @@ where
     type Error = OpEthApiError;
     type NetworkTypes = NetworkT;
     type TransactionCompat =
-        RpcTransactionConverter<N::Primitives, NetworkT, OpEthApiError, OpTxInfoMapper<N>>;
+        RpcConverter<N::Primitives, NetworkT, OpEthApiError, OpTxInfoMapper<N>>;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
         &self.tx_resp_builder

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -8,6 +8,7 @@ mod block;
 mod call;
 mod pending_block;
 
+use crate::{eth::transaction::OpTxInfoMapper, OpEthApiError, SequencerClient};
 use alloy_primitives::U256;
 use eyre::WrapErr;
 use op_alloy_network::Optimism;
@@ -25,6 +26,7 @@ use reth_rpc_eth_api::{
         SpawnBlocking, Trace,
     },
     EthApiTypes, FromEvmError, FullEthApiServer, RpcNodeCore, RpcNodeCoreExt,
+    RpcTransactionConverter,
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{
@@ -36,9 +38,7 @@ use reth_tasks::{
     TaskSpawner,
 };
 use reth_transaction_pool::TransactionPool;
-use std::{fmt, marker::PhantomData, sync::Arc};
-
-use crate::{OpEthApiError, SequencerClient};
+use std::{fmt, fmt::Formatter, marker::PhantomData, sync::Arc};
 
 /// Adapter for [`EthApiInner`], which holds all the data required to serve core `eth_` API.
 pub type EthApiNodeBackend<N> = EthApiInner<
@@ -68,6 +68,8 @@ pub struct OpEthApi<N: OpNodeCore, NetworkT = Optimism> {
     inner: Arc<OpEthApiInner<N>>,
     /// Marker for the network types.
     _nt: PhantomData<NetworkT>,
+    tx_resp_builder:
+        RpcTransactionConverter<N::Primitives, NetworkT, OpEthApiError, OpTxInfoMapper<N>>,
 }
 
 impl<N: OpNodeCore, NetworkT> OpEthApi<N, NetworkT> {
@@ -77,13 +79,12 @@ impl<N: OpNodeCore, NetworkT> OpEthApi<N, NetworkT> {
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
     ) -> Self {
+        let inner =
+            Arc::new(OpEthApiInner { eth_api, sequencer_client, min_suggested_priority_fee });
         Self {
-            inner: Arc::new(OpEthApiInner {
-                eth_api,
-                sequencer_client,
-                min_suggested_priority_fee,
-            }),
+            inner: inner.clone(),
             _nt: PhantomData,
+            tx_resp_builder: RpcTransactionConverter::with_mapper(OpTxInfoMapper::new(inner)),
         }
     }
 }
@@ -112,16 +113,18 @@ where
 
 impl<N, NetworkT> EthApiTypes for OpEthApi<N, NetworkT>
 where
-    Self: Send + Sync + std::fmt::Debug,
+    Self: Send + Sync + fmt::Debug,
     N: OpNodeCore,
-    NetworkT: op_alloy_network::Network + Clone + std::fmt::Debug,
+    NetworkT: op_alloy_network::Network + Clone + fmt::Debug,
+    <N as RpcNodeCore>::Primitives: fmt::Debug,
 {
     type Error = OpEthApiError;
     type NetworkTypes = NetworkT;
-    type TransactionCompat = Self;
+    type TransactionCompat =
+        RpcTransactionConverter<N::Primitives, NetworkT, OpEthApiError, OpTxInfoMapper<N>>;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
-        self
+        &self.tx_resp_builder
     }
 }
 
@@ -202,6 +205,7 @@ where
     Self: Send + Sync + Clone + 'static,
     N: OpNodeCore,
     NetworkT: op_alloy_network::Network,
+    <N as RpcNodeCore>::Primitives: fmt::Debug,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {
@@ -252,6 +256,7 @@ where
         Pool: TransactionPool,
     >,
     NetworkT: op_alloy_network::Network,
+    <N as RpcNodeCore>::Primitives: fmt::Debug,
 {
 }
 
@@ -305,7 +310,7 @@ impl<N: OpNodeCore, NetworkT> fmt::Debug for OpEthApi<N, NetworkT> {
 }
 
 /// Container type `OpEthApi`
-struct OpEthApiInner<N: OpNodeCore> {
+pub struct OpEthApiInner<N: OpNodeCore> {
     /// Gateway to node's core components.
     eth_api: EthApiNodeBackend<N>,
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
@@ -315,6 +320,12 @@ struct OpEthApiInner<N: OpNodeCore> {
     ///
     /// See also <https://github.com/ethereum-optimism/op-geth/blob/d4e0fe9bb0c2075a9bff269fb975464dd8498f75/eth/gasprice/optimism-gasprice.go#L38-L38>
     min_suggested_priority_fee: U256,
+}
+
+impl<N: OpNodeCore> fmt::Debug for OpEthApiInner<N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpEthApiInner").finish()
+    }
 }
 
 impl<N: OpNodeCore> OpEthApiInner<N> {

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -13,7 +13,8 @@ use reth_optimism_primitives::DepositReceipt;
 use reth_primitives_traits::{NodePrimitives, TxTy};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
-    EthApiTypes, FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt, TransactionCompat,
+    CompatError, EthApiTypes, FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
+    TransactionCompat,
 };
 use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError};
 use reth_storage_api::{
@@ -84,6 +85,12 @@ where
     /// Returns the [`SequencerClient`] if one is set.
     pub fn raw_tx_forwarder(&self) -> Option<SequencerClient> {
         self.inner.sequencer_client.clone()
+    }
+}
+
+impl From<CompatError> for OpEthApiError {
+    fn from(value: CompatError) -> Self {
+        Self::Eth(EthApiError::from(value))
     }
 }
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -54,5 +54,6 @@ serde = [
     "reth-trie?/serde",
     "reth-ethereum-forks/serde",
     "reth-primitives-traits/serde",
+    "reth-storage-api/serde",
 ]
 portable = ["revm/portable"]

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -31,8 +31,8 @@ pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
 pub use reth_rpc_types_compat::{
-    try_into_op_tx_info, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
-    TransactionConversionError, TryIntoSimTx, TxInfoMapper,
+    try_into_op_tx_info, IntoRpcTx, RpcConverter, TransactionCompat, TransactionConversionError,
+    TryIntoSimTx, TxInfoMapper,
 };
 pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -31,7 +31,8 @@ pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
 pub use reth_rpc_types_compat::{
-    CompatError, IntoRpcTx, RpcTransactionConverter, TransactionCompat, TryIntoSimTx,
+    try_into_op_tx_info, CompatError, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
+    TryIntoSimTx, TxInfoMapper,
 };
 pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -31,8 +31,8 @@ pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
 pub use reth_rpc_types_compat::{
-    try_into_op_tx_info, CompatError, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
-    TryIntoSimTx, TxInfoMapper,
+    try_into_op_tx_info, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
+    TransactionConversionError, TryIntoSimTx, TxInfoMapper,
 };
 pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -30,7 +30,9 @@ pub use pubsub::EthPubSubApiServer;
 pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
-pub use reth_rpc_types_compat::TransactionCompat;
+pub use reth_rpc_types_compat::{
+    CompatError, IntoRpcTx, RpcTransactionConverter, TransactionCompat, TryIntoSimTx,
+};
 pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 
 #[cfg(feature = "client")]

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -13,6 +13,7 @@ use reth_primitives_traits::transaction::{error::InvalidTransactionError, signed
 use reth_rpc_server_types::result::{
     block_id_to_str, internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code,
 };
+use reth_rpc_types_compat::transaction::CompatError;
 use reth_transaction_pool::error::{
     Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
     PoolError, PoolErrorKind, PoolTransactionError,
@@ -226,6 +227,14 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             err @ EthApiError::TransactionInputError(_) => invalid_params_rpc_err(err.to_string()),
             EthApiError::Other(err) => err.to_rpc_error(),
             EthApiError::MuxTracerError(msg) => internal_rpc_err(msg.to_string()),
+        }
+    }
+}
+
+impl From<CompatError> for EthApiError {
+    fn from(value: CompatError) -> Self {
+        match value {
+            CompatError::TransactionConversionError => Self::TransactionConversionError,
         }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -235,6 +235,7 @@ impl From<CompatError> for EthApiError {
     fn from(value: CompatError) -> Self {
         match value {
             CompatError::TransactionConversionError => Self::TransactionConversionError,
+            CompatError::Provider(err) => Self::from(err),
         }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -13,7 +13,7 @@ use reth_primitives_traits::transaction::{error::InvalidTransactionError, signed
 use reth_rpc_server_types::result::{
     block_id_to_str, internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code,
 };
-use reth_rpc_types_compat::transaction::CompatError;
+use reth_rpc_types_compat::TransactionConversionError;
 use reth_transaction_pool::error::{
     Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
     PoolError, PoolErrorKind, PoolTransactionError,
@@ -231,12 +231,9 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     }
 }
 
-impl From<CompatError> for EthApiError {
-    fn from(value: CompatError) -> Self {
-        match value {
-            CompatError::TransactionConversionError => Self::TransactionConversionError,
-            CompatError::Provider(err) => Self::from(err),
-        }
+impl From<TransactionConversionError> for EthApiError {
+    fn from(_: TransactionConversionError) -> Self {
+        Self::TransactionConversionError
     }
 }
 

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -14,12 +14,19 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives-traits.workspace = true
+reth-storage-api.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true
 alloy-rpc-types-eth = { workspace = true, default-features = false, features = ["serde"] }
 alloy-consensus.workspace = true
 alloy-network.workspace = true
+
+# optimism
+op-alloy-consensus.workspace = true
+op-alloy-rpc-types.workspace = true
+reth-optimism-primitives.workspace = true
+reth-optimism-primitives.features = ["serde"]
 
 # io
 serde.workspace = true

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives-traits.workspace = true
-reth-storage-api.workspace = true
+reth-storage-api = { workspace = true, features = ["serde", "serde-bincode-compat"] }
 
 # ethereum
 alloy-primitives.workspace = true
@@ -25,8 +25,7 @@ alloy-network.workspace = true
 # optimism
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types.workspace = true
-reth-optimism-primitives.workspace = true
-reth-optimism-primitives.features = ["serde"]
+reth-optimism-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"] }
 
 # io
 serde.workspace = true

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -19,7 +19,11 @@ reth-primitives-traits.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-eth = { workspace = true, default-features = false, features = ["serde"] }
 alloy-consensus.workspace = true
+alloy-network.workspace = true
 
 # io
 serde.workspace = true
 jsonrpsee-types.workspace = true
+
+# error
+thiserror.workspace = true

--- a/crates/rpc/rpc-types-compat/src/lib.rs
+++ b/crates/rpc/rpc-types-compat/src/lib.rs
@@ -13,6 +13,6 @@
 pub mod block;
 pub mod transaction;
 pub use transaction::{
-    try_into_op_tx_info, CompatError, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
-    TryIntoSimTx, TxInfoMapper,
+    try_into_op_tx_info, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
+    TransactionConversionError, TryIntoSimTx, TxInfoMapper,
 };

--- a/crates/rpc/rpc-types-compat/src/lib.rs
+++ b/crates/rpc/rpc-types-compat/src/lib.rs
@@ -12,4 +12,7 @@
 
 pub mod block;
 pub mod transaction;
-pub use transaction::TransactionCompat;
+pub use transaction::{
+    try_into_op_tx_info, CompatError, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
+    TryIntoSimTx, TxInfoMapper,
+};

--- a/crates/rpc/rpc-types-compat/src/lib.rs
+++ b/crates/rpc/rpc-types-compat/src/lib.rs
@@ -13,6 +13,6 @@
 pub mod block;
 pub mod transaction;
 pub use transaction::{
-    try_into_op_tx_info, IntoRpcTx, RpcTransactionConverter, TransactionCompat,
-    TransactionConversionError, TryIntoSimTx, TxInfoMapper,
+    try_into_op_tx_info, IntoRpcTx, RpcConverter, TransactionCompat, TransactionConversionError,
+    TryIntoSimTx, TxInfoMapper,
 };

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -195,6 +195,21 @@ impl<N, E, Err, Map> RpcConverter<N, E, Err, Map> {
     pub const fn with_mapper(mapper: Map) -> Self {
         Self { phantom: PhantomData, mapper }
     }
+
+    /// Converts the generic types.
+    pub fn convert<N2, E2, Err2>(self) -> RpcConverter<N2, E2, Err2, Map> {
+        RpcConverter::with_mapper(self.mapper)
+    }
+
+    /// Swaps the inner `mapper`.
+    pub fn map<Map2>(self, mapper: Map2) -> RpcConverter<N, E, Err, Map2> {
+        RpcConverter::with_mapper(mapper)
+    }
+
+    /// Converts the generic types and swaps the inner `mapper`.
+    pub fn convert_map<N2, E2, Err2, Map2>(self, mapper: Map2) -> RpcConverter<N2, E2, Err2, Map2> {
+        self.convert().map(mapper)
+    }
 }
 
 impl<N, E, Err, Map: Clone> Clone for RpcConverter<N, E, Err, Map> {

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -2,7 +2,6 @@
 
 use alloy_consensus::{
     error::ValueError, transaction::Recovered, EthereumTxEnvelope, SignableTransaction, TxEip4844,
-    TxEip4844Variant,
 };
 use alloy_network::Network;
 use alloy_primitives::{Address, Signature};
@@ -94,16 +93,7 @@ impl IntoRpcTx<Transaction> for EthereumTxEnvelope<TxEip4844> {
     type TxInfo = TransactionInfo;
 
     fn into_rpc_tx(self, signer: Address, tx_info: TransactionInfo) -> Transaction {
-        Transaction::from_transaction(
-            self.with_signer(signer).map(|v| match v {
-                Self::Eip4844(v) => EthereumTxEnvelope::Eip4844(v.map(TxEip4844Variant::TxEip4844)),
-                Self::Legacy(v) => EthereumTxEnvelope::Legacy(v),
-                Self::Eip2930(v) => EthereumTxEnvelope::Eip2930(v),
-                Self::Eip1559(v) => EthereumTxEnvelope::Eip1559(v),
-                Self::Eip7702(v) => EthereumTxEnvelope::Eip7702(v),
-            }),
-            tx_info,
-        )
+        Transaction::from_transaction(self.with_signer(signer).convert(), tx_info)
     }
 }
 

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -178,38 +178,38 @@ pub struct TransactionConversionError;
 
 /// Generic RPC response object converter for primitives `N` and network `E`.
 #[derive(Debug)]
-pub struct RpcTransactionConverter<N, E, Err, Map = ()> {
+pub struct RpcConverter<N, E, Err, Map = ()> {
     phantom: PhantomData<(N, E, Err)>,
     mapper: Map,
 }
 
-impl<N, E, Err> RpcTransactionConverter<N, E, Err, ()> {
-    /// Creates a new [`RpcTransactionConverter`] with the default mapper.
+impl<N, E, Err> RpcConverter<N, E, Err, ()> {
+    /// Creates a new [`RpcConverter`] with the default mapper.
     pub const fn new() -> Self {
         Self::with_mapper(())
     }
 }
 
-impl<N, E, Err, Map> RpcTransactionConverter<N, E, Err, Map> {
-    /// Creates a new [`RpcTransactionConverter`] with `mapper`.
+impl<N, E, Err, Map> RpcConverter<N, E, Err, Map> {
+    /// Creates a new [`RpcConverter`] with `mapper`.
     pub const fn with_mapper(mapper: Map) -> Self {
         Self { phantom: PhantomData, mapper }
     }
 }
 
-impl<N, E, Err, Map: Clone> Clone for RpcTransactionConverter<N, E, Err, Map> {
+impl<N, E, Err, Map: Clone> Clone for RpcConverter<N, E, Err, Map> {
     fn clone(&self) -> Self {
         Self::with_mapper(self.mapper.clone())
     }
 }
 
-impl<N, E, Err> Default for RpcTransactionConverter<N, E, Err> {
+impl<N, E, Err> Default for RpcConverter<N, E, Err> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<N, E, Err, Map> TransactionCompat for RpcTransactionConverter<N, E, Err, Map>
+impl<N, E, Err, Map> TransactionCompat for RpcConverter<N, E, Err, Map>
 where
     N: NodePrimitives,
     E: Network + Unpin,

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -69,6 +69,12 @@ where
     Self: Sized,
 {
     /// Performs the conversion.
+    ///
+    /// Should return a signed typed transaction envelope for the [`eth_simulateV1`] endpoint with a
+    /// dummy signature or an error if [required fields] are missing.
+    ///
+    /// [`eth_simulateV1`]: <https://github.com/ethereum/execution-apis/pull/484>
+    /// [required fields]: TransactionRequest::buildable_type
     fn try_into_sim_tx(self) -> Result<T, ValueError<Self>>;
 }
 

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -1,13 +1,21 @@
 //! Compatibility functions for rpc `Transaction` type.
 
 use alloy_consensus::{
-    error::ValueError, transaction::Recovered, EthereumTxEnvelope, TxEip4844, TxEip4844Variant,
+    error::ValueError, transaction::Recovered, EthereumTxEnvelope, SignableTransaction, TxEip4844,
+    TxEip4844Variant,
 };
 use alloy_network::Network;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, Signature};
 use alloy_rpc_types_eth::{request::TransactionRequest, Transaction, TransactionInfo};
 use core::error;
+use op_alloy_consensus::{
+    transaction::{OpDepositInfo, OpTransactionInfo},
+    OpTxEnvelope,
+};
+use op_alloy_rpc_types::OpTransactionRequest;
+use reth_optimism_primitives::DepositReceipt;
 use reth_primitives_traits::{NodePrimitives, SignedTransaction, TxTy};
+use reth_storage_api::{errors::ProviderError, ReceiptProvider};
 use serde::{Deserialize, Serialize};
 use std::{error::Error, fmt::Debug, marker::PhantomData};
 use thiserror::Error;
@@ -55,10 +63,14 @@ pub trait TransactionCompat: Send + Sync + Unpin + Clone + Debug {
 /// Converts `self` into `T`.
 ///
 /// Should create an RPC transaction response object based on a consensus transaction, its signer
-/// [`Address`] and an additional context carried as [`TransactionInfo`].
+/// [`Address`] and an additional context.
 pub trait IntoRpcTx<T> {
+    /// An additional context, usually [`TransactionInfo`] in a wrapper that carries some
+    /// implementation specific extra information.
+    type TxInfo;
+
     /// Performs the conversion.
-    fn into_rpc_tx(self, signer: Address, tx_info: TransactionInfo) -> T;
+    fn into_rpc_tx(self, signer: Address, tx_info: Self::TxInfo) -> T;
 }
 
 /// Converts `self` into `T`.
@@ -79,6 +91,8 @@ where
 }
 
 impl IntoRpcTx<Transaction> for EthereumTxEnvelope<TxEip4844> {
+    type TxInfo = TransactionInfo;
+
     fn into_rpc_tx(self, signer: Address, tx_info: TransactionInfo) -> Transaction {
         Transaction::from_transaction(
             self.with_signer(signer).map(|v| match v {
@@ -93,37 +107,122 @@ impl IntoRpcTx<Transaction> for EthereumTxEnvelope<TxEip4844> {
     }
 }
 
+/// Adds extra context to [`TransactionInfo`].
+pub trait TxInfoMapper<T> {
+    /// An associated output type that carries [`TransactionInfo`] with some extra context.
+    type Out;
+
+    /// Performs the conversion.
+    fn try_map(&self, tx: T, tx_info: TransactionInfo) -> Result<Self::Out, CompatError>;
+}
+
+impl<T> TxInfoMapper<&T> for () {
+    type Out = TransactionInfo;
+
+    fn try_map(&self, _tx: &T, tx_info: TransactionInfo) -> Result<Self::Out, CompatError> {
+        Ok(tx_info)
+    }
+}
+
+/// Creates [`OpTransactionInfo`] by adding [`OpDepositInfo`] to [`TransactionInfo`] if `tx` is a
+/// deposit.
+pub fn try_into_op_tx_info<T: ReceiptProvider<Receipt: DepositReceipt>>(
+    provider: &T,
+    tx: &OpTxEnvelope,
+    tx_info: TransactionInfo,
+) -> Result<OpTransactionInfo, CompatError> {
+    let deposit_meta = if tx.is_deposit() {
+        provider.receipt_by_hash(tx.tx_hash())?.and_then(|receipt| {
+            receipt.as_deposit_receipt().map(|receipt| OpDepositInfo {
+                deposit_receipt_version: receipt.deposit_receipt_version,
+                deposit_nonce: receipt.deposit_nonce,
+            })
+        })
+    } else {
+        None
+    }
+    .unwrap_or_default();
+
+    Ok(OpTransactionInfo::new(tx_info, deposit_meta))
+}
+
+impl IntoRpcTx<op_alloy_rpc_types::Transaction> for OpTxEnvelope {
+    type TxInfo = OpTransactionInfo;
+
+    fn into_rpc_tx(
+        self,
+        signer: Address,
+        tx_info: OpTransactionInfo,
+    ) -> op_alloy_rpc_types::Transaction {
+        op_alloy_rpc_types::Transaction::from_transaction(self.with_signer(signer), tx_info)
+    }
+}
+
 impl TryIntoSimTx<EthereumTxEnvelope<TxEip4844>> for TransactionRequest {
     fn try_into_sim_tx(self) -> Result<EthereumTxEnvelope<TxEip4844>, ValueError<Self>> {
         Self::build_typed_simulate_transaction(self)
     }
 }
 
+impl TryIntoSimTx<OpTxEnvelope> for TransactionRequest {
+    fn try_into_sim_tx(self) -> Result<OpTxEnvelope, ValueError<Self>> {
+        let request: OpTransactionRequest = self.into();
+        let tx = request.build_typed_tx().map_err(|request| {
+            ValueError::new(request.as_ref().clone(), "Required fields missing")
+        })?;
+
+        // Create an empty signature for the transaction.
+        let signature = Signature::new(Default::default(), Default::default(), false);
+
+        Ok(tx.into_signed(signature).into())
+    }
+}
+
 /// Error that occurred during conversions into RPC response.
 #[derive(Debug, Clone, Error)]
 pub enum CompatError {
-    /// Error that happens on conversion into transaction RPC response.
+    /// Conversion into transaction RPC response failed.
     #[error("Failed to convert transaction into RPC response")]
     TransactionConversionError,
+    /// Storage access failed.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
 }
 
 /// Generic RPC response object converter for primitives `N` and network `E`.
 #[derive(Debug)]
-pub struct RpcTransactionConverter<N, E, Err>(PhantomData<(N, E, Err)>);
+pub struct RpcTransactionConverter<N, E, Err, Map = ()> {
+    phantom: PhantomData<(N, E, Err)>,
+    mapper: Map,
+}
 
-impl<N, E, Err> Clone for RpcTransactionConverter<N, E, Err> {
+impl<N, E, Err> RpcTransactionConverter<N, E, Err, ()> {
+    /// Creates a new [`RpcTransactionConverter`] with the default mapper.
+    pub const fn new() -> Self {
+        Self::with_mapper(())
+    }
+}
+
+impl<N, E, Err, Map> RpcTransactionConverter<N, E, Err, Map> {
+    /// Creates a new [`RpcTransactionConverter`] with `mapper`.
+    pub const fn with_mapper(mapper: Map) -> Self {
+        Self { phantom: PhantomData, mapper }
+    }
+}
+
+impl<N, E, Err, Map: Clone> Clone for RpcTransactionConverter<N, E, Err, Map> {
     fn clone(&self) -> Self {
-        Default::default()
+        Self::with_mapper(self.mapper.clone())
     }
 }
 
 impl<N, E, Err> Default for RpcTransactionConverter<N, E, Err> {
     fn default() -> Self {
-        Self(PhantomData)
+        Self::new()
     }
 }
 
-impl<N, E, Err> TransactionCompat for RpcTransactionConverter<N, E, Err>
+impl<N, E, Err, Map> TransactionCompat for RpcTransactionConverter<N, E, Err, Map>
 where
     N: NodePrimitives,
     E: Network + Unpin,
@@ -135,6 +234,14 @@ where
         + Sync
         + Send
         + Into<jsonrpsee_types::ErrorObject<'static>>,
+    Map: for<'a> TxInfoMapper<
+            &'a TxTy<N>,
+            Out = <TxTy<N> as IntoRpcTx<<E as Network>::TransactionResponse>>::TxInfo,
+        > + Clone
+        + Debug
+        + Unpin
+        + Send
+        + Sync,
 {
     type Primitives = N;
     type Transaction = <E as Network>::TransactionResponse;
@@ -146,6 +253,8 @@ where
         tx_info: TransactionInfo,
     ) -> Result<Self::Transaction, Self::Error> {
         let (tx, signer) = tx.into_parts();
+        let tx_info = self.mapper.try_map(&tx, tx_info)?;
+
         Ok(tx.into_rpc_tx(signer, tx_info))
     }
 

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -123,7 +123,6 @@ where
     E: Network + Unpin,
     TxTy<N>: IntoRpcTx<<E as Network>::TransactionResponse> + Clone + Debug,
     TransactionRequest: TryIntoSimTx<TxTy<N>>,
-    Self: Send + Sync,
 {
     type Primitives = N;
     type Transaction = <E as Network>::TransactionResponse;

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -173,8 +173,8 @@ impl TryIntoSimTx<OpTxEnvelope> for TransactionRequest {
 
 /// Conversion into transaction RPC response failed.
 #[derive(Debug, Clone, Error)]
-#[error("Failed to convert transaction into RPC response")]
-pub struct TransactionConversionError;
+#[error("Failed to convert transaction into RPC response: {0}")]
+pub struct TransactionConversionError(String);
 
 /// Generic RPC response object converter for primitives `N` and network `E`.
 #[derive(Debug)]
@@ -250,6 +250,6 @@ where
         &self,
         request: TransactionRequest,
     ) -> Result<TxTy<N>, Self::Error> {
-        Ok(request.try_into_sim_tx().map_err(|_| TransactionConversionError)?)
+        Ok(request.try_into_sim_tx().map_err(|e| TransactionConversionError(e.to_string()))?)
     }
 }

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -1,9 +1,6 @@
 //! `EthApiBuilder` implementation
 
-use crate::{
-    eth::{core::EthApiInner, EthTxBuilder},
-    EthApi,
-};
+use crate::{eth::core::EthApiInner, EthApi};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::ChainSpecProvider;
 use reth_node_api::NodePrimitives;
@@ -241,6 +238,6 @@ where
             + Unpin
             + 'static,
     {
-        EthApi { inner: Arc::new(self.build_inner()), tx_resp_builder: EthTxBuilder }
+        EthApi { inner: Arc::new(self.build_inner()), tx_resp_builder: Default::default() }
     }
 }

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -19,7 +19,7 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{
     EthApiError, EthStateCache, FeeHistoryCache, GasCap, GasPriceOracle, PendingBlock,
 };
-use reth_rpc_types_compat::transaction::RpcTransactionConverter;
+use reth_rpc_types_compat::transaction::RpcConverter;
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, NodePrimitivesProvider, ProviderBlock, ProviderReceipt,
 };
@@ -67,7 +67,7 @@ pub struct EthApi<Provider: BlockReader, Pool, Network, EvmConfig> {
     #[deref]
     pub(super) inner: Arc<EthApiInner<Provider, Pool, Network, EvmConfig>>,
     /// Transaction RPC response builder.
-    pub tx_resp_builder: RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError>,
+    pub tx_resp_builder: RpcConverter<EthPrimitives, Ethereum, EthApiError>,
 }
 
 impl<Provider, Pool, Network, EvmConfig> Clone for EthApi<Provider, Pool, Network, EvmConfig>
@@ -160,7 +160,7 @@ where
 {
     type Error = EthApiError;
     type NetworkTypes = Ethereum;
-    type TransactionCompat = RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError>;
+    type TransactionCompat = RpcConverter<EthPrimitives, Ethereum, EthApiError>;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
         &self.tx_resp_builder

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -75,7 +75,7 @@ where
     Provider: BlockReader,
 {
     fn clone(&self) -> Self {
-        Self { inner: self.inner.clone(), tx_resp_builder: Default::default() }
+        Self { inner: self.inner.clone(), tx_resp_builder: self.tx_resp_builder.clone() }
     }
 }
 

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -3,13 +3,12 @@
 
 use std::sync::Arc;
 
-use crate::EthApiBuilder;
+use crate::{eth::helpers::types::EthRpcConverter, EthApiBuilder};
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
 use alloy_network::Ethereum;
 use alloy_primitives::{Bytes, U256};
 use derive_more::Deref;
-use reth_ethereum_primitives::EthPrimitives;
 use reth_node_api::{FullNodeComponents, FullNodeTypes};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, SpawnBlocking},
@@ -19,7 +18,6 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{
     EthApiError, EthStateCache, FeeHistoryCache, GasCap, GasPriceOracle, PendingBlock,
 };
-use reth_rpc_types_compat::transaction::RpcConverter;
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, NodePrimitivesProvider, ProviderBlock, ProviderReceipt,
 };
@@ -67,7 +65,7 @@ pub struct EthApi<Provider: BlockReader, Pool, Network, EvmConfig> {
     #[deref]
     pub(super) inner: Arc<EthApiInner<Provider, Pool, Network, EvmConfig>>,
     /// Transaction RPC response builder.
-    pub tx_resp_builder: RpcConverter<EthPrimitives, Ethereum, EthApiError>,
+    pub tx_resp_builder: EthRpcConverter,
 }
 
 impl<Provider, Pool, Network, EvmConfig> Clone for EthApi<Provider, Pool, Network, EvmConfig>
@@ -160,7 +158,7 @@ where
 {
     type Error = EthApiError;
     type NetworkTypes = Ethereum;
-    type TransactionCompat = RpcConverter<EthPrimitives, Ethereum, EthApiError>;
+    type TransactionCompat = EthRpcConverter;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
         &self.tx_resp_builder

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -9,6 +9,7 @@ use reth_primitives_traits::{Recovered, TxTy};
 use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::TransactionCompat;
+use std::fmt::Debug;
 
 /// A standalone [`EthApiTypes`] implementation for Ethereum.
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -1,59 +1,23 @@
 //! L1 `eth` API types.
 
-use alloy_consensus::TxEnvelope;
-use alloy_network::{Ethereum, Network};
-use alloy_rpc_types::TransactionRequest;
-use alloy_rpc_types_eth::{Transaction, TransactionInfo};
+use alloy_network::Ethereum;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_primitives_traits::{Recovered, TxTy};
 use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcTransactionConverter;
 use std::fmt::Debug;
 
 /// A standalone [`EthApiTypes`] implementation for Ethereum.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct EthereumEthApiTypes(EthTxBuilder);
+#[derive(Debug, Clone, Default)]
+pub struct EthereumEthApiTypes(RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError>);
 
 impl EthApiTypes for EthereumEthApiTypes {
     type Error = EthApiError;
     type NetworkTypes = Ethereum;
-    type TransactionCompat = EthTxBuilder;
+    type TransactionCompat = RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError>;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
         &self.0
-    }
-}
-
-/// Builds RPC transaction response for l1.
-#[derive(Debug, Clone, Copy, Default)]
-#[non_exhaustive]
-pub struct EthTxBuilder;
-
-impl TransactionCompat for EthTxBuilder
-where
-    Self: Send + Sync,
-{
-    type Primitives = EthPrimitives;
-    type Transaction = <Ethereum as Network>::TransactionResponse;
-
-    type Error = EthApiError;
-
-    fn fill(
-        &self,
-        tx: Recovered<TxTy<Self::Primitives>>,
-        tx_info: TransactionInfo,
-    ) -> Result<Self::Transaction, Self::Error> {
-        let tx = tx.convert::<TxEnvelope>();
-        Ok(Transaction::from_transaction(tx, tx_info))
-    }
-
-    fn build_simulate_v1_transaction(
-        &self,
-        request: TransactionRequest,
-    ) -> Result<TxTy<Self::Primitives>, Self::Error> {
-        TransactionRequest::build_typed_simulate_transaction(request)
-            .map_err(|_| EthApiError::TransactionConversionError)
     }
 }
 
@@ -62,12 +26,15 @@ where
 mod tests {
     use super::*;
     use alloy_consensus::{Transaction, TxType};
+    use alloy_rpc_types_eth::TransactionRequest;
     use reth_rpc_eth_types::simulate::resolve_transaction;
+    use reth_rpc_types_compat::RpcTransactionConverter;
     use revm::database::CacheDB;
 
     #[test]
     fn test_resolve_transaction_empty_request() {
-        let builder = EthTxBuilder::default();
+        let builder: RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError> =
+            Default::default();
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
         let tx = TransactionRequest::default();
         let result = resolve_transaction(tx, 21000, 0, 1, &mut db, &builder).unwrap();
@@ -82,7 +49,8 @@ mod tests {
     #[test]
     fn test_resolve_transaction_legacy() {
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
-        let builder = EthTxBuilder::default();
+        let builder: RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError> =
+            Default::default();
 
         let tx = TransactionRequest { gas_price: Some(100), ..Default::default() };
 
@@ -98,7 +66,8 @@ mod tests {
     #[test]
     fn test_resolve_transaction_partial_eip1559() {
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
-        let builder = EthTxBuilder::default();
+        let builder: RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError> =
+            Default::default();
 
         let tx = TransactionRequest {
             max_fee_per_gas: Some(200),

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -7,14 +7,17 @@ use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::RpcConverter;
 use std::fmt::Debug;
 
+/// An [`RpcConverter`] with its generics set to Ethereum specific.
+pub type EthRpcConverter = RpcConverter<EthPrimitives, Ethereum, EthApiError>;
+
 /// A standalone [`EthApiTypes`] implementation for Ethereum.
 #[derive(Debug, Clone, Default)]
-pub struct EthereumEthApiTypes(RpcConverter<EthPrimitives, Ethereum, EthApiError>);
+pub struct EthereumEthApiTypes(EthRpcConverter);
 
 impl EthApiTypes for EthereumEthApiTypes {
     type Error = EthApiError;
     type NetworkTypes = Ethereum;
-    type TransactionCompat = RpcConverter<EthPrimitives, Ethereum, EthApiError>;
+    type TransactionCompat = EthRpcConverter;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
         &self.0
@@ -28,12 +31,11 @@ mod tests {
     use alloy_consensus::{Transaction, TxType};
     use alloy_rpc_types_eth::TransactionRequest;
     use reth_rpc_eth_types::simulate::resolve_transaction;
-    use reth_rpc_types_compat::RpcConverter;
     use revm::database::CacheDB;
 
     #[test]
     fn test_resolve_transaction_empty_request() {
-        let builder: RpcConverter<EthPrimitives, Ethereum, EthApiError> = Default::default();
+        let builder = EthRpcConverter::default();
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
         let tx = TransactionRequest::default();
         let result = resolve_transaction(tx, 21000, 0, 1, &mut db, &builder).unwrap();
@@ -48,7 +50,7 @@ mod tests {
     #[test]
     fn test_resolve_transaction_legacy() {
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
-        let builder: RpcConverter<EthPrimitives, Ethereum, EthApiError> = Default::default();
+        let builder = EthRpcConverter::default();
 
         let tx = TransactionRequest { gas_price: Some(100), ..Default::default() };
 
@@ -64,7 +66,7 @@ mod tests {
     #[test]
     fn test_resolve_transaction_partial_eip1559() {
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
-        let builder: RpcConverter<EthPrimitives, Ethereum, EthApiError> = Default::default();
+        let builder = EthRpcConverter::default();
 
         let tx = TransactionRequest {
             max_fee_per_gas: Some(200),

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -4,17 +4,17 @@ use alloy_network::Ethereum;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
-use reth_rpc_types_compat::RpcTransactionConverter;
+use reth_rpc_types_compat::RpcConverter;
 use std::fmt::Debug;
 
 /// A standalone [`EthApiTypes`] implementation for Ethereum.
 #[derive(Debug, Clone, Default)]
-pub struct EthereumEthApiTypes(RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError>);
+pub struct EthereumEthApiTypes(RpcConverter<EthPrimitives, Ethereum, EthApiError>);
 
 impl EthApiTypes for EthereumEthApiTypes {
     type Error = EthApiError;
     type NetworkTypes = Ethereum;
-    type TransactionCompat = RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError>;
+    type TransactionCompat = RpcConverter<EthPrimitives, Ethereum, EthApiError>;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
         &self.0
@@ -28,13 +28,12 @@ mod tests {
     use alloy_consensus::{Transaction, TxType};
     use alloy_rpc_types_eth::TransactionRequest;
     use reth_rpc_eth_types::simulate::resolve_transaction;
-    use reth_rpc_types_compat::RpcTransactionConverter;
+    use reth_rpc_types_compat::RpcConverter;
     use revm::database::CacheDB;
 
     #[test]
     fn test_resolve_transaction_empty_request() {
-        let builder: RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError> =
-            Default::default();
+        let builder: RpcConverter<EthPrimitives, Ethereum, EthApiError> = Default::default();
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
         let tx = TransactionRequest::default();
         let result = resolve_transaction(tx, 21000, 0, 1, &mut db, &builder).unwrap();
@@ -49,8 +48,7 @@ mod tests {
     #[test]
     fn test_resolve_transaction_legacy() {
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
-        let builder: RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError> =
-            Default::default();
+        let builder: RpcConverter<EthPrimitives, Ethereum, EthApiError> = Default::default();
 
         let tx = TransactionRequest { gas_price: Some(100), ..Default::default() };
 
@@ -66,8 +64,7 @@ mod tests {
     #[test]
     fn test_resolve_transaction_partial_eip1559() {
         let mut db = CacheDB::<reth_revm::db::EmptyDBTyped<reth_errors::ProviderError>>::default();
-        let builder: RpcTransactionConverter<EthPrimitives, Ethereum, EthApiError> =
-            Default::default();
+        let builder: RpcConverter<EthPrimitives, Ethereum, EthApiError> = Default::default();
 
         let tx = TransactionRequest {
             max_fee_per_gas: Some(200),

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -2,27 +2,11 @@
 
 use alloy_network::Ethereum;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_rpc_eth_api::EthApiTypes;
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::RpcConverter;
-use std::fmt::Debug;
 
 /// An [`RpcConverter`] with its generics set to Ethereum specific.
 pub type EthRpcConverter = RpcConverter<EthPrimitives, Ethereum, EthApiError>;
-
-/// A standalone [`EthApiTypes`] implementation for Ethereum.
-#[derive(Debug, Clone, Default)]
-pub struct EthereumEthApiTypes(EthRpcConverter);
-
-impl EthApiTypes for EthereumEthApiTypes {
-    type Error = EthApiError;
-    type NetworkTypes = Ethereum;
-    type TransactionCompat = EthRpcConverter;
-
-    fn tx_resp_builder(&self) -> &Self::TransactionCompat {
-        &self.0
-    }
-}
 
 //tests for simulate
 #[cfg(test)]

--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -15,6 +15,6 @@ pub use core::{EthApi, EthApiFor};
 pub use filter::EthFilter;
 pub use pubsub::EthPubSub;
 
-pub use helpers::{signer::DevSigner, types::EthereumEthApiTypes};
+pub use helpers::signer::DevSigner;
 
 pub use reth_rpc_eth_api::{EthApiServer, EthApiTypes, FullEthApiServer, RpcNodeCore};

--- a/crates/rpc/rpc/src/eth/mod.rs
+++ b/crates/rpc/rpc/src/eth/mod.rs
@@ -15,9 +15,6 @@ pub use core::{EthApi, EthApiFor};
 pub use filter::EthFilter;
 pub use pubsub::EthPubSub;
 
-pub use helpers::{
-    signer::DevSigner,
-    types::{EthTxBuilder, EthereumEthApiTypes},
-};
+pub use helpers::{signer::DevSigner, types::EthereumEthApiTypes};
 
 pub use reth_rpc_eth_api::{EthApiServer, EthApiTypes, FullEthApiServer, RpcNodeCore};

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -57,3 +57,30 @@ db-api = [
     "dep:reth-db-api",
     "dep:reth-trie-db",
 ]
+
+serde = [
+    "reth-ethereum-primitives/serde",
+    "reth-db-models/serde",
+    "reth-execution-types/serde",
+    "reth-primitives-traits/serde",
+    "reth-prune-types/serde",
+    "reth-stages-types/serde",
+    "reth-trie-common/serde",
+    "reth-trie-db?/serde",
+    "revm-database/serde",
+    "reth-ethereum-primitives/serde",
+    "alloy-eips/serde",
+    "alloy-primitives/serde",
+    "alloy-consensus/serde",
+    "alloy-rpc-types-engine/serde",
+]
+
+serde-bincode-compat = [
+    "reth-ethereum-primitives/serde-bincode-compat",
+    "reth-execution-types/serde-bincode-compat",
+    "reth-primitives-traits/serde-bincode-compat",
+    "reth-trie-common/serde-bincode-compat",
+    "reth-ethereum-primitives/serde-bincode-compat",
+    "alloy-eips/serde-bincode-compat",
+    "alloy-consensus/serde-bincode-compat",
+]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -89,6 +89,7 @@ serde = [
     "reth-primitives-traits/serde",
     "reth-ethereum-primitives/serde",
     "reth-chain-state/serde",
+    "reth-storage-api/serde",
 ]
 test-utils = [
     "rand",


### PR DESCRIPTION
Closes #16451
Closes #16498

The trait `TransactionCompat` is manually implemented in a couple of ways. But overall it just facilitates conversions from consensus transaction into rpc response object and from transaction request into simulate transaction. The consensus transaction type can be extracted from `NodePrimitives` and the response object from `Network`.

This PR captures this using the type system by introducing dedicated conversion traits and a universal `TransactionCompat` implementation called `RpcConverter`.