### PR TITLE
polishing docs and comments

### DIFF
--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -44,7 +44,7 @@ pub enum EthSnapStreamError {
     StatusNotInHandshake,
 }
 
-/// Combined message type that include either eth or snao protocol messages
+/// Combined message type that include either eth or snap protocol messages
 #[derive(Debug)]
 pub enum EthSnapMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// An Ethereum protocol message

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -65,7 +65,7 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         }
     }
 
-    /// Returns  access to the underlying stream.
+    /// Returns access to the underlying stream.
     #[inline]
     pub(crate) const fn inner(&self) -> &P2PStream<ECIESStream<TcpStream>> {
         match self {


### PR DESCRIPTION
two fixes:

in _crates/net/eth-wire/src/eth_snap_stream.rs_
`snao` - `snap` - fix typo

in _crates/net/network/src/session/conn.rs_
`Returns__access` - `Returns _access` deleted double space