### PR TITLE
perf(trie): implement `ParallelSparseTrie::root` method

### DIFF
--- a/crates/trie/sparse-parallel/Cargo.toml
+++ b/crates/trie/sparse-parallel/Cargo.toml
@@ -31,6 +31,7 @@ smallvec.workspace = true
 reth-primitives-traits.workspace = true
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie.workspace = true
+reth-trie-sparse = { workspace = true, features = ["test-utils"] }
 
 arbitrary.workspace = true
 assert_matches.workspace = true
@@ -39,3 +40,7 @@ proptest-arbitrary-interop.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true
+
+[features]
+default = []
+test-utils = ["reth-trie-sparse/test-utils"]

--- a/crates/trie/sparse-parallel/Cargo.toml
+++ b/crates/trie/sparse-parallel/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 reth-execution-errors.workspace = true
 reth-trie-common.workspace = true
 reth-trie-sparse.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 alloy-trie.workspace = true
 
 # alloy

--- a/crates/trie/sparse-parallel/Cargo.toml
+++ b/crates/trie/sparse-parallel/Cargo.toml
@@ -40,7 +40,3 @@ proptest-arbitrary-interop.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true
-
-[features]
-default = []
-test-utils = ["reth-trie-sparse/test-utils"]

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -57,19 +57,6 @@ impl Default for ParallelSparseTrie {
 }
 
 impl ParallelSparseTrie {
-    /// Gets a node for the given path, checking upper subtrie for short paths
-    /// and lower subtries for longer paths.
-    fn get_node_for_path(&self, path: &Nibbles) -> &SparseNode {
-        if path.len() < UPPER_TRIE_MAX_DEPTH {
-            self.upper_subtrie.nodes.get(path).expect("upper subtrie node must exist")
-        } else {
-            let index = path_subtrie_index_unchecked(path);
-            self.lower_subtries[index]
-                .as_ref().expect("lower subtrie must exist")
-                .nodes.get(path).expect("lower subtrie node must exist")
-        }
-    }
-
     /// Returns mutable ref to the lower `SparseSubtrie` for the given path, or None if the path
     /// belongs to the upper trie.
     fn lower_subtrie_for_path(&mut self, path: &Nibbles) -> Option<&mut Box<SparseSubtrie>> {
@@ -248,200 +235,58 @@ impl ParallelSparseTrie {
 
         debug_assert!(self.upper_subtrie.buffers.path_stack.is_empty());
         self.upper_subtrie.buffers.path_stack.push(RlpNodePathStackItem {
-            level: 0,
             path: Nibbles::default(), // Start from root
             is_in_prefix_set: None,
         });
 
-        'main: while let Some(RlpNodePathStackItem { level, path, mut is_in_prefix_set }) =
+        while let Some(RlpNodePathStackItem { path, mut is_in_prefix_set }) =
             self.upper_subtrie.buffers.path_stack.pop()
         {
-            // Clone the node data to avoid borrow checker issues
-            let node = self.get_node_for_path(&path).clone();
+            let node = if path.len() < UPPER_TRIE_MAX_DEPTH {
+                self.upper_subtrie.nodes.get_mut(&path).expect("upper subtrie node must exist")
+            } else {
+                let index = path_subtrie_index_unchecked(&path);
+                let node = self.lower_subtries[index]
+                    .as_mut()
+                    .expect("lower subtrie must exist")
+                    .nodes
+                    .get_mut(&path)
+                    .expect("lower subtrie node must exist");
+                debug_assert!(node.hash().is_some());
+                node
+            };
             trace!(
                 target: "trie::parallel_sparse",
-                ?level,
                 ?path,
                 ?is_in_prefix_set,
                 ?node,
                 "Processing node in upper subtrie update"
             );
 
-            // Check if the path is in the prefix set
-            let mut prefix_set_contains =
-                |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path));
+            if let Some((rlp_node, node_type)) = node_rlp(
+                &self.upper_subtrie.branch_node_tree_masks,
+                &self.upper_subtrie.branch_node_hash_masks,
+                &self.upper_subtrie.values,
+                &mut self.upper_subtrie.updates,
+                &mut self.upper_subtrie.buffers,
+                prefix_set,
+                path,
+                &mut is_in_prefix_set,
+                node,
+            ) {
+                trace!(
+                    target: "trie::parallel_sparse",
+                    ?path,
+                    ?node_type,
+                    "Added node to rlp node stack"
+                );
 
-            let (rlp_node, node_type) = match &node {
-                SparseNode::Empty => (RlpNode::word_rlp(&EMPTY_ROOT_HASH), SparseNodeType::Empty),
-                SparseNode::Hash(hash) => (RlpNode::word_rlp(hash), SparseNodeType::Hash),
-                SparseNode::Leaf { key, hash } => {
-                    let mut full_path = path;
-                    full_path.extend(key);
-                    if let Some(hash) = hash.filter(|_| !prefix_set_contains(&full_path)) {
-                        (RlpNode::word_rlp(&hash), SparseNodeType::Leaf)
-                    } else {
-                        // For leaf nodes in lower subtries, we expect the hash to be computed
-                        if path.len() >= UPPER_TRIE_MAX_DEPTH {
-                            let hash = node.hash().expect("lower subtrie leaf must have computed hash");
-                            (RlpNode::word_rlp(&hash), SparseNodeType::Leaf)
-                        } else {
-                            // Upper subtrie leaf - need to get value and compute hash
-                            let value = self.upper_subtrie.values.get(&full_path).expect("leaf value must exist");
-                            self.upper_subtrie.buffers.rlp_buf.clear();
-                            let rlp_node = LeafNodeRef { key, value }.rlp(&mut self.upper_subtrie.buffers.rlp_buf);
-                            // Update hash in upper subtrie node
-                            if let SparseNode::Leaf { hash: node_hash, .. } = self.upper_subtrie.nodes.get_mut(&path).unwrap() {
-                                *node_hash = rlp_node.as_hash();
-                            }
-                            (rlp_node, SparseNodeType::Leaf)
-                        }
-                    }
-                }
-                SparseNode::Extension { key, hash, store_in_db_trie } => {
-                    let mut child_path = path;
-                    child_path.extend(key);
-                    if let Some((hash, store_in_db_trie)) =
-                        hash.zip(*store_in_db_trie).filter(|_| !prefix_set_contains(&path))
-                    {
-                        (
-                            RlpNode::word_rlp(&hash),
-                            SparseNodeType::Extension { store_in_db_trie: Some(store_in_db_trie) },
-                        )
-                    } else if self
-                        .upper_subtrie.buffers
-                        .rlp_node_stack
-                        .last()
-                        .is_some_and(|e| e.path == child_path)
-                    {
-                        let RlpNodeStackItem {
-                            path: _,
-                            rlp_node: child,
-                            node_type: child_node_type,
-                        } = self.upper_subtrie.buffers.rlp_node_stack.pop().unwrap();
-                        self.upper_subtrie.buffers.rlp_buf.clear();
-                        let rlp_node =
-                            ExtensionNodeRef::new(key, &child).rlp(&mut self.upper_subtrie.buffers.rlp_buf);
-                        
-                        // Update hash in upper subtrie node if it belongs to upper subtrie
-                        if path.len() < UPPER_TRIE_MAX_DEPTH {
-                            if let SparseNode::Extension { hash: node_hash, store_in_db_trie: node_store, .. } = 
-                                self.upper_subtrie.nodes.get_mut(&path).unwrap() 
-                            {
-                                *node_hash = rlp_node.as_hash();
-                                *node_store = child_node_type.store_in_db_trie();
-                            }
-                        }
-
-                        let store_in_db_trie_value = child_node_type.store_in_db_trie();
-                        (
-                            rlp_node,
-                            SparseNodeType::Extension { store_in_db_trie: store_in_db_trie_value },
-                        )
-                    } else {
-                        // need to get rlp node for child first
-                        self.upper_subtrie.buffers.path_stack.extend([
-                            RlpNodePathStackItem { level, path, is_in_prefix_set },
-                            RlpNodePathStackItem {
-                                level: level + 1,
-                                path: child_path,
-                                is_in_prefix_set: None,
-                            },
-                        ]);
-                        continue
-                    }
-                }
-                SparseNode::Branch { state_mask, hash, store_in_db_trie } => {
-                    if let Some((hash, store_in_db_trie)) =
-                        hash.zip(*store_in_db_trie).filter(|_| !prefix_set_contains(&path))
-                    {
-                        self.upper_subtrie.buffers.rlp_node_stack.push(RlpNodeStackItem {
-                            path,
-                            rlp_node: RlpNode::word_rlp(&hash),
-                            node_type: SparseNodeType::Branch {
-                                store_in_db_trie: Some(store_in_db_trie),
-                            },
-                        });
-                        continue
-                    }
-
-                    self.upper_subtrie.buffers.branch_child_buf.clear();
-                    // Walk children in reverse order
-                    for bit in CHILD_INDEX_RANGE.rev() {
-                        if state_mask.is_bit_set(bit) {
-                            let mut child = path;
-                            child.push_unchecked(bit);
-                            self.upper_subtrie.buffers.branch_child_buf.push(child);
-                        }
-                    }
-
-                    self.upper_subtrie.buffers
-                        .branch_value_stack_buf
-                        .resize(self.upper_subtrie.buffers.branch_child_buf.len(), Default::default());
-                    let mut added_children = false;
-
-                    for (i, child_path) in self.upper_subtrie.buffers.branch_child_buf.iter().enumerate() {
-                        if self.upper_subtrie.buffers.rlp_node_stack.last().is_some_and(|e| &e.path == child_path)
-                        {
-                            let RlpNodeStackItem {
-                                path: _,
-                                rlp_node: child,
-                                node_type: _child_node_type,
-                            } = self.upper_subtrie.buffers.rlp_node_stack.pop().unwrap();
-
-                            // Insert children in normal order
-                            let original_idx = self.upper_subtrie.buffers.branch_child_buf.len() - i - 1;
-                            self.upper_subtrie.buffers.branch_value_stack_buf[original_idx] = child;
-                            added_children = true;
-                        } else {
-                            debug_assert!(!added_children);
-                            self.upper_subtrie.buffers.path_stack.push(RlpNodePathStackItem {
-                                level,
-                                path,
-                                is_in_prefix_set,
-                            });
-                            self.upper_subtrie.buffers.path_stack.extend(
-                                self.upper_subtrie.buffers.branch_child_buf.drain(..).map(|path| {
-                                    RlpNodePathStackItem {
-                                        level: level + 1,
-                                        path,
-                                        is_in_prefix_set: None,
-                                    }
-                                }),
-                            );
-                            continue 'main
-                        }
-                    }
-
-                    self.upper_subtrie.buffers.rlp_buf.clear();
-                    let branch_node_ref =
-                        BranchNodeRef::new(&self.upper_subtrie.buffers.branch_value_stack_buf, *state_mask);
-                    let rlp_node = branch_node_ref.rlp(&mut self.upper_subtrie.buffers.rlp_buf);
-                    
-                    // Update hash in upper subtrie node if it belongs to upper subtrie
-                    if path.len() < UPPER_TRIE_MAX_DEPTH {
-                        if let SparseNode::Branch { hash: node_hash, .. } = 
-                            self.upper_subtrie.nodes.get_mut(&path).unwrap() 
-                        {
-                            *node_hash = rlp_node.as_hash();
-                        }
-                    }
-
-                    (
-                        rlp_node,
-                        SparseNodeType::Branch { store_in_db_trie: Some(false) },
-                    )
-                }
-            };
-
-            trace!(
-                target: "trie::parallel_sparse",
-                ?level,
-                ?path,
-                ?node_type,
-                "Added node to rlp node stack"
-            );
-
-            self.upper_subtrie.buffers.rlp_node_stack.push(RlpNodeStackItem { path, rlp_node, node_type });
+                self.upper_subtrie.buffers.rlp_node_stack.push(RlpNodeStackItem {
+                    path,
+                    rlp_node,
+                    node_type,
+                });
+            }
         }
 
         debug_assert_eq!(self.upper_subtrie.buffers.rlp_node_stack.len(), 1);
@@ -456,15 +301,15 @@ impl ParallelSparseTrie {
     /// 2. The keccak256 hash of the root node's RLP representation
     pub fn root(&mut self) -> B256 {
         trace!(target: "trie::parallel_sparse", "Calculating trie root hash");
-        
+
         // Step 1: Update all lower subtrie hashes (not in parallel for simplicity)
         self.update_subtrie_hashes();
-        
+
         // Step 2: Update hashes for the upper subtrie using our specialized function
         // that can access both upper and lower subtrie nodes
         let mut prefix_set = core::mem::take(&mut self.prefix_set).freeze();
         let root_rlp = self.update_upper_subtrie_hashes(&mut prefix_set);
-        
+
         // Step 4: Return the root hash
         root_rlp.as_hash().unwrap_or(EMPTY_ROOT_HASH)
     }
@@ -836,11 +681,23 @@ impl SparseSubtrie {
                 "Popped node from path stack"
             );
 
-            // Check if the path is in the prefix set.
-            // First, check the cached value. If it's `None`, then check the prefix set, and update
-            // the cached value.
-            let mut prefix_set_contains =
-                |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path));
+            if let Some((rlp_node, node_type)) = node_rlp(
+                &self.branch_node_tree_masks,
+                &self.branch_node_hash_masks,
+                &self.values,
+                &mut self.updates,
+                &mut self.buffers,
+                prefix_set,
+                path,
+                &mut is_in_prefix_set,
+                node,
+            ) {
+                trace!(
+                    target: "trie::parallel_sparse",
+                    ?path,
+                    ?node_type,
+                    "Added node to rlp node stack"
+                );
 
             self.inner.rlp_node(prefix_set_contains, path, node);
         }
