### PR TITLE
fix: check if dir exists before removing

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -274,9 +274,11 @@ impl<R, ChainSpec: EthChainSpec> LaunchContextWith<Attached<WithConfigs<ChainSpe
     pub fn ensure_etl_datadir(mut self) -> Self {
         if self.toml_config_mut().stages.etl.dir.is_none() {
             let etl_path = EtlConfig::from_datadir(self.data_dir().data_dir());
-            // Remove etl-path files on launch
-            if let Err(err) = fs::remove_dir_all(&etl_path) {
-                warn!(target: "reth::cli", ?etl_path, %err, "Failed to remove ETL path on launch");
+            if etl_path.exists() {
+                // Remove etl-path files on launch
+                if let Err(err) = fs::remove_dir_all(&etl_path) {
+                    warn!(target: "reth::cli", ?etl_path, %err, "Failed to remove ETL path on launch");
+                }
             }
             self.toml_config_mut().stages.etl.dir = Some(etl_path);
         }


### PR DESCRIPTION
otherwise this would show up as warning on launch