### PR TITLE
fix(op-reth, rpc): eth_getBlockReceipts err for genesis block in op-reth

### DIFF
--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -40,7 +40,17 @@ where
             let excess_blob_gas = block.excess_blob_gas();
             let timestamp = block.timestamp();
 
-            let mut l1_block_info = reth_optimism_evm::extract_l1_info(block.body())?;
+            let mut l1_block_info = match reth_optimism_evm::extract_l1_info(block.body()) {
+                Ok(l1_block_info) => l1_block_info,
+                Err(err) => {
+                    // If it is the genesis block (i.e block number is 0), there is no L1 info, so
+                    // we return an empty l1_block_info.
+                    if block_number == 0 {
+                        return Ok(Some(vec![]));
+                    }
+                    return Err(err.into());
+                }
+            };
 
             return block
                 .body()


### PR DESCRIPTION
Fixes #16877 

This PR fixes an issue where the eth_getBlockReceipts RPC method would return an error for the genesis block due to the unconditional attempt to extract the L1 Info transaction. Since the genesis block does not contain an L1 Info tx, this behaviour is incompatible with standard RPC semantics.

Compared the behaviour with a call to Alchemy's Optimism Mainnet RPC:
```bash
curl --location 'https://opt-mainnet.g.alchemy.com/v2/<key>' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "eth_getBlockReceipts",
    "params": [
        "0x0"
    ],
    "id": 67
}' | jq

{
  "jsonrpc": "2.0",
  "id": 67,
  "result": []
}
```

Localhost:
```bash
curl --location 'http://localhost:8545' \                                     
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "eth_getBlockReceipts",
    "params": [
        "0x0"
    ],
    "id": 67
}' | jq

{
  "jsonrpc": "2.0",
  "id": 67,
  "result": []
}
```
