### PR TITLE
chore: pin hive and add test to expected failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -40,6 +40,9 @@ engine-api: []
 # no fix due to https://github.com/paradigmxyz/reth/issues/8732
 engine-cancun:
   - Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun) (reth)
+  # the test fails with older verions of the code for which it passed before, probably related to changes
+  # in hive or its dependencies
+  - Blob Transaction Ordering, Multiple Clients (Cancun) (reth)
 
 sync: []
 

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ethereum/hive
-          ref: master
+          # TODO: unpin when https://github.com/ethereum/hive/issues/1306 is fixed
+          ref: edd9969338dd1798ba2e61f049c7e3a15cef53e6
           path: hivetests
 
       - uses: actions/setup-go@v5


### PR DESCRIPTION
prevents failures after hive changes, successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/15614798585