### PR TITLE
feat: add from_root for ParallelSparseTrie

### DIFF
--- a/crates/trie/sparse/src/parallel_trie.rs
+++ b/crates/trie/sparse/src/parallel_trie.rs
@@ -1,7 +1,8 @@
-use crate::{SparseNode, SparseTrieUpdates};
+use crate::{SparseNode, SparseTrieUpdates, TrieMasks};
 use alloc::vec::Vec;
 use alloy_primitives::map::HashMap;
-use reth_trie_common::Nibbles;
+use reth_execution_errors::SparseTrieResult;
+use reth_trie_common::{Nibbles, TrieNode};
 
 /// A revealed sparse trie with subtries that can be updated in parallel.
 ///
@@ -35,6 +36,56 @@ impl Default for ParallelSparseTrie {
             values: HashMap::default(),
             updates: None,
         }
+    }
+}
+
+impl ParallelSparseTrie {
+    /// Creates a new revealed sparse trie from the given root node.
+    ///
+    /// # Returns
+    ///
+    /// A [`ParallelSparseTrie`] if successful, or an error if revealing fails.
+    pub fn from_root(
+        root_node: TrieNode,
+        masks: TrieMasks,
+        retain_updates: bool,
+    ) -> SparseTrieResult<Self> {
+        let mut trie = Self::default().with_updates(retain_updates);
+        trie.reveal_node(Nibbles::default(), root_node, masks)?;
+        Ok(trie)
+    }
+
+    /// Reveals a trie node if it has not been revealed before.
+    ///
+    /// This internal function decodes a trie node and inserts it into the nodes map.
+    /// It handles different node types (leaf, extension, branch) by appropriately
+    /// adding them to the trie structure and recursively revealing their children.
+    ///
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if successful, or an error if node was not revealed.
+    pub fn reveal_node(
+        &mut self,
+        path: Nibbles,
+        node: TrieNode,
+        masks: TrieMasks,
+    ) -> SparseTrieResult<()> {
+        let _path = path;
+        let _node = node;
+        let _masks = masks;
+        todo!()
+    }
+
+    /// Configures the trie to retain information about updates.
+    ///
+    /// If `retain_updates` is true, the trie will record branch node updates and deletions.
+    /// This information can then be used to efficiently update an external database.
+    pub fn with_updates(mut self, retain_updates: bool) -> Self {
+        if retain_updates {
+            self.updates = Some(SparseTrieUpdates::default());
+        }
+        self
     }
 }
 


### PR DESCRIPTION
This adds a stub for `reveal_node` and a `from_root` method mirroring that of the regular sparse trie.