### PR TITLE
refactor(era): Remove `start_from` from `EraClient` and use it instead of last file index

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -1,5 +1,4 @@
-use crate::BLOCKS_PER_FILE;
-use alloy_primitives::{hex, hex::ToHexExt, BlockNumber};
+use alloy_primitives::{hex, hex::ToHexExt};
 use bytes::Bytes;
 use eyre::{eyre, OptionExt};
 use futures_util::{stream::StreamExt, Stream, TryStreamExt};
@@ -42,7 +41,6 @@ pub struct EraClient<Http> {
     client: Http,
     url: Url,
     folder: Box<Path>,
-    start_from: Option<u64>,
 }
 
 impl<Http: HttpClient + Clone> EraClient<Http> {
@@ -50,15 +48,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
 
     /// Constructs [`EraClient`] using `client` to download from `url` into `folder`.
     pub fn new(client: Http, url: Url, folder: impl Into<Box<Path>>) -> Self {
-        Self { client, url, folder: folder.into(), start_from: None }
-    }
-
-    /// Overrides the starting ERA file based on `block_number`.
-    ///
-    /// The normal behavior is that the index is recovered based on files contained in the `folder`.
-    pub const fn start_from(mut self, block_number: BlockNumber) -> Self {
-        self.start_from.replace(block_number / BLOCKS_PER_FILE);
-        self
+        Self { client, url, folder: folder.into() }
     }
 
     /// Performs a GET request on `url` and stores the response body into a file located within
@@ -125,11 +115,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     }
 
     /// Recovers index of file following the latest downloaded file from a different run.
-    pub async fn recover_index(&self) -> u64 {
-        if let Some(block_number) = self.start_from {
-            return block_number;
-        }
-
+    pub async fn recover_index(&self) -> Option<usize> {
         let mut max = None;
 
         if let Ok(mut dir) = fs::read_dir(&self.folder).await {
@@ -137,18 +123,18 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                 if let Some(name) = entry.file_name().to_str() {
                     if let Some(number) = self.file_name_to_number(name) {
                         if max.is_none() || matches!(max, Some(max) if number > max) {
-                            max.replace(number);
+                            max.replace(number + 1);
                         }
                     }
                 }
             }
         }
 
-        max.map(|v| v + 1).unwrap_or(0)
+        max
     }
 
     /// Returns a download URL for the file corresponding to `number`.
-    pub async fn url(&self, number: u64) -> eyre::Result<Option<Url>> {
+    pub async fn url(&self, number: usize) -> eyre::Result<Option<Url>> {
         Ok(self.number_to_file_name(number).await?.map(|name| self.url.join(&name)).transpose()?)
     }
 
@@ -229,7 +215,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     }
 
     /// Returns ERA1 file name that is ordered at `number`.
