### PR TITLE
feat: convert reth-bench scripts to use uv script format

### DIFF
--- a/bin/reth-bench/scripts/compare_newpayload_latency.py
+++ b/bin/reth-bench/scripts/compare_newpayload_latency.py
@@ -1,4 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "pandas",
+#     "matplotlib", 
+#     "numpy",
+# ]
+# ///
 
 # A simple script which plots graphs comparing two combined_latency.csv files
 # output by reth-bench. The graphs which are plotted are:


### PR DESCRIPTION
Convert Python scripts in `bin/reth-bench/scripts/` to use uv script format for better dependency management. This allows scripts to declare their dependencies directly in the file and have uv automatically manage the virtual environment and package installation.

Changes:
- Updated shebang to use uv run
- Added dependency metadata block with pandas, matplotlib, numpy
- Preserved all original functionality

🤖 Generated with [Claude Code](https://claude.ai/code)