### PR TITLE
chore: resolve unused import warning in reth RPC API subscription attribute

### DIFF
--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -1,8 +1,10 @@
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_chain_state::CanonStateNotification;
 use std::collections::HashMap;
+
+// Required for the subscription attribute below
+use reth_chain_state as _;
 
 /// Reth API namespace for reth-specific methods
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "reth"))]
@@ -19,7 +21,7 @@ pub trait RethApi {
     #[subscription(
         name = "subscribeChainNotifications",
         unsubscribe = "unsubscribeChainNotifications",
-        item = CanonStateNotification
+        item = reth_chain_state::CanonStateNotification
     )]
     async fn reth_subscribe_chain_notifications(&self) -> jsonrpsee::core::SubscriptionResult;
 }


### PR DESCRIPTION
resolves this warning:
```
$ cargo clippy --lib -p reth-rpc-api
warning: unused import: `reth_chain_state::CanonStateNotification`
 --> crates/rpc/rpc-api/src/reth.rs:4:5
  |
4 | use reth_chain_state::CanonStateNotification;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `reth-rpc-api` (lib) generated 1 warning (run `cargo clippy --fix --lib -p reth-rpc-api` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.60s
```