### PR TITLE
feat: add graph selection option to newpayload latency comparison script

### DIFF
--- a/bin/reth-bench/scripts/compare_newpayload_latency.py
+++ b/bin/reth-bench/scripts/compare_newpayload_latency.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.8"
 # dependencies = [
 #     "pandas",
-#     "matplotlib", 
+#     "matplotlib",
 #     "numpy",
 # ]
 # ///
@@ -29,8 +29,20 @@ def main():
     parser.add_argument('baseline_csv', help='First CSV file, used as the baseline/control')
     parser.add_argument('comparison_csv', help='Second CSV file, which is being compared to the baseline')
     parser.add_argument('-o', '--output', default='latency.png', help='Output image file (default: latency.png)')
+    parser.add_argument('--graphs', default='all', help='Comma-separated list of graphs to plot: histogram, line, all (default: all)')
 
     args = parser.parse_args()
+
+    # Parse graph selection
+    if args.graphs.lower() == 'all':
+        selected_graphs = {'histogram', 'line'}
+    else:
+        selected_graphs = set(graph.strip().lower() for graph in args.graphs.split(','))
+        valid_graphs = {'histogram', 'line'}
+        invalid_graphs = selected_graphs - valid_graphs
+        if invalid_graphs:
+            print(f"Error: Invalid graph types: {', '.join(invalid_graphs)}. Valid options are: histogram, line, all", file=sys.stderr)
+            sys.exit(1)
 
     try:
         df1 = pd.read_csv(args.baseline_csv)
@@ -70,54 +82,86 @@ def main():
         print("Error: No valid percent differences could be calculated", file=sys.stderr)
         sys.exit(1)
 
-    # Create histogram with 1% buckets
-    min_diff = np.floor(percent_diff.min())
-    max_diff = np.ceil(percent_diff.max())
-
-    bins = np.arange(min_diff, max_diff + 1, 1)
-
-    # Create figure with two subplots
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 12))
-
-    # Top subplot: Histogram
-    ax1.hist(percent_diff, bins=bins, edgecolor='black', alpha=0.7)
-    ax1.set_xlabel('Percent Difference (%)')
-    ax1.set_ylabel('Number of Blocks')
-    ax1.set_title(f'Total Latency Percent Difference Histogram\n({args.baseline_csv} vs {args.comparison_csv})')
-    ax1.grid(True, alpha=0.3)
-
-    # Add statistics to the histogram
+    # Calculate statistics once for use in graphs and output
     mean_diff = np.mean(percent_diff)
     median_diff = np.median(percent_diff)
-    ax1.axvline(mean_diff, color='red', linestyle='--', label=f'Mean: {mean_diff:.2f}%')
-    ax1.axvline(median_diff, color='orange', linestyle='--', label=f'Median: {median_diff:.2f}%')
-    ax1.legend()
 
-    # Bottom subplot: Latency vs Block Number
-    if 'block_number' in df1.columns and 'block_number' in df2.columns:
-        block_numbers = df1['block_number'].values[:len(percent_diff)]
-        ax2.plot(block_numbers, latency1[:len(percent_diff)], 'b-', alpha=0.7, label=f'Baseline ({args.baseline_csv})')
-        ax2.plot(block_numbers, latency2[:len(percent_diff)], 'r-', alpha=0.7, label=f'Comparison ({args.comparison_csv})')
-        ax2.set_xlabel('Block Number')
-        ax2.set_ylabel('Total Latency (ms)')
-        ax2.set_title('Total Latency vs Block Number')
-        ax2.grid(True, alpha=0.3)
-        ax2.legend()
+    # Determine number of subplots and create figure
+    num_plots = len(selected_graphs)
+    if num_plots == 0:
+        print("Error: No valid graphs selected", file=sys.stderr)
+        sys.exit(1)
+
+    if num_plots == 1:
+        fig, ax = plt.subplots(1, 1, figsize=(12, 6))
+        axes = [ax]
     else:
