### PR TITLE
bench: disable sparse trie update bench as it's flaky

### DIFF
--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -88,7 +88,3 @@ harness = false
 [[bench]]
 name = "rlp_node"
 harness = false
-
-[[bench]]
-name = "update"
-harness = false


### PR DESCRIPTION
Need to fix it first, otherwise the CI is always red.