### PR TITLE
chore: fix typo bootnode.rs

### DIFF
--- a/crates/cli/commands/src/p2p/bootnode.rs
+++ b/crates/cli/commands/src/p2p/bootnode.rs
@@ -10,7 +10,7 @@ use tokio::select;
 use tokio_stream::StreamExt;
 use tracing::info;
 
-/// Satrt a discovery only bootnode.
+/// Start a discovery only bootnode.
 #[derive(Parser, Debug)]
 pub struct Command {
     /// Listen address for the bootnode (default: ":30301").


### PR DESCRIPTION
fix typo: `Satrt` --> `Start`