### PR TITLE
test: special case for nibbles implementations of `Compact`

### DIFF
--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -222,6 +222,16 @@ where
         };
         let res = obj.to_compact(&mut compact_buffer);
 
+        // `Compact` for `StoredNibbles` and `StoredNibblesSubKey` is implemented as converting to
+        // an array of nybbles, with each byte representing one nibble. This also matches the
+        // internal representation of `nybbles::Nibbles`: each nibble is stored in a separate byte,
+        // with high nibble set to zero.
+        //
+        // Unfortunately, the `Arbitrary` implementation for `nybbles::Nibbles` doesn't generate
+        // valid nibbles, as it sets the high nibble to a non-zero value.
+        //
+        // This hack sets the high nibble to zero.
+        //
         // TODO: remove this, see https://github.com/paradigmxyz/reth/pull/17006
         if type_name == "StoredNibbles" || type_name == "StoredNibblesSubKey" {
             for byte in &mut compact_buffer {

--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -222,6 +222,13 @@ where
         };
         let res = obj.to_compact(&mut compact_buffer);
 
+        // TODO: remove this, see https://github.com/paradigmxyz/reth/pull/17006
+        if type_name == "StoredNibbles" || type_name == "StoredNibblesSubKey" {
+            for byte in &mut compact_buffer {
+                *byte &= 0x0F;
+            }
+        }
+
         if IDENTIFIER_TYPE.contains(&type_name) {
             compact_buffer.push(res as u8);
         }


### PR DESCRIPTION
## Problem

`nybbles` incorrectly implements `Arbitrary` by simply deriving it https://github.com/alloy-rs/nybbles/blob/5a4e3846d9e3f5c5ee12e2324c255fb638e74e30/src/nibbles.rs#L49. It can lead to both nibbles of each byte getting set, while `Nibbles` expect the high nibble to be zero. proptest's `Arbitrary` has a correct implementation https://github.com/alloy-rs/nybbles/blob/5a4e3846d9e3f5c5ee12e2324c255fb638e74e30/src/nibbles.rs#L160, but we can't easily use it just for nibbles types.

## Solution

Clear the high nibble of compact implementation output for `StoredNibbles` and `StoredNibblesSubKey`. This can be reverted after https://github.com/paradigmxyz/reth/pull/16727 is merged, because new version of `nybbles` implements `Arbitrary` correctly.