### PR TITLE
fix: typo in test comment

### DIFF
--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -599,7 +599,7 @@ mod tests {
         ///
         /// 1. If there are any entries in the [`tables::TransactionSenders`] table above a given
         ///    block number.
-        /// 2. If the is no requested block entry in the bodies table, but
+        /// 2. If there is no requested block entry in the bodies table, but
         ///    [`tables::TransactionSenders`] is not empty.
         fn ensure_no_senders_by_block(&self, block: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -460,7 +460,7 @@ mod tests {
         ///
         /// 1. If there are any entries in the [`tables::TransactionHashNumbers`] table above a
         ///    given block number.
-        /// 2. f there is no requested block entry in the bodies table, but
+        /// 2. If there is no requested block entry in the bodies table, but
         ///    [`tables::TransactionHashNumbers`] is    not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -460,7 +460,7 @@ mod tests {
         ///
         /// 1. If there are any entries in the [`tables::TransactionHashNumbers`] table above a
         ///    given block number.
-        /// 2. If the is no requested block entry in the bodies table, but
+        /// 2. f there is no requested block entry in the bodies table, but
         ///    [`tables::TransactionHashNumbers`] is    not empty.
         fn ensure_no_hash_by_block(&self, number: BlockNumber) -> Result<(), TestRunnerError> {
             let body_result = self


### PR DESCRIPTION


**Description:**  
This pull request fixes a typo in the comment for the `ensure_no_senders_by_block` function.  
The phrase `If the is no requested block entry in the bodies table` has been corrected to `If there is no requested block entry in the bodies table` for improved clarity and correctness. No functional code changes were made.