### PR TITLE
refactor(rpc): rename crate reth_rpc_types_compat → reth_rpc_convert

### DIFF
--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -135,7 +135,7 @@ The IPC transport lives in [`rpc/ipc`](../../crates/rpc/ipc).
 
 #### Utilities Crates
 
-- [`rpc/rpc-types-compat`](../../crates/rpc/rpc-types-compat): This crate various helper functions to convert between reth primitive types and rpc types.
+- [`rpc/rpc-convert`](../../crates/rpc/rpc-convert): This crate various helper functions to convert between reth primitive types and rpc types.
 - [`rpc/layer`](../../crates/rpc/rpc-layer/): Some RPC middleware layers (e.g. `AuthValidator`, `JwtAuthValidator`)
 - [`rpc/rpc-testing-util`](../../crates/rpc/rpc-testing-util/): Reth RPC testing helpers
 


### PR DESCRIPTION


**Description:**  
- Updated the crate reference in `docs/repo/layout.md` from `rpc-types-compat` to `rpc-convert`.
