### PR TITLE
chore: update op-alloy deps to 0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5925,9 +5925,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931e9d8513773478289283064ee6b49b40247b57e2884782c5a1f01f6d76f93a"
+checksum = "1f83ed68f4d32a807e25e8efa5ea4ca432bbbcffce3223571a0f92fc6d4941fc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5951,9 +5951,9 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a41ad5c040cf34e09cbd8278fb965f3c9c59ad80c4af8be7f2146697c8001e"
+checksum = "734b2d75375cf1ddff6d71be332021383bb04dd2ab753a29892312e4b3ab387d"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5967,9 +5967,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be4e3667dc3ced203d0d5356fa79817852d9deabbc697a8d2b7b4f4204d9e5b"
+checksum = "3cfd25bef0af26c85011e98ca9be0713f855d47e110c6be4a36eebefa1b002f2"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -5977,9 +5977,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a3b08a5ffa27eb527dbde5b2452a9f15c142325e977bfacdaaf56b43de7a25"
+checksum = "59bd889eddcb7d4faec487a6c0f67127218c9b2daadc061177164d6cac552c38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5996,9 +5996,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3524953ce0213b0c654c05ddc93dcb5676347ad05a84a5a25c140cb0c5807bc9"
+checksum = "708c2101fb6ad607ebaf13ee830550c782d551557fd8d1f5f53bba60ac39a9ea"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -505,11 +505,11 @@ alloy-transport-ws = { version = "1.0.9", default-features = false }
 # op
 alloy-op-evm = { version = "0.11", default-features = false }
 alloy-op-hardforks = "0.2.2"
-op-alloy-rpc-types = { version = "0.18", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.18", default-features = false }
-op-alloy-network = { version = "0.18", default-features = false }
-op-alloy-consensus = { version = "0.18", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.18", default-features = false }
+op-alloy-rpc-types = { version = "0.18.2", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.18.2", default-features = false }
+op-alloy-network = { version = "0.18.2", default-features = false }
+op-alloy-consensus = { version = "0.18.2", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.18.2", default-features = false }
 op-alloy-flz = { version = "0.13.1", default-features = false }
 
 # misc

--- a/crates/optimism/primitives/src/transaction/mod.rs
+++ b/crates/optimism/primitives/src/transaction/mod.rs
@@ -6,34 +6,7 @@ mod tx_type;
 #[cfg(test)]
 mod signed;
 
-pub use op_alloy_consensus::{OpTxType, OpTypedTransaction};
-use reth_primitives_traits::Extended;
+pub use op_alloy_consensus::{OpTransaction, OpTxType, OpTypedTransaction};
 
 /// Signed transaction.
 pub type OpTransactionSigned = op_alloy_consensus::OpTxEnvelope;
-
-/// A trait that represents an optimism transaction, mainly used to indicate whether or not the
-/// transaction is a deposit transaction.
-pub trait OpTransaction {
-    /// Whether or not the transaction is a dpeosit transaction.
-    fn is_deposit(&self) -> bool;
-}
-
-impl OpTransaction for op_alloy_consensus::OpTxEnvelope {
-    fn is_deposit(&self) -> bool {
-        Self::is_deposit(self)
-    }
-}
-
-impl<B, T> OpTransaction for Extended<B, T>
-where
-    B: OpTransaction,
-    T: OpTransaction,
-{
-    fn is_deposit(&self) -> bool {
-        match self {
-            Self::BuiltIn(b) => b.is_deposit(),
-            Self::Other(t) => t.is_deposit(),
-        }
-    }
-}

--- a/crates/primitives-traits/src/extended.rs
+++ b/crates/primitives-traits/src/extended.rs
@@ -274,8 +274,28 @@ impl<Eip4844, Tx> From<EthereumTxEnvelope<Eip4844>> for Extended<EthereumTxEnvel
 mod op {
     use crate::Extended;
     use alloy_consensus::error::ValueError;
-    use alloy_primitives::{Signature, B256};
-    use op_alloy_consensus::{OpPooledTransaction, OpTxEnvelope};
+    use alloy_primitives::{Sealed, Signature, B256};
+    use op_alloy_consensus::{OpPooledTransaction, OpTransaction, OpTxEnvelope, TxDeposit};
+
+    impl<B, T> OpTransaction for Extended<B, T>
+    where
+        B: OpTransaction,
+        T: OpTransaction,
+    {
+        fn is_deposit(&self) -> bool {
+            match self {
+                Self::BuiltIn(b) => b.is_deposit(),
+                Self::Other(t) => t.is_deposit(),
+            }
+        }
+
+        fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+            match self {
+                Self::BuiltIn(b) => b.as_deposit(),
+                Self::Other(t) => t.as_deposit(),
+            }
+        }
+    }
 
     impl<Tx> TryFrom<Extended<OpTxEnvelope, Tx>> for Extended<OpPooledTransaction, Tx> {
         type Error = <OpPooledTransaction as TryFrom<OpTxEnvelope>>::Error;

--- a/examples/custom-node/src/primitives/tx.rs
+++ b/examples/custom-node/src/primitives/tx.rs
@@ -8,9 +8,9 @@ use alloy_consensus::{
     SignableTransaction, Signed, Transaction,
 };
 use alloy_eips::{eip2718::Eip2718Result, Decodable2718, Encodable2718, Typed2718};
-use alloy_primitives::{keccak256, Signature, TxHash};
+use alloy_primitives::{keccak256, Sealed, Signature, TxHash};
 use alloy_rlp::{BufMut, Decodable, Encodable, Result as RlpResult};
-use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
 use reth_codecs::{
     alloy::transaction::{FromTxCompact, ToTxCompact},
     Compact,
@@ -242,5 +242,9 @@ impl Compact for CustomTransactionEnvelope {
 impl OpTransaction for CustomTransactionEnvelope {
     fn is_deposit(&self) -> bool {
         false
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        None
     }
 }


### PR DESCRIPTION
Updates all op-alloy dependencies from 0.18 to 0.18.2:
- op-alloy-rpc-types
- op-alloy-rpc-types-engine  
- op-alloy-network
- op-alloy-consensus
- op-alloy-rpc-jsonrpsee

The 0.18.2 release moved the `OpTransaction` trait directly into op-alloy-consensus, so this PR:
- Removes the local `OpTransaction` trait definition from reth-optimism-primitives
- Re-exports `OpTransaction` from op-alloy-consensus instead
- Removes the orphan rule-violating implementation for `Extended` types (no longer needed)

This simplifies the codebase by removing duplicate trait definitions and using the upstream implementation.