### PR TITLE
feat: add to_message convenience method to BlockRangeInfo

### DIFF
--- a/crates/net/network/src/session/types.rs
+++ b/crates/net/network/src/session/types.rs
@@ -87,39 +87,3 @@ pub(crate) struct BlockRangeInfoInner {
     /// Latest available block's hash.
     latest_hash: RwLock<B256>,
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_primitives::B256;
-
-    #[test]
-    fn test_block_range_info_to_message() {
-        let earliest = 100;
-        let latest = 200;
-        let hash = B256::from([1; 32]);
-
-        let range_info = BlockRangeInfo::new(earliest, latest, hash);
-        let message = range_info.to_message();
-
-        assert_eq!(message.earliest, earliest);
-        assert_eq!(message.latest, latest);
-        assert_eq!(message.latest_hash, hash);
-    }
-
-    #[test]
-    fn test_block_range_info_update_and_to_message() {
-        let range_info = BlockRangeInfo::new(0, 0, B256::ZERO);
-
-        let new_earliest = 500;
-        let new_latest = 1000;
-        let new_hash = B256::from([42; 32]);
-
-        range_info.update(new_earliest, new_latest, new_hash);
-        let message = range_info.to_message();
-
-        assert_eq!(message.earliest, new_earliest);
-        assert_eq!(message.latest, new_latest);
-        assert_eq!(message.latest_hash, new_hash);
-    }
-}


### PR DESCRIPTION
## Summary
- Add missing convenience function to convert \ to \ message
