### PR TITLE
feat(examples): Add `extension` into `engine_getPayload` RPC method response in `custom_node` example

### DIFF
--- a/examples/custom-node/src/engine_api.rs
+++ b/examples/custom-node/src/engine_api.rs
@@ -27,15 +27,20 @@ pub struct CustomExecutionPayloadInput {}
 #[derive(Clone, serde::Serialize)]
 pub struct CustomExecutionPayloadEnvelope {
     execution_payload: ExecutionPayloadV3,
+    extension: u64,
 }
 
 impl From<CustomBuiltPayload> for CustomExecutionPayloadEnvelope {
     fn from(value: CustomBuiltPayload) -> Self {
         let sealed_block = value.0.into_sealed_block();
         let hash = sealed_block.hash();
+        let extension = sealed_block.header().extension;
         let block = sealed_block.into_block();
 
-        Self { execution_payload: ExecutionPayloadV3::from_block_unchecked(hash, &block.clone()) }
+        Self {
+            execution_payload: ExecutionPayloadV3::from_block_unchecked(hash, &block.clone()),
+            extension,
+        }
     }
 }
 


### PR DESCRIPTION
# Motivation
The engine API of the custom node accepts `extension` field, which is an attribute of the `CustomBlockHeader`.

But the `engine_getPayload` does not include this field.

Since it is part of the payload that I wrote, it should be included when I read it.
