### PR TITLE
feat(test): rewrite test_engine_tree_valid_and_invalid_forks_with_older_canonical_head_e2e using e2e framework

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -15,8 +15,9 @@ pub mod reorg;
 pub use fork::{CreateFork, ForkBase, SetForkBase, SetForkBaseFromBlockInfo, ValidateFork};
 pub use produce_blocks::{
     AssertMineBlock, BroadcastLatestForkchoice, BroadcastNextNewPayload, CheckPayloadAccepted,
-    GenerateNextPayload, GeneratePayloadAttributes, PickNextBlockProducer, ProduceBlocks,
-    UpdateBlockInfo, UpdateBlockInfoToLatestPayload,
+    ExpectFcuStatus, GenerateNextPayload, GeneratePayloadAttributes, PickNextBlockProducer,
+    ProduceBlocks, ProduceInvalidBlocks, TestFcuToTag, UpdateBlockInfo,
+    UpdateBlockInfoToLatestPayload, ValidateCanonicalTag,
 };
 pub use reorg::{ReorgTarget, ReorgTo, SetReorgTarget};
 


### PR DESCRIPTION
towards #14376

besides the old test it also removes methods no longer used in the unit tests `TestHarness`.

Adds a `ProduceInvalidBlocks` action required by the test, also adds `TestFcuToTag`, `ExpectFcuStatus` and `ValidateCanonicalTag` to improve ergonomics.