### PR TITLE
feat: centralize EIP-1559 base fee calculation in EthChainSpec

### DIFF
--- a/crates/chainspec/tests/base_fee.rs
+++ b/crates/chainspec/tests/base_fee.rs
@@ -1,0 +1,70 @@
+use alloy_eips::eip1559::INITIAL_BASE_FEE;
+use reth_chainspec::{ChainSpecBuilder, EthChainSpec};
+
+#[test]
+fn test_next_block_base_fee() {
+    let chain_spec = ChainSpecBuilder::mainnet().build();
+
+    // Test case 1: Base fee increases when gas used > target
+    let parent_gas_used = 20_000_000; // More than target (15M)
+    let parent_gas_limit = 30_000_000;
+    let parent_base_fee = 1_000_000_000;
+    let parent_timestamp = 1_700_000_000; // Recent timestamp
+
+    let next_base_fee = chain_spec.next_block_base_fee(
+        parent_gas_used,
+        parent_gas_limit,
+        parent_base_fee,
+        parent_timestamp,
+    );
+
+    // Base fee should increase when block is more than half full
+    assert!(next_base_fee > parent_base_fee);
+
+    // Test case 2: Base fee decreases when gas used < target
+    let parent_gas_used = 10_000_000; // Less than target (15M)
+    let next_base_fee = chain_spec.next_block_base_fee(
+        parent_gas_used,
+        parent_gas_limit,
+        parent_base_fee,
+        parent_timestamp,
+    );
+
+    // Base fee should decrease when block is less than half full
+    assert!(next_base_fee < parent_base_fee);
+
+    // Test case 3: Base fee stays same when gas used = target
+    let parent_gas_used = parent_gas_limit / 2; // Exactly at target
+    let next_base_fee = chain_spec.next_block_base_fee(
+        parent_gas_used,
+        parent_gas_limit,
+        parent_base_fee,
+        parent_timestamp,
+    );
+
+    // Base fee should stay the same when block is exactly half full
+    assert_eq!(next_base_fee, parent_base_fee);
+}
+
+#[test]
+fn test_london_activation_base_fee() {
+    let chain_spec = ChainSpecBuilder::mainnet().build();
+
+    // At London activation, the base fee should be INITIAL_BASE_FEE
+    // regardless of parent block's gas usage
+    let parent_gas_used = 30_000_000;
+    let parent_gas_limit = 30_000_000;
+    let parent_timestamp = 1_000_000;
+
+    // The validation logic should use INITIAL_BASE_FEE for London activation block
+    // This test verifies the centralized method works with the validation logic
+    let next_base_fee = chain_spec.next_block_base_fee(
+        parent_gas_used,
+        parent_gas_limit,
+        INITIAL_BASE_FEE, // For London activation, parent base fee is set to INITIAL_BASE_FEE
+        parent_timestamp,
+    );
+
+    // Should calculate normally from INITIAL_BASE_FEE
+    assert!(next_base_fee > INITIAL_BASE_FEE);
+}

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::{
     constants::MAXIMUM_EXTRA_DATA_SIZE, BlockHeader as _, EMPTY_OMMER_ROOT_HASH,
 };
-use alloy_eips::{calc_next_block_base_fee, eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
+use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{
@@ -269,11 +269,11 @@ pub fn validate_against_parent_eip1559_base_fee<
             // This BaseFeeMissing will not happen as previous blocks are checked to have
             // them.
             let base_fee = parent.base_fee_per_gas().ok_or(ConsensusError::BaseFeeMissing)?;
-            calc_next_block_base_fee(
+            chain_spec.next_block_base_fee(
                 parent.gas_used(),
                 parent.gas_limit(),
                 base_fee,
-                chain_spec.base_fee_params_at_timestamp(header.timestamp()),
+                parent.timestamp(),
             )
         };
         if expected_base_fee != base_fee {

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,5 +1,5 @@
 use crate::utils::eth_payload_attributes;
-use alloy_eips::{calc_next_block_base_fee, eip2718::Encodable2718};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder, SendableTx};
 use alloy_rpc_types_beacon::relay::{
@@ -9,7 +9,7 @@ use alloy_rpc_types_beacon::relay::{
 use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 use alloy_rpc_types_eth::TransactionRequest;
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
 use reth_e2e_test_utils::setup_engine;
 use reth_node_ethereum::EthereumNode;
 use reth_payload_primitives::BuiltPayload;
@@ -98,11 +98,11 @@ async fn test_fee_history() -> eyre::Result<()> {
             .unwrap()
             .header;
         for block in (latest_block + 2 - block_count)..=latest_block {
-            let expected_base_fee = calc_next_block_base_fee(
+            let expected_base_fee = chain_spec.next_block_base_fee(
                 prev_header.gas_used,
                 prev_header.gas_limit,
                 prev_header.base_fee_per_gas.unwrap(),
-                chain_spec.base_fee_params_at_block(block),
+                prev_header.timestamp,
             );
 
             let header = provider.get_block_by_number(block.into()).await?.unwrap().header;

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use alloy_consensus::{BlockHeader, Transaction, TxReceipt};
-use alloy_eips::{eip1559::calc_next_block_base_fee, eip7840::BlobParams};
+use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::TxGasAndReward;
 use futures::{
@@ -399,11 +399,11 @@ impl FeeHistoryEntry {
 
     /// Returns the base fee for the next block according to the EIP-1559 spec.
     pub fn next_block_base_fee(&self, chain_spec: impl EthChainSpec) -> u64 {
-        calc_next_block_base_fee(
+        chain_spec.next_block_base_fee(
             self.gas_used,
             self.gas_limit,
             self.base_fee_per_gas,
-            chain_spec.base_fee_params_at_timestamp(self.timestamp),
+            self.timestamp,
         )
     }
 


### PR DESCRIPTION
## Summary
- Centralizes EIP-1559 base fee calculation logic into the `EthChainSpec` trait
- Removes direct usage of `calc_next_block_base_fee` from validation and RPC components
- Ensures consistent base fee calculation across all components

## Changes
- Added `next_block_base_fee` method to `EthChainSpec` trait that encapsulates the base fee calculation logic
- Updated `validate_against_parent_eip1559_base_fee` in consensus validation to use the centralized method
- Updated `FeeHistoryEntry::next_block_base_fee` in RPC to use the centralized method
- Updated e2e tests to use the new centralized approach
- Added comprehensive unit tests for the base fee calculation

## Benefits
- **Consistency**: All base fee calculations now go through a single method
- **Maintainability**: Future changes to base fee calculation only need to be made in one place
- **Extensibility**: Chain-specific implementations can override the method if needed (e.g., for custom chain specs like bera-reth)
- **Type Safety**: The trait-based approach ensures proper typing and chain spec awareness

## Test Plan
- [x] Added unit tests for base fee increase/decrease/no-change scenarios
- [x] Added test for London activation base fee handling
- [x] All existing tests pass
- [x] Code is properly formatted with `cargo +nightly fmt`