### PR TITLE
feat(rpc): Use generic transaction request as input

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -48,6 +48,7 @@ exclude_crates=(
   reth-rpc-api
   reth-rpc-api-testing-util
   reth-rpc-builder
+  reth-rpc-convert
   reth-rpc-e2e-tests
   reth-rpc-engine-api
   reth-rpc-eth-api

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a694d8be621ee12b45ae23e7f18393b9a1e04f1ba47a0136767cb8c955f7f8"
+checksum = "73e7f99e3a50210eaee2abd57293a2e72b1a5b7bb251b44c4bf33d02ddd402ab"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1647d47f59288584cc3b40eff3e7dde6af8c88a2fca8fe02c22de7b9ab218ffa"
+checksum = "9945351a277c914f3776ae72b3fc1d22f90d2e840276830e48e9be5bf371a8fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bea12b41db8e25614b48636609549d721c3888a34a9512a7677a1b665c2c08c"
+checksum = "1f27be9e6b587904ee5135f72182a565adaf0c7dd341bae330ee6f0e342822b1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715ae25d525c567481ba2fc97000415624836d516958b9c3f189f1e267d1d90a"
+checksum = "4134375e533d095e045982cd7684a29c37089ab7a605ecf2b4aa17a5e61d72d3"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696a83af273bfc512e02693bd4b5056c8c57898328bd0ce594013fb864de4dcf"
+checksum = "d61d58e94791b74c2566a2f240f3f796366e2479d4d39b4a3ec848c733fb92ce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cc040744bc63111a70dd295984858e33a1ef1aff00c1c86be166b5c475ad23"
+checksum = "1edaf2255b0ea9213ecbb056fa92870d858719911e04fb4260bcc43f7743d370"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2d7663b088e11bed83ec9269347d7f56a5a80fb80c33a1ba1e60b470874e9"
+checksum = "c224eafcd1bd4c54cc45b5fc3634ae42722bdb9253780ac64a5deffd794a6cec"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35648c318b4649d2d141d1ed4f6e32c69f4959bdc2f6e44d53c0a333ed615a37"
+checksum = "0b21283a28b117505a75ee1f2e63c16ea2ea72afca44f670b1f02795d9f5d988"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef5509f1f2ff26650eb4f8b715f31dacbf583cdadc70013824405c5940d9e5"
+checksum = "09e5f02654272d9a95c66949b78f30c87701c232cf8302d4a1dab02957f5a0c1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eb6f7c6f65f878362e07a96fc872969f46ce465e07b5a36b696d0b26033afe"
+checksum = "08acc8843da1207a80f778bc0ac3e5dc94c2683280fa70ff3090b895d0179537"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbbf4c34305ae1ff0a38e63e88690920d030ac197a71d009f36b3e48dc47c1"
+checksum = "c956d223a5fa7ef28af1c6ae41b77ecb95a36d686d5644ee22266f6b517615b4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953b106defef74307b1379611ae9180e48d6b1ab8122d9a6fb8d6b7de1392cf9"
+checksum = "99074f79ad4b188b1049807f8f96637abc3cc019fde53791906edc26bc092a57"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86331c311dbabaa16828d557ed1028ae0b3f0ce1e62da89eb5cccf7b65e14eb6"
+checksum = "61ad30ddbec9c315b002e02ba13f4327767cd5e6bdefadbfcec3d95ff6a3206e"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad84b1927e3c5985afca4a3c3a3a5bdce433de30cf8b2f7e52b642758d235d9"
+checksum = "9d34231e06b5f1ad5f274a6ddb3eca8730db5eb868b70a4494a1e4b716b7fe88"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1e99233cff99aff94fe29cea9e9dd6014c85eeea7890ea4f0e4eada9957ceb"
+checksum = "0c13e5081ae6b99a7f4e46c18b80d652440320ff404790932cb8259ec73f596e"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149a5c4d1f3aed206cf736c7538e67962196cf474e53a5352cdc49f7694b86a4"
+checksum = "544101ff1933e5c8074238b7b49cecb87d47afc411e74927ef58201561c98bf7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d99bde26f9750e3a90ed66d300c5163fa1f767e48955c6a754be895d1896ba8"
+checksum = "220aeda799891b518a171d3d640ec310bab2f4d80c3987c9ea089cedd8a67008"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed717902ec7e7e5b737cf416f29c21f43a4e86db90ff6fddde199f4ed6ea1ac"
+checksum = "14796fd8574c77213802b0dc0e85886b5cb27c44e72678ab7d0a4a2d5aee79e9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8300d59b0126876a1914102c588f9a4792eb4c754d483a954dc29904ddf79d6"
+checksum = "1bea7326ca6cd6971c58042055a039d5c97a1431e30380d8b4883ad98067c1b5"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6049a2cd653a1229541cf5273d09b264412446259182f80c6ccd6cbcd51450d0"
+checksum = "15aac86a4cb20c2f36b1d14202a20eca6baa92691b0aebcfacfe31dd0fedc6ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2423f70f4da52acc53fc45abd334f8ef80c61a74f515e21bb8f10b715e003c23"
+checksum = "fbc92f9dd9e56a9edcfe0c28c0d1898a2c5281a2944d89e2b8a4effeca13823e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dcb220f11bb3fe1eaec24621f0d13a3efd029d7b61e2ba392c9cb8008db76b"
+checksum = "fadc5c919b4e8b3bdcbea2705d63dccb8ed2ce864399d005fed534eefebc8fe4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8070bc2af2d48969e3aa709ea3ebf1f8316176b91c2132efe33d113f74383a9e"
+checksum = "06c02a06ae34d2354398dc9d2de0503129c3f0904a3eb791b5d0149f267c2688"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f19a87067de976c8c8a0526d6d70de612bbd08bb8051a297b9a12084a9a4ae1"
+checksum = "2389ec473fc24735896960b1189f1d92177ed53c4e464d285e54ed3483f9cca3"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6611724477b6b914202392c2f2d9dfd5c88e4eb8b1422ef90ac6cda3649b62a6"
+checksum = "ab70b75dee5f4673ace65058927310658c8ffac63a94aa4b973f925bab020367"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f5b563b89faff55a3705e23972e40ee0c59634e356f1a79cc1e9c0be31744"
+checksum = "b99ffb19be54a61d18599843ef887ddd12c3b713244462c184e2eab67106d51a"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d25d5b547ce62a699957bcc3b3bd21d141d784dcc1b5b7dfc8a71cd36cd56d"
+checksum = "92b5a640491f3ab18d17bd6e521c64744041cd86f741b25cdb6a346ca0e90c66"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc256856a09b20ddea662fabd773e5627ea6fa139bc5e2ed3642a762cbe93f17"
+checksum = "17fe2576d9689409724f7cb737aa7fdd70674edfec4b9c3ce54f6ffac00e83ca"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c191d9df0681c2b96813f6cab35b473bf9b2b929257461e30c8bc62f74f6b0"
+checksum = "4816ea8425e789057d08804452eff399204808b7b7a233ac3f7534183cae2236"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472e12600c46b766110edd8382b4804d70188870f064531ee8fd61a35ed18686"
+checksum = "afd621a9ddef2fdc06d17089f45e47cf84d0b46ca5a1bc6c83807c9119636f52"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -8709,8 +8709,10 @@ dependencies = [
 name = "reth-network-api"
 version = "1.5.1"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-admin",
+ "alloy-rpc-types-eth",
  "auto_impl",
  "derive_more",
  "enr",
@@ -8720,6 +8722,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-network-types",
+ "reth-rpc-convert",
  "reth-tokio-util",
  "serde",
  "thiserror 2.0.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9384,7 +9384,6 @@ dependencies = [
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "op-revm",
- "parking_lot",
  "reqwest",
  "reth-chainspec",
  "reth-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e7f99e3a50210eaee2abd57293a2e72b1a5b7bb251b44c4bf33d02ddd402ab"
+checksum = "b8f278d90bfe5edc8b178eaeff4680797566b7c7788b3c7aa095cc1fcf2b6de1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9945351a277c914f3776ae72b3fc1d22f90d2e840276830e48e9be5bf371a8fe"
+checksum = "88e9fa835cdaa5aedecd0c09444aa91dc1b3b3ea2c06967eb3d276cc9fc77a63"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f27be9e6b587904ee5135f72182a565adaf0c7dd341bae330ee6f0e342822b1"
+checksum = "23a6da7b77b3881affe4ebc66d7aac2ac54b9afd78476f06c683f4d401c79fd2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4134375e533d095e045982cd7684a29c37089ab7a605ecf2b4aa17a5e61d72d3"
+checksum = "d5de92d113bc7d11d9f76980b47551bfd42c6d164076c929cee1f54853be47e1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61d58e94791b74c2566a2f240f3f796366e2479d4d39b4a3ec848c733fb92ce"
+checksum = "9e6d3a6de55b37c009749ccca0c4c61698dca0ceb2fc859a969bf38774abf5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edaf2255b0ea9213ecbb056fa92870d858719911e04fb4260bcc43f7743d370"
+checksum = "d82a73f8be4a2cb511b39ab644b20df2007a4943e23fed1d5dc2025f0427d2fe"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c224eafcd1bd4c54cc45b5fc3634ae42722bdb9253780ac64a5deffd794a6cec"
+checksum = "d0745e180886d29963eff6e5f2dddb2cdcc058f35773f90736d1acfddd1543ef"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b21283a28b117505a75ee1f2e63c16ea2ea72afca44f670b1f02795d9f5d988"
+checksum = "a0af9b5b6e2b761dd2e929e7b1c13b4efd9fb7d4c32424c4bff7f197c26d422c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e5f02654272d9a95c66949b78f30c87701c232cf8302d4a1dab02957f5a0c1"
+checksum = "655cdd84c0de704a9e92bbef203da9cf4be229ead3cce1cfe40575a917804d0c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08acc8843da1207a80f778bc0ac3e5dc94c2683280fa70ff3090b895d0179537"
+checksum = "7c38e3ca802871963d5fb5a6e8cfac851162ad90d6a105808cf965d9aec098e9"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c956d223a5fa7ef28af1c6ae41b77ecb95a36d686d5644ee22266f6b517615b4"
+checksum = "24b502380388209cae9af74015c23db152ac2ff41fde0f60f198fdf8f777a0b8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99074f79ad4b188b1049807f8f96637abc3cc019fde53791906edc26bc092a57"
+checksum = "a27d378f4fad3496365efb5e5ad4ec704a66e280644b6c425a89cd5a2e852f33"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ad30ddbec9c315b002e02ba13f4327767cd5e6bdefadbfcec3d95ff6a3206e"
+checksum = "563b0905b2456b2d75c18b6086bbb051120f6d5e2613fef8488ed8309df1fea8"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d34231e06b5f1ad5f274a6ddb3eca8730db5eb868b70a4494a1e4b716b7fe88"
+checksum = "23cde150686256e52f0b419506d623ad460f076d69584a2ba6ec3f10f13acb48"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c13e5081ae6b99a7f4e46c18b80d652440320ff404790932cb8259ec73f596e"
+checksum = "b35a27b9ea5ab75aa15ef94f18f6daf70a3a5d11b2a89f7651e88d56cd0fa98e"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544101ff1933e5c8074238b7b49cecb87d47afc411e74927ef58201561c98bf7"
+checksum = "37dde6ccc43eb56deaa0a4eecb1bb27161fa45b9fc8ab10a4a1f41c6202aef38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220aeda799891b518a171d3d640ec310bab2f4d80c3987c9ea089cedd8a67008"
+checksum = "96ff722ee7f023135ca119b7c865774f8a93a4518c5179f8d6541a6b879c02da"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14796fd8574c77213802b0dc0e85886b5cb27c44e72678ab7d0a4a2d5aee79e9"
+checksum = "8690adea8f0a6b453c9b2031ed159b61f119fa9c8f89f1f4c10a465dbe5a5a2d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bea7326ca6cd6971c58042055a039d5c97a1431e30380d8b4883ad98067c1b5"
+checksum = "21313fffcce0dcf4acd5ed1e053fd38b361151090c294a1e537aa3f23cd2da16"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -661,14 +661,15 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15aac86a4cb20c2f36b1d14202a20eca6baa92691b0aebcfacfe31dd0fedc6ee"
+checksum = "eca77da5e999325a7372d0354e06873c3b3895dcf046e1cf2c74f02b138ebfb6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -681,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc92f9dd9e56a9edcfe0c28c0d1898a2c5281a2944d89e2b8a4effeca13823e"
+checksum = "b227dc11259fade071906720d03cd08e0d2f8f90ec3825cf7bb22df31beb77de"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -695,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadc5c919b4e8b3bdcbea2705d63dccb8ed2ce864399d005fed534eefebc8fe4"
+checksum = "5debf3d884ea376586da917104dcd615ae7045070a9f90224cc1c9188bba139f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -707,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c02a06ae34d2354398dc9d2de0503129c3f0904a3eb791b5d0149f267c2688"
+checksum = "9f3e246f82e7deb5676577285aabd21f3b485195a4f407a3dfb03f5cbdc7a2e4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -719,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2389ec473fc24735896960b1189f1d92177ed53c4e464d285e54ed3483f9cca3"
+checksum = "52d6606781afe3169d4b53fd5400594180ee83387815002dced9586d1222b3fd"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -734,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70b75dee5f4673ace65058927310658c8ffac63a94aa4b973f925bab020367"
+checksum = "0296c917ad0a95b4ca010f1ecc959c9eb6df59ea2f88c2e11cbb67d844c28b29"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -822,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99ffb19be54a61d18599843ef887ddd12c3b713244462c184e2eab67106d51a"
+checksum = "97ccf4dfb0a4e7a4fab6fae781bf4678611440ffb64afff613d6183f45053273"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -845,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b5a640491f3ab18d17bd6e521c64744041cd86f741b25cdb6a346ca0e90c66"
+checksum = "fc1df9c2c44674dca3eda18c1f3d65d0a8e4298b5676e7d03d9ad100a65f136d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -860,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fe2576d9689409724f7cb737aa7fdd70674edfec4b9c3ce54f6ffac00e83ca"
+checksum = "04b4201f1534f988a41e5de4d0363ad8c7243bad586d9c2729c823a77f758866"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -880,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4816ea8425e789057d08804452eff399204808b7b7a233ac3f7534183cae2236"
+checksum = "9dfbda6f1a3706e74bb241982eb568a77da7dc1c65753dc17765ee8b8703954c"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -918,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd621a9ddef2fdc06d17089f45e47cf84d0b46ca5a1bc6c83807c9119636f52"
+checksum = "554c599ee3eb226fb8bcf00914e98128d48ab420d52eaf339a9a0c56852e0b61"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -9247,7 +9248,6 @@ dependencies = [
  "eyre",
  "futures",
  "op-alloy-consensus",
- "op-alloy-network",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "reth-chainspec",
@@ -9953,6 +9953,7 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "alloy-signer",
  "jsonrpsee-types",
  "op-alloy-consensus",
  "op-alloy-rpc-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b31d7560fdebcf24e21fcba9ed316c2fdf2854b2ca652a24741bf8192cd40a"
+checksum = "74a694d8be621ee12b45ae23e7f18393b9a1e04f1ba47a0136767cb8c955f7f8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf397edad57b696501702d5887e4e14d7d0bbae9fbb6439e148d361f7254f45"
+checksum = "1647d47f59288584cc3b40eff3e7dde6af8c88a2fca8fe02c22de7b9ab218ffa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efc90130119c22079b468c30eab6feda1ab4981c3ea88ed8e12dc155cc26ea1"
+checksum = "8bea12b41db8e25614b48636609549d721c3888a34a9512a7677a1b665c2c08c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe854e4051afb5b47931b78ba7b5af1952d06e903637430e98c8321192d29eca"
+checksum = "715ae25d525c567481ba2fc97000415624836d516958b9c3f189f1e267d1d90a"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cc4c7363f48a2b61de395d9b2df52280e303a5af45a22ed33cf27cd30d7975"
+checksum = "696a83af273bfc512e02693bd4b5056c8c57898328bd0ce594013fb864de4dcf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce138b29a2f8e7ed97c064af8359dfa6559c12cba5e821ae4eb93081a56557e"
+checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2c0cb72ef87173b9d78cd29be898820c44498ce60a7d5de82b577c8c002bb8"
+checksum = "42cc040744bc63111a70dd295984858e33a1ef1aff00c1c86be166b5c475ad23"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4965cff485617f5c2f4016a2e48503b735fb6ec3845ba86c68fdf338da9e85e7"
+checksum = "49f2d7663b088e11bed83ec9269347d7f56a5a80fb80c33a1ba1e60b470874e9"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03ad273e1c55cc481889b4130e82860e33624e6969e9a08854e0f3ebe659295"
+checksum = "35648c318b4649d2d141d1ed4f6e32c69f4959bdc2f6e44d53c0a333ed615a37"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9a510692bef4871797062ca09ec7873c45dc68c7f3f72291165320f53606a3"
+checksum = "2090f21bb6df43e147d976e754bc9a007ca851badbfc6685377aa679b5f151d9"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956116526887a732fb5823648544ae56c78a38cf56d4e1c2c076d7432a90674c"
+checksum = "2bef5509f1f2ff26650eb4f8b715f31dacbf583cdadc70013824405c5940d9e5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19131a9cbf17486ef7fa37663f8c3631c3fa606aec3d77733042066439d68"
+checksum = "60eb6f7c6f65f878362e07a96fc872969f46ce465e07b5a36b696d0b26033afe"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5699f859f61936425d753c0709b8049ec7d83988ea4f0793526885f63d8d863b"
+checksum = "07bbbf4c34305ae1ff0a38e63e88690920d030ac197a71d009f36b3e48dc47c1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca073dd05362d7a66241468862a18d95255f5eb7c28a9d83b458c8216b751bd"
+checksum = "953b106defef74307b1379611ae9180e48d6b1ab8122d9a6fb8d6b7de1392cf9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e7c6f85d9b38302ca0051420cb687d035f75cc1ff09cdf4f98991ff211fb9f"
+checksum = "86331c311dbabaa16828d557ed1028ae0b3f0ce1e62da89eb5cccf7b65e14eb6"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6425892f9addc08b0c687878feb8e4a61a89e085ffdf52865fd44fa1d54f84f"
+checksum = "5ad84b1927e3c5985afca4a3c3a3a5bdce433de30cf8b2f7e52b642758d235d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5b22062142ce3b2ed3374337d4b343437e5de6959397f55d2c9fe2c2ce0162"
+checksum = "ed1e99233cff99aff94fe29cea9e9dd6014c85eeea7890ea4f0e4eada9957ceb"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d8751cf34201ceb637974388971e38abbd84f9e10a03103170ac7b1e9f3137"
+checksum = "149a5c4d1f3aed206cf736c7538e67962196cf474e53a5352cdc49f7694b86a4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acde603d444a8f6f50bb79e1296602e8c0bf193b2fa9af0afe0287e8aaf87df"
+checksum = "3d99bde26f9750e3a90ed66d300c5163fa1f767e48955c6a754be895d1896ba8"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24aa5a872715979dbb831ed9a50e983a1d2500c44ded79550000c905a4d5ca8e"
+checksum = "3ed717902ec7e7e5b737cf416f29c21f43a4e86db90ff6fddde199f4ed6ea1ac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce2ac0e27fe24f27f1a6d0e0088b94c03c67dfcfb0461813a4a44b8197a8105"
+checksum = "c8300d59b0126876a1914102c588f9a4792eb4c754d483a954dc29904ddf79d6"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e082bf96fb0eec9efa1d981d6d9ff9880266884aea32ecf2f344c25073e19d5"
+checksum = "6049a2cd653a1229541cf5273d09b264412446259182f80c6ccd6cbcd51450d0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18db18563210da6a1e7e172c9bf0049bc8e00058e31043458ec3cae92c51d1cb"
+checksum = "2423f70f4da52acc53fc45abd334f8ef80c61a74f515e21bb8f10b715e003c23"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c202af188d9a60000d09309c6a2605cabf49d0b1de0307c3b9f221e8a545a5"
+checksum = "13dcb220f11bb3fe1eaec24621f0d13a3efd029d7b61e2ba392c9cb8008db76b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad318c341481a5f5e50d69d830853873d8b5e8d2b73ea2c0da69cf78537c970"
+checksum = "8070bc2af2d48969e3aa709ea3ebf1f8316176b91c2132efe33d113f74383a9e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a758b004483b906d622f607d27e1bc0923246a092adc475069b5509ab83c8148"
+checksum = "3f19a87067de976c8c8a0526d6d70de612bbd08bb8051a297b9a12084a9a4ae1"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d44ff6b720feb3fc17763f5d6cd90e57b05400acd2a5083a7d7020e351e5bb"
+checksum = "6611724477b6b914202392c2f2d9dfd5c88e4eb8b1422ef90ac6cda3649b62a6"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e551a125a5a96377ee0befc63db27b68078873d316c65b74587f14704dac630"
+checksum = "e53f5b563b89faff55a3705e23972e40ee0c59634e356f1a79cc1e9c0be31744"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640f66b33f0d85df0fcb0528739fb5d424f691a7c58963395b2417a68274703"
+checksum = "a6d25d5b547ce62a699957bcc3b3bd21d141d784dcc1b5b7dfc8a71cd36cd56d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88ab7ac8a7aac07313bdeabbcd70818e6f675e4a9f101a3056d15aeb15be279"
+checksum = "cc256856a09b20ddea662fabd773e5627ea6fa139bc5e2ed3642a762cbe93f17"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972664516ff27c90b156a7df9870d813b85b948d5063d3a1e9093109810b77b7"
+checksum = "89c191d9df0681c2b96813f6cab35b473bf9b2b929257461e30c8bc62f74f6b0"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bf2869e66904b2148c809e7a75e23ca26f5d7b46663a149a1444fb98a69d1d"
+checksum = "472e12600c46b766110edd8382b4804d70188870f064531ee8fd61a35ed18686"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -4388,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5926,12 +5926,13 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
+checksum = "675b3a54e5b12af997abc8b6638b0aee51a28caedab70d4967e0d5db3a3f1d06"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
+ "cfg-if",
  "proptest",
  "ruint",
  "serde",
@@ -11243,9 +11244,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -11480,7 +11481,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.10.0",
  "schemars 0.9.0",
- "schemars 1.0.3",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8722,7 +8722,6 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-network-types",
- "reth-rpc-convert",
  "reth-tokio-util",
  "serde",
  "thiserror 2.0.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10070,6 +10070,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f278d90bfe5edc8b178eaeff4680797566b7c7788b3c7aa095cc1fcf2b6de1"
+checksum = "ca3b746060277f3d7f9c36903bb39b593a741cb7afcb0044164c28f0e9b673f0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e9fa835cdaa5aedecd0c09444aa91dc1b3b3ea2c06967eb3d276cc9fc77a63"
+checksum = "bf98679329fa708fa809ea596db6d974da892b068ad45e48ac1956f582edf946"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a6da7b77b3881affe4ebc66d7aac2ac54b9afd78476f06c683f4d401c79fd2"
+checksum = "a10e47f5305ea08c37b1772086c1573e9a0a257227143996841172d37d3831bb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5de92d113bc7d11d9f76980b47551bfd42c6d164076c929cee1f54853be47e1"
+checksum = "f562a81278a3ed83290e68361f2d1c75d018ae3b8589a314faf9303883e18ec9"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d3a6de55b37c009749ccca0c4c61698dca0ceb2fc859a969bf38774abf5e4"
+checksum = "dc41384e9ab8c9b2fb387c52774d9d432656a28edcda1c2d4083e96051524518"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82a73f8be4a2cb511b39ab644b20df2007a4943e23fed1d5dc2025f0427d2fe"
+checksum = "12c454fcfcd5d26ed3b8cae5933cbee9da5f0b05df19b46d4bd4446d1f082565"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0745e180886d29963eff6e5f2dddb2cdcc058f35773f90736d1acfddd1543ef"
+checksum = "42d6d39eabe5c7b3d8f23ac47b0b683b99faa4359797114636c66e0743103d05"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0af9b5b6e2b761dd2e929e7b1c13b4efd9fb7d4c32424c4bff7f197c26d422c"
+checksum = "3704fa8b7ba9ba3f378d99b3d628c8bc8c2fc431b709947930f154e22a8368b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655cdd84c0de704a9e92bbef203da9cf4be229ead3cce1cfe40575a917804d0c"
+checksum = "08800e8cbe70c19e2eb7cf3d7ff4b28bdd9b3933f8e1c8136c7d910617ba03bf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c38e3ca802871963d5fb5a6e8cfac851162ad90d6a105808cf965d9aec098e9"
+checksum = "ae68457a2c2ead6bd7d7acb5bf5f1623324b1962d4f8e7b0250657a3c3ab0a0b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b502380388209cae9af74015c23db152ac2ff41fde0f60f198fdf8f777a0b8"
+checksum = "162301b5a57d4d8f000bf30f4dcb82f9f468f3e5e846eeb8598dd39e7886932c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -531,7 +531,6 @@ dependencies = [
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
- "async-stream",
  "futures",
  "pin-project",
  "reqwest",
@@ -541,16 +540,15 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d378f4fad3496365efb5e5ad4ec704a66e280644b6c425a89cd5a2e852f33"
+checksum = "6cd8ca94ae7e2b32cc3895d9981f3772aab0b4756aa60e9ed0bcfee50f0e1328"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -561,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563b0905b2456b2d75c18b6086bbb051120f6d5e2613fef8488ed8309df1fea8"
+checksum = "e7bff682e76f3f72e9ddc75e54a1bd1db5ce53cbdf2cce2d63a3a981437f78f5"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -573,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cde150686256e52f0b419506d623ad460f076d69584a2ba6ec3f10f13acb48"
+checksum = "9f3ff6a778ebda3deaed9af17930d678611afe1effa895c4260b61009c314f82"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -585,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35a27b9ea5ab75aa15ef94f18f6daf70a3a5d11b2a89f7651e88d56cd0fa98e"
+checksum = "076b47e834b367d8618c52dd0a0d6a711ddf66154636df394805300af4923b8a"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -596,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dde6ccc43eb56deaa0a4eecb1bb27161fa45b9fc8ab10a4a1f41c6202aef38"
+checksum = "48f39da9b760e78fc3f347fba4da257aa6328fb33f73682b26cc0a6874798f7d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -614,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ff722ee7f023135ca119b7c865774f8a93a4518c5179f8d6541a6b879c02da"
+checksum = "94a2a86ad7b7d718c15e79d0779bd255561b6b22968dc5ed2e7c0fbc43bb55fe"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -624,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8690adea8f0a6b453c9b2031ed159b61f119fa9c8f89f1f4c10a465dbe5a5a2d"
+checksum = "4ba838417c42e8f1fe5eb4f4bbfacb7b5d4b9e615b8d2e831b921e04bf0bed62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -645,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21313fffcce0dcf4acd5ed1e053fd38b361151090c294a1e537aa3f23cd2da16"
+checksum = "2c2f847e635ec0be819d06e2ada4bcc4e4204026a83c4bfd78ae8d550e027ae7"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -667,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca77da5e999325a7372d0354e06873c3b3895dcf046e1cf2c74f02b138ebfb6"
+checksum = "fb1c9b23cedf70aeb99ea9f16b78cdf902f524e227922fb340e3eb899ebe96dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -682,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b227dc11259fade071906720d03cd08e0d2f8f90ec3825cf7bb22df31beb77de"
+checksum = "6fc58180302a94c934d455eeedb3ecb99cdc93da1dbddcdbbdb79dd6fe618b2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -696,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5debf3d884ea376586da917104dcd615ae7045070a9f90224cc1c9188bba139f"
+checksum = "0f9f089d78bb94148e0fcfda087d4ce5fd35a7002847b5e90610c0fcb140f7b4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -708,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e246f82e7deb5676577285aabd21f3b485195a4f407a3dfb03f5cbdc7a2e4"
+checksum = "ae699248d02ade9db493bbdae61822277dc14ae0f82a5a4153203b60e34422a6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -720,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d6606781afe3169d4b53fd5400594180ee83387815002dced9586d1222b3fd"
+checksum = "3cf7d793c813515e2b627b19a15693960b3ed06670f9f66759396d06ebe5747b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -735,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0296c917ad0a95b4ca010f1ecc959c9eb6df59ea2f88c2e11cbb67d844c28b29"
+checksum = "51a424bc5a11df0d898ce0fd15906b88ebe2a6e4f17a514b51bc93946bb756bd"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -823,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccf4dfb0a4e7a4fab6fae781bf4678611440ffb64afff613d6183f45053273"
+checksum = "4f317d20f047b3de4d9728c556e2e9a92c9a507702d2016424cd8be13a74ca5e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -846,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1df9c2c44674dca3eda18c1f3d65d0a8e4298b5676e7d03d9ad100a65f136d"
+checksum = "ff084ac7b1f318c87b579d221f11b748341d68b9ddaa4ffca5e62ed2b8cfefb4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -861,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b4201f1534f988a41e5de4d0363ad8c7243bad586d9c2729c823a77f758866"
+checksum = "edb099cdad8ed2e6a80811cdf9bbf715ebf4e34c981b4a6e2d1f9daacbf8b218"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -881,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfbda6f1a3706e74bb241982eb568a77da7dc1c65753dc17765ee8b8703954c"
+checksum = "0e915e1250dc129ad48d264573ccd08e4716fdda564a772fd217875b8459aff9"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -919,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554c599ee3eb226fb8bcf00914e98128d48ab420d52eaf339a9a0c56852e0b61"
+checksum = "1154c8187a5ff985c95a8b2daa2fedcf778b17d7668e5e50e556c4ff9c881154"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -12486,8 +12484,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,33 +478,33 @@ alloy-trie = { version = "0.9.0", default-features = false }
 
 alloy-hardforks = "0.2.7"
 
-alloy-consensus = { version = "1.0.18", default-features = false }
-alloy-contract = { version = "1.0.18", default-features = false }
-alloy-eips = { version = "1.0.18", default-features = false }
-alloy-genesis = { version = "1.0.18", default-features = false }
-alloy-json-rpc = { version = "1.0.18", default-features = false }
-alloy-network = { version = "1.0.18", default-features = false }
-alloy-network-primitives = { version = "1.0.18", default-features = false }
-alloy-provider = { version = "1.0.18", features = ["reqwest"], default-features = false }
-alloy-pubsub = { version = "1.0.18", default-features = false }
-alloy-rpc-client = { version = "1.0.18", default-features = false }
-alloy-rpc-types = { version = "1.0.18", features = ["eth"], default-features = false }
-alloy-rpc-types-admin = { version = "1.0.18", default-features = false }
-alloy-rpc-types-anvil = { version = "1.0.18", default-features = false }
-alloy-rpc-types-beacon = { version = "1.0.18", default-features = false }
-alloy-rpc-types-debug = { version = "1.0.18", default-features = false }
-alloy-rpc-types-engine = { version = "1.0.18", default-features = false }
-alloy-rpc-types-eth = { version = "1.0.18", default-features = false }
-alloy-rpc-types-mev = { version = "1.0.18", default-features = false }
-alloy-rpc-types-trace = { version = "1.0.18", default-features = false }
-alloy-rpc-types-txpool = { version = "1.0.18", default-features = false }
-alloy-serde = { version = "1.0.18", default-features = false }
-alloy-signer = { version = "1.0.18", default-features = false }
-alloy-signer-local = { version = "1.0.18", default-features = false }
-alloy-transport = { version = "1.0.18" }
-alloy-transport-http = { version = "1.0.18", features = ["reqwest-rustls-tls"], default-features = false }
-alloy-transport-ipc = { version = "1.0.18", default-features = false }
-alloy-transport-ws = { version = "1.0.18", default-features = false }
+alloy-consensus = { version = "1.0.21", default-features = false }
+alloy-contract = { version = "1.0.21", default-features = false }
+alloy-eips = { version = "1.0.21", default-features = false }
+alloy-genesis = { version = "1.0.21", default-features = false }
+alloy-json-rpc = { version = "1.0.21", default-features = false }
+alloy-network = { version = "1.0.21", default-features = false }
+alloy-network-primitives = { version = "1.0.21", default-features = false }
+alloy-provider = { version = "1.0.21", features = ["reqwest"], default-features = false }
+alloy-pubsub = { version = "1.0.21", default-features = false }
+alloy-rpc-client = { version = "1.0.21", default-features = false }
+alloy-rpc-types = { version = "1.0.21", features = ["eth"], default-features = false }
+alloy-rpc-types-admin = { version = "1.0.21", default-features = false }
+alloy-rpc-types-anvil = { version = "1.0.21", default-features = false }
+alloy-rpc-types-beacon = { version = "1.0.21", default-features = false }
+alloy-rpc-types-debug = { version = "1.0.21", default-features = false }
+alloy-rpc-types-engine = { version = "1.0.21", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.21", default-features = false }
+alloy-rpc-types-mev = { version = "1.0.21", default-features = false }
+alloy-rpc-types-trace = { version = "1.0.21", default-features = false }
+alloy-rpc-types-txpool = { version = "1.0.21", default-features = false }
+alloy-serde = { version = "1.0.21", default-features = false }
+alloy-signer = { version = "1.0.21", default-features = false }
+alloy-signer-local = { version = "1.0.21", default-features = false }
+alloy-transport = { version = "1.0.21" }
+alloy-transport-http = { version = "1.0.21", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-ipc = { version = "1.0.21", default-features = false }
+alloy-transport-ws = { version = "1.0.21", default-features = false }
 
 # op
 alloy-op-evm = { version = "0.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,33 +478,33 @@ alloy-trie = { version = "0.9.0", default-features = false }
 
 alloy-hardforks = "0.2.7"
 
-alloy-consensus = { version = "1.0.21", default-features = false }
-alloy-contract = { version = "1.0.21", default-features = false }
-alloy-eips = { version = "1.0.21", default-features = false }
-alloy-genesis = { version = "1.0.21", default-features = false }
-alloy-json-rpc = { version = "1.0.21", default-features = false }
-alloy-network = { version = "1.0.21", default-features = false }
-alloy-network-primitives = { version = "1.0.21", default-features = false }
-alloy-provider = { version = "1.0.21", features = ["reqwest"], default-features = false }
-alloy-pubsub = { version = "1.0.21", default-features = false }
-alloy-rpc-client = { version = "1.0.21", default-features = false }
-alloy-rpc-types = { version = "1.0.21", features = ["eth"], default-features = false }
-alloy-rpc-types-admin = { version = "1.0.21", default-features = false }
-alloy-rpc-types-anvil = { version = "1.0.21", default-features = false }
-alloy-rpc-types-beacon = { version = "1.0.21", default-features = false }
-alloy-rpc-types-debug = { version = "1.0.21", default-features = false }
-alloy-rpc-types-engine = { version = "1.0.21", default-features = false }
-alloy-rpc-types-eth = { version = "1.0.21", default-features = false }
-alloy-rpc-types-mev = { version = "1.0.21", default-features = false }
-alloy-rpc-types-trace = { version = "1.0.21", default-features = false }
-alloy-rpc-types-txpool = { version = "1.0.21", default-features = false }
-alloy-serde = { version = "1.0.21", default-features = false }
-alloy-signer = { version = "1.0.21", default-features = false }
-alloy-signer-local = { version = "1.0.21", default-features = false }
-alloy-transport = { version = "1.0.21" }
-alloy-transport-http = { version = "1.0.21", features = ["reqwest-rustls-tls"], default-features = false }
-alloy-transport-ipc = { version = "1.0.21", default-features = false }
-alloy-transport-ws = { version = "1.0.21", default-features = false }
+alloy-consensus = { version = "1.0.22", default-features = false }
+alloy-contract = { version = "1.0.22", default-features = false }
+alloy-eips = { version = "1.0.22", default-features = false }
+alloy-genesis = { version = "1.0.22", default-features = false }
+alloy-json-rpc = { version = "1.0.22", default-features = false }
+alloy-network = { version = "1.0.22", default-features = false }
+alloy-network-primitives = { version = "1.0.22", default-features = false }
+alloy-provider = { version = "1.0.22", features = ["reqwest"], default-features = false }
+alloy-pubsub = { version = "1.0.22", default-features = false }
+alloy-rpc-client = { version = "1.0.22", default-features = false }
+alloy-rpc-types = { version = "1.0.22", features = ["eth"], default-features = false }
+alloy-rpc-types-admin = { version = "1.0.22", default-features = false }
+alloy-rpc-types-anvil = { version = "1.0.22", default-features = false }
+alloy-rpc-types-beacon = { version = "1.0.22", default-features = false }
+alloy-rpc-types-debug = { version = "1.0.22", default-features = false }
+alloy-rpc-types-engine = { version = "1.0.22", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.22", default-features = false }
+alloy-rpc-types-mev = { version = "1.0.22", default-features = false }
+alloy-rpc-types-trace = { version = "1.0.22", default-features = false }
+alloy-rpc-types-txpool = { version = "1.0.22", default-features = false }
+alloy-serde = { version = "1.0.22", default-features = false }
+alloy-signer = { version = "1.0.22", default-features = false }
+alloy-signer-local = { version = "1.0.22", default-features = false }
+alloy-transport = { version = "1.0.22" }
+alloy-transport-http = { version = "1.0.22", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-ipc = { version = "1.0.22", default-features = false }
+alloy-transport-ws = { version = "1.0.22", default-features = false }
 
 # op
 alloy-op-evm = { version = "0.14", default-features = false }

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -230,8 +230,11 @@ where
         if let Some(healthy_node_client) = &self.healthy_node_client {
             // Compare the witness against the healthy node.
             let healthy_node_witness = futures::executor::block_on(async move {
-                DebugApiClient::debug_execution_witness(healthy_node_client, block.number().into())
-                    .await
+                DebugApiClient::<()>::debug_execution_witness(
+                    healthy_node_client,
+                    block.number().into(),
+                )
+                .await
             })?;
 
             let healthy_path = self.save_file(

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -27,6 +27,7 @@ reth-evm-ethereum.workspace = true
 reth-consensus.workspace = true
 reth-rpc.workspace = true
 reth-rpc-api.workspace = true
+reth-rpc-eth-api.workspace = true
 reth-rpc-builder.workspace = true
 reth-rpc-server-types.workspace = true
 reth-node-api.workspace = true

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -38,6 +38,7 @@ use reth_provider::{providers::ProviderFactoryBuilder, EthStorage};
 use reth_rpc::{eth::core::EthApiFor, ValidationApi};
 use reth_rpc_api::{eth::FullEthApiServer, servers::BlockSubmissionValidationApiServer};
 use reth_rpc_builder::{config::RethRpcServerConfig, middleware::RethRpcMiddleware};
+use reth_rpc_eth_api::helpers::AddDevSigners;
 use reth_rpc_eth_types::{error::FromEvmError, EthApiError};
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
@@ -137,7 +138,7 @@ pub struct EthereumEthApiBuilder;
 impl<N> EthApiBuilder<N> for EthereumEthApiBuilder
 where
     N: FullNodeComponents,
-    EthApiFor<N>: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>,
+    EthApiFor<N>: FullEthApiServer<Provider = N::Provider, Pool = N::Pool> + AddDevSigners,
 {
     type EthApi = EthApiFor<N>;
 

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -19,8 +19,11 @@ reth-network-p2p.workspace = true
 reth-eth-wire-types.workspace = true
 reth-tokio-util.workspace = true
 reth-ethereum-forks.workspace = true
+reth-rpc-convert.workspace = true
 
 # ethereum
+alloy-consensus.workspace = true
+alloy-rpc-types-eth.workspace = true
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 alloy-rpc-types-admin.workspace = true
 enr = { workspace = true, default-features = false, features = ["rust-secp256k1"] }

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -47,4 +47,6 @@ serde = [
     "alloy-primitives/serde",
     "enr/serde",
     "reth-ethereum-forks/serde",
+    "alloy-consensus/serde",
+    "alloy-rpc-types-eth/serde",
 ]

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -19,7 +19,6 @@ reth-network-p2p.workspace = true
 reth-eth-wire-types.workspace = true
 reth-tokio-util.workspace = true
 reth-ethereum-forks.workspace = true
-reth-rpc-convert.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -21,7 +21,6 @@ use reth_eth_wire_types::{
 use reth_network_p2p::{sync::NetworkSyncUpdater, NoopFullBlockClient};
 use reth_network_peers::NodeRecord;
 use reth_network_types::{PeerKind, Reputation, ReputationChangeKind};
-use reth_rpc_convert::RpcTypes;
 use reth_tokio_util::{EventSender, EventStream};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -218,11 +217,4 @@ where
     fn peers_handle(&self) -> &PeersHandle {
         &self.peers_handle
     }
-}
-
-impl RpcTypes for NoopNetwork<EthNetworkPrimitives> {
-    type Header = alloy_consensus::Header;
-    type TransactionRequest = alloy_rpc_types_eth::transaction::TransactionRequest;
-    type TransactionResponse = alloy_rpc_types_eth::Transaction;
-    type Receipt = alloy_rpc_types_eth::TransactionReceipt;
 }

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -6,6 +6,13 @@
 use core::{fmt, marker::PhantomData};
 use std::net::{IpAddr, SocketAddr};
 
+use crate::{
+    events::{NetworkPeersEvents, PeerEventStream},
+    test_utils::{PeersHandle, PeersHandleProvider},
+    BlockDownloaderProvider, DiscoveryEvent, NetworkError, NetworkEvent,
+    NetworkEventListenerProvider, NetworkInfo, NetworkStatus, PeerId, PeerInfo, PeerRequest, Peers,
+    PeersInfo,
+};
 use alloy_rpc_types_admin::EthProtocolInfo;
 use enr::{secp256k1::SecretKey, Enr};
 use reth_eth_wire_types::{
@@ -17,14 +24,6 @@ use reth_network_types::{PeerKind, Reputation, ReputationChangeKind};
 use reth_tokio_util::{EventSender, EventStream};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-
-use crate::{
-    events::{NetworkPeersEvents, PeerEventStream},
-    test_utils::{PeersHandle, PeersHandleProvider},
-    BlockDownloaderProvider, DiscoveryEvent, NetworkError, NetworkEvent,
-    NetworkEventListenerProvider, NetworkInfo, NetworkStatus, PeerId, PeerInfo, PeerRequest, Peers,
-    PeersInfo,
-};
 
 /// A type that implements all network trait that does nothing.
 ///

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -21,6 +21,7 @@ use reth_eth_wire_types::{
 use reth_network_p2p::{sync::NetworkSyncUpdater, NoopFullBlockClient};
 use reth_network_peers::NodeRecord;
 use reth_network_types::{PeerKind, Reputation, ReputationChangeKind};
+use reth_rpc_convert::RpcTypes;
 use reth_tokio_util::{EventSender, EventStream};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -217,4 +218,11 @@ where
     fn peers_handle(&self) -> &PeersHandle {
         &self.peers_handle
     }
+}
+
+impl RpcTypes for NoopNetwork<EthNetworkPrimitives> {
+    type Header = alloy_consensus::Header;
+    type TransactionRequest = alloy_rpc_types_eth::transaction::TransactionRequest;
+    type TransactionResponse = alloy_rpc_types_eth::Transaction;
+    type Receipt = alloy_rpc_types_eth::TransactionReceipt;
 }

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -52,7 +52,6 @@ op-revm.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 op-alloy-consensus.workspace = true
-op-alloy-network.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-eth.workspace = true

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -7,6 +7,7 @@ use crate::{
     OpEngineApiBuilder, OpEngineTypes,
 };
 use op_alloy_consensus::{interop::SafetyLevel, OpPooledTransaction};
+use op_alloy_network::{EthereumWallet, NetworkWallet};
 use op_alloy_rpc_types_engine::{OpExecutionData, OpPayloadAttributes};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_engine_local::LocalPayloadAttributesBuilder;
@@ -444,6 +445,7 @@ where
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
+    EthereumWallet: NetworkWallet<NetworkT>,
 {
     type Handle = RpcHandle<N, OpEthApi<N, NetworkT>>;
 
@@ -563,6 +565,7 @@ where
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
+    EthereumWallet: NetworkWallet<NetworkT>,
 {
     type EthApi = OpEthApi<N, NetworkT>;
 

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -7,7 +7,6 @@ use crate::{
     OpEngineApiBuilder, OpEngineTypes,
 };
 use op_alloy_consensus::{interop::SafetyLevel, OpPooledTransaction};
-use op_alloy_network::{EthereumWallet, NetworkWallet};
 use op_alloy_rpc_types_engine::{OpExecutionData, OpPayloadAttributes};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_engine_local::LocalPayloadAttributesBuilder;
@@ -55,9 +54,9 @@ use reth_optimism_txpool::{
     supervisor::{SupervisorClient, DEFAULT_SUPERVISOR_URL},
     OpPooledTx,
 };
-use reth_provider::{providers::ProviderFactoryBuilder, CanonStateSubscriptions};
+use reth_provider::{providers::ProviderFactoryBuilder, CanonStateSubscriptions, ProviderTx};
 use reth_rpc_api::DebugApiServer;
-use reth_rpc_eth_api::{ext::L2EthApiExtServer, FullEthApiServer};
+use reth_rpc_eth_api::{ext::L2EthApiExtServer, FullEthApiServer, RpcTypes, SignableTxRequest};
 use reth_rpc_eth_types::error::FromEvmError;
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
@@ -441,11 +440,10 @@ where
     <N::Pool as TransactionPool>::Transaction: OpPooledTx,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = op_revm::OpTransaction<TxEnv>>,
     OpEthApi<N, NetworkT>: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>,
-    NetworkT: op_alloy_network::Network + Unpin,
+    NetworkT: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<N::Provider>>>,
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
-    EthereumWallet: NetworkWallet<NetworkT>,
 {
     type Handle = RpcHandle<N, OpEthApi<N, NetworkT>>;
 
@@ -561,11 +559,10 @@ where
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: OpPooledTx,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = op_revm::OpTransaction<TxEnv>>,
     OpEthApi<N, NetworkT>: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>,
-    NetworkT: op_alloy_network::Network + Unpin,
+    NetworkT: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<N::Provider>>>,
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
-    EthereumWallet: NetworkWallet<NetworkT>,
 {
     type EthApi = OpEthApi<N, NetworkT>;
 

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -57,7 +57,6 @@ revm.workspace = true
 op-revm.workspace = true
 
 # async
-parking_lot.workspace = true
 tokio.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls-native-roots"] }
 async-trait.workspace = true

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,6 +1,7 @@
 use super::OpNodeCore;
 use crate::{OpEthApi, OpEthApiError};
 use alloy_rpc_types_eth::TransactionRequest;
+use op_alloy_network::TransactionBuilder;
 use op_revm::OpTransaction;
 use reth_evm::{execute::BlockExecutorFactory, ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;
@@ -39,7 +40,10 @@ where
                 >,
             >,
             RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Self::NetworkTypes>,
-            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
+            NetworkTypes: alloy_network::Network
+                              + RpcTypes<
+                TransactionRequest: TransactionBuilder<<Self::RpcConvert as RpcConvert>::Network>,
+            >,
             Error: FromEvmError<Self::Evm>
                        + From<<Self::RpcConvert as RpcConvert>::Error>
                        + From<ProviderError>,

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,6 +1,5 @@
 use super::OpNodeCore;
 use crate::{OpEthApi, OpEthApiError};
-use alloy_rpc_types_eth::TransactionRequest;
 use op_alloy_network::TransactionBuilder;
 use op_revm::OpTransaction;
 use reth_evm::{execute::BlockExecutorFactory, ConfigureEvm, EvmFactory, TxEnvFor};
@@ -40,7 +39,7 @@ where
                 >,
             >,
             RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Self::NetworkTypes>,
-            NetworkTypes: alloy_network::Network
+            NetworkTypes: op_alloy_network::Network
                               + RpcTypes<
                 TransactionRequest: TransactionBuilder<<Self::RpcConvert as RpcConvert>::Network>,
             >,

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,12 +1,11 @@
 use super::OpNodeCore;
 use crate::{OpEthApi, OpEthApiError};
-use op_alloy_network::TransactionBuilder;
 use op_revm::OpTransaction;
 use reth_evm::{execute::BlockExecutorFactory, ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadBlock, LoadState, SpawnBlocking},
-    FromEvmError, FullEthApiTypes, RpcConvert, RpcTypes,
+    FromEvmError, FullEthApiTypes, RpcConvert,
 };
 use reth_storage_api::{errors::ProviderError, ProviderHeader, ProviderTx};
 use revm::context::TxEnv;
@@ -39,10 +38,6 @@ where
                 >,
             >,
             RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Self::NetworkTypes>,
-            NetworkTypes: op_alloy_network::Network
-                              + RpcTypes<
-                TransactionRequest: TransactionBuilder<<Self::RpcConvert as RpcConvert>::Network>,
-            >,
             Error: FromEvmError<Self::Evm>
                        + From<<Self::RpcConvert as RpcConvert>::Error>
                        + From<ProviderError>,

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -21,8 +21,8 @@ use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
 use reth_rpc::eth::{core::EthApiInner, DevSigner};
 use reth_rpc_eth_api::{
     helpers::{
-        AddDevSigners, EthApiSpec, EthFees, EthSigner, EthState, LoadBlock, LoadFee, LoadState,
-        SpawnBlocking, Trace,
+        spec::Signers, AddDevSigners, EthApiSpec, EthFees, EthSigner, EthState, LoadBlock, LoadFee,
+        LoadState, SpawnBlocking, Trace,
     },
     EthApiTypes, FromEvmError, FullEthApiServer, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     RpcTxReq,
@@ -184,11 +184,7 @@ where
     }
 
     #[inline]
-    fn signers(
-        &self,
-    ) -> &parking_lot::RwLock<
-        Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>, NetworkT, RpcTxReq<NetworkT>>>>,
-    > {
+    fn signers(&self) -> &Signers<Self> {
         self.inner.eth_api.signers()
     }
 }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -25,6 +25,7 @@ use reth_rpc_eth_api::{
         SpawnBlocking, Trace,
     },
     EthApiTypes, FromEvmError, FullEthApiServer, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
+    RpcTxReq,
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{
@@ -175,6 +176,7 @@ where
     NetworkT: op_alloy_network::Network,
 {
     type Transaction = ProviderTx<Self::Provider>;
+    type Rpc = NetworkT;
 
     #[inline]
     fn starting_block(&self) -> U256 {
@@ -182,7 +184,11 @@ where
     }
 
     #[inline]
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>> {
+    fn signers(
+        &self,
+    ) -> &parking_lot::RwLock<
+        Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>, NetworkT, RpcTxReq<NetworkT>>>>,
+    > {
         self.inner.eth_api.signers()
     }
 }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -45,6 +45,7 @@ pub type EthApiNodeBackend<N> = EthApiInner<
     <N as RpcNodeCore>::Pool,
     <N as RpcNodeCore>::Network,
     <N as RpcNodeCore>::Evm,
+    RpcTxReq<<N as RpcNodeCore>::Network>,
 >;
 
 /// A helper trait with requirements for [`RpcNodeCore`] to be used in [`OpEthApi`].

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -12,7 +12,7 @@ use reth_optimism_primitives::DepositReceipt;
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
     try_into_op_tx_info, EthApiTypes, FromEthApiError, FullEthApiTypes, RpcNodeCore,
-    RpcNodeCoreExt, TxInfoMapper,
+    RpcNodeCoreExt, RpcTxReq, TxInfoMapper,
 };
 use reth_rpc_eth_types::utils::recover_raw_transaction;
 use reth_storage_api::{
@@ -30,7 +30,19 @@ where
     Self: LoadTransaction<Provider: BlockReaderIdExt> + EthApiTypes<Error = OpEthApiError>,
     N: OpNodeCore<Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>>,
 {
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>> {
+    fn signers(
+        &self,
+    ) -> &parking_lot::RwLock<
+        Vec<
+            Box<
+                dyn EthSigner<
+                    ProviderTx<Self::Provider>,
+                    Self::NetworkTypes,
+                    RpcTxReq<Self::NetworkTypes>,
+                >,
+            >,
+        >,
+    > {
         self.inner.eth_api.signers()
     }
 

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -127,6 +127,7 @@ serde-bincode-compat = [
     "op-alloy-consensus?/serde",
     "op-alloy-consensus?/serde-bincode-compat",
     "alloy-genesis/serde-bincode-compat",
+    "alloy-rpc-types-eth?/serde-bincode-compat",
 ]
 serde = [
     "dep:serde",

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,8 +1,9 @@
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
+use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256};
 use alloy_rpc_types_debug::ExecutionWitness;
-use alloy_rpc_types_eth::{transaction::TransactionRequest, Block, Bundle, StateContext};
+use alloy_rpc_types_eth::{Block, Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
@@ -12,7 +13,7 @@ use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 /// Debug rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "debug"))]
-pub trait DebugApi {
+pub trait DebugApi<TxReq: RpcObject> {
     /// Returns an RLP-encoded header.
     #[method(name = "getRawHeader")]
     async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes>;
@@ -105,7 +106,7 @@ pub trait DebugApi {
     #[method(name = "traceCall")]
     async fn debug_trace_call(
         &self,
-        request: TransactionRequest,
+        request: TxReq,
         block_id: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<GethTrace>;

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -129,7 +129,7 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[method(name = "traceCallMany")]
     async fn debug_trace_call_many(
         &self,
-        bundles: Vec<Bundle>,
+        bundles: Vec<Bundle<TxReq>>,
         state_context: Option<StateContext>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<Vec<GethTrace>>>;

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -15,8 +15,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
 use alloy_rpc_types_eth::{
-    state::StateOverride, transaction::TransactionRequest, BlockOverrides,
-    EIP1186AccountProofResponse, Filter, Log, SyncStatus,
+    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, Log, SyncStatus,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
@@ -250,7 +249,7 @@ pub trait EngineApi<Engine: EngineTypes> {
 /// Specifically for the engine auth server: <https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#underlying-protocol>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
-pub trait EngineEthApi<B: RpcObject, R: RpcObject> {
+pub trait EngineEthApi<TxReq: RpcObject, B: RpcObject, R: RpcObject> {
     /// Returns an object with data about the sync status or false.
     #[method(name = "syncing")]
     fn syncing(&self) -> RpcResult<SyncStatus>;
@@ -267,7 +266,7 @@ pub trait EngineEthApi<B: RpcObject, R: RpcObject> {
     #[method(name = "call")]
     async fn call(
         &self,
-        request: TransactionRequest,
+        request: TxReq,
         block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -1,8 +1,6 @@
 use alloy_eips::BlockId;
 use alloy_primitives::{map::HashSet, Bytes, B256};
-use alloy_rpc_types_eth::{
-    state::StateOverride, transaction::TransactionRequest, BlockOverrides, Index,
-};
+use alloy_rpc_types_eth::{state::StateOverride, BlockOverrides, Index};
 use alloy_rpc_types_trace::{
     filter::TraceFilter,
     opcode::{BlockOpcodeGas, TransactionOpcodeGas},
@@ -13,12 +11,12 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 /// Ethereum trace API
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "trace"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "trace"))]
-pub trait TraceApi {
+pub trait TraceApi<TxReq> {
     /// Executes the given call and returns a number of possible traces for it.
     #[method(name = "call")]
     async fn trace_call(
         &self,
-        call: TransactionRequest,
+        call: TxReq,
         trace_types: HashSet<TraceType>,
         block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
@@ -31,7 +29,7 @@ pub trait TraceApi {
     #[method(name = "callMany")]
     async fn trace_call_many(
         &self,
-        calls: Vec<(TransactionRequest, HashSet<TraceType>)>,
+        calls: Vec<(TxReq, HashSet<TraceType>)>,
         block_id: Option<BlockId>,
     ) -> RpcResult<Vec<TraceResults>>;
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -268,7 +268,7 @@ impl<N, Provider, Pool, Network, EvmConfig, Consensus>
     /// Note: This spawns all necessary tasks.
     ///
     /// See also [`EthApiBuilder`].
-    pub fn bootstrap_eth_api(&self) -> EthApi<Provider, Pool, Network, EvmConfig>
+    pub fn bootstrap_eth_api(&self) -> EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
     where
         N: NodePrimitives,
         Provider: BlockReaderIdExt<Block = N::Block, Header = N::BlockHeader, Receipt = N::Receipt>

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -124,7 +124,7 @@ pub struct RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus> {
 
 // === impl RpcBuilder ===
 
-impl<N, Provider, Pool, Network, EvmConfig, Consensus>
+impl<N, Provider, Pool, Network, EvmConfig, Consensus, Rpc>
     RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus>
 {
     /// Create a new instance of the builder
@@ -268,7 +268,7 @@ impl<N, Provider, Pool, Network, EvmConfig, Consensus>
     /// Note: This spawns all necessary tasks.
     ///
     /// See also [`EthApiBuilder`].
-    pub fn bootstrap_eth_api(&self) -> EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    pub fn bootstrap_eth_api(&self) -> EthApi<Provider, Pool, Network, EvmConfig, Rpc>
     where
         N: NodePrimitives,
         Provider: BlockReaderIdExt<Block = N::Block, Header = N::BlockHeader, Receipt = N::Receipt>

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -98,6 +98,7 @@ use crate::middleware::RethRpcMiddleware;
 pub use metrics::{MeteredRequestFuture, RpcRequestMetricsService};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_rpc::eth::sim_bundle::EthSimBundle;
+use reth_rpc_eth_api::RpcTypes;
 
 // Rpc rate limiter
 pub mod rate_limiter;
@@ -128,7 +129,7 @@ pub struct RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus, Rp
 impl<N, Provider, Pool, Network, EvmConfig, Consensus, Rpc>
     RpcModuleBuilder<N, Provider, Pool, Network, EvmConfig, Consensus, Rpc>
 where
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     /// Create a new instance of the builder
     pub const fn new(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -37,7 +37,7 @@ use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc::{
     AdminApi, DebugApi, EngineEthApi, EthApi, EthApiBuilder, EthBundle, MinerApi, NetApi,
-    OtterscanApi, RPCApi, RethApi, TraceApi, TxPoolApi, ValidationApiConfig, Web3Api,
+    OtterscanApi, RPCApi, RethApi, RpcTypes, TraceApi, TxPoolApi, ValidationApiConfig, Web3Api,
 };
 use reth_rpc_api::servers::*;
 use reth_rpc_eth_api::{
@@ -98,7 +98,6 @@ use crate::middleware::RethRpcMiddleware;
 pub use metrics::{MeteredRequestFuture, RpcRequestMetricsService};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_rpc::eth::sim_bundle::EthSimBundle;
-use reth_rpc_eth_api::RpcTypes;
 
 // Rpc rate limiter
 pub mod rate_limiter;

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -410,11 +410,11 @@ where
 {
     let block_id = BlockId::Number(BlockNumberOrTag::default());
 
-    DebugApiClient::raw_header(client, block_id).await.unwrap();
-    DebugApiClient::raw_block(client, block_id).await.unwrap_err();
-    DebugApiClient::raw_transaction(client, B256::default()).await.unwrap();
-    DebugApiClient::raw_receipts(client, block_id).await.unwrap();
-    DebugApiClient::bad_blocks(client).await.unwrap();
+    DebugApiClient::<TransactionRequest>::raw_header(client, block_id).await.unwrap();
+    DebugApiClient::<TransactionRequest>::raw_block(client, block_id).await.unwrap_err();
+    DebugApiClient::<TransactionRequest>::raw_transaction(client, B256::default()).await.unwrap();
+    DebugApiClient::<TransactionRequest>::raw_receipts(client, block_id).await.unwrap();
+    DebugApiClient::<TransactionRequest>::bad_blocks(client).await.unwrap();
 }
 
 async fn test_basic_net_calls<C>(client: &C)
@@ -441,22 +441,39 @@ where
         count: None,
     };
 
-    TraceApiClient::trace_raw_transaction(client, Bytes::default(), HashSet::default(), None)
-        .await
-        .unwrap_err();
-    TraceApiClient::trace_call_many(client, vec![], Some(BlockNumberOrTag::Latest.into()))
-        .await
-        .unwrap_err();
-    TraceApiClient::replay_transaction(client, B256::default(), HashSet::default())
-        .await
-        .err()
-        .unwrap();
-    TraceApiClient::trace_block(client, block_id).await.unwrap_err();
-    TraceApiClient::replay_block_transactions(client, block_id, HashSet::default())
-        .await
-        .unwrap_err();
+    TraceApiClient::<TransactionRequest>::trace_raw_transaction(
+        client,
+        Bytes::default(),
+        HashSet::default(),
+        None,
+    )
+    .await
+    .unwrap_err();
+    TraceApiClient::<TransactionRequest>::trace_call_many(
+        client,
+        vec![],
+        Some(BlockNumberOrTag::Latest.into()),
+    )
+    .await
+    .unwrap_err();
+    TraceApiClient::<TransactionRequest>::replay_transaction(
+        client,
+        B256::default(),
+        HashSet::default(),
+    )
+    .await
+    .err()
+    .unwrap();
+    TraceApiClient::<TransactionRequest>::trace_block(client, block_id).await.unwrap_err();
+    TraceApiClient::<TransactionRequest>::replay_block_transactions(
+        client,
+        block_id,
+        HashSet::default(),
+    )
+    .await
+    .unwrap_err();
 
-    TraceApiClient::trace_filter(client, trace_filter).await.unwrap();
+    TraceApiClient::<TransactionRequest>::trace_filter(client, trace_filter).await.unwrap();
 }
 
 async fn test_basic_web3_calls<C>(client: &C)

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -1,11 +1,11 @@
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-
+use alloy_network::Ethereum;
 use alloy_rpc_types_engine::{ClientCode, ClientVersionV1};
 use reth_chainspec::MAINNET;
 use reth_consensus::noop::NoopConsensus;
 use reth_engine_primitives::BeaconConsensusEngineHandle;
 use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_ethereum_primitives::EthPrimitives;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use reth_evm_ethereum::EthEvmConfig;
 use reth_network_api::noop::NoopNetwork;
@@ -118,9 +118,15 @@ pub async fn launch_http_ws_same_port(modules: impl Into<RpcModuleSelection>) ->
 }
 
 /// Returns an [`RpcModuleBuilder`] with testing components.
-pub fn test_rpc_builder(
-) -> RpcModuleBuilder<EthPrimitives, NoopProvider, TestPool, NoopNetwork, EthEvmConfig, NoopConsensus>
-{
+pub fn test_rpc_builder() -> RpcModuleBuilder<
+    EthPrimitives,
+    NoopProvider,
+    TestPool,
+    NoopNetwork,
+    EthEvmConfig,
+    NoopConsensus,
+    Ethereum,
+> {
     RpcModuleBuilder::default()
         .with_provider(NoopProvider::default())
         .with_pool(TestPoolBuilder::default().into())

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -20,6 +20,7 @@ reth-evm.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
+alloy-signer.workspace = true
 alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-json-rpc.workspace = true

--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -1,10 +1,17 @@
+use std::{fmt::Debug, future::Future};
+
+use alloy_consensus::{
+    EthereumTxEnvelope, EthereumTypedTransaction, SignableTransaction, TxEip4844,
+};
 use alloy_json_rpc::RpcObject;
-use alloy_network::{Network, ReceiptResponse, TransactionResponse};
+use alloy_network::{Network, ReceiptResponse, TransactionResponse, TxSigner};
+use alloy_primitives::Signature;
+use alloy_rpc_types_eth::TransactionRequest;
 
 /// RPC types used by the `eth_` RPC API.
 ///
 /// This is a subset of [`Network`] trait with only RPC response types kept.
-pub trait RpcTypes {
+pub trait RpcTypes: Send + Sync + Clone + Unpin + Debug + 'static {
     /// Header response type.
     type Header: RpcObject;
     /// Receipt response type.
@@ -12,12 +19,12 @@ pub trait RpcTypes {
     /// Transaction response type.
     type TransactionResponse: RpcObject + TransactionResponse;
     /// Transaction response type.
-    type TransactionRequest: RpcObject;
+    type TransactionRequest: RpcObject + AsRef<TransactionRequest> + AsMut<TransactionRequest>;
 }
 
 impl<T> RpcTypes for T
 where
-    T: Network,
+    T: Network<TransactionRequest: AsRef<TransactionRequest> + AsMut<TransactionRequest>> + Unpin,
 {
     type Header = T::HeaderResponse;
     type Receipt = T::ReceiptResponse;
@@ -30,3 +37,85 @@ pub type RpcTransaction<T> = <T as RpcTypes>::TransactionResponse;
 
 /// Adapter for network specific transaction request.
 pub type RpcTxReq<T> = <T as RpcTypes>::TransactionRequest;
+
+/// Error for [`SignableTxRequest`] trait.
+#[derive(Debug, thiserror::Error)]
+pub enum SignTxRequestError {
+    /// The transaction request is invalid.
+    #[error("invalid transaction request")]
+    InvalidTransactionRequest,
+
+    /// The signer is not supported.
+    #[error(transparent)]
+    SignerNotSupported(#[from] alloy_signer::Error),
+}
+
+/// An abstraction over transaction requests that can be signed.
+pub trait SignableTxRequest<T>: Send + Sync + 'static {
+    /// Attempts to build a transaction request and sign it with the given signer.
+    fn try_build_and_sign(
+        self,
+        signer: impl TxSigner<Signature> + Send,
+    ) -> impl Future<Output = Result<T, SignTxRequestError>> + Send;
+}
+
+impl SignableTxRequest<EthereumTxEnvelope<TxEip4844>> for TransactionRequest {
+    async fn try_build_and_sign(
+        self,
+        signer: impl TxSigner<Signature> + Send,
+    ) -> Result<EthereumTxEnvelope<TxEip4844>, SignTxRequestError> {
+        let mut tx =
+            self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
+        let signature = signer.sign_transaction(&mut tx).await?;
+        let signed = match tx {
+            EthereumTypedTransaction::Legacy(tx) => {
+                EthereumTxEnvelope::Legacy(tx.into_signed(signature))
+            }
+            EthereumTypedTransaction::Eip2930(tx) => {
+                EthereumTxEnvelope::Eip2930(tx.into_signed(signature))
+            }
+            EthereumTypedTransaction::Eip1559(tx) => {
+                EthereumTxEnvelope::Eip1559(tx.into_signed(signature))
+            }
+            EthereumTypedTransaction::Eip4844(tx) => {
+                EthereumTxEnvelope::Eip4844(TxEip4844::from(tx).into_signed(signature))
+            }
+            EthereumTypedTransaction::Eip7702(tx) => {
+                EthereumTxEnvelope::Eip7702(tx.into_signed(signature))
+            }
+        };
+        Ok(signed)
+    }
+}
+
+#[cfg(feature = "op")]
+impl SignableTxRequest<op_alloy_consensus::OpTxEnvelope>
+    for op_alloy_rpc_types::OpTransactionRequest
+{
+    async fn try_build_and_sign(
+        self,
+        signer: impl TxSigner<Signature> + Send,
+    ) -> Result<op_alloy_consensus::OpTxEnvelope, SignTxRequestError> {
+        let mut tx =
+            self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
+        let signature = signer.sign_transaction(&mut tx).await?;
+        let signed = match tx {
+            op_alloy_consensus::OpTypedTransaction::Legacy(tx) => {
+                op_alloy_consensus::OpTxEnvelope::Legacy(tx.into_signed(signature))
+            }
+            op_alloy_consensus::OpTypedTransaction::Eip2930(tx) => {
+                op_alloy_consensus::OpTxEnvelope::Eip2930(tx.into_signed(signature))
+            }
+            op_alloy_consensus::OpTypedTransaction::Eip1559(tx) => {
+                op_alloy_consensus::OpTxEnvelope::Eip1559(tx.into_signed(signature))
+            }
+            op_alloy_consensus::OpTypedTransaction::Eip7702(tx) => {
+                op_alloy_consensus::OpTxEnvelope::Eip7702(tx.into_signed(signature))
+            }
+            op_alloy_consensus::OpTypedTransaction::Deposit(_) => {
+                return Err(SignTxRequestError::InvalidTransactionRequest);
+            }
+        };
+        Ok(signed)
+    }
+}

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_eth::{
     simulate::{SimulatePayload, SimulatedBlock},
     state::{EvmOverrides, StateOverride},
     BlockOverrides, Bundle, EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Index,
-    StateContext, SyncStatus, TransactionRequest, Work,
+    StateContext, SyncStatus, Work,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -222,7 +222,7 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     #[method(name = "call")]
     async fn call(
         &self,
-        request: TransactionRequest,
+        request: TxReq,
         block_number: Option<BlockId>,
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
@@ -233,7 +233,7 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     #[method(name = "callMany")]
     async fn call_many(
         &self,
-        bundles: Vec<Bundle>,
+        bundles: Vec<Bundle<TxReq>>,
         state_context: Option<StateContext>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<Vec<Vec<EthCallResponse>>>;
@@ -255,7 +255,7 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     #[method(name = "createAccessList")]
     async fn create_access_list(
         &self,
-        request: TransactionRequest,
+        request: TxReq,
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<AccessListResult>;
@@ -265,7 +265,7 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     #[method(name = "estimateGas")]
     async fn estimate_gas(
         &self,
-        request: TransactionRequest,
+        request: TxReq,
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<U256>;
@@ -333,7 +333,7 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.
     #[method(name = "sendTransaction")]
-    async fn send_transaction(&self, request: TransactionRequest) -> RpcResult<B256>;
+    async fn send_transaction(&self, request: TxReq) -> RpcResult<B256>;
 
     /// Sends signed transaction, returning its hash.
     #[method(name = "sendRawTransaction")]
@@ -353,7 +353,7 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     /// Signs a transaction that can be submitted to the network at a later time using with
     /// `sendRawTransaction.`
     #[method(name = "signTransaction")]
-    async fn sign_transaction(&self, transaction: TransactionRequest) -> RpcResult<Bytes>;
+    async fn sign_transaction(&self, transaction: TxReq) -> RpcResult<Bytes>;
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
     #[method(name = "signTypedData")]
@@ -667,7 +667,7 @@ where
     /// Handler for: `eth_call`
     async fn call(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<T::NetworkTypes>,
         block_number: Option<BlockId>,
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
@@ -685,7 +685,7 @@ where
     /// Handler for: `eth_callMany`
     async fn call_many(
         &self,
-        bundles: Vec<Bundle>,
+        bundles: Vec<Bundle<RpcTxReq<T::NetworkTypes>>>,
         state_context: Option<StateContext>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<Vec<Vec<EthCallResponse>>> {
@@ -696,7 +696,7 @@ where
     /// Handler for: `eth_createAccessList`
     async fn create_access_list(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<T::NetworkTypes>,
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<AccessListResult> {
@@ -707,7 +707,7 @@ where
     /// Handler for: `eth_estimateGas`
     async fn estimate_gas(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<T::NetworkTypes>,
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<U256> {
@@ -799,7 +799,7 @@ where
     }
 
     /// Handler for: `eth_sendTransaction`
-    async fn send_transaction(&self, request: TransactionRequest) -> RpcResult<B256> {
+    async fn send_transaction(&self, request: RpcTxReq<T::NetworkTypes>) -> RpcResult<B256> {
         trace!(target: "rpc::eth", ?request, "Serving eth_sendTransaction");
         Ok(EthTransactions::send_transaction(self, request).await?)
     }
@@ -823,7 +823,7 @@ where
     }
 
     /// Handler for: `eth_signTransaction`
-    async fn sign_transaction(&self, request: TransactionRequest) -> RpcResult<Bytes> {
+    async fn sign_transaction(&self, request: RpcTxReq<T::NetworkTypes>) -> RpcResult<Bytes> {
         trace!(target: "rpc::eth", ?request, "Serving eth_signTransaction");
         Ok(EthTransactions::sign_transaction(self, request).await?)
     }

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -214,7 +214,7 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     #[method(name = "simulateV1")]
     async fn simulate_v1(
         &self,
-        opts: SimulatePayload,
+        opts: SimulatePayload<TxReq>,
         block_number: Option<BlockId>,
     ) -> RpcResult<Vec<SimulatedBlock<B>>>;
 
@@ -656,7 +656,7 @@ where
     /// Handler for: `eth_simulateV1`
     async fn simulate_v1(
         &self,
-        payload: SimulatePayload,
+        payload: SimulatePayload<RpcTxReq<T::NetworkTypes>>,
         block_number: Option<BlockId>,
     ) -> RpcResult<Vec<SimulatedBlock<RpcBlock<T::NetworkTypes>>>> {
         trace!(target: "rpc::eth", ?block_number, "Serving eth_simulateV1");

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -13,11 +13,11 @@ use alloy_evm::{
     call::caller_gas_allowance,
     overrides::{apply_block_overrides, apply_state_overrides, OverrideBlockHashes},
 };
+use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_eth::{
     simulate::{SimBlock, SimulatePayload, SimulatedBlock},
     state::{EvmOverrides, StateOverride},
-    transaction::TransactionRequest,
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
 use futures::Future;
@@ -32,7 +32,7 @@ use reth_revm::{
     database::StateProviderDatabase,
     db::{CacheDB, State},
 };
-use reth_rpc_convert::{RpcConvert, RpcTypes};
+use reth_rpc_convert::{RpcConvert, RpcTxReq, RpcTypes};
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},
     error::{api::FromEvmHalt, ensure_success, FromEthApiError},
@@ -59,7 +59,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     /// Estimate gas needed for execution of the `request` at the [`BlockId`].
     fn estimate_gas_at(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         at: BlockId,
         state_override: Option<StateOverride>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
@@ -216,7 +216,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     /// Executes the call request (`eth_call`) and returns the output
     fn call(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         block_number: Option<BlockId>,
         overrides: EvmOverrides,
     ) -> impl Future<Output = Result<Bytes, Self::Error>> + Send {
@@ -232,7 +232,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     /// optionality of state overrides
     fn call_many(
         &self,
-        bundles: Vec<Bundle>,
+        bundles: Vec<Bundle<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>>,
         state_context: Option<StateContext>,
         mut state_override: Option<StateOverride>,
     ) -> impl Future<Output = Result<Vec<Vec<EthCallResponse>>, Self::Error>> + Send {
@@ -348,11 +348,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         }
     }
 
-    /// Creates [`AccessListResult`] for the [`TransactionRequest`] at the given
+    /// Creates [`AccessListResult`] for the [`RpcTxReq`] at the given
     /// [`BlockId`], or latest block.
     fn create_access_list_at(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> impl Future<Output = Result<AccessListResult, Self::Error>> + Send
@@ -370,13 +370,13 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         }
     }
 
-    /// Creates [`AccessListResult`] for the [`TransactionRequest`] at the given
+    /// Creates [`AccessListResult`] for the [`RpcTxReq`] at the given
     /// [`BlockId`].
     fn create_access_list_with(
         &self,
         mut evm_env: EvmEnvFor<Self::Evm>,
         at: BlockId,
-        mut request: TransactionRequest,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         state_override: Option<StateOverride>,
     ) -> Result<AccessListResult, Self::Error>
     where
@@ -403,14 +403,14 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         // Disabled because eth_createAccessList is sometimes used with non-eoa senders
         evm_env.cfg_env.disable_eip3607 = true;
 
-        if request.gas.is_none() && tx_env.gas_price() > 0 {
+        if request.gas_limit().is_none() && tx_env.gas_price() > 0 {
             let cap = caller_gas_allowance(&mut db, &tx_env).map_err(Self::Error::from_eth_err)?;
             // no gas limit was provided in the request, so we need to cap the request's gas limit
             tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit));
         }
 
         // can consume the list since we're not using the request anymore
-        let initial = request.access_list.take().unwrap_or_default();
+        let initial = request.access_list().cloned().unwrap_or_default();
 
         let mut inspector = AccessListInspector::new(initial);
 
@@ -463,7 +463,10 @@ pub trait Call:
         >,
         RpcConvert: RpcConvert<
             TxEnv = TxEnvFor<Self::Evm>,
-            Network: RpcTypes<TransactionRequest: From<TransactionRequest>>,
+            Network: alloy_network::Network
+                         + RpcTypes<
+                TransactionRequest: TransactionBuilder<<Self::RpcConvert as RpcConvert>::Network>,
+            >,
         >,
         Error: FromEvmError<Self::Evm>
                    + From<<Self::RpcConvert as RpcConvert>::Error>
@@ -526,7 +529,7 @@ pub trait Call:
     /// Executes the call request at the given [`BlockId`].
     fn transact_call_at(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         at: BlockId,
         overrides: EvmOverrides,
     ) -> impl Future<Output = Result<ResultAndState<HaltReasonFor<Self::Evm>>, Self::Error>> + Send
@@ -555,10 +558,10 @@ pub trait Call:
         })
     }
 
-    /// Prepares the state and env for the given [`TransactionRequest`] at the given [`BlockId`] and
+    /// Prepares the state and env for the given [`RpcTxReq`] at the given [`BlockId`] and
     /// executes the closure on a new task returning the result of the closure.
     ///
-    /// This returns the configured [`EvmEnv`] for the given [`TransactionRequest`] at
+    /// This returns the configured [`EvmEnv`] for the given [`RpcTxReq`] at
     /// the given [`BlockId`] and with configured call settings: `prepare_call_env`.
     ///
     /// This is primarily used by `eth_call`.
@@ -572,7 +575,7 @@ pub trait Call:
     /// instead, where blocking IO is less problematic.
     fn spawn_with_call_at<F, R>(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         at: BlockId,
         overrides: EvmOverrides,
         f: F,
@@ -694,26 +697,25 @@ pub trait Call:
         Ok(index)
     }
 
-    /// Configures a new `TxEnv`  for the [`TransactionRequest`]
     ///
-    /// All `TxEnv` fields are derived from the given [`TransactionRequest`], if fields are
+    /// All `TxEnv` fields are derived from the given [`RpcTxReq`], if fields are
     /// `None`, they fall back to the [`EvmEnv`]'s settings.
     fn create_txn_env(
         &self,
         evm_env: &EvmEnv<SpecFor<Self::Evm>>,
-        mut request: TransactionRequest,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         mut db: impl Database<Error: Into<EthApiError>>,
     ) -> Result<TxEnvFor<Self::Evm>, Self::Error> {
-        if request.nonce.is_none() {
-            request.nonce.replace(
-                db.basic(request.from.unwrap_or_default())
+        if request.nonce().is_none() {
+            request.set_nonce(
+                db.basic(request.from().unwrap_or_default())
                     .map_err(Into::into)?
                     .map(|acc| acc.nonce)
                     .unwrap_or_default(),
             );
         }
 
-        Ok(self.tx_resp_builder().tx_env(request.into(), &evm_env.cfg_env, &evm_env.block_env)?)
+        Ok(self.tx_resp_builder().tx_env(request, &evm_env.cfg_env, &evm_env.block_env)?)
     }
 
     /// Prepares the [`EvmEnv`] for execution of calls.
@@ -733,7 +735,7 @@ pub trait Call:
     fn prepare_call_env<DB>(
         &self,
         mut evm_env: EvmEnvFor<Self::Evm>,
-        mut request: TransactionRequest,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         db: &mut DB,
         overrides: EvmOverrides,
     ) -> Result<(EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>), Self::Error>
@@ -741,7 +743,7 @@ pub trait Call:
         DB: Database + DatabaseCommit + OverrideBlockHashes,
         EthApiError: From<<DB as Database>::Error>,
     {
-        if request.gas > Some(self.call_gas_limit()) {
+        if request.gas_limit() > Some(self.call_gas_limit()) {
             // configured gas exceeds limit
             return Err(
                 EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
@@ -761,7 +763,7 @@ pub trait Call:
         evm_env.cfg_env.disable_base_fee = true;
 
         // set nonce to None so that the correct nonce is chosen by the EVM
-        request.nonce = None;
+        request.take_nonce();
 
         if let Some(block_overrides) = overrides.block {
             apply_block_overrides(*block_overrides, db, &mut evm_env.block_env);
@@ -771,7 +773,7 @@ pub trait Call:
                 .map_err(EthApiError::from_state_overrides_err)?;
         }
 
-        let request_gas = request.gas;
+        let request_gas = request.gas_limit();
         let mut tx_env = self.create_txn_env(&evm_env, request, &mut *db)?;
 
         if request_gas.is_none() {

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -72,7 +72,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     /// See also: <https://github.com/ethereum/go-ethereum/pull/27720>
     fn simulate_v1(
         &self,
-        payload: SimulatePayload,
+        payload: SimulatePayload<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>,
         block: Option<BlockId>,
     ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send {
         async move {
@@ -144,9 +144,10 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     let chain_id = evm_env.cfg_env.chain_id;
 
                     let default_gas_limit = {
-                        let total_specified_gas = calls.iter().filter_map(|tx| tx.gas).sum::<u64>();
+                        let total_specified_gas =
+                            calls.iter().filter_map(|tx| tx.gas_limit()).sum::<u64>();
                         let txs_without_gas_limit =
-                            calls.iter().filter(|tx| tx.gas.is_none()).count();
+                            calls.iter().filter(|tx| tx.gas_limit().is_none()).count();
 
                         if total_specified_gas > block_gas_limit {
                             return Err(EthApiError::Other(Box::new(

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -54,11 +54,11 @@ pub trait EstimateCall: Call {
         evm_env.cfg_env.disable_base_fee = true;
 
         // set nonce to None so that the correct nonce is chosen by the EVM
-        request.take_nonce();
+        request.as_mut().take_nonce();
 
         // Keep a copy of gas related request values
-        let tx_request_gas_limit = request.gas_limit();
-        let tx_request_gas_price = request.gas_price();
+        let tx_request_gas_limit = request.as_ref().gas_limit();
+        let tx_request_gas_price = request.as_ref().gas_price();
         // the gas limit of the corresponding block
         let block_env_gas_limit = evm_env.block_env.gas_limit;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -3,13 +3,15 @@
 use super::{Call, LoadPendingBlock};
 use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
 use alloy_evm::{call::caller_gas_allowance, overrides::apply_state_overrides};
+use alloy_network::TransactionBuilder;
 use alloy_primitives::{TxKind, U256};
-use alloy_rpc_types_eth::{state::StateOverride, transaction::TransactionRequest, BlockId};
+use alloy_rpc_types_eth::{state::StateOverride, BlockId};
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, Database, Evm, EvmEnvFor, EvmFor, TransactionEnv, TxEnvFor};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};
+use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
     error::{api::FromEvmHalt, FromEvmError},
     EthApiError, RevertError, RpcInvalidTransactionError,
@@ -23,7 +25,7 @@ use tracing::trace;
 pub trait EstimateCall: Call {
     /// Estimates the gas usage of the `request` with the state.
     ///
-    /// This will execute the [`TransactionRequest`] and find the best gas limit via binary search.
+    /// This will execute the [`RpcTxReq`] and find the best gas limit via binary search.
     ///
     /// ## EVM settings
     ///
@@ -35,7 +37,7 @@ pub trait EstimateCall: Call {
     fn estimate_gas_with<S>(
         &self,
         mut evm_env: EvmEnvFor<Self::Evm>,
-        mut request: TransactionRequest,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         state: S,
         state_override: Option<StateOverride>,
     ) -> Result<U256, Self::Error>
@@ -52,11 +54,11 @@ pub trait EstimateCall: Call {
         evm_env.cfg_env.disable_base_fee = true;
 
         // set nonce to None so that the correct nonce is chosen by the EVM
-        request.nonce = None;
+        request.take_nonce();
 
         // Keep a copy of gas related request values
-        let tx_request_gas_limit = request.gas;
-        let tx_request_gas_price = request.gas_price;
+        let tx_request_gas_limit = request.gas_limit();
+        let tx_request_gas_price = request.gas_price();
         // the gas limit of the corresponding block
         let block_env_gas_limit = evm_env.block_env.gas_limit;
 
@@ -268,7 +270,7 @@ pub trait EstimateCall: Call {
     /// Estimate gas needed for execution of the `request` at the [`BlockId`].
     fn estimate_gas_at(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         at: BlockId,
         state_override: Option<StateOverride>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send

--- a/crates/rpc/rpc-eth-api/src/helpers/signer.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/signer.rs
@@ -1,6 +1,7 @@
 //! An abstraction over ethereum signers.
 
 use alloy_dyn_abi::TypedData;
+use alloy_network::{Ethereum, TransactionBuilder};
 use alloy_primitives::{Address, Signature};
 use alloy_rpc_types_eth::TransactionRequest;
 use dyn_clone::DynClone;
@@ -12,7 +13,12 @@ pub type Result<T> = result::Result<T, SignError>;
 
 /// An Ethereum Signer used via RPC.
 #[async_trait::async_trait]
-pub trait EthSigner<T>: Send + Sync + DynClone {
+pub trait EthSigner<
+    T,
+    N: alloy_network::Network = Ethereum,
+    TxReq: TransactionBuilder<N> = TransactionRequest,
+>: Send + Sync + DynClone
+{
     /// Returns the available accounts for this signer.
     fn accounts(&self) -> Vec<Address>;
 
@@ -25,7 +31,7 @@ pub trait EthSigner<T>: Send + Sync + DynClone {
     async fn sign(&self, address: Address, message: &[u8]) -> Result<Signature>;
 
     /// signs a transaction request using the given account in request
-    async fn sign_transaction(&self, request: TransactionRequest, address: &Address) -> Result<T>;
+    async fn sign_transaction(&self, request: TxReq, address: &Address) -> Result<T>;
 
     /// Encodes and signs the typed data according EIP-712. Payload must implement Eip712 trait.
     fn sign_typed_data(&self, address: Address, payload: &TypedData) -> Result<Signature>;

--- a/crates/rpc/rpc-eth-api/src/helpers/signer.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/signer.rs
@@ -1,7 +1,7 @@
 //! An abstraction over ethereum signers.
 
 use alloy_dyn_abi::TypedData;
-use alloy_network::{Ethereum, TransactionBuilder};
+use alloy_network::Ethereum;
 use alloy_primitives::{Address, Signature};
 use alloy_rpc_types_eth::TransactionRequest;
 use dyn_clone::DynClone;
@@ -13,12 +13,7 @@ pub type Result<T> = result::Result<T, SignError>;
 
 /// An Ethereum Signer used via RPC.
 #[async_trait::async_trait]
-pub trait EthSigner<
-    T,
-    N: alloy_network::Network = Ethereum,
-    TxReq: TransactionBuilder<N> = TransactionRequest,
->: Send + Sync + DynClone
-{
+pub trait EthSigner<T, N = Ethereum, TxReq = TransactionRequest>: Send + Sync + DynClone {
     /// Returns the available accounts for this signer.
     fn accounts(&self) -> Vec<Address>;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/signer.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/signer.rs
@@ -1,7 +1,6 @@
 //! An abstraction over ethereum signers.
 
 use alloy_dyn_abi::TypedData;
-use alloy_network::Ethereum;
 use alloy_primitives::{Address, Signature};
 use alloy_rpc_types_eth::TransactionRequest;
 use dyn_clone::DynClone;
@@ -13,7 +12,7 @@ pub type Result<T> = result::Result<T, SignError>;
 
 /// An Ethereum Signer used via RPC.
 #[async_trait::async_trait]
-pub trait EthSigner<T, N = Ethereum, TxReq = TransactionRequest>: Send + Sync + DynClone {
+pub trait EthSigner<T, TxReq = TransactionRequest>: Send + Sync + DynClone {
     /// Returns the available accounts for this signer.
     fn accounts(&self) -> Vec<Address>;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -95,19 +95,11 @@ pub trait EthApiSpec:
 
 /// A handle to [`EthSigner`]s with its generics set from [`EthApiSpec`].
 pub type SignersForApi<Api> = parking_lot::RwLock<
-    Vec<
-        Box<
-            dyn EthSigner<
-                <Api as EthApiSpec>::Transaction,
-                <Api as EthApiSpec>::Rpc,
-                RpcTxReq<<Api as EthApiSpec>::Rpc>,
-            >,
-        >,
-    >,
+    Vec<Box<dyn EthSigner<<Api as EthApiSpec>::Transaction, RpcTxReq<<Api as EthApiSpec>::Rpc>>>>,
 >;
 
 /// A handle to [`EthSigner`]s with its generics set from [`TransactionsProvider`] and
 /// [`reth_rpc_convert::RpcTypes`].
 pub type SignersForRpc<Provider, Rpc> = parking_lot::RwLock<
-    Vec<Box<dyn EthSigner<<Provider as TransactionsProvider>::Transaction, Rpc, RpcTxReq<Rpc>>>>,
+    Vec<Box<dyn EthSigner<<Provider as TransactionsProvider>::Transaction, RpcTxReq<Rpc>>>>,
 >;

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -7,7 +7,7 @@ use reth_chainspec::{ChainInfo, ChainSpecProvider, EthereumHardforks};
 use reth_errors::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
 use reth_rpc_convert::RpcTxReq;
-use reth_storage_api::{BlockNumReader, StageCheckpointReader};
+use reth_storage_api::{BlockNumReader, StageCheckpointReader, TransactionsProvider};
 
 use crate::{helpers::EthSigner, RpcNodeCore};
 
@@ -33,7 +33,7 @@ pub trait EthApiSpec:
     fn starting_block(&self) -> U256;
 
     /// Returns a handle to the signers owned by provider.
-    fn signers(&self) -> &Signers<Self>;
+    fn signers(&self) -> &SignersForApi<Self>;
 
     /// Returns the current ethereum protocol version.
     fn protocol_version(&self) -> impl Future<Output = RethResult<U64>> + Send {
@@ -93,8 +93,8 @@ pub trait EthApiSpec:
     }
 }
 
-/// A handle to [`EthSigner`]s owned by the [`EthApiSpec::Provider`].
-pub type Signers<Api> = parking_lot::RwLock<
+/// A handle to [`EthSigner`]s with its generics set from [`EthApiSpec`].
+pub type SignersForApi<Api> = parking_lot::RwLock<
     Vec<
         Box<
             dyn EthSigner<
@@ -104,4 +104,10 @@ pub type Signers<Api> = parking_lot::RwLock<
             >,
         >,
     >,
+>;
+
+/// A handle to [`EthSigner`]s with its generics set from [`TransactionsProvider`] and
+/// [`reth_rpc_convert::RpcTypes`].
+pub type SignersForRpc<Provider, Rpc> = parking_lot::RwLock<
+    Vec<Box<dyn EthSigner<<Provider as TransactionsProvider>::Transaction, Rpc, RpcTxReq<Rpc>>>>,
 >;

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -6,6 +6,7 @@ use futures::Future;
 use reth_chainspec::{ChainInfo, ChainSpecProvider, EthereumHardforks};
 use reth_errors::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
+use reth_rpc_convert::RpcTxReq;
 use reth_storage_api::{BlockNumReader, StageCheckpointReader};
 
 use crate::{helpers::EthSigner, RpcNodeCore};
@@ -25,11 +26,18 @@ pub trait EthApiSpec:
     /// The transaction type signers are using.
     type Transaction;
 
+    /// The RPC requests and responses.
+    type Rpc: alloy_network::Network;
+
     /// Returns the block node is started on.
     fn starting_block(&self) -> U256;
 
     /// Returns a handle to the signers owned by provider.
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<Self::Transaction>>>>;
+    fn signers(
+        &self,
+    ) -> &parking_lot::RwLock<
+        Vec<Box<dyn EthSigner<Self::Transaction, Self::Rpc, RpcTxReq<Self::Rpc>>>>,
+    >;
 
     /// Returns the current ethereum protocol version.
     fn protocol_version(&self) -> impl Future<Output = RethResult<U64>> + Send {

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -33,11 +33,7 @@ pub trait EthApiSpec:
     fn starting_block(&self) -> U256;
 
     /// Returns a handle to the signers owned by provider.
-    fn signers(
-        &self,
-    ) -> &parking_lot::RwLock<
-        Vec<Box<dyn EthSigner<Self::Transaction, Self::Rpc, RpcTxReq<Self::Rpc>>>>,
-    >;
+    fn signers(&self) -> &Signers<Self>;
 
     /// Returns the current ethereum protocol version.
     fn protocol_version(&self) -> impl Future<Output = RethResult<U64>> + Send {
@@ -96,3 +92,16 @@ pub trait EthApiSpec:
         Ok(status)
     }
 }
+
+/// A handle to [`EthSigner`]s owned by the [`EthApiSpec::Provider`].
+pub type Signers<Api> = parking_lot::RwLock<
+    Vec<
+        Box<
+            dyn EthSigner<
+                <Api as EthApiSpec>::Transaction,
+                <Api as EthApiSpec>::Rpc,
+                RpcTxReq<<Api as EthApiSpec>::Rpc>,
+            >,
+        >,
+    >,
+>;

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -6,7 +6,7 @@ use futures::Future;
 use reth_chainspec::{ChainInfo, ChainSpecProvider, EthereumHardforks};
 use reth_errors::{RethError, RethResult};
 use reth_network_api::NetworkInfo;
-use reth_rpc_convert::RpcTxReq;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_storage_api::{BlockNumReader, StageCheckpointReader, TransactionsProvider};
 
 use crate::{helpers::EthSigner, RpcNodeCore};
@@ -27,7 +27,7 @@ pub trait EthApiSpec:
     type Transaction;
 
     /// The RPC requests and responses.
-    type Rpc: alloy_network::Network;
+    type Rpc: RpcTypes;
 
     /// Returns the block node is started on.
     fn starting_block(&self) -> U256;

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -3,8 +3,9 @@
 
 use super::{EthApiSpec, EthSigner, LoadBlock, LoadReceipt, LoadState, SpawnBlocking};
 use crate::{
-    helpers::estimate::EstimateCall, FromEthApiError, FullEthApiTypes, IntoEthApiError,
-    RpcNodeCore, RpcNodeCoreExt, RpcReceipt, RpcTransaction,
+    helpers::{estimate::EstimateCall, spec::SignersForRpc},
+    FromEthApiError, FullEthApiTypes, IntoEthApiError, RpcNodeCore, RpcNodeCoreExt, RpcReceipt,
+    RpcTransaction,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta},
@@ -57,20 +58,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     /// Returns a handle for signing data.
     ///
     /// Signer access in default (L1) trait method implementations.
-    #[expect(clippy::type_complexity)]
-    fn signers(
-        &self,
-    ) -> &parking_lot::RwLock<
-        Vec<
-            Box<
-                dyn EthSigner<
-                    ProviderTx<Self::Provider>,
-                    Self::NetworkTypes,
-                    RpcTxReq<Self::NetworkTypes>,
-                >,
-            >,
-        >,
-    >;
+    fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes>;
 
     /// Decodes and recovers the transaction and submits it to the pool.
     ///

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -14,12 +14,12 @@ use alloy_dyn_abi::TypedData;
 use alloy_eips::{eip2718::Encodable2718, BlockId};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, Bytes, TxHash, B256};
-use alloy_rpc_types_eth::{transaction::TransactionRequest, BlockNumberOrTag, TransactionInfo};
+use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionInfo};
 use futures::{Future, StreamExt};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_node_api::BlockBody;
 use reth_primitives_traits::{RecoveredBlock, SignedTransaction};
-use reth_rpc_convert::transaction::RpcConvert;
+use reth_rpc_convert::{transaction::RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
     utils::binary_search, EthApiError, EthApiError::TransactionConfirmationTimeout, SignError,
     TransactionSource,
@@ -41,7 +41,7 @@ use std::sync::Arc;
 ///
 /// ## Calls
 ///
-/// There are subtle differences between when transacting [`TransactionRequest`]:
+/// There are subtle differences between when transacting [`RpcTxReq`]:
 ///
 /// The endpoints `eth_call` and `eth_estimateGas` and `eth_createAccessList` should always
 /// __disable__ the base fee check in the [`CfgEnv`](revm::context::CfgEnv).
@@ -58,7 +58,19 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     ///
     /// Signer access in default (L1) trait method implementations.
     #[expect(clippy::type_complexity)]
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>>;
+    fn signers(
+        &self,
+    ) -> &parking_lot::RwLock<
+        Vec<
+            Box<
+                dyn EthSigner<
+                    ProviderTx<Self::Provider>,
+                    Self::NetworkTypes,
+                    RpcTxReq<Self::NetworkTypes>,
+                >,
+            >,
+        >,
+    >;
 
     /// Decodes and recovers the transaction and submits it to the pool.
     ///
@@ -379,13 +391,13 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     /// Returns the hash of the signed transaction.
     fn send_transaction(
         &self,
-        mut request: TransactionRequest,
+        mut request: RpcTxReq<Self::NetworkTypes>,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send
     where
         Self: EthApiSpec + LoadBlock + EstimateCall,
     {
         async move {
-            let from = match request.from {
+            let from = match request.from() {
                 Some(from) => from,
                 None => return Err(SignError::NoAccount.into_eth_err()),
             };
@@ -395,13 +407,13 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             }
 
             // set nonce if not already set before
-            if request.nonce.is_none() {
+            if request.nonce().is_none() {
                 let nonce = self.next_available_nonce(from).await?;
-                request.nonce = Some(nonce);
+                request.set_nonce(nonce);
             }
 
             let chain_id = self.chain_id();
-            request.chain_id = Some(chain_id.to());
+            request.set_chain_id(chain_id.to());
 
             let estimated_gas =
                 self.estimate_gas_at(request.clone(), BlockId::pending(), None).await?;
@@ -431,7 +443,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn sign_request(
         &self,
         from: &Address,
-        txn: TransactionRequest,
+        txn: RpcTxReq<Self::NetworkTypes>,
     ) -> impl Future<Output = Result<ProviderTx<Self::Provider>, Self::Error>> + Send {
         async move {
             self.find_signer(from)?
@@ -462,10 +474,10 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     /// Returns the EIP-2718 encoded signed transaction.
     fn sign_transaction(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<Self::NetworkTypes>,
     ) -> impl Future<Output = Result<Bytes, Self::Error>> + Send {
         async move {
-            let from = match request.from {
+            let from = match request.from() {
                 Some(from) => from,
                 None => return Err(SignError::NoAccount.into_eth_err()),
             };
@@ -489,7 +501,16 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn find_signer(
         &self,
         account: &Address,
-    ) -> Result<Box<dyn EthSigner<ProviderTx<Self::Provider>> + 'static>, Self::Error> {
+    ) -> Result<
+        Box<
+            (dyn EthSigner<
+                ProviderTx<Self::Provider>,
+                Self::NetworkTypes,
+                RpcTxReq<Self::NetworkTypes>,
+            > + 'static),
+        >,
+        Self::Error,
+    > {
         self.signers()
             .read()
             .iter()

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -385,7 +385,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         Self: EthApiSpec + LoadBlock + EstimateCall,
     {
         async move {
-            let from = match request.from() {
+            let from = match request.as_ref().from() {
                 Some(from) => from,
                 None => return Err(SignError::NoAccount.into_eth_err()),
             };
@@ -395,18 +395,18 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             }
 
             // set nonce if not already set before
-            if request.nonce().is_none() {
+            if request.as_ref().nonce().is_none() {
                 let nonce = self.next_available_nonce(from).await?;
-                request.set_nonce(nonce);
+                request.as_mut().set_nonce(nonce);
             }
 
             let chain_id = self.chain_id();
-            request.set_chain_id(chain_id.to());
+            request.as_mut().set_chain_id(chain_id.to());
 
             let estimated_gas =
                 self.estimate_gas_at(request.clone(), BlockId::pending(), None).await?;
             let gas_limit = estimated_gas;
-            request.set_gas_limit(gas_limit.to());
+            request.as_mut().set_gas_limit(gas_limit.to());
 
             let transaction = self.sign_request(&from, request).await?.with_signer(from);
 
@@ -465,7 +465,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         request: RpcTxReq<Self::NetworkTypes>,
     ) -> impl Future<Output = Result<Bytes, Self::Error>> + Send {
         async move {
-            let from = match request.from() {
+            let from = match request.as_ref().from() {
                 Some(from) => from,
                 None => return Err(SignError::NoAccount.into_eth_err()),
             };
@@ -490,13 +490,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         &self,
         account: &Address,
     ) -> Result<
-        Box<
-            dyn EthSigner<
-                    ProviderTx<Self::Provider>,
-                    Self::NetworkTypes,
-                    RpcTxReq<Self::NetworkTypes>,
-                > + 'static,
-        >,
+        Box<dyn EthSigner<ProviderTx<Self::Provider>, RpcTxReq<Self::NetworkTypes>> + 'static>,
         Self::Error,
     > {
         self.signers()

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -503,11 +503,11 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         account: &Address,
     ) -> Result<
         Box<
-            (dyn EthSigner<
-                ProviderTx<Self::Provider>,
-                Self::NetworkTypes,
-                RpcTxReq<Self::NetworkTypes>,
-            > + 'static),
+            dyn EthSigner<
+                    ProviderTx<Self::Provider>,
+                    Self::NetworkTypes,
+                    RpcTxReq<Self::NetworkTypes>,
+                > + 'static,
         >,
         Self::Error,
     > {

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -1,17 +1,17 @@
 //! Trait for specifying `eth` network dependent API types.
 
 use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
-use alloy_rpc_types_eth::{Block, TransactionRequest};
+use alloy_network::TransactionBuilder;
+use alloy_rpc_types_eth::Block;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_rpc_convert::RpcConvert;
+pub use reth_rpc_convert::{RpcTransaction, RpcTxReq, RpcTypes};
 use reth_storage_api::{ProviderTx, ReceiptProvider, TransactionsProvider};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{
     error::Error,
     fmt::{self},
 };
-
-pub use reth_rpc_convert::{RpcTransaction, RpcTxReq, RpcTypes};
 
 /// Network specific `eth` API types.
 ///
@@ -64,7 +64,10 @@ where
                 Network = Self::NetworkTypes,
                 Error = RpcError<Self>,
             >,
-            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
+            NetworkTypes: alloy_network::Network
+                              + RpcTypes<
+                TransactionRequest: TransactionBuilder<<Self as EthApiTypes>::NetworkTypes>,
+            >,
         >,
 {
 }
@@ -81,7 +84,10 @@ impl<T> FullEthApiTypes for T where
                 Network = Self::NetworkTypes,
                 Error = RpcError<T>,
             >,
-            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
+            NetworkTypes: alloy_network::Network
+                              + RpcTypes<
+                TransactionRequest: TransactionBuilder<<T as EthApiTypes>::NetworkTypes>,
+            >,
         >
 {
 }

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -1,7 +1,6 @@
 //! Trait for specifying `eth` network dependent API types.
 
 use crate::{AsEthApiError, FromEthApiError, RpcNodeCore};
-use alloy_network::TransactionBuilder;
 use alloy_rpc_types_eth::Block;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_rpc_convert::RpcConvert;
@@ -64,10 +63,6 @@ where
                 Network = Self::NetworkTypes,
                 Error = RpcError<Self>,
             >,
-            NetworkTypes: alloy_network::Network
-                              + RpcTypes<
-                TransactionRequest: TransactionBuilder<<Self as EthApiTypes>::NetworkTypes>,
-            >,
         >,
 {
 }
@@ -83,10 +78,6 @@ impl<T> FullEthApiTypes for T where
                 Primitives = <Self as RpcNodeCore>::Primitives,
                 Network = Self::NetworkTypes,
                 Error = RpcError<T>,
-            >,
-            NetworkTypes: alloy_network::Network
-                              + RpcTypes<
-                TransactionRequest: TransactionBuilder<<T as EthApiTypes>::NetworkTypes>,
             >,
         >
 {

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -35,6 +35,7 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-network.workspace = true
 revm.workspace = true
 revm-inspectors.workspace = true
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -8,7 +8,7 @@ use crate::{
     EthApiError, RevertError,
 };
 use alloy_consensus::{BlockHeader, Transaction as _};
-use alloy_eips::{eip2718::WithEncoded, Typed2718};
+use alloy_eips::eip2718::WithEncoded;
 use alloy_network::TransactionBuilder;
 use alloy_rpc_types_eth::{
     simulate::{SimCallResult, SimulateError, SimulatedBlock},
@@ -22,7 +22,7 @@ use reth_evm::{
 use reth_primitives_traits::{
     block::BlockTx, BlockBody as _, NodePrimitives, Recovered, RecoveredBlock, SignedTransaction,
 };
-use reth_rpc_convert::{RpcConvert, RpcTransaction, RpcTxReq, RpcTypes};
+use reth_rpc_convert::{RpcConvert, RpcTransaction, RpcTxReq};
 use reth_rpc_server_types::result::rpc_err;
 use reth_storage_api::noop::NoopProvider;
 use revm::{
@@ -79,11 +79,7 @@ pub fn execute_transactions<S, T>(
 >
 where
     S: BlockBuilder<Executor: BlockExecutor<Evm: Evm<DB: Database<Error: Into<EthApiError>>>>>,
-    T: RpcConvert<
-        Primitives = S::Primitives,
-        Network: alloy_network::Network
-                     + RpcTypes<TransactionRequest: TransactionBuilder<<T as RpcConvert>::Network>>,
-    >,
+    T: RpcConvert<Primitives = S::Primitives>,
 {
     builder.apply_pre_execution_changes()?;
 
@@ -129,58 +125,56 @@ pub fn resolve_transaction<DB: Database, Tx, T>(
 ) -> Result<Recovered<Tx>, EthApiError>
 where
     DB::Error: Into<EthApiError>,
-    T: RpcConvert<
-        Primitives: NodePrimitives<SignedTx = Tx>,
-        Network: alloy_network::Network
-                     + RpcTypes<TransactionRequest: TransactionBuilder<<T as RpcConvert>::Network>>,
-    >,
+    T: RpcConvert<Primitives: NodePrimitives<SignedTx = Tx>>,
 {
     // If we're missing any fields we try to fill nonce, gas and
     // gas price.
-    let tx_type = tx.output_tx_type();
+    let tx_type = tx.as_ref().output_tx_type();
 
-    let from = if let Some(from) = tx.from() {
+    let from = if let Some(from) = tx.as_ref().from() {
         from
     } else {
-        tx.set_from(Address::ZERO);
+        tx.as_mut().set_from(Address::ZERO);
         Address::ZERO
     };
 
-    if tx.nonce().is_none() {
-        tx.set_nonce(db.basic(from).map_err(Into::into)?.map(|acc| acc.nonce).unwrap_or_default());
+    if tx.as_ref().nonce().is_none() {
+        tx.as_mut().set_nonce(
+            db.basic(from).map_err(Into::into)?.map(|acc| acc.nonce).unwrap_or_default(),
+        );
     }
 
-    if tx.gas_limit().is_none() {
-        tx.set_gas_limit(default_gas_limit);
+    if tx.as_ref().gas_limit().is_none() {
+        tx.as_mut().set_gas_limit(default_gas_limit);
     }
 
-    if tx.chain_id().is_none() {
-        tx.set_chain_id(chain_id);
+    if tx.as_ref().chain_id().is_none() {
+        tx.as_mut().set_chain_id(chain_id);
     }
 
-    if tx.kind().is_none() {
-        tx.set_kind(TxKind::Create);
+    if tx.as_ref().kind().is_none() {
+        tx.as_mut().set_kind(TxKind::Create);
     }
 
     // if we can't build the _entire_ transaction yet, we need to check the fee values
-    if tx.output_tx_type_checked().is_none() {
+    if tx.as_ref().output_tx_type_checked().is_none() {
         if tx_type.is_legacy() || tx_type.is_eip2930() {
-            if tx.gas_price().is_none() {
-                tx.set_gas_price(block_base_fee_per_gas as u128);
+            if tx.as_ref().gas_price().is_none() {
+                tx.as_mut().set_gas_price(block_base_fee_per_gas as u128);
             }
         } else {
             // set dynamic 1559 fees
-            if tx.max_fee_per_gas().is_none() {
+            if tx.as_ref().max_fee_per_gas().is_none() {
                 let mut max_fee_per_gas = block_base_fee_per_gas as u128;
-                if let Some(prio_fee) = tx.max_priority_fee_per_gas() {
+                if let Some(prio_fee) = tx.as_ref().max_priority_fee_per_gas() {
                     // if a prio fee is provided we need to select the max fee accordingly
                     // because the base fee must be higher than the prio fee.
                     max_fee_per_gas = prio_fee.max(max_fee_per_gas);
                 }
-                tx.set_max_fee_per_gas(max_fee_per_gas);
+                tx.as_mut().set_max_fee_per_gas(max_fee_per_gas);
             }
-            if tx.max_priority_fee_per_gas().is_none() {
-                tx.set_max_priority_fee_per_gas(0);
+            if tx.as_ref().max_priority_fee_per_gas().is_none() {
+                tx.as_mut().set_max_priority_fee_per_gas(0);
             }
         }
     }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -61,6 +61,8 @@ impl ToRpcError for EthSimulateError {
 /// given [`BlockExecutor`].
 ///
 /// Returns all executed transactions and the result of the execution.
+///
+/// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 #[expect(clippy::type_complexity)]
 pub fn execute_transactions<S, T>(
     mut builder: S,
@@ -115,6 +117,8 @@ where
 /// them into primitive transactions.
 ///
 /// This will set the defaults as defined in <https://github.com/ethereum/execution-apis/blob/e56d3208789259d0b09fa68e9d8594aa4d73c725/docs/ethsimulatev1-notes.md#default-values-for-transactions>
+///
+/// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 pub fn resolve_transaction<DB: Database, Tx, T>(
     mut tx: RpcTxReq<T::Network>,
     default_gas_limit: u64,

--- a/crates/rpc/rpc-testing-util/src/debug.rs
+++ b/crates/rpc/rpc-testing-util/src/debug.rs
@@ -78,7 +78,7 @@ pub trait DebugApiExt {
 impl<T> DebugApiExt for T
 where
     T: EthApiClient<TransactionRequest, Transaction, Block, Receipt, Header>
-        + DebugApiClient
+        + DebugApiClient<TransactionRequest>
         + Sync,
 {
     type Provider = T;

--- a/crates/rpc/rpc-testing-util/src/trace.rs
+++ b/crates/rpc/rpc-testing-util/src/trace.rs
@@ -250,7 +250,7 @@ impl std::fmt::Debug for ReplayTransactionStream<'_> {
     }
 }
 
-impl<T: TraceApiClient + Sync> TraceApiExt for T {
+impl<T: TraceApiClient<TransactionRequest> + Sync> TraceApiExt for T {
     type Provider = T;
 
     fn trace_block_buffered<I, B>(&self, params: I, n: usize) -> TraceBlockStream<'_>

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1047,7 +1047,7 @@ where
 
     async fn debug_trace_call_many(
         &self,
-        bundles: Vec<Bundle>,
+        bundles: Vec<Bundle<RpcTxReq<Eth::NetworkTypes>>>,
         state_context: Option<StateContext>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<Vec<GethTrace>>> {

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -1,8 +1,7 @@
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
 use alloy_rpc_types_eth::{
-    state::StateOverride, transaction::TransactionRequest, BlockOverrides,
-    EIP1186AccountProofResponse, Filter, Log, SyncStatus,
+    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, Log, SyncStatus,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::core::RpcResult as Result;
@@ -37,8 +36,12 @@ impl<Eth, EthFilter> EngineEthApi<Eth, EthFilter> {
 }
 
 #[async_trait::async_trait]
-impl<Eth, EthFilter> EngineEthApiServer<RpcBlock<Eth::NetworkTypes>, RpcReceipt<Eth::NetworkTypes>>
-    for EngineEthApi<Eth, EthFilter>
+impl<Eth, EthFilter>
+    EngineEthApiServer<
+        RpcTxReq<Eth::NetworkTypes>,
+        RpcBlock<Eth::NetworkTypes>,
+        RpcReceipt<Eth::NetworkTypes>,
+    > for EngineEthApi<Eth, EthFilter>
 where
     Eth: EthApiServer<
             RpcTxReq<Eth::NetworkTypes>,
@@ -73,7 +76,7 @@ where
     /// Handler for: `eth_call`
     async fn call(
         &self,
-        request: TransactionRequest,
+        request: RpcTxReq<Eth::NetworkTypes>,
         block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -4,6 +4,7 @@ use crate::{eth::core::EthApiInner, EthApi};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::ChainSpecProvider;
 use reth_node_api::NodePrimitives;
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_types::{
     fee_history::fee_history_cache_new_blocks_task, EthStateCache, EthStateCacheConfig,
     FeeHistoryCache, FeeHistoryCacheConfig, GasCap, GasPriceOracle, GasPriceOracleConfig,
@@ -45,7 +46,7 @@ where
 impl<Provider, Pool, Network, EvmConfig, Rpc> EthApiBuilder<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReaderIdExt,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     /// Creates a new `EthApiBuilder` instance.
     pub fn new(provider: Provider, pool: Pool, network: Network, evm_config: EvmConfig) -> Self

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -4,6 +4,7 @@ use crate::{eth::core::EthApiInner, EthApi};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::ChainSpecProvider;
 use reth_node_api::NodePrimitives;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_types::{
     fee_history::fee_history_cache_new_blocks_task, EthStateCache, EthStateCacheConfig,
     FeeHistoryCache, FeeHistoryCacheConfig, GasCap, GasPriceOracle, GasPriceOracleConfig,
@@ -154,8 +155,9 @@ where
     ///
     /// This function panics if the blocking task pool cannot be built.
     /// This will panic if called outside the context of a Tokio runtime.
-    pub fn build_inner(self) -> EthApiInner<Provider, Pool, Network, EvmConfig>
+    pub fn build_inner(self) -> EthApiInner<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
     where
+        Network: RpcTypes,
         Provider: BlockReaderIdExt
             + StateProviderFactory
             + ChainSpecProvider
@@ -231,8 +233,9 @@ where
     ///
     /// This function panics if the blocking task pool cannot be built.
     /// This will panic if called outside the context of a Tokio runtime.
-    pub fn build(self) -> EthApi<Provider, Pool, Network, EvmConfig>
+    pub fn build(self) -> EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
     where
+        Network: RpcTypes,
         Provider: BlockReaderIdExt
             + StateProviderFactory
             + CanonStateSubscriptions<

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -10,6 +10,7 @@ use alloy_network::Ethereum;
 use alloy_primitives::{Bytes, U256};
 use derive_more::Deref;
 use reth_node_api::{FullNodeComponents, FullNodeTypes};
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForRpc, SpawnBlocking},
     node::RpcNodeCoreExt,
@@ -63,7 +64,7 @@ pub type EthApiBuilderFor<N, Rpc = Ethereum> = EthApiBuilder<
 /// While this type requires various unrestricted generic components, trait bounds are enforced when
 /// additional traits are implemented for this type.
 #[derive(Deref)]
-pub struct EthApi<Provider: BlockReader, Pool, Network, EvmConfig, Rpc: alloy_network::Network> {
+pub struct EthApi<Provider: BlockReader, Pool, Network, EvmConfig, Rpc: RpcTypes> {
     /// All nested fields bundled together.
     #[deref]
     pub(super) inner: Arc<EthApiInner<Provider, Pool, Network, EvmConfig, Rpc>>,
@@ -75,7 +76,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> Clone
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     fn clone(&self) -> Self {
         Self { inner: self.inner.clone(), tx_resp_builder: self.tx_resp_builder.clone() }
@@ -85,7 +86,7 @@ where
 impl<Provider, Pool, Network, EvmConfig, Rpc> EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReaderIdExt,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     /// Convenience fn to obtain a new [`EthApiBuilder`] instance with mandatory components.
     ///
@@ -180,7 +181,7 @@ where
     Pool: Send + Sync + Clone + Unpin,
     Network: Send + Sync + Clone,
     EvmConfig: Send + Sync + Clone + Unpin,
-    Rpc: alloy_network::Network + Send + Sync + Clone + Unpin,
+    Rpc: RpcTypes + Send + Sync + Clone + Unpin,
 {
     type Primitives = Provider::Primitives;
     type Provider = Provider;
@@ -217,7 +218,7 @@ where
     Pool: Send + Sync + Clone + Unpin,
     Network: Send + Sync + Clone,
     EvmConfig: Send + Sync + Clone + Unpin,
-    Rpc: alloy_network::Network + Send + Sync + Clone + Unpin,
+    Rpc: RpcTypes + Send + Sync + Clone + Unpin,
 {
     #[inline]
     fn cache(&self) -> &EthStateCache<ProviderBlock<Provider>, ProviderReceipt<Provider>> {
@@ -229,7 +230,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> std::fmt::Debug
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EthApi").finish_non_exhaustive()
@@ -241,7 +242,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> SpawnBlocking
 where
     Self: EthApiTypes<NetworkTypes = Rpc> + Clone + Send + Sync + 'static,
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {
@@ -261,8 +262,7 @@ where
 
 /// Container type `EthApi`
 #[expect(missing_debug_implementations)]
-pub struct EthApiInner<Provider: BlockReader, Pool, Network, EvmConfig, Rpc: alloy_network::Network>
-{
+pub struct EthApiInner<Provider: BlockReader, Pool, Network, EvmConfig, Rpc: RpcTypes> {
     /// The transaction pool.
     pool: Pool,
     /// The provider that can interact with the chain.
@@ -304,7 +304,7 @@ pub struct EthApiInner<Provider: BlockReader, Pool, Network, EvmConfig, Rpc: all
 impl<Provider, Pool, Network, EvmConfig, Rpc> EthApiInner<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReaderIdExt,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     /// Creates a new, shareable instance using the default tokio task spawner.
     #[expect(clippy::too_many_arguments)]
@@ -361,7 +361,7 @@ where
 impl<Provider, Pool, Network, EvmConfig, Rpc> EthApiInner<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     /// Returns a handle to data on disk.
     #[inline]

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -181,7 +181,7 @@ where
     Pool: Send + Sync + Clone + Unpin,
     Network: Send + Sync + Clone,
     EvmConfig: Send + Sync + Clone + Unpin,
-    Rpc: RpcTypes + Send + Sync + Clone + Unpin,
+    Rpc: RpcTypes,
 {
     type Primitives = Provider::Primitives;
     type Provider = Provider;
@@ -218,7 +218,7 @@ where
     Pool: Send + Sync + Clone + Unpin,
     Network: Send + Sync + Clone,
     EvmConfig: Send + Sync + Clone + Unpin,
-    Rpc: RpcTypes + Send + Sync + Clone + Unpin,
+    Rpc: RpcTypes,
 {
     #[inline]
     fn cache(&self) -> &EthStateCache<ProviderBlock<Provider>, ProviderReceipt<Provider>> {

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -10,6 +10,7 @@ use alloy_network::Ethereum;
 use alloy_primitives::{Bytes, U256};
 use derive_more::Deref;
 use reth_node_api::{FullNodeComponents, FullNodeTypes};
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, SpawnBlocking},
     node::RpcNodeCoreExt,
@@ -230,6 +231,7 @@ impl<Provider, Pool, Network, EvmConfig> SpawnBlocking
 where
     Self: Clone + Send + Sync + 'static,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {
@@ -347,6 +349,7 @@ where
 impl<Provider, Pool, Network, EvmConfig> EthApiInner<Provider, Pool, Network, EvmConfig>
 where
     Provider: BlockReader,
+    Network: RpcTypes,
 {
     /// Returns a handle to data on disk.
     #[inline]
@@ -420,7 +423,9 @@ where
     #[inline]
     pub const fn signers(
         &self,
-    ) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<Provider::Transaction>>>> {
+    ) -> &parking_lot::RwLock<
+        Vec<Box<dyn EthSigner<Provider::Transaction, Network, RpcTxReq<Network>>>>,
+    > {
         &self.signers
     }
 

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -1084,6 +1084,7 @@ impl<
 mod tests {
     use super::*;
     use crate::{eth::EthApi, EthApiBuilder};
+    use alloy_network::Ethereum;
     use alloy_primitives::FixedBytes;
     use rand::Rng;
     use reth_chainspec::ChainSpecProvider;
@@ -1121,7 +1122,7 @@ mod tests {
     // Helper function to create a test EthApi instance
     fn build_test_eth_api(
         provider: MockEthProvider,
-    ) -> EthApi<MockEthProvider, TestPool, NoopNetwork, EthEvmConfig> {
+    ) -> EthApi<MockEthProvider, TestPool, NoopNetwork, EthEvmConfig, Ethereum> {
         EthApiBuilder::new(
             provider.clone(),
             testing_pool(),

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -28,6 +28,7 @@ where
             Receipt = reth_ethereum_primitives::Receipt,
         >,
     >,
+    Network: RpcTypes,
     Provider: BlockReader + ChainSpecProvider,
 {
     async fn block_receipts(
@@ -81,6 +82,7 @@ where
             Evm = EvmConfig,
         >,
     Provider: BlockReader,
+    Network: RpcTypes,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_eth::{BlockId, TransactionReceipt};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
-use reth_rpc_convert::RpcConvert;
+use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
     types::RpcTypes,
@@ -17,7 +17,8 @@ use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthBlocks for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> EthBlocks
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadBlock<
         Error = EthApiError,
@@ -70,7 +71,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig> LoadBlock for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> LoadBlock
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadPendingBlock
         + SpawnBlocking

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_eth::{BlockId, TransactionReceipt};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
-use reth_rpc_convert::{RpcConvert, RpcTxReq};
+use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt, SpawnBlocking},
     types::RpcTypes,
@@ -17,20 +17,20 @@ use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthBlocks
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, Rpc> EthBlocks
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: LoadBlock<
         Error = EthApiError,
-        NetworkTypes: RpcTypes<Receipt = TransactionReceipt>,
-        RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
+        NetworkTypes = Rpc,
+        RpcConvert: RpcConvert<Network = Rpc>,
         Provider: BlockReader<
             Transaction = reth_ethereum_primitives::TransactionSigned,
             Receipt = reth_ethereum_primitives::Receipt,
         >,
     >,
-    Network: RpcTypes,
     Provider: BlockReader + ChainSpecProvider,
+    Rpc: RpcTypes<Receipt = TransactionReceipt>,
 {
     async fn block_receipts(
         &self,
@@ -71,8 +71,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig> LoadBlock
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, Rpc> LoadBlock
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: LoadPendingBlock
         + SpawnBlocking
@@ -84,7 +84,6 @@ where
             Evm = EvmConfig,
         >,
     Provider: BlockReader,
-    Network: RpcTypes,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -30,7 +30,7 @@ where
         >,
     >,
     Provider: BlockReader + ChainSpecProvider,
-    Rpc: RpcTypes<Receipt = TransactionReceipt>,
+    Rpc: alloy_network::Network + RpcTypes<Receipt = TransactionReceipt>,
 {
     async fn block_receipts(
         &self,
@@ -85,5 +85,6 @@ where
         >,
     Provider: BlockReader,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
+    Rpc: alloy_network::Network,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -30,7 +30,7 @@ where
         >,
     >,
     Provider: BlockReader + ChainSpecProvider,
-    Rpc: alloy_network::Network + RpcTypes<Receipt = TransactionReceipt>,
+    Rpc: RpcTypes<Receipt = TransactionReceipt>,
 {
     async fn block_receipts(
         &self,
@@ -85,6 +85,6 @@ where
         >,
     Provider: BlockReader,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -6,7 +6,7 @@ use alloy_network::TransactionBuilder;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;
-use reth_rpc_convert::{RpcConvert, RpcTxReq, RpcTypes};
+use reth_rpc_convert::{RpcConvert, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEvmError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
@@ -16,7 +16,7 @@ use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm::context::TxEnv;
 
 impl<Provider, Pool, Network, EvmConfig> EthCall
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    for EthApi<Provider, Pool, Network, EvmConfig, Self::NetworkTypes>
 where
     Self: EstimateCall
         + LoadPendingBlock
@@ -30,12 +30,11 @@ where
         >,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
 }
 
 impl<Provider, Pool, Network, EvmConfig> Call
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    for EthApi<Provider, Pool, Network, EvmConfig, Self::NetworkTypes>
 where
     Self: LoadState<
             Evm: ConfigureEvm<
@@ -53,7 +52,6 @@ where
                        + From<ProviderError>,
         > + SpawnBlocking,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -67,10 +65,9 @@ where
 }
 
 impl<Provider, Pool, Network, EvmConfig> EstimateCall
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    for EthApi<Provider, Pool, Network, EvmConfig, Self::NetworkTypes>
 where
     Self: Call,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -3,7 +3,6 @@
 use crate::EthApi;
 use alloy_evm::block::BlockExecutorFactory;
 use alloy_network::TransactionBuilder;
-use alloy_rpc_types_eth::TransactionRequest;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -6,7 +6,7 @@ use alloy_network::TransactionBuilder;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;
-use reth_rpc_convert::{RpcConvert, RpcTypes};
+use reth_rpc_convert::{RpcConvert, RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEvmError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
@@ -15,7 +15,8 @@ use reth_storage_api::{BlockReader, ProviderHeader, ProviderTx};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm::context::TxEnv;
 
-impl<Provider, Pool, Network, EvmConfig> EthCall for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> EthCall
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: EstimateCall
         + LoadPendingBlock
@@ -33,7 +34,8 @@ where
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig> Call for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> Call
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadState<
             Evm: ConfigureEvm<
@@ -64,7 +66,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig> EstimateCall for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> EstimateCall
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: Call,
     Provider: BlockReader,

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -29,6 +29,7 @@ where
         >,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
 }
 
@@ -50,6 +51,7 @@ where
                        + From<ProviderError>,
         > + SpawnBlocking,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -66,5 +68,6 @@ impl<Provider, Pool, Network, EvmConfig> EstimateCall for EthApi<Provider, Pool,
 where
     Self: Call,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -2,7 +2,6 @@
 
 use crate::EthApi;
 use alloy_evm::block::BlockExecutorFactory;
-use alloy_network::TransactionBuilder;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmFactory, TxEnvFor};
 use reth_node_api::NodePrimitives;
@@ -52,7 +51,7 @@ where
                        + From<ProviderError>,
         > + SpawnBlocking,
     Provider: BlockReader,
-    Rpc: alloy_network::Network + RpcTypes<TransactionRequest: TransactionBuilder<Rpc>>,
+    Rpc: RpcTypes,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -30,7 +30,7 @@ where
         >,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
     Provider: BlockReader,
-    Rpc: alloy_network::Network + RpcTypes<TransactionRequest: TransactionBuilder<Rpc>>,
+    Rpc: RpcTypes,
 {
 }
 
@@ -70,6 +70,6 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> EstimateCall
 where
     Self: Call<NetworkTypes = Rpc>,
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -2,6 +2,7 @@
 
 use crate::EthApi;
 use alloy_evm::block::BlockExecutorFactory;
+use alloy_network::TransactionBuilder;
 use alloy_rpc_types_eth::TransactionRequest;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmFactory, TxEnvFor};
@@ -43,7 +44,8 @@ where
                 >,
             >,
             RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Self::NetworkTypes>,
-            NetworkTypes: RpcTypes<TransactionRequest: From<TransactionRequest>>,
+            NetworkTypes: alloy_network::Network
+                              + RpcTypes<TransactionRequest: TransactionBuilder<Self::NetworkTypes>>,
             Error: FromEvmError<Self::Evm>
                        + From<<Self::RpcConvert as RpcConvert>::Error>
                        + From<ProviderError>,

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,6 +1,7 @@
 //! Contains RPC handler implementations for fee history.
 
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
 use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderHeader, StateProviderFactory};
@@ -16,7 +17,7 @@ where
         >,
     >,
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
 }
 
@@ -27,7 +28,7 @@ where
     Provider: BlockReaderIdExt
         + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
         + StateProviderFactory,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,15 +1,14 @@
 //! Contains RPC handler implementations for fee history.
 
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
-use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
 use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderHeader, StateProviderFactory};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthFees
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, TxReq> EthFees
+    for EthApi<Provider, Pool, Network, EvmConfig, TxReq>
 where
     Self: LoadFee<
         Provider: ChainSpecProvider<
@@ -17,18 +16,16 @@ where
         >,
     >,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig> LoadFee
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, TxReq> LoadFee
+    for EthApi<Provider, Pool, Network, EvmConfig, TxReq>
 where
     Self: LoadBlock<Provider = Provider>,
     Provider: BlockReaderIdExt
         + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
         + StateProviderFactory,
-    Network: RpcTypes,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,14 +1,15 @@
 //! Contains RPC handler implementations for fee history.
 
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
-use reth_rpc_convert::RpcTypes;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
 use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderHeader, StateProviderFactory};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthFees for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> EthFees
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadFee<
         Provider: ChainSpecProvider<
@@ -20,7 +21,8 @@ where
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig> LoadFee for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> LoadFee
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadBlock<Provider = Provider>,
     Provider: BlockReaderIdExt

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -7,8 +7,8 @@ use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderHeader, StateProvi
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig, TxReq> EthFees
-    for EthApi<Provider, Pool, Network, EvmConfig, TxReq>
+impl<Provider, Pool, Network, EvmConfig, Rpc> EthFees
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: LoadFee<
         Provider: ChainSpecProvider<
@@ -16,16 +16,18 @@ where
         >,
     >,
     Provider: BlockReader,
+    Rpc: alloy_network::Network,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, TxReq> LoadFee
-    for EthApi<Provider, Pool, Network, EvmConfig, TxReq>
+impl<Provider, Pool, Network, EvmConfig, Rpc> LoadFee
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: LoadBlock<Provider = Provider>,
     Provider: BlockReaderIdExt
         + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
         + StateProviderFactory,
+    Rpc: alloy_network::Network,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,6 +1,7 @@
 //! Contains RPC handler implementations for fee history.
 
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
 use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderHeader, StateProviderFactory};
@@ -15,6 +16,7 @@ where
         >,
     >,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
 }
 
@@ -24,6 +26,7 @@ where
     Provider: BlockReaderIdExt
         + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
         + StateProviderFactory,
+    Network: RpcTypes,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -6,7 +6,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
 use reth_node_api::NodePrimitives;
 use reth_primitives_traits::SealedHeader;
-use reth_rpc_convert::{RpcConvert, RpcTxReq};
+use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
     types::RpcTypes,
@@ -20,8 +20,8 @@ use reth_storage_api::{
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm_primitives::B256;
 
-impl<Provider, Pool, Network, EvmConfig> LoadPendingBlock
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, Rpc> LoadPendingBlock
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: SpawnBlocking<
             NetworkTypes: RpcTypes<
@@ -48,7 +48,6 @@ where
             >,
         >,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
     #[inline]
     fn pending_block(

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -6,7 +6,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
 use reth_node_api::NodePrimitives;
 use reth_primitives_traits::SealedHeader;
-use reth_rpc_convert::RpcConvert;
+use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_api::{
     helpers::{LoadPendingBlock, SpawnBlocking},
     types::RpcTypes,
@@ -21,7 +21,7 @@ use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm_primitives::B256;
 
 impl<Provider, Pool, Network, EvmConfig> LoadPendingBlock
-    for EthApi<Provider, Pool, Network, EvmConfig>
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: SpawnBlocking<
             NetworkTypes: RpcTypes<

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -48,6 +48,7 @@ where
             >,
         >,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
     #[inline]
     fn pending_block(

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -24,11 +24,9 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> LoadPendingBlock
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: SpawnBlocking<
-            NetworkTypes: RpcTypes<
-                Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>,
-            >,
+            NetworkTypes = Rpc,
             Error: FromEvmError<Self::Evm>,
-            RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
+            RpcConvert: RpcConvert<Network = Rpc>,
         > + RpcNodeCore<
             Provider: BlockReaderIdExt<Receipt = Provider::Receipt, Block = Provider::Block>
                           + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
@@ -48,6 +46,8 @@ where
             >,
         >,
     Provider: BlockReader,
+    Rpc: alloy_network::Network
+        + RpcTypes<Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>>,
 {
     #[inline]
     fn pending_block(

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -46,8 +46,7 @@ where
             >,
         >,
     Provider: BlockReader,
-    Rpc: alloy_network::Network
-        + RpcTypes<Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>>,
+    Rpc: RpcTypes<Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>>,
 {
     #[inline]
     fn pending_block(

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -8,6 +8,7 @@ use alloy_consensus::{
 use alloy_rpc_types_eth::TransactionReceipt;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::{
     helpers::LoadReceipt, EthApiTypes, FromEthApiError, RpcNodeCoreExt, RpcReceipt,
 };
@@ -22,7 +23,7 @@ where
                           + ReceiptProvider<Receipt = reth_ethereum_primitives::Receipt>,
         > + EthApiTypes<NetworkTypes = Rpc, Error: From<RecoveryError>>,
     Provider: BlockReader + ChainSpecProvider,
-    Rpc: alloy_network::Network<ReceiptResponse = TransactionReceipt>,
+    Rpc: RpcTypes<Receipt = TransactionReceipt>,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -5,6 +5,7 @@ use alloy_consensus::{
     crypto::RecoveryError,
     transaction::{SignerRecoverable, TransactionMeta},
 };
+use alloy_rpc_types_eth::TransactionReceipt;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
 use reth_rpc_eth_api::{
@@ -21,7 +22,7 @@ where
                           + ReceiptProvider<Receipt = reth_ethereum_primitives::Receipt>,
         > + EthApiTypes<NetworkTypes = Rpc, Error: From<RecoveryError>>,
     Provider: BlockReader + ChainSpecProvider,
-    Rpc: alloy_network::Network,
+    Rpc: alloy_network::Network<ReceiptResponse = TransactionReceipt>,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -4,20 +4,18 @@ use crate::EthApi;
 use alloy_consensus::transaction::{SignerRecoverable, TransactionMeta};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
-use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 use reth_storage_api::{BlockReader, ReceiptProvider, TransactionsProvider};
 
 impl<Provider, Pool, Network, EvmConfig> LoadReceipt
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    for EthApi<Provider, Pool, Network, EvmConfig, Self::NetworkTypes>
 where
     Self: RpcNodeCoreExt<
         Provider: TransactionsProvider<Transaction = TransactionSigned>
                       + ReceiptProvider<Receipt = reth_ethereum_primitives::Receipt>,
     >,
     Provider: BlockReader + ChainSpecProvider,
-    Network: RpcTypes,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,21 +1,27 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
 use crate::EthApi;
-use alloy_consensus::transaction::{SignerRecoverable, TransactionMeta};
+use alloy_consensus::{
+    crypto::RecoveryError,
+    transaction::{SignerRecoverable, TransactionMeta},
+};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
-use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
+use reth_rpc_eth_api::{
+    helpers::LoadReceipt, EthApiTypes, FromEthApiError, RpcNodeCoreExt, RpcReceipt,
+};
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 use reth_storage_api::{BlockReader, ReceiptProvider, TransactionsProvider};
 
-impl<Provider, Pool, Network, EvmConfig> LoadReceipt
-    for EthApi<Provider, Pool, Network, EvmConfig, Self::NetworkTypes>
+impl<Provider, Pool, Network, EvmConfig, Rpc> LoadReceipt
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: RpcNodeCoreExt<
-        Provider: TransactionsProvider<Transaction = TransactionSigned>
-                      + ReceiptProvider<Receipt = reth_ethereum_primitives::Receipt>,
-    >,
+            Provider: TransactionsProvider<Transaction = TransactionSigned>
+                          + ReceiptProvider<Receipt = reth_ethereum_primitives::Receipt>,
+        > + EthApiTypes<NetworkTypes = Rpc, Error: From<RecoveryError>>,
     Provider: BlockReader + ChainSpecProvider,
+    Rpc: alloy_network::Network,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -4,12 +4,13 @@ use crate::EthApi;
 use alloy_consensus::transaction::{SignerRecoverable, TransactionMeta};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
-use reth_rpc_convert::RpcTypes;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 use reth_storage_api::{BlockReader, ReceiptProvider, TransactionsProvider};
 
-impl<Provider, Pool, Network, EvmConfig> LoadReceipt for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> LoadReceipt
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: RpcNodeCoreExt<
         Provider: TransactionsProvider<Transaction = TransactionSigned>

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -4,6 +4,7 @@ use crate::EthApi;
 use alloy_consensus::transaction::{SignerRecoverable, TransactionMeta};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::{helpers::LoadReceipt, FromEthApiError, RpcNodeCoreExt, RpcReceipt};
 use reth_rpc_eth_types::{EthApiError, EthReceiptBuilder};
 use reth_storage_api::{BlockReader, ReceiptProvider, TransactionsProvider};
@@ -15,6 +16,7 @@ where
                       + ReceiptProvider<Receipt = reth_ethereum_primitives::Receipt>,
     >,
     Provider: BlockReader + ChainSpecProvider,
+    Network: RpcTypes,
 {
     async fn build_transaction_receipt(
         &self,

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::EthApi;
 use alloy_dyn_abi::TypedData;
 use alloy_eips::eip2718::Decodable2718;
-use alloy_network::{eip2718::Encodable2718, EthereumWallet, TransactionBuilder};
+use alloy_network::{eip2718::Encodable2718, Ethereum, EthereumWallet, TransactionBuilder};
 use alloy_primitives::{eip191_hash_message, Address, Signature, B256};
 use alloy_rpc_types_eth::TransactionRequest;
 use alloy_signer::SignerSync;
@@ -65,7 +65,9 @@ impl DevSigner {
 }
 
 #[async_trait::async_trait]
-impl<T: Decodable2718> EthSigner<T> for DevSigner {
+impl<T: Decodable2718, N: alloy_network::Network, TxReq: TransactionBuilder<N>> EthSigner<T>
+    for DevSigner
+{
     fn accounts(&self) -> Vec<Address> {
         self.addresses.clone()
     }
@@ -81,7 +83,7 @@ impl<T: Decodable2718> EthSigner<T> for DevSigner {
         self.sign_hash(hash, address)
     }
 
-    async fn sign_transaction(&self, request: TransactionRequest, address: &Address) -> Result<T> {
+    async fn sign_transaction(&self, request: TxReq, address: &Address) -> Result<T> {
         // create local signer wallet from signing key
         let signer = self.accounts.get(address).ok_or(SignError::NoAccount)?.clone();
         let wallet = EthereumWallet::from(signer);

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -9,6 +9,7 @@ use alloy_network::{eip2718::Encodable2718, EthereumWallet, TransactionBuilder};
 use alloy_primitives::{eip191_hash_message, Address, Signature, B256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::helpers::{signer::Result, AddDevSigners, EthSigner};
 use reth_rpc_eth_types::SignError;
 use reth_storage_api::BlockReader;
@@ -17,6 +18,7 @@ impl<Provider, Pool, Network, EvmConfig> AddDevSigners
     for EthApi<Provider, Pool, Network, EvmConfig>
 where
     Provider: BlockReader,
+    Network: RpcTypes,
 {
     fn with_dev_accounts(&self) {
         *self.inner.signers().write() = DevSigner::random_signers(20)

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -9,17 +9,16 @@ use alloy_network::{eip2718::Encodable2718, EthereumWallet, NetworkWallet, Trans
 use alloy_primitives::{eip191_hash_message, Address, Signature, B256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::helpers::{signer::Result, AddDevSigners, EthSigner};
 use reth_rpc_eth_types::SignError;
 use reth_storage_api::BlockReader;
 
-impl<Provider, Pool, Network, EvmConfig> AddDevSigners
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, Rpc> AddDevSigners
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReader,
-    Network: alloy_network::Network,
-    EthereumWallet: NetworkWallet<Network>,
+    Rpc: alloy_network::Network,
+    EthereumWallet: NetworkWallet<Rpc>,
 {
     fn with_dev_accounts(&self) {
         *self.inner.signers().write() = DevSigner::random_signers(20)

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -5,9 +5,8 @@ use std::collections::HashMap;
 use crate::EthApi;
 use alloy_dyn_abi::TypedData;
 use alloy_eips::eip2718::Decodable2718;
-use alloy_network::{eip2718::Encodable2718, Ethereum, EthereumWallet, TransactionBuilder};
+use alloy_network::{eip2718::Encodable2718, EthereumWallet, TransactionBuilder};
 use alloy_primitives::{eip191_hash_message, Address, Signature, B256};
-use alloy_rpc_types_eth::TransactionRequest;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use reth_rpc_eth_api::helpers::{signer::Result, AddDevSigners, EthSigner};
@@ -65,8 +64,8 @@ impl DevSigner {
 }
 
 #[async_trait::async_trait]
-impl<T: Decodable2718, N: alloy_network::Network, TxReq: TransactionBuilder<N>> EthSigner<T>
-    for DevSigner
+impl<T: Decodable2718, N: alloy_network::Network, TxReq: TransactionBuilder<N>>
+    EthSigner<T, N, TxReq> for DevSigner
 {
     fn accounts(&self) -> Vec<Address> {
         self.addresses.clone()
@@ -111,7 +110,7 @@ mod tests {
     use super::*;
     use alloy_consensus::Transaction;
     use alloy_primitives::{Bytes, U256};
-    use alloy_rpc_types_eth::TransactionInput;
+    use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
     use reth_ethereum_primitives::TransactionSigned;
     use revm_primitives::TxKind;
 

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,6 +1,8 @@
+use alloy_network::Ethereum;
 use alloy_primitives::U256;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_network_api::NetworkInfo;
+use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{helpers::EthApiSpec, RpcNodeCore};
 use reth_storage_api::{BlockNumReader, BlockReader, ProviderTx, StageCheckpointReader};
 
@@ -17,6 +19,7 @@ where
     Provider: BlockReader,
 {
     type Transaction = ProviderTx<Provider>;
+    type Rpc = Ethereum;
 
     fn starting_block(&self) -> U256 {
         self.inner.starting_block()
@@ -24,8 +27,17 @@ where
 
     fn signers(
         &self,
-    ) -> &parking_lot::RwLock<Vec<Box<dyn reth_rpc_eth_api::helpers::EthSigner<Self::Transaction>>>>
-    {
+    ) -> &parking_lot::RwLock<
+        Vec<
+            Box<
+                dyn reth_rpc_eth_api::helpers::EthSigner<
+                    Self::Transaction,
+                    Self::Rpc,
+                    RpcTxReq<Self::Rpc>,
+                >,
+            >,
+        >,
+    > {
         self.inner.signers()
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -2,8 +2,10 @@ use alloy_network::Ethereum;
 use alloy_primitives::U256;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_network_api::NetworkInfo;
-use reth_rpc_convert::RpcTxReq;
-use reth_rpc_eth_api::{helpers::EthApiSpec, RpcNodeCore};
+use reth_rpc_eth_api::{
+    helpers::{spec::Signers, EthApiSpec},
+    RpcNodeCore,
+};
 use reth_storage_api::{BlockNumReader, BlockReader, ProviderTx, StageCheckpointReader};
 
 use crate::EthApi;
@@ -25,19 +27,7 @@ where
         self.inner.starting_block()
     }
 
-    fn signers(
-        &self,
-    ) -> &parking_lot::RwLock<
-        Vec<
-            Box<
-                dyn reth_rpc_eth_api::helpers::EthSigner<
-                    Self::Transaction,
-                    Self::Rpc,
-                    RpcTxReq<Self::Rpc>,
-                >,
-            >,
-        >,
-    > {
+    fn signers(&self) -> &Signers<Self> {
         self.inner.signers()
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -11,7 +11,7 @@ use reth_storage_api::{BlockNumReader, BlockReader, ProviderTx, StageCheckpointR
 use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> EthApiSpec
-    for EthApi<Provider, Pool, Network, EvmConfig, Self::Rpc>
+    for EthApi<Provider, Pool, Network, EvmConfig, Ethereum>
 where
     Self: RpcNodeCore<
         Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -2,7 +2,7 @@ use alloy_network::Ethereum;
 use alloy_primitives::U256;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_network_api::NetworkInfo;
-use reth_rpc_convert::RpcTypes;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{spec::Signers, EthApiSpec},
     RpcNodeCore,
@@ -11,7 +11,8 @@ use reth_storage_api::{BlockNumReader, BlockReader, ProviderTx, StageCheckpointR
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthApiSpec for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> EthApiSpec
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: RpcNodeCore<
         Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -2,7 +2,6 @@ use alloy_network::Ethereum;
 use alloy_primitives::U256;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_network_api::NetworkInfo;
-use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{spec::Signers, EthApiSpec},
     RpcNodeCore,
@@ -12,7 +11,7 @@ use reth_storage_api::{BlockNumReader, BlockReader, ProviderTx, StageCheckpointR
 use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig> EthApiSpec
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    for EthApi<Provider, Pool, Network, EvmConfig, Self::Rpc>
 where
     Self: RpcNodeCore<
         Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
@@ -21,7 +20,6 @@ where
         Network: NetworkInfo,
     >,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
     type Transaction = ProviderTx<Provider>;
     type Rpc = Ethereum;

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -3,7 +3,7 @@ use alloy_primitives::U256;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_network_api::NetworkInfo;
 use reth_rpc_eth_api::{
-    helpers::{spec::Signers, EthApiSpec},
+    helpers::{spec::SignersForApi, EthApiSpec},
     RpcNodeCore,
 };
 use reth_storage_api::{BlockNumReader, BlockReader, ProviderTx, StageCheckpointReader};
@@ -28,7 +28,7 @@ where
         self.inner.starting_block()
     }
 
-    fn signers(&self) -> &Signers<Self> {
+    fn signers(&self) -> &SignersForApi<Self> {
         self.inner.signers()
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -2,6 +2,7 @@ use alloy_network::Ethereum;
 use alloy_primitives::U256;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_network_api::NetworkInfo;
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::{
     helpers::{spec::Signers, EthApiSpec},
     RpcNodeCore,
@@ -19,6 +20,7 @@ where
         Network: NetworkInfo,
     >,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
     type Transaction = ProviderTx<Provider>;
     type Rpc = Ethereum;

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,7 +1,6 @@
 //! Contains RPC handler implementations specific to state.
 
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_storage_api::{BlockReader, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
@@ -12,20 +11,20 @@ use reth_rpc_eth_api::{
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthState
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, Rpc> EthState
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: LoadState + SpawnBlocking,
     Provider: BlockReader,
-    Network: RpcTypes,
+    Rpc: alloy_network::Network,
 {
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_proof_window()
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig> LoadState
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, Rpc> LoadState
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: RpcNodeCoreExt<
         Provider: BlockReader
@@ -34,7 +33,7 @@ where
         Pool: TransactionPool,
     >,
     Provider: BlockReader,
-    Network: RpcTypes,
+    Rpc: alloy_network::Network,
 {
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,6 +1,7 @@
 //! Contains RPC handler implementations specific to state.
 
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_rpc_convert::RpcTypes;
 use reth_storage_api::{BlockReader, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
@@ -16,7 +17,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> EthState
 where
     Self: LoadState + SpawnBlocking,
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_proof_window()
@@ -33,7 +34,7 @@ where
             Pool: TransactionPool,
         > + EthApiTypes<NetworkTypes = Rpc>,
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -6,7 +6,7 @@ use reth_transaction_pool::TransactionPool;
 
 use reth_rpc_eth_api::{
     helpers::{EthState, LoadState, SpawnBlocking},
-    RpcNodeCoreExt,
+    EthApiTypes, RpcNodeCoreExt,
 };
 
 use crate::EthApi;
@@ -27,11 +27,11 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> LoadState
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: RpcNodeCoreExt<
-        Provider: BlockReader
-                      + StateProviderFactory
-                      + ChainSpecProvider<ChainSpec: EthereumHardforks>,
-        Pool: TransactionPool,
-    >,
+            Provider: BlockReader
+                          + StateProviderFactory
+                          + ChainSpecProvider<ChainSpec: EthereumHardforks>,
+            Pool: TransactionPool,
+        > + EthApiTypes<NetworkTypes = Rpc>,
     Provider: BlockReader,
     Rpc: alloy_network::Network,
 {
@@ -42,8 +42,8 @@ mod tests {
     use super::*;
     use alloy_consensus::Header;
     use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
+    use alloy_network::Ethereum;
     use alloy_primitives::{Address, StorageKey, StorageValue, U256};
-    use alloy_rpc_types_eth::TransactionRequest;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider, NoopProvider};
@@ -58,8 +58,7 @@ mod tests {
     use reth_transaction_pool::test_utils::{testing_pool, TestPool};
     use std::collections::HashMap;
 
-    fn noop_eth_api(
-    ) -> EthApi<NoopProvider, TestPool, NoopNetwork, EthEvmConfig, TransactionRequest> {
+    fn noop_eth_api() -> EthApi<NoopProvider, TestPool, NoopNetwork, EthEvmConfig, Ethereum> {
         let pool = testing_pool();
         let evm_config = EthEvmConfig::mainnet();
 
@@ -82,7 +81,7 @@ mod tests {
 
     fn mock_eth_api(
         accounts: HashMap<Address, ExtendedAccount>,
-    ) -> EthApi<MockEthProvider, TestPool, (), EthEvmConfig, TransactionRequest> {
+    ) -> EthApi<MockEthProvider, TestPool, (), EthEvmConfig, Ethereum> {
         let pool = testing_pool();
         let mock_provider = MockEthProvider::default();
 

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,6 +1,7 @@
 //! Contains RPC handler implementations specific to state.
 
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_rpc_convert::RpcTypes;
 use reth_storage_api::{BlockReader, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
@@ -15,6 +16,7 @@ impl<Provider, Pool, Network, EvmConfig> EthState for EthApi<Provider, Pool, Net
 where
     Self: LoadState + SpawnBlocking,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_proof_window()
@@ -30,6 +32,7 @@ where
         Pool: TransactionPool,
     >,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,7 +1,7 @@
 //! Contains RPC handler implementations specific to state.
 
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_rpc_convert::RpcTypes;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_storage_api::{BlockReader, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
@@ -12,7 +12,8 @@ use reth_rpc_eth_api::{
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> EthState for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> EthState
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadState + SpawnBlocking,
     Provider: BlockReader,
@@ -23,7 +24,8 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig> LoadState for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> LoadState
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: RpcNodeCoreExt<
         Provider: BlockReader
@@ -42,6 +44,7 @@ mod tests {
     use alloy_consensus::Header;
     use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use alloy_primitives::{Address, StorageKey, StorageValue, U256};
+    use alloy_rpc_types_eth::TransactionRequest;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider, NoopProvider};
@@ -56,7 +59,8 @@ mod tests {
     use reth_transaction_pool::test_utils::{testing_pool, TestPool};
     use std::collections::HashMap;
 
-    fn noop_eth_api() -> EthApi<NoopProvider, TestPool, NoopNetwork, EthEvmConfig> {
+    fn noop_eth_api(
+    ) -> EthApi<NoopProvider, TestPool, NoopNetwork, EthEvmConfig, TransactionRequest> {
         let pool = testing_pool();
         let evm_config = EthEvmConfig::mainnet();
 
@@ -79,7 +83,7 @@ mod tests {
 
     fn mock_eth_api(
         accounts: HashMap<Address, ExtendedAccount>,
-    ) -> EthApi<MockEthProvider, TestPool, (), EthEvmConfig> {
+    ) -> EthApi<MockEthProvider, TestPool, (), EthEvmConfig, TransactionRequest> {
         let pool = testing_pool();
         let mock_provider = MockEthProvider::default();
 

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -2,7 +2,7 @@
 
 use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
-use reth_rpc_convert::RpcTypes;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{LoadState, Trace},
     FromEvmError,
@@ -11,7 +11,8 @@ use reth_storage_api::{BlockReader, ProviderHeader, ProviderTx};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig> Trace
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadState<
         Provider: BlockReader,

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -2,6 +2,7 @@
 
 use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::{
     helpers::{LoadState, Trace},
     FromEvmError,
@@ -23,5 +24,6 @@ where
         Error: FromEvmError<Self::Evm>,
     >,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -2,6 +2,7 @@
 
 use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::{
     helpers::{LoadState, Trace},
     FromEvmError,
@@ -24,6 +25,6 @@ where
         Error: FromEvmError<Self::Evm>,
     >,
     Provider: BlockReader,
-    Rpc: alloy_network::Network,
+    Rpc: RpcTypes,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -24,5 +24,6 @@ where
         Error: FromEvmError<Self::Evm>,
     >,
     Provider: BlockReader,
+    Rpc: alloy_network::Network,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -2,7 +2,6 @@
 
 use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
-use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{LoadState, Trace},
     FromEvmError,
@@ -11,8 +10,8 @@ use reth_storage_api::{BlockReader, ProviderHeader, ProviderTx};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig> Trace
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+impl<Provider, Pool, Network, EvmConfig, Rpc> Trace
+    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: LoadState<
         Provider: BlockReader,
@@ -25,6 +24,5 @@ where
         Error: FromEvmError<Self::Evm>,
     >,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -12,7 +12,7 @@ use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderTx, TransactionsPr
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 
 impl<Provider, Pool, Network, EvmConfig> EthTransactions
-    for EthApi<Provider, Pool, Network, EvmConfig>
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt>,
     Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
@@ -58,12 +58,13 @@ where
 }
 
 impl<Provider, Pool, Network, EvmConfig> LoadTransaction
-    for EthApi<Provider, Pool, Network, EvmConfig>
+    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
 where
     Self: SpawnBlocking
         + FullEthApiTypes
         + RpcNodeCoreExt<Provider: TransactionsProvider, Pool: TransactionPool>,
     Provider: BlockReader,
+    Network: RpcTypes,
 {
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -2,7 +2,7 @@
 
 use crate::EthApi;
 use alloy_primitives::{Bytes, B256};
-use reth_rpc_convert::RpcTxReq;
+use reth_rpc_convert::{RpcTxReq, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
     FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
@@ -16,6 +16,7 @@ impl<Provider, Pool, Network, EvmConfig> EthTransactions
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt>,
     Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
+    Network: RpcTypes,
 {
     #[inline]
     fn signers(

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -2,6 +2,7 @@
 
 use crate::EthApi;
 use alloy_primitives::{Bytes, B256};
+use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
     FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
@@ -17,7 +18,19 @@ where
     Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
 {
     #[inline]
-    fn signers(&self) -> &parking_lot::RwLock<Vec<Box<dyn EthSigner<ProviderTx<Self::Provider>>>>> {
+    fn signers(
+        &self,
+    ) -> &parking_lot::RwLock<
+        Vec<
+            Box<
+                dyn EthSigner<
+                    ProviderTx<Self::Provider>,
+                    Self::NetworkTypes,
+                    RpcTxReq<Self::NetworkTypes>,
+                >,
+            >,
+        >,
+    > {
         self.inner.signers()
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -2,7 +2,7 @@
 
 use crate::EthApi;
 use alloy_primitives::{Bytes, B256};
-use reth_rpc_convert::{RpcTxReq, RpcTypes};
+use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
     FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
@@ -12,11 +12,10 @@ use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderTx, TransactionsPr
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 
 impl<Provider, Pool, Network, EvmConfig> EthTransactions
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    for EthApi<Provider, Pool, Network, EvmConfig, Self::NetworkTypes>
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt>,
     Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
-    Network: RpcTypes,
 {
     #[inline]
     fn signers(
@@ -58,13 +57,12 @@ where
 }
 
 impl<Provider, Pool, Network, EvmConfig> LoadTransaction
-    for EthApi<Provider, Pool, Network, EvmConfig, RpcTxReq<Network>>
+    for EthApi<Provider, Pool, Network, EvmConfig, Self::NetworkTypes>
 where
     Self: SpawnBlocking
         + FullEthApiTypes
         + RpcNodeCoreExt<Provider: TransactionsProvider, Pool: TransactionPool>,
     Provider: BlockReader,
-    Network: RpcTypes,
 {
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -1,11 +1,10 @@
 //! Contains RPC handler implementations specific to transactions
 
 use crate::EthApi;
-use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256};
-use reth_rpc_convert::{RpcTxReq, RpcTypes};
+use reth_rpc_convert::RpcTypes;
 use reth_rpc_eth_api::{
-    helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
+    helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction, SpawnBlocking},
     EthApiTypes, FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
 };
 use reth_rpc_eth_types::utils::recover_raw_transaction;
@@ -17,22 +16,10 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> EthTransactions
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt> + EthApiTypes<NetworkTypes = Rpc>,
     Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
-    Rpc: alloy_network::Network + RpcTypes<TransactionRequest: TransactionBuilder<Rpc>>,
+    Rpc: RpcTypes,
 {
     #[inline]
-    fn signers(
-        &self,
-    ) -> &parking_lot::RwLock<
-        Vec<
-            Box<
-                dyn EthSigner<
-                    ProviderTx<Self::Provider>,
-                    Self::NetworkTypes,
-                    RpcTxReq<Self::NetworkTypes>,
-                >,
-            >,
-        >,
-    > {
+    fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.signers()
     }
 
@@ -66,7 +53,7 @@ where
         + RpcNodeCoreExt<Provider: TransactionsProvider, Pool: TransactionPool>
         + EthApiTypes<NetworkTypes = Rpc>,
     Provider: BlockReader,
-    Rpc: alloy_network::Network + RpcTypes<TransactionRequest: TransactionBuilder<Rpc>>,
+    Rpc: RpcTypes,
 {
 }
 

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -54,6 +54,7 @@ pub use miner::MinerApi;
 pub use net::NetApi;
 pub use otterscan::OtterscanApi;
 pub use reth::RethApi;
+pub use reth_rpc_convert::RpcTypes;
 pub use rpc::RPCApi;
 pub use trace::TraceApi;
 pub use txpool::TxPoolApi;

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -4,7 +4,6 @@ use alloy_evm::block::calc::{base_block_reward_pre_merge, block_reward, ommer_re
 use alloy_primitives::{map::HashSet, Bytes, B256, U256};
 use alloy_rpc_types_eth::{
     state::{EvmOverrides, StateOverride},
-    transaction::TransactionRequest,
     BlockOverrides, Index,
 };
 use alloy_rpc_types_trace::{
@@ -569,7 +568,7 @@ where
 }
 
 #[async_trait]
-impl<Eth> TraceApiServer for TraceApi<Eth>
+impl<Eth> TraceApiServer<RpcTxReq<Eth::NetworkTypes>> for TraceApi<Eth>
 where
     Eth: TraceExt + 'static,
 {
@@ -578,7 +577,7 @@ where
     /// Handler for `trace_call`
     async fn trace_call(
         &self,
-        call: TransactionRequest,
+        call: RpcTxReq<Eth::NetworkTypes>,
         trace_types: HashSet<TraceType>,
         block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
@@ -593,7 +592,7 @@ where
     /// Handler for `trace_callMany`
     async fn trace_call_many(
         &self,
-        calls: Vec<(TransactionRequest, HashSet<TraceType>)>,
+        calls: Vec<(RpcTxReq<Eth::NetworkTypes>, HashSet<TraceType>)>,
         block_id: Option<BlockId>,
     ) -> RpcResult<Vec<TraceResults>> {
         let _permit = self.acquire_trace_permit().await;

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -20,6 +20,7 @@ use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{BlockBody, BlockHeader};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};
 use reth_rpc_api::TraceApiServer;
+use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{Call, LoadPendingBlock, LoadTransaction, Trace, TraceExt},
     FromEthApiError, RpcNodeCore,
@@ -87,7 +88,7 @@ where
     /// Executes the given call and returns a number of possible traces for it.
     pub async fn trace_call(
         &self,
-        trace_request: TraceCallRequest,
+        trace_request: TraceCallRequest<RpcTxReq<Eth::NetworkTypes>>,
     ) -> Result<TraceResults, Eth::Error> {
         let at = trace_request.block_id.unwrap_or_default();
         let config = TracingInspectorConfig::from_parity_config(&trace_request.trace_types);
@@ -142,7 +143,7 @@ where
     /// Note: Allows tracing dependent transactions, hence all transactions are traced in sequence
     pub async fn trace_call_many(
         &self,
-        calls: Vec<(TransactionRequest, HashSet<TraceType>)>,
+        calls: Vec<(RpcTxReq<Eth::NetworkTypes>, HashSet<TraceType>)>,
         block_id: Option<BlockId>,
     ) -> Result<Vec<TraceResults>, Eth::Error> {
         let at = block_id.unwrap_or(BlockId::pending());

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -105,6 +105,7 @@ serde-bincode-compat = [
     "alloy-consensus/serde-bincode-compat",
     "dep:serde_with",
     "alloy-genesis/serde-bincode-compat",
+    "alloy-rpc-types-eth?/serde-bincode-compat",
 ]
 test-utils = [
     "dep:plain_hasher",


### PR DESCRIPTION
Closes #17051

Depends on `alloy` features alloy-rs/alloy#2622 alloy-rs/alloy#2623 alloy-rs/alloy#2624 alloy-rs/alloy#2631 alloy-rs/alloy#2662 alloy-rs/alloy#2674 alloy-rs/alloy#2677

The work so far associated with #15117 paved a road to implement the generic input transaction request type that is introduced here.

This allows for custom RPC request bodies in custom nodes while reusing all the default components. To make this possible a `TransactionBuilder` trait is used as a bound for the generic transaction request type.