### PR TITLE
chore: simplify test HttpClient implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8058,6 +8058,7 @@ dependencies = [
  "reth-storage-api",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -9,10 +9,9 @@ mod stream;
 const fn main() {}
 
 use bytes::Bytes;
-use futures_util::Stream;
+use futures::Stream;
 use reqwest::IntoUrl;
 use reth_era_downloader::HttpClient;
-use std::future::Future;
 
 pub(crate) const NIMBUS: &[u8] = include_bytes!("../res/nimbus.html");
 pub(crate) const ETH_PORTAL: &[u8] = include_bytes!("../res/ethportal.html");
@@ -27,91 +26,30 @@ pub(crate) const MAINNET_1: &[u8] = include_bytes!("../res/mainnet-00001-a5364e9
 struct StubClient;
 
 impl HttpClient for StubClient {
-    fn get<U: IntoUrl + Send + Sync>(
+    async fn get<U: IntoUrl + Send + Sync>(
         &self,
         url: U,
-    ) -> impl Future<
-        Output = eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>,
-    > + Send
-           + Sync {
+    ) -> eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin> {
         let url = url.into_url().unwrap();
 
-        async move {
-            match url.to_string().as_str() {
-                "https://mainnet.era1.nimbus.team/" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(NIMBUS))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(ETH_PORTAL))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era.ithaca.xyz/era1/index.html" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(ITHACA))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://mainnet.era1.nimbus.team/checksums.txt" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(CHECKSUMS))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/checksums.txt" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(CHECKSUMS))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era.ithaca.xyz/era1/checksums.txt" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(CHECKSUMS))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_0))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_0))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_0))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_1))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_1))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
-                    Ok(Box::new(futures::stream::once(Box::pin(async move {
-                        Ok(bytes::Bytes::from(MAINNET_1))
-                    })))
-                        as Box<dyn Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin>)
-                }
-                v => unimplemented!("Unexpected URL \"{v}\""),
+        Ok(futures::stream::iter(vec![Ok(match url.to_string().as_str() {
+            "https://mainnet.era1.nimbus.team/" => Bytes::from_static(NIMBUS),
+            "https://era1.ethportal.net/" => Bytes::from_static(ETH_PORTAL),
+            "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(ITHACA),
+            "https://mainnet.era1.nimbus.team/checksums.txt" |
+            "https://era1.ethportal.net/checksums.txt" |
+            "https://era.ithaca.xyz/era1/checksums.txt" => Bytes::from_static(CHECKSUMS),
+            "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1" |
+            "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1" |
+            "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
+                Bytes::from_static(MAINNET_0)
             }
-        }
+            "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1" |
+            "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1" |
+            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
+                Bytes::from_static(MAINNET_1)
+            }
+            v => unimplemented!("Unexpected URL \"{v}\""),
+        })]))
     }
 }

--- a/crates/era-utils/Cargo.toml
+++ b/crates/era-utils/Cargo.toml
@@ -42,6 +42,7 @@ reth-db-common.workspace = true
 # async
 tokio.workspace = true
 tokio.features = ["fs", "io-util", "macros", "rt-multi-thread"]
+tokio-util.workspace = true
 futures.workspace = true
 bytes.workspace = true
 


### PR DESCRIPTION
Removes unnecessary boxing and type casts in test HTTP clients.

## Changes
- Use `async fn` directly instead of `future::ready` wrapper
- Use `futures::stream::iter` for already Unpin streams instead of `stream::once` with boxing
- Use `Bytes::from_static` for zero-copy static data instead of `Bytes::from`
- Use `tokio_util::either::Either` in ClientWithFakeIndex to avoid boxing different stream types

## Benefits
- Eliminates heap allocations in test code
- Removes dynamic dispatch overhead
- Cleaner, more readable test implementations