### PR TITLE
fix: track earliest available block correctly

### DIFF
--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -346,14 +346,9 @@ impl<N: ProviderNodeTypes> BlockNumReader for ProviderFactory<N> {
     }
 
     fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
-        // expired height tracks the lowest block number that has been expired, therefore the
-        // earliest block number is one more than that.
-        let mut earliest = self.static_file_provider.expired_history_height();
-        if earliest > 0 {
-            // If the expired history height is 0, then the earliest block number is still 0.
-            earliest += 1;
-        }
-        Ok(earliest)
+        // earliest history height tracks the lowest block number that has __not__ been expired, in
+        // other words, the first/earlierst available block.
+        Ok(self.static_file_provider.earliest_history_height())
     }
 
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {


### PR DESCRIPTION
this logic is wrong and would always return the end block number of the lowest static file.

e.g. if nothing was expired this would return 500k because the first file includes 0..499k

fixed by tracking the entire range of the lowest file instead