### PR TITLE
chore: fix spelling errors

### DIFF
--- a/crates/alloy-provider/src/lib.rs
+++ b/crates/alloy-provider/src/lib.rs
@@ -143,7 +143,7 @@ impl<P, Node: NodeTypes, N> AlloyRethProvider<P, Node, N> {
         tokio::task::block_in_place(move || Handle::current().block_on(fut))
     }
 
-    /// Get a reference to the conon state notification sender
+    /// Get a reference to the canon state notification sender
     pub const fn canon_state_notification(
         &self,
     ) -> &broadcast::Sender<CanonStateNotification<PrimitivesTy<Node>>> {

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -24,7 +24,7 @@ use tokio::{
 };
 use tracing::{debug, error};
 
-/// Configuration for setting upa test environment
+/// Configuration for setting up test environment
 #[derive(Debug)]
 pub struct Setup<I> {
     /// Chain specification to use


### PR DESCRIPTION
Hi! Fixed errors in **crates/alloy-provider/src/lib.rs** // **crates/e2e-test-utils/src/testsuite/setup.rs**

`conon` -- `canon`
`upa` -- `up`