### PR TITLE
chore: Expose payload_id

### DIFF
--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod payload;
-pub use payload::{BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
+pub use payload::{payload_id, BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
 
 mod error;
 pub use error::*;

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -404,7 +404,7 @@ impl PayloadBuilderAttributes for EthPayloadBuilderAttributes {
 /// Generates the payload id for the configured payload from the [`PayloadAttributes`].
 ///
 /// Returns an 8-byte identifier by hashing the payload components with sha256 hash.
-pub(crate) fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> PayloadId {
+pub fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> PayloadId {
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();
     hasher.update(parent.as_slice());

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -16,7 +16,9 @@ pub use builder::OpPayloadBuilder;
 pub mod error;
 pub mod payload;
 use op_alloy_rpc_types_engine::OpExecutionData;
-pub use payload::{OpBuiltPayload, OpPayloadAttributes, OpPayloadBuilderAttributes};
+pub use payload::{
+    payload_id_optimism, OpBuiltPayload, OpPayloadAttributes, OpPayloadBuilderAttributes,
+};
 mod traits;
 use reth_optimism_primitives::OpPrimitives;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -327,7 +327,7 @@ where
 /// Generates the payload id for the configured payload from the [`OpPayloadAttributes`].
 ///
 /// Returns an 8-byte identifier by hashing the payload components with sha256 hash.
-pub(crate) fn payload_id_optimism(
+pub fn payload_id_optimism(
     parent: &B256,
     attributes: &OpPayloadAttributes,
     payload_version: u8,


### PR DESCRIPTION
Expose payload_id so it's possible to use this function in id calculation outside of client.
In our use case we handle FCU on proxy level and need to determine future payload_id before client answered to FCU