### PR TITLE
docs: remove reference to ContextStatefulPrecompile in precompile cache example

### DIFF
--- a/examples/precompile-cache/src/main.rs
+++ b/examples/precompile-cache/src/main.rs
@@ -45,11 +45,9 @@ type PrecompileLRUCache = LruMap<(Bytes, u64), PrecompileResult>;
 
 /// A cache for precompile inputs / outputs.
 ///
-/// This assumes that the precompile is a standard precompile, as in `StandardPrecompileFn`, meaning
-/// its inputs are only `(Bytes, u64)`.
-///
-/// NOTE: This does not work with "context stateful precompiles", ie `ContextStatefulPrecompile` or
-/// `ContextStatefulPrecompileMut`. They are explicitly banned.
+/// This cache works with standard precompiles that take input data and gas limit as parameters.
+/// The cache key is composed of the input bytes and gas limit, and the cached value is the
+/// precompile execution result.
 #[derive(Debug)]
 pub struct PrecompileCache {
     /// Caches for each precompile input / output.


### PR DESCRIPTION
## Summary
- Remove outdated references to `ContextStatefulPrecompile` and `StandardPrecompileFn` in the precompile cache example
- Replace with more accurate documentation explaining how the cache works with standard precompiles
- Update comments to reflect current implementation without referencing removed revm types

## Changes
- Updated documentation in `examples/precompile-cache/src/main.rs` (lines 46-50)
- Removed mentions of deprecated `ContextStatefulPrecompile` and `StandardPrecompileFn` types
- Improved clarity of how the precompile cache functions

## Test plan
- [x] Verified example compiles successfully with `cargo check`
- [x] Confirmed documentation is more accurate and up-to-date

Fixes #17111

🤖 Generated with [Claude Code](https://claude.ai/code)