### PR TITLE
feat: add configurable RPC middleware to RpcAddOns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8884,6 +8884,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tower",
  "tracing",
 ]
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -25,7 +25,7 @@ use reth_node_builder::{
     node::{FullNodeTypes, NodeTypes},
     rpc::{
         BasicEngineApiBuilder, EngineApiBuilder, EngineValidatorAddOn, EngineValidatorBuilder,
-        EthApiBuilder, EthApiCtx, RethRpcAddOns, RpcAddOns, RpcHandle,
+        EthApiBuilder, EthApiCtx, RethRpcAddOns, RpcAddOns, RpcHandle, RpcServiceBuilder,
     },
     BuilderContext, DebugNode, Node, NodeAdapter, NodeComponentsBuilder, PayloadBuilderConfig,
     PayloadTypes,
@@ -174,6 +174,7 @@ where
                 EthereumEthApiBuilder,
                 EthereumEngineValidatorBuilder::default(),
                 BasicEngineApiBuilder::default(),
+                RpcServiceBuilder::new(),
             ),
         }
     }

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -82,6 +82,9 @@ serde_json.workspace = true
 # tracing
 tracing.workspace = true
 
+# tower
+tower.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -510,7 +510,7 @@ where
     /// Sets the RPC middleware stack for processing RPC requests.
     ///
     /// This method configures a custom middleware stack that will be applied to all RPC requests
-    /// across HTTP, WebSocket, and IPC transports. The middleware is applied to the RPC service
+    /// across HTTP, `WebSocket`, and IPC transports. The middleware is applied to the RPC service
     /// layer, allowing you to intercept, modify, or enhance RPC request processing.
     ///
     ///

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -434,7 +434,7 @@ pub struct RpcAddOns<
     /// Configurable RPC middleware stack.
     ///
     /// This middleware is applied to all RPC requests across all transports (HTTP, WS, IPC).
-    /// See [`RpcAddOns::set_rpc_middleware`] for more details.
+    /// See [`RpcAddOns::with_rpc_middleware`] for more details.
     rpc_middleware: RpcServiceBuilder<RpcMiddleware>,
 }
 
@@ -528,7 +528,7 @@ where
     ///
     /// // Simple example with metrics
     /// let metrics_layer = RpcRequestMetrics::new(metrics_recorder);
-    /// let with_metrics = rpc_addons.set_rpc_middleware(
+    /// let with_metrics = rpc_addons.with_rpc_middleware(
     ///     RpcServiceBuilder::new().layer(metrics_layer)
     /// );
     ///
@@ -537,7 +537,7 @@ where
     ///     .layer(rate_limit_layer)
     ///     .layer(logging_layer)
     ///     .layer(metrics_layer);
-    /// let with_full_stack = rpc_addons.set_rpc_middleware(middleware_stack);
+    /// let with_full_stack = rpc_addons.with_rpc_middleware(middleware_stack);
     /// ```
     ///
     /// # Notes
@@ -545,7 +545,7 @@ where
     /// - Middleware is applied to the RPC service layer, not the HTTP transport layer
     /// - The default middleware is `Identity` (no-op), which passes through requests unchanged
     /// - Middleware layers are applied in the order they are added via `.layer()`
