### PR TITLE
feat: add per-address metrics for precompile cache

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -18,7 +18,7 @@ use error::{InsertBlockError, InsertBlockErrorKind, InsertBlockFatalError};
 use instrumented_state::InstrumentedStateProvider;
 use payload_processor::sparse_trie::StateRootComputeOutcome;
 use persistence_state::CurrentPersistenceAction;
-use precompile_cache::{create_precompile_metrics_with_address, CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap};
+use precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap};
 use reth_chain_state::{
     CanonicalInMemoryState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
     MemoryOverlayStateProvider, NewCanonicalChain,
@@ -2448,7 +2448,11 @@ where
             executor.evm_mut().precompiles_mut().map_precompiles(|address, precompile| {
                 let metrics = precompile_cache_metrics
                     .entry(*address)
-                    .or_insert_with(|| create_precompile_metrics_with_address(*address))
+                    .or_insert_with(|| {
+                        CachedPrecompileMetrics::new_with_labels(&[
+                            ("address", format!("0x{:02x}", address))
+                        ])
+                    })
                     .clone();
                 CachedPrecompile::wrap(
                     precompile,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -18,7 +18,7 @@ use error::{InsertBlockError, InsertBlockErrorKind, InsertBlockFatalError};
 use instrumented_state::InstrumentedStateProvider;
 use payload_processor::sparse_trie::StateRootComputeOutcome;
 use persistence_state::CurrentPersistenceAction;
-use precompile_cache::{precompile_address_label, CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap};
+use precompile_cache::{create_precompile_metrics_with_address, CachedPrecompile, PrecompileCacheMap};
 use reth_chain_state::{
     CanonicalInMemoryState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
     MemoryOverlayStateProvider, NewCanonicalChain,
@@ -2439,9 +2439,7 @@ where
 
         if !self.config.precompile_cache_disabled() {
             executor.evm_mut().precompiles_mut().map_precompiles(|address, precompile| {
-                let precompile_metrics = CachedPrecompileMetrics::new_with_labels(&[
-                    ("address", precompile_address_label(*address))
-                ]);
+                let precompile_metrics = create_precompile_metrics_with_address(*address);
                 CachedPrecompile::wrap(
                     precompile,
                     self.precompile_cache_map.cache_for_address(*address),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -18,7 +18,7 @@ use error::{InsertBlockError, InsertBlockErrorKind, InsertBlockFatalError};
 use instrumented_state::InstrumentedStateProvider;
 use payload_processor::sparse_trie::StateRootComputeOutcome;
 use persistence_state::CurrentPersistenceAction;
-use precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap};
+use precompile_cache::{precompile_address_label, CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap};
 use reth_chain_state::{
     CanonicalInMemoryState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
     MemoryOverlayStateProvider, NewCanonicalChain,
@@ -276,9 +276,6 @@ where
     evm_config: C,
     /// Precompile cache map.
     precompile_cache_map: PrecompileCacheMap<SpecFor<C>>,
-    /// Metrics for precompile cache, saved between block executions so we don't re-allocate for
-    /// every block.
-    precompile_cache_metrics: CachedPrecompileMetrics,
 }
 
 impl<N, P: Debug, T: PayloadTypes + Debug, V: Debug, C> std::fmt::Debug
@@ -373,7 +370,6 @@ where
             payload_processor,
             evm_config,
             precompile_cache_map,
-            precompile_cache_metrics: Default::default(),
         }
     }
 
@@ -2443,11 +2439,14 @@ where
 
         if !self.config.precompile_cache_disabled() {
             executor.evm_mut().precompiles_mut().map_precompiles(|address, precompile| {
+                let precompile_metrics = CachedPrecompileMetrics::new_with_labels(&[
+                    ("address", precompile_address_label(*address))
+                ]);
                 CachedPrecompile::wrap(
                     precompile,
                     self.precompile_cache_map.cache_for_address(*address),
                     *self.evm_config.evm_env(block.header()).spec_id(),
-                    Some(self.precompile_cache_metrics.clone()),
+                    Some(precompile_metrics),
                 )
             });
         }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -5,7 +5,7 @@ use crate::tree::{
     payload_processor::{
         executor::WorkloadExecutor, multiproof::MultiProofMessage, ExecutionCache,
     },
-    precompile_cache::{precompile_address_label, CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
+    precompile_cache::{create_precompile_metrics_with_address, CachedPrecompile, PrecompileCacheMap},
     StateProviderBuilder,
 };
 use alloy_consensus::transaction::Recovered;
@@ -271,9 +271,7 @@ where
 
         if !precompile_cache_disabled {
             evm.precompiles_mut().map_precompiles(|address, precompile| {
-                let precompile_metrics = CachedPrecompileMetrics::new_with_labels(&[
-                    ("address", precompile_address_label(*address))
-                ]);
+                let precompile_metrics = create_precompile_metrics_with_address(*address);
                 CachedPrecompile::wrap(
                     precompile,
                     precompile_cache_map.cache_for_address(*address),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -5,7 +5,7 @@ use crate::tree::{
     payload_processor::{
         executor::WorkloadExecutor, multiproof::MultiProofMessage, ExecutionCache,
     },
-    precompile_cache::{CachedPrecompile, PrecompileCacheMap},
+    precompile_cache::{precompile_address_label, CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     StateProviderBuilder,
 };
 use alloy_consensus::transaction::Recovered;
@@ -271,11 +271,14 @@ where
 
         if !precompile_cache_disabled {
             evm.precompiles_mut().map_precompiles(|address, precompile| {
+                let precompile_metrics = CachedPrecompileMetrics::new_with_labels(&[
+                    ("address", precompile_address_label(*address))
+                ]);
                 CachedPrecompile::wrap(
                     precompile,
                     precompile_cache_map.cache_for_address(*address),
                     spec_id,
-                    None, // CachedPrecompileMetrics
+                    Some(precompile_metrics),
                 )
             });
         }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -5,7 +5,7 @@ use crate::tree::{
     payload_processor::{
         executor::WorkloadExecutor, multiproof::MultiProofMessage, ExecutionCache,
     },
-    precompile_cache::{create_precompile_metrics_with_address, CachedPrecompile, PrecompileCacheMap},
+    precompile_cache::{CachedPrecompile, PrecompileCacheMap},
     StateProviderBuilder,
 };
 use alloy_consensus::transaction::Recovered;
@@ -271,12 +271,11 @@ where
 
         if !precompile_cache_disabled {
             evm.precompiles_mut().map_precompiles(|address, precompile| {
-                let precompile_metrics = create_precompile_metrics_with_address(*address);
                 CachedPrecompile::wrap(
                     precompile,
                     precompile_cache_map.cache_for_address(*address),
                     spec_id,
-                    Some(precompile_metrics),
+                    None, // No metrics for prewarm
                 )
             });
         }

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -225,6 +225,16 @@ pub(crate) struct CachedPrecompileMetrics {
     precompile_errors: metrics::Counter,
 }
 
+impl CachedPrecompileMetrics {
+    /// Creates a new instance of [`CachedPrecompileMetrics`] with the given address.
+    ///
+    /// Adds address as an `address` label padded with zeros to at least two hex symbols, prefixed
+    /// by `0x`.
+    pub(crate) fn new_with_address(address: Address) -> Self {
+        Self::new_with_labels(&[("address", format!("0x{:02x}", address))])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::hash::DefaultHasher;

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -358,15 +358,4 @@ mod tests {
             .unwrap();
         assert_eq!(result3.bytes.as_ref(), b"output_from_precompile_1");
     }
-
-    #[test]
-    fn test_precompile_address_formatting() {
-        // Test address formatting
-        let addr_1 = Address::from([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]);
-        let addr_2 = Address::from([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2]);
-        
-        assert_eq!(format!("0x{:02x}", addr_1), "0x0000000000000000000000000000000000000001");
-        assert_eq!(format!("0x{:02x}", addr_2), "0x0000000000000000000000000000000000000002");
-        assert_eq!(format!("0x{:02x}", Address::ZERO), "0x0000000000000000000000000000000000000000");
-    }
 }

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -15,15 +15,6 @@ use std::{
 /// Default max cache size for [`PrecompileCache`]
 const MAX_CACHE_SIZE: u32 = 10_000;
 
-/// Create precompile metrics with address label.
-/// Uses 0x prefix with at least two hex digits for the address label.
-pub(crate) fn create_precompile_metrics_with_address(address: Address) -> CachedPrecompileMetrics {
-    let address_label = format!("0x{:02x}", address);
-    // Leak the string to get a 'static reference for the metrics
-    let static_label: &'static str = Box::leak(address_label.into_boxed_str());
-    CachedPrecompileMetrics::new_with_labels(&[("address", static_label)])
-}
-
 /// Stores caches for each precompile.
 #[derive(Debug, Clone, Default)]
 pub struct PrecompileCacheMap<S>(HashMap<Address, PrecompileCache<S>>)
@@ -369,17 +360,11 @@ mod tests {
     }
 
     #[test]
-    fn test_precompile_metrics_creation() {
-        // Test that metrics can be created with proper address labels
+    fn test_precompile_address_formatting() {
+        // Test address formatting
         let addr_1 = Address::from([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]);
         let addr_2 = Address::from([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2]);
         
-        // Just verify that metrics creation doesn't panic
-        let _metrics_1 = create_precompile_metrics_with_address(addr_1);
-        let _metrics_2 = create_precompile_metrics_with_address(addr_2);
-        let _metrics_zero = create_precompile_metrics_with_address(Address::ZERO);
-        
-        // Test address formatting directly
         assert_eq!(format!("0x{:02x}", addr_1), "0x0000000000000000000000000000000000000001");
         assert_eq!(format!("0x{:02x}", addr_2), "0x0000000000000000000000000000000000000002");
         assert_eq!(format!("0x{:02x}", Address::ZERO), "0x0000000000000000000000000000000000000000");

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -231,7 +231,7 @@ impl CachedPrecompileMetrics {
     /// Adds address as an `address` label padded with zeros to at least two hex symbols, prefixed
     /// by `0x`.
     pub(crate) fn new_with_address(address: Address) -> Self {
-        Self::new_with_labels(&[("address", format!("0x{:02x}", address))])
+        Self::new_with_labels(&[("address", format!("0x{address:02x}"))])
     }
 }
 

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -15,25 +15,13 @@ use std::{
 /// Default max cache size for [`PrecompileCache`]
 const MAX_CACHE_SIZE: u32 = 10_000;
 
-/// Get a static string representation of a precompile address for metrics.
-/// Falls back to a generic label for unknown addresses.
-pub(crate) fn precompile_address_label(address: Address) -> &'static str {
-    match address.0[19] {
-        1 => "0x01",
-        2 => "0x02",
-        3 => "0x03",
-        4 => "0x04",
-        5 => "0x05",
-        6 => "0x06",
-        7 => "0x07",
-        8 => "0x08",
-        9 => "0x09",
-        10 => "0x0a",
-        11 => "0x0b",
-        12 => "0x0c",
-        13 => "0x0d",
-        _ => "unknown",
-    }
+/// Create precompile metrics with address label.
+/// Uses 0x prefix with at least two hex digits for the address label.
+pub(crate) fn create_precompile_metrics_with_address(address: Address) -> CachedPrecompileMetrics {
+    let address_label = format!("0x{:02x}", address);
+    // Leak the string to get a 'static reference for the metrics
+    let static_label: &'static str = Box::leak(address_label.into_boxed_str());
+    CachedPrecompileMetrics::new_with_labels(&[("address", static_label)])
 }
 
 /// Stores caches for each precompile.
@@ -381,16 +369,19 @@ mod tests {
     }
 
     #[test]
-    fn test_precompile_address_label() {
-        // Test common precompile addresses
-        assert_eq!(precompile_address_label(Address::repeat_byte(1)), "0x01");
-        assert_eq!(precompile_address_label(Address::repeat_byte(2)), "0x02");
-        assert_eq!(precompile_address_label(Address::repeat_byte(9)), "0x09");
-        assert_eq!(precompile_address_label(Address::repeat_byte(10)), "0x0a");
-        assert_eq!(precompile_address_label(Address::repeat_byte(13)), "0x0d");
+    fn test_precompile_metrics_creation() {
+        // Test that metrics can be created with proper address labels
+        let addr_1 = Address::from([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]);
+        let addr_2 = Address::from([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2]);
         
-        // Test unknown address
-        assert_eq!(precompile_address_label(Address::repeat_byte(255)), "unknown");
-        assert_eq!(precompile_address_label(Address::ZERO), "unknown");
+        // Just verify that metrics creation doesn't panic
+        let _metrics_1 = create_precompile_metrics_with_address(addr_1);
+        let _metrics_2 = create_precompile_metrics_with_address(addr_2);
+        let _metrics_zero = create_precompile_metrics_with_address(Address::ZERO);
+        
+        // Test address formatting directly
+        assert_eq!(format!("0x{:02x}", addr_1), "0x0000000000000000000000000000000000000001");
+        assert_eq!(format!("0x{:02x}", addr_2), "0x0000000000000000000000000000000000000002");
+        assert_eq!(format!("0x{:02x}", Address::ZERO), "0x0000000000000000000000000000000000000000");
     }
 }

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -15,6 +15,27 @@ use std::{
 /// Default max cache size for [`PrecompileCache`]
 const MAX_CACHE_SIZE: u32 = 10_000;
 
+/// Get a static string representation of a precompile address for metrics.
+/// Falls back to a generic label for unknown addresses.
+pub(crate) fn precompile_address_label(address: Address) -> &'static str {
+    match address.0[19] {
+        1 => "0x01",
+        2 => "0x02",
+        3 => "0x03",
+        4 => "0x04",
+        5 => "0x05",
+        6 => "0x06",
+        7 => "0x07",
+        8 => "0x08",
+        9 => "0x09",
+        10 => "0x0a",
+        11 => "0x0b",
+        12 => "0x0c",
+        13 => "0x0d",
+        _ => "unknown",
+    }
+}
+
 /// Stores caches for each precompile.
 #[derive(Debug, Clone, Default)]
 pub struct PrecompileCacheMap<S>(HashMap<Address, PrecompileCache<S>>)
@@ -357,5 +378,19 @@ mod tests {
             })
             .unwrap();
         assert_eq!(result3.bytes.as_ref(), b"output_from_precompile_1");
+    }
+
+    #[test]
+    fn test_precompile_address_label() {
+        // Test common precompile addresses
+        assert_eq!(precompile_address_label(Address::repeat_byte(1)), "0x01");
+        assert_eq!(precompile_address_label(Address::repeat_byte(2)), "0x02");
+        assert_eq!(precompile_address_label(Address::repeat_byte(9)), "0x09");
+        assert_eq!(precompile_address_label(Address::repeat_byte(10)), "0x0a");
+        assert_eq!(precompile_address_label(Address::repeat_byte(13)), "0x0d");
+        
+        // Test unknown address
+        assert_eq!(precompile_address_label(Address::repeat_byte(255)), "unknown");
+        assert_eq!(precompile_address_label(Address::ZERO), "unknown");
     }
 }


### PR DESCRIPTION
Record cache hit/miss metrics separately for each precompile address.

Changes:
- Create metrics instances with address labels using new_with_labels
- Remove shared metrics field, create per-address instances
- Update both prewarm and main execution integration points

🤖 Generated with [Claude Code](https://claude.ai/code)