@@ -1130,6 +987,238 @@ impl SparseSubtrieInner {
 
         self.buffers.rlp_node_stack.push(RlpNodeStackItem { path, rlp_node, node_type });
     }
+}
+
+fn node_rlp(
+    branch_node_tree_masks: &HashMap<Nibbles, TrieMask>,
+    branch_node_hash_masks: &HashMap<Nibbles, TrieMask>,
+    values: &HashMap<Nibbles, Vec<u8>>,
+    updates: &mut Option<SparseTrieUpdates>,
+    buffers: &mut SparseSubtrieBuffers,
+    prefix_set: &mut PrefixSet,
+    path: Nibbles,
+    is_in_prefix_set: &mut Option<bool>,
+    node: &mut SparseNode,
+) -> Option<(RlpNode, SparseNodeType)> {
+    let mut prefix_set_contains =
+        |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path));
+
+    let (rlp_node, node_type) = match node {
+        SparseNode::Empty => (RlpNode::word_rlp(&EMPTY_ROOT_HASH), SparseNodeType::Empty),
+        SparseNode::Hash(hash) => (RlpNode::word_rlp(hash), SparseNodeType::Hash),
+        SparseNode::Leaf { key, hash } => {
+            let mut path = path;
+            path.extend(key);
+            if let Some(hash) = hash.filter(|_| !prefix_set_contains(&path)) {
+                (RlpNode::word_rlp(&hash), SparseNodeType::Leaf)
+            } else {
+                let value = values.get(&path).unwrap();
+                buffers.rlp_buf.clear();
+                let rlp_node = LeafNodeRef { key, value }.rlp(&mut buffers.rlp_buf);
+                *hash = rlp_node.as_hash();
+                (rlp_node, SparseNodeType::Leaf)
+            }
+        }
+        SparseNode::Extension { key, hash, store_in_db_trie } => {
+            let mut child_path = path;
+            child_path.extend(key);
+            if let Some((hash, store_in_db_trie)) =
+                hash.zip(*store_in_db_trie).filter(|_| !prefix_set_contains(&path))
+            {
+                (
+                    RlpNode::word_rlp(&hash),
+                    SparseNodeType::Extension { store_in_db_trie: Some(store_in_db_trie) },
+                )
+            } else if buffers.rlp_node_stack.last().is_some_and(|e| e.path == child_path) {
+                let RlpNodeStackItem { path: _, rlp_node: child, node_type: child_node_type } =
+                    buffers.rlp_node_stack.pop().unwrap();
+                buffers.rlp_buf.clear();
+                let rlp_node = ExtensionNodeRef::new(key, &child).rlp(&mut buffers.rlp_buf);
+                *hash = rlp_node.as_hash();
+
+                let store_in_db_trie_value = child_node_type.store_in_db_trie();
+
+                trace!(
+                    target: "trie::parallel_sparse",
+                    ?path,
+                    ?child_path,
+                    ?child_node_type,
+                    "Extension node"
+                );
+
+                *store_in_db_trie = store_in_db_trie_value;
+
+                (
+                    rlp_node,
+                    SparseNodeType::Extension {
+                        // Inherit the `store_in_db_trie` flag from the child node, which is
+                        // always the branch node
+                        store_in_db_trie: store_in_db_trie_value,
+                    },
+                )
+            } else {
+                // need to get rlp node for child first
+                buffers.path_stack.extend([
+                    RlpNodePathStackItem { path, is_in_prefix_set: *is_in_prefix_set },
+                    RlpNodePathStackItem { path: child_path, is_in_prefix_set: None },
+                ]);
+                return None
+            }
+        }
+        SparseNode::Branch { state_mask, hash, store_in_db_trie } => {
+            if let Some((hash, store_in_db_trie)) =
+                hash.zip(*store_in_db_trie).filter(|_| !prefix_set_contains(&path))
+            {
+                buffers.rlp_node_stack.push(RlpNodeStackItem {
+                    path,
+                    rlp_node: RlpNode::word_rlp(&hash),
+                    node_type: SparseNodeType::Branch { store_in_db_trie: Some(store_in_db_trie) },
+                });
+                return None
+            }
+            let retain_updates = updates.is_some() && prefix_set_contains(&path);
+
+            buffers.branch_child_buf.clear();
+            // Walk children in a reverse order from `f` to `0`, so we pop the `0` first
+            // from the stack and keep walking in the sorted order.
+            for bit in CHILD_INDEX_RANGE.rev() {
+                if state_mask.is_bit_set(bit) {
+                    let mut child = path;
+                    child.push_unchecked(bit);
+                    buffers.branch_child_buf.push(child);
+                }
+            }
+
+            buffers
+                .branch_value_stack_buf
+                .resize(buffers.branch_child_buf.len(), Default::default());
+            let mut added_children = false;
+
+            let mut tree_mask = TrieMask::default();
+            let mut hash_mask = TrieMask::default();
+            let mut hashes = Vec::new();
+            for (i, child_path) in buffers.branch_child_buf.iter().enumerate() {
+                if buffers.rlp_node_stack.last().is_some_and(|e| &e.path == child_path) {
+                    let RlpNodeStackItem { path: _, rlp_node: child, node_type: child_node_type } =
+                        buffers.rlp_node_stack.pop().unwrap();
+
+                    // Update the masks only if we need to retain trie updates
+                    if retain_updates {
+                        // SAFETY: it's a child, so it's never empty
+                        let last_child_nibble = child_path.last().unwrap();
+
+                        // Determine whether we need to set trie mask bit.
+                        let should_set_tree_mask_bit =
+                            if let Some(store_in_db_trie) = child_node_type.store_in_db_trie() {
+                                // A branch or an extension node explicitly set the
+                                // `store_in_db_trie` flag
+                                store_in_db_trie
+                            } else {
+                                // A blinded node has the tree mask bit set
+                                child_node_type.is_hash() &&
+                                    branch_node_tree_masks
+                                        .get(&path)
+                                        .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
+                            };
+                        if should_set_tree_mask_bit {
+                            tree_mask.set_bit(last_child_nibble);
+                        }
+
+                        // Set the hash mask. If a child node is a revealed branch node OR
+                        // is a blinded node that has its hash mask bit set according to the
+                        // database, set the hash mask bit and save the hash.
+                        let hash = child.as_hash().filter(|_| {
+                            child_node_type.is_branch() ||
+                                (child_node_type.is_hash() &&
+                                    branch_node_hash_masks.get(&path).is_some_and(|mask| {
+                                        mask.is_bit_set(last_child_nibble)
+                                    }))
+                        });
+                        if let Some(hash) = hash {
+                            hash_mask.set_bit(last_child_nibble);
+                            hashes.push(hash);
+                        }
+                    }
+
+                    // Insert children in the resulting buffer in a normal order,
+                    // because initially we iterated in reverse.
+                    // SAFETY: i < len and len is never 0
+                    let original_idx = buffers.branch_child_buf.len() - i - 1;
+                    buffers.branch_value_stack_buf[original_idx] = child;
+                    added_children = true;
+                } else {
+                    debug_assert!(!added_children);
+                    buffers
+                        .path_stack
+                        .push(RlpNodePathStackItem { path, is_in_prefix_set: *is_in_prefix_set });
+                    buffers.path_stack.extend(
+                        buffers
+                            .branch_child_buf
+                            .drain(..)
+                            .map(|path| RlpNodePathStackItem { path, is_in_prefix_set: None }),
+                    );
+                    return None
+                }
+            }
+
+            trace!(
+                target: "trie::parallel_sparse",
+                ?path,
+                ?tree_mask,
+                ?hash_mask,
+                "Branch node masks"
+            );
+
+            buffers.rlp_buf.clear();
+            let branch_node_ref = BranchNodeRef::new(&buffers.branch_value_stack_buf, *state_mask);
+            let rlp_node = branch_node_ref.rlp(&mut buffers.rlp_buf);
+            *hash = rlp_node.as_hash();
+
+            // Save a branch node update only if it's not a root node, and we need to
+            // persist updates.
+            let store_in_db_trie_value = if let Some(updates) =
+                updates.as_mut().filter(|_| retain_updates && !path.is_empty())
+            {
+                let store_in_db_trie = !tree_mask.is_empty() || !hash_mask.is_empty();
+                if store_in_db_trie {
+                    // Store in DB trie if there are either any children that are stored in
+                    // the DB trie, or any children represent hashed values
+                    hashes.reverse();
+                    let branch_node = BranchNodeCompact::new(
+                        *state_mask,
+                        tree_mask,
+                        hash_mask,
+                        hashes,
+                        hash.filter(|_| path.is_empty()),
+                    );
+                    updates.updated_nodes.insert(path, branch_node);
+                } else if branch_node_tree_masks.get(&path).is_some_and(|mask| !mask.is_empty()) ||
+                    branch_node_hash_masks.get(&path).is_some_and(|mask| !mask.is_empty())
+                {
+                    // If new tree and hash masks are empty, but previously they weren't, we
+                    // need to remove the node update and add the node itself to the list of
+                    // removed nodes.
+                    updates.updated_nodes.remove(&path);
+                    updates.removed_nodes.insert(path);
+                } else if branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty()) &&
+                    branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty())
+                {
+                    // If new tree and hash masks are empty, and they were previously empty
+                    // as well, we need to remove the node update.
+                    updates.updated_nodes.remove(&path);
+                }
+
+                store_in_db_trie
+            } else {
+                false
+            };
+            *store_in_db_trie = Some(store_in_db_trie_value);
+
+            (rlp_node, SparseNodeType::Branch { store_in_db_trie: Some(store_in_db_trie_value) })
+        }
+    };
+
+    Some((rlp_node, node_type))
 }
 
 /// Sparse Subtrie Type.
