### PR TITLE
refactor(trie): move auxiliary sparse trie types into modules

### DIFF
--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -5,16 +5,25 @@
 
 extern crate alloc;
 
+pub mod blinded;
+
+mod node;
+use node::*;
+
+mod parallel_trie;
+pub use parallel_trie::*;
+
+mod rlp;
+use rlp::*;
+
 mod state;
 pub use state::*;
 
 mod trie;
 pub use trie::*;
 
-mod parallel_trie;
-pub use parallel_trie::*;
-
-pub mod blinded;
+mod updates;
+use updates::*;
 
 #[cfg(feature = "metrics")]
 mod metrics;

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -8,13 +8,13 @@ extern crate alloc;
 pub mod blinded;
 
 mod node;
-use node::*;
+pub use node::*;
 
 mod parallel_trie;
 pub use parallel_trie::*;
 
 mod rlp;
-use rlp::*;
+pub use rlp::*;
 
 mod state;
 pub use state::*;
@@ -23,7 +23,7 @@ mod trie;
 pub use trie::*;
 
 mod updates;
-use updates::*;
+pub use updates::*;
 
 #[cfg(feature = "metrics")]
 mod metrics;

--- a/crates/trie/sparse/src/node.rs
+++ b/crates/trie/sparse/src/node.rs
@@ -1,0 +1,150 @@
+use alloy_primitives::B256;
+use alloy_trie::{Nibbles, TrieMask};
+use reth_trie_common::TrieNode;
+
+/// Enum representing sparse trie node type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SparseNodeType {
+    /// Empty trie node.
+    Empty,
+    /// A placeholder that stores only the hash for a node that has not been fully revealed.
+    Hash,
+    /// Sparse leaf node.
+    Leaf,
+    /// Sparse extension node.
+    Extension {
+        /// A flag indicating whether the extension node should be stored in the database.
+        store_in_db_trie: Option<bool>,
+    },
+    /// Sparse branch node.
+    Branch {
+        /// A flag indicating whether the branch node should be stored in the database.
+        store_in_db_trie: Option<bool>,
+    },
+}
+
+impl SparseNodeType {
+    pub const fn is_hash(&self) -> bool {
+        matches!(self, Self::Hash)
+    }
+
+    pub const fn is_branch(&self) -> bool {
+        matches!(self, Self::Branch { .. })
+    }
+
+    pub const fn store_in_db_trie(&self) -> Option<bool> {
+        match *self {
+            Self::Extension { store_in_db_trie } | Self::Branch { store_in_db_trie } => {
+                store_in_db_trie
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Enum representing trie nodes in sparse trie.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SparseNode {
+    /// Empty trie node.
+    Empty,
+    /// The hash of the node that was not revealed.
+    Hash(B256),
+    /// Sparse leaf node with remaining key suffix.
+    Leaf {
+        /// Remaining key suffix for the leaf node.
+        key: Nibbles,
+        /// Pre-computed hash of the sparse node.
+        /// Can be reused unless this trie path has been updated.
+        hash: Option<B256>,
+    },
+    /// Sparse extension node with key.
+    Extension {
+        /// The key slice stored by this extension node.
+        key: Nibbles,
+        /// Pre-computed hash of the sparse node.
+        /// Can be reused unless this trie path has been updated.
+        ///
+        /// If [`None`], then the value is not known and should be calculated from scratch.
+        hash: Option<B256>,
+        /// Pre-computed flag indicating whether the trie node should be stored in the database.
+        /// Can be reused unless this trie path has been updated.
+        ///
+        /// If [`None`], then the value is not known and should be calculated from scratch.
+        store_in_db_trie: Option<bool>,
+    },
+    /// Sparse branch node with state mask.
+    Branch {
+        /// The bitmask representing children present in the branch node.
+        state_mask: TrieMask,
+        /// Pre-computed hash of the sparse node.
+        /// Can be reused unless this trie path has been updated.
+        ///
+        /// If [`None`], then the value is not known and should be calculated from scratch.
+        hash: Option<B256>,
+        /// Pre-computed flag indicating whether the trie node should be stored in the database.
+        /// Can be reused unless this trie path has been updated.
+        ///
+        /// If [`None`], then the value is not known and should be calculated from scratch.
+        store_in_db_trie: Option<bool>,
+    },
+}
+
+impl SparseNode {
+    /// Create new sparse node from [`TrieNode`].
+    pub fn from_node(node: TrieNode) -> Self {
+        match node {
+            TrieNode::EmptyRoot => Self::Empty,
+            TrieNode::Leaf(leaf) => Self::new_leaf(leaf.key),
+            TrieNode::Extension(ext) => Self::new_ext(ext.key),
+            TrieNode::Branch(branch) => Self::new_branch(branch.state_mask),
+        }
+    }
+
+    /// Create new [`SparseNode::Branch`] from state mask.
+    pub const fn new_branch(state_mask: TrieMask) -> Self {
+        Self::Branch { state_mask, hash: None, store_in_db_trie: None }
+    }
+
+    /// Create new [`SparseNode::Branch`] with two bits set.
+    pub const fn new_split_branch(bit_a: u8, bit_b: u8) -> Self {
+        let state_mask = TrieMask::new(
+            // set bits for both children
+            (1u16 << bit_a) | (1u16 << bit_b),
+        );
+        Self::Branch { state_mask, hash: None, store_in_db_trie: None }
+    }
+
+    /// Create new [`SparseNode::Extension`] from the key slice.
+    pub const fn new_ext(key: Nibbles) -> Self {
+        Self::Extension { key, hash: None, store_in_db_trie: None }
+    }
+
+    /// Create new [`SparseNode::Leaf`] from leaf key and value.
+    pub const fn new_leaf(key: Nibbles) -> Self {
+        Self::Leaf { key, hash: None }
+    }
+
+    /// Returns `true` if the node is a hash node.
+    pub const fn is_hash(&self) -> bool {
+        matches!(self, Self::Hash(_))
+    }
+}
+
+/// A helper struct used to store information about a node that has been removed
+/// during a deletion operation.
+#[derive(Debug)]
+pub struct RemovedSparseNode {
+    /// The path at which the node was located.
+    pub path: Nibbles,
+    /// The removed node
+    pub node: SparseNode,
+    /// For branch nodes, an optional nibble that should be unset due to the node being removed.
+    ///
+    /// During leaf deletion, this identifies the specific branch nibble path that
+    /// connects to the leaf being deleted. Then when restructuring the trie after deletion,
+    /// this nibble position will be cleared from the branch node's to
+    /// indicate that the child no longer exists.
+    ///
+    /// This is only set for branch nodes that have a direct path to the leaf being deleted.
+    pub unset_branch_nibble: Option<u8>,
+}

--- a/crates/trie/sparse/src/node.rs
+++ b/crates/trie/sparse/src/node.rs
@@ -24,14 +24,17 @@ pub enum SparseNodeType {
 }
 
 impl SparseNodeType {
+    /// Returns true if the node is a hash.
     pub const fn is_hash(&self) -> bool {
         matches!(self, Self::Hash)
     }
 
+    /// Returns true if the node is a branch.
     pub const fn is_branch(&self) -> bool {
         matches!(self, Self::Branch { .. })
     }
 
+    /// Returns true if the node should be stored in the database.
     pub const fn store_in_db_trie(&self) -> Option<bool> {
         match *self {
             Self::Extension { store_in_db_trie } | Self::Branch { store_in_db_trie } => {

--- a/crates/trie/sparse/src/rlp.rs
+++ b/crates/trie/sparse/src/rlp.rs
@@ -1,0 +1,58 @@
+use alloy_trie::Nibbles;
+use reth_trie_common::RlpNode;
+use smallvec::SmallVec;
+
+use crate::SparseNodeType;
+
+/// Collection of reusable buffers for [`crate::RevealedSparseTrie::rlp_node`] calculations.
+///
+/// These buffers reduce allocations when computing RLP representations during trie updates.
+#[derive(Debug, Default)]
+pub struct RlpNodeBuffers {
+    /// Stack of RLP node paths
+    pub path_stack: Vec<RlpNodePathStackItem>,
+    /// Stack of RLP nodes
+    pub rlp_node_stack: Vec<RlpNodeStackItem>,
+    /// Reusable branch child path
+    pub branch_child_buf: SmallVec<[Nibbles; 16]>,
+    /// Reusable branch value stack
+    pub branch_value_stack_buf: SmallVec<[RlpNode; 16]>,
+}
+
+impl RlpNodeBuffers {
+    /// Creates a new instance of buffers with the root path on the stack.
+    pub fn new_with_root_path() -> Self {
+        Self {
+            path_stack: vec![RlpNodePathStackItem {
+                level: 0,
+                path: Nibbles::default(),
+                is_in_prefix_set: None,
+            }],
+            rlp_node_stack: Vec::new(),
+            branch_child_buf: SmallVec::<[Nibbles; 16]>::new_const(),
+            branch_value_stack_buf: SmallVec::<[RlpNode; 16]>::new_const(),
+        }
+    }
+}
+
+/// RLP node path stack item.
+#[derive(Debug)]
+pub struct RlpNodePathStackItem {
+    /// Level at which the node is located. Higher numbers correspond to lower levels in the trie.
+    pub level: usize,
+    /// Path to the node.
+    pub path: Nibbles,
+    /// Whether the path is in the prefix set. If [`None`], then unknown yet.
+    pub is_in_prefix_set: Option<bool>,
+}
+
+/// RLP node stack item.
+#[derive(Debug)]
+pub struct RlpNodeStackItem {
+    /// Path to the node.
+    pub path: Nibbles,
+    /// RLP node.
+    pub rlp_node: RlpNode,
+    /// Type of the node.
+    pub node_type: SparseNodeType,
+}

--- a/crates/trie/sparse/src/rlp.rs
+++ b/crates/trie/sparse/src/rlp.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use alloy_trie::Nibbles;
 use reth_trie_common::RlpNode;
 use smallvec::SmallVec;

--- a/crates/trie/sparse/src/updates.rs
+++ b/crates/trie/sparse/src/updates.rs
@@ -1,0 +1,29 @@
+use alloy_primitives::map::{HashMap, HashSet};
+use alloy_trie::{BranchNodeCompact, Nibbles};
+
+/// Tracks modifications to the sparse trie structure.
+///
+/// Maintains references to both modified and pruned/removed branches, enabling
+/// one to make batch updates to a persistent database.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SparseTrieUpdates {
+    pub updated_nodes: HashMap<Nibbles, BranchNodeCompact>,
+    pub removed_nodes: HashSet<Nibbles>,
+    pub wiped: bool,
+}
+
+impl SparseTrieUpdates {
+    /// Create new wiped sparse trie updates.
+    pub fn wiped() -> Self {
+        Self { wiped: true, ..Default::default() }
+    }
+
+    /// Clears the updates, but keeps the backing data structures allocated.
+    ///
+    /// Sets `wiped` to `false`.
+    pub fn clear(&mut self) {
+        self.updated_nodes.clear();
+        self.removed_nodes.clear();
+        self.wiped = false;
+    }
+}

--- a/crates/trie/sparse/src/updates.rs
+++ b/crates/trie/sparse/src/updates.rs
@@ -7,8 +7,11 @@ use alloy_trie::{BranchNodeCompact, Nibbles};
 /// one to make batch updates to a persistent database.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SparseTrieUpdates {
+    /// Collection of updated intermediate nodes indexed by full path.
     pub updated_nodes: HashMap<Nibbles, BranchNodeCompact>,
+    /// Collection of removed intermediate nodes indexed by full path.
     pub removed_nodes: HashSet<Nibbles>,
+    /// Flag indicating whether the trie was wiped.
     pub wiped: bool,
 }
 


### PR DESCRIPTION
Preparation for https://github.com/paradigmxyz/reth/issues/16086, makes the type reuse easier.