### PR TITLE
refactor: move ERA import source creation to LaunchContext

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -964,7 +964,7 @@ where
         if !node_config.era.enabled {
             return None;
         }
-        
+
         EraImportSource::maybe_new(
             node_config.era.source.path.clone(),
             node_config.era.source.url.clone(),

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -25,7 +25,7 @@ use reth_invalid_block_hooks::InvalidBlockWitnessHook;
 use reth_network_p2p::headers::client::HeadersClient;
 use reth_node_api::{FullNodeTypes, NodeTypes, NodeTypesWithDB, NodeTypesWithDBAdapter};
 use reth_node_core::{
-    args::InvalidBlockHookType,
+    args::{DefaultEraHost, InvalidBlockHookType},
     dirs::{ChainPath, DataDirPath},
     node_config::NodeConfig,
     primitives::BlockHeader,
@@ -51,7 +51,10 @@ use reth_prune::{PruneModes, PrunerBuilder};
 use reth_rpc_api::clients::EthApiClient;
 use reth_rpc_builder::config::RethRpcServerConfig;
 use reth_rpc_layer::JwtSecret;
-use reth_stages::{sets::DefaultStages, MetricEvent, PipelineBuilder, PipelineTarget, StageId};
+use reth_stages::{
+    sets::DefaultStages, stages::EraImportSource, MetricEvent, PipelineBuilder, PipelineTarget,
+    StageId,
+};
 use reth_static_file::StaticFileProducer;
 use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::{debug, error, info, warn};
@@ -951,6 +954,23 @@ where
         )
         .launch()
         .await
+    }
+
+    /// Creates the ERA import source based on node configuration.
+    ///
+    /// Returns `Some(EraImportSource)` if ERA is enabled in the node config, otherwise `None`.
+    pub fn era_import_source(&self) -> Option<EraImportSource> {
+        let node_config = self.node_config();
+        if !node_config.era.enabled {
+            return None;
+        }
+        
+        EraImportSource::maybe_new(
+            node_config.era.source.path.clone(),
+            node_config.era.source.url.clone(),
+            || node_config.chain.chain().kind().default_era_host(),
+            || node_config.datadir().data_dir().join("era").into(),
+        )
     }
 }
 

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -152,12 +152,6 @@ where
 
         let consensus = Arc::new(ctx.components().consensus().clone());
 
-        // Configure the pipeline
-        let pipeline_exex_handle =
-            maybe_exex_manager_handle.clone().unwrap_or_else(ExExManagerHandle::empty);
-
-        let era_import_source = ctx.era_import_source();
-
         let pipeline = build_networked_pipeline(
             &ctx.toml_config().stages,
             network_client.clone(),
@@ -169,8 +163,8 @@ where
             max_block,
             static_file_producer,
             ctx.components().evm_config().clone(),
-            pipeline_exex_handle,
-            era_import_source,
+            maybe_exex_manager_handle.clone().unwrap_or_else(ExExManagerHandle::empty),
+            ctx.era_import_source(),
         )?;
 
         // The new engine writes directly to static files. This ensures that they're up to the tip.


### PR DESCRIPTION
Extract ERA import source creation logic from engine.rs into a dedicated method on LaunchContext.

## Summary

This PR improves code organization by encapsulating the ERA import configuration within the context that has access to the node configuration.

## Changes

- Added `era_import_source()` method to `LaunchContext` that creates the ERA import source based on node configuration
- The method returns early with `None` if ERA is not enabled
- Updated `engine.rs` to use the new method instead of inline creation
- Removed unused imports from `engine.rs`

This follows the same pattern as the ExEx launcher refactoring, moving configuration logic into the context where it has access to all required components.