### PR TITLE
feat(trie): Embed a SparseSubtrie into the ParallelSparseTrie as its upper trie

### DIFF
--- a/crates/trie/sparse/src/parallel_trie.rs
+++ b/crates/trie/sparse/src/parallel_trie.rs
@@ -13,16 +13,10 @@ use reth_trie_common::{Nibbles, TrieNode};
 /// - All keys in `values` collection are full leaf paths.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ParallelSparseTrie {
-    /// The root of the sparse trie.
-    root_node: SparseNode,
-    /// Map from a path (nibbles) to its corresponding sparse trie node.
     /// This contains the trie nodes for the upper part of the trie.
-    upper_trie: HashMap<Nibbles, SparseNode>,
+    upper_subtrie: SparseSubtrie,
     /// An array containing the subtries at the second level of the trie.
     subtries: [Option<SparseSubtrie>; 256],
-    /// Map from leaf key paths to their values.
-    /// All values are stored here instead of directly in leaf nodes.
-    values: HashMap<Nibbles, Vec<u8>>,
     /// Optional tracking of trie updates for later use.
     updates: Option<SparseTrieUpdates>,
 }
@@ -30,10 +24,8 @@ pub struct ParallelSparseTrie {
 impl Default for ParallelSparseTrie {
     fn default() -> Self {
         Self {
-            root_node: SparseNode::Empty,
-            upper_trie: HashMap::default(),
+            upper_subtrie: SparseSubtrie::default(),
             subtries: [const { None }; 256],
-            values: HashMap::default(),
             updates: None,
         }
     }
@@ -91,10 +83,13 @@ impl ParallelSparseTrie {
 
 /// This is a subtrie of the `ParallelSparseTrie` that contains a map from path to sparse trie
 /// nodes.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct SparseSubtrie {
     /// The root path of this subtrie.
     path: Nibbles,
     /// The map from paths to sparse trie nodes within this subtrie.
     nodes: HashMap<Nibbles, SparseNode>,
+    /// Map from leaf key paths to their values.
+    /// All values are stored here instead of directly in leaf nodes.
+    values: HashMap<Nibbles, Vec<u8>>,
 }


### PR DESCRIPTION
Rather than having separate hashmaps for tracking nodes and values in the upper trie, use a SparseSubtrie to do the same. This will make sharing logic between the upper and lower tries simpler, as well as allow lower tries to track their leaf values themselves.