### PR TITLE
chore: pass provider into SparseTrie and SparseStateTrie via impl argument in update/remove_leaf

### DIFF
--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -7,7 +7,7 @@ use proptest::{prelude::*, test_runner::TestRunner};
 use rand::{seq::IteratorRandom, Rng};
 use reth_testing_utils::generators;
 use reth_trie::Nibbles;
-use reth_trie_sparse::RevealedSparseTrie;
+use reth_trie_sparse::{blinded::DefaultBlindedProvider, RevealedSparseTrie};
 
 fn update_rlp_node_level(c: &mut Criterion) {
     let mut rng = generators::rng();
@@ -22,10 +22,15 @@ fn update_rlp_node_level(c: &mut Criterion) {
             .current();
 
         // Create a sparse trie with `size` leaves
+        let provider = DefaultBlindedProvider;
         let mut sparse = RevealedSparseTrie::default();
         for (key, value) in &state {
             sparse
-                .update_leaf(Nibbles::unpack(key), alloy_rlp::encode_fixed_size(value).to_vec())
+                .update_leaf(
+                    Nibbles::unpack(key),
+                    alloy_rlp::encode_fixed_size(value).to_vec(),
+                    &provider,
+                )
                 .unwrap();
         }
         sparse.root();
@@ -39,6 +44,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
                     .update_leaf(
                         Nibbles::unpack(key),
                         alloy_rlp::encode_fixed_size(&rng.random::<U256>()).to_vec(),
+                        &provider,
                     )
                     .unwrap();
             }

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -13,7 +13,7 @@ use reth_trie::{
     HashedStorage,
 };
 use reth_trie_common::{HashBuilder, Nibbles};
-use reth_trie_sparse::SparseTrie;
+use reth_trie_sparse::{blinded::DefaultBlindedProvider, SparseTrie};
 
 fn calculate_root_from_leaves(c: &mut Criterion) {
     let mut group = c.benchmark_group("calculate root from leaves");
@@ -40,6 +40,7 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
         });
 
         // sparse trie
