### PR TITLE
chore: simplify `RpcConverter`

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -65,10 +65,8 @@ impl<T> OpNodeCore for T where T: RpcNodeCore<Provider: BlockReader> {}
 pub struct OpEthApi<N: OpNodeCore, NetworkT = Optimism> {
     /// Gateway to node's core components.
     inner: Arc<OpEthApiInner<N>>,
-    /// Marker for the network types.
-    _nt: PhantomData<NetworkT>,
-    tx_resp_builder:
-        RpcConverter<N::Primitives, NetworkT, N::Evm, OpEthApiError, OpTxInfoMapper<N>>,
+    /// Converter for RPC types.
+    tx_resp_builder: RpcConverter<NetworkT, N::Evm, OpEthApiError, OpTxInfoMapper<N>>,
 }
 
 impl<N: OpNodeCore, NetworkT> OpEthApi<N, NetworkT> {
@@ -82,7 +80,6 @@ impl<N: OpNodeCore, NetworkT> OpEthApi<N, NetworkT> {
             Arc::new(OpEthApiInner { eth_api, sequencer_client, min_suggested_priority_fee });
         Self {
             inner: inner.clone(),
-            _nt: PhantomData,
             tx_resp_builder: RpcConverter::with_mapper(OpTxInfoMapper::new(inner)),
         }
     }
@@ -120,8 +117,7 @@ where
 {
     type Error = OpEthApiError;
     type NetworkTypes = NetworkT;
-    type TransactionCompat =
-        RpcConverter<N::Primitives, NetworkT, N::Evm, OpEthApiError, OpTxInfoMapper<N>>;
+    type TransactionCompat = RpcConverter<NetworkT, N::Evm, OpEthApiError, OpTxInfoMapper<N>>;
 
     fn tx_resp_builder(&self) -> &Self::TransactionCompat {
         &self.tx_resp_builder

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -303,60 +303,60 @@ pub struct TransactionConversionError(String);
 
 /// Generic RPC response object converter for primitives `N` and network `E`.
 #[derive(Debug)]
-pub struct RpcConverter<N, E, Evm, Err, Map = ()> {
-    phantom: PhantomData<(N, E, Evm, Err)>,
+pub struct RpcConverter<E, Evm, Err, Map = ()> {
+    phantom: PhantomData<(E, Evm, Err)>,
     mapper: Map,
 }
 
-impl<N, E, Evm, Err> RpcConverter<N, E, Evm, Err, ()> {
+impl<E, Evm, Err> RpcConverter<E, Evm, Err, ()> {
     /// Creates a new [`RpcConverter`] with the default mapper.
     pub const fn new() -> Self {
         Self::with_mapper(())
     }
 }
 
-impl<N, E, Evm, Err, Map> RpcConverter<N, E, Evm, Err, Map> {
+impl<E, Evm, Err, Map> RpcConverter<E, Evm, Err, Map> {
     /// Creates a new [`RpcConverter`] with `mapper`.
     pub const fn with_mapper(mapper: Map) -> Self {
         Self { phantom: PhantomData, mapper }
     }
 
     /// Converts the generic types.
-    pub fn convert<N2, E2, Evm2, Err2>(self) -> RpcConverter<N2, E2, Evm2, Err2, Map> {
+    pub fn convert<E2, Evm2, Err2>(self) -> RpcConverter<E2, Evm2, Err2, Map> {
         RpcConverter::with_mapper(self.mapper)
     }
 
     /// Swaps the inner `mapper`.
-    pub fn map<Map2>(self, mapper: Map2) -> RpcConverter<N, E, Evm, Err, Map2> {
+    pub fn map<Map2>(self, mapper: Map2) -> RpcConverter<E, Evm, Err, Map2> {
         RpcConverter::with_mapper(mapper)
     }
 
     /// Converts the generic types and swaps the inner `mapper`.
-    pub fn convert_map<N2, E2, Evm2, Err2, Map2>(
+    pub fn convert_map<E2, Evm2, Err2, Map2>(
         self,
         mapper: Map2,
-    ) -> RpcConverter<N2, E2, Evm2, Err2, Map2> {
+    ) -> RpcConverter<E2, Evm2, Err2, Map2> {
         self.convert().map(mapper)
     }
 }
 
-impl<N, E, Evm, Err, Map: Clone> Clone for RpcConverter<N, E, Evm, Err, Map> {
+impl<E, Evm, Err, Map: Clone> Clone for RpcConverter<E, Evm, Err, Map> {
     fn clone(&self) -> Self {
         Self::with_mapper(self.mapper.clone())
     }
 }
 
-impl<N, E, Evm, Err> Default for RpcConverter<N, E, Evm, Err> {
+impl<E, Evm, Err> Default for RpcConverter<E, Evm, Err> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<N, E, Evm, Err, Map> TransactionCompat for RpcConverter<N, E, Evm, Err, Map>
+impl<N, E, Evm, Err, Map> TransactionCompat for RpcConverter<E, Evm, Err, Map>
 where
     N: NodePrimitives,
     E: RpcTypes + Send + Sync + Unpin + Clone + Debug,
-    Evm: ConfigureEvm,
+    Evm: ConfigureEvm<Primitives = N>,
     TxTy<N>: IntoRpcTx<E::Transaction> + Clone + Debug,
     TransactionRequest: TryIntoSimTx<TxTy<N>> + TryIntoTxEnv<TxEnvFor<Evm>>,
     Err: From<TransactionConversionError>

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -1,13 +1,12 @@
 //! L1 `eth` API types.
 
 use alloy_network::Ethereum;
-use reth_ethereum_primitives::EthPrimitives;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_types_compat::RpcConverter;
 
 /// An [`RpcConverter`] with its generics set to Ethereum specific.
-pub type EthRpcConverter = RpcConverter<EthPrimitives, Ethereum, EthEvmConfig, EthApiError>;
+pub type EthRpcConverter = RpcConverter<Ethereum, EthEvmConfig, EthApiError>;
 
 //tests for simulate
 #[cfg(test)]


### PR DESCRIPTION
Given that it gets `ConfigureEvm` which already has primitives we don't need a separate `N: NodePrimitives` generic here