### PR TITLE
Revert "bench: disable sparse trie update bench as it's flaky (#16953)"

### DIFF
--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -88,3 +88,7 @@ harness = false
 [[bench]]
 name = "rlp_node"
 harness = false
+
+[[bench]]
+name = "update"
+harness = false


### PR DESCRIPTION
This reverts commit ea5ffa51fc11021289ecf656f77001d95eb9b53e.