### PR TITLE
feat(rpc): Replace associated type `Transaction` with `Network` in `TransactionCompat`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10008,7 +10008,6 @@ version = "1.4.8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -10082,6 +10081,7 @@ name = "reth-rpc-types-compat"
 version = "1.4.8"
 dependencies = [
  "alloy-consensus",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10008,6 +10008,7 @@ version = "1.4.8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -10093,7 +10094,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "revm-context",
- "serde",
  "thiserror 2.0.12",
 ]
 

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -14,7 +14,7 @@ use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
     types::RpcTypes,
-    EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore,
+    EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore, TransactionCompat,
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock};
 use reth_storage_api::{
@@ -27,10 +27,14 @@ impl<N> LoadPendingBlock for OpEthApi<N>
 where
     Self: SpawnBlocking
         + EthApiTypes<
-            NetworkTypes: RpcTypes<
-                Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+            NetworkTypes: op_alloy_network::Network<
+                HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+            > + RpcTypes<
+                Header = <<Self as EthApiTypes>::NetworkTypes as op_alloy_network::Network>::HeaderResponse,
+                Transaction = <<Self as EthApiTypes>::NetworkTypes as op_alloy_network::Network>::TransactionResponse,
             >,
             Error: FromEvmError<Self::Evm>,
+            TransactionCompat: TransactionCompat<Network = <Self as EthApiTypes>::NetworkTypes>,
         >,
     N: RpcNodeCore<
         Provider: BlockReaderIdExt<

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -27,14 +27,11 @@ impl<N> LoadPendingBlock for OpEthApi<N>
 where
     Self: SpawnBlocking
         + EthApiTypes<
-            NetworkTypes: op_alloy_network::Network<
-                HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
-            > + RpcTypes<
-                Header = <<Self as EthApiTypes>::NetworkTypes as op_alloy_network::Network>::HeaderResponse,
-                Transaction = <<Self as EthApiTypes>::NetworkTypes as op_alloy_network::Network>::TransactionResponse,
+            NetworkTypes: RpcTypes<
+                Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
             >,
             Error: FromEvmError<Self::Evm>,
-            TransactionCompat: TransactionCompat<Network = <Self as EthApiTypes>::NetworkTypes>,
+            TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
         >,
     N: RpcNodeCore<
         Provider: BlockReaderIdExt<

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -19,6 +19,7 @@ use reth_primitives_traits::{
 };
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_rpc_eth_types::{EthApiError, PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
+use reth_rpc_types_compat::TransactionCompat;
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, ProviderBlock, ProviderHeader, ProviderReceipt, ProviderTx,
     ReceiptProvider, StateProviderFactory,
@@ -37,10 +38,14 @@ use tracing::debug;
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` blocks RPC methods.
 pub trait LoadPendingBlock:
     EthApiTypes<
-        NetworkTypes: RpcTypes<
-            Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+        NetworkTypes: alloy_network::Network<
+            HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
+        > + RpcTypes<
+            Header = <<Self as EthApiTypes>::NetworkTypes as alloy_network::Network>::HeaderResponse,
+            Transaction = <<Self as EthApiTypes>::NetworkTypes as alloy_network::Network>::TransactionResponse,
         >,
         Error: FromEvmError<Self::Evm>,
+        TransactionCompat: TransactionCompat<Network = <Self as EthApiTypes>::NetworkTypes>,
     > + RpcNodeCore<
         Provider: BlockReaderIdExt<Receipt: Receipt>
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -38,14 +38,11 @@ use tracing::debug;
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` blocks RPC methods.
 pub trait LoadPendingBlock:
     EthApiTypes<
-        NetworkTypes: alloy_network::Network<
-            HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
-        > + RpcTypes<
-            Header = <<Self as EthApiTypes>::NetworkTypes as alloy_network::Network>::HeaderResponse,
-            Transaction = <<Self as EthApiTypes>::NetworkTypes as alloy_network::Network>::TransactionResponse,
+        NetworkTypes: RpcTypes<
+            Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
         >,
         Error: FromEvmError<Self::Evm>,
-        TransactionCompat: TransactionCompat<Network = <Self as EthApiTypes>::NetworkTypes>,
+        TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
     > + RpcNodeCore<
         Provider: BlockReaderIdExt<Receipt: Receipt>
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -11,7 +11,7 @@ use std::{
     fmt::{self},
 };
 
-pub use reth_rpc_types_compat::RpcTypes;
+pub use reth_rpc_types_compat::{RpcTransaction, RpcTypes};
 
 /// Network specific `eth` API types.
 ///
@@ -37,9 +37,6 @@ pub trait EthApiTypes: Send + Sync + Clone {
     /// Returns reference to transaction response builder.
     fn tx_resp_builder(&self) -> &Self::TransactionCompat;
 }
-
-/// Adapter for network specific transaction type.
-pub type RpcTransaction<T> = reth_rpc_types_compat::RpcTransaction<T>;
 
 /// Adapter for network specific block type.
 pub type RpcBlock<T> = Block<RpcTransaction<T>, RpcHeader<T>>;

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -1,8 +1,6 @@
 //! Trait for specifying `eth` network dependent API types.
 
 use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
-use alloy_json_rpc::RpcObject;
-use alloy_network::{Network, ReceiptResponse, TransactionResponse};
 use alloy_rpc_types_eth::Block;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_rpc_types_compat::TransactionCompat;
@@ -13,32 +11,13 @@ use std::{
     fmt::{self},
 };
 
-/// RPC types used by the `eth_` RPC API.
-///
-/// This is a subset of [`alloy_network::Network`] trait with only RPC response types kept.
-pub trait RpcTypes {
-    /// Header response type.
-    type Header: RpcObject;
-    /// Receipt response type.
-    type Receipt: RpcObject + ReceiptResponse;
-    /// Transaction response type.
-    type Transaction: RpcObject + TransactionResponse;
-}
-
-impl<T> RpcTypes for T
-where
-    T: Network,
-{
-    type Header = T::HeaderResponse;
-    type Receipt = T::ReceiptResponse;
-    type Transaction = T::TransactionResponse;
-}
+pub use reth_rpc_types_compat::RpcTypes;
 
 /// Network specific `eth` API types.
 ///
 /// This trait defines the network specific rpc types and helpers required for the `eth_` and
-/// adjacent endpoints. `NetworkTypes` is [`Network`] as defined by the alloy crate, see also
-/// [`alloy_network::Ethereum`].
+/// adjacent endpoints. `NetworkTypes` is [`alloy_network::Network`] as defined by the alloy crate,
+/// see also [`alloy_network::Ethereum`].
 ///
 /// This type is stateful so that it can provide additional context if necessary, e.g. populating
 /// receipts with additional data.
@@ -83,13 +62,10 @@ where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
-            NetworkTypes: Network
-                              + RpcTypes<
-                Transaction = <<Self as EthApiTypes>::NetworkTypes as Network>::TransactionResponse,
-            >,
+            NetworkTypes: RpcTypes,
             TransactionCompat: TransactionCompat<
                 Primitives = <Self as RpcNodeCore>::Primitives,
-                Network = <Self as EthApiTypes>::NetworkTypes,
+                Network = Self::NetworkTypes,
                 Error = RpcError<Self>,
             >,
         >,
@@ -103,13 +79,10 @@ impl<T> FullEthApiTypes for T where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
-            NetworkTypes: Network
-                              + RpcTypes<
-                Transaction = <<Self as EthApiTypes>::NetworkTypes as Network>::TransactionResponse,
-            >,
+            NetworkTypes: RpcTypes,
             TransactionCompat: TransactionCompat<
                 Primitives = <Self as RpcNodeCore>::Primitives,
-                Network = <Self as EthApiTypes>::NetworkTypes,
+                Network = Self::NetworkTypes,
                 Error = RpcError<T>,
             >,
         >

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -39,7 +39,7 @@ pub trait EthApiTypes: Send + Sync + Clone {
 }
 
 /// Adapter for network specific transaction type.
-pub type RpcTransaction<T> = <T as RpcTypes>::Transaction;
+pub type RpcTransaction<T> = reth_rpc_types_compat::RpcTransaction<T>;
 
 /// Adapter for network specific block type.
 pub type RpcBlock<T> = Block<RpcTransaction<T>, RpcHeader<T>>;

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -59,7 +59,6 @@ where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
-            NetworkTypes: RpcTypes,
             TransactionCompat: TransactionCompat<
                 Primitives = <Self as RpcNodeCore>::Primitives,
                 Network = Self::NetworkTypes,
@@ -76,7 +75,6 @@ impl<T> FullEthApiTypes for T where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
-            NetworkTypes: RpcTypes,
             TransactionCompat: TransactionCompat<
                 Primitives = <Self as RpcNodeCore>::Primitives,
                 Network = Self::NetworkTypes,

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -83,9 +83,13 @@ where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
+            NetworkTypes: Network
+                              + RpcTypes<
+                Transaction = <<Self as EthApiTypes>::NetworkTypes as Network>::TransactionResponse,
+            >,
             TransactionCompat: TransactionCompat<
                 Primitives = <Self as RpcNodeCore>::Primitives,
-                Transaction = RpcTransaction<Self::NetworkTypes>,
+                Network = <Self as EthApiTypes>::NetworkTypes,
                 Error = RpcError<Self>,
             >,
         >,
@@ -99,9 +103,13 @@ impl<T> FullEthApiTypes for T where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
+            NetworkTypes: Network
+                              + RpcTypes<
+                Transaction = <<Self as EthApiTypes>::NetworkTypes as Network>::TransactionResponse,
+            >,
             TransactionCompat: TransactionCompat<
                 Primitives = <Self as RpcNodeCore>::Primitives,
-                Transaction = RpcTransaction<T::NetworkTypes>,
+                Network = <Self as EthApiTypes>::NetworkTypes,
                 Error = RpcError<T>,
             >,
         >

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -34,6 +34,7 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-network.workspace = true
 revm.workspace = true
 revm-inspectors.workspace = true
 

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -34,7 +34,6 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
 alloy-rpc-types-eth.workspace = true
-alloy-network.workspace = true
 revm.workspace = true
 revm-inspectors.workspace = true
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -23,7 +23,7 @@ use reth_primitives_traits::{
     block::BlockTx, BlockBody as _, NodePrimitives, Recovered, RecoveredBlock, SignedTransaction,
 };
 use reth_rpc_server_types::result::rpc_err;
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::{RpcTypes, TransactionCompat};
 use reth_storage_api::noop::NoopProvider;
 use revm::{
     context_interface::result::ExecutionResult,
@@ -191,12 +191,7 @@ pub fn build_simulated_block<T, B, Halt: Clone>(
     results: Vec<ExecutionResult<Halt>>,
     full_transactions: bool,
     tx_resp_builder: &T,
-) -> Result<
-    SimulatedBlock<
-        Block<<T::Network as alloy_network::Network>::TransactionResponse, Header<B::Header>>,
-    >,
-    T::Error,
->
+) -> Result<SimulatedBlock<Block<<T::Network as RpcTypes>::Transaction, Header<B::Header>>>, T::Error>
 where
     T: TransactionCompat<
         Primitives: NodePrimitives<SignedTx = BlockTx<B>>,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -23,7 +23,7 @@ use reth_primitives_traits::{
     block::BlockTx, BlockBody as _, NodePrimitives, Recovered, RecoveredBlock, SignedTransaction,
 };
 use reth_rpc_server_types::result::rpc_err;
-use reth_rpc_types_compat::{RpcTypes, TransactionCompat};
+use reth_rpc_types_compat::{RpcTransaction, TransactionCompat};
 use reth_storage_api::noop::NoopProvider;
 use revm::{
     context_interface::result::ExecutionResult,
@@ -191,7 +191,7 @@ pub fn build_simulated_block<T, B, Halt: Clone>(
     results: Vec<ExecutionResult<Halt>>,
     full_transactions: bool,
     tx_resp_builder: &T,
-) -> Result<SimulatedBlock<Block<<T::Network as RpcTypes>::Transaction, Header<B::Header>>>, T::Error>
+) -> Result<SimulatedBlock<Block<RpcTransaction<T::Network>, Header<B::Header>>>, T::Error>
 where
     T: TransactionCompat<
         Primitives: NodePrimitives<SignedTx = BlockTx<B>>,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -191,7 +191,12 @@ pub fn build_simulated_block<T, B, Halt: Clone>(
     results: Vec<ExecutionResult<Halt>>,
     full_transactions: bool,
     tx_resp_builder: &T,
-) -> Result<SimulatedBlock<Block<T::Transaction, Header<B::Header>>>, T::Error>
+) -> Result<
+    SimulatedBlock<
+        Block<<T::Network as alloy_network::Network>::TransactionResponse, Header<B::Header>>,
+    >,
+    T::Error,
+>
 where
     T: TransactionCompat<
         Primitives: NodePrimitives<SignedTx = BlockTx<B>>,

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -6,7 +6,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_primitives_traits::{NodePrimitives, Recovered, SignedTransaction};
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::{RpcTypes, TransactionCompat};
 
 /// Represents from where a transaction was fetched.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -42,7 +42,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     pub fn into_transaction<Builder>(
         self,
         resp_builder: &Builder,
-    ) -> Result<<Builder::Network as alloy_network::Network>::TransactionResponse, Builder::Error>
+    ) -> Result<<Builder::Network as RpcTypes>::Transaction, Builder::Error>
     where
         Builder: TransactionCompat<Primitives: NodePrimitives<SignedTx = T>>,
     {

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -6,7 +6,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_primitives_traits::{NodePrimitives, Recovered, SignedTransaction};
-use reth_rpc_types_compat::{RpcTypes, TransactionCompat};
+use reth_rpc_types_compat::{RpcTransaction, TransactionCompat};
 
 /// Represents from where a transaction was fetched.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -42,7 +42,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     pub fn into_transaction<Builder>(
         self,
         resp_builder: &Builder,
-    ) -> Result<<Builder::Network as RpcTypes>::Transaction, Builder::Error>
+    ) -> Result<RpcTransaction<Builder::Network>, Builder::Error>
     where
         Builder: TransactionCompat<Primitives: NodePrimitives<SignedTx = T>>,
     {

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -42,7 +42,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     pub fn into_transaction<Builder>(
         self,
         resp_builder: &Builder,
-    ) -> Result<Builder::Transaction, Builder::Error>
+    ) -> Result<<Builder::Network as alloy_network::Network>::TransactionResponse, Builder::Error>
     where
         Builder: TransactionCompat<Primitives: NodePrimitives<SignedTx = T>>,
     {

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -33,7 +33,6 @@ op-revm = { workspace = true, optional = true }
 revm-context.workspace = true
 
 # io
-serde.workspace = true
 jsonrpsee-types.workspace = true
 
 # error

--- a/crates/rpc/rpc-types-compat/Cargo.toml
+++ b/crates/rpc/rpc-types-compat/Cargo.toml
@@ -22,6 +22,7 @@ alloy-primitives.workspace = true
 alloy-rpc-types-eth = { workspace = true, default-features = false, features = ["serde"] }
 alloy-consensus.workspace = true
 alloy-network.workspace = true
+alloy-json-rpc.workspace = true
 
 # optimism
 op-alloy-consensus = { workspace = true, optional = true }

--- a/crates/rpc/rpc-types-compat/src/lib.rs
+++ b/crates/rpc/rpc-types-compat/src/lib.rs
@@ -11,8 +11,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod fees;
+mod rpc;
 pub mod transaction;
+
 pub use fees::{CallFees, CallFeesError};
+pub use rpc::*;
 pub use transaction::{
     EthTxEnvError, IntoRpcTx, RpcConverter, TransactionCompat, TransactionConversionError,
     TryIntoSimTx, TxInfoMapper,

--- a/crates/rpc/rpc-types-compat/src/rpc.rs
+++ b/crates/rpc/rpc-types-compat/src/rpc.rs
@@ -21,3 +21,6 @@ where
     type Receipt = T::ReceiptResponse;
     type Transaction = T::TransactionResponse;
 }
+
+/// Adapter for network specific transaction type.
+pub type RpcTransaction<T> = <T as RpcTypes>::Transaction;

--- a/crates/rpc/rpc-types-compat/src/rpc.rs
+++ b/crates/rpc/rpc-types-compat/src/rpc.rs
@@ -1,0 +1,23 @@
+use alloy_json_rpc::RpcObject;
+use alloy_network::{Network, ReceiptResponse, TransactionResponse};
+
+/// RPC types used by the `eth_` RPC API.
+///
+/// This is a subset of [`Network`] trait with only RPC response types kept.
+pub trait RpcTypes {
+    /// Header response type.
+    type Header: RpcObject;
+    /// Receipt response type.
+    type Receipt: RpcObject + ReceiptResponse;
+    /// Transaction response type.
+    type Transaction: RpcObject + TransactionResponse;
+}
+
+impl<T> RpcTypes for T
+where
+    T: Network,
+{
+    type Header = T::HeaderResponse;
+    type Receipt = T::ReceiptResponse;
+    type Transaction = T::TransactionResponse;
+}

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -22,10 +22,11 @@ use thiserror::Error;
 
 /// Builds RPC transaction w.r.t. network.
 pub trait TransactionCompat: Send + Sync + Unpin + Clone + Debug {
-    /// The lower layer consensus types to convert from.
+    /// Associated lower layer consensus types to convert from and into types of [`Self::Network`].
     type Primitives: NodePrimitives;
 
-    /// RPC transaction response type.
+    /// Associated upper layer JSON-RPC API network requests and responses to convert from and into
+    /// types of [`Self::Primitives`].
     type Network: RpcTypes + Send + Sync + Unpin + Clone + Debug;
 
     /// A set of variables for executing a transaction.

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -356,7 +356,7 @@ where
     N: NodePrimitives,
     E: RpcTypes + Send + Sync + Unpin + Clone + Debug,
     Evm: ConfigureEvm,
-    TxTy<N>: IntoRpcTx<<E as RpcTypes>::Transaction> + Clone + Debug,
+    TxTy<N>: IntoRpcTx<E::Transaction> + Clone + Debug,
     TransactionRequest: TryIntoSimTx<TxTy<N>> + TryIntoTxEnv<TxEnvFor<Evm>>,
     Err: From<TransactionConversionError>
         + From<<TransactionRequest as TryIntoTxEnv<TxEnvFor<Evm>>>::Err>
@@ -366,10 +366,8 @@ where
         + Sync
         + Send
         + Into<jsonrpsee_types::ErrorObject<'static>>,
-    Map: for<'a> TxInfoMapper<
-            &'a TxTy<N>,
-            Out = <TxTy<N> as IntoRpcTx<<E as RpcTypes>::Transaction>>::TxInfo,
-        > + Clone
+    Map: for<'a> TxInfoMapper<&'a TxTy<N>, Out = <TxTy<N> as IntoRpcTx<E::Transaction>>::TxInfo>
+        + Clone
         + Debug
         + Unpin
         + Send
@@ -384,7 +382,7 @@ where
         &self,
         tx: Recovered<TxTy<N>>,
         tx_info: TransactionInfo,
-    ) -> Result<<E as RpcTypes>::Transaction, Self::Error> {
+    ) -> Result<E::Transaction, Self::Error> {
         let (tx, signer) = tx.into_parts();
         let tx_info = self.mapper.try_map(&tx, tx_info)?;
 

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     fees::{CallFees, CallFeesError},
-    RpcTypes,
+    RpcTransaction, RpcTypes,
 };
 use alloy_consensus::{error::ValueError, transaction::Recovered, EthereumTxEnvelope, TxEip4844};
 use alloy_primitives::{Address, TxKind, U256};
@@ -40,7 +40,7 @@ pub trait TransactionCompat: Send + Sync + Unpin + Clone + Debug {
     fn fill_pending(
         &self,
         tx: Recovered<TxTy<Self::Primitives>>,
-    ) -> Result<<Self::Network as RpcTypes>::Transaction, Self::Error> {
+    ) -> Result<RpcTransaction<Self::Network>, Self::Error> {
         self.fill(tx, TransactionInfo::default())
     }
 
@@ -53,7 +53,7 @@ pub trait TransactionCompat: Send + Sync + Unpin + Clone + Debug {
         &self,
         tx: Recovered<TxTy<Self::Primitives>>,
         tx_inf: TransactionInfo,
-    ) -> Result<<Self::Network as RpcTypes>::Transaction, Self::Error>;
+    ) -> Result<RpcTransaction<Self::Network>, Self::Error>;
 
     /// Builds a fake transaction from a transaction request for inclusion into block built in
     /// `eth_simulateV1`.

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -20,7 +20,6 @@ use reth_rpc_eth_types::{
     EthApiError, EthFilterConfig, EthStateCache, EthSubscriptionIdProvider,
 };
 use reth_rpc_server_types::{result::rpc_error_with_code, ToRpcResult};
-use reth_rpc_types_compat::RpcTypes;
 use reth_storage_api::{
     BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, HeaderProvider, ProviderBlock,
     ProviderReceipt, TransactionsProvider,
@@ -695,7 +694,7 @@ where
     }
 
     /// Returns all new pending transactions received since the last poll.
-    async fn drain(&self) -> FilterChanges<<TxCompat::Network as RpcTypes>::Transaction> {
+    async fn drain(&self) -> FilterChanges<RpcTransaction<TxCompat::Network>> {
         let mut pending_txs = Vec::new();
         let mut prepared_stream = self.txs_stream.lock().await;
 
@@ -721,13 +720,13 @@ trait FullTransactionsFilter<T>: fmt::Debug + Send + Sync + Unpin + 'static {
 }
 
 #[async_trait]
-impl<T, TxCompat> FullTransactionsFilter<<TxCompat::Network as RpcTypes>::Transaction>
+impl<T, TxCompat> FullTransactionsFilter<RpcTransaction<TxCompat::Network>>
     for FullTransactionsReceiver<T, TxCompat>
 where
     T: PoolTransaction + 'static,
     TxCompat: TransactionCompat<Primitives: NodePrimitives<SignedTx = T::Consensus>> + 'static,
 {
-    async fn drain(&self) -> FilterChanges<<TxCompat::Network as RpcTypes>::Transaction> {
+    async fn drain(&self) -> FilterChanges<RpcTransaction<TxCompat::Network>> {
         Self::drain(self).await
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -8,9 +8,10 @@ use reth_primitives_traits::{BlockBody, NodePrimitives};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
     types::RpcTypes,
-    RpcNodeCore, RpcNodeCoreExt, RpcReceipt,
+    EthApiTypes, RpcNodeCore, RpcNodeCoreExt, RpcReceipt,
 };
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
+use reth_rpc_types_compat::TransactionCompat;
 use reth_storage_api::{BlockReader, ProviderTx};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
@@ -21,6 +22,7 @@ where
     Self: LoadBlock<
         Error = EthApiError,
         NetworkTypes: RpcTypes<Receipt = TransactionReceipt>,
+        TransactionCompat: TransactionCompat<Network = <Self as EthApiTypes>::NetworkTypes>,
         Provider: BlockReader<
             Transaction = reth_ethereum_primitives::TransactionSigned,
             Receipt = reth_ethereum_primitives::Receipt,

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -8,7 +8,7 @@ use reth_primitives_traits::{BlockBody, NodePrimitives};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
     types::RpcTypes,
-    EthApiTypes, RpcNodeCore, RpcNodeCoreExt, RpcReceipt,
+    RpcNodeCore, RpcNodeCoreExt, RpcReceipt,
 };
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 use reth_rpc_types_compat::TransactionCompat;
@@ -22,7 +22,7 @@ where
     Self: LoadBlock<
         Error = EthApiError,
         NetworkTypes: RpcTypes<Receipt = TransactionReceipt>,
-        TransactionCompat: TransactionCompat<Network = <Self as EthApiTypes>::NetworkTypes>,
+        TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
         Provider: BlockReader<
             Transaction = reth_ethereum_primitives::TransactionSigned,
             Receipt = reth_ethereum_primitives::Receipt,

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -9,7 +9,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
     types::RpcTypes,
-    EthApiTypes, FromEvmError, RpcNodeCore,
+    FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::PendingBlock;
 use reth_rpc_types_compat::TransactionCompat;
@@ -24,14 +24,11 @@ impl<Provider, Pool, Network, EvmConfig> LoadPendingBlock
     for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Self: SpawnBlocking<
-            NetworkTypes: alloy_network::Network<
-                HeaderResponse = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
-            > + RpcTypes<
-                Header = <<Self as EthApiTypes>::NetworkTypes as alloy_network::Network>::HeaderResponse,
-                Transaction = <<Self as EthApiTypes>::NetworkTypes as alloy_network::Network>::TransactionResponse,
+            NetworkTypes: RpcTypes<
+                Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
             >,
             Error: FromEvmError<Self::Evm>,
-            TransactionCompat: TransactionCompat<Network = <Self as EthApiTypes>::NetworkTypes>,
+            TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
         > + RpcNodeCore<
             Provider: BlockReaderIdExt<
                 Transaction = reth_ethereum_primitives::TransactionSigned,

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_api::TxPoolApiServer;
+use reth_rpc_eth_api::RpcTransaction;
 use reth_rpc_types_compat::{RpcTypes, TransactionCompat};
 use reth_transaction_pool::{
     AllPoolTransactions, PoolConsensusTx, PoolTransaction, TransactionPool,
@@ -38,9 +39,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus: Transaction>> + 'static,
     Eth: TransactionCompat<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>>,
 {
-    fn content(
-        &self,
-    ) -> Result<TxpoolContent<<Eth::Network as RpcTypes>::Transaction>, Eth::Error> {
+    fn content(&self) -> Result<TxpoolContent<RpcTransaction<Eth::Network>>, Eth::Error> {
         #[inline]
         fn insert<Tx, RpcTxB>(
             tx: &Tx,
@@ -77,7 +76,7 @@ where
 }
 
 #[async_trait]
-impl<Pool, Eth> TxPoolApiServer<<Eth::Network as RpcTypes>::Transaction> for TxPoolApi<Pool, Eth>
+impl<Pool, Eth> TxPoolApiServer<RpcTransaction<Eth::Network>> for TxPoolApi<Pool, Eth>
 where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus: Transaction>> + 'static,
     Eth: TransactionCompat<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>> + 'static,
@@ -134,7 +133,7 @@ where
     async fn txpool_content_from(
         &self,
         from: Address,
-    ) -> RpcResult<TxpoolContentFrom<<Eth::Network as RpcTypes>::Transaction>> {
+    ) -> RpcResult<TxpoolContentFrom<RpcTransaction<Eth::Network>>> {
         trace!(target: "rpc::eth", ?from, "Serving txpool_contentFrom");
         Ok(self.content().map_err(Into::into)?.remove_from(&from))
     }
@@ -144,9 +143,7 @@ where
     ///
     /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content) for more details
     /// Handler for `txpool_content`
-    async fn txpool_content(
-        &self,
-    ) -> RpcResult<TxpoolContent<<Eth::Network as RpcTypes>::Transaction>> {
+    async fn txpool_content(&self) -> RpcResult<TxpoolContent<RpcTransaction<Eth::Network>>> {
         trace!(target: "rpc::eth", "Serving txpool_content");
         Ok(self.content().map_err(Into::into)?)
     }

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -38,11 +38,19 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus: Transaction>> + 'static,
     Eth: TransactionCompat<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>>,
 {
-    fn content(&self) -> Result<TxpoolContent<Eth::Transaction>, Eth::Error> {
+    fn content(
+        &self,
+    ) -> Result<
+        TxpoolContent<<Eth::Network as alloy_network::Network>::TransactionResponse>,
+        Eth::Error,
+    > {
         #[inline]
         fn insert<Tx, RpcTxB>(
             tx: &Tx,
-            content: &mut BTreeMap<Address, BTreeMap<String, RpcTxB::Transaction>>,
+            content: &mut BTreeMap<
+                Address,
+                BTreeMap<String, <RpcTxB::Network as alloy_network::Network>::TransactionResponse>,
+            >,
             resp_builder: &RpcTxB,
         ) -> Result<(), RpcTxB::Error>
         where
@@ -72,7 +80,8 @@ where
 }
 
 #[async_trait]
-impl<Pool, Eth> TxPoolApiServer<Eth::Transaction> for TxPoolApi<Pool, Eth>
+impl<Pool, Eth> TxPoolApiServer<<Eth::Network as alloy_network::Network>::TransactionResponse>
+    for TxPoolApi<Pool, Eth>
 where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus: Transaction>> + 'static,
     Eth: TransactionCompat<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>> + 'static,
@@ -129,7 +138,8 @@ where
     async fn txpool_content_from(
         &self,
         from: Address,
-    ) -> RpcResult<TxpoolContentFrom<Eth::Transaction>> {
+    ) -> RpcResult<TxpoolContentFrom<<Eth::Network as alloy_network::Network>::TransactionResponse>>
+    {
         trace!(target: "rpc::eth", ?from, "Serving txpool_contentFrom");
         Ok(self.content().map_err(Into::into)?.remove_from(&from))
     }
@@ -139,7 +149,10 @@ where
     ///
     /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content) for more details
     /// Handler for `txpool_content`
-    async fn txpool_content(&self) -> RpcResult<TxpoolContent<Eth::Transaction>> {
+    async fn txpool_content(
+        &self,
+    ) -> RpcResult<TxpoolContent<<Eth::Network as alloy_network::Network>::TransactionResponse>>
+    {
         trace!(target: "rpc::eth", "Serving txpool_content");
         Ok(self.content().map_err(Into::into)?)
     }

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_api::TxPoolApiServer;
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::{RpcTypes, TransactionCompat};
 use reth_transaction_pool::{
     AllPoolTransactions, PoolConsensusTx, PoolTransaction, TransactionPool,
 };
@@ -40,16 +40,13 @@ where
 {
     fn content(
         &self,
-    ) -> Result<
-        TxpoolContent<<Eth::Network as alloy_network::Network>::TransactionResponse>,
-        Eth::Error,
-    > {
+    ) -> Result<TxpoolContent<<Eth::Network as RpcTypes>::Transaction>, Eth::Error> {
         #[inline]
         fn insert<Tx, RpcTxB>(
             tx: &Tx,
             content: &mut BTreeMap<
                 Address,
-                BTreeMap<String, <RpcTxB::Network as alloy_network::Network>::TransactionResponse>,
+                BTreeMap<String, <RpcTxB::Network as RpcTypes>::Transaction>,
             >,
             resp_builder: &RpcTxB,
         ) -> Result<(), RpcTxB::Error>
@@ -80,8 +77,7 @@ where
 }
 
 #[async_trait]
-impl<Pool, Eth> TxPoolApiServer<<Eth::Network as alloy_network::Network>::TransactionResponse>
-    for TxPoolApi<Pool, Eth>
+impl<Pool, Eth> TxPoolApiServer<<Eth::Network as RpcTypes>::Transaction> for TxPoolApi<Pool, Eth>
 where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus: Transaction>> + 'static,
     Eth: TransactionCompat<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>> + 'static,
@@ -138,8 +134,7 @@ where
     async fn txpool_content_from(
         &self,
         from: Address,
-    ) -> RpcResult<TxpoolContentFrom<<Eth::Network as alloy_network::Network>::TransactionResponse>>
-    {
+    ) -> RpcResult<TxpoolContentFrom<<Eth::Network as RpcTypes>::Transaction>> {
         trace!(target: "rpc::eth", ?from, "Serving txpool_contentFrom");
         Ok(self.content().map_err(Into::into)?.remove_from(&from))
     }
@@ -151,8 +146,7 @@ where
     /// Handler for `txpool_content`
     async fn txpool_content(
         &self,
-    ) -> RpcResult<TxpoolContent<<Eth::Network as alloy_network::Network>::TransactionResponse>>
-    {
+    ) -> RpcResult<TxpoolContent<<Eth::Network as RpcTypes>::Transaction>> {
         trace!(target: "rpc::eth", "Serving txpool_content");
         Ok(self.content().map_err(Into::into)?)
     }


### PR DESCRIPTION
Related to #14964

Adds an associated type `Network` which implements `alloy_network::Network`.

Then, instead of having `Transaction` associated type, it uses the `TransactionResponse` of the `Network`.

Simplifies passing down the network that is associated with the node.
