### PR TITLE
chore(ci): update hive expected failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -36,7 +36,6 @@ engine-api: []
 # no fix due to https://github.com/paradigmxyz/reth/issues/8732
 engine-cancun:
   - Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun) (reth)
-  - Invalid NewPayload, ExcessBlobGas, Syncing=True, EmptyTxs=False, DynFeeTxs=False (Cancun) (reth)
 
 sync: []
 


### PR DESCRIPTION
`engine-cancun/Invalid NewPayload, ExcessBlobGas, Syncing=True, EmptyTxs=False, DynFeeTxs=False` is fixed after https://github.com/paradigmxyz/reth/pull/16729, sucessful execution with the changes in this branch here https://github.com/paradigmxyz/reth/actions/runs/15551149493