### PR TITLE
chore: use best perf flags by default in perf dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
-# Build profile, release by default
+# Build profile, maxperf by default
 ARG BUILD_PROFILE=maxperf
 ENV BUILD_PROFILE=$BUILD_PROFILE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,15 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build profile, release by default
-ARG BUILD_PROFILE=release
+ARG BUILD_PROFILE=maxperf
 ENV BUILD_PROFILE=$BUILD_PROFILE
 
 # Extra Cargo flags
-ARG RUSTFLAGS=""
+ARG RUSTFLAGS="-C target-cpu=native"
 ENV RUSTFLAGS="$RUSTFLAGS"
 
 # Extra Cargo features
-ARG FEATURES=""
+ARG FEATURES="jemalloc,asm-keccak"
 ENV FEATURES=$FEATURES
 
 # Builds dependencies


### PR DESCRIPTION
This is so we can use maxperf everything on perfnet