### PR TITLE
feat(cli): Create `folder` in chain specific data directory for `import-era` command

### DIFF
--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -2,14 +2,14 @@
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use alloy_chains::{ChainKind, NamedChain};
 use clap::{Args, Parser};
-use eyre::{eyre, OptionExt};
+use eyre::eyre;
 use reqwest::{Client, Url};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_era_downloader::{read_dir, EraClient, EraStream, EraStreamConfig};
 use reth_era_utils as era;
 use reth_etl::Collector;
-use reth_node_core::{dirs::data_dir, version::SHORT_VERSION};
+use reth_node_core::version::SHORT_VERSION;
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
@@ -81,7 +81,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
                 Some(url) => url,
                 None => self.env.chain.chain().kind().try_to_url()?,
             };
-            let folder = data_dir().ok_or_eyre("Missing data directory")?.join("era");
+            let folder =
+                self.env.datadir.resolve_datadir(self.env.chain.chain()).data_dir().join("era");
+
             let folder = folder.into_boxed_path();
             let client = EraClient::new(Client::new(), url, folder);
             let stream = EraStream::new(client, EraStreamConfig::default());


### PR DESCRIPTION
The `folder` was created in the general `reth` data directory. Since the ERA files are chain specific, so should be the directory. This is also consistent with ERA stage.