### PR TITLE
docs: improve transaction-related trait documentation

### DIFF
--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -5,6 +5,10 @@ use crate::{
 use core::fmt;
 
 /// Configures all the primitive types of the node.
+///
+/// This trait defines the core types used throughout the node for representing
+/// blockchain data. It serves as the foundation for type consistency across
+/// different node implementations.
 pub trait NodePrimitives:
     Send + Sync + Unpin + Clone + Default + fmt::Debug + PartialEq + Eq + 'static
 {
@@ -15,6 +19,9 @@ pub trait NodePrimitives:
     /// Block body primitive.
     type BlockBody: FullBlockBody<Transaction = Self::SignedTx, OmmerHeader = Self::BlockHeader>;
     /// Signed version of the transaction type.
+    ///
+    /// This represents the transaction as it exists in the blockchain - the consensus
+    /// format that includes the signature and can be included in a block.
     type SignedTx: FullSignedTx;
     /// A receipt.
     type Receipt: Receipt;

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1,3 +1,55 @@
+//! Transaction Pool Traits and Types
+//!
+//! This module defines the core abstractions for transaction pool implementations,
+//! handling the complexity of different transaction representations across the
+//! network, mempool, and the chain itself.
+//!
+//! ## Key Concepts
+//!
+//! ### Transaction Representations
+//!
+//! Transactions exist in different formats throughout their lifecycle:
+//!
+//! 1. **Consensus Format** ([`PoolTransaction::Consensus`])
+//!    - The canonical format stored in blocks
+//!    - Minimal size for efficient storage
+//!    - Example: EIP-4844 transactions store only blob hashes: ([`TransactionSigned::Eip4844`])
+//!
+//! 2. **Pooled Format** ([`PoolTransaction::Pooled`])
+//!    - Extended format for network propagation
+//!    - Includes additional validation data
+//!    - Example: EIP-4844 transactions include full blob sidecars: ([`PooledTransactionVariant`])
+//!
+//! ### Type Relationships
+//!
+//! ```text
+//! NodePrimitives::SignedTx  ←──   NetworkPrimitives::BroadcastedTransaction
+//!        │                              │
+//!        │ (consensus format)           │ (announced to peers)
+//!        │                              │
+//!        └──────────┐  ┌────────────────┘
+//!                   ▼  ▼
+//!            PoolTransaction::Consensus
+//!                   │ ▲
+//!                   │ │ from pooled (always succeeds)
+//!                   │ │
+//!                   ▼ │ try_from consensus (may fail)
+//!            PoolTransaction::Pooled  ←──→  NetworkPrimitives::PooledTransaction
+//!                                             (sent on request)
+//! ```
+//!
+//! ### Special Cases
+//!
+//! #### EIP-4844 Blob Transactions
+//! - Consensus format: Only blob hashes (32 bytes each)
+//! - Pooled format: Full blobs + commitments + proofs (large data per blob)
+//! - Network behavior: Not broadcast automatically, only sent on explicit request
+//!
+//! #### Optimism Deposit Transactions
+//! - Only exist in consensus format
+//! - Never enter the mempool (system transactions)
+//! - Conversion from consensus to pooled always fails
+
 use crate::{
     blobstore::BlobStoreError,
     error::{InvalidPoolTransactionError, PoolResult},
@@ -932,19 +984,62 @@ impl BestTransactionsAttributes {
     }
 }
 
-/// Trait for transaction types used inside the pool.
+/// Trait for transaction types stored in the transaction pool.
 ///
-/// This supports two transaction formats
-/// - Consensus format: the form the transaction takes when it is included in a block.
-/// - Pooled format: the form the transaction takes when it is gossiping around the network.
+/// This trait represents the actual transaction object stored in the mempool, which includes not
+/// only the transaction data itself but also additional metadata needed for efficient pool
+/// operations. Implementations typically cache values that are frequently accessed during
+/// transaction ordering, validation, and eviction.
 ///
-/// This distinction is necessary for the EIP-4844 blob transactions, which require an additional
-/// sidecar when they are gossiped around the network. It is expected that the `Consensus` format is
-/// a subset of the `Pooled` format.
+/// ## Key Responsibilities
 ///
-/// The assumption is that fallible conversion from `Consensus` to `Pooled` will encapsulate
-/// handling of all valid `Consensus` transactions that can't be pooled (e.g Deposit transactions or
-/// blob-less EIP-4844 transactions).
+/// 1. **Metadata Caching**: Store computed values like address, cost and encoded size
+/// 2. **Representation Conversion**: Handle conversions between consensus and pooled
+///    representations
+/// 3. **Validation Support**: Provide methods for pool-specific validation rules
+///
+/// ## Cached Metadata
+///
+/// Implementations should cache frequently accessed values to avoid recomputation:
+/// - **Address**: Recovered sender address of the transaction
+/// - **Cost**: Max amount spendable (gas × price + value + blob costs)
+/// - **Size**: RLP encoded length for mempool size limits
+///
+/// See [`EthPooledTransaction`] for a reference implementation.
+///
+/// ## Transaction Representations
+///
+/// This trait abstracts over the different representations a transaction can have:
+///
+/// 1. **Consensus representation** (`Consensus` associated type): The canonical form included in
+///    blocks
+///    - Compact representation without networking metadata
+///    - For EIP-4844: includes only blob hashes, not the actual blobs
+///    - Used for block execution and state transitions
+///
+/// 2. **Pooled representation** (`Pooled` associated type): The form used for network propagation
+///    - May include additional data for validation
+///    - For EIP-4844: includes full blob sidecars (blobs, commitments, proofs)
+///    - Used for mempool validation and p2p gossiping
+///
+/// ## Why Two Representations?
+///
+/// This distinction is necessary because:
+///
+/// - **EIP-4844 blob transactions**: Require large blob sidecars for validation that would bloat
+///   blocks if included. Only blob hashes are stored on-chain.
+///
+/// - **Network efficiency**: Blob transactions are not broadcast to all peers automatically but
+///   must be explicitly requested to reduce bandwidth usage.
+///
+/// - **Special transactions**: Some transactions (like OP deposit transactions) exist only in
+///   consensus format and are never in the mempool.
+///
+/// ## Conversion Rules
+///
+/// - `Consensus` → `Pooled`: May fail for transactions that cannot be pooled (e.g., OP deposit
+///   transactions, blob transactions without sidecars)
+/// - `Pooled` → `Consensus`: Always succeeds (pooled is a superset)
 pub trait PoolTransaction:
     alloy_consensus::Transaction + InMemorySize + Debug + Send + Sync + Clone
 {
@@ -959,8 +1054,13 @@ pub trait PoolTransaction:
 
     /// Define a method to convert from the `Consensus` type to `Self`
     ///
-    /// Note: this _must_ fail on any transactions that cannot be pooled (e.g OP Deposit
-    /// transactions).
+    /// This conversion may fail for transactions that are valid for inclusion in blocks
+    /// but cannot exist in the transaction pool. Examples include:
+    ///
+    /// - **OP Deposit transactions**: These are special system transactions that are directly
+    ///   included in blocks by the sequencer/validator and never enter the mempool
+    /// - **Blob transactions without sidecars**: After being included in a block, the sidecar data
+    ///   is pruned, making the consensus transaction unpoolable
     fn try_from_consensus(
         tx: Recovered<Self::Consensus>,
     ) -> Result<Self, Self::TryFromConsensusError> {
@@ -1079,8 +1179,14 @@ pub trait EthPoolTransaction: PoolTransaction {
 
 /// The default [`PoolTransaction`] for the [Pool](crate::Pool) for Ethereum.
 ///
-/// This type is essentially a wrapper around [`Recovered`] with additional
-/// fields derived from the transaction that are frequently used by the pools for ordering.
+/// This type wraps a consensus transaction with additional cached data that's
+/// frequently accessed by the pool for transaction ordering and validation:
+///
+/// - `cost`: Pre-calculated max cost (gas * price + value + blob costs)
+/// - `encoded_length`: Cached RLP encoding length for size limits
+/// - `blob_sidecar`: Blob data state (None/Missing/Present)
+///
+/// This avoids recalculating these values repeatedly during pool operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EthPooledTransaction<T = TransactionSigned> {
     /// `EcRecovered` transaction, the consensus format.
@@ -1330,16 +1436,31 @@ impl EthPoolTransaction for EthPooledTransaction {
 }
 
 /// Represents the blob sidecar of the [`EthPooledTransaction`].
+///
+/// EIP-4844 blob transactions require additional data (blobs, commitments, proofs)
+/// for validation that is not included in the consensus format. This enum tracks
+/// the sidecar state throughout the transaction's lifecycle in the pool.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EthBlobTransactionSidecar {
     /// This transaction does not have a blob sidecar
+    /// (applies to all non-EIP-4844 transaction types)
     None,
-    /// This transaction has a blob sidecar (EIP-4844) but it is missing
+    /// This transaction has a blob sidecar (EIP-4844) but it is missing.
     ///
-    /// It was either extracted after being inserted into the pool or re-injected after reorg
-    /// without the blob sidecar
+    /// This can happen when:
+    /// - The sidecar was extracted after the transaction was added to the pool
+    /// - The transaction was re-injected after a reorg without its sidecar
+    /// - The transaction was recovered from the consensus format (e.g., from a block)
     Missing,
-    /// The eip-4844 transaction was pulled from the network and still has its blob sidecar
+    /// The EIP-4844 transaction was received from the network with its complete sidecar.
+    ///
+    /// This sidecar contains:
+    /// - The actual blob data (large data per blob)
+    /// - KZG commitments for each blob
+    /// - KZG proofs for validation
+    ///
+    /// The sidecar is required for validating the transaction but is not included
+    /// in blocks (only the blob hashes are included in the consensus format).
     Present(BlobTransactionSidecarVariant),
 }
 


### PR DESCRIPTION
## Summary

Improved documentation for transaction-related traits to clarify their relationships and the different transaction representations used throughout Reth.

## Motivation

The existing documentation didn't fully explain:
- How `NetworkPrimitives` and `NodePrimitives` relate to each other
- What `PoolTransaction` actually represents and why it exists
- The distinction between consensus and pooled transaction formats
- Why these different representations are necessary

This led to confusion about:
- Which types to use in different contexts
- How transactions flow between network, mempool, and consensus layers
- The purpose of cached metadata in pool transactions

## Changes

### Enhanced trait documentation

**`NetworkPrimitives`**: Clarified that it defines network wire protocol types, not an extension of `NodePrimitives`. These traits work together through `NetPrimitivesFor` to ensure type compatibility.

**`NodePrimitives`**: Added note that this defines consensus-level types used throughout the node, distinct from network representations.

**`PoolTransaction`**: Completely rewrote documentation to explain:
- Its role as the mempool storage type with cached metadata
- Why caching sender, cost, and size is important for pool operations
- The two transaction representations (consensus vs pooled) and conversion rules
- Special cases like EIP-4844 blob transactions and OP deposits

### Added visual type relationship diagram

```text
NodePrimitives::SignedTx  ←──→  NetworkPrimitives::BroadcastedTransaction
       │                              │
       │ (consensus format)           │ (announced to peers)
       │                              │
       └──────────┐  ┌────────────────┘
                  ▼  ▼
           PoolTransaction::Consensus
                  │ ▲
                  │ │ from pooled (always succeeds)
                  │ │
                  ▼ │ try_from consensus (may fail)
           PoolTransaction::Pooled  ←──→  NetworkPrimitives::PooledTransaction
                                            (sent on request)
```
