### PR TITLE
feat(rpc): Propagate the RPC transaction request from `Network` and `RpcTypes`

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/engine_api.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/engine_api.rs
@@ -5,7 +5,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_engine::{
     ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, PayloadStatusEnum,
 };
-use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use eyre::Result;
 use futures_util::future::BoxFuture;
 use reth_node_api::{EngineTypes, PayloadTypes};
@@ -85,7 +85,7 @@ where
             const MAX_RETRIES: u32 = 5;
 
             while retries < MAX_RETRIES {
-                match EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
+                match EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_by_number(
                     source_rpc,
                     alloy_eips::BlockNumberOrTag::Number(self.block_number),
                     true, // include transactions

--- a/crates/e2e-test-utils/src/testsuite/actions/fork.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/fork.rs
@@ -5,7 +5,7 @@ use crate::testsuite::{
     Action, BlockInfo, Environment,
 };
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
-use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use eyre::Result;
 use futures_util::future::BoxFuture;
 use reth_node_api::{EngineTypes, PayloadTypes};
@@ -130,14 +130,19 @@ where
 
             // get the block at the fork base number to establish the fork point
             let rpc_client = &env.node_clients[0].rpc;
-            let fork_base_block =
-                EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
-                    rpc_client,
-                    alloy_eips::BlockNumberOrTag::Number(self.fork_base_block),
-                    false,
-                )
-                .await?
-                .ok_or_else(|| eyre::eyre!("Fork base block {} not found", self.fork_base_block))?;
+            let fork_base_block = EthApiClient::<
+                TransactionRequest,
+                Transaction,
+                Block,
+                Receipt,
+                Header,
+            >::block_by_number(
+                rpc_client,
+                alloy_eips::BlockNumberOrTag::Number(self.fork_base_block),
+                false,
+            )
+            .await?
+            .ok_or_else(|| eyre::eyre!("Fork base block {} not found", self.fork_base_block))?;
 
             // update active node state to point to the fork base block
             let active_node_state = env.active_node_state_mut()?;
@@ -243,7 +248,7 @@ where
 
             // walk backwards through the chain until we reach the fork base
             while current_number > self.fork_base_number {
-                let block = EthApiClient::<Transaction, Block, Receipt, Header>::block_by_hash(
+                let block = EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_by_hash(
                     rpc_client,
                     current_hash,
                     false,

--- a/crates/e2e-test-utils/src/testsuite/actions/node_ops.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/node_ops.rs
@@ -1,7 +1,7 @@
 //! Node-specific operations for multi-node testing.
 
 use crate::testsuite::{Action, Environment};
-use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use eyre::Result;
 use futures_util::future::BoxFuture;
 use reth_node_api::EngineTypes;
@@ -74,7 +74,7 @@ where
             let node_b_client = &env.node_clients[self.node_b];
 
             // Get latest block from each node
-            let block_a = EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
+            let block_a = EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_by_number(
                 &node_a_client.rpc,
                 alloy_eips::BlockNumberOrTag::Latest,
                 false,
@@ -82,7 +82,7 @@ where
             .await?
             .ok_or_else(|| eyre::eyre!("Failed to get latest block from node {}", self.node_a))?;
 
-            let block_b = EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
+            let block_b = EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_by_number(
                 &node_b_client.rpc,
                 alloy_eips::BlockNumberOrTag::Latest,
                 false,
@@ -272,27 +272,37 @@ where
                     let node_b_client = &env.node_clients[self.node_b];
 
                     // Get latest block from each node
-                    let block_a =
-                        EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
-                            &node_a_client.rpc,
-                            alloy_eips::BlockNumberOrTag::Latest,
-                            false,
-                        )
-                        .await?
-                        .ok_or_else(|| {
-                            eyre::eyre!("Failed to get latest block from node {}", self.node_a)
-                        })?;
+                    let block_a = EthApiClient::<
+                        TransactionRequest,
+                        Transaction,
+                        Block,
+                        Receipt,
+                        Header,
+                    >::block_by_number(
+                        &node_a_client.rpc,
+                        alloy_eips::BlockNumberOrTag::Latest,
+                        false,
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        eyre::eyre!("Failed to get latest block from node {}", self.node_a)
+                    })?;
 
-                    let block_b =
-                        EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
-                            &node_b_client.rpc,
-                            alloy_eips::BlockNumberOrTag::Latest,
-                            false,
-                        )
-                        .await?
-                        .ok_or_else(|| {
-                            eyre::eyre!("Failed to get latest block from node {}", self.node_b)
-                        })?;
+                    let block_b = EthApiClient::<
+                        TransactionRequest,
+                        Transaction,
+                        Block,
+                        Receipt,
+                        Header,
+                    >::block_by_number(
+                        &node_b_client.rpc,
+                        alloy_eips::BlockNumberOrTag::Latest,
+                        false,
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        eyre::eyre!("Failed to get latest block from node {}", self.node_b)
+                    })?;
 
                     debug!(
                         "Sync check: Node {} tip: {} (block {}), Node {} tip: {} (block {})",

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_engine::{
     payload::ExecutionPayloadEnvelopeV3, ForkchoiceState, PayloadAttributes, PayloadStatusEnum,
 };
-use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use eyre::Result;
 use futures_util::future::BoxFuture;
 use reth_node_api::{EngineTypes, PayloadTypes};
@@ -73,13 +73,16 @@ where
             let engine_client = node_client.engine.http_client();
 
             // get the latest block to use as parent
-            let latest_block =
-                EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
-                    rpc_client,
-                    alloy_eips::BlockNumberOrTag::Latest,
-                    false,
-                )
-                .await?;
+            let latest_block = EthApiClient::<
+                TransactionRequest,
+                Transaction,
+                Block,
+                Receipt,
+                Header,
+            >::block_by_number(
+                rpc_client, alloy_eips::BlockNumberOrTag::Latest, false
+            )
+            .await?;
 
             let latest_block = latest_block.ok_or_else(|| eyre::eyre!("Latest block not found"))?;
             let parent_hash = latest_block.header.hash;
@@ -339,14 +342,17 @@ where
             } else {
                 // fallback to RPC query
                 let rpc_client = &env.node_clients[0].rpc;
-                let current_head_block =
-                    EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
-                        rpc_client,
-                        alloy_eips::BlockNumberOrTag::Latest,
-                        false,
-                    )
-                    .await?
-                    .ok_or_else(|| eyre::eyre!("No latest block found from RPC"))?;
+                let current_head_block = EthApiClient::<
+                    TransactionRequest,
+                    Transaction,
+                    Block,
+                    Receipt,
+                    Header,
+                >::block_by_number(
+                    rpc_client, alloy_eips::BlockNumberOrTag::Latest, false
+                )
+                .await?
+                .ok_or_else(|| eyre::eyre!("No latest block found from RPC"))?;
                 debug!("Using RPC latest block hash as head: {}", current_head_block.header.hash);
                 current_head_block.header.hash
             };