-    pub fn set_rpc_middleware<T>(
+    pub fn with_rpc_middleware<T>(
         self,
         rpc_middleware: RpcServiceBuilder<T>,
     ) -> RpcAddOns<Node, EthB, EV, EB, T> {

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -561,7 +561,7 @@ where
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     RpcMiddleware: Layer<RpcRequestMetricsService<RpcService>> + Clone + Send + 'static,
-    for<'a> <RpcMiddleware as Layer<RpcRequestMetricsService<RpcService>>>::Service:
+    <RpcMiddleware as Layer<RpcRequestMetricsService<RpcService>>>::Service:
         Send
             + Sync
             + 'static
@@ -833,7 +833,7 @@ where
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     RpcMiddleware: Layer<RpcRequestMetricsService<RpcService>> + Clone + Send + 'static,
-    for<'a> <RpcMiddleware as Layer<RpcRequestMetricsService<RpcService>>>::Service:
+    <RpcMiddleware as Layer<RpcRequestMetricsService<RpcService>>>::Service:
         Send
             + Sync
             + 'static

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -258,20 +258,6 @@ impl NodeTypes for OpNode {
 ///
 /// This type provides optimism-specific addons to the node and exposes the RPC server and engine
 /// API.
-///
-/// # Middleware Configuration
-///
-/// The RPC middleware can be configured through the public `rpc_add_ons` field. Since `RpcAddOns`
-/// now supports middleware configuration via `set_rpc_middleware`, you can do:
-///
-/// ```ignore
-/// let op_addons = OpAddOns::builder().build();
-/// let custom_middleware = RpcServiceBuilder::new().layer(MyCustomLayer);
-/// let op_addons = OpAddOns {
-///     rpc_add_ons: op_addons.rpc_add_ons.set_rpc_middleware(custom_middleware),
-///     ..op_addons
-/// };
-/// ```
 #[derive(Debug)]
 pub struct OpAddOns<N: FullNodeComponents, EthB: EthApiBuilder<N>, EV, EB> {
     /// Rpc add-ons responsible for launching the RPC servers and instantiating the RPC handlers

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -27,7 +27,7 @@ use reth_node_builder::{
     node::{FullNodeTypes, NodeTypes},
     rpc::{
         EngineApiBuilder, EngineValidatorAddOn, EngineValidatorBuilder, EthApiBuilder,
-        RethRpcAddOns, RethRpcServerHandles, RpcAddOns, RpcContext, RpcHandle,
+        RethRpcAddOns, RethRpcServerHandles, RpcAddOns, RpcContext, RpcHandle, RpcServiceBuilder,
     },
     BuilderContext, DebugNode, Node, NodeAdapter, NodeComponentsBuilder,
 };
@@ -255,6 +255,22 @@ impl NodeTypes for OpNode {
 }
 
 /// Add-ons w.r.t. optimism.
+///
+/// This type provides optimism-specific addons to the node and exposes the RPC server and engine API.
+///
+/// # Middleware Configuration
+///
+/// The RPC middleware can be configured through the public `rpc_add_ons` field. Since `RpcAddOns` now
+/// supports middleware configuration via `set_rpc_middleware`, you can do:
+///
+/// ```ignore
+/// let op_addons = OpAddOns::builder().build();
+/// let custom_middleware = RpcServiceBuilder::new().layer(MyCustomLayer);
+/// let op_addons = OpAddOns {
+///     rpc_add_ons: op_addons.rpc_add_ons.set_rpc_middleware(custom_middleware),
+///     ..op_addons
+/// };
+/// ```
 #[derive(Debug)]
 pub struct OpAddOns<N: FullNodeComponents, EthB: EthApiBuilder<N>, EV, EB> {
     /// Rpc add-ons responsible for launching the RPC servers and instantiating the RPC handlers
@@ -591,6 +607,7 @@ impl<NetworkT> OpAddOnsBuilder<NetworkT> {
                     .with_min_suggested_priority_fee(min_suggested_priority_fee),
                 EV::default(),
                 EB::default(),
+                RpcServiceBuilder::new(),
             ),
             da_config: da_config.unwrap_or_default(),
             sequencer_url,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -256,12 +256,13 @@ impl NodeTypes for OpNode {
 
 /// Add-ons w.r.t. optimism.
 ///
-/// This type provides optimism-specific addons to the node and exposes the RPC server and engine API.
+/// This type provides optimism-specific addons to the node and exposes the RPC server and engine
+/// API.
 ///
 /// # Middleware Configuration
 ///
-/// The RPC middleware can be configured through the public `rpc_add_ons` field. Since `RpcAddOns` now
-/// supports middleware configuration via `set_rpc_middleware`, you can do:
+/// The RPC middleware can be configured through the public `rpc_add_ons` field. Since `RpcAddOns`
+/// now supports middleware configuration via `set_rpc_middleware`, you can do:
 ///
 /// ```ignore
 /// let op_addons = OpAddOns::builder().build();


### PR DESCRIPTION
## Summary

Adds configurable RPC middleware support to `RpcAddOns`, allowing users to customize middleware layers for RPC servers.

## Changes

- Added a new generic parameter `RpcMiddleware` to `RpcAddOns` with a default of `Identity`
- Added `rpc_middleware: RpcServiceBuilder<RpcMiddleware>` field to the struct
- Updated the constructor to accept the middleware parameter
- Added `set_rpc_middleware()` method for runtime middleware configuration
- Integrated middleware with RPC server launching (HTTP, WS, IPC)
- Updated Ethereum and Optimism node implementations to use default middleware

## Implementation Details

The middleware is applied when launching RPC servers through the `launch_rpc_server` and `launch_add_ons_with` methods. The implementation mirrors the existing `RpcServerConfig` middleware pattern, providing consistent API design.

Users can now:
- Use default Identity middleware (no-op) without specifying type parameters
- Configure custom middleware layers for request logging, metrics, rate limiting, etc.
- Change middleware at runtime using `set_rpc_middleware()`

Closes #16942