@@ -1720,10 +1809,13 @@ mod tests {
 
         // Add some nodes to subtrie_2 so it has something to hash
         // First, add a root node for the subtrie at its path [0x1, 0x0]
-        subtrie_2.nodes.insert(subtrie_2.path, SparseNode::Leaf { 
-            key: Nibbles::new(), // empty key since the full path is already used
-            hash: None 
-        });
+        subtrie_2.nodes.insert(
+            subtrie_2.path,
+            SparseNode::Leaf {
+                key: Nibbles::new(), // empty key since the full path is already used
+                hash: None,
+            },
+        );
         subtrie_2.values.insert(subtrie_2.path, vec![1, 2, 3, 4]);
 
         // Add subtries at specific positions
@@ -1806,16 +1898,28 @@ mod tests {
         trie.reveal_node(leaf_2_path, leaf_2, TrieMasks::none()).unwrap();
 
         // Step 3: Reset hashes for all revealed nodes to test actual hash calculation
-        // Reset upper subtrie node hashes  
+        // Reset upper subtrie node hashes
         trie.upper_subtrie.nodes.get_mut(&extension_path).unwrap().set_hash(None);
         trie.upper_subtrie.nodes.get_mut(&branch_path).unwrap().set_hash(None);
-        
+
         // Reset lower subtrie node hashes
         let leaf_1_subtrie_idx = path_subtrie_index_unchecked(&leaf_1_path);
         let leaf_2_subtrie_idx = path_subtrie_index_unchecked(&leaf_2_path);
-        
-        trie.lower_subtries[leaf_1_subtrie_idx].as_mut().unwrap().nodes.get_mut(&leaf_1_path).unwrap().set_hash(None);
-        trie.lower_subtries[leaf_2_subtrie_idx].as_mut().unwrap().nodes.get_mut(&leaf_2_path).unwrap().set_hash(None);
+
+        trie.lower_subtries[leaf_1_subtrie_idx]
+            .as_mut()
+            .unwrap()
+            .nodes
+            .get_mut(&leaf_1_path)
+            .unwrap()
+            .set_hash(None);
+        trie.lower_subtries[leaf_2_subtrie_idx]
+            .as_mut()
+            .unwrap()
+            .nodes
+            .get_mut(&leaf_2_path)
+            .unwrap()
+            .set_hash(None);
 
         // Step 4: Add changed paths to prefix set
         trie.prefix_set.insert(leaf_1_full_path);
@@ -1829,8 +1933,22 @@ mod tests {
         // Verify that hashes were indeed reset
         assert!(trie.upper_subtrie.nodes.get(&extension_path).unwrap().hash().is_none());
         assert!(trie.upper_subtrie.nodes.get(&branch_path).unwrap().hash().is_none());
-        assert!(trie.lower_subtries[leaf_1_subtrie_idx].as_ref().unwrap().nodes.get(&leaf_1_path).unwrap().hash().is_none());
-        assert!(trie.lower_subtries[leaf_2_subtrie_idx].as_ref().unwrap().nodes.get(&leaf_2_path).unwrap().hash().is_none());
+        assert!(trie.lower_subtries[leaf_1_subtrie_idx]
+            .as_ref()
+            .unwrap()
+            .nodes
+            .get(&leaf_1_path)
+            .unwrap()
+            .hash()
+            .is_none());
+        assert!(trie.lower_subtries[leaf_2_subtrie_idx]
+            .as_ref()
+            .unwrap()
+            .nodes
+            .get(&leaf_2_path)
+            .unwrap()
+            .hash()
+            .is_none());
 
         // Step 5: Calculate root using our implementation
         let parallel_trie_root = trie.root();

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -16,7 +16,7 @@ use reth_trie_sparse::{
     TrieMasks,
 };
 use smallvec::SmallVec;
-use tracing::trace;
+use tracing::{instrument, trace};
 
 /// The maximum length of a path, in nibbles, which belongs to the upper subtrie of a
 /// [`ParallelSparseTrie`]. All longer paths belong to a lower subtrie.
@@ -228,7 +228,7 @@ impl ParallelSparseTrie {
     }
 
     /// Updates hashes for the upper subtrie, using nodes from both upper and lower subtries.
-    #[tracing::instrument(level = "trace", target = "engine::tree", skip_all, ret)]
+    #[instrument(level = "trace", target = "engine::tree", skip_all, ret)]
     fn update_upper_subtrie_hashes(&mut self, prefix_set: &mut PrefixSet) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating upper subtrie hashes");
 
@@ -624,7 +624,7 @@ impl SparseSubtrie {
     /// # Panics
     ///
     /// If the node at the root path does not exist.
-    #[tracing::instrument(level = "trace", target = "engine::tree", skip_all, fields(root = ?self.path), ret)]
+    #[instrument(level = "trace", target = "engine::tree", skip_all, fields(root = ?self.path), ret)]
     pub fn update_hashes(&mut self, prefix_set: &mut PrefixSet) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating subtrie hashes");
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -693,7 +693,7 @@ struct SparseSubtrieInner {
 }
 
 impl SparseSubtrieInner {
-    /// Computes the RLP encoding for a single (trie node)[`SparseTrieNode`] and manages the
+    /// Computes the RLP encoding for a single (trie node)[`SparseNode`] and manages the
     /// traversal state.
     ///
     /// # Node Processing Details
@@ -1572,12 +1572,30 @@ mod tests {
     fn test_update_subtrie_hashes() {
         // Create a trie with three subtries
         let mut trie = ParallelSparseTrie::default();
-        let subtrie_1 = Box::new(SparseSubtrie::new(Nibbles::from_nibbles([0x0, 0x0])));
+        let mut subtrie_1 = Box::new(SparseSubtrie::new(Nibbles::from_nibbles([0x0, 0x0])));
         let subtrie_1_index = path_subtrie_index_unchecked(&subtrie_1.path);
-        let subtrie_2 = Box::new(SparseSubtrie::new(Nibbles::from_nibbles([0x1, 0x0])));
+        let mut subtrie_2 = Box::new(SparseSubtrie::new(Nibbles::from_nibbles([0x1, 0x0])));
         let subtrie_2_index = path_subtrie_index_unchecked(&subtrie_2.path);
-        let subtrie_3 = Box::new(SparseSubtrie::new(Nibbles::from_nibbles([0x3, 0x0])));
+        let mut subtrie_3 = Box::new(SparseSubtrie::new(Nibbles::from_nibbles([0x3, 0x0])));
         let subtrie_3_index = path_subtrie_index_unchecked(&subtrie_3.path);
+
+        // Reveal dummy leaf nodes that form an incorrect trie structure but enough to test the
+        // method
+        let leaf_1_full_path = Nibbles::from_nibbles([0; 64]);
+        let leaf_1_path = leaf_1_full_path.slice(..2);
+        let leaf_1_key = leaf_1_full_path.slice(2..);
+        let leaf_2_full_path = Nibbles::from_nibbles([vec![1, 0], vec![0; 62]].concat());
+        let leaf_2_path = leaf_2_full_path.slice(..2);
+        let leaf_2_key = leaf_2_full_path.slice(2..);
+        let leaf_3_full_path = Nibbles::from_nibbles([vec![3, 0], vec![0; 62]].concat());
+        let leaf_3_path = leaf_3_full_path.slice(..2);
+        let leaf_3_key = leaf_3_full_path.slice(2..);
+        let leaf_1 = create_leaf_node(leaf_1_key.to_vec(), 1);
+        let leaf_2 = create_leaf_node(leaf_2_key.to_vec(), 2);
+        let leaf_3 = create_leaf_node(leaf_3_key.to_vec(), 3);
+        subtrie_1.reveal_node(leaf_1_path, &leaf_1, TrieMasks::none()).unwrap();
+        subtrie_2.reveal_node(leaf_2_path, &leaf_2, TrieMasks::none()).unwrap();
+        subtrie_3.reveal_node(leaf_3_path, &leaf_3, TrieMasks::none()).unwrap();
 
         // Add subtries at specific positions
         trie.lower_subtries[subtrie_1_index] = Some(subtrie_1);

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -215,9 +215,7 @@ impl ParallelSparseTrie {
         // Update subtrie hashes in parallel
         // TODO: call `update_hashes` on each subtrie in parallel
         let (tx, rx) = mpsc::channel();
-        for ChangedSubtrie { index, mut subtrie, prefix_set } in subtries {
-            // For now, compute sequentially (TODO: make parallel)
-            let mut prefix_set = prefix_set;
+        for ChangedSubtrie { index, mut subtrie, mut prefix_set } in subtries {
             subtrie.update_hashes(&mut prefix_set);
             tx.send((index, subtrie)).unwrap();
         }

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -202,7 +202,7 @@ impl ParallelSparseTrie {
     ///
     /// This function first identifies all nodes that have changed (based on the prefix set) below
     /// level [`UPPER_TRIE_MAX_DEPTH`] of the trie, then recalculates their RLP representation.
-    pub fn update_subtrie_hashes(&mut self) {
+    pub fn update_lower_subtrie_hashes(&mut self) {
         trace!(target: "trie::parallel_sparse", "Updating subtrie hashes");
 
         // Take changed subtries according to the prefix set
@@ -274,7 +274,7 @@ impl ParallelSparseTrie {
         trace!(target: "trie::parallel_sparse", "Calculating trie root hash");
 
         // Update all lower subtrie hashes
-        self.update_subtrie_hashes();
+        self.update_lower_subtrie_hashes();
 
         // Update hashes for the upper subtrie using our specialized function
         // that can access both upper and lower subtrie nodes
@@ -1606,7 +1606,7 @@ mod tests {
         trie.prefix_set = prefix_set;
 
         // Update subtrie hashes
-        trie.update_subtrie_hashes();
+        trie.update_lower_subtrie_hashes();
 
         // Check that the prefix set was updated
         assert_eq!(trie.prefix_set, unchanged_prefix_set);

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -16,7 +16,7 @@ use reth_trie_sparse::{
     TrieMasks,
 };
 use smallvec::SmallVec;
-use tracing::{instrument, trace};
+use tracing::trace;
 
 /// The maximum length of a path, in nibbles, which belongs to the upper subtrie of a
 /// [`ParallelSparseTrie`]. All longer paths belong to a lower subtrie.
@@ -228,7 +228,7 @@ impl ParallelSparseTrie {
     }
 
     /// Updates hashes for the upper subtrie, using nodes from both upper and lower subtries.
-    #[instrument(level = "trace", target = "engine::tree", skip_all, ret)]
+    #[tracing::instrument(level = "trace", target = "engine::tree", skip_all, ret)]
     fn update_upper_subtrie_hashes(&mut self, prefix_set: &mut PrefixSet) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating upper subtrie hashes");
 
@@ -624,7 +624,7 @@ impl SparseSubtrie {
     /// # Panics
     ///
     /// If the node at the root path does not exist.
-    #[instrument(level = "trace", target = "engine::tree", skip_all, fields(root = ?self.path), ret)]
+    #[tracing::instrument(level = "trace", target = "engine::tree", skip_all, fields(root = ?self.path), ret)]
     pub fn update_hashes(&mut self, prefix_set: &mut PrefixSet) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating subtrie hashes");
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -264,11 +264,9 @@ impl ParallelSparseTrie {
                 "Popped node from path stack"
             );
 
-            self.upper_subtrie.inner.rlp_node(
-                |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path)),
-                path,
-                node,
-            );
+            let prefix_set_contains =
+                |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path));
+            self.upper_subtrie.inner.rlp_node(prefix_set_contains, path, node);
         }
 
         debug_assert_eq!(self.upper_subtrie.inner.buffers.rlp_node_stack.len(), 1);
@@ -655,11 +653,9 @@ impl SparseSubtrie {
                 .get_mut(&path)
                 .unwrap_or_else(|| panic!("node at path {path:?} does not exist"));
 
-            self.inner.rlp_node(
-                |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path)),
-                path,
-                node,
-            );
+            let prefix_set_contains =
+                |path: &Nibbles| *is_in_prefix_set.get_or_insert_with(|| prefix_set.contains(path));
+            self.inner.rlp_node(prefix_set_contains, path, node);
         }
 
         debug_assert_eq!(self.inner.buffers.rlp_node_stack.len(), 1);

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1801,37 +1801,12 @@ mod tests {
             .unwrap()
             .set_hash(None);
 
-        // Step 4: Add changed paths to prefix set
+        // Step 4: Add changed leaf node paths to prefix set
         trie.prefix_set.insert(leaf_1_full_path);
         trie.prefix_set.insert(leaf_2_full_path);
-        // Also add the upper subtrie paths that need updating
-        trie.prefix_set.insert(extension_path);
-        trie.prefix_set.insert(branch_path);
-        trie.prefix_set.insert(leaf_1_path);
-        trie.prefix_set.insert(leaf_2_path);
-
-        // Verify that hashes were indeed reset
-        assert!(trie.upper_subtrie.nodes.get(&extension_path).unwrap().hash().is_none());
-        assert!(trie.upper_subtrie.nodes.get(&branch_path).unwrap().hash().is_none());
-        assert!(trie.lower_subtries[leaf_1_subtrie_idx]
-            .as_ref()
-            .unwrap()
-            .nodes
-            .get(&leaf_1_path)
-            .unwrap()
-            .hash()
-            .is_none());
-        assert!(trie.lower_subtries[leaf_2_subtrie_idx]
-            .as_ref()
-            .unwrap()
-            .nodes
-            .get(&leaf_2_path)
-            .unwrap()
-            .hash()
-            .is_none());
 
         // Step 5: Calculate root using our implementation
-        let parallel_trie_root = trie.root();
+        let root = trie.root();
 
         // Step 6: Calculate root using HashBuilder for comparison
         let (hash_builder_root, _, _proof_nodes, _, _) = run_hash_builder(
@@ -1842,25 +1817,11 @@ mod tests {
         );
 
         // Step 7: Verify the roots match
-        assert_eq!(parallel_trie_root, hash_builder_root);
-
-        // Additional checks to verify the structure
-        // Check that extension and branch are in upper subtrie
-        assert!(trie.upper_subtrie.nodes.contains_key(&extension_path));
-        assert!(trie.upper_subtrie.nodes.contains_key(&branch_path));
-
-        // Check that leaf nodes are in lower subtries
-        let leaf_1_subtrie_idx = path_subtrie_index_unchecked(&leaf_1_path);
-        let leaf_2_subtrie_idx = path_subtrie_index_unchecked(&leaf_2_path);
-        assert!(trie.lower_subtries[leaf_1_subtrie_idx].is_some());
-        assert!(trie.lower_subtries[leaf_2_subtrie_idx].is_some());
-
-        let leaf_1_subtrie = trie.lower_subtries[leaf_1_subtrie_idx].as_ref().unwrap();
-        let leaf_2_subtrie = trie.lower_subtries[leaf_2_subtrie_idx].as_ref().unwrap();
-        assert!(leaf_1_subtrie.nodes.contains_key(&leaf_1_path));
-        assert!(leaf_2_subtrie.nodes.contains_key(&leaf_2_path));
+        assert_eq!(root, hash_builder_root);
 
         // Verify hashes were computed
+        let leaf_1_subtrie = trie.lower_subtries[leaf_1_subtrie_idx].as_ref().unwrap();
+        let leaf_2_subtrie = trie.lower_subtries[leaf_2_subtrie_idx].as_ref().unwrap();
         assert!(trie.upper_subtrie.nodes.get(&extension_path).unwrap().hash().is_some());
         assert!(trie.upper_subtrie.nodes.get(&branch_path).unwrap().hash().is_some());
         assert!(leaf_1_subtrie.nodes.get(&leaf_1_path).unwrap().hash().is_some());

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -677,8 +677,7 @@ struct SparseSubtrieInner {
 }
 
 impl SparseSubtrieInner {
-    /// Computes the RLP encoding for a single (trie node)[`SparseNode`] and manages the
-    /// traversal state.
+    /// Computes the RLP encoding and its hash for a single (trie node)[`SparseNode`].
     ///
     /// # Node Processing Details
     ///

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2063,6 +2063,20 @@ impl SparseNode {
             }
         }
     }
+
+    /// Sets the hash of the node for testing purposes.
+    /// This method is only available when the `test-utils` feature is enabled.
+    #[cfg(feature = "test-utils")]
+    pub fn set_hash(&mut self, new_hash: Option<B256>) {
+        match self {
+            Self::Empty | Self::Hash(_) => {
+                // Cannot set hash for Empty or Hash nodes
+            }
+            Self::Leaf { hash, .. } | Self::Extension { hash, .. } | Self::Branch { hash, .. } => {
+                *hash = new_hash;
+            }
+        }
+    }
 }
 
 /// A helper struct used to store information about a node that has been removed

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2065,8 +2065,9 @@ impl SparseNode {
     }
 
     /// Sets the hash of the node for testing purposes.
-    /// This method is only available when the `test-utils` feature is enabled.
-    #[cfg(feature = "test-utils")]
+    ///
+    /// For [`SparseNode::Empty`] and [`SparseNode::Hash`] nodes, this method does nothing.
+    #[cfg(any(test, feature = "test-utils"))]
     pub const fn set_hash(&mut self, new_hash: Option<B256>) {
         match self {
             Self::Empty | Self::Hash(_) => {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2067,7 +2067,7 @@ impl SparseNode {
     /// Sets the hash of the node for testing purposes.
     /// This method is only available when the `test-utils` feature is enabled.
     #[cfg(feature = "test-utils")]
-    pub fn set_hash(&mut self, new_hash: Option<B256>) {
+    pub const fn set_hash(&mut self, new_hash: Option<B256>) {
         match self {
             Self::Empty | Self::Hash(_) => {
                 // Cannot set hash for Empty or Hash nodes


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/16866

This PR implements the method `ParallelSparseTrie::root` that does the following:
1. Call `ParallelSparseTrie::update_subtrie_hashes` to update the hashes of lower subtries
2. Call `ParallelSparseTrie::update_upper_subtrie_hashes` to update the hashes of upper subtrie.

`ParallelSparseTrie::update_upper_subtrie_hashes` has almost the same functionality as `SparseSubtrie::update_hashes`, but instead of just looking into the upper subtrie, it also checks the lower subtries if the path is long enough and we expect the node to be there. To abstract this common behaviour of calculating the RLP and hashes of nodes, `SparseSubtrieInner::rlp_node` is used.