### PR TITLE
perf(trie): `ParallelSparseTrie::update_subtrie_hashes` boilerplate

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -607,7 +607,7 @@ impl SparseSubtrieType {
     }
 }
 
-/// Collection of reusable buffers for [`SparseSubtrie::update_hashes`].
+/// Collection of reusable buffers for calculating subtrie hashes.
 ///
 /// These buffers reduce allocations when computing RLP representations during trie updates.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
@@ -624,7 +624,7 @@ pub struct SparseSubtrieBuffers {
     rlp_buf: Vec<u8>,
 }
 
-/// Changed subtrie returned by [`ParallelSparseTrie::take_changed_subtries`].
+/// Changed subtrie.
 #[derive(Debug)]
 struct ChangedSubtrie {
     /// Lower subtrie index in the range [0, 255].

--- a/crates/trie/sparse/src/parallel_trie.rs
+++ b/crates/trie/sparse/src/parallel_trie.rs
@@ -215,8 +215,8 @@ impl ParallelSparseTrie {
         drop(tx);
 
         // Return updated subtries back to the trie
-        for (i, subtrie) in rx {
-            self.lower_subtries[i] = Some(subtrie);
+        for (index, subtrie) in rx {
+            self.lower_subtries[index] = Some(subtrie);
         }
     }
 
@@ -736,7 +736,7 @@ mod tests {
             Nibbles::from_nibbles_unchecked([0x1, 0x0, 0x0]),
             Nibbles::from_nibbles_unchecked([0x1, 0x0, 0x1, 0x0]),
         ]);
-        prefix_set.extend(unchanged_prefix_set.clone());
+        prefix_set.extend(unchanged_prefix_set);
         let mut prefix_set = prefix_set.freeze();
 
         // Second subtrie should be removed and returned
@@ -1006,8 +1006,8 @@ mod tests {
         let subtrie_3_index = path_subtrie_index_unchecked(&subtrie_3.path);
 
         // Add subtries at specific positions
-        trie.lower_subtries[subtrie_1_index] = Some(subtrie_1.clone());
-        trie.lower_subtries[subtrie_2_index] = Some(subtrie_2.clone());
+        trie.lower_subtries[subtrie_1_index] = Some(subtrie_1);
+        trie.lower_subtries[subtrie_2_index] = Some(subtrie_2);
         trie.lower_subtries[subtrie_3_index] = Some(subtrie_3);
 
         let unchanged_prefix_set = PrefixSetMut::from([

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2101,25 +2101,25 @@ impl RlpNodeBuffers {
 }
 
 /// RLP node path stack item.
-#[derive(Debug)]
-struct RlpNodePathStackItem {
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RlpNodePathStackItem {
     /// Level at which the node is located. Higher numbers correspond to lower levels in the trie.
-    level: usize,
+    pub level: usize,
     /// Path to the node.
-    path: Nibbles,
+    pub path: Nibbles,
     /// Whether the path is in the prefix set. If [`None`], then unknown yet.
-    is_in_prefix_set: Option<bool>,
+    pub is_in_prefix_set: Option<bool>,
 }
 
 /// RLP node stack item.
-#[derive(Debug)]
-struct RlpNodeStackItem {
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RlpNodeStackItem {
     /// Path to the node.
-    path: Nibbles,
+    pub path: Nibbles,
     /// RLP node.
-    rlp_node: RlpNode,
+    pub rlp_node: RlpNode,
     /// Type of the node.
-    node_type: SparseNodeType,
+    pub node_type: SparseNodeType,
 }
 
 /// Tracks modifications to the sparse trie structure.
@@ -2146,6 +2146,13 @@ impl SparseTrieUpdates {
         self.updated_nodes.clear();
         self.removed_nodes.clear();
         self.wiped = false;
+    }
+
+    /// Extends the updates with another set of updates.
+    pub fn extend(&mut self, other: Self) {
+        self.updated_nodes.extend(other.updated_nodes);
+        self.removed_nodes.extend(other.removed_nodes);
+        self.wiped |= other.wiped;
     }
 }
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1924,7 +1924,7 @@ impl<P: BlindedProvider> RevealedSparseTrie<P> {
 
 /// Enum representing sparse trie node type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SparseNodeType {
+pub enum SparseNodeType {
     /// Empty trie node.
     Empty,
     /// A placeholder that stores only the hash for a node that has not been fully revealed.


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/16866

Implements the boilerplate for `update_subtrie_hashes` that will be later extended with parallel calls to `SparseSubtrie::update_hashes`.

Additionally, the following preparations are made:
1. One `PrefixSetMut` is stored on top-level `ParallelSparseTrie`
1. `prefix_set` field on `ParallelSparseTrie`
1. `updates` field on `SparseSubtrie`