### PR TITLE
feat(era): Accept anything that converts into `Box<Path>` as `folder` of `EraClient`

### DIFF
--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -85,8 +85,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
             let folder =
                 self.env.datadir.resolve_datadir(self.env.chain.chain()).data_dir().join("era");
 
-            let folder = folder.into_boxed_path();
-
             fs::create_dir_all(&folder)?;
 
             let client = EraClient::new(Client::new(), url, folder);

--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -49,8 +49,8 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     const CHECKSUMS: &'static str = "checksums.txt";
 
     /// Constructs [`EraClient`] using `client` to download from `url` into `folder`.
-    pub const fn new(client: Http, url: Url, folder: Box<Path>) -> Self {
-        Self { client, url, folder, start_from: None }
+    pub fn new(client: Http, url: Url, folder: impl Into<Box<Path>>) -> Self {
+        Self { client, url, folder: folder.into(), start_from: None }
     }
 
     /// Overrides the starting ERA file based on `block_number`.
@@ -254,11 +254,7 @@ mod tests {
 
     impl EraClient<Client> {
         fn empty() -> Self {
-            Self::new(
-                Client::new(),
-                Url::from_str("file:///").unwrap(),
-                PathBuf::new().into_boxed_path(),
-            )
+            Self::new(Client::new(), Url::from_str("file:///").unwrap(), PathBuf::new())
         }
     }
 

--- a/crates/era-downloader/src/lib.rs
+++ b/crates/era-downloader/src/lib.rs
@@ -12,7 +12,7 @@
 //! let url = Url::from_str("file:///")?;
 //!
 //! // Directory where the ERA1 files will be downloaded to
-//! let folder = PathBuf::new().into_boxed_path();
+//! let folder = PathBuf::new();
 //!
 //! let client = EraClient::new(Client::new(), url, folder);
 //!

--- a/crates/era-downloader/tests/it/checksums.rs
+++ b/crates/era-downloader/tests/it/checksums.rs
@@ -14,8 +14,8 @@ use test_case::test_case;
 async fn test_invalid_checksum_returns_error(url: &str) {
     let base_url = Url::from_str(url).unwrap();
     let folder = tempdir().unwrap();
-    let folder = folder.path().to_owned().into_boxed_path();
-    let client = EraClient::new(FailingClient, base_url, folder.clone());
+    let folder = folder.path();
+    let client = EraClient::new(FailingClient, base_url, folder);
 
     let mut stream = EraStream::new(
         client,

--- a/crates/era-downloader/tests/it/download.rs
+++ b/crates/era-downloader/tests/it/download.rs
@@ -13,7 +13,7 @@ use test_case::test_case;
 async fn test_getting_file_url_after_fetching_file_list(url: &str) {
     let base_url = Url::from_str(url).unwrap();
     let folder = tempdir().unwrap();
-    let folder = folder.path().to_owned().into_boxed_path();
+    let folder = folder.path();
     let client = EraClient::new(StubClient, base_url.clone(), folder);
 
     client.fetch_file_list().await.unwrap();
@@ -31,7 +31,7 @@ async fn test_getting_file_url_after_fetching_file_list(url: &str) {
 async fn test_getting_file_after_fetching_file_list(url: &str) {
     let base_url = Url::from_str(url).unwrap();
     let folder = tempdir().unwrap();
-    let folder = folder.path().to_owned().into_boxed_path();
+    let folder = folder.path();
     let mut client = EraClient::new(StubClient, base_url, folder);
 
     client.fetch_file_list().await.unwrap();

--- a/crates/era-downloader/tests/it/list.rs
+++ b/crates/era-downloader/tests/it/list.rs
@@ -13,7 +13,7 @@ use test_case::test_case;
 async fn test_getting_file_name_after_fetching_file_list(url: &str) {
     let url = Url::from_str(url).unwrap();
     let folder = tempdir().unwrap();
-    let folder = folder.path().to_owned().into_boxed_path();
+    let folder = folder.path();
     let client = EraClient::new(StubClient, url, folder);
 
     client.fetch_file_list().await.unwrap();

--- a/crates/era-downloader/tests/it/stream.rs
+++ b/crates/era-downloader/tests/it/stream.rs
@@ -14,8 +14,8 @@ use test_case::test_case;
 async fn test_streaming_files_after_fetching_file_list(url: &str) {
     let base_url = Url::from_str(url).unwrap();
     let folder = tempdir().unwrap();
-    let folder = folder.path().to_owned().into_boxed_path();
-    let client = EraClient::new(StubClient, base_url, folder.clone());
+    let folder = folder.path();
+    let client = EraClient::new(StubClient, base_url, folder);
 
     let mut stream = EraStream::new(
         client,
@@ -36,8 +36,8 @@ async fn test_streaming_files_after_fetching_file_list(url: &str) {
 #[tokio::test]
 async fn test_streaming_files_after_fetching_file_list_into_missing_folder_fails() {
     let base_url = Url::from_str("https://era.ithaca.xyz/era1/index.html").unwrap();
-    let folder = tempdir().unwrap().path().to_owned().into_boxed_path();
-    let client = EraClient::new(StubClient, base_url, folder.clone());
+    let folder = tempdir().unwrap().path().to_owned();
+    let client = EraClient::new(StubClient, base_url, folder);
 
     let mut stream = EraStream::new(
         client,

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -15,7 +15,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
 
     // Directory where the ERA1 files will be downloaded to
     let folder = tempdir().unwrap();
-    let folder = folder.path().to_owned().into_boxed_path();
+    let folder = folder.path();
 
     let client = EraClient::new(ClientWithFakeIndex(Client::new()), url, folder);
 

--- a/crates/era/tests/it/main.rs
+++ b/crates/era/tests/it/main.rs
@@ -115,7 +115,7 @@ impl Era1TestDownloader {
 
         let final_url = Url::from_str(url).map_err(|e| eyre!("Failed to parse URL: {}", e))?;
 
-        let folder = self.temp_dir.path().to_owned().into_boxed_path();
+        let folder = self.temp_dir.path();
 
         // set up the client
         let client = EraClient::new(Client::new(), final_url, folder);


### PR DESCRIPTION
It's unneeded to require `Box<Path>` as that can be delegated to already implemented `Into<Box<Path>>` implementations, making for an API that accepts wider range of arguments.