### PR TITLE
fix: validate BlockRangeUpdate message per devp2p spec

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -16,7 +16,7 @@ use crate::{
     status::StatusMessage, BlockRangeUpdate, EthNetworkPrimitives, EthVersion, NetworkPrimitives,
     RawCapabilityMessage, Receipts69, SharedTransactions,
 };
-use alloc::{boxed::Box, sync::Arc};
+use alloc::{boxed::Box, string::String, sync::Arc};
 use alloy_primitives::{
     bytes::{Buf, BufMut},
     Bytes,

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -37,6 +37,9 @@ pub enum MessageError {
     /// Thrown when rlp decoding a message failed.
     #[error("RLP error: {0}")]
     RlpError(#[from] alloy_rlp::Error),
+    /// Other message error with custom message
+    #[error("{0}")]
+    Other(String),
 }
 
 /// An `eth` protocol message, containing a message ID and payload.

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -24,7 +24,7 @@ use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::Gauge;
 use reth_eth_wire::{
     errors::{EthHandshakeError, EthStreamError},
-    message::{EthBroadcastMessage, RequestPair},
+    message::{EthBroadcastMessage, MessageError, RequestPair},
     Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
 };
 use reth_eth_wire_types::RawCapabilityMessage;
@@ -273,6 +273,17 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 on_response!(resp, GetReceipts)
             }
             EthMessage::BlockRangeUpdate(msg) => {
+                // Validate that earliest <= latest according to the spec
+                if msg.earliest > msg.latest {
+                    return OnIncomingMessageOutcome::BadMessage {
+                        error: EthStreamError::InvalidMessage(MessageError::Other(format!(
+                            "invalid block range: earliest ({}) > latest ({})",
+                            msg.earliest, msg.latest
+                        ))),
+                        message: EthMessage::BlockRangeUpdate(msg),
+                    };
+                }
+
                 if let Some(range_info) = self.range_info.as_ref() {
                     range_info.update(msg.earliest, msg.latest, msg.latest_hash);
                 }


### PR DESCRIPTION
Per the [devp2p specification](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#blockrangeupdate-0x11), if `earliest > latest` in a BlockRangeUpdate message, the peer should be disconnected.

This PR adds the missing validation check in the session handler and returns `BadMessage` when the condition is violated, which causes the peer to be disconnected as required by the spec.