### PR TITLE
feat: add blanket impl for Receipt trait

### DIFF
--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -283,8 +283,6 @@ impl InMemorySize for Receipt {
     }
 }
 
-impl reth_primitives_traits::Receipt for Receipt {}
-
 impl<T> From<alloy_consensus::ReceiptEnvelope<T>> for Receipt
 where
     T: Into<Log>,

--- a/crates/optimism/primitives/src/receipt.rs
+++ b/crates/optimism/primitives/src/receipt.rs
@@ -377,8 +377,6 @@ impl InMemorySize for OpReceipt {
     }
 }
 
-impl reth_primitives_traits::Receipt for OpReceipt {}
-
 /// Trait for deposit receipt.
 pub trait DepositReceipt: reth_primitives_traits::Receipt {
     /// Converts a `Receipt` into a mutable Optimism deposit receipt.

--- a/crates/primitives-traits/src/receipt.rs
+++ b/crates/primitives-traits/src/receipt.rs
@@ -14,7 +14,6 @@ pub trait FullReceipt: Receipt + MaybeCompact {}
 impl<T> FullReceipt for T where T: Receipt + MaybeCompact {}
 
 /// Abstraction of a receipt.
-#[auto_impl::auto_impl(&, Arc)]
 pub trait Receipt:
     Send
     + Sync
@@ -31,6 +30,26 @@ pub trait Receipt:
     + MaybeSerde
     + InMemorySize
     + MaybeSerdeBincodeCompat
+{
+}
+
+// Blanket implementation for any type that satisfies all the supertrait bounds
+impl<T> Receipt for T where
+    T: Send
+        + Sync
+        + Unpin
+        + Clone
+        + fmt::Debug
+        + TxReceipt<Log = alloy_primitives::Log>
+        + RlpEncodableReceipt
+        + RlpDecodableReceipt
+        + Encodable
+        + Decodable
+        + Eip2718EncodableReceipt
+        + Typed2718
+        + MaybeSerde
+        + InMemorySize
+        + MaybeSerdeBincodeCompat
 {
 }
 


### PR DESCRIPTION
## Summary

This PR implements a blanket implementation for the `Receipt` trait, automatically implementing it for any type that satisfies all the supertrait bounds. This eliminates the need for manual empty implementations.

## Changes

- Added blanket implementation in `crates/primitives-traits/src/receipt.rs`:
  ```rust
  impl<T> Receipt for T where
      T: Send
          + Sync
          + Unpin
          + Clone
          + fmt::Debug
          + TxReceipt<Log = alloy_primitives::Log>
          + RlpEncodableReceipt
          + RlpDecodableReceipt
          + Encodable
          + Decodable
          + Eip2718EncodableReceipt
          + Typed2718
          + MaybeSerde
          + InMemorySize
          + MaybeSerdeBincodeCompat
  {
  }
  ```

- Removed `auto_impl` attribute from the `Receipt` trait to avoid conflicts with the blanket implementation
- Removed manual empty implementations:
  - `impl reth_primitives_traits::Receipt for Receipt {}` from `crates/ethereum/primitives/src/receipt.rs`
  - `impl reth_primitives_traits::Receipt for OpReceipt {}` from `crates/optimism/primitives/src/receipt.rs`

## Benefits

- Reduces boilerplate code
- Any type that satisfies the trait bounds automatically implements `Receipt`
- More maintainable - no need to remember to add empty implementations

## Testing

- All tests in `reth-primitives-traits` pass
- The crates compile successfully with all features enabled