### PR TITLE
fix: prevent invalid range in fee_history when newest_block is pending

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -86,8 +86,6 @@ pub trait EthFees: LoadFee {
             if newest_block.is_pending() {
                 // cap the target block since we don't have fee history for the pending block
                 newest_block = BlockNumberOrTag::Latest;
-                // account for missing pending block
-                block_count = block_count.saturating_sub(1);
             }
 
             let end_block = self

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -132,7 +132,7 @@ impl FeeHistoryCache {
         self.inner.lower_bound.load(SeqCst)
     }
 
-    /// Collect fee history for given range.
+    /// Collect fee history for the given range (inclusive `start_block..=end_block`).
     ///
     /// This function retrieves fee history entries from the cache for the specified range.
     /// If the requested range (`start_block` to `end_block`) is within the cache bounds,
@@ -143,6 +143,10 @@ impl FeeHistoryCache {
         start_block: u64,
         end_block: u64,
     ) -> Option<Vec<FeeHistoryEntry>> {
+        if end_block < start_block {
+            // invalid range, return None
+            return None
+        }
         let lower_bound = self.lower_bound();
         let upper_bound = self.upper_bound();
         if start_block >= lower_bound && end_block <= upper_bound {


### PR DESCRIPTION
## Summary

Fixes an edge case in `fee_history` that could result in `start_block > end_block`, causing an invalid range.

## The Problem

When `fee_history` was called with `newest_block = "pending"`, the code would:
1. Change `newest_block` to `"latest"` (correct)
2. Subtract 1 from `block_count` (incorrect)

This subtraction could cause an edge case where:
```
fee_history(block_count=1, newest_block="pending", ...)
```

Would result in:
- `block_count` becomes 0 after `saturating_sub(1)`
- Later: `start_block = end_block_plus - block_count = (end_block + 1) - 0 = end_block + 1`
- This makes `start_block > end_block`, which is an invalid range

## The Fix

This PR removes the unnecessary `block_count = block_count.saturating_sub(1)` line. 

The subtraction was based on a misunderstanding: when we fall back from pending to latest, users still expect the requested number of blocks. For example:
- `fee_history(5, "pending")` should return 5 blocks ending at latest, not 4 blocks
- `fee_history(1, "pending")` should return the latest block, not an empty result

## Impact

This fix ensures that:
- The block count remains what the user requested
- `start_block` can never exceed `end_block` 
- The API behavior is more intuitive and matches user expectations
