### PR TITLE
chore: update performance revm pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,16 +1418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "aurora-engine-modexp"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
-dependencies = [
- "hex",
- "num",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4402,7 +4392,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -5773,20 +5763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5795,15 +5771,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -5818,28 +5785,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -6051,7 +5996,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "5.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -10513,7 +10458,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "24.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10531,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "4.0.1"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -10543,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "5.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10558,7 +10503,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "5.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10573,7 +10518,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "4.0.1"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10586,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "4.0.1"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10597,7 +10542,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "5.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10614,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "5.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10650,7 +10595,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "20.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10661,14 +10606,13 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "21.0.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
- "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
@@ -10686,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "19.1.0"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10696,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "4.0.1"
-source = "git+https://github.com/rjected/revm?branch=dan%2Fgmp-24.0#48630a4693334a6b809ac045b407a8c4c396f22a"
+source = "git+https://github.com/bluealloy/revm?branch=performance#4e684364276fcfb8bb1a8b07fec0e0fecb2c031e"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -12406,7 +12350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c032d68a49d25d9012a864fef1c64ac17aee43c87e0477bf7301d8ae8bfea7b7"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -12952,7 +12896,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -730,17 +730,17 @@ vergen-git2 = "1.0.5"
 # alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
 # alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
 
-revm = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-op-revm = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-bytecode = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-database = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-state = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-primitives = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-interpreter = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-inspector = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-context = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-context-interface = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
-revm-database-interface = { git = "https://github.com/rjected/revm", branch = "dan/gmp-24.0" }
+revm = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+op-revm = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-database = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-state = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-context = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "performance" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "performance" }
 # alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "main" }
 # alloy-op-evm = { git = "https://github.com/alloy-rs/evm", branch = "main" }
 #


### PR DESCRIPTION
Patch revm to performance branch: https://github.com/bluealloy/revm/tree/performance

Based on revm 24, includes some PRs for perf: https://github.com/bluealloy/revm/compare/main...performance
