### PR TITLE
perf: Reuse CachedPrecompileMetrics across block executions

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -275,6 +275,7 @@ where
                     precompile,
                     precompile_cache_map.cache_for_address(*address),
                     spec_id,
+                    None, // CachedPrecompileMetrics
                 )
             });
         }


### PR DESCRIPTION
This saves some time allocating the metrics on every instantiation of a CachedPrecompile.

Fixes #16860