### PR TITLE
fix: typos in documentation and source code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ Before submitting changes, ensure:
 Label PRs appropriately, first check the available labels and then apply the relevant ones:
 * when changes are RPC related, add A-rpc label
 * when changes are docs related, add C-docs label
-* when changes are optimism related (e.g. new feature or exlusive changes to crates/optimism), add A-op-reth label
+* when changes are optimism related (e.g. new feature or exclusive changes to crates/optimism), add A-op-reth label
 * ... and so on, check the available labels for more options.
 
 If changes in reth include changes to dependencies, run commands `zepter` and `make lint-toml` before finalizing the pr. Assume `zepter` binary is installed.

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -33,7 +33,7 @@ impl EthVersion {
     /// The latest known eth version
     pub const LATEST: Self = Self::Eth68;
 
-    /// All known eth vesions
+    /// All known eth versions
     pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns the total number of messages the protocol version supports.


### PR DESCRIPTION


**Description:**  
This PR fixes minor spelling mistakes in documentation and code comments:
- "exlusive" → "exclusive" in CLAUDE.md
- "vesions" → "versions" in version.rs
