### PR TITLE
fix: Improve comment in historical RPC tests

### DIFF
--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -215,7 +215,7 @@ mod tests {
         assert!(result.is_none());
     }
 
-    /// Tests that the function doesn't parse anyhing if the parameter is not a valid block id.
+    /// Tests that the function doesn't parse anything if the parameter is not a valid block id.
     #[test]
     fn returns_error_for_invalid_input() {
         let params = Params::new(Some(r#"[true]"#));


### PR DESCRIPTION


**Description:**

A small grammatical fix in a test comment to improve readability.



