### PR TITLE
perf: Reduce unnecessary memory copies in `compare_storage_trie_updates`

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1505,8 +1505,8 @@ where
     fn canonical_block_by_hash(&self, hash: B256) -> ProviderResult<Option<ExecutedBlock<N>>> {
         trace!(target: "engine::tree", ?hash, "Fetching executed block by hash");
         // check memory first
-        if let Some(block) = self.state.tree_state.executed_block_by_hash(hash).cloned() {
-            return Ok(Some(block.block))
+        if let Some(block) = self.state.tree_state.executed_block_by_hash(hash) {
+            return Ok(Some(block.block.clone()))
         }
 
         let (block, senders) = self
@@ -1914,12 +1914,13 @@ where
             let old = old
                 .iter()
                 .filter_map(|block| {
-                    let (_, trie) = self
+                    let trie = self
                         .state
                         .tree_state
                         .persisted_trie_updates
-                        .get(&block.recovered_block.hash())
-                        .cloned()?;
+                        .get(&block.recovered_block.hash())?
+                        .1
+                        .clone();
                     Some(ExecutedBlockWithTrieUpdates {
                         block: block.clone(),
                         trie: ExecutedTrieUpdates::Present(trie),

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -218,22 +218,21 @@ fn compare_storage_trie_updates<C: TrieCursor>(
 
     // compare removed nodes
     let mut storage_trie_cursor = trie_cursor()?;
-    for key in task
-        .removed_nodes
-        .iter()
-        .chain(regular.removed_nodes.iter())
-        .cloned()
-        .collect::<BTreeSet<_>>()
+    for key in
+        task.removed_nodes.iter().chain(regular.removed_nodes.iter()).collect::<BTreeSet<_>>()
     {
         let (task_removed, regular_removed) =
-            (task.removed_nodes.contains(&key), regular.removed_nodes.contains(&key));
+            (task.removed_nodes.contains(key), regular.removed_nodes.contains(key));
+        if task_removed == regular_removed {
+            continue;
+        }
         let database_not_exists =
             storage_trie_cursor.seek_exact(key.clone())?.map(|x| x.1).is_none();
         // If the deletion is a no-op, meaning that the entry is not in the
         // database, do not add it to the diff.
-        if task_removed != regular_removed && !database_not_exists {
+        if !database_not_exists {
             diff.removed_nodes.insert(
-                key,
+                key.clone(),
                 EntryDiff {
                     task: task_removed,
                     regular: regular_removed,


### PR DESCRIPTION
This PR optimizes `compare_storage_trie_updates` by eliminating unnecessary memory copies when processing removed nodes that fail the if-branch check.