### PR TITLE
docs: fix spelling errors

### DIFF
--- a/crates/net/network/src/test_utils/init.rs
+++ b/crates/net/network/src/test_utils/init.rs
@@ -13,7 +13,7 @@ pub fn enr_to_peer_id(enr: Enr<SigningKey>) -> PeerId {
 // copied from ethers-rs
 /// A bit of hack to find an unused TCP port.
 ///
-/// Does not guarantee that the given port is unused after the function exists, just that it was
+/// Does not guarantee that the given port is unused after the function exits, just that it was
 /// unused before the function started (i.e., it does not reserve a port).
 pub fn unused_port() -> u16 {
     unused_tcp_addr().port()

--- a/crates/net/network/src/test_utils/transactions.rs
+++ b/crates/net/network/src/test_utils/transactions.rs
@@ -51,7 +51,7 @@ pub async fn new_tx_manager(
     (transactions, network)
 }
 
-/// Directly buffer hahs into tx fetcher for testing.
+/// Directly buffer hash into tx fetcher for testing.
 pub fn buffer_hash_to_tx_fetcher(
     tx_fetcher: &mut TransactionFetcher,
     hash: TxHash,


### PR DESCRIPTION
HI team, fixed spelling errors in _crates/net/network/src/test_utils/init.rs_ // _crates/net/network/src/test_utils/transactions.rs_

`exists` - `exits` --> "Exists" means "to be"; "exits" means "to leave." Functions terminate execution (exit), they don't "exist after" running

`hahs` - `hash` --> fix error