### PR TITLE
feat: Add StatelessTrie trait for `reth-stateless`

### DIFF
--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -42,6 +42,7 @@ pub mod trie;
 pub use trie::StatelessTrieTrait;
 #[doc(inline)]
 pub use validation::stateless_validation_with_trie;
+
 /// Implementation of stateless validation
 pub mod validation;
 pub(crate) mod witness_db;

--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -39,7 +39,7 @@ extern crate alloc;
 pub mod trie;
 
 #[doc(inline)]
-pub use trie::StatelessTrieTrait;
+pub use trie::StatelessTrie;
 #[doc(inline)]
 pub use validation::stateless_validation_with_trie;
 

--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -37,6 +37,11 @@ extern crate alloc;
 
 /// Sparse trie implementation for stateless validation
 pub mod trie;
+
+#[doc(inline)]
+pub use trie::StatelessTrieTrait;
+#[doc(inline)]
+pub use validation::stateless_validation_with_trie;
 /// Implementation of stateless validation
 pub mod validation;
 pub(crate) mod witness_db;

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -14,7 +14,7 @@ use reth_trie_sparse::{
 };
 
 /// Trait for stateless trie implementations that can be used for stateless validation.
-pub trait StatelessTrieTrait: core::fmt::Debug {
+pub trait StatelessTrie: core::fmt::Debug {
     /// Initialize the stateless trie using the `ExecutionWitness`
     fn new(
         witness: &ExecutionWitness,
@@ -42,13 +42,13 @@ pub trait StatelessTrieTrait: core::fmt::Debug {
     ) -> Result<B256, StatelessValidationError>;
 }
 
-/// `StatelessTrie` structure for usage during stateless validation
+/// `StatelessSparseTrie` structure for usage during stateless validation
 #[derive(Debug)]
-pub struct StatelessTrie {
+pub struct StatelessSparseTrie {
     inner: SparseStateTrie,
 }
 
-impl StatelessTrie {
+impl StatelessSparseTrie {
     /// Initialize the stateless trie using the `ExecutionWitness`
     ///
     /// Note: Currently this method does not check that the `ExecutionWitness`
@@ -128,7 +128,7 @@ impl StatelessTrie {
     }
 }
 
-impl StatelessTrieTrait for StatelessTrie {
+impl StatelessTrie for StatelessSparseTrie {
     fn new(
         witness: &ExecutionWitness,
         pre_state_root: B256,

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -13,6 +13,35 @@ use reth_trie_sparse::{
     SparseTrie,
 };
 
+/// Trait for stateless trie implementations that can be used for stateless validation.
+pub trait StatelessTrieTrait: core::fmt::Debug {
+    /// Initialize the stateless trie using the `ExecutionWitness`
+    fn new(
+        witness: &ExecutionWitness,
+        pre_state_root: B256,
+    ) -> Result<(Self, B256Map<Bytecode>), StatelessValidationError>
+    where
+        Self: Sized;
+
+    /// Returns the `TrieAccount` that corresponds to the `Address`
+    ///
+    /// This method will error if the `ExecutionWitness` is not able to guarantee
+    /// that the account is missing from the Trie _and_ the witness was complete.
+    fn account(&self, address: Address) -> Result<Option<TrieAccount>, ProviderError>;
+
+    /// Returns the storage slot value that corresponds to the given (address, slot) tuple.
+    ///
+    /// This method will error if the `ExecutionWitness` is not able to guarantee
+    /// that the storage was missing from the Trie _and_ the witness was complete.
+    fn storage(&self, address: Address, slot: U256) -> Result<U256, ProviderError>;
+
+    /// Computes the new state root from the `HashedPostState`.
+    fn calculate_state_root(
+        &mut self,
+        state: HashedPostState,
+    ) -> Result<B256, StatelessValidationError>;
+}
+
 /// `StatelessTrie` structure for usage during stateless validation
 #[derive(Debug)]
 pub struct StatelessTrie {
@@ -96,6 +125,30 @@ impl StatelessTrie {
     ) -> Result<B256, StatelessValidationError> {
         calculate_state_root(&mut self.inner, state)
             .map_err(|_e| StatelessValidationError::StatelessStateRootCalculationFailed)
+    }
+}
+
+impl StatelessTrieTrait for StatelessTrie {
+    fn new(
+        witness: &ExecutionWitness,
+        pre_state_root: B256,
+    ) -> Result<(Self, B256Map<Bytecode>), StatelessValidationError> {
+        Self::new(witness, pre_state_root)
+    }
+
+    fn account(&self, address: Address) -> Result<Option<TrieAccount>, ProviderError> {
+        self.account(address)
+    }
+
+    fn storage(&self, address: Address, slot: U256) -> Result<U256, ProviderError> {
+        self.storage(address, slot)
+    }
+
+    fn calculate_state_root(
+        &mut self,
+        state: HashedPostState,
+    ) -> Result<B256, StatelessValidationError> {
+        self.calculate_state_root(state)
     }
 }
 

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    trie::{StatelessTrie, StatelessTrieTrait},
+    trie::{StatelessSparseTrie, StatelessTrie},
     witness_db::WitnessDatabase,
     ExecutionWitness,
 };
@@ -138,7 +138,7 @@ where
     ChainSpec: Send + Sync + EthChainSpec + EthereumHardforks + Debug,
     E: ConfigureEvm<Primitives = EthPrimitives> + Clone + 'static,
 {
-    stateless_validation_with_trie::<StatelessTrie, ChainSpec, E>(
+    stateless_validation_with_trie::<StatelessSparseTrie, ChainSpec, E>(
         current_block,
         witness,
         chain_spec,
@@ -146,10 +146,10 @@ where
     )
 }
 
-/// Performs stateless validation of a block using a custom `StatelessTrieTrait` implementation.
+/// Performs stateless validation of a block using a custom `StatelessTrie` implementation.
 ///
 /// This is a generic version of `stateless_validation` that allows users to provide their own
-/// implementation of the `StatelessTrieTrait` for custom trie backends or optimizations.
+/// implementation of the `StatelessTrie` for custom trie backends or optimizations.
 ///
 /// See `stateless_validation` for detailed documentation of the validation process.
 pub fn stateless_validation_with_trie<T, ChainSpec, E>(
@@ -159,7 +159,7 @@ pub fn stateless_validation_with_trie<T, ChainSpec, E>(
     evm_config: E,
 ) -> Result<B256, StatelessValidationError>
 where
-    T: StatelessTrieTrait,
+    T: StatelessTrie,
     ChainSpec: Send + Sync + EthChainSpec + EthereumHardforks + Debug,
     E: ConfigureEvm<Primitives = EthPrimitives> + Clone + 'static,
 {

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -201,7 +201,7 @@ where
     let (mut trie, bytecode) = T::new(&witness, pre_state_root)?;
 
     // Create an in-memory database that will use the reads to validate the block
-    let db = WitnessDatabase::new(&trie as &dyn StatelessTrieTrait, bytecode, ancestor_hashes);
+    let db = WitnessDatabase::new(&trie, bytecode, ancestor_hashes);
 
     // Execute the block
     let executor = evm_config.executor(db);

--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -55,7 +55,7 @@ where
     ///    to 256 including the current block number). It assumes these hashes correspond to a
     ///    contiguous chain of blocks. The caller is responsible for verifying the contiguity and
     ///    the block limit.
-    pub(crate) fn new(
+    pub(crate) const fn new(
         trie: &'a T,
         bytecode: B256Map<Bytecode>,
         ancestor_hashes: BTreeMap<u64, B256>,

--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -1,7 +1,7 @@
 //! Provides the [`WitnessDatabase`] type, an implementation of [`reth_revm::Database`]
 //! specifically designed for stateless execution environments.
 
-use crate::trie::StatelessTrie;
+use crate::trie::StatelessTrieTrait;
 use alloc::{collections::btree_map::BTreeMap, format};
 use alloy_primitives::{map::B256Map, Address, B256, U256};
 use reth_errors::ProviderError;
@@ -11,7 +11,7 @@ use reth_revm::{bytecode::Bytecode, state::AccountInfo, Database};
 ///
 /// This struct implements the [`reth_revm::Database`] trait, allowing the EVM to execute
 /// transactions using:
-///  - Account and storage slot data provided by a [`StatelessTrie`].
+///  - Account and storage slot data provided by a [`StatelessTrieTrait`] implementation.
 ///  - Bytecode and ancestor block hashes provided by in-memory maps.
 ///
 /// This is designed for stateless execution scenarios where direct access to a full node's
@@ -32,7 +32,7 @@ pub(crate) struct WitnessDatabase<'a> {
     /// TODO: Ideally we do not have this trie and instead a simple map.
     /// TODO: Then as a corollary we can avoid unnecessary hashing in `Database::storage`
     /// TODO: and `Database::basic` without needing to cache the hashed Addresses and Keys
-    trie: &'a StatelessTrie,
+    trie: &'a dyn StatelessTrieTrait,
 }
 
 impl<'a> WitnessDatabase<'a> {
@@ -49,8 +49,8 @@ impl<'a> WitnessDatabase<'a> {
     ///    to 256 including the current block number). It assumes these hashes correspond to a
     ///    contiguous chain of blocks. The caller is responsible for verifying the contiguity and
     ///    the block limit.
-    pub(crate) const fn new(
-        trie: &'a StatelessTrie,
+    pub(crate) fn new(
+        trie: &'a dyn StatelessTrieTrait,
         bytecode: B256Map<Bytecode>,
         ancestor_hashes: BTreeMap<u64, B256>,
     ) -> Self {
@@ -63,7 +63,7 @@ impl Database for WitnessDatabase<'_> {
     type Error = ProviderError;
 
     /// Get basic account information by hashing the address and looking up the account RLP
-    /// in the underlying [`StatelessTrie`].
+    /// in the underlying [`StatelessTrieTrait`] implementation.
     ///
     /// Returns `Ok(None)` if the account is not found in the trie.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {

--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -1,7 +1,7 @@
 //! Provides the [`WitnessDatabase`] type, an implementation of [`reth_revm::Database`]
 //! specifically designed for stateless execution environments.
 
-use crate::trie::StatelessTrieTrait;
+use crate::trie::StatelessTrie;
 use alloc::{collections::btree_map::BTreeMap, format};
 use alloy_primitives::{map::B256Map, Address, B256, U256};
 use reth_errors::ProviderError;
@@ -11,7 +11,7 @@ use reth_revm::{bytecode::Bytecode, state::AccountInfo, Database};
 ///
 /// This struct implements the [`reth_revm::Database`] trait, allowing the EVM to execute
 /// transactions using:
-///  - Account and storage slot data provided by a [`StatelessTrieTrait`] implementation.
+///  - Account and storage slot data provided by a [`StatelessTrie`] implementation.
 ///  - Bytecode and ancestor block hashes provided by in-memory maps.
 ///
 /// This is designed for stateless execution scenarios where direct access to a full node's
@@ -19,7 +19,7 @@ use reth_revm::{bytecode::Bytecode, state::AccountInfo, Database};
 #[derive(Debug)]
 pub(crate) struct WitnessDatabase<'a, T>
 where
-    T: StatelessTrieTrait,
+    T: StatelessTrie,
 {
     /// Map of block numbers to block hashes.
     /// This is used to service the `BLOCKHASH` opcode.
@@ -40,7 +40,7 @@ where
 
 impl<'a, T> WitnessDatabase<'a, T>
 where
-    T: StatelessTrieTrait,
+    T: StatelessTrie,
 {
     /// Creates a new [`WitnessDatabase`] instance.
     ///
@@ -66,13 +66,13 @@ where
 
 impl<T> Database for WitnessDatabase<'_, T>
 where
-    T: StatelessTrieTrait,
+    T: StatelessTrie,
 {
     /// The database error type.
     type Error = ProviderError;
 
     /// Get basic account information by hashing the address and looking up the account RLP
-    /// in the underlying [`StatelessTrieTrait`] implementation.
+    /// in the underlying [`StatelessTrie`] implementation.
     ///
     /// Returns `Ok(None)` if the account is not found in the trie.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {


### PR DESCRIPTION
The current implementation of SparseStateTrie has been shown to be in-efficient for zkVMs -- while this is the case, this PR creates a trait such that downstream users can switch out the trie while keeping all of the other logic