### PR TITLE
docs: fix installation source URL in ARM devices guide

### DIFF
--- a/docs/vocs/docs/pages/installation/build-for-arm-devices.mdx
+++ b/docs/vocs/docs/pages/installation/build-for-arm-devices.mdx
@@ -46,7 +46,7 @@ Some newer versions of ARM architecture offer support for Large Virtual Address 
 
 ## Build Reth
 
-If both your CPU architecture and the memory layout are valid, the instructions for building Reth will not differ from [the standard process](https://paradigmxyz.github.io/reth/installation/source).
+If both your CPU architecture and the memory layout are valid, the instructions for building Reth will not differ from [the standard process](https://reth.rs/installation/source/).
 
 ## Troubleshooting
 

--- a/docs/vocs/docs/pages/installation/build-for-arm-devices.mdx
+++ b/docs/vocs/docs/pages/installation/build-for-arm-devices.mdx
@@ -46,7 +46,7 @@ Some newer versions of ARM architecture offer support for Large Virtual Address 
 
 ## Build Reth
 
-If both your CPU architecture and the memory layout are valid, the instructions for building Reth will not differ from [the standard process](https://paradigmxyz.github.io/reth/installation/source.html).
+If both your CPU architecture and the memory layout are valid, the instructions for building Reth will not differ from [the standard process](https://paradigmxyz.github.io/reth/installation/source).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Removed .html extension from the installation source URL to match the current documentation structure. The updated link ensures proper redirection to the ARM build instructions.