### PR TITLE
fix: don't use target-cpu=native in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG BUILD_PROFILE=maxperf
 ENV BUILD_PROFILE=$BUILD_PROFILE
 
 # Extra Cargo flags
-ARG RUSTFLAGS="-C target-cpu=native"
+ARG RUSTFLAGS=""
 ENV RUSTFLAGS="$RUSTFLAGS"
 
 # Extra Cargo features


### PR DESCRIPTION
newest dockerfiles failed at runtime on the perfnet nodes, it's either this or asm-keccak, but will try removing this first