### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -67,7 +67,7 @@ There are many tables within the node, all used to store different types of data
 
 ## Database
 
-Reth's database design revolves around it's main [Database trait](https://github.com/paradigmxyz/reth/blob/bf9cac7571f018fec581fe3647862dab527aeafb/crates/storage/db-api/src/database.rs#L8-L52), which implements the database's functionality across many types. Let's take a quick look at the `Database` trait and how it works.
+Reth's database design revolves around its main [Database trait](https://github.com/paradigmxyz/reth/blob/bf9cac7571f018fec581fe3647862dab527aeafb/crates/storage/db-api/src/database.rs#L8-L52), which implements the database's functionality across many types. Let's take a quick look at the `Database` trait and how it works.
 
 [File: crates/storage/db-api/src/database.rs](https://github.com/paradigmxyz/reth/blob/bf9cac7571f018fec581fe3647862dab527aeafb/crates/storage/db-api/src/database.rs#L8-L52)
 

--- a/docs/design/goals.md
+++ b/docs/design/goals.md
@@ -34,7 +34,7 @@ Why? This is a win for everyone. RPC providers meet more impressive SLAs, MEV se
 
 The biggest bottleneck in this pipeline is not the execution of the EVM interpreter itself, but rather in accessing state and managing I/O. As such, we think the largest optimizations to be made are closest to the DB layer.
 
-Ideally, we can achieve such fast runtime operation that we can avoid storing certain things (e.g.?) on the disk, and are able to generate them on the fly, instead - minimizing disk footprint.
+Ideally, we can achieve such fast runtime operation that we can avoid storing certain things (e.g., transaction receipts) on the disk, and are able to generate them on the fly, instead - minimizing disk footprint.
 
 ---
 

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -2,7 +2,7 @@
 
 This repository contains several Rust crates that implement the different building blocks of an Ethereum node. The high-level structure of the repository is as follows:
 
-Generally reth is composed of a few components, with supporting crates. The main components can be defined as:
+Generally, reth is composed of a few components, with supporting crates. The main components can be defined as:
 
 - [Project Layout](#project-layout)
   - [Documentation](#documentation)


### PR DESCRIPTION
Fixed several typos found during a comprehensive scan of the docs folder:

- Changed "it's" to "its" (possessive) in `docs/crates/db.md`
- Completed incomplete example "(e.g.?)" to "(e.g., transaction receipts)" in `docs/design/goals.md`
- Added missing comma after "Generally" in `docs/repo/layout.md`

These are minor grammatical and punctuation corrections to improve documentation clarity.