### PR TITLE
feat: reintroduce generic executors

### DIFF
--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -17,7 +17,7 @@
 
 extern crate alloc;
 
-use crate::execute::BasicBlockBuilder;
+use crate::execute::{BasicBlockBuilder, Executor};
 use alloc::vec::Vec;
 use alloy_eips::{
     eip2718::{EIP2930_TX_TYPE_ID, LEGACY_TX_TYPE_ID},
@@ -31,6 +31,7 @@ use alloy_evm::{
 use alloy_primitives::{Address, B256};
 use core::{error::Error, fmt::Debug};
 use execute::{BasicBlockExecutor, BlockAssembler, BlockBuilder};
+use reth_execution_errors::BlockExecutionError;
 use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, ReceiptTy, SealedBlock, SealedHeader, TxTy,
 };
@@ -281,13 +282,19 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
 
     /// Returns a new [`BasicBlockExecutor`].
     #[auto_impl(keep_default_for(&, Arc))]
-    fn executor<DB: Database>(&self, db: DB) -> BasicBlockExecutor<&Self, DB> {
+    fn executor<DB: Database>(
+        &self,
+        db: DB,
+    ) -> impl Executor<DB, Primitives = Self::Primitives, Error = BlockExecutionError> {
         BasicBlockExecutor::new(self, db)
     }
 
     /// Returns a new [`BasicBlockExecutor`].
     #[auto_impl(keep_default_for(&, Arc))]
-    fn batch_executor<DB: Database>(&self, db: DB) -> BasicBlockExecutor<&Self, DB> {
+    fn batch_executor<DB: Database>(
+        &self,
+        db: DB,
+    ) -> impl Executor<DB, Primitives = Self::Primitives, Error = BlockExecutionError> {
         BasicBlockExecutor::new(self, db)
     }
 }

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -12,7 +12,7 @@ mod tests {
     use op_alloy_consensus::TxDeposit;
     use op_revm::constants::L1_BLOCK_CONTRACT;
     use reth_chainspec::MIN_TRANSACTION_GAS;
-    use reth_evm::{execute::Executor, ConfigureEvm};
+    use reth_evm::execute::{BasicBlockExecutor, Executor};
     use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
     use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
     use reth_primitives_traits::{Account, RecoveredBlock};
@@ -90,7 +90,7 @@ mod tests {
         .into();
 
         let provider = evm_config(chain_spec);
-        let mut executor = provider.batch_executor(StateProviderDatabase::new(&db));
+        let mut executor = BasicBlockExecutor::new(provider, StateProviderDatabase::new(&db));
 
         // make sure the L1 block contract state is preloaded.
         executor.with_state_mut(|state| {
@@ -163,7 +163,7 @@ mod tests {
         .into();
 
         let provider = evm_config(chain_spec);
-        let mut executor = provider.batch_executor(StateProviderDatabase::new(&db));
+        let mut executor = BasicBlockExecutor::new(provider, StateProviderDatabase::new(&db));
 
         // make sure the L1 block contract state is preloaded.
         executor.with_state_mut(|state| {


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/16621

Changes `ConfigureEvm::executor`/`ConfigureEvm::batch_executor` to return `impl Executor<DB>` instead of a concrete executor implementation.

Usecases requiring abstraction on this level are kind of out of scope of our abstraction an e.g won't propagate the custom logic to RPC but it's not that big of change and I'm ok with doing it for backwards compatiblility