### PR TITLE
refactor(rpc): Rename `TransactionCompat` => `RpcConvert`

### DIFF
--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -5,7 +5,7 @@ use reth_evm::{execute::BlockExecutorFactory, ConfigureEvm, EvmFactory, TxEnvFor
 use reth_node_api::NodePrimitives;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadBlock, LoadState, SpawnBlocking},
-    FromEvmError, FullEthApiTypes, TransactionCompat,
+    FromEvmError, FullEthApiTypes, RpcConvert,
 };
 use reth_storage_api::{errors::ProviderError, ProviderHeader, ProviderTx};
 use revm::context::TxEnv;
@@ -37,9 +37,9 @@ where
                     EvmFactory: EvmFactory<Tx = OpTransaction<TxEnv>>,
                 >,
             >,
-            TransactionCompat: TransactionCompat<TxEnv = TxEnvFor<Self::Evm>>,
+            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>>,
             Error: FromEvmError<Self::Evm>
-                       + From<<Self::TransactionCompat as TransactionCompat>::Error>
+                       + From<<Self::RpcConvert as RpcConvert>::Error>
                        + From<ProviderError>,
         > + SpawnBlocking,
     Self::Error: From<OpEthApiError>,

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -117,9 +117,9 @@ where
 {
     type Error = OpEthApiError;
     type NetworkTypes = NetworkT;
-    type TransactionCompat = RpcConverter<NetworkT, N::Evm, OpEthApiError, OpTxInfoMapper<N>>;
+    type RpcConvert = RpcConverter<NetworkT, N::Evm, OpEthApiError, OpTxInfoMapper<N>>;
 
-    fn tx_resp_builder(&self) -> &Self::TransactionCompat {
+    fn tx_resp_builder(&self) -> &Self::RpcConvert {
         &self.tx_resp_builder
     }
 }

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -13,7 +13,7 @@ use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
     types::RpcTypes,
-    EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore, TransactionCompat,
+    EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock};
 use reth_storage_api::{
@@ -30,7 +30,7 @@ where
                 Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
             >,
             Error: FromEvmError<Self::Evm>,
-            TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
+            RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
         >,
     N: RpcNodeCore<
         Provider: BlockReaderIdExt

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -13,7 +13,7 @@ use futures::Future;
 use reth_evm::ConfigureEvm;
 use reth_node_api::BlockBody;
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock, SealedBlock};
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcConvert;
 use reth_storage_api::{BlockIdReader, BlockReader, ProviderHeader, ProviderReceipt, ProviderTx};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::sync::Arc;

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -34,7 +34,7 @@ use reth_rpc_eth_types::{
     simulate::{self, EthSimulateError},
     EthApiError, RevertError, RpcInvalidTransactionError, StateCacheDb,
 };
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcConvert;
 use reth_storage_api::{BlockIdReader, ProviderHeader, ProviderTx};
 use revm::{
     context_interface::{
@@ -456,9 +456,9 @@ pub trait Call:
                 SignedTx = ProviderTx<Self::Provider>,
             >,
         >,
-        TransactionCompat: TransactionCompat<TxEnv = TxEnvFor<Self::Evm>>,
+        RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>>,
         Error: FromEvmError<Self::Evm>
-                   + From<<Self::TransactionCompat as TransactionCompat>::Error>
+                   + From<<Self::RpcConvert as RpcConvert>::Error>
                    + From<ProviderError>,
     > + SpawnBlocking
 {

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -20,7 +20,7 @@ use reth_primitives_traits::{
 };
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_rpc_eth_types::{EthApiError, PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcConvert;
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, ProviderBlock, ProviderHeader, ProviderReceipt, ProviderTx,
     ReceiptProvider, StateProviderFactory,
@@ -43,7 +43,7 @@ pub trait LoadPendingBlock:
             Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
         >,
         Error: FromEvmError<Self::Evm>,
-        TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
+        RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
     > + RpcNodeCore<
         Provider: BlockReaderIdExt<Receipt: Receipt>
                       + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -23,7 +23,7 @@ use reth_rpc_eth_types::{
     utils::binary_search, EthApiError, EthApiError::TransactionConfirmationTimeout, SignError,
     TransactionSource,
 };
-use reth_rpc_types_compat::transaction::TransactionCompat;
+use reth_rpc_types_compat::transaction::RpcConvert;
 use reth_storage_api::{
     BlockNumReader, BlockReaderIdExt, ProviderBlock, ProviderReceipt, ProviderTx, ReceiptProvider,
     TransactionsProvider,

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -3,7 +3,7 @@
 use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
 use alloy_rpc_types_eth::Block;
 use reth_chain_state::CanonStateSubscriptions;
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcConvert;
 use reth_storage_api::{ProviderTx, ReceiptProvider, TransactionsProvider};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{
@@ -32,10 +32,10 @@ pub trait EthApiTypes: Send + Sync + Clone {
     /// Blockchain primitive types, specific to network, e.g. block and transaction.
     type NetworkTypes: RpcTypes;
     /// Conversion methods for transaction RPC type.
-    type TransactionCompat: Send + Sync + Clone + fmt::Debug;
+    type RpcConvert: Send + Sync + Clone + fmt::Debug;
 
     /// Returns reference to transaction response builder.
-    fn tx_resp_builder(&self) -> &Self::TransactionCompat;
+    fn tx_resp_builder(&self) -> &Self::RpcConvert;
 }
 
 /// Adapter for network specific block type.
@@ -59,7 +59,7 @@ where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
-            TransactionCompat: TransactionCompat<
+            RpcConvert: RpcConvert<
                 Primitives = <Self as RpcNodeCore>::Primitives,
                 Network = Self::NetworkTypes,
                 Error = RpcError<Self>,
@@ -75,7 +75,7 @@ impl<T> FullEthApiTypes for T where
                 Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
             >,
         > + EthApiTypes<
-            TransactionCompat: TransactionCompat<
+            RpcConvert: RpcConvert<
                 Primitives = <Self as RpcNodeCore>::Primitives,
                 Network = Self::NetworkTypes,
                 Error = RpcError<T>,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -23,7 +23,7 @@ use reth_primitives_traits::{
     block::BlockTx, BlockBody as _, NodePrimitives, Recovered, RecoveredBlock, SignedTransaction,
 };
 use reth_rpc_server_types::result::rpc_err;
-use reth_rpc_types_compat::{RpcTransaction, TransactionCompat};
+use reth_rpc_types_compat::{RpcConvert, RpcTransaction};
 use reth_storage_api::noop::NoopProvider;
 use revm::{
     context_interface::result::ExecutionResult,
@@ -77,7 +77,7 @@ pub fn execute_transactions<S, T>(
 >
 where
     S: BlockBuilder<Executor: BlockExecutor<Evm: Evm<DB: Database<Error: Into<EthApiError>>>>>,
-    T: TransactionCompat<Primitives = S::Primitives>,
+    T: RpcConvert<Primitives = S::Primitives>,
 {
     builder.apply_pre_execution_changes()?;
 
@@ -121,7 +121,7 @@ pub fn resolve_transaction<DB: Database, Tx, T>(
 ) -> Result<Recovered<Tx>, EthApiError>
 where
     DB::Error: Into<EthApiError>,
-    T: TransactionCompat<Primitives: NodePrimitives<SignedTx = Tx>>,
+    T: RpcConvert<Primitives: NodePrimitives<SignedTx = Tx>>,
 {
     // If we're missing any fields we try to fill nonce, gas and
     // gas price.
@@ -193,7 +193,7 @@ pub fn build_simulated_block<T, B, Halt: Clone>(
     tx_resp_builder: &T,
 ) -> Result<SimulatedBlock<Block<RpcTransaction<T::Network>, Header<B::Header>>>, T::Error>
 where
-    T: TransactionCompat<
+    T: RpcConvert<
         Primitives: NodePrimitives<SignedTx = BlockTx<B>>,
         Error: FromEthApiError + FromEvmHalt<Halt>,
     >,

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -6,7 +6,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_primitives_traits::{NodePrimitives, Recovered, SignedTransaction};
-use reth_rpc_types_compat::{RpcTransaction, TransactionCompat};
+use reth_rpc_types_compat::{RpcConvert, RpcTransaction};
 
 /// Represents from where a transaction was fetched.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -44,7 +44,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
         resp_builder: &Builder,
     ) -> Result<RpcTransaction<Builder::Network>, Builder::Error>
     where
-        Builder: TransactionCompat<Primitives: NodePrimitives<SignedTx = T>>,
+        Builder: RpcConvert<Primitives: NodePrimitives<SignedTx = T>>,
     {
         match self {
             Self::Pool(tx) => resp_builder.fill_pending(tx),

--- a/crates/rpc/rpc-types-compat/src/lib.rs
+++ b/crates/rpc/rpc-types-compat/src/lib.rs
@@ -17,8 +17,8 @@ pub mod transaction;
 pub use fees::{CallFees, CallFeesError};
 pub use rpc::*;
 pub use transaction::{
-    EthTxEnvError, IntoRpcTx, RpcConverter, TransactionCompat, TransactionConversionError,
-    TryIntoSimTx, TxInfoMapper,
+    EthTxEnvError, IntoRpcTx, RpcConvert, RpcConverter, TransactionConversionError, TryIntoSimTx,
+    TxInfoMapper,
 };
 
 #[cfg(feature = "op")]

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -20,7 +20,14 @@ use revm_context::{BlockEnv, CfgEnv, TxEnv};
 use std::{convert::Infallible, error::Error, fmt::Debug, marker::PhantomData};
 use thiserror::Error;
 
-/// Builds RPC transaction w.r.t. network.
+/// Responsible for the conversions from and into RPC requests and responses.
+///
+/// The JSON-RPC schema and the Node primitives are configurable using the [`RpcConvert::Network`]
+/// and [`RpcConvert::Primitives`] associated types respectively.
+///
+/// A generic implementation [`RpcConverter`] should be preferred over a manual implementation. As
+/// long as its trait bound requirements are met, the implementation is created automatically and
+/// can be used in RPC method handlers for all the conversions.
 pub trait RpcConvert: Send + Sync + Unpin + Clone + Debug {
     /// Associated lower layer consensus types to convert from and into types of [`Self::Network`].
     type Primitives: NodePrimitives;
@@ -32,7 +39,7 @@ pub trait RpcConvert: Send + Sync + Unpin + Clone + Debug {
     /// A set of variables for executing a transaction.
     type TxEnv;
 
-    /// RPC transaction error type.
+    /// An associated RPC conversion error.
     type Error: error::Error + Into<jsonrpsee_types::ErrorObject<'static>>;
 
     /// Wrapper for `fill()` with default `TransactionInfo`

--- a/crates/rpc/rpc-types-compat/src/transaction.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction.rs
@@ -21,7 +21,7 @@ use std::{convert::Infallible, error::Error, fmt::Debug, marker::PhantomData};
 use thiserror::Error;
 
 /// Builds RPC transaction w.r.t. network.
-pub trait TransactionCompat: Send + Sync + Unpin + Clone + Debug {
+pub trait RpcConvert: Send + Sync + Unpin + Clone + Debug {
     /// Associated lower layer consensus types to convert from and into types of [`Self::Network`].
     type Primitives: NodePrimitives;
 
@@ -352,7 +352,7 @@ impl<E, Evm, Err> Default for RpcConverter<E, Evm, Err> {
     }
 }
 
-impl<N, E, Evm, Err, Map> TransactionCompat for RpcConverter<E, Evm, Err, Map>
+impl<N, E, Evm, Err, Map> RpcConvert for RpcConverter<E, Evm, Err, Map>
 where
     N: NodePrimitives,
     E: RpcTypes + Send + Sync + Unpin + Clone + Debug,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -158,9 +158,9 @@ where
 {
     type Error = EthApiError;
     type NetworkTypes = Ethereum;
-    type TransactionCompat = EthRpcConverter;
+    type RpcConvert = EthRpcConverter;
 
-    fn tx_resp_builder(&self) -> &Self::TransactionCompat {
+    fn tx_resp_builder(&self) -> &Self::RpcConvert {
         &self.tx_resp_builder
     }
 }

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -12,8 +12,8 @@ use jsonrpsee::{core::RpcResult, server::IdProvider};
 use reth_errors::ProviderError;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_eth_api::{
-    EngineEthFilter, EthApiTypes, EthFilterApiServer, FullEthApiTypes, QueryLimits, RpcNodeCore,
-    RpcNodeCoreExt, RpcTransaction, TransactionCompat,
+    EngineEthFilter, EthApiTypes, EthFilterApiServer, FullEthApiTypes, QueryLimits, RpcConvert,
+    RpcNodeCore, RpcNodeCoreExt, RpcTransaction,
 };
 use reth_rpc_eth_types::{
     logs_utils::{self, append_matching_block_logs, ProviderOrBlock},
@@ -686,7 +686,7 @@ struct FullTransactionsReceiver<T: PoolTransaction, TxCompat> {
 impl<T, TxCompat> FullTransactionsReceiver<T, TxCompat>
 where
     T: PoolTransaction + 'static,
-    TxCompat: TransactionCompat<Primitives: NodePrimitives<SignedTx = T::Consensus>>,
+    TxCompat: RpcConvert<Primitives: NodePrimitives<SignedTx = T::Consensus>>,
 {
     /// Creates a new `FullTransactionsReceiver` encapsulating the provided transaction stream.
     fn new(stream: NewSubpoolTransactionStream<T>, tx_resp_builder: TxCompat) -> Self {
@@ -724,7 +724,7 @@ impl<T, TxCompat> FullTransactionsFilter<RpcTransaction<TxCompat::Network>>
     for FullTransactionsReceiver<T, TxCompat>
 where
     T: PoolTransaction + 'static,
-    TxCompat: TransactionCompat<Primitives: NodePrimitives<SignedTx = T::Consensus>> + 'static,
+    TxCompat: RpcConvert<Primitives: NodePrimitives<SignedTx = T::Consensus>> + 'static,
 {
     async fn drain(&self) -> FilterChanges<RpcTransaction<TxCompat::Network>> {
         Self::drain(self).await

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -11,7 +11,7 @@ use reth_rpc_eth_api::{
     RpcNodeCore, RpcNodeCoreExt, RpcReceipt,
 };
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcConvert;
 use reth_storage_api::{BlockReader, ProviderTx};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
@@ -22,7 +22,7 @@ where
     Self: LoadBlock<
         Error = EthApiError,
         NetworkTypes: RpcTypes<Receipt = TransactionReceipt>,
-        TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
+        RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
         Provider: BlockReader<
             Transaction = reth_ethereum_primitives::TransactionSigned,
             Receipt = reth_ethereum_primitives::Receipt,

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -9,7 +9,7 @@ use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEvmError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
 };
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcConvert;
 use reth_storage_api::{BlockReader, ProviderHeader, ProviderTx};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm::context::TxEnv;
@@ -41,9 +41,9 @@ where
                     SignedTx = ProviderTx<Self::Provider>,
                 >,
             >,
-            TransactionCompat: TransactionCompat<TxEnv = TxEnvFor<Self::Evm>>,
+            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>>,
             Error: FromEvmError<Self::Evm>
-                       + From<<Self::TransactionCompat as TransactionCompat>::Error>
+                       + From<<Self::RpcConvert as RpcConvert>::Error>
                        + From<ProviderError>,
         > + SpawnBlocking,
     Provider: BlockReader,

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -12,7 +12,7 @@ use reth_rpc_eth_api::{
     FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::PendingBlock;
-use reth_rpc_types_compat::TransactionCompat;
+use reth_rpc_types_compat::RpcConvert;
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, ProviderBlock, ProviderHeader, ProviderReceipt, ProviderTx,
     StateProviderFactory,
@@ -28,7 +28,7 @@ where
                 Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
             >,
             Error: FromEvmError<Self::Evm>,
-            TransactionCompat: TransactionCompat<Network = Self::NetworkTypes>,
+            RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
         > + RpcNodeCore<
             Provider: BlockReaderIdExt<Receipt = Provider::Receipt, Block = Provider::Block>
                           + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -15,7 +15,7 @@ use reth_chain_state::CanonStateSubscriptions;
 use reth_network_api::NetworkInfo;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_eth_api::{
-    pubsub::EthPubSubApiServer, EthApiTypes, RpcNodeCore, RpcTransaction, TransactionCompat,
+    pubsub::EthPubSubApiServer, EthApiTypes, RpcConvert, RpcNodeCore, RpcTransaction,
 };
 use reth_rpc_eth_types::logs_utils;
 use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err};
@@ -62,7 +62,7 @@ where
             Pool: TransactionPool,
             Network: NetworkInfo,
         > + EthApiTypes<
-            TransactionCompat: TransactionCompat<
+            RpcConvert: RpcConvert<
                 Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Eth::Pool>>,
             >,
         >,
@@ -211,7 +211,7 @@ where
             Pool: TransactionPool,
             Network: NetworkInfo,
         > + EthApiTypes<
-            TransactionCompat: TransactionCompat<
+            RpcConvert: RpcConvert<
                 Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Eth::Pool>>,
             >,
         > + 'static,

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -11,7 +11,7 @@ use jsonrpsee::core::RpcResult;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_api::TxPoolApiServer;
 use reth_rpc_eth_api::RpcTransaction;
-use reth_rpc_types_compat::{RpcTypes, TransactionCompat};
+use reth_rpc_types_compat::{RpcConvert, RpcTypes};
 use reth_transaction_pool::{
     AllPoolTransactions, PoolConsensusTx, PoolTransaction, TransactionPool,
 };
@@ -37,7 +37,7 @@ impl<Pool, Eth> TxPoolApi<Pool, Eth> {
 impl<Pool, Eth> TxPoolApi<Pool, Eth>
 where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus: Transaction>> + 'static,
-    Eth: TransactionCompat<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>>,
+    Eth: RpcConvert<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>>,
 {
     fn content(&self) -> Result<TxpoolContent<RpcTransaction<Eth::Network>>, Eth::Error> {
         #[inline]
@@ -51,7 +51,7 @@ where
         ) -> Result<(), RpcTxB::Error>
         where
             Tx: PoolTransaction,
-            RpcTxB: TransactionCompat<Primitives: NodePrimitives<SignedTx = Tx::Consensus>>,
+            RpcTxB: RpcConvert<Primitives: NodePrimitives<SignedTx = Tx::Consensus>>,
         {
             content.entry(tx.sender()).or_default().insert(
                 tx.nonce().to_string(),
@@ -79,7 +79,7 @@ where
 impl<Pool, Eth> TxPoolApiServer<RpcTransaction<Eth::Network>> for TxPoolApi<Pool, Eth>
 where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus: Transaction>> + 'static,
-    Eth: TransactionCompat<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>> + 'static,
+    Eth: RpcConvert<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>> + 'static,
 {
     /// Returns the number of transactions currently pending for inclusion in the next block(s), as
     /// well as the ones that are being scheduled for future execution only.


### PR DESCRIPTION
The new name fits better with the trait as it's responsible for conversions from and into JSON-RPC io objects.