### PR TITLE
feat: expose chain_spec field in LocalPayloadAttributesBuilder

### DIFF
--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct LocalPayloadAttributesBuilder<ChainSpec> {
-    chain_spec: Arc<ChainSpec>,
+    /// The chainspec
+    pub chain_spec: Arc<ChainSpec>,
 }
 
 impl<ChainSpec> LocalPayloadAttributesBuilder<ChainSpec> {


### PR DESCRIPTION
## Summary
- Make the `chain_spec` field public in `LocalPayloadAttributesBuilder`
- Add documentation comment for the field
- Enable external access to chain specification for downstream users

## Motivation
This change allows downstream users to access the chain specification from `LocalPayloadAttributesBuilder` instances, which is useful when implementing custom payload attribute builders that need to reference chain-specific configuration.

## Example Usage
```rust
/// Implementation for LocalPayloadAttributesBuilder to build BeraPayloadAttributes
impl PayloadAttributesBuilder<BeraPayloadAttributes>
    for LocalPayloadAttributesBuilder<BerachainChainSpec>
{
    fn build(&self, timestamp: u64) -> BeraPayloadAttributes {
        BeraPayloadAttributes {
            inner: EthPayloadAttributes {
                timestamp,
                prev_randao: B256::random(),
                suggested_fee_recipient: Address::random(),
                withdrawals: self
                    .chain_spec
                    .is_shanghai_active_at_timestamp(timestamp)
                    .then(Default::default),
                parent_beacon_block_root: self
                    .chain_spec
                    .is_cancun_active_at_timestamp(timestamp)
                    .then(B256::random),
            },
        }
    }
}
```

## Test plan
- [x] Existing tests pass
- [x] No breaking changes to public API (only adding public access)
- [x] Field is properly documented