### PR TITLE
feat: make EthereumConsensusBuilder generic over chainSpec

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -398,7 +398,9 @@ pub struct EthereumConsensusBuilder {
 
 impl<Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec:EthChainSpec+EthereumHardforks, Primitives = EthPrimitives>>,
+    Node: FullNodeTypes<
+        Types: NodeTypes<ChainSpec: EthChainSpec + EthereumHardforks, Primitives = EthPrimitives>,
+    >,
 {
     type Consensus = Arc<dyn FullConsensus<EthPrimitives, Error = ConsensusError>>;
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -398,7 +398,7 @@ pub struct EthereumConsensusBuilder {
 
 impl<Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = EthPrimitives>>,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec:EthChainSpec+EthereumHardforks, Primitives = EthPrimitives>>,
 {
     type Consensus = Arc<dyn FullConsensus<EthPrimitives, Error = ConsensusError>>;
 


### PR DESCRIPTION
I'm kicking off Reth SDK adoption at Berachain.

Projects like ours may start by only wanting to tweak the ChainSpec type, while reusing things like the `EthereumConsensusBuilder`, `EthereumNetworkBuilder` etc. 

This change allows us to reduce lines of code by not having to reimplement `EthereumConsensusBuilder` because our chain spec type is different.

Feel free to close if already in progress