### PR TITLE
docs: fix broken tutorial link

### DIFF
--- a/docs/vocs/docs/pages/exex/remote.mdx
+++ b/docs/vocs/docs/pages/exex/remote.mdx
@@ -35,7 +35,7 @@ but some of specific to what we need now.
 
 We also added a build dependency for Tonic. We will use it to generate the Rust code for our
 Protobuf definitions at compile time. Read more about using Tonic in the
-[introductory tutorial](https://github.com/hyperium/tonic/blob/6a213e9485965db0628591e30577ed81cdaeaf2b/examples/helloworld-tutorial).
+[introductory tutorial](https://github.com/hyperium/tonic/blob/6a213e9485965db0628591e30577ed81cdaeaf2b/examples/helloworld-tutorial.md).
 
 Also, we now have two separate binaries:
 


### PR DESCRIPTION
Fixed 404 error by updating the Hyperium Tonic tutorial link with .md extension in docs/vocs/docs/pages/exex/remote.mdx.
This is a simple documentation fix to ensure the tutorial link remains accessible.