### PR TITLE
[crates]: move apostrophe  to the right place in word

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
@@ -3080,7 +3080,7 @@ LIBMDBX_INLINE_API(int, mdbx_env_get_syncperiod, (const MDBX_env *env, unsigned 
  * \param [in] env        An environment handle returned by
  *                        \ref mdbx_env_create().
  *
- * \param [in] dont_sync  A dont'sync flag, if non-zero the last checkpoint
+ * \param [in] dont_sync  A don't sync flag, if non-zero the last checkpoint
  *                        will be kept "as is" and may be still "weak" in the
  *                        \ref MDBX_SAFE_NOSYNC or \ref MDBX_UTTERLY_NOSYNC
  *                        modes. Such "weak" checkpoint will be ignored on

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h++
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h++
@@ -3691,7 +3691,7 @@ public:
   /// `SIGSEGV`. The environment handle will be freed and must not be used again
   /// after this call.
   ///
-  /// \param [in] dont_sync  A dont'sync flag, if non-zero the last checkpoint
+  /// \param [in] dont_sync  A don't sync flag, if non-zero the last checkpoint
   /// will be kept "as is" and may be still "weak" in the \ref lazy_weak_tail
   /// or \ref whole_fragile modes. Such "weak" checkpoint will be ignored
   /// on opening next time, and transactions since the last non-weak checkpoint


### PR DESCRIPTION
`dont'sync `should be `don't sync`