### PR TITLE
fix: use >= comparison for eth69 version checks in decode_message

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -72,13 +72,13 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 StatusMessage::Eth69(StatusEth69::decode(buf)?)
             }),
             EthMessageID::NewBlockHashes => {
-                if version.is_eth69() {
+                if version >= EthVersion::Eth69 {
                     return Err(MessageError::Invalid(version, EthMessageID::NewBlockHashes));
                 }
                 EthMessage::NewBlockHashes(NewBlockHashes::decode(buf)?)
             }
             EthMessageID::NewBlock => {
-                if version.is_eth69() {
+                if version >= EthVersion::Eth69 {
                     return Err(MessageError::Invalid(version, EthMessageID::NewBlock));
                 }
                 EthMessage::NewBlock(Box::new(N::NewBlockPayload::decode(buf)?))


### PR DESCRIPTION
Uses `version >= EthVersion::Eth69` instead of `version.is_eth69()` when validating NewBlockHashes and NewBlock messages in decode_message.

This ensures these messages are rejected for eth69 and any future protocol versions, not just exactly eth69.