### PR TITLE
docs: add comprehensive documentation for LaunchContext type system

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1,4 +1,33 @@
 //! Helper types that can be used by launchers.
+//!
+//! ## Launch Context Type System
+//!
+//! The node launch process uses a type-state pattern to ensure correct initialization 
+//! order at compile time. Methods are only available when their prerequisites are met.
+//!
+//! ### Core Types
+//!
+//! - [`LaunchContext`]: Base context with executor and data directory
+//! - [`LaunchContextWith<T>`]: Context with an attached value of type `T`
+//! - [`Attached<L, R>`]: Pairs values, preserving both previous (L) and new (R) state
+//!
+//! ### Helper Attachments
+//!
+//! - [`WithConfigs`]: Node config + TOML config
+//! - [`WithMeteredProvider`]: Provider factory with metrics
+//! - [`WithMeteredProviders`]: Provider factory + blockchain provider  
+//! - [`WithComponents`]: Final form with all components
+//!
+//! ### Method Availability
+//!
+//! Methods are implemented on specific type combinations:
+//! - `impl<T> LaunchContextWith<T>`: Generic methods available for any attachment
+//! - `impl LaunchContextWith<WithConfigs>`: Config-specific methods
+//! - `impl LaunchContextWith<Attached<WithConfigs, DB>>`: Database operations
+//! - `impl LaunchContextWith<Attached<WithConfigs, ProviderFactory>>`: Provider operations
+//! - etc.
+//!
+//! This ensures correct initialization order without runtime checks.
 
 use crate::{
     components::{NodeComponents, NodeComponentsBuilder},
@@ -70,7 +99,22 @@ use reth_node_events::{cl::ConsensusLayerHealthEvents, node::NodeEvent};
 
 /// Reusable setup for launching a node.
 ///
-/// This provides commonly used boilerplate for launching a node.
+/// This is the entry point for the node launch process. It implements a builder
+/// pattern using type-state programming to enforce correct initialization order.
+///
+/// ## Type Evolution
+///
+/// Starting from `LaunchContext`, each method transforms the type to reflect
+/// accumulated state:
+///
+/// ```text
+/// LaunchContext
+///   └─> LaunchContextWith<WithConfigs>
+///       └─> LaunchContextWith<Attached<WithConfigs, DB>>
+///           └─> LaunchContextWith<Attached<WithConfigs, ProviderFactory>>
+///               └─> LaunchContextWith<Attached<WithConfigs, WithMeteredProviders>>
+///                   └─> LaunchContextWith<Attached<WithConfigs, WithComponents>>
+/// ```
 #[derive(Debug, Clone)]
 pub struct LaunchContext {
     /// The task executor for the node.
@@ -192,9 +236,14 @@ impl LaunchContext {
 
 /// A [`LaunchContext`] along with an additional value.
 ///
-/// This can be used to sequentially attach additional values to the type during the launch process.
+/// The type parameter `T` represents the current state of the launch process.
+/// Methods are conditionally implemented based on `T`, ensuring operations
+/// are only available when their prerequisites are met.
 ///
-/// The type provides common boilerplate for launching a node depending on the additional value.
+/// For example:
+/// - Config methods when `T = WithConfigs<ChainSpec>`
+/// - Database operations when `T = Attached<WithConfigs<ChainSpec>, DB>`
+/// - Provider operations when `T = Attached<WithConfigs<ChainSpec>, ProviderFactory<N>>`
 #[derive(Debug, Clone)]
 pub struct LaunchContextWith<T> {
     /// The wrapped launch context.
@@ -1074,7 +1123,11 @@ where
     }
 }
 
-/// Joins two attachments together.
+/// Joins two attachments together, preserving access to both values.
+///
+/// This type enables the launch process to accumulate state while maintaining
+/// access to all previously attached components. The `left` field holds the
+/// previous state, while `right` holds the newly attached component.
 #[derive(Clone, Copy, Debug)]
 pub struct Attached<L, R> {
     left: L,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Launch Context Type System
 //!
-//! The node launch process uses a type-state pattern to ensure correct initialization 
+//! The node launch process uses a type-state pattern to ensure correct initialization
 //! order at compile time. Methods are only available when their prerequisites are met.
 //!
 //! ### Core Types
@@ -15,7 +15,7 @@
 //!
 //! - [`WithConfigs`]: Node config + TOML config
 //! - [`WithMeteredProvider`]: Provider factory with metrics
-//! - [`WithMeteredProviders`]: Provider factory + blockchain provider  
+//! - [`WithMeteredProviders`]: Provider factory + blockchain provider
 //! - [`WithComponents`]: Final form with all components
 //!
 //! ### Method Availability


### PR DESCRIPTION
Documents the sophisticated type-state pattern used in the node launch process.

## Summary

The LaunchContext system uses a clever type-state pattern that wasn't well documented. This PR adds comprehensive documentation explaining how the system works and why it's designed this way.

## Key Documentation Added

1. **Module-level overview** explaining the core types and their relationships
2. **Type evolution documentation** showing how the context transforms through the launch process
3. **Explanation of the `Attached<L, R>` type** and how it enables state accumulation
4. **Clarification of conditional method availability** - methods only exist when prerequisites are met

## Benefits

- Makes the codebase more approachable for new contributors
- Explains the compile-time safety guarantees
- Documents the intended usage patterns
- Reduces duplication by consolidating explanations in one place

The type system enforces initialization order at compile time, preventing entire classes of runtime errors. This documentation makes that design intent clear.