### PR TITLE
docs: fix typo in section of node-components.mdx

### DIFF
--- a/docs/vocs/docs/pages/sdk/node-components.mdx
+++ b/docs/vocs/docs/pages/sdk/node-components.mdx
@@ -93,7 +93,7 @@ let node = NodeBuilder::new(config)
 
 ## Component Lifecycle
 
-Components follow a specific lifecycle startng from node builder initialization to shutdown:
+Components follow a specific lifecycle starting from node builder initialization to shutdown:
 
 1. **Initialization**: Components are created with their dependencies
 2. **Configuration**: Settings and parameters are applied


### PR DESCRIPTION


**Description:**
This pull request corrects a minor typo ("startng" → "starting") in the "Component Lifecycle" section of the node-components.mdx documentation.  