@@ -409,14 +415,17 @@ where
         Box::pin(async move {
             // get the latest block from the first client to update environment state
             let rpc_client = &env.node_clients[0].rpc;
-            let latest_block =
-                EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
-                    rpc_client,
-                    alloy_eips::BlockNumberOrTag::Latest,
-                    false,
-                )
-                .await?
-                .ok_or_else(|| eyre::eyre!("No latest block found from RPC"))?;
+            let latest_block = EthApiClient::<
+                TransactionRequest,
+                Transaction,
+                Block,
+                Receipt,
+                Header,
+            >::block_by_number(
+                rpc_client, alloy_eips::BlockNumberOrTag::Latest, false
+            )
+            .await?
+            .ok_or_else(|| eyre::eyre!("No latest block found from RPC"))?;
 
             // update environment with the new block information
             env.set_current_block_info(BlockInfo {
@@ -516,13 +525,17 @@ where
                 let rpc_client = &client.rpc;
 
                 // get the last header by number using latest_head_number
-                let rpc_latest_header =
-                    EthApiClient::<Transaction, Block, Receipt, Header>::header_by_number(
-                        rpc_client,
-                        alloy_eips::BlockNumberOrTag::Latest,
-                    )
-                    .await?
-                    .ok_or_else(|| eyre::eyre!("No latest header found from rpc"))?;
+                let rpc_latest_header = EthApiClient::<
+                    TransactionRequest,
+                    Transaction,
+                    Block,
+                    Receipt,
+                    Header,
+                >::header_by_number(
+                    rpc_client, alloy_eips::BlockNumberOrTag::Latest
+                )
+                .await?
+                .ok_or_else(|| eyre::eyre!("No latest header found from rpc"))?;
 
                 // perform several checks
                 let next_new_payload = env

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
-use alloy_rpc_types_eth::{Block as RpcBlock, Header, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block as RpcBlock, Header, Receipt, Transaction, TransactionRequest};
 use eyre::{eyre, Result};
 use reth_chainspec::ChainSpec;
 use reth_engine_local::LocalPayloadAttributesBuilder;
@@ -210,7 +210,7 @@ where
             let mut last_error = None;
 
             while retry_count < MAX_RETRIES {
-                match EthApiClient::<Transaction, RpcBlock, Receipt, Header>::block_by_number(
+                match EthApiClient::<TransactionRequest, Transaction, RpcBlock, Receipt, Header>::block_by_number(
                     &client.rpc,
                     BlockNumberOrTag::Latest,
                     false,
@@ -244,14 +244,17 @@ where
         // Initialize each node's state with genesis block information
         let genesis_block_info = {
             let first_client = &env.node_clients[0];
-            let genesis_block =
-                EthApiClient::<Transaction, RpcBlock, Receipt, Header>::block_by_number(
-                    &first_client.rpc,
-                    BlockNumberOrTag::Number(0),
-                    false,
-                )
-                .await?
-                .ok_or_else(|| eyre!("Genesis block not found"))?;
+            let genesis_block = EthApiClient::<
+                TransactionRequest,
+                Transaction,
+                RpcBlock,
+                Receipt,
+                Header,
+            >::block_by_number(
+                &first_client.rpc, BlockNumberOrTag::Number(0), false
+            )
+            .await?
+            .ok_or_else(|| eyre!("Genesis block not found"))?;
 
             crate::testsuite::BlockInfo {
                 hash: genesis_block.header.hash,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -941,6 +941,7 @@ where
                 // Verify that the healthy node is running the same chain as the current node.
                 let chain_id = futures::executor::block_on(async {
                     EthApiClient::<
+                        alloy_rpc_types::TransactionRequest,
                         alloy_rpc_types::Transaction,
                         alloy_rpc_types::Block,
                         alloy_rpc_types::Receipt,

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,11 +1,12 @@
 use super::OpNodeCore;
 use crate::{OpEthApi, OpEthApiError};
+use alloy_rpc_types_eth::TransactionRequest;
 use op_revm::OpTransaction;
 use reth_evm::{execute::BlockExecutorFactory, ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadBlock, LoadState, SpawnBlocking},
-    FromEvmError, FullEthApiTypes, RpcConvert,
+    FromEvmError, FullEthApiTypes, RpcConvert, RpcTypes,
 };
 use reth_storage_api::{errors::ProviderError, ProviderHeader, ProviderTx};
 use revm::context::TxEnv;
@@ -37,7 +38,8 @@ where
                     EvmFactory: EvmFactory<Tx = OpTransaction<TxEnv>>,
                 >,
             >,
-            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>>,
+            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Self::NetworkTypes>,
+            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
             Error: FromEvmError<Self::Evm>
                        + From<<Self::RpcConvert as RpcConvert>::Error>
                        + From<ProviderError>,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -45,6 +45,7 @@ use reth_rpc_api::servers::*;
 use reth_rpc_eth_api::{
     helpers::{Call, EthApiSpec, EthTransactions, LoadPendingBlock, TraceExt},
     EthApiServer, EthApiTypes, FullEthApiServer, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
+    RpcTxReq,
 };
 use reth_rpc_eth_types::{EthConfig, EthSubscriptionIdProvider};
 use reth_rpc_layer::{AuthLayer, Claims, CompressionLayer, JwtAuthValidator, JwtSecret};
@@ -663,6 +664,7 @@ where
         + CanonStateSubscriptions,
     Network: NetworkInfo + Peers + Clone + 'static,
     EthApi: EthApiServer<
+            RpcTxReq<EthApi::NetworkTypes>,
             RpcTransaction<EthApi::NetworkTypes>,
             RpcBlock<EthApi::NetworkTypes>,
             RpcReceipt<EthApi::NetworkTypes>,

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -176,24 +176,38 @@ where
     .unwrap();
 
     // Implemented
-    EthApiClient::<Transaction, Block, Receipt, Header>::protocol_version(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::chain_id(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::accounts(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::get_account(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::protocol_version(
+        client,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::chain_id(client)
+        .await
+        .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::accounts(client)
+        .await
+        .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::get_account(
         client,
         address,
         block_number.into(),
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::block_number(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::get_code(client, address, None)
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_number(client)
         .await
         .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::send_raw_transaction(client, tx)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::fee_history(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::get_code(
+        client, address, None,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::send_raw_transaction(
+        client, tx,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::fee_history(
         client,
         U64::from(0),
         block_number,
@@ -201,13 +215,17 @@ where
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::balance(client, address, None)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_count(client, address, None)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::storage_at(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::balance(
+        client, address, None,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::transaction_count(
+        client, address, None,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::storage_at(
         client,
         address,
         U256::default().into(),
@@ -215,72 +233,80 @@ where
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::block_by_hash(client, hash, false)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::block_by_number(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_by_hash(
+        client, hash, false,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_by_number(
         client,
         block_number,
         false,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::block_transaction_count_by_number(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_transaction_count_by_number(
         client,
         block_number,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::block_transaction_count_by_hash(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_transaction_count_by_hash(
         client, hash,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::block_uncles_count_by_hash(client, hash)
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_uncles_count_by_hash(client, hash)
         .await
         .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::block_uncles_count_by_number(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::block_uncles_count_by_number(
         client,
         block_number,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::uncle_by_block_hash_and_index(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::uncle_by_block_hash_and_index(
         client, hash, index,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::uncle_by_block_number_and_index(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::uncle_by_block_number_and_index(
         client,
         block_number,
         index,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::sign(client, address, bytes.clone())
-        .await
-        .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::sign_typed_data(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::sign(
+        client,
+        address,
+        bytes.clone(),
+    )
+    .await
+    .unwrap_err();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::sign_typed_data(
         client, address, typed_data,
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_by_hash(client, tx_hash)
-        .await
-        .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_by_block_hash_and_index(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::transaction_by_hash(
+        client, tx_hash,
+    )
+    .await
+    .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::transaction_by_block_hash_and_index(
         client, hash, index,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::transaction_by_block_number_and_index(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::transaction_by_block_number_and_index(
         client,
         block_number,
         index,
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::create_access_list(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::create_access_list(
         client,
         call_request.clone(),
         Some(block_number.into()),
@@ -288,7 +314,7 @@ where
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::estimate_gas(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::estimate_gas(
         client,
         call_request.clone(),
         Some(block_number.into()),
@@ -296,7 +322,7 @@ where
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::call(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::call(
         client,
         call_request.clone(),
         Some(block_number.into()),
@@ -305,47 +331,67 @@ where
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::syncing(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::send_transaction(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::syncing(client)
+        .await
+        .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::send_transaction(
         client,
         transaction_request.clone(),
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::sign_transaction(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::sign_transaction(
         client,
         transaction_request,
     )
     .await
     .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::hashrate(client).await.unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::submit_hashrate(
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::hashrate(client)
+        .await
+        .unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::submit_hashrate(
         client,
         U256::default(),
         B256::default(),
     )
     .await
     .unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::gas_price(client).await.unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::max_priority_fee_per_gas(client)
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::gas_price(client)
         .await
         .unwrap_err();
-    EthApiClient::<Transaction, Block, Receipt, Header>::get_proof(client, address, vec![], None)
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::max_priority_fee_per_gas(client)
         .await
-        .unwrap();
+        .unwrap_err();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::get_proof(
+        client,
+        address,
+        vec![],
+        None,
+    )
+    .await
+    .unwrap();
 
     // Unimplemented
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt, Header>::author(client).await.err().unwrap()
+        EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::author(client)
+            .await
+            .err()
+            .unwrap()
     ));
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt, Header>::is_mining(client).await.err().unwrap()
+        EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::is_mining(client)
+            .await
+            .err()
+            .unwrap()
     ));
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt, Header>::get_work(client).await.err().unwrap()
+        EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::get_work(client)
+            .await
+            .err()
+            .unwrap()
     ));
     assert!(is_unimplemented(
-        EthApiClient::<Transaction, Block, Receipt, Header>::submit_work(
+        EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::submit_work(
             client,
             B64::default(),
             B256::default(),

--- a/crates/rpc/rpc-builder/tests/it/middleware.rs
+++ b/crates/rpc/rpc-builder/tests/it/middleware.rs
@@ -1,5 +1,5 @@
 use crate::utils::{test_address, test_rpc_builder};
-use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use jsonrpsee::{
     core::middleware::{Batch, Notification},
     server::middleware::rpc::{RpcServiceBuilder, RpcServiceT},
@@ -85,7 +85,11 @@ async fn test_rpc_middleware() {
         .unwrap();
 
     let client = handle.http_client().unwrap();
-    EthApiClient::<Transaction, Block, Receipt, Header>::protocol_version(&client).await.unwrap();
+    EthApiClient::<TransactionRequest, Transaction, Block, Receipt, Header>::protocol_version(
+        &client,
+    )
+    .await
+    .unwrap();
     let count = mylayer.count.load(Ordering::Relaxed);
     assert_eq!(count, 1);
 }

--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -25,5 +25,8 @@ where
     type TransactionRequest = T::TransactionRequest;
 }
 
-/// Adapter for network specific transaction type.
+/// Adapter for network specific transaction response.
 pub type RpcTransaction<T> = <T as RpcTypes>::TransactionResponse;
+
+/// Adapter for network specific transaction request.
+pub type RpcTxReq<T> = <T as RpcTypes>::TransactionRequest;

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -27,7 +27,7 @@ use reth_revm::{
     db::{CacheDB, State},
     DatabaseRef,
 };
-use reth_rpc_convert::RpcConvert;
+use reth_rpc_convert::{RpcConvert, RpcTypes};
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},
     error::{api::FromEvmHalt, ensure_success, FromEthApiError},
@@ -456,7 +456,10 @@ pub trait Call:
                 SignedTx = ProviderTx<Self::Provider>,
             >,
         >,
-        RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>>,
+        RpcConvert: RpcConvert<
+            TxEnv = TxEnvFor<Self::Evm>,
+            Network: RpcTypes<TransactionRequest: From<TransactionRequest>>,
+        >,
         Error: FromEvmError<Self::Evm>
                    + From<<Self::RpcConvert as RpcConvert>::Error>
                    + From<ProviderError>,
@@ -705,7 +708,7 @@ pub trait Call:
             );
         }
 
-        Ok(self.tx_resp_builder().tx_env(request, &evm_env.cfg_env, &evm_env.block_env)?)
+        Ok(self.tx_resp_builder().tx_env(request.into(), &evm_env.cfg_env, &evm_env.block_env)?)
     }
 
     /// Prepares the [`EvmEnv`] for execution of calls.

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -1,7 +1,7 @@
 //! Trait for specifying `eth` network dependent API types.
 
 use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
-use alloy_rpc_types_eth::Block;
+use alloy_rpc_types_eth::{Block, TransactionRequest};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_rpc_convert::RpcConvert;
 use reth_storage_api::{ProviderTx, ReceiptProvider, TransactionsProvider};
@@ -11,7 +11,7 @@ use std::{
     fmt::{self},
 };
 
-pub use reth_rpc_convert::{RpcTransaction, RpcTypes};
+pub use reth_rpc_convert::{RpcTransaction, RpcTxReq, RpcTypes};
 
 /// Network specific `eth` API types.
 ///
@@ -64,6 +64,7 @@ where
                 Network = Self::NetworkTypes,
                 Error = RpcError<Self>,
             >,
+            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
         >,
 {
 }
@@ -80,6 +81,7 @@ impl<T> FullEthApiTypes for T where
                 Network = Self::NetworkTypes,
                 Error = RpcError<T>,
             >,
+            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
         >
 {
 }

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -77,7 +77,9 @@ pub trait DebugApiExt {
 
 impl<T> DebugApiExt for T
 where
-    T: EthApiClient<Transaction, Block, Receipt, Header> + DebugApiClient + Sync,
+    T: EthApiClient<TransactionRequest, Transaction, Block, Receipt, Header>
+        + DebugApiClient
+        + Sync,
 {
     type Provider = T;
 

--- a/crates/rpc/rpc-testing-util/tests/it/trace.rs
+++ b/crates/rpc/rpc-testing-util/tests/it/trace.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the trace API.
 
 use alloy_primitives::map::HashSet;
-use alloy_rpc_types_eth::{Block, Header, Transaction};
+use alloy_rpc_types_eth::{Block, Header, Transaction, TransactionRequest};
 use alloy_rpc_types_trace::{
     filter::TraceFilter, parity::TraceType, tracerequest::TraceCallRequest,
 };
@@ -112,12 +112,17 @@ async fn debug_trace_block_entire_chain() {
     let url = url.unwrap();
 
     let client = HttpClientBuilder::default().build(url).unwrap();
-    let current_block: u64 =
-        <HttpClient as EthApiClient<Transaction, Block, Receipt, Header>>::block_number(&client)
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+    let current_block: u64 = <HttpClient as EthApiClient<
+        TransactionRequest,
+        Transaction,
+        Block,
+        Receipt,
+        Header,
+    >>::block_number(&client)
+    .await
+    .unwrap()
+    .try_into()
+    .unwrap();
     let range = 0..=current_block;
     let mut stream = client.debug_trace_block_buffered_unordered(range, None, 20);
     let now = Instant::now();
@@ -141,12 +146,17 @@ async fn debug_trace_block_opcodes_entire_chain() {
     let url = url.unwrap();
 
     let client = HttpClientBuilder::default().build(url).unwrap();
-    let current_block: u64 =
-        <HttpClient as EthApiClient<Transaction, Block, Receipt, Header>>::block_number(&client)
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+    let current_block: u64 = <HttpClient as EthApiClient<
+        TransactionRequest,
+        Transaction,
+        Block,
+        Receipt,
+        Header,
+    >>::block_number(&client)
+    .await
+    .unwrap()
+    .try_into()
+    .unwrap();
     let range = 0..=current_block;
     println!("Tracing blocks {range:?} for opcodes");
     let mut stream = client.trace_block_opcode_gas_unordered(range, 2).enumerate();

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -7,6 +7,7 @@ use alloy_rpc_types_eth::{
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::core::RpcResult as Result;
 use reth_rpc_api::{EngineEthApiServer, EthApiServer};
+use reth_rpc_convert::RpcTxReq;
 /// Re-export for convenience
 pub use reth_rpc_engine_api::EngineApi;
 use reth_rpc_eth_api::{
@@ -40,6 +41,7 @@ impl<Eth, EthFilter> EngineEthApiServer<RpcBlock<Eth::NetworkTypes>, RpcReceipt<
     for EngineEthApi<Eth, EthFilter>
 where
     Eth: EthApiServer<
+            RpcTxReq<Eth::NetworkTypes>,
             RpcTransaction<Eth::NetworkTypes>,
             RpcBlock<Eth::NetworkTypes>,
             RpcReceipt<Eth::NetworkTypes>,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -594,7 +594,7 @@ mod tests {
     /// Invalid block range
     #[tokio::test]
     async fn test_fee_history_empty() {
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _, _>>::fee_history(
             &build_test_eth_api(NoopProvider::default()),
             U64::from(1),
             BlockNumberOrTag::Latest,
@@ -616,7 +616,7 @@ mod tests {
         let (eth_api, _, _) =
             prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
 
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _, _>>::fee_history(
             &eth_api,
             U64::from(newest_block + 1),
             newest_block.into(),
@@ -639,7 +639,7 @@ mod tests {
         let (eth_api, _, _) =
             prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
 
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _, _>>::fee_history(
             &eth_api,
             U64::from(1),
             (newest_block + 1000).into(),
@@ -662,7 +662,7 @@ mod tests {
         let (eth_api, _, _) =
             prepare_eth_api(newest_block, oldest_block, block_count, MockEthProvider::default());
 
-        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _>>::fee_history(
+        let response = <EthApi<_, _, _, _> as EthApiServer<_, _, _, _, _>>::fee_history(
             &eth_api,
             U64::from(0),
             newest_block.into(),

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -2,10 +2,11 @@
 
 use crate::EthApi;
 use alloy_evm::block::BlockExecutorFactory;
+use alloy_rpc_types_eth::TransactionRequest;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;
-use reth_rpc_convert::RpcConvert;
+use reth_rpc_convert::{RpcConvert, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEvmError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
@@ -41,7 +42,8 @@ where
                     SignedTx = ProviderTx<Self::Provider>,
                 >,
             >,
-            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>>,
+            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Self::NetworkTypes>,
+            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
             Error: FromEvmError<Self::Evm>
                        + From<<Self::RpcConvert as RpcConvert>::Error>
                        + From<ProviderError>,

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -13,6 +13,7 @@ use alloy_rpc_types_trace::{
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
 use reth_rpc_api::{EthApiServer, OtterscanServer};
+use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
     FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
@@ -67,6 +68,7 @@ impl<Eth> OtterscanServer<RpcTransaction<Eth::NetworkTypes>, RpcHeader<Eth::Netw
     for OtterscanApi<Eth>
 where
     Eth: EthApiServer<
+            RpcTxReq<Eth::NetworkTypes>,
             RpcTransaction<Eth::NetworkTypes>,
             RpcBlock<Eth::NetworkTypes>,
             RpcReceipt<Eth::NetworkTypes>,


### PR DESCRIPTION
Part of #15117 

Propagates the associated transaction request type throughout the RPC API.

For example, `Optimism` has `OpTransactionRequest` associated with it and that's the target of `TryIntoSimTx` and `TryIntoTxEnv` impls now enforced by the `OpEthApi`.

There are some places that still work directly with the `TransactionRequest` struct, accessing its fields. Those should be probably abstracted out.

The struct `TransactionRequest` is still the input of some of the `EthApiServer` methods, despite now having a generic for it.

In this PR we simply use `From<TransactionRequest>` bound to make it work.
