### PR TITLE
docs: fix broken overview link

### DIFF
--- a/docs/vocs/docs/pages/overview.mdx
+++ b/docs/vocs/docs/pages/overview.mdx
@@ -111,4 +111,4 @@ You can contribute to the docs on [GitHub][gh-docs].
 
 [tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fparadigm%5Freth
 [tg-url]: https://t.me/paradigm_reth
-[gh-docs]: https://github.com/paradigmxyz/reth/tree/main/book
+[gh-docs]: https://github.com/paradigmxyz/reth/tree/main/docs


### PR DESCRIPTION
Old link: https://github.com/paradigmxyz/reth/tree/main/book 
New link: https://github.com/paradigmxyz/reth/tree/main/docs