### PR TITLE
fix: resolve external ip on launch

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -256,7 +256,7 @@ impl Discv4 {
             Discv4Service::new(socket, local_addr, local_node_record, secret_key, config);
 
         // resolve the external address immediately
-        service.resolve_external_ip().await;
+        service.resolve_external_ip();
 
         let discv4 = service.handle();
         Ok((discv4, service))
@@ -625,10 +625,10 @@ impl Discv4Service {
         self.lookup_interval = tokio::time::interval(duration);
     }
 
-    /// Frocefully resolves the external ip and updates it if successful.
-    async fn resolve_external_ip(&mut self) {
+    /// Sets the external Ip to the configured external IP if [`NatResolver::ExternalIp`].
+    fn resolve_external_ip(&mut self) {
         if let Some(r) = &self.resolve_external_ip_interval {
-            if let Some(external_ip) = r.resolver().external_addr().await {
+            if let Some(external_ip) = r.resolver().as_external_ip() {
                 self.set_external_ip_addr(external_ip);
             }
         }

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -252,7 +252,12 @@ impl Discv4 {
         local_node_record.udp_port = local_addr.port();
         trace!(target: "discv4", ?local_addr,"opened UDP socket");
 
-        let service = Discv4Service::new(socket, local_addr, local_node_record, secret_key, config);
+        let mut service =
+            Discv4Service::new(socket, local_addr, local_node_record, secret_key, config);
+
+        // resolve the external address immediately
+        service.resolve_external_ip().await;
+
         let discv4 = service.handle();
         Ok((discv4, service))
     }
@@ -618,6 +623,15 @@ impl Discv4Service {
     /// Sets the [Interval] used for periodically looking up targets over the network
     pub fn set_lookup_interval(&mut self, duration: Duration) {
         self.lookup_interval = tokio::time::interval(duration);
+    }
+
+    /// Frocefully resolves the external ip and updates it if successful.
+    async fn resolve_external_ip(&mut self) {
+        if let Some(r) = &self.resolve_external_ip_interval {
+            if let Some(external_ip) = r.resolver().external_addr().await {
+                self.set_external_ip_addr(external_ip);
+            }
+        }
     }
 
     /// Sets the given ip address as the node's external IP in the node record announced in

--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -161,6 +161,11 @@ impl ResolveNatInterval {
         Self::with_interval(resolver, interval)
     }
 
+    /// Returns the resolver used by this interval
+    pub const fn resolver(&self) -> &NatResolver {
+        &self.resolver
+    }
+
     /// Completes when the next [`IpAddr`] in the interval has been reached.
     pub async fn tick(&mut self) -> Option<IpAddr> {
         poll_fn(|cx| self.poll_tick(cx)).await


### PR DESCRIPTION
closes #16766

we only resolved the external ip on first poll, we should resolve it right away when the launch the service so it is already set when we start peering.

https://github.com/paradigmxyz/reth/blob/d670dfea8f630c0dc365569fcc90efd22f9d2bb5/crates/net/discv4/src/lib.rs#L1719-L1723