### PR TITLE
fix(era): Commit all writers and save stages checkpoint per file in `import`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7991,6 +7991,7 @@ dependencies = [
  "reth-fs-util",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-stages-types",
  "reth-storage-api",
  "tempfile",
  "tokio",

--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -71,12 +71,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
         let Environment { provider_factory, config, .. } = self.env.init::<N>(AccessRights::RW)?;
 
         let mut hash_collector = Collector::new(config.stages.etl.file_size, config.stages.etl.dir);
-        let provider_factory = &provider_factory.provider_rw()?.0;
 
         if let Some(path) = self.import.path {
             let stream = read_dir(path, 0)?;
 
-            era::import(stream, provider_factory, &mut hash_collector)?;
+            era::import(stream, &provider_factory, &mut hash_collector)?;
         } else {
             let url = match self.import.url {
                 Some(url) => url,
@@ -92,7 +91,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
             let client = EraClient::new(Client::new(), url, folder);
             let stream = EraStream::new(client, EraStreamConfig::default());
 
-            era::import(stream, provider_factory, &mut hash_collector)?;
+            era::import(stream, &provider_factory, &mut hash_collector)?;
         }
 
         Ok(())

--- a/crates/era-utils/Cargo.toml
+++ b/crates/era-utils/Cargo.toml
@@ -20,6 +20,7 @@ reth-era-downloader.workspace = true
 reth-etl.workspace = true
 reth-fs-util.workspace = true
 reth-provider.workspace = true
+reth-stages-types.workspace = true
 reth-storage-api.workspace = true
 reth-primitives-traits.workspace = true
 

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -20,7 +20,13 @@ use reth_provider::{
     providers::StaticFileProviderRWRefMut, BlockWriter, ProviderError, StaticFileProviderFactory,
     StaticFileSegment, StaticFileWriter,
 };
-use reth_storage_api::{DBProvider, HeaderProvider, NodePrimitivesProvider, StorageLocation};
+use reth_stages_types::{
+    CheckpointBlockRange, EntitiesCheckpoint, HeadersCheckpoint, StageCheckpoint, StageId,
+};
+use reth_storage_api::{
+    errors::ProviderResult, DBProvider, DatabaseProviderFactory, HeaderProvider,
+    NodePrimitivesProvider, StageCheckpointWriter, StorageLocation,
+};
 use std::{
     collections::Bound,
     error::Error,
@@ -35,22 +41,26 @@ use tracing::info;
 /// Imports blocks from `downloader` using `provider`.
 ///
 /// Returns current block height.
-pub fn import<Downloader, Era, P, B, BB, BH>(
+pub fn import<Downloader, Era, PF, B, BB, BH>(
     mut downloader: Downloader,
-    provider: &P,
+    provider_factory: &PF,
     hash_collector: &mut Collector<BlockHash, BlockNumber>,
 ) -> eyre::Result<BlockNumber>
 where
     B: Block<Header = BH, Body = BB>,
     BH: FullBlockHeader + Value,
     BB: FullBlockBody<
-        Transaction = <<P as NodePrimitivesProvider>::Primitives as NodePrimitives>::SignedTx,
+        Transaction = <<<PF as DatabaseProviderFactory>::ProviderRW as NodePrimitivesProvider>::Primitives as NodePrimitives>::SignedTx,
         OmmerHeader = BH,
     >,
     Downloader: Stream<Item = eyre::Result<Era>> + Send + 'static + Unpin,
     Era: EraMeta + Send + 'static,
-    P: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + BlockWriter<Block = B>,
-    <P as NodePrimitivesProvider>::Primitives: NodePrimitives<BlockHeader = BH, BlockBody = BB>,
+    PF: DatabaseProviderFactory<
+        ProviderRW: BlockWriter<Block = B>
+            + DBProvider
+            + NodePrimitivesProvider<Primitives: NodePrimitives<Block = B, BlockHeader = BH, BlockBody = BB>>
+            + StageCheckpointWriter,
+    > + StaticFileProviderFactory<Primitives = <<PF as DatabaseProviderFactory>::ProviderRW as NodePrimitivesProvider>::Primitives>,
 {
     let (tx, rx) = mpsc::channel();
 
@@ -62,7 +72,7 @@ where
         tx.send(None)
     });
 
-    let static_file_provider = provider.static_file_provider();
+    let static_file_provider = provider_factory.static_file_provider();
 
     // Consistency check of expected headers in static files vs DB is done on provider::sync_gap
     // when poll_execute_ready is polled.
@@ -78,15 +88,59 @@ where
     // Although headers were downloaded in reverse order, the collector iterates it in ascending
     // order
     let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
+    let mut total = 0;
 
     while let Some(meta) = rx.recv()? {
+        let from = last_header_number;
+        let provider = provider_factory.database_provider_rw()?;
+
         last_header_number =
-            process(&meta?, &mut writer, provider, hash_collector, &mut td, last_header_number..)?;
+            process(&meta?, &mut writer, &provider, hash_collector, &mut td, last_header_number..)?;
+
+        total += 1;
+        save_stage_checkpoints(&provider, from, last_header_number, 1, total)?;
+
+        writer.commit()?;
+        provider.commit()?;
     }
 
-    build_index(provider, hash_collector)?;
+    let provider = provider_factory.database_provider_rw()?;
+
+    build_index(&provider, hash_collector)?;
+
+    provider.commit()?;
 
     Ok(last_header_number)
+}
+
+/// Saves progress of ERA import into stages sync.
+///
+/// Since the ERA import does the same work as `HeaderStage` and `BodyStage`, it needs to inform
+/// these stages that this work has already been done. Otherwise, there might be some conflict with
+/// database integrity.
+pub fn save_stage_checkpoints<P>(
+    provider: &P,
+    from: BlockNumber,
+    to: BlockNumber,
+    processed: u64,
+    total: u64,
+) -> ProviderResult<()>
+where
+    P: StageCheckpointWriter,
+{
+    provider.save_stage_checkpoint(
+        StageId::Headers,
+        StageCheckpoint::new(to).with_headers_stage_checkpoint(HeadersCheckpoint {
+            block_range: CheckpointBlockRange { from, to },
+            progress: EntitiesCheckpoint { processed, total },
+        }),
+    )?;
+    provider.save_stage_checkpoint(
+        StageId::Bodies,
+        StageCheckpoint::new(to)
+            .with_entities_stage_checkpoint(EntitiesCheckpoint { processed, total }),
+    )?;
+    Ok(())
 }
 
 /// Extracts block headers and bodies from `meta` and appends them using `writer` and `provider`.
@@ -116,7 +170,7 @@ where
         OmmerHeader = BH,
     >,
     Era: EraMeta + ?Sized,
-    P: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + BlockWriter<Block = B>,
+    P: DBProvider<Tx: DbTxMut> + NodePrimitivesProvider + BlockWriter<Block = B>,
     <P as NodePrimitivesProvider>::Primitives: NodePrimitives<BlockHeader = BH, BlockBody = BB>,
 {
     let reader = open(meta)?;
@@ -226,7 +280,7 @@ where
         Transaction = <<P as NodePrimitivesProvider>::Primitives as NodePrimitives>::SignedTx,
         OmmerHeader = BH,
     >,
-    P: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + BlockWriter<Block = B>,
+    P: DBProvider<Tx: DbTxMut> + NodePrimitivesProvider + BlockWriter<Block = B>,
     <P as NodePrimitivesProvider>::Primitives: NodePrimitives<BlockHeader = BH, BlockBody = BB>,
 {
     let mut last_header_number = match block_numbers.start_bound() {
@@ -287,7 +341,7 @@ where
         Transaction = <<P as NodePrimitivesProvider>::Primitives as NodePrimitives>::SignedTx,
         OmmerHeader = BH,
     >,
-    P: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + BlockWriter<Block = B>,
+    P: DBProvider<Tx: DbTxMut> + NodePrimitivesProvider + BlockWriter<Block = B>,
     <P as NodePrimitivesProvider>::Primitives: NodePrimitives<BlockHeader = BH, BlockBody = BB>,
 {
     let total_headers = hash_collector.len();

--- a/crates/era-utils/src/lib.rs
+++ b/crates/era-utils/src/lib.rs
@@ -5,4 +5,6 @@
 mod history;
 
 /// Imports history from ERA files.
-pub use history::{build_index, decode, import, open, process, process_iter, ProcessIter};
+pub use history::{
+    build_index, decode, import, open, process, process_iter, save_stage_checkpoints, ProcessIter,
+};

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -31,8 +31,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
     let mut hash_collector = Collector::new(4096, folder);
 
     let expected_block_number = 8191;
-    let actual_block_number =
-        reth_era_utils::import(stream, &pf.provider_rw().unwrap().0, &mut hash_collector).unwrap();
+    let actual_block_number = reth_era_utils::import(stream, &pf, &mut hash_collector).unwrap();
 
     assert_eq!(actual_block_number, expected_block_number);
 }

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -13,10 +13,7 @@ use reth_provider::{
     BlockReader, BlockWriter, DBProvider, HeaderProvider, StageCheckpointWriter,
     StaticFileProviderFactory, StaticFileWriter,
 };
-use reth_stages_api::{
-    CheckpointBlockRange, EntitiesCheckpoint, ExecInput, ExecOutput, HeadersCheckpoint, Stage,
-    StageError, UnwindInput, UnwindOutput,
-};
+use reth_stages_api::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_errors::ProviderError;
 use std::{
@@ -205,22 +202,12 @@ where
                 self.hash_collector.clear();
             }
 
-            provider.save_stage_checkpoint(
-                StageId::Headers,
-                StageCheckpoint::new(height).with_headers_stage_checkpoint(HeadersCheckpoint {
-                    block_range: CheckpointBlockRange {
-                        from: input.checkpoint().block_number,
-                        to: height,
-                    },
-                    progress: EntitiesCheckpoint { processed: height, total: input.target() },
-                }),
-            )?;
-            provider.save_stage_checkpoint(
-                StageId::Bodies,
-                StageCheckpoint::new(height).with_entities_stage_checkpoint(EntitiesCheckpoint {
-                    processed: height,
-                    total: input.target(),
-                }),
+            era::save_stage_checkpoints(
+                &provider,
+                input.checkpoint().block_number,
+                height,
+                height,
+                input.target(),
             )?;
 
             height


### PR DESCRIPTION
Resolves #16059

This change adds a transaction commit that was missing in the all-in-one scenario `era::import`.

After this change the commits are performed per era-file, changes are persistent and recover from interruption.