### PR TITLE
perf: reuse accounts trie in payload processing

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -227,7 +227,7 @@ fn bench_state_root(c: &mut Criterion) {
 
                         (genesis_hash, payload_processor, provider, state_updates)
                     },
-                    |(genesis_hash, payload_processor, provider, state_updates)| {
+                    |(genesis_hash, mut payload_processor, provider, state_updates)| {
                         black_box({
                             let mut handle = payload_processor.spawn(
                                 Default::default(),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2283,7 +2283,7 @@ where
             // background task or try to compute it in parallel
             if use_state_root_task {
                 match handle.state_root() {
-                    Ok(StateRootComputeOutcome { state_root, trie_updates }) => {
+                    Ok(StateRootComputeOutcome { state_root, trie_updates, trie }) => {
                         let elapsed = execution_finish.elapsed();
                         info!(target: "engine::tree", ?state_root, ?elapsed, "State root task finished");
                         // we double check the state root here for good measure
@@ -2297,6 +2297,9 @@ where
                                 "State root task returned incorrect state root"
                             );
                         }
+
+                        // hold on to the sparse trie for the next payload
+                        self.payload_processor.set_sparse_trie(trie);
                     }
                     Err(error) => {
                         debug!(target: "engine::tree", %error, "Background parallel state root computation failed");

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -113,9 +113,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         if let Some(new_trie) = self.state.as_revealed_mut() {
             new_trie.use_allocated_state(trie);
         } else {
-            self.state = SparseTrie::AllocatedEmpty {
-                allocated: trie,
-            };
+            self.state = SparseTrie::AllocatedEmpty { allocated: trie };
         }
     }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     blinded::{BlindedProvider, BlindedProviderFactory, DefaultBlindedProviderFactory},
-    LeafLookup, RevealedSparseTrie, SparseTrie, TrieMasks,
+    LeafLookup, RevealedSparseTrie, SparseTrie, SparseTrieState, TrieMasks,
 };
 use alloc::{collections::VecDeque, vec::Vec};
 use alloy_primitives::{
@@ -105,6 +105,18 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     /// Returns `true` if account was already revealed.
     pub fn is_account_revealed(&self, account: B256) -> bool {
         self.revealed_account_paths.contains(&Nibbles::unpack(account))
+    }
+
+    /// Uses the input `SparseTrieState` to populate the backing data structures in the `state`
+    /// trie.
+    pub fn populate_from(&mut self, trie: SparseTrieState) {
+        if let Some(new_trie) = self.state.as_revealed_mut() {
+            new_trie.use_allocated_state(trie);
+        } else {
+            self.state = SparseTrie::AllocatedEmpty {
+                allocated: trie,
+            };
+        }
     }
 
     /// Was the account witness for `address` complete?
@@ -343,7 +355,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
     ) -> SparseStateTrieResult<()> {
         let FilteredProofNodes {
             nodes,
-            new_nodes,
+            new_nodes: _,
             total_nodes: _total_nodes,
             skipped_nodes: _skipped_nodes,
         } = filter_revealed_nodes(account_subtree, &self.revealed_account_paths)?;
@@ -365,9 +377,6 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
                 },
                 self.retain_updates,
             )?;
-
-            // Reserve the capacity for new nodes ahead of time.
-            trie.reserve_nodes(new_nodes);
 
             // Reveal the remaining proof nodes.
             for (path, node) in account_nodes {
@@ -650,7 +659,7 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         &mut self,
     ) -> SparseStateTrieResult<&mut RevealedSparseTrie<F::AccountNodeProvider>> {
         match self.state {
-            SparseTrie::Blind => {
+            SparseTrie::Blind | SparseTrie::AllocatedEmpty { .. } => {
                 let (root_node, hash_mask, tree_mask) = self
                     .provider_factory
                     .account_node_provider()
@@ -867,6 +876,12 @@ impl<F: BlindedProviderFactory> SparseStateTrie<F> {
         let storage_trie = self.storages.get_mut(&address).ok_or(SparseTrieErrorKind::Blind)?;
         storage_trie.remove_leaf(slot)?;
         Ok(())
+    }
+
+    /// Clears and takes the account trie.
+    pub fn take_cleared_account_trie_state(&mut self) -> SparseTrieState {
+        let trie = core::mem::take(&mut self.state);
+        trie.cleared()
     }
 }
 


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/pull/16181 would panic on the second block executed, this is because we still had some code around from the design that used the `Revealed` variant for the sparse trie for reusing the allocated space. Specifically this was the `revealed_with_provider` method:
https://github.com/paradigmxyz/reth/pull/16181/files#diff-34295e224a9be95b3e7b2b011b905bfb787322f02b666357ab4505394addd8a9R241-R254

In the previous PR, the `populate_from` method was:
```rust
    pub fn populate_from(&mut self, trie: SparseTrieState) {
        if let Some(new_trie) = self.state.as_revealed_mut() {
            new_trie.use_allocated_state(trie);
        } else {
            self.state = SparseTrie::revealed_with_provider(
                self.provider_factory.account_node_provider(),
                trie,
            )
        }
    }
```

This would cause the sparse trie to become a `Revealed` variant, instead of `AllocatedEmpty`. Then, we would call `get_changed_nodes_at_depth`, which expects the root node to be present in a revealed trie, and panic from an unwrap.


Now we do this:
```rust
    pub fn populate_from(&mut self, trie: SparseTrieState) {
        if let Some(new_trie) = self.state.as_revealed_mut() {
            new_trie.use_allocated_state(trie);
        } else {
            self.state = SparseTrie::AllocatedEmpty {
                allocated: trie,
            };
        }
    }
```
which does not cause the node to panic