### PR TITLE
refactor: make get_healthy_node_client async

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -249,7 +249,7 @@ where
             ctx.components().payload_builder_handle().clone(),
             engine_payload_validator,
             engine_tree_config,
-            ctx.invalid_block_hook()?,
+            ctx.invalid_block_hook().await?,
             ctx.sync_metrics_tx(),
             ctx.components().evm_config().clone(),
         );


### PR DESCRIPTION
Refactors `get_healthy_node_client` to be an async function, eliminating the need for `futures::executor::block_on`. 

Changes:
- Made `get_healthy_node_client` async
- Made `invalid_block_hook` async (since it calls `get_healthy_node_client`)
- Used the `let Some ... else` pattern for early return when no healthy node URL is configured
- Updated the call site in `engine.rs` to await the async call

This makes the code more idiomatic and consistent with other async methods in the codebase.