### PR TITLE
chore(era): complete doc for `ClientWithFakeIndex`

### DIFF
--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -1,11 +1,10 @@
-use alloy_primitives::bytes::Bytes;
-use futures_util::{Stream, TryStreamExt};
-use reqwest::{Client, IntoUrl, Url};
+use crate::ClientWithFakeIndex;
+use reqwest::{Client, Url};
 use reth_db_common::init::init_genesis;
-use reth_era_downloader::{EraClient, EraStream, EraStreamConfig, HttpClient};
+use reth_era_downloader::{EraClient, EraStream, EraStreamConfig};
 use reth_etl::Collector;
 use reth_provider::test_utils::create_test_provider_factory;
-use std::{future::Future, str::FromStr};
+use std::str::FromStr;
 use tempfile::tempdir;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -34,39 +33,4 @@ async fn test_history_imports_from_fresh_state_successfully() {
     let actual_block_number = reth_era_utils::import(stream, &pf, &mut hash_collector).unwrap();
 
     assert_eq!(actual_block_number, expected_block_number);
-}
-
-/// An HTTP client pre-programmed with canned answer to index.
-///
-/// Passes any other calls to a real HTTP client!
-#[derive(Debug, Clone)]
-struct ClientWithFakeIndex(Client);
-
-impl HttpClient for ClientWithFakeIndex {
-    fn get<U: IntoUrl + Send + Sync>(
-        &self,
-        url: U,
-    ) -> impl Future<
-        Output = eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>,
-    > + Send
-           + Sync {
-        let url = url.into_url().unwrap();
-
-        async move {
-            match url.to_string().as_str() {
-                "https://era.ithaca.xyz/era1/index.html" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from_static(b"<a href=\"https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1\">mainnet-00000-5ec1ffb8.era1</a>"))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                _ => {
-                    let response = Client::get(&self.0, url).send().await?;
-
-                    Ok(Box::new(response.bytes_stream().map_err(|e| eyre::Error::new(e)))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-            }
-        }
-    }
 }

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -1,4 +1,4 @@
-use crate::ClientWithFakeIndex;
+use crate::{ClientWithFakeIndex, ITHACA_ERA_INDEX_URL};
 use reqwest::{Client, Url};
 use reth_db_common::init::init_genesis;
 use reth_era_downloader::{EraClient, EraStream, EraStreamConfig};
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_history_imports_from_fresh_state_successfully() {
     // URL where the ERA1 files are hosted
-    let url = Url::from_str("https://era.ithaca.xyz/era1/index.html").unwrap();
+    let url = Url::from_str(ITHACA_ERA_INDEX_URL).unwrap();
 
     // Directory where the ERA1 files will be downloaded to
     let folder = tempdir().unwrap();

--- a/crates/era-utils/tests/it/main.rs
+++ b/crates/era-utils/tests/it/main.rs
@@ -10,9 +10,11 @@ use reqwest::{Client, IntoUrl};
 use reth_era_downloader::HttpClient;
 use std::future::Future;
 
-/// An HTTP client pre-programmed with canned answer to index.
+/// An HTTP client that fakes the file list to always show one known file
 ///
-/// Passes any other calls to a real HTTP client!
+/// but passes all other calls including actual downloads to a real HTTP client
+/// 
+/// In that way, only one file is used but downloads are still performed from the normal source.
 #[derive(Debug, Clone)]
 struct ClientWithFakeIndex(Client);
 

--- a/crates/era-utils/tests/it/main.rs
+++ b/crates/era-utils/tests/it/main.rs
@@ -3,3 +3,44 @@
 mod history;
 
 const fn main() {}
+
+use alloy_primitives::bytes::Bytes;
+use futures_util::{Stream, TryStreamExt};
+use reqwest::{Client, IntoUrl};
+use reth_era_downloader::HttpClient;
+use std::future::Future;
+
+/// An HTTP client pre-programmed with canned answer to index.
+///
+/// Passes any other calls to a real HTTP client!
+#[derive(Debug, Clone)]
+struct ClientWithFakeIndex(Client);
+
+impl HttpClient for ClientWithFakeIndex {
+    fn get<U: IntoUrl + Send + Sync>(
+        &self,
+        url: U,
+    ) -> impl Future<
+        Output = eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>,
+    > + Send
+           + Sync {
+        let url = url.into_url().unwrap();
+
+        async move {
+            match url.to_string().as_str() {
+                "https://era.ithaca.xyz/era1/index.html" => {
+                    Ok(Box::new(futures::stream::once(Box::pin(async move {
+                        Ok(bytes::Bytes::from_static(b"<a href=\"https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1\">mainnet-00000-5ec1ffb8.era1</a>"))
+                    })))
+                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
+                }
+                _ => {
+                    let response = Client::get(&self.0, url).send().await?;
+
+                    Ok(Box::new(response.bytes_stream().map_err(|e| eyre::Error::new(e)))
+                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Some preparation to help to finalize https://github.com/paradigmxyz/reth/pull/15909.

- Move `ClientWithFakeIndex` to `/test/it/main.rs` instead of `/test/it/history.rs`, it can also be moved to a `src/test_utils` file (probably better),
- Make doc for `ClientWithFakeIndex` more explicit,
- make impl for ClientWithFakeIndex,  `get` method used async directly,
- use some const for the index url/response.

cc @RomanHodulak, @mattsse.