### PR TITLE
fix: correctly set sync gap

### DIFF
--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -224,6 +224,7 @@ where
                 "Target block already reached"
             );
             self.is_etl_ready = true;
+            self.sync_gap = Some(gap);
             return Poll::Ready(Ok(()))
         }
 


### PR DESCRIPTION
Introduced in https://github.com/paradigmxyz/reth/pull/16693

Should fix failing hive tests, we want to always set it to `Some` to make sure that it can be accessed here https://github.com/paradigmxyz/reth/blob/e45a561664254c9e1c1925ecb087f3b042d78865/crates/stages/stages/src/stages/headers.rs#L289-L291

This only occurs during pipeline runs when header stage is already synced (i.e runs from block X to block X). However, because of a bug in pipeline consistency check this is basically always running for archive nodes.

The bug is in this check:
https://github.com/paradigmxyz/reth/blob/e45a561664254c9e1c1925ecb087f3b042d78865/crates/node/builder/src/launch/common.rs#L841-L862

Which will always consider `PruneSenderRecovery` stage inconsistent because it is never run for archive nodes and thus will always have 0 checkpoint. This is not really critical though, so don't think there are any action items here