### PR TITLE
chore(trie): rephrase the log about storage proof task result sending

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -279,7 +279,7 @@ where
                 hashed_address = ?input.hashed_address,
                 ?error,
                 task_time = ?proof_start.elapsed(),
-                "Failed to send proof result"
+                "Storage proof receiver is dropped, discarding the result"
             );
         }
 


### PR DESCRIPTION
Make it less scary, as it's not really an issue