### PR TITLE
fix: allow eth69 block propagation

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -72,15 +72,9 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 StatusMessage::Eth69(StatusEth69::decode(buf)?)
             }),
             EthMessageID::NewBlockHashes => {
-                if version.is_eth69() {
-                    return Err(MessageError::Invalid(version, EthMessageID::NewBlockHashes));
-                }
                 EthMessage::NewBlockHashes(NewBlockHashes::decode(buf)?)
             }
             EthMessageID::NewBlock => {
-                if version.is_eth69() {
-                    return Err(MessageError::Invalid(version, EthMessageID::NewBlock));
-                }
                 EthMessage::NewBlock(Box::new(N::NewBlockPayload::decode(buf)?))
             }
             EthMessageID::Transactions => EthMessage::Transactions(Transactions::decode(buf)?),


### PR DESCRIPTION
these are still valid for eth69

https://eips.ethereum.org/EIPS/eip-7642