### PR TITLE
feat(gas_oracle): implement median-based priority fee suggestion for Optimism

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -244,9 +244,8 @@ where
     }
 
     async fn suggested_priority_fee(&self) -> Result<U256, Self::Error> {
-        let base_tip = self.inner.eth_api.gas_oracle().suggest_tip_cap().await?;
         let min_tip = U256::from(self.inner.min_suggested_priority_fee);
-        Ok(base_tip.max(min_tip))
+        self.inner.eth_api.gas_oracle().op_suggest_tip_cap(min_tip).await.map_err(Into::into)
     }
 }
 

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -300,20 +300,28 @@ where
         // find the maximum gas used by any of the transactions in the block to use as the
         // capacity margin for the block, if no receipts are found return the
         // suggested_min_priority_fee
-        let Some(max_gas_used) = self
+        let Some(max_tx_gas_used) = self
             .cache
             .get_receipts(header.hash())
             .await?
             .ok_or(EthApiError::ReceiptsNotFound(BlockId::latest()))?
-            .iter()
-            .map(|r| r.cumulative_gas_used())
+            // get the gas used by each transaction in the block, by subtracting the
+            // cumulative gas used of the previous transaction from the cumulative gas used of the
+            // current transaction. This is because there is no gas_used() method on the Receipt
+            // trait.
+            .windows(2)
+            .map(|window| {
+                let prev = window[0].cumulative_gas_used();
+                let curr = window[1].cumulative_gas_used();
+                curr - prev
+            })
             .max()
         else {
             return Ok(suggestion);
         };
 
         // if the block is at capacity, the suggestion must be increased
-        if header.gas_used() + max_gas_used > header.gas_limit() {
+        if header.gas_used() + max_tx_gas_used > header.gas_limit() {
             let Some(median_tip) = self.get_block_median_tip(header.hash()).await? else {
                 return Ok(suggestion);
             };


### PR DESCRIPTION
Resolve #16669 by implementing the op-geth's fee suggestion logic.

I created a separate `op_suggest_tip_cap`. But the overall architecture of `gas-price` module may be refactored.

Here are some remarks:
- In op-geth, there is a unique `suggest_tip_cap` function, and the specific OP logic is triggered by checking the chain type. For Reth the current trait bounds for `GasPriceOracle<Provider>` do not include `EthChainSpec` to implement the exactly the same logic (I tried to add it but it breaks at other levels, eg. EthApiBuilder)
- On the other hand, this new OP-specific `GasPriceOracle` logic may be moved to optimism crate, with something like `OpGasPriceOracle`

Please, let me know what do you think about it...