### PR TITLE
fix: small networking fixes

### DIFF
--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -83,12 +83,16 @@ impl Peer {
     }
 
     /// Applies a reputation change to the peer and returns what action should be taken.
-    pub fn apply_reputation(&mut self, reputation: i32) -> ReputationChangeOutcome {
+    pub fn apply_reputation(
+        &mut self,
+        reputation: i32,
+        kind: ReputationChangeKind,
+    ) -> ReputationChangeOutcome {
         let previous = self.reputation;
         // we add reputation since negative reputation change decrease total reputation
         self.reputation = previous.saturating_add(reputation);
 
-        trace!(target: "net::peers", reputation=%self.reputation, banned=%self.is_banned(), "applied reputation change");
+        trace!(target: "net::peers", reputation=%self.reputation, banned=%self.is_banned(), ?kind, "applied reputation change");
 
         if self.state.is_connected() && self.is_banned() {
             self.state.disconnect();

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -480,7 +480,7 @@ impl PeersManager {
                         reputation_change = MAX_TRUSTED_PEER_REPUTATION_CHANGE;
                     }
                 }
-                peer.apply_reputation(reputation_change)
+                peer.apply_reputation(reputation_change, rep)
             }
         } else {
             return


### PR DESCRIPTION
Right now, before the initial backfill sync starts, the node assumes itself synced which is wrong and results in peers getting penalized for sending "invalid" transactions while we're just not able to validate them:
https://github.com/paradigmxyz/reth/blob/85ddd1f366404b88517dcad445cccd4e92039efc/crates/net/network/src/transactions/mod.rs#L459-L462

This PR changes the logic to only set the pipeline state to `SyncState::Idle` once the live sync starts