-    pub async fn number_to_file_name(&self, number: u64) -> eyre::Result<Option<String>> {
+    pub async fn number_to_file_name(&self, number: usize) -> eyre::Result<Option<String>> {
         let path = self.folder.to_path_buf().join("index");
         let file = File::open(&path).await?;
         let reader = io::BufReader::new(file);
@@ -241,8 +227,8 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
         Ok(lines.next_line().await?)
     }
 
-    fn file_name_to_number(&self, file_name: &str) -> Option<u64> {
-        file_name.split('-').nth(1).and_then(|v| u64::from_str(v).ok())
+    fn file_name_to_number(&self, file_name: &str) -> Option<usize> {
+        file_name.split('-').nth(1).and_then(|v| usize::from_str(v).ok())
     }
 }
 
@@ -262,7 +248,7 @@ mod tests {
     #[test_case("mainnet-00000-a81ae85f.era1", Some(0))]
     #[test_case("00000-a81ae85f.era1", None)]
     #[test_case("", None)]
-    fn test_file_name_to_number(file_name: &str, expected_number: Option<u64>) {
+    fn test_file_name_to_number(file_name: &str, expected_number: Option<usize>) {
         let client = EraClient::empty();
 
         let actual_number = client.file_name_to_number(file_name);

--- a/crates/era-downloader/src/fs.rs
+++ b/crates/era-downloader/src/fs.rs
@@ -45,7 +45,7 @@ pub fn read_dir(
 
     entries.sort_by(|(left, _), (right, _)| left.cmp(right));
 
-    Ok(stream::iter(entries.into_iter().skip((start_from / BLOCKS_PER_FILE) as usize).map(
+    Ok(stream::iter(entries.into_iter().skip(start_from as usize / BLOCKS_PER_FILE).map(
         move |(_, path)| {
             let expected_checksum =
                 checksums.next().transpose()?.ok_or_eyre("Got less checksums than ERA files")?;

--- a/crates/era-downloader/src/lib.rs
+++ b/crates/era-downloader/src/lib.rs
@@ -42,4 +42,4 @@ pub use client::{EraClient, HttpClient};
 pub use fs::read_dir;
 pub use stream::{EraMeta, EraStream, EraStreamConfig};
 
-pub(crate) const BLOCKS_PER_FILE: u64 = 8192;
+pub(crate) const BLOCKS_PER_FILE: usize = 8192;

--- a/crates/era-downloader/src/stream.rs
+++ b/crates/era-downloader/src/stream.rs
@@ -1,4 +1,4 @@
-use crate::{client::HttpClient, EraClient};
+use crate::{client::HttpClient, EraClient, BLOCKS_PER_FILE};
 use alloy_primitives::BlockNumber;
 use futures_util::{stream::FuturesOrdered, FutureExt, Stream, StreamExt};
 use reqwest::Url;
@@ -24,7 +24,7 @@ use std::{
 pub struct EraStreamConfig {
     max_files: usize,
     max_concurrent_downloads: usize,
-    start_from: Option<BlockNumber>,
+    start_from: Option<usize>,
 }
 
 impl Default for EraStreamConfig {
@@ -47,11 +47,8 @@ impl EraStreamConfig {
     }
 
     /// Overrides the starting ERA file index to be the first one that contains `block_number`.
-    ///
-    /// The normal behavior is that the ERA file index is recovered from the last file inside the
-    /// download folder.
     pub const fn start_from(mut self, block_number: BlockNumber) -> Self {
-        self.start_from.replace(block_number);
+        self.start_from.replace(block_number as usize / BLOCKS_PER_FILE);
         self
     }
 }
@@ -93,11 +90,12 @@ impl<Http> EraStream<Http> {
                 client,
                 files_count: Box::pin(async move { usize::MAX }),
                 next_url: Box::pin(async move { Ok(None) }),
-                recover_index: Box::pin(async move { 0 }),
+                recover_index: Box::pin(async move { None }),
                 fetch_file_list: Box::pin(async move { Ok(()) }),
                 state: Default::default(),
                 max_files: config.max_files,
-                index: 0,
+                index: config.start_from.unwrap_or_default(),
+                last: None,
                 downloading: 0,
             },
         }
@@ -223,11 +221,12 @@ struct StartingStream<Http> {
     client: EraClient<Http>,
     files_count: Pin<Box<dyn Future<Output = usize> + Send + Sync + 'static>>,
     next_url: Pin<Box<dyn Future<Output = eyre::Result<Option<Url>>> + Send + Sync + 'static>>,
-    recover_index: Pin<Box<dyn Future<Output = u64> + Send + Sync + 'static>>,
+    recover_index: Pin<Box<dyn Future<Output = Option<usize>> + Send + Sync + 'static>>,
     fetch_file_list: Pin<Box<dyn Future<Output = eyre::Result<()>> + Send + Sync + 'static>>,
     state: State,
     max_files: usize,
-    index: u64,
+    index: usize,
+    last: Option<usize>,
     downloading: usize,
 }
 
@@ -274,15 +273,18 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static + Unpin> Stream for Starti
         }
 
         if self.state == State::RecoverIndex {
-            if let Poll::Ready(index) = self.recover_index.poll_unpin(cx) {
-                self.index = index;
+            if let Poll::Ready(last) = self.recover_index.poll_unpin(cx) {
+                self.last = last;
                 self.count_files();
             }
         }
 
         if self.state == State::CountFiles {
             if let Poll::Ready(downloaded) = self.files_count.poll_unpin(cx) {
-                let max_missing = self.max_files.saturating_sub(downloaded + self.downloading);
+                let max_missing = self
+                    .max_files
+                    .saturating_sub(downloaded + self.downloading)
+                    .max(self.last.unwrap_or_default().saturating_sub(self.index));
                 self.state = State::Missing(max_missing);
             }
         }
@@ -349,7 +351,7 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static> StartingStream<Http> {
         self.state = State::CountFiles;
     }
 
-    fn next_url(&mut self, index: u64, max_missing: usize) {
+    fn next_url(&mut self, index: usize, max_missing: usize) {
         let client = self.client.clone();
 
         Pin::new(&mut self.next_url).set(Box::pin(async move { client.url(index).await }));

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -67,7 +67,7 @@ where
                 let client = EraClient::new(Client::new(), url, folder);
 
                 Self::convert(EraStream::new(
-                    client.start_from(input.next_block()),
+                    client,
                     EraStreamConfig::default().start_from(input.next_block()),
                 ))
             }


### PR DESCRIPTION
Improves robustness as:
* There is a single source of truth for the start index
* Counts missing files as a difference of last and current index to prevent freezes due to dirty download directory on restart
* Changes index type `u64` => `usize` to reduce the number of conversions