### PR TITLE
chore: make SparseStateTrie generic with respect to SparseTrie implementation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -52,7 +52,7 @@ where
     BPF::AccountNodeProvider: BlindedProvider + Send + Sync,
     BPF::StorageNodeProvider: BlindedProvider + Send + Sync,
 {
-    /// Creates a new sparse trie task which will use a [`SerialSparseTrie`] to compute the state
+    /// Creates a new sparse trie task which will use a `SerialSparseTrie` to compute the state
     /// root.
     pub(super) fn new(
         executor: WorkloadExecutor,

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -9,8 +9,8 @@ use reth_errors::ProviderError;
 use reth_revm::state::Bytecode;
 use reth_trie_common::{HashedPostState, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE};
 use reth_trie_sparse::{
-    blinded::DefaultBlindedProviderFactory, errors::SparseStateTrieResult, SparseStateTrie,
-    SparseTrie,
+    blinded::DefaultBlindedProviderFactory, errors::SparseStateTrieResult, RevealedSparseTrie,
+    SparseStateTrie, SparseTrie,
 };
 
 /// `StatelessTrie` structure for usage during stateless validation

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -7,7 +7,7 @@ use proptest::{prelude::*, test_runner::TestRunner};
 use rand::{seq::IteratorRandom, Rng};
 use reth_testing_utils::generators;
 use reth_trie::Nibbles;
-use reth_trie_sparse::RevealedSparseTrie;
+use reth_trie_sparse::{RevealedSparseTrie, SerialSparseTrie};
 
 fn update_rlp_node_level(c: &mut Criterion) {
     let mut rng = generators::rng();
@@ -22,7 +22,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
             .current();
 
         // Create a sparse trie with `size` leaves
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         for (key, value) in &state {
             sparse
                 .update_leaf(Nibbles::unpack(key), alloy_rlp::encode_fixed_size(value).to_vec())

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -4,24 +4,22 @@ use crate::{
     proof::{Proof, ProofBlindedProviderFactory},
     trie_cursor::TrieCursorFactory,
 };
-use alloy_rlp::EMPTY_STRING_CODE;
-use alloy_trie::EMPTY_ROOT_HASH;
-use reth_trie_common::HashedPostState;
-
 use alloy_primitives::{
     keccak256,
     map::{B256Map, B256Set, Entry, HashMap},
     Bytes, B256,
 };
+use alloy_rlp::EMPTY_STRING_CODE;
+use alloy_trie::EMPTY_ROOT_HASH;
 use itertools::Itertools;
 use reth_execution_errors::{
     SparseStateTrieErrorKind, SparseTrieError, SparseTrieErrorKind, StateProofError,
     TrieWitnessError,
 };
-use reth_trie_common::{MultiProofTargets, Nibbles};
+use reth_trie_common::{HashedPostState, MultiProofTargets, Nibbles};
 use reth_trie_sparse::{
     blinded::{BlindedProvider, BlindedProviderFactory, RevealedNode},
-    SparseStateTrie,
+    RevealedSparseTrie, SparseStateTrie,
 };
 use std::sync::{mpsc, Arc};
 


### PR DESCRIPTION
This refactoring introduces generics that allow using different trie implementations while maintaining the same interface.

**Changes made:**

- Renamed `RevealedSparseTrie` to `SerialSparseTrie` to better contrast it against the `ParallelSparseTrie`, and to make room for a trait encompassing both.

- Extracted revealed trie functionality into a new `RevealedSparseTrie` trait that abstracts over different sparse trie implementations.

- Made `SparseStateTrie` generic over both account and storage trie types (`R` and `S`), defaulting to `SerialSparseTrie`.

Fixes #17088