### PR TITLE
chore: fixed dead link in docs/.../sync-op-mainnet.mdx

### DIFF
--- a/docs/vocs/docs/pages/run/faq/sync-op-mainnet.mdx
+++ b/docs/vocs/docs/pages/run/faq/sync-op-mainnet.mdx
@@ -11,7 +11,7 @@ To sync OP mainnet, Bedrock state needs to be imported as a starting point. Ther
 
 ## Minimal bootstrap (recommended)
 
-**The state snapshot at Bedrock block is required.** It can be exported from [op-geth](https://github.com/testinprod-io/op-erigon/blob/pcw109550/bedrock-db-migration/bedrock-migration#export-state) (**.jsonl**) or downloaded directly from [here](https://mega.nz/file/GdZ1xbAT#a9cBv3AqzsTGXYgX7nZc_3fl--tcBmOAIwIA5ND6kwc).
+**The state snapshot at Bedrock block is required.** It can be exported from [op-geth](https://github.com/testinprod-io/op-erigon/blob/pcw109550/bedrock-db-migration/bedrock-migration.md#export-state) (**.jsonl**) or downloaded directly from [here](https://mega.nz/file/GdZ1xbAT#a9cBv3AqzsTGXYgX7nZc_3fl--tcBmOAIwIA5ND6kwc).
 
 Import the state snapshot
 


### PR DESCRIPTION
Fixed 404 link
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/89b4ee5a-f405-4437-9c20-33062d839ed2" />
https://github.com/testinprod-io/op-erigon/blob/pcw109550/bedrock-db-migration/bedrock-migration#export-state