### PR TITLE
feat(rpc): Add `TransactionRequest` into `RpcTypes`

### DIFF
--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -10,7 +10,9 @@ pub trait RpcTypes {
     /// Receipt response type.
     type Receipt: RpcObject + ReceiptResponse;
     /// Transaction response type.
-    type Transaction: RpcObject + TransactionResponse;
+    type TransactionResponse: RpcObject + TransactionResponse;
+    /// Transaction response type.
+    type TransactionRequest: RpcObject;
 }
 
 impl<T> RpcTypes for T
@@ -19,8 +21,9 @@ where
 {
     type Header = T::HeaderResponse;
     type Receipt = T::ReceiptResponse;
-    type Transaction = T::TransactionResponse;
+    type TransactionResponse = T::TransactionResponse;
+    type TransactionRequest = T::TransactionRequest;
 }
 
 /// Adapter for network specific transaction type.
-pub type RpcTransaction<T> = <T as RpcTypes>::Transaction;
+pub type RpcTransaction<T> = <T as RpcTypes>::TransactionResponse;

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -377,7 +377,7 @@ where
     N: NodePrimitives,
     E: RpcTypes + Send + Sync + Unpin + Clone + Debug,
     Evm: ConfigureEvm<Primitives = N>,
-    TxTy<N>: IntoRpcTx<E::Transaction> + Clone + Debug,
+    TxTy<N>: IntoRpcTx<E::TransactionResponse> + Clone + Debug,
     TransactionRequest: TryIntoSimTx<TxTy<N>> + TryIntoTxEnv<TxEnvFor<Evm>>,
     Err: From<TransactionConversionError>
         + From<<TransactionRequest as TryIntoTxEnv<TxEnvFor<Evm>>>::Err>
@@ -387,8 +387,10 @@ where
         + Sync
         + Send
         + Into<jsonrpsee_types::ErrorObject<'static>>,
-    Map: for<'a> TxInfoMapper<&'a TxTy<N>, Out = <TxTy<N> as IntoRpcTx<E::Transaction>>::TxInfo>
-        + Clone
+    Map: for<'a> TxInfoMapper<
+            &'a TxTy<N>,
+            Out = <TxTy<N> as IntoRpcTx<E::TransactionResponse>>::TxInfo,
+        > + Clone
         + Debug
         + Unpin
         + Send
@@ -403,7 +405,7 @@ where
         &self,
         tx: Recovered<TxTy<N>>,
         tx_info: TransactionInfo,
-    ) -> Result<E::Transaction, Self::Error> {
+    ) -> Result<E::TransactionResponse, Self::Error> {
         let (tx, signer) = tx.into_parts();
         let tx_info = self.mapper.try_map(&tx, tx_info)?;
 

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -45,7 +45,7 @@ where
             tx: &Tx,
             content: &mut BTreeMap<
                 Address,
-                BTreeMap<String, <RpcTxB::Network as RpcTypes>::Transaction>,
+                BTreeMap<String, <RpcTxB::Network as RpcTypes>::TransactionResponse>,
             >,
             resp_builder: &RpcTxB,
         ) -> Result<(), RpcTxB::Error>


### PR DESCRIPTION
Part of #15117

Adds an associated type `TransactionRequest` into `RpcTypes` as a preparation for its custom definition.

Renames the existing `Transaction` associated type to `TransactionResponse` for a differentiation.
