### PR TITLE
chore: use earliest block number

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -261,6 +261,10 @@ impl<N: ProviderNodeTypes> BlockNumReader for BlockchainProvider<N> {
         self.database.last_block_number()
     }
 
+    fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.database.earliest_block_number()
+    }
+
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
         self.consistent_provider()?.block_number(hash)
     }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -345,6 +345,17 @@ impl<N: ProviderNodeTypes> BlockNumReader for ProviderFactory<N> {
         self.provider()?.last_block_number()
     }
 
+    fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
+        // expired height tracks the lowest block number that has been expired, therefore the
+        // earliest block number is one more than that.
+        let mut earliest = self.static_file_provider.expired_history_height();
+        if earliest > 0 {
+            // If the expired history height is 0, then the earliest block number is still 0.
+            earliest += 1;
+        }
+        Ok(earliest)
+    }
+
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
         self.provider()?.block_number(hash)
     }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1019,6 +1019,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ///
     /// The earliest block that is still available in the static files is `expired_history_height +
     /// 1`.
+    ///
+    /// Returns `0` if no history has been expired.
     pub fn expired_history_height(&self) -> BlockNumber {
         self.expired_history_height.load(std::sync::atomic::Ordering::Relaxed)
     }


### PR DESCRIPTION
now that we can expiry history, we should use this value for the `earliest` block