### PR TITLE
feat(rpc): Implement `FromConsensusTx` for generic `OpTransaction`

### DIFF
--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -2,8 +2,7 @@
 
 use crate::fees::{CallFees, CallFeesError};
 use alloy_consensus::{
-    error::ValueError, transaction::Recovered, EthereumTxEnvelope, SignableTransaction,
-    Transaction as ConsensusTransaction, TxEip4844,
+    error::ValueError, transaction::Recovered, EthereumTxEnvelope, SignableTransaction, TxEip4844,
 };
 use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
@@ -14,7 +13,7 @@ use alloy_rpc_types_eth::{
 use core::error;
 use op_alloy_consensus::{
     transaction::{OpDepositInfo, OpTransactionInfo},
-    OpTransaction as OpConsensusTransaction, OpTxEnvelope,
+    OpTxEnvelope,
 };
 use op_alloy_rpc_types::OpTransactionRequest;
 use op_revm::OpTransaction;
@@ -124,7 +123,7 @@ pub trait FromConsensusTx<T> {
     fn from_consensus_tx(tx: T, signer: Address, tx_info: Self::TxInfo) -> Self;
 }
 
-impl<T: ConsensusTransaction> FromConsensusTx<T> for Transaction<T> {
+impl<T: alloy_consensus::Transaction> FromConsensusTx<T> for Transaction<T> {
     type TxInfo = TransactionInfo;
 
     fn from_consensus_tx(tx: T, signer: Address, tx_info: Self::TxInfo) -> Self {
@@ -149,7 +148,7 @@ impl<T: ConsensusTransaction> FromConsensusTx<T> for Transaction<T> {
 
 impl<ConsensusTx, RpcTx> IntoRpcTx<RpcTx> for ConsensusTx
 where
-    ConsensusTx: ConsensusTransaction,
+    ConsensusTx: alloy_consensus::Transaction,
     RpcTx: FromConsensusTx<Self>,
 {
     type TxInfo = RpcTx::TxInfo;
@@ -226,7 +225,7 @@ pub fn try_into_op_tx_info<T: ReceiptProvider<Receipt: DepositReceipt>>(
     Ok(OpTransactionInfo::new(tx_info, deposit_meta))
 }
 
-impl<T: OpConsensusTransaction + ConsensusTransaction> FromConsensusTx<T>
+impl<T: op_alloy_consensus::OpTransaction + alloy_consensus::Transaction> FromConsensusTx<T>
     for op_alloy_rpc_types::Transaction<T>
 {
     type TxInfo = OpTransactionInfo;

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -231,31 +231,7 @@ impl<T: op_alloy_consensus::OpTransaction + alloy_consensus::Transaction> FromCo
     type TxInfo = OpTransactionInfo;
 
     fn from_consensus_tx(tx: T, signer: Address, tx_info: Self::TxInfo) -> Self {
-        let base_fee = tx_info.inner.base_fee;
-        let effective_gas_price = if tx.is_deposit() {
-            // For deposits, we must always set the `gasPrice` field to 0 in rpc
-            // deposit tx don't have a gas price field, but serde of `Transaction` will take care of
-            // it
-            0
-        } else {
-            base_fee
-                .map(|base_fee| {
-                    tx.effective_tip_per_gas(base_fee).unwrap_or_default() + base_fee as u128
-                })
-                .unwrap_or_else(|| tx.max_fee_per_gas())
-        };
-
-        Self {
-            inner: Transaction {
-                inner: Recovered::new_unchecked(tx, signer),
-                block_hash: tx_info.inner.block_hash,
-                block_number: tx_info.inner.block_number,
-                transaction_index: tx_info.inner.index,
-                effective_gas_price: Some(effective_gas_price),
-            },
-            deposit_nonce: tx_info.deposit_meta.deposit_nonce,
-            deposit_receipt_version: tx_info.deposit_meta.deposit_receipt_version,
-        }
+        Self::from_transaction(Recovered::new_unchecked(tx, signer), tx_info)
     }
 }
 


### PR DESCRIPTION
To simplify custom node creation, this change relaxes the RPC-Consensus bidirectional conversion from concrete `OpTxEnvelope` to generic type that implements `OpTransaction`.