### PR TITLE
fix: use safe math for withdrawals check

### DIFF
--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -307,7 +307,7 @@ where
             }
         }
 
-        if balance_after >= balance_before + message.value {
+        if balance_after >= balance_before.saturating_add(message.value) {
             return Ok(())
         }
 


### PR DESCRIPTION
this is user input and could lead to a overflow panic