### PR TITLE
feat: remove preemptive excess blob gas check

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -198,15 +198,6 @@ pub fn validate_4844_header_standalone<H: BlockHeader>(
         })
     }
 
-    // `excess_blob_gas` must also be a multiple of `DATA_GAS_PER_BLOB`. This will be checked later
-    // (via `calc_excess_blob_gas`), but it doesn't hurt to catch the problem sooner.
-    if excess_blob_gas % DATA_GAS_PER_BLOB != 0 {
-        return Err(ConsensusError::ExcessBlobGasNotMultipleOfBlobGasPerBlob {
-            excess_blob_gas,
-            blob_gas_per_blob: DATA_GAS_PER_BLOB,
-        })
-    }
-
     if blob_gas_used > blob_params.max_blob_gas_per_block() {
         return Err(ConsensusError::BlobGasUsedExceedsMaxBlobGasPerBlock {
             blob_gas_used,

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -185,7 +185,6 @@ pub fn validate_4844_header_standalone<H: BlockHeader>(
     blob_params: BlobParams,
 ) -> Result<(), ConsensusError> {
     let blob_gas_used = header.blob_gas_used().ok_or(ConsensusError::BlobGasUsedMissing)?;
-    let excess_blob_gas = header.excess_blob_gas().ok_or(ConsensusError::ExcessBlobGasMissing)?;
 
     if header.parent_beacon_block_root().is_none() {
         return Err(ConsensusError::ParentBeaconBlockRootMissing)

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -320,17 +320,6 @@ pub enum ConsensusError {
         blob_gas_per_blob: u64,
     },
 
-    /// Error when excess blob gas is not a multiple of blob gas per blob.
-    #[error(
-        "excess blob gas {excess_blob_gas} is not a multiple of blob gas per blob {blob_gas_per_blob}"
-    )]
-    ExcessBlobGasNotMultipleOfBlobGasPerBlob {
-        /// The actual excess blob gas.
-        excess_blob_gas: u64,
-        /// The blob gas per blob.
-        blob_gas_per_blob: u64,
-    },
-
     /// Error when the blob gas used in the header does not match the expected blob gas used.
     #[error("blob gas used mismatch: {0}")]
     BlobGasUsedDiff(GotExpected<u64>),


### PR DESCRIPTION
## Description

Extracted from https://github.com/paradigmxyz/reth/tree/fusaka/devnet1. Remove pre-emptive excess blob gas check as it's no longer feasible after Osaka due to [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918) and was not needed in the first place.