-        # If no block_number column, use index
-        indices = np.arange(len(percent_diff))
-        ax2.plot(indices, latency1[:len(percent_diff)], 'b-', alpha=0.7, label=f'Baseline ({args.baseline_csv})')
-        ax2.plot(indices, latency2[:len(percent_diff)], 'r-', alpha=0.7, label=f'Comparison ({args.comparison_csv})')
-        ax2.set_xlabel('Block Index')
-        ax2.set_ylabel('Total Latency (ms)')
-        ax2.set_title('Total Latency vs Block Index')
-        ax2.grid(True, alpha=0.3)
-        ax2.legend()
+        fig, axes = plt.subplots(num_plots, 1, figsize=(12, 6 * num_plots))
+
+    plot_idx = 0
+
+    # Plot histogram if selected
+    if 'histogram' in selected_graphs:
+        min_diff = np.floor(percent_diff.min())
+        max_diff = np.ceil(percent_diff.max())
+
+        # Create histogram with 1% buckets
+        bins = np.arange(min_diff, max_diff + 1, 1)
+
+        ax = axes[plot_idx]
+        ax.hist(percent_diff, bins=bins, edgecolor='black', alpha=0.7)
+        ax.set_xlabel('Percent Difference (%)')
+        ax.set_ylabel('Number of Blocks')
+        ax.set_title(f'Total Latency Percent Difference Histogram\n({args.baseline_csv} vs {args.comparison_csv})')
+        ax.grid(True, alpha=0.3)
+
+        # Add statistics to the histogram
+        ax.axvline(mean_diff, color='red', linestyle='--', label=f'Mean: {mean_diff:.2f}%')
+        ax.axvline(median_diff, color='orange', linestyle='--', label=f'Median: {median_diff:.2f}%')
+        ax.legend()
+        plot_idx += 1
+
+    # Plot line graph if selected
+    if 'line' in selected_graphs:
+        # Determine comparison color based on median change. The median being
+        # negative means processing time got faster, so that becomes green.
+        comparison_color = 'green' if median_diff < 0 else 'red'
+
+        ax = axes[plot_idx]
+        if 'block_number' in df1.columns and 'block_number' in df2.columns:
+            block_numbers = df1['block_number'].values[:len(percent_diff)]
+            ax.plot(block_numbers, latency1[:len(percent_diff)], 'orange', alpha=0.7, label=f'Baseline ({args.baseline_csv})')
+            ax.plot(block_numbers, latency2[:len(percent_diff)], comparison_color, alpha=0.7, label=f'Comparison ({args.comparison_csv})')
+            ax.set_xlabel('Block Number')
+            ax.set_ylabel('Total Latency (ms)')
+            ax.set_title('Total Latency vs Block Number')
+            ax.grid(True, alpha=0.3)
+            ax.legend()
+        else:
+            # If no block_number column, use index
+            indices = np.arange(len(percent_diff))
+            ax.plot(indices, latency1[:len(percent_diff)], 'orange', alpha=0.7, label=f'Baseline ({args.baseline_csv})')
+            ax.plot(indices, latency2[:len(percent_diff)], comparison_color, alpha=0.7, label=f'Comparison ({args.comparison_csv})')
+            ax.set_xlabel('Block Index')
+            ax.set_ylabel('Total Latency (ms)')
+            ax.set_title('Total Latency vs Block Index')
+            ax.grid(True, alpha=0.3)
+            ax.legend()
+        plot_idx += 1
 
     plt.tight_layout()
     plt.savefig(args.output, dpi=300, bbox_inches='tight')
-    print(f"Histogram and latency graph saved to {args.output}")
 
+    # Create graph type description for output message
+    graph_types = []
+    if 'histogram' in selected_graphs:
+        graph_types.append('histogram')
+    if 'line' in selected_graphs:
+        graph_types.append('latency graph')
+    graph_desc = ' and '.join(graph_types)
+    print(f"{graph_desc.capitalize()} saved to {args.output}")
+
+    # Always print statistics
     print(f"\nStatistics:")
     print(f"Mean percent difference: {mean_diff:.2f}%")
     print(f"Median percent difference: {median_diff:.2f}%")


### PR DESCRIPTION
Allow users to choose which graphs to generate when comparing newpayload latency between different reth versions. The `--graphs` option accepts:
- `histogram` - shows distribution of percent differences
- `line` - shows latency over time/block number
- `all` - generates both graphs (default behavior)

**Additional improvements:**
- Dynamic color coding for comparison line (green if faster, red if slower)
- Changed baseline color from blue to orange for better contrast