### PR TITLE
Allow payload jobs to stay alive after getPayload call

### DIFF
--- a/crates/ethereum/cli/src/debug_cmd/build_block.rs
+++ b/crates/ethereum/cli/src/debug_cmd/build_block.rs
@@ -23,6 +23,7 @@ use reth_execution_types::ExecutionOutcome;
 use reth_fs_util as fs;
 use reth_node_api::{BlockTy, EngineApiMessageVersion, PayloadBuilderAttributes};
 use reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig};
+use reth_payload_builder::KeepPayloadJobAlive;
 use reth_primitives_traits::{Block as _, SealedBlock, SealedHeader, SignedTransaction};
 use reth_provider::{
     providers::{BlockchainProvider, ProviderNodeTypes},
@@ -199,6 +200,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                 payload_attrs,
                 EngineApiMessageVersion::default() as u8,
             )?,
+            KeepPayloadJobAlive::No,
         );
 
         let args = BuildArguments::new(

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -148,7 +148,7 @@ where
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
 {
     let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
-    let PayloadConfig { parent_header, attributes } = config;
+    let PayloadConfig { parent_header, attributes, keep_alive: _ } = config;
 
     let state_provider = client.state_by_block_hash(parent_header.hash())?;
     let state = StateProviderDatabase::new(&state_provider);

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -95,8 +95,7 @@ where
 
         let payload_job_config = BasicPayloadJobGeneratorConfig::default()
             .interval(conf.interval)
-            .deadline(conf.deadline)
-            .max_payload_tasks(conf.max_payload_tasks);
+            .deadline(conf.deadline);
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
@@ -105,7 +104,7 @@ where
             payload_builder,
         );
         let (payload_service, payload_service_handle) =
-            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
+            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream(), conf.max_payload_tasks);
 
         ctx.task_executor().spawn_critical("payload builder service", Box::pin(payload_service));
 

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -29,6 +29,7 @@ use reth_optimism_txpool::{
     interop::{is_valid_interop, MaybeInteropTransaction},
     OpPooledTx,
 };
+use reth_payload_builder::KeepPayloadJobAlive;
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_payload_util::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
@@ -183,7 +184,7 @@ where
         let attributes = OpPayloadBuilderAttributes::try_new(parent.hash(), attributes, 3)
             .map_err(PayloadBuilderError::other)?;
 
-        let config = PayloadConfig { parent_header: Arc::new(parent), attributes };
+        let config = PayloadConfig { parent_header: Arc::new(parent), attributes, keep_alive: KeepPayloadJobAlive::No };
         let ctx = OpPayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
             da_config: self.config.da_config.clone(),

--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -201,6 +201,7 @@ where
                     config: PayloadConfig {
                         parent_header: args.config.parent_header.clone(),
                         attributes: left_attr.clone(),
+                        keep_alive: args.config.keep_alive,
                     },
                     cancel: args.cancel.clone(),
                     best_payload: args.best_payload.clone().and_then(|payload| {
@@ -220,6 +221,7 @@ where
                     config: PayloadConfig {
                         parent_header: args.config.parent_header.clone(),
                         attributes: right_attr.clone(),
+                        keep_alive: args.config.keep_alive,
                     },
                     cancel: args.cancel.clone(),
                     best_payload: args.best_payload.clone().and_then(|payload| {
@@ -245,6 +247,7 @@ where
                 let left_config = PayloadConfig {
                     parent_header: config.parent_header.clone(),
                     attributes: left_attr,
+                    keep_alive: config.keep_alive,
                 };
                 self.left.build_empty_payload(left_config).map(Either::Left)
             }
@@ -252,6 +255,7 @@ where
                 let right_config = PayloadConfig {
                     parent_header: config.parent_header.clone(),
                     attributes: right_attr,
+                    keep_alive: config.keep_alive,
                 };
                 self.right.build_empty_payload(right_config).map(Either::Right)
             }

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -33,7 +33,7 @@ where
             BuiltPayload = EthBuiltPayload,
         > + 'static,
 {
-    PayloadBuilderService::new(Default::default(), futures_util::stream::empty())
+    PayloadBuilderService::new(Default::default(), futures_util::stream::empty(), 3)
 }
 
 /// Creates a new [`PayloadBuilderService`] for testing purposes and spawns it in the background.

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -69,8 +69,7 @@ where
 
         let payload_job_config = BasicPayloadJobGeneratorConfig::default()
             .interval(conf.interval())
-            .deadline(conf.deadline())
-            .max_payload_tasks(conf.max_payload_tasks());
+            .deadline(conf.deadline());
 
         let payload_generator = EmptyBlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
@@ -80,7 +79,7 @@ where
         );
 
         let (payload_service, payload_builder) =
-            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
+            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream(), conf.max_payload_tasks());
 
         ctx.task_executor()
             .spawn_critical("custom payload builder service", Box::pin(payload_service));


### PR DESCRIPTION
Rationale
-----
Chainweb is a PoW L1 consensus layer which uses multiple parallel EVMs as execution layers. We want to keep payload build jobs alive even after a payload is requested, because there's no telling when a block will be mined, and we want to have fresh payloads ready for mining inside the CL at all times.

Behavior for other consensus layers should remain the same.

Description
-----
- Major change: instead of using a semaphore to limit payload job concurrency, use a fixed size circular buffer to store the list of running payload jobs, throwing out older jobs as the capacity is exceeded.
- Allows making deadlines for payload jobs optional.
- Allows configuring a BasicPayloadJobGenerator to keep jobs alive after payloads are requested.

Behavior should remain the same for other consensus layers, because their payload jobs will still die after payloads are requested, still be subject to a deadline, and have the same concurrency level.

Breaking Changes
-----
- `PayloadConfig` now contains a new member `keep_alive: KeepPayloadJobAlive`.
- `max_payload_tasks` is no longer configurable for a `BasicPayloadJobGeneratorConfig`. Instead, it's a new parameter to `PayloadBuilderService::new`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210452994957439