### PR TITLE
feat: add shared local block range info between SessionManager and ActiveSession

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -116,6 +116,9 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
         Option<(PollSender<ActiveSessionMessage<N>>, ActiveSessionMessage<N>)>,
     /// The eth69 range info for the remote peer.
     pub(crate) range_info: Option<BlockRangeInfo>,
+    /// The eth69 range info for the local node (this node).
+    /// This represents the range of blocks that this node can serve to other peers.
+    pub(crate) local_range_info: BlockRangeInfo,
 }
 
 impl<N: NetworkPrimitives> ActiveSession<N> {
@@ -998,6 +1001,11 @@ mod tests {
                         protocol_breach_request_timeout: PROTOCOL_BREACH_REQUEST_TIMEOUT,
                         terminate_message: None,
                         range_info: None,
+                        local_range_info: BlockRangeInfo::new(
+                            0,
+                            1000,
+                            alloy_primitives::B256::ZERO,
+                        ),
                     }
                 }
                 ev => {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -672,11 +672,6 @@ impl<N: NetworkPrimitives> SessionManager<N> {
     /// and the shared local range information that gets propagated to active sessions (Eth69).
     /// The range information is used in ETH69 protocol where peers announce the range of blocks
     /// they can serve to optimize data synchronization.
-    ///
-    /// # Arguments
-    ///
-    /// * `block_range_update` - The new block range information containing the earliest and latest
-    ///   block numbers and the hash of the latest block.
     pub(crate) fn update_advertised_block_range(&mut self, block_range_update: BlockRangeUpdate) {
         self.status.earliest_block = Some(block_range_update.earliest);
         self.status.latest_block = Some(block_range_update.latest);

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -116,6 +116,9 @@ pub struct SessionManager<N: NetworkPrimitives> {
     metrics: SessionManagerMetrics,
     /// The [`EthRlpxHandshake`] is used to perform the initial handshake with the peer.
     handshake: Arc<dyn EthRlpxHandshake>,
+    /// Shared local range information that gets propagated to active sessions.
+    /// This represents the range of blocks that this node can serve to other peers.
+    local_range_info: BlockRangeInfo,
 }
 
 // === impl SessionManager ===
@@ -136,6 +139,13 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         let (pending_sessions_tx, pending_sessions_rx) = mpsc::channel(config.session_event_buffer);
         let (active_session_tx, active_session_rx) = mpsc::channel(config.session_event_buffer);
         let active_session_tx = PollSender::new(active_session_tx);
+
+        // Initialize local range info from the status
+        let local_range_info = BlockRangeInfo::new(
+            status.earliest_block.unwrap_or_default(),
+            status.latest_block.unwrap_or_default(),
+            status.blockhash,
+        );
 
         Self {
             next_id: 0,
@@ -159,6 +169,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
             disconnections_counter: Default::default(),
             metrics: Default::default(),
             handshake,
+            local_range_info,
         }
     }
 
@@ -544,6 +555,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     protocol_breach_request_timeout: self.protocol_breach_request_timeout,
                     terminate_message: None,
                     range_info: None,
+                    local_range_info: self.local_range_info.clone(),
                 };
 
                 self.spawn(session);
@@ -653,13 +665,29 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         }
     }
 
-    pub(crate) const fn update_advertised_block_range(
-        &mut self,
-        block_range_update: BlockRangeUpdate,
-    ) {
+    /// Updates the advertised block range that this node can serve to other peers starting with
+    /// Eth69.
+    ///
+    /// This method updates both the local status message that gets sent to peers during handshake
+    /// and the shared local range information that gets propagated to active sessions (Eth69).
+    /// The range information is used in ETH69 protocol where peers announce the range of blocks
+    /// they can serve to optimize data synchronization.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_range_update` - The new block range information containing the earliest and latest
+    ///   block numbers and the hash of the latest block.
+    pub(crate) fn update_advertised_block_range(&mut self, block_range_update: BlockRangeUpdate) {
         self.status.earliest_block = Some(block_range_update.earliest);
         self.status.latest_block = Some(block_range_update.latest);
         self.status.blockhash = block_range_update.latest_hash;
+
+        // Update the shared local range info that gets propagated to active sessions
+        self.local_range_info.update(
+            block_range_update.earliest,
+            block_range_update.latest,
+            block_range_update.latest_hash,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Add shared `local_range_info` field to both SessionManager and ActiveSession for ETH69 protocol support
- Update `update_advertised_block_range` method to maintain both status and shared range information

## Test plan
- [x] Existing tests pass
- [x] Compilation succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)