### PR TITLE
refactor: remove CallFees re-export and relocate tests

### DIFF
--- a/crates/rpc/rpc-eth-types/src/revm_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/revm_utils.rs
@@ -15,8 +15,6 @@ use std::collections::{BTreeMap, HashMap};
 
 use super::{EthApiError, EthResult, RpcInvalidTransactionError};
 
-pub use reth_rpc_types_compat::CallFees;
-
 /// Calculates the caller gas allowance.
 ///
 /// `allowance = (account.balance - tx.value) / tx.gas_price`
@@ -206,119 +204,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::constants::GWEI_TO_WEI;
     use alloy_primitives::{address, bytes};
     use reth_revm::db::EmptyDB;
-
-    #[test]
-    fn test_ensure_0_fallback() {
-        let CallFees { gas_price, .. } =
-            CallFees::ensure_fees(None, None, None, U256::from(99), None, None, Some(U256::ZERO))
-                .unwrap();
-        assert!(gas_price.is_zero());
-    }
-
-    #[test]
-    fn test_ensure_max_fee_0_exception() {
-        let CallFees { gas_price, .. } =
-            CallFees::ensure_fees(None, Some(U256::ZERO), None, U256::from(99), None, None, None)
-                .unwrap();
-        assert!(gas_price.is_zero());
-    }
-
-    #[test]
-    fn test_blob_fees() {
-        let CallFees { gas_price, max_fee_per_blob_gas, .. } =
-            CallFees::ensure_fees(None, None, None, U256::from(99), None, None, Some(U256::ZERO))
-                .unwrap();
-        assert!(gas_price.is_zero());
-        assert_eq!(max_fee_per_blob_gas, None);
-
-        let CallFees { gas_price, max_fee_per_blob_gas, .. } = CallFees::ensure_fees(
-            None,
-            None,
-            None,
-            U256::from(99),
-            Some(&[B256::from(U256::ZERO)]),
-            None,
-            Some(U256::from(99)),
-        )
-        .unwrap();
-        assert!(gas_price.is_zero());
-        assert_eq!(max_fee_per_blob_gas, Some(U256::from(99)));
-    }
-
-    #[test]
-    fn test_eip_1559_fees() {
-        let CallFees { gas_price, .. } = CallFees::ensure_fees(
-            None,
-            Some(U256::from(25 * GWEI_TO_WEI)),
-            Some(U256::from(15 * GWEI_TO_WEI)),
-            U256::from(15 * GWEI_TO_WEI),
-            None,
-            None,
-            Some(U256::ZERO),
-        )
-        .unwrap();
-        assert_eq!(gas_price, U256::from(25 * GWEI_TO_WEI));
-
-        let CallFees { gas_price, .. } = CallFees::ensure_fees(
-            None,
-            Some(U256::from(25 * GWEI_TO_WEI)),
-            Some(U256::from(5 * GWEI_TO_WEI)),
-            U256::from(15 * GWEI_TO_WEI),
-            None,
-            None,
-            Some(U256::ZERO),
-        )
-        .unwrap();
-        assert_eq!(gas_price, U256::from(20 * GWEI_TO_WEI));
-
-        let CallFees { gas_price, .. } = CallFees::ensure_fees(
-            None,
-            Some(U256::from(30 * GWEI_TO_WEI)),
-            Some(U256::from(30 * GWEI_TO_WEI)),
-            U256::from(15 * GWEI_TO_WEI),
-            None,
-            None,
-            Some(U256::ZERO),
-        )
-        .unwrap();
-        assert_eq!(gas_price, U256::from(30 * GWEI_TO_WEI));
-
-        let call_fees = CallFees::ensure_fees(
-            None,
-            Some(U256::from(30 * GWEI_TO_WEI)),
-            Some(U256::from(31 * GWEI_TO_WEI)),
-            U256::from(15 * GWEI_TO_WEI),
-            None,
-            None,
-            Some(U256::ZERO),
-        );
-        assert!(call_fees.is_err());
-
-        let call_fees = CallFees::ensure_fees(
-            None,
-            Some(U256::from(5 * GWEI_TO_WEI)),
-            Some(U256::from(GWEI_TO_WEI)),
-            U256::from(15 * GWEI_TO_WEI),
-            None,
-            None,
-            Some(U256::ZERO),
-        );
-        assert!(call_fees.is_err());
-
-        let call_fees = CallFees::ensure_fees(
-            None,
-            Some(U256::MAX),
-            Some(U256::MAX),
-            U256::from(5 * GWEI_TO_WEI),
-            None,
-            None,
-            Some(U256::ZERO),
-        );
-        assert!(call_fees.is_err());
-    }
 
     #[test]
     fn state_override_state() {


### PR DESCRIPTION
Removed the `CallFees` re-export from `revm_utils.rs` as part of the preparation for removing `revm_utils.rs`. The tests for `CallFees` have been moved to `fees.rs` where the struct is defined, improving code organization by co-locating tests with their implementation.

Changes:
- Removed `pub use reth_rpc_types_compat::CallFees` from `revm_utils.rs`
- Moved all `CallFees` tests from `revm_utils.rs` to `fees.rs`
- Updated imports in `revm_utils.rs` tests to import `CallFees` directly
- Removed unused `GWEI_TO_WEI` import that was only used by the moved tests