### PR TITLE
docs: clarify txpool docs

### DIFF
--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -9,7 +9,7 @@ use reth_storage_errors::provider::{ProviderError, ProviderResult};
 
 /// Enum to control transaction hash inclusion.
 ///
-/// This serves as a hint to the provider to include or omit exclude hashes because hashes are
+/// This serves as a hint to the provider to include or omit hashes because hashes are
 /// stored separately and are not always needed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum TransactionVariant {

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -14,7 +14,7 @@ bitflags::bitflags! {
     pub(crate) struct TxState: u8 {
         /// Set to `1` if all ancestor transactions are pending.
         const NO_PARKED_ANCESTORS = 0b10000000;
-        /// Set to `1` of the transaction is either the next transaction of the sender (on chain nonce == tx.nonce) or all prior transactions are also present in the pool.
+        /// Set to `1` if the transaction is either the next transaction of the sender (on chain nonce == tx.nonce) or all prior transactions are also present in the pool.
         const NO_NONCE_GAPS = 0b01000000;
         /// Bit derived from the sender's balance.
         ///


### PR DESCRIPTION
This change refines documentation wording for better precision:

1. Corrects conditional statement in `NO_NONCE_GAPS` comment ("of" → "if")
2. Removes redundant terminology in `TransactionVariant` enum description

Documentation-only changes, no functional modifications.