### PR TITLE
docs: typo in comment for `get_pending_transactions_by_origin`

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -902,7 +902,7 @@ where
             .collect()
     }
 
-    /// Returns all pending transactions filted by [`TransactionOrigin`]
+    /// Returns all pending transactions filtered by [`TransactionOrigin`]
     pub fn get_pending_transactions_by_origin(
         &self,
         origin: TransactionOrigin,


### PR DESCRIPTION


---

### 📝 Description

This PR updates the documentation comment for the `get_pending_transactions_by_origin` function to correct formatting and improve clarity.

* Changed: `filted` → `filtered` for consistency.
  No functional code changes were made.

---