+        let provider = DefaultBlindedProvider;
         group.bench_function(BenchmarkId::new("sparse trie", size), |b| {
             b.iter_with_setup(SparseTrie::revealed_empty, |mut sparse| {
                 for (key, value) in &state {
@@ -47,6 +48,7 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
                         .update_leaf(
                             Nibbles::unpack(key),
                             alloy_rlp::encode_fixed_size(value).to_vec(),
+                            &provider,
                         )
                         .unwrap();
                 }
@@ -177,6 +179,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                 });
 
                 // sparse trie
+                let provider = DefaultBlindedProvider;
                 let benchmark_id = BenchmarkId::new(
                     "sparse trie",
                     format!(
@@ -192,6 +195,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     .update_leaf(
                                         Nibbles::unpack(key),
                                         alloy_rlp::encode_fixed_size(value).to_vec(),
+                                        &provider,
                                     )
                                     .unwrap();
                             }
@@ -205,6 +209,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                         .update_leaf(
                                             Nibbles::unpack(key),
                                             alloy_rlp::encode_fixed_size(value).to_vec(),
+                                            &provider,
                                         )
                                         .unwrap();
                                 }

--- a/crates/trie/sparse/benches/update.rs
+++ b/crates/trie/sparse/benches/update.rs
@@ -5,7 +5,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 use proptest::{prelude::*, strategy::ValueTree};
 use rand::seq::IteratorRandom;
 use reth_trie_common::Nibbles;
-use reth_trie_sparse::SparseTrie;
+use reth_trie_sparse::{blinded::DefaultBlindedProvider, SparseTrie};
 
 const LEAF_COUNTS: [usize; 2] = [1_000, 5_000];
 
@@ -16,10 +16,11 @@ fn update_leaf(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(leaf_count), |b| {
             let leaves = generate_leaves(leaf_count);
             // Start with an empty trie
+            let provider = DefaultBlindedProvider;
             let mut trie = SparseTrie::revealed_empty();
             // Pre-populate with data
             for (path, value) in leaves.iter().cloned() {
-                trie.update_leaf(path, value).unwrap();
+                trie.update_leaf(path, value, &provider).unwrap();
             }
 
             b.iter_batched(
@@ -41,7 +42,7 @@ fn update_leaf(c: &mut Criterion) {
                 },
                 |(mut trie, new_leaves)| {
                     for (path, new_value) in new_leaves {
-                        trie.update_leaf(*path, new_value).unwrap();
+                        trie.update_leaf(*path, new_value, &provider).unwrap();
                     }
                     trie
                 },
@@ -58,10 +59,11 @@ fn remove_leaf(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(leaf_count), |b| {
             let leaves = generate_leaves(leaf_count);
             // Start with an empty trie
+            let provider = DefaultBlindedProvider;
             let mut trie = SparseTrie::revealed_empty();
             // Pre-populate with data
             for (path, value) in leaves.iter().cloned() {
-                trie.update_leaf(path, value).unwrap();
+                trie.update_leaf(path, value, &provider).unwrap();
             }
 
             b.iter_batched(
@@ -76,7 +78,7 @@ fn remove_leaf(c: &mut Criterion) {
                 },
                 |(mut trie, delete_leaves)| {
                     for path in delete_leaves {
-                        trie.remove_leaf(path).unwrap();
+                        trie.remove_leaf(path, &provider).unwrap();
                     }
                     trie
                 },

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -40,7 +40,6 @@ pub struct SparseStateTrie {
     metrics: crate::metrics::SparseStateTrieMetrics,
 }
 
-#[cfg(test)]
 impl Default for SparseStateTrie {
     fn default() -> Self {
         Self {
@@ -65,18 +64,9 @@ impl SparseStateTrie {
 }
 
 impl SparseStateTrie {
-    /// Create new [`SparseStateTrie`] with blinded node provider factory.
+    /// Create new [`SparseStateTrie`]
     pub fn new() -> Self {
-        Self {
-            state: Default::default(),
-            storages: Default::default(),
-            revealed_account_paths: Default::default(),
-            revealed_storage_paths: Default::default(),
-            retain_updates: false,
-            account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
-            #[cfg(feature = "metrics")]
-            metrics: Default::default(),
-        }
+        Self::default()
     }
 
     /// Set the retention of branch node updates and deletions.

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -153,7 +153,7 @@ where
             ),
             tx,
         );
-        let mut sparse_trie = SparseStateTrie::new(blinded_provider_factory);
+        let mut sparse_trie = SparseStateTrie::new(blinded_provider_factory.clone());
         sparse_trie.reveal_multiproof(multiproof)?;
 
         // Attempt to update state trie to gather additional information for the witness.
@@ -161,6 +161,7 @@ where
             proof_targets.into_iter().sorted_unstable_by_key(|(ha, _)| *ha)
         {
             // Update storage trie first.
+            let provider = blinded_provider_factory.storage_node_provider(hashed_address);
             let storage = state.storages.get(&hashed_address);
             let storage_trie = sparse_trie.storage_trie_mut(&hashed_address).ok_or(
                 SparseStateTrieErrorKind::SparseStorageTrie(
@@ -176,11 +177,11 @@ where
                     .map(|v| alloy_rlp::encode_fixed_size(v).to_vec());
 
                 if let Some(value) = maybe_leaf_value {
-                    storage_trie.update_leaf(storage_nibbles, value).map_err(|err| {
+                    storage_trie.update_leaf(storage_nibbles, value, &provider).map_err(|err| {
                         SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())
                     })?;
                 } else {
-                    storage_trie.remove_leaf(&storage_nibbles).map_err(|err| {
+                    storage_trie.remove_leaf(&storage_nibbles, &provider).map_err(|err| {
                         SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())
                     })?;
                 }

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -153,7 +153,7 @@ where
             ),
             tx,
         );
-        let mut sparse_trie = SparseStateTrie::new(blinded_provider_factory.clone());
+        let mut sparse_trie = SparseStateTrie::new();
         sparse_trie.reveal_multiproof(multiproof)?;
 
         // Attempt to update state trie to gather additional information for the witness.
@@ -195,7 +195,7 @@ where
                 .get(&hashed_address)
                 .ok_or(TrieWitnessError::MissingAccount(hashed_address))?
                 .unwrap_or_default();
-            sparse_trie.update_account(hashed_address, account)?;
+            sparse_trie.update_account(hashed_address, account, &blinded_provider_factory)?;
 
             while let Ok(node) = rx.try_recv() {
                 self.witness.insert(keccak256(&node), node);


### PR DESCRIPTION
Working towards #17088

Only the `remove_leaf` and `update_leaf` methods of the RevealedSparseTrie actually use the Provider. This PR takes the Provider off the trie struct and passes it into those methods as an argument.

By not keeping the Provider on the trie itself it makes the trie into a pure datastructure, opening up our options in terms of re-using it across payloads.