### PR TITLE
docs: update comment for is_eip7702() method

### DIFF
--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -653,7 +653,7 @@ impl MockTransaction {
         matches!(self, Self::Eip2930 { .. })
     }
 
-    /// Checks if the transaction is of the EIP-2930 type.
+    /// Checks if the transaction is of the EIP-7702 type.
     pub const fn is_eip7702(&self) -> bool {
         matches!(self, Self::Eip7702 { .. })
     }


### PR DESCRIPTION
The comment incorrectly described checking for EIP-2930 transaction type, while the method actually checks for EIP-7702 transaction type.
