### PR TITLE
fix: dead link in tracking-state.md

### DIFF
--- a/book/developers/exex/tracking-state.md
+++ b/book/developers/exex/tracking-state.md
@@ -27,7 +27,7 @@ but let's unpack what's going on here:
 
 1. Our ExEx is now a `struct` that contains the context and implements the `Future` trait. It's now pollable (hence `await`-able).
 1. We can't use `self` directly inside our `poll` method, and instead need to acquire a mutable reference to the data inside of the `Pin`.
-   Read more about pinning in [the book](https://rust-lang.github.io/async-book/04_pinning/01_chapter.html).
+   Read more about pinning in [the book](https://rust-lang.github.io/async-book/part-reference/pinning.html).
 1. We also can't use `await` directly inside `poll`, and instead need to poll futures manually.
    We wrap the call to `poll_recv(cx)` into a [`ready!`](https://doc.rust-lang.org/std/task/macro.ready.html) macro,
    so that if the channel of notifications has no value ready, we will instantly return `Poll::Pending` from our Future.


### PR DESCRIPTION
Hey! I updated a broken link in `tracking-state.md` that pointed to an outdated chapter in the async-book about pinning. It's now replaced with the current version:

https://rust-lang.github.io/async-book/part-reference/pinning.html

If it's important to keep access to the old content, the archived version is still available via the Wayback Machine:
https://web.archive.org/web/20250330122732/https://rust-lang.github.io/async-book/04_pinning/01_chapter.html

Either option works, but the current one points to the latest maintained content.
