### PR TITLE
docs: error fixes for clarity 

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_MAX_PROOF_TASK_CONCURRENCY: u64 = 256;
 
 /// Default number of reserved CPU cores for non-reth processes.
 ///
-/// This will be deducated from the thread count of main reth global threadpool.
+/// This will be deducted from the thread count of main reth global threadpool.
 pub const DEFAULT_RESERVED_CPU_CORES: usize = 1;
 
 const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = 256;

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -135,7 +135,7 @@ The IPC transport lives in [`rpc/ipc`](../../crates/rpc/ipc).
 
 #### Utilities Crates
 
-- [`rpc/rpc-convert`](../../crates/rpc/rpc-convert): This crate various helper functions to convert between reth primitive types and rpc types.
+- [`rpc/rpc-convert`](../../crates/rpc/rpc-convert): This crate provides various helper functions to convert between reth primitive types and rpc types.
 - [`rpc/layer`](../../crates/rpc/rpc-layer/): Some RPC middleware layers (e.g. `AuthValidator`, `JwtAuthValidator`)
 - [`rpc/rpc-testing-util`](../../crates/rpc/rpc-testing-util/): Reth RPC testing helpers
 


### PR DESCRIPTION
- Fix typo in `crates/engine/primitives/src/config.rs`: 
Change "deducated" to "deducted" in thread pool comment
- Fix description in `docs/repo/layout.md`: 
Add missing word "provides" to rpc-convert crate description
