### PR TITLE
chore: remove unused approx_capacity_get_pooled_transactions_req

### DIFF
--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -201,14 +201,16 @@ pub mod tx_fetcher {
 
     /// Default divisor of the max inflight request when calculating search breadth of the search
     /// for any idle peer to which to send a request filled with hashes pending fetch. The max
-    /// inflight requests is configured in [`TransactionFetcherInfo`].
+    /// inflight requests is configured in
+    /// [`TransactionFetcherInfo`](crate::transactions::fetcher::TransactionFetcherInfo).
     ///
     /// Default is 3 requests.
     pub const DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER: usize = 3;
 
     /// Default divisor of the max inflight request when calculating search breadth of the search
     /// for the intersection of hashes announced by a peer and hashes pending fetch. The max
-    /// inflight requests is configured in [`TransactionFetcherInfo`].
+    /// inflight requests is configured in
+    /// [`TransactionFetcherInfo`](crate::transactions::fetcher::TransactionFetcherInfo).
     ///
     /// Default is 3 requests.
     pub const DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION: usize = 3;

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -57,7 +57,6 @@ pub mod tx_manager {
 
 /// Constants used by [`TransactionFetcher`](super::TransactionFetcher).
 pub mod tx_fetcher {
-    use crate::transactions::fetcher::TransactionFetcherInfo;
     use reth_network_types::peers::config::{
         DEFAULT_MAX_COUNT_PEERS_INBOUND, DEFAULT_MAX_COUNT_PEERS_OUTBOUND,
     };
@@ -256,26 +255,4 @@ pub mod tx_fetcher {
     ///
     /// Default is 8 hashes.
     pub const DEFAULT_MARGINAL_COUNT_HASHES_GET_POOLED_TRANSACTIONS_REQUEST: usize = 8;
-
-    /// Returns the approx number of transaction hashes that a
-    /// [`GetPooledTransactions`](reth_eth_wire::GetPooledTransactions) request will have capacity
-    /// for w.r.t. the [`Eth68`](reth_eth_wire::EthVersion::Eth68) protocol version. This is useful
-    /// for preallocating memory.
-    pub const fn approx_capacity_get_pooled_transactions_req_eth68(
-        info: &TransactionFetcherInfo,
-    ) -> usize {
-        let max_size_expected_response =
-            info.soft_limit_byte_size_pooled_transactions_response_on_pack_request;
-
-        max_size_expected_response / MEDIAN_BYTE_SIZE_SMALL_LEGACY_TX_ENCODED +
-            DEFAULT_MARGINAL_COUNT_HASHES_GET_POOLED_TRANSACTIONS_REQUEST
-    }
-
-    /// Returns the approx number of transactions that a
-    /// [`GetPooledTransactions`](reth_eth_wire::GetPooledTransactions) request will
-    /// have capacity for w.r.t. the [`Eth66`](reth_eth_wire::EthVersion::Eth66) protocol version.
-    /// This is useful for preallocating memory.
-    pub const fn approx_capacity_get_pooled_transactions_req_eth66() -> usize {
-        SOFT_LIMIT_COUNT_HASHES_IN_GET_POOLED_TRANSACTIONS_REQUEST
-    }
 }

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -1285,6 +1285,7 @@ mod test {
     use alloy_primitives::{hex, B256};
     use alloy_rlp::Decodable;
     use derive_more::IntoIterator;
+    use reth_eth_wire_types::EthVersion;
     use reth_ethereum_primitives::TransactionSigned;
     use std::{collections::HashSet, str::FromStr};
 

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -41,7 +41,7 @@ use derive_more::{Constructor, Deref};
 use futures::{stream::FuturesUnordered, Future, FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
 use reth_eth_wire::{
-    DedupPayload, EthVersion, GetPooledTransactions, HandleMempoolData, HandleVersionedMempoolData,
+    DedupPayload, GetPooledTransactions, HandleMempoolData, HandleVersionedMempoolData,
     PartiallyValidData, RequestTxHashes, ValidAnnouncementData,
 };
 use reth_eth_wire_types::{EthNetworkPrimitives, NetworkPrimitives};
@@ -837,19 +837,6 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             );
 
             Some(limit)
-        }
-    }
-
-    /// Returns the approx number of transactions that a [`GetPooledTransactions`] request will
-    /// have capacity for w.r.t. the given version of the protocol.
-    pub const fn approx_capacity_get_pooled_transactions_req(
-        &self,
-        announcement_version: EthVersion,
-    ) -> usize {
-        if announcement_version.is_eth68() {
-            approx_capacity_get_pooled_transactions_req_eth68(&self.info)
-        } else {
-            approx_capacity_get_pooled_transactions_req_eth66()
         }
     }
 


### PR DESCRIPTION
## Summary
Removes the unused `approx_capacity_get_pooled_transactions_req` method from `TransactionFetcher`.

This method was not being called anywhere in the codebase. Also removes the `EthVersion` import that was only used by this method.

## Changes
- Remove `approx_capacity_get_pooled_transactions_req` method from `TransactionFetcher`
- Remove unused `EthVersion` import
