### PR TITLE
fix: include bpo hardforks in forkid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7200,6 +7200,7 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "derive_more",
+ "itertools 0.14.0",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -29,6 +29,7 @@ alloy-consensus.workspace = true
 auto_impl.workspace = true
 serde_json.workspace = true
 derive_more.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 # eth

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1,5 +1,6 @@
 pub use alloy_eips::eip1559::BaseFeeParams;
 use alloy_evm::eth::spec::EthExecutorSpec;
+use itertools::Itertools;
 
 use crate::{
     constants::{MAINNET_DEPOSIT_CONTRACT, MAINNET_PRUNE_DELETE_LIMIT},
@@ -522,23 +523,20 @@ impl ChainSpec {
             }
         }
 
-        let bpo_condition = self
-            .blob_params
-            .scheduled
-            .iter()
-            .map(|(activation, _)| ForkCondition::Timestamp(*activation));
+        let bpo_forks = self.blob_params.scheduled.iter().map(|(activation, _)| *activation);
 
-        let hardforks_iter = self.hardforks.forks_iter().map(|(_, cond)| cond).chain(bpo_condition);
-        // TODO: handle case where more regular hardforks are activated after bpos, needs timestamp
-        // sorting but can be optimized
+        let timestamp_forks = self
+            .hardforks
+            .forks_iter()
+            .filter_map(|(_, cond)| cond.as_timestamp())
+            .chain(bpo_forks)
+            .filter(|time| time > &self.genesis.timestamp)
+            .sorted();
 
         // timestamp are ALWAYS applied after the merge.
         //
         // this filter ensures that no block-based forks are returned
-        for timestamp in hardforks_iter.filter_map(|cond| {
-            // ensure we only get timestamp forks activated __after__ the genesis block
-            cond.as_timestamp().filter(|time| time > &self.genesis.timestamp)
-        }) {
+        for timestamp in timestamp_forks {
             if head.timestamp >= timestamp {
                 // skip duplicated hardfork activated at the same timestamp
                 if timestamp != current_applied {


### PR DESCRIPTION
we need to include bpo timestamps in the forkid calc

this still needs a better followup to handle the case where bpos and regular hardforks are interleaved 