### PR TITLE
docs: add security warnings for NippyJar and Compact formats

### DIFF
--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -1,3 +1,13 @@
+/*! 
+ * Compact - A space-efficient encoding format for Ethereum data.
+ * 
+ * # Security Warning
+ * 
+ * The `Compact` encoding format and its implementations are designed for storing 
+ * and retrieving data internally. They are not hardened to safely read potentially malicious data.
+ * This library should not be used to decode untrusted input from external sources without proper validation.
+ */
+
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{format_ident, quote};

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -1,3 +1,13 @@
+/*! 
+ * Compression module for NippyJar format.
+ * 
+ * # Security Warning
+ * 
+ * These compression implementations are designed for storing and retrieving data internally.
+ * They are not hardened to safely read potentially malicious data and could be vulnerable to
+ * decompression bombs or other attacks if used with untrusted input.
+ */
+
 use crate::NippyJarError;
 use serde::{Deserialize, Serialize};
 

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -1,8 +1,12 @@
-//! Immutable data store format.
-//!
-//! *Warning*: The `NippyJar` encoding format and its implementations are
-//! designed for storing and retrieving data internally. They are not hardened
-//! to safely read potentially malicious data.
+/*! 
+ * NippyJar - A file format for storing compressed columnar data.
+ * 
+ * # Security Warning
+ * 
+ * The `NippyJar` and `Compact` encoding formats and their implementations are designed for storing 
+ * and retrieving data internally. They are not hardened to safely read potentially malicious data.
+ * This library should not be used to decode untrusted input from external sources without proper validation.
+ */
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",


### PR DESCRIPTION
Add explicit security warnings in module documentation for NippyJar and Compact formats.

These formats are mentioned in README.md as not being hardened against malicious input,but the warning wasn't properly reflected in the code documentation itself.
This change makes the security considerations more visible to developers.