### PR TITLE
feat: make jwt-secret argument consistent across reth-bench commands

### DIFF
--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -21,7 +21,7 @@ pub struct BenchmarkArgs {
     ///
     /// If no path is provided, a secret will be generated and stored in the datadir under
     /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
-    #[arg(long = "jwtsecret", value_name = "PATH", global = true, required = false)]
+    #[arg(long = "jwt-secret", value_name = "PATH", global = true, required = false)]
     pub auth_jwtsecret: Option<PathBuf>,
 
     /// The RPC url to use for sending engine requests.

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -21,7 +21,13 @@ pub struct BenchmarkArgs {
     ///
     /// If no path is provided, a secret will be generated and stored in the datadir under
     /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
-    #[arg(long = "jwt-secret", alias = "jwtsecret", value_name = "PATH", global = true, required = false)]
+    #[arg(
+        long = "jwt-secret",
+        alias = "jwtsecret",
+        value_name = "PATH",
+        global = true,
+        required = false
+    )]
     pub auth_jwtsecret: Option<PathBuf>,
 
     /// The RPC url to use for sending engine requests.

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -21,7 +21,7 @@ pub struct BenchmarkArgs {
     ///
     /// If no path is provided, a secret will be generated and stored in the datadir under
     /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
-    #[arg(long = "jwt-secret", value_name = "PATH", global = true, required = false)]
+    #[arg(long = "jwt-secret", alias = "jwtsecret", value_name = "PATH", global = true, required = false)]
     pub auth_jwtsecret: Option<PathBuf>,
 
     /// The RPC url to use for sending engine requests.


### PR DESCRIPTION
Previously, reth-bench commands used inconsistent argument names:
- `new-payload-fcu` and `new-payload-only` used `--jwtsecret`
- `send-payload` used `--jwt-secret`

This change standardizes all commands to use `--jwt-secret` with hyphens for consistency with other CLI tools.

🤖 Generated with [Claude Code](https://claude.ai/code)