### PR TITLE
chore(`ci`): rm concurrency from book workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,11 +10,6 @@ on:
     types: [opened, reopened, synchronize, closed]
   merge_group:
 
-# Add concurrency to prevent conflicts when multiple PR previews are being deployed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Book deploy job didn't run: https://github.com/paradigmxyz/reth/actions/runs/15854447495/job/44696089905 post vocs migration https://github.com/paradigmxyz/reth/pull/16605

Removing concurrency, as this was added for setting up previews. 