### PR TITLE
chore(ci): pin kurtosis-op optimism package

### DIFF
--- a/.github/workflows/kurtosis-op.yml
+++ b/.github/workflows/kurtosis-op.yml
@@ -62,7 +62,9 @@ jobs:
           sudo apt update
           sudo apt install kurtosis-cli
           kurtosis engine start
-          kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params.yaml
+          # TODO: unpin optimism-package when https://github.com/ethpandaops/optimism-package/issues/340 is fixed
+          # kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package --args-file .github/assets/kurtosis_op_network_params.yaml
+          kurtosis run --enclave op-devnet github.com/ethpandaops/optimism-package@452133367b693e3ba22214a6615c86c60a1efd5e --args-file .github/assets/kurtosis_op_network_params.yaml
           ENCLAVE_ID=$(curl http://127.0.0.1:9779/api/enclaves | jq --raw-output 'keys[0]')
           GETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-2151908-1-op-geth-op-node-op-kurtosis".public_ports.rpc.number')
           RETH_PORT=$(curl "http://127.0.0.1:9779/api/enclaves/$ENCLAVE_ID/services" | jq '."op-el-2151908-2-op-reth-op-node-op-kurtosis".public_ports.rpc.number')


### PR DESCRIPTION
kurtosis-op workflow started failing like https://github.com/paradigmxyz/reth/actions/runs/15699563869/job/44231514656

this PR pins `optimism-package` to a working commit until https://github.com/ethpandaops/optimism-package/issues/340 is fixed.

successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/15701988215