### PR TITLE
fix: set parent beacon block to zero hash if parent's beacon block is Some

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -71,7 +71,9 @@ where
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),
-            parent_beacon_block_root: parent.parent_beacon_block_root(),
+            parent_beacon_block_root: parent
+                .parent_beacon_block_root()
+                .and_then(|_| Some(B256::ZERO)),
             withdrawals: None,
         })
     }

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -71,9 +71,7 @@ where
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),
-            parent_beacon_block_root: parent
-                .parent_beacon_block_root()
-                .and_then(|_| Some(B256::ZERO)),
+            parent_beacon_block_root: parent.parent_beacon_block_root().map(|_| B256::ZERO),
             withdrawals: None,
         })
     }


### PR DESCRIPTION
resolves https://github.com/paradigmxyz/reth/issues/16734