### PR TITLE
fix: use empty withdrawals if parent has withdrawals root

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -72,7 +72,7 @@ where
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),
             parent_beacon_block_root: parent.parent_beacon_block_root().map(|_| B256::ZERO),
-            withdrawals: None,
+            withdrawals: parent.withdrawals_root().map(|_| Default::default()),
         })
     }
 }


### PR DESCRIPTION
for pending block we were always providing None, but we can easily check the parent