### PR TITLE
fix(era): Rollback state of `StartingStream` if fetching file list fails

### DIFF
--- a/crates/era-downloader/src/stream.rs
+++ b/crates/era-downloader/src/stream.rs
@@ -264,7 +264,11 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static + Unpin> Stream for Starti
             if let Poll::Ready(result) = self.fetch_file_list.poll_unpin(cx) {
                 match result {
                     Ok(_) => self.recover_index(),
-                    Err(e) => return Poll::Ready(Some(Box::pin(async move { Err(e) }))),
+                    Err(e) => {
+                        self.fetch_file_list();
+
+                        return Poll::Ready(Some(Box::pin(async move { Err(e) })))
+                    }
                 }
             }
         }

--- a/crates/era-downloader/tests/it/stream.rs
+++ b/crates/era-downloader/tests/it/stream.rs
@@ -32,3 +32,20 @@ async fn test_streaming_files_after_fetching_file_list(url: &str) {
 
     assert_eq!(actual_file.as_ref(), expected_file.as_ref());
 }
+
+#[tokio::test]
+async fn test_streaming_files_after_fetching_file_list_into_missing_folder_fails() {
+    let base_url = Url::from_str("https://era.ithaca.xyz/era1/index.html").unwrap();
+    let folder = tempdir().unwrap().path().to_owned().into_boxed_path();
+    let client = EraClient::new(StubClient, base_url, folder.clone());
+
+    let mut stream = EraStream::new(
+        client,
+        EraStreamConfig::default().with_max_files(2).with_max_concurrent_downloads(1),
+    );
+
+    let actual_error = stream.next().await.unwrap().unwrap_err().to_string();
+    let expected_error = "No such file or directory (os error 2)".to_owned();
+
+    assert_eq!(actual_error, expected_error);
+}


### PR DESCRIPTION
Fixes the issue when `EraStream` would reexecute the finished async fn triggerring panic hiding the actual error

```
thread 'tokio-runtime-worker' panicked at /home/roman/work/reth/crates/era-downloader/src/stream.rs:326:27:
`async fn` resumed after completion
```