### PR TITLE
feat(optimism): add debug namespace endpoints to historical RPC forwarding

### DIFF
--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -136,16 +136,24 @@ where
 
         Box::pin(async move {
             let maybe_block_id = match req.method_name() {
-                "eth_getBlockByNumber" | "eth_getBlockByHash" => {
-                    parse_block_id_from_params(&req.params(), 0)
-                }
+                "eth_getBlockByNumber" |
+                "eth_getBlockByHash" |
+                "debug_traceBlockByNumber" |
+                "debug_traceBlockByHash" => parse_block_id_from_params(&req.params(), 0),
                 "eth_getBalance" |
                 "eth_getCode" |
                 "eth_getTransactionCount" |
                 "eth_call" |
                 "eth_estimateGas" |
-                "eth_createAccessList" => parse_block_id_from_params(&req.params(), 1),
+                "eth_createAccessList" |
+                "debug_traceCall" => parse_block_id_from_params(&req.params(), 1),
                 "eth_getStorageAt" | "eth_getProof" => parse_block_id_from_params(&req.params(), 2),
+                "debug_traceTransaction" => {
+                    // debug_traceTransaction takes a transaction hash as its first parameter,
+                    // not a BlockId. We assume the op-reth instance is configured with minimal
+                    // bootstrap without the bodies so we can't check if this tx is pre bedrock
+                    None
+                }
                 _ => None,
             };
 


### PR DESCRIPTION
This PR adds support for forwarding debug namespace RPC calls to the historical endpoint for pre-bedrock blocks on OP mainnet.

Closes #17129

## Context
The optimism historical RPC client forwards requests for pre-bedrock data to a dedicated endpoint. This PR extends that functionality to include debug namespace methods that were missing from the initial implementation.

## Changes
Added the following debug namespace endpoints to the method matching logic:
- `debug_traceBlockByNumber` - BlockId parameter at position 0
- `debug_traceBlockByHash` - BlockId parameter at position 0  
- `debug_traceCall` - BlockId parameter at position 1
- `debug_traceTransaction` - Explicitly handled with None return and documentation explaining why special handling would be needed

The `debug_traceTransaction` method is documented but returns `None` because it takes a transaction hash rather than a BlockId, and would require looking up the transaction's block to determine if it's pre-bedrock. Since op-reth instances are typically configured with minimal bootstrap without bodies, we can't perform this check.

## Reference
Based on the op-geth implementation: https://github.com/ethereum-optimism/op-geth/blob/d4e0fe9bb0c2075a9bff269fb975464dd8498f75/eth/tracers/api.go#L478