### PR TITLE
test: flaky connection test

### DIFF
--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -19,7 +19,9 @@ use reth_network_p2p::{
     sync::{NetworkSyncUpdater, SyncState},
 };
 use reth_network_peers::{mainnet_nodes, NodeRecord, TrustedPeer};
+use reth_network_types::peers::config::PeerBackoffDurations;
 use reth_storage_api::noop::NoopProvider;
+use reth_tracing::init_test_tracing;
 use reth_transaction_pool::test_utils::testing_pool;
 use secp256k1::SecretKey;
 use std::time::Duration;
@@ -359,6 +361,7 @@ async fn test_shutdown() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_trusted_peer_only() {
+    init_test_tracing();
     let net = Testnet::create(2).await;
     let mut handles = net.handles();
 
@@ -376,7 +379,10 @@ async fn test_trusted_peer_only() {
     let _handle = net.spawn();
 
     let secret_key = SecretKey::new(&mut rand_08::thread_rng());
-    let peers_config = PeersConfig::default().with_trusted_nodes_only(true);
+    let peers_config = PeersConfig::default()
+        .with_backoff_durations(PeerBackoffDurations::test())
+        .with_ban_duration(Duration::from_millis(200))
+        .with_trusted_nodes_only(true);
 
     let config = NetworkConfigBuilder::eth(secret_key)
         .listener_port(0)
@@ -416,11 +422,13 @@ async fn test_trusted_peer_only() {
     tokio::time::sleep(Duration::from_secs(1)).await;
     assert_eq!(handle.num_connected_peers(), 1);
 
-    handle1.add_trusted_peer(*handle.peer_id(), handle.local_addr());
+    handle.add_trusted_peer(*handle1.peer_id(), handle1.local_addr());
 
     // wait for the next session established event to check the handle1 incoming connection
     let outgoing_peer_id1 = event_stream.next_session_established().await.unwrap();
     assert_eq!(outgoing_peer_id1, *handle1.peer_id());
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
     assert_eq!(handle.num_connected_peers(), 2);
 
     // check that handle0 and handle1 both have peers.


### PR DESCRIPTION
closes #16921

I believe this test setup was flawed, because the the trusted_peer was applied in the wrong order, this was flaky because the num_active_peers is increased before we check if the connection is from a trusted peer

https://github.com/paradigmxyz/reth/blob/14d7058eb29e1af16fd572bce7a92d47806d58e8/crates/net/network/src/manager.rs#L767-L767 