### PR TITLE
deps: Upgrade `alloy` version `1.0.9` => `1.0.10` and all other deps minor versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6764,9 +6764,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1033,6 +1033,7 @@ mod tests {
     use super::*;
     use alloy_chains::Chain;
     use alloy_consensus::constants::ETH_TO_WEI;
+    use alloy_eips::{eip4844::BLOB_TX_MIN_BLOB_GASPRICE, eip7840::BlobParams};
     use alloy_evm::block::calc::{base_block_reward, block_reward};
     use alloy_genesis::{ChainConfig, GenesisAccount};
     use alloy_primitives::{b256, hex};
@@ -2500,5 +2501,43 @@ Post-merge hard forks (timestamp based):
         for (num_ommers, expected_reward) in cases {
             assert_eq!(block_reward(base_reward, num_ommers), expected_reward);
         }
+    }
+
+    #[test]
+    fn blob_params_from_genesis() {
+        let s = r#"{
+            "blobSchedule": {
+                "cancun":{
+                    "baseFeeUpdateFraction":3338477,
+                    "max":6,
+                    "target":3
+                },
+                "prague":{
+                    "baseFeeUpdateFraction":3338477,
+                    "max":6,
+                    "target":3
+                }
+            }
+        }"#;
+        let config: ChainConfig = serde_json::from_str(s).unwrap();
+        let hardfork_params = config.blob_schedule_blob_params();
+        let expected = BlobScheduleBlobParams {
+            cancun: BlobParams {
+                target_blob_count: 3,
+                max_blob_count: 6,
+                update_fraction: 3338477,
+                min_blob_fee: BLOB_TX_MIN_BLOB_GASPRICE,
+                max_blobs_per_tx: 6,
+            },
+            prague: BlobParams {
+                target_blob_count: 3,
+                max_blob_count: 6,
+                update_fraction: 3338477,
+                min_blob_fee: BLOB_TX_MIN_BLOB_GASPRICE,
+                max_blobs_per_tx: 6,
+            },
+            ..Default::default()
+        };
+        assert_eq!(hardfork_params, expected);
     }
 }


### PR DESCRIPTION
To bring in alloy-rs/alloy#2585 and alloy-rs/alloy#2586, this PR bumps the `alloy` crates using `cargo update`. Apart from `alloy`, the `r-efi` crate is bumped `5.2.0` => `5.3.0`.

Some changes weren't trivial, for example, integrating the breaking change here alloy-rs/alloy#2542, but it only affects tests.