### PR TITLE
feat(op): export OpEthApiBuilder from reth-optimism-rpc

### DIFF
--- a/crates/optimism/rpc/src/lib.rs
+++ b/crates/optimism/rpc/src/lib.rs
@@ -20,5 +20,5 @@ pub mod witness;
 pub use engine::OpEngineApiClient;
 pub use engine::{OpEngineApi, OpEngineApiServer, OP_ENGINE_CAPABILITIES};
 pub use error::{OpEthApiError, OpInvalidTransactionError, SequencerClientError};
-pub use eth::{OpEthApi, OpReceiptBuilder};
+pub use eth::{OpEthApi, OpEthApiBuilder, OpReceiptBuilder};
 pub use sequencer::SequencerClient;


### PR DESCRIPTION
Adds `OpEthApiBuilder` to the public exports of `reth-optimism-rpc` alongside the existing `OpEthApi` and `OpReceiptBuilder` exports.

This provides access to the builder pattern for constructing the Optimism Ethereum API implementation.