### PR TITLE
feat: re-export MerklePatriciaTrie from reth-ethereum and reth-op

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8105,6 +8105,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
+ "reth-trie-db",
 ]
 
 [[package]]
@@ -9001,6 +9002,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
+ "reth-trie-db",
 ]
 
 [[package]]

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -33,6 +33,7 @@ reth-rpc-eth-types = { workspace = true, optional = true }
 reth-rpc-builder = { workspace = true, optional = true }
 reth-exex = { workspace = true, optional = true }
 reth-trie = { workspace = true, optional = true }
+reth-trie-db = { workspace = true, optional = true }
 reth-node-builder = { workspace = true, optional = true }
 reth-tasks = { workspace = true, optional = true }
 reth-cli-util = { workspace = true, optional = true }
@@ -91,6 +92,7 @@ test-utils = [
     "reth-transaction-pool?/test-utils",
     "reth-evm-ethereum?/test-utils",
     "reth-node-builder?/test-utils",
+    "reth-trie-db?/test-utils",
 ]
 
 full = [
@@ -122,7 +124,7 @@ node = [
     "dep:reth-node-ethereum",
     "dep:reth-node-builder",
     "rpc",
-    "trie",
+    "trie-db",
 ]
 pool = ["dep:reth-transaction-pool"]
 rpc = [
@@ -140,3 +142,4 @@ network = ["dep:reth-network", "tasks", "dep:reth-network-api", "dep:reth-eth-wi
 provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db"]
 storage-api = ["dep:reth-storage-api"]
 trie = ["dep:reth-trie"]
+trie-db = ["trie", "dep:reth-trie-db"]

--- a/crates/ethereum/reth/src/lib.rs
+++ b/crates/ethereum/reth/src/lib.rs
@@ -116,6 +116,10 @@ pub mod node {
 pub mod trie {
     #[doc(inline)]
     pub use reth_trie::*;
+
+    #[cfg(feature = "trie-db")]
+    #[doc(inline)]
+    pub use reth_trie_db::*;
 }
 
 /// Re-exported rpc types

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -33,6 +33,7 @@ reth-rpc-builder = { workspace = true, optional = true }
 reth-exex = { workspace = true, optional = true }
 reth-transaction-pool = { workspace = true, optional = true }
 reth-trie = { workspace = true, optional = true }
+reth-trie-db = { workspace = true, optional = true }
 reth-node-builder = { workspace = true, optional = true }
 reth-tasks = { workspace = true, optional = true }
 reth-cli-util = { workspace = true, optional = true }
@@ -84,6 +85,7 @@ test-utils = [
     "reth-trie?/test-utils",
     "reth-transaction-pool?/test-utils",
     "reth-node-builder?/test-utils",
+    "reth-trie-db?/test-utils",
 ]
 
 full = ["consensus", "evm", "node", "provider", "rpc", "trie", "pool", "network"]
@@ -106,7 +108,7 @@ node = [
     "dep:reth-optimism-node",
     "dep:reth-node-builder",
     "rpc",
-    "trie",
+    "trie-db",
 ]
 rpc = [
     "tasks",
@@ -123,3 +125,4 @@ provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db"]
 pool = ["dep:reth-transaction-pool"]
 storage-api = ["dep:reth-storage-api"]
 trie = ["dep:reth-trie"]
+trie-db = ["trie", "dep:reth-trie-db"]

--- a/crates/optimism/reth/src/lib.rs
+++ b/crates/optimism/reth/src/lib.rs
@@ -124,6 +124,10 @@ pub mod node {
 pub mod trie {
     #[doc(inline)]
     pub use reth_trie::*;
+
+    #[cfg(feature = "trie-db")]
+    #[doc(inline)]
+    pub use reth_trie_db::*;
 }
 
 /// Re-exported rpc types


### PR DESCRIPTION
This PR adds convenient re-exports of `MerklePatriciaTrie` from the `reth-ethereum` and `reth-op` meta crates. Previously, users needed to add `reth-trie-db` as a direct dependency in their Cargo.toml to access this type, as seen in projects like Odyssey.

The changes introduce a new `trie-db` feature that extends the existing `trie` feature to include `reth-trie-db` exports. The `node` feature automatically enables `trie-db` to ensure `MerklePatriciaTrie` is available when building complete node implementations.

This improves developer experience by providing all commonly needed types through the meta crates without requiring additional dependencies.