### PR TITLE
chore: feature gate all op rpc types compat impl

### DIFF
--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -17,7 +17,7 @@ reth-evm.workspace = true
 reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-chain-state.workspace = true
-reth-rpc-eth-api.workspace = true
+reth-rpc-eth-api = { workspace = true, features = ["op"] }
 reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -62,3 +62,8 @@ tracing.workspace = true
 [features]
 js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]
+op = [
+    "reth-evm/op",
+    "reth-primitives-traits/op",
+    "reth-rpc-types-compat/op",
+]

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -30,10 +30,7 @@ pub use pubsub::EthPubSubApiServer;
 pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
-pub use reth_rpc_types_compat::{
-    try_into_op_tx_info, CallFeesError, EthTxEnvError, IntoRpcTx, RpcConverter, TransactionCompat,
-    TransactionConversionError, TryIntoSimTx, TxInfoMapper,
-};
+pub use reth_rpc_types_compat::*;
 pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 
 #[cfg(feature = "client")]

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives-traits.workspace = true
-reth-storage-api = { workspace = true, features = ["serde", "serde-bincode-compat"] }
+reth-storage-api = { workspace = true, features = ["serde", "serde-bincode-compat"], optional = true }
 reth-evm.workspace = true
 
 # ethereum
@@ -24,10 +24,10 @@ alloy-consensus.workspace = true
 alloy-network.workspace = true
 
 # optimism
-op-alloy-consensus.workspace = true
-op-alloy-rpc-types.workspace = true
-reth-optimism-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"] }
-op-revm.workspace = true
+op-alloy-consensus = { workspace = true, optional = true }
+op-alloy-rpc-types = { workspace = true, optional = true }
+reth-optimism-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"], optional = true }
+op-revm = { workspace = true, optional = true }
 
 # revm
 revm-context.workspace = true
@@ -38,3 +38,15 @@ jsonrpsee-types.workspace = true
 
 # error
 thiserror.workspace = true
+
+[features]
+default = []
+op = [
+	"dep:op-alloy-consensus",
+	"dep:op-alloy-rpc-types",
+	"dep:reth-optimism-primitives",
+	"dep:reth-storage-api",
+	"dep:op-revm",
+	"reth-evm/op",
+	"reth-primitives-traits/op"
+]

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -42,11 +42,11 @@ thiserror.workspace = true
 [features]
 default = []
 op = [
-	"dep:op-alloy-consensus",
-	"dep:op-alloy-rpc-types",
-	"dep:reth-optimism-primitives",
-	"dep:reth-storage-api",
-	"dep:op-revm",
-	"reth-evm/op",
-	"reth-primitives-traits/op"
+    "dep:op-alloy-consensus",
+    "dep:op-alloy-rpc-types",
+    "dep:reth-optimism-primitives",
+    "dep:reth-storage-api",
+    "dep:op-revm",
+    "reth-evm/op",
+    "reth-primitives-traits/op",
 ]

--- a/crates/rpc/rpc-types-compat/src/lib.rs
+++ b/crates/rpc/rpc-types-compat/src/lib.rs
@@ -14,6 +14,9 @@ mod fees;
 pub mod transaction;
 pub use fees::{CallFees, CallFeesError};
 pub use transaction::{
-    try_into_op_tx_info, EthTxEnvError, IntoRpcTx, RpcConverter, TransactionCompat,
-    TransactionConversionError, TryIntoSimTx, TxInfoMapper,
+    EthTxEnvError, IntoRpcTx, RpcConverter, TransactionCompat, TransactionConversionError,
+    TryIntoSimTx, TxInfoMapper,
 };
+
+#[cfg(feature = "op")]
+pub use transaction::op::*;


### PR DESCRIPTION
these should be feature gated because we want to avoid pulling in these impls for regular eth.

Introduced an additional op feature in reth-rpc-eth-api for convenience