### PR TITLE
fix: add missing historical RPC endpoints for Optimism pre-bedrock

### DIFF
--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -114,10 +114,12 @@ where
                     parse_block_id_from_params(&req.params(), 0)
                 }
                 "eth_getBalance" |
-                "eth_getStorageAt" |
                 "eth_getCode" |
                 "eth_getTransactionCount" |
-                "eth_call" => parse_block_id_from_params(&req.params(), 1),
+                "eth_call" |
+                "eth_estimateGas" |
+                "eth_createAccessList" => parse_block_id_from_params(&req.params(), 1),
+                "eth_getStorageAt" | "eth_getProof" => parse_block_id_from_params(&req.params(), 2),
                 _ => None,
             };
 


### PR DESCRIPTION
Added missing endpoints that check `IsOptimismPreBedrock` in op-geth:
- `eth_estimateGas`
- `eth_createAccessList`  
- `eth_getProof`

Also fixed `eth_getStorageAt` to parse block ID from correct parameter position (2 instead of 1), as parameters are `[address, key, block]`.

Found by comparing op-geth's usage of `HistoricalRPCService()` with our implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)