### PR TITLE
fix: move remaining trait methods of `StateProvider` to `AccountReader`

### DIFF
--- a/crates/alloy-provider/src/lib.rs
+++ b/crates/alloy-provider/src/lib.rs
@@ -39,7 +39,7 @@ use reth_provider::{
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BytecodeReader,
     CanonChainTracker, CanonStateNotification, CanonStateNotifications, CanonStateSubscriptions,
     ChainStateBlockReader, ChainStateBlockWriter, ChangeSetReader, DatabaseProviderFactory,
-    HeaderProvider, PruneCheckpointReader, ReceiptProvider, StageCheckpointReader, StateProvider,
+    HeaderProvider, PruneCheckpointReader, ReceiptProvider, StageCheckpointReader,
     StateProviderBox, StateProviderFactory, StateReader, StateRootProvider, StorageReader,
     TransactionVariant, TransactionsProvider,
 };
@@ -848,12 +848,28 @@ impl<P: Clone, Node: NodeTypes, N> AlloyRethStateProvider<P, Node, N> {
     }
 }
 
-impl<P, Node, N> StateProvider for AlloyRethStateProvider<P, Node, N>
+impl<P, Node, N> BytecodeReader for AlloyRethStateProvider<P, Node, N>
 where
     P: Provider<N> + Clone + 'static,
     N: Network,
     Node: NodeTypes,
 {
+    fn bytecode_by_hash(&self, _code_hash: &B256) -> Result<Option<Bytecode>, ProviderError> {
+        // Cannot fetch bytecode by hash via RPC
+        Err(ProviderError::UnsupportedProvider)
+    }
+}
+
+impl<P, Node, N> AccountReader for AlloyRethStateProvider<P, Node, N>
+where
+    P: Provider<N> + Clone + 'static,
+    N: Network,
+    Node: NodeTypes,
+{
+    fn basic_account(&self, address: &Address) -> Result<Option<Account>, ProviderError> {
+        self.get_account(*address)
+    }
+
     fn storage(
         &self,
         address: Address,
@@ -898,29 +914,6 @@ where
 
     fn account_nonce(&self, addr: &Address) -> Result<Option<u64>, ProviderError> {
         self.get_account(*addr).map(|acc| acc.map(|a| a.nonce))
-    }
-}
-
-impl<P, Node, N> BytecodeReader for AlloyRethStateProvider<P, Node, N>
-where
-    P: Provider<N> + Clone + 'static,
-    N: Network,
-    Node: NodeTypes,
-{
-    fn bytecode_by_hash(&self, _code_hash: &B256) -> Result<Option<Bytecode>, ProviderError> {
-        // Cannot fetch bytecode by hash via RPC
-        Err(ProviderError::UnsupportedProvider)
-    }
-}
-
-impl<P, Node, N> AccountReader for AlloyRethStateProvider<P, Node, N>
-where
-    P: Provider<N> + Clone + 'static,
-    N: Network,
-    Node: NodeTypes,
-{
-    fn basic_account(&self, address: &Address) -> Result<Option<Account>, ProviderError> {
-        self.get_account(*address)
     }
 }
 

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -997,7 +997,7 @@ mod tests {
     use reth_primitives_traits::{Account, Bytecode};
     use reth_storage_api::{
         AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider,
-        StateProofProvider, StateProvider, StateRootProvider, StorageRootProvider,
+        StateProofProvider, StateRootProvider, StorageRootProvider,
     };
     use reth_trie::{
         AccountProof, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
@@ -1037,16 +1037,6 @@ mod tests {
 
     struct MockStateProvider;
 
-    impl StateProvider for MockStateProvider {
-        fn storage(
-            &self,
-            _address: Address,
-            _storage_key: StorageKey,
-        ) -> ProviderResult<Option<StorageValue>> {
-            Ok(None)
-        }
-    }
-
     impl BytecodeReader for MockStateProvider {
         fn bytecode_by_hash(&self, _code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
             Ok(None)
@@ -1069,6 +1059,14 @@ mod tests {
 
     impl AccountReader for MockStateProvider {
         fn basic_account(&self, _address: &Address) -> ProviderResult<Option<Account>> {
+            Ok(None)
+        }
+
+        fn storage(
+            &self,
+            _address: Address,
+            _storage_key: StorageKey,
+        ) -> ProviderResult<Option<StorageValue>> {
             Ok(None)
         }
     }

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -109,6 +109,20 @@ impl<N: NodePrimitives> AccountReader for MemoryOverlayStateProviderRef<'_, N> {
 
         self.historical.basic_account(address)
     }
+
+    fn storage(
+        &self,
+        address: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        for block in &self.in_memory {
+            if let Some(value) = block.execution_output.storage(&address, storage_key.into()) {
+                return Ok(Some(value));
+            }
+        }
+
+        self.historical.storage(address, storage_key)
+    }
 }
 
 impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, N> {
@@ -208,21 +222,7 @@ impl<N: NodePrimitives> HashedPostStateProvider for MemoryOverlayStateProviderRe
     }
 }
 
-impl<N: NodePrimitives> StateProvider for MemoryOverlayStateProviderRef<'_, N> {
-    fn storage(
-        &self,
-        address: Address,
-        storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        for block in &self.in_memory {
-            if let Some(value) = block.execution_output.storage(&address, storage_key.into()) {
-                return Ok(Some(value));
-            }
-        }
-
-        self.historical.storage(address, storage_key)
-    }
-}
+impl<N: NodePrimitives> StateProvider for MemoryOverlayStateProviderRef<'_, N> {}
 
 impl<N: NodePrimitives> BytecodeReader for MemoryOverlayStateProviderRef<'_, N> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -222,8 +222,6 @@ impl<N: NodePrimitives> HashedPostStateProvider for MemoryOverlayStateProviderRe
     }
 }
 
-impl<N: NodePrimitives> StateProvider for MemoryOverlayStateProviderRef<'_, N> {}
-
 impl<N: NodePrimitives> BytecodeReader for MemoryOverlayStateProviderRef<'_, N> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         for block in &self.in_memory {

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -162,8 +162,6 @@ pub(crate) enum SlotStatus {
     Value(StorageValue),
 }
 
-impl<S: StateProvider> StateProvider for CachedStateProvider<S> {}
-
 impl<S: BytecodeReader> BytecodeReader for CachedStateProvider<S> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         if let Some(res) = self.caches.code_cache.get(code_hash) {

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -126,20 +126,7 @@ impl<S: AccountReader> AccountReader for CachedStateProvider<S> {
         self.caches.account_cache.insert(*address, res);
         Ok(res)
     }
-}
 
-/// Represents the status of a storage slot in the cache
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum SlotStatus {
-    /// The account's storage cache doesn't exist
-    NotCached,
-    /// The storage slot is empty (either not in cache or explicitly None)
-    Empty,
-    /// The storage slot has a value
-    Value(StorageValue),
-}
-
-impl<S: StateProvider> StateProvider for CachedStateProvider<S> {
     fn storage(
         &self,
         account: Address,
@@ -163,6 +150,19 @@ impl<S: StateProvider> StateProvider for CachedStateProvider<S> {
         }
     }
 }
+
+/// Represents the status of a storage slot in the cache
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SlotStatus {
+    /// The account's storage cache doesn't exist
+    NotCached,
+    /// The storage slot is empty (either not in cache or explicitly None)
+    Empty,
+    /// The storage slot has a value
+    Value(StorageValue),
+}
+
+impl<S: StateProvider> StateProvider for CachedStateProvider<S> {}
 
 impl<S: BytecodeReader> BytecodeReader for CachedStateProvider<S> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -191,8 +191,6 @@ impl<S: AccountReader> AccountReader for InstrumentedStateProvider<S> {
     }
 }
 
-impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {}
-
 impl<S: BytecodeReader> BytecodeReader for InstrumentedStateProvider<S> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         let start = Instant::now();

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -178,9 +178,7 @@ impl<S: AccountReader> AccountReader for InstrumentedStateProvider<S> {
         self.record_account_fetch(start.elapsed());
         res
     }
-}
 
-impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {
     fn storage(
         &self,
         account: Address,
@@ -192,6 +190,8 @@ impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {
         res
     }
 }
+
+impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {}
 
 impl<S: BytecodeReader> BytecodeReader for InstrumentedStateProvider<S> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -55,7 +55,7 @@ impl<T: StateProvider> EvmStateProvider for T {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
-        <T as StateProvider>::storage(self, account, storage_key)
+        <T as AccountReader>::storage(self, account, storage_key)
     }
 }
 

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
 use reth_primitives_traits::{Account, Bytecode};
 use reth_storage_api::{
     AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
-    StateProvider, StateRootProvider, StorageRootProvider,
+    StateRootProvider, StorageRootProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
@@ -47,6 +47,14 @@ impl StateProviderTest {
 impl AccountReader for StateProviderTest {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         Ok(self.accounts.get(address).map(|(_, acc)| *acc))
+    }
+
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<alloy_primitives::StorageValue>> {
+        Ok(self.accounts.get(&account).and_then(|(storage, _)| storage.get(&storage_key).copied()))
     }
 }
 
@@ -147,16 +155,6 @@ impl StateProofProvider for StateProviderTest {
 impl HashedPostStateProvider for StateProviderTest {
     fn hashed_post_state(&self, bundle_state: &revm::database::BundleState) -> HashedPostState {
         HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
-    }
-}
-
-impl StateProvider for StateProviderTest {
-    fn storage(
-        &self,
-        account: Address,
-        storage_key: StorageKey,
-    ) -> ProviderResult<Option<alloy_primitives::StorageValue>> {
-        Ok(self.accounts.get(&account).and_then(|(storage, _)| storage.get(&storage_key).copied()))
     }
 }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -12,9 +12,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
 use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_rpc_eth_types::{EthApiError, PendingBlockEnv, RpcInvalidTransactionError};
-use reth_storage_api::{
-    BlockIdReader, BlockNumReader, StateProvider, StateProviderBox, StateProviderFactory,
-};
+use reth_storage_api::{BlockIdReader, BlockNumReader, StateProviderBox, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
 /// Helper methods for `eth_` methods relating to state (accounts).

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -114,6 +114,29 @@ impl reth_storage_api::AccountReader for StateProviderTraitObjWrapper<'_> {
     ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Account>> {
         self.0.basic_account(address)
     }
+
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: alloy_primitives::StorageKey,
+    ) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>> {
+        self.0.storage(account, storage_key)
+    }
+
+    fn account_code(
+        &self,
+        addr: &Address,
+    ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+        self.0.account_code(addr)
+    }
+
+    fn account_balance(&self, addr: &Address) -> reth_errors::ProviderResult<Option<U256>> {
+        self.0.account_balance(addr)
+    }
+
+    fn account_nonce(&self, addr: &Address) -> reth_errors::ProviderResult<Option<u64>> {
+        self.0.account_nonce(addr)
+    }
 }
 
 impl reth_storage_api::BlockHashReader for StateProviderTraitObjWrapper<'_> {
@@ -146,30 +169,7 @@ impl HashedPostStateProvider for StateProviderTraitObjWrapper<'_> {
     }
 }
 
-impl StateProvider for StateProviderTraitObjWrapper<'_> {
-    fn storage(
-        &self,
-        account: Address,
-        storage_key: alloy_primitives::StorageKey,
-    ) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>> {
-        self.0.storage(account, storage_key)
-    }
-
-    fn account_code(
-        &self,
-        addr: &Address,
-    ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Bytecode>> {
-        self.0.account_code(addr)
-    }
-
-    fn account_balance(&self, addr: &Address) -> reth_errors::ProviderResult<Option<U256>> {
-        self.0.account_balance(addr)
-    }
-
-    fn account_nonce(&self, addr: &Address) -> reth_errors::ProviderResult<Option<u64>> {
-        self.0.account_nonce(addr)
-    }
-}
+impl StateProvider for StateProviderTraitObjWrapper<'_> {}
 
 impl BytecodeReader for StateProviderTraitObjWrapper<'_> {
     fn bytecode_by_hash(

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -169,8 +169,6 @@ impl HashedPostStateProvider for StateProviderTraitObjWrapper<'_> {
     }
 }
 
-impl StateProvider for StateProviderTraitObjWrapper<'_> {}
-
 impl BytecodeReader for StateProviderTraitObjWrapper<'_> {
     fn bytecode_by_hash(
         &self,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -14,7 +14,10 @@ use alloy_eips::{
     eip4895::{Withdrawal, Withdrawals},
     BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
 };
-use alloy_primitives::{Address, BlockHash, BlockNumber, Sealable, TxHash, TxNumber, B256, U256};
+use alloy_primitives::{
+    Address, BlockHash, BlockNumber, Sealable, StorageKey, StorageValue, TxHash, TxNumber, B256,
+    U256,
+};
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
@@ -31,13 +34,14 @@ use reth_evm::{ConfigureEvm, EvmEnv};
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{
-    Account, BlockBody, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader, StorageEntry,
+    Account, BlockBody, Bytecode, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
+    StorageEntry,
 };
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
-    BlockBodyIndicesProvider, DBProvider, NodePrimitivesProvider, StateCommitmentProvider,
-    StorageChangeSetReader,
+    BlockBodyIndicesProvider, BytecodeReader, DBProvider, NodePrimitivesProvider,
+    StateCommitmentProvider, StorageChangeSetReader,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::HashedPostState;
@@ -718,6 +722,20 @@ impl<N: ProviderNodeTypes> AccountReader for BlockchainProvider<N> {
     /// Get basic account information.
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         self.consistent_provider()?.basic_account(address)
+    }
+
+    fn storage(
+        &self,
+        address: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        self.consistent_provider()?.storage(address, storage_key)
+    }
+}
+
+impl<N: ProviderNodeTypes> BytecodeReader for BlockchainProvider<N> {
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.consistent_provider()?.bytecode_by_hash(code_hash)
     }
 }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -13,19 +13,19 @@ use alloy_eips::{
 };
 use alloy_primitives::{
     map::{hash_map, HashMap},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
+    Address, BlockHash, BlockNumber, StorageKey, StorageValue, TxHash, TxNumber, B256, U256,
 };
 use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStateProviderRef};
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::{BundleStateInit, ExecutionOutcome, RevertsInit};
 use reth_node_types::{BlockTy, HeaderTy, ReceiptTy, TxTy};
-use reth_primitives_traits::{Account, BlockBody, RecoveredBlock, SealedHeader, StorageEntry};
+use reth_primitives_traits::{Account, BlockBody, Bytecode, RecoveredBlock, SealedHeader, StorageEntry};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
-    BlockBodyIndicesProvider, DatabaseProviderFactory, NodePrimitivesProvider, StateProvider,
-    StorageChangeSetReader, TryIntoHistoricalStateProvider,
+    BlockBodyIndicesProvider, BytecodeReader, DatabaseProviderFactory, NodePrimitivesProvider,
+    StateProvider, StorageChangeSetReader, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
 use revm_database::states::PlainStorageRevert;
@@ -1422,6 +1422,22 @@ impl<N: ProviderNodeTypes> AccountReader for ConsistentProvider<N> {
         // use latest state provider
         let state_provider = self.latest_ref()?;
         state_provider.basic_account(address)
+    }
+
+    fn storage(
+        &self,
+        address: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let state_provider = self.latest_ref()?;
+        state_provider.storage(address, storage_key)
+    }
+}
+
+impl<N: ProviderNodeTypes> BytecodeReader for ConsistentProvider<N> {
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        let state_provider = self.latest_ref()?;
+        state_provider.bytecode_by_hash(code_hash)
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -1,6 +1,6 @@
 use crate::{
     providers::state::macros::delegate_provider_impls, AccountReader, BlockHashReader,
-    HashedPostStateProvider, ProviderError, StateProvider, StateRootProvider,
+    HashedPostStateProvider, ProviderError, StateRootProvider,
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
@@ -430,12 +430,6 @@ impl<Provider: StateCommitmentProvider> HashedPostStateProvider
             <Provider::StateCommitment as StateCommitment>::KeyHasher,
         >(bundle_state.state())
     }
-}
-
-impl<
-        Provider: DBProvider + BlockNumReader + BlockHashReader + StateCommitmentProvider + AccountReader,
-    > StateProvider for HistoricalStateProviderRef<'_, Provider>
-{
 }
 
 impl<Provider: DBProvider + BlockNumReader + StateCommitmentProvider> BytecodeReader

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -1,6 +1,6 @@
 use crate::{
     providers::state::macros::delegate_provider_impls, AccountReader, BlockHashReader,
-    HashedPostStateProvider, StateProvider, StateRootProvider,
+    HashedPostStateProvider, StateRootProvider,
 };
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
@@ -175,11 +175,6 @@ impl<Provider: DBProvider + StateCommitmentProvider> HashedPostStateProvider
             <Provider::StateCommitment as StateCommitment>::KeyHasher,
         >(bundle_state.state())
     }
-}
-
-impl<Provider: DBProvider + BlockHashReader + StateCommitmentProvider> StateProvider
-    for LatestStateProviderRef<'_, Provider>
-{
 }
 
 impl<Provider: DBProvider + BlockHashReader + StateCommitmentProvider> BytecodeReader

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -219,6 +219,7 @@ delegate_provider_impls!(LatestStateProvider<Provider> where [Provider: DBProvid
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_storage_api::StateProvider;
 
     const fn assert_state_provider<T: StateProvider>() {}
     #[expect(dead_code)]

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -38,8 +38,6 @@ macro_rules! delegate_provider_impls {
                 fn block_hash(&self, number: u64) -> reth_storage_errors::provider::ProviderResult<Option<alloy_primitives::B256>>;
                 fn canonical_hashes_range(&self, start: alloy_primitives::BlockNumber, end: alloy_primitives::BlockNumber) -> reth_storage_errors::provider::ProviderResult<Vec<alloy_primitives::B256>>;
             }
-            StateProvider $(where [$($generics)*])? {
-            }
             BytecodeReader $(where [$($generics)*])? {
                 fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_storage_errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;
             }

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -32,13 +32,13 @@ macro_rules! delegate_provider_impls {
             for $target =>
             AccountReader $(where [$($generics)*])? {
                 fn basic_account(&self, address: &alloy_primitives::Address) -> reth_storage_errors::provider::ProviderResult<Option<reth_primitives_traits::Account>>;
+                fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
             }
             BlockHashReader $(where [$($generics)*])? {
                 fn block_hash(&self, number: u64) -> reth_storage_errors::provider::ProviderResult<Option<alloy_primitives::B256>>;
                 fn canonical_hashes_range(&self, start: alloy_primitives::BlockNumber, end: alloy_primitives::BlockNumber) -> reth_storage_errors::provider::ProviderResult<Vec<alloy_primitives::B256>>;
             }
             StateProvider $(where [$($generics)*])? {
-                fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
             }
             BytecodeReader $(where [$($generics)*])? {
                 fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_storage_errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;

--- a/crates/storage/storage-api/src/account.rs
+++ b/crates/storage/storage-api/src/account.rs
@@ -1,21 +1,74 @@
+use crate::BytecodeReader;
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
-use alloy_primitives::{Address, BlockNumber};
+use alloy_consensus::constants::KECCAK_EMPTY;
+use alloy_primitives::{Address, BlockNumber, StorageKey, StorageValue, U256};
 use auto_impl::auto_impl;
 use core::ops::{RangeBounds, RangeInclusive};
 use reth_db_models::AccountBeforeTx;
-use reth_primitives_traits::Account;
+use reth_primitives_traits::{Account, Bytecode};
 use reth_storage_errors::provider::ProviderResult;
 
 /// Account reader
 #[auto_impl(&, Arc, Box)]
-pub trait AccountReader {
+pub trait AccountReader: BytecodeReader {
     /// Get basic account information.
     ///
     /// Returns `None` if the account doesn't exist.
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>>;
+
+    /// Get storage of given account.
+    ///
+    /// Returns `None` if the account doesn't exist or the storage key is not found.
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>>;
+
+    /// Get account code by its address.
+    ///
+    /// Returns `None` if the account doesn't exist or account is not a contract
+    fn account_code(&self, addr: &Address) -> ProviderResult<Option<Bytecode>> {
+        // Get basic account information
+        // Returns None if acc doesn't exist
+        let acc = match self.basic_account(addr)? {
+            Some(acc) => acc,
+            None => return Ok(None),
+        };
+
+        if let Some(code_hash) = acc.bytecode_hash {
+            if code_hash == KECCAK_EMPTY {
+                return Ok(None)
+            }
+            // Get the code from the code hash
+            return self.bytecode_by_hash(&code_hash)
+        }
+
+        // Return `None` if no code hash is set
+        Ok(None)
+    }
+
+    /// Get account balance by its address.
+    ///
+    /// Returns `None` if the account doesn't exist
+    fn account_balance(&self, addr: &Address) -> ProviderResult<Option<U256>> {
+        // Get basic account information
+        // Returns None if acc doesn't exist
+
+        self.basic_account(addr)?.map_or_else(|| Ok(None), |acc| Ok(Some(acc.balance)))
+    }
+
+    /// Get account nonce by its address.
+    ///
+    /// Returns `None` if the account doesn't exist
+    fn account_nonce(&self, addr: &Address) -> ProviderResult<Option<u64>> {
+        // Get basic account information
+        // Returns None if acc doesn't exist
+        self.basic_account(addr)?.map_or_else(|| Ok(None), |acc| Ok(Some(acc.nonce)))
+    }
 }
 
 /// Account reader

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -353,6 +353,14 @@ impl<C: Send + Sync, N: NodePrimitives> AccountReader for NoopProvider<C, N> {
     fn basic_account(&self, _address: &Address) -> ProviderResult<Option<Account>> {
         Ok(None)
     }
+
+    fn storage(
+        &self,
+        _account: Address,
+        _storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        Ok(None)
+    }
 }
 
 impl<C: Send + Sync, N: NodePrimitives> ChangeSetReader for NoopProvider<C, N> {
@@ -445,15 +453,7 @@ impl<C: Send + Sync, N: NodePrimitives> HashedPostStateProvider for NoopProvider
     }
 }
 
-impl<C: Send + Sync, N: NodePrimitives> StateProvider for NoopProvider<C, N> {
-    fn storage(
-        &self,
-        _account: Address,
-        _storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        Ok(None)
-    }
-}
+impl<C: Send + Sync, N: NodePrimitives> StateProvider for NoopProvider<C, N> {}
 
 impl<C: Send + Sync, N: NodePrimitives> BytecodeReader for NoopProvider<C, N> {
     fn bytecode_by_hash(&self, _code_hash: &B256) -> ProviderResult<Option<Bytecode>> {

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -5,7 +5,7 @@ use crate::{
     BlockReader, BlockReaderIdExt, BlockSource, BytecodeReader, ChangeSetReader,
     HashedPostStateProvider, HeaderProvider, NodePrimitivesProvider, PruneCheckpointReader,
     ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StateProofProvider,
-    StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, StorageRootProvider,
+    StateProviderBox, StateProviderFactory, StateRootProvider, StorageRootProvider,
     TransactionVariant, TransactionsProvider,
 };
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
@@ -452,8 +452,6 @@ impl<C: Send + Sync, N: NodePrimitives> HashedPostStateProvider for NoopProvider
         HashedPostState::default()
     }
 }
-
-impl<C: Send + Sync, N: NodePrimitives> StateProvider for NoopProvider<C, N> {}
 
 impl<C: Send + Sync, N: NodePrimitives> BytecodeReader for NoopProvider<C, N> {
     fn bytecode_by_hash(&self, _code_hash: &B256) -> ProviderResult<Option<Bytecode>> {

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -29,7 +29,6 @@ pub trait StateReader: Send + Sync {
 pub type StateProviderBox = Box<dyn StateProvider>;
 
 /// An abstraction for a type that provides state data.
-#[auto_impl(&, Arc, Box)]
 pub trait StateProvider:
     BlockHashReader
     + AccountReader
@@ -40,6 +39,19 @@ pub trait StateProvider:
     + HashedPostStateProvider
     + Send
     + Sync
+{
+}
+
+impl<T> StateProvider for T where
+    T: BlockHashReader
+        + AccountReader
+        + BytecodeReader
+        + StateRootProvider
+        + StorageRootProvider
+        + StateProofProvider
+        + HashedPostStateProvider
+        + Send
+        + Sync
 {
 }
 

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -3,9 +3,8 @@ use super::{
     StorageRootProvider,
 };
 use alloc::boxed::Box;
-use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};
+use alloy_primitives::{BlockHash, BlockNumber, B256};
 use auto_impl::auto_impl;
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::Bytecode;
@@ -42,54 +41,6 @@ pub trait StateProvider:
     + Send
     + Sync
 {
-    /// Get storage of given account.
-    fn storage(
-        &self,
-        account: Address,
-        storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>>;
-
-    /// Get account code by its address.
-    ///
-    /// Returns `None` if the account doesn't exist or account is not a contract
-    fn account_code(&self, addr: &Address) -> ProviderResult<Option<Bytecode>> {
-        // Get basic account information
-        // Returns None if acc doesn't exist
-        let acc = match self.basic_account(addr)? {
-            Some(acc) => acc,
-            None => return Ok(None),
-        };
-
-        if let Some(code_hash) = acc.bytecode_hash {
-            if code_hash == KECCAK_EMPTY {
-                return Ok(None)
-            }
-            // Get the code from the code hash
-            return self.bytecode_by_hash(&code_hash)
-        }
-
-        // Return `None` if no code hash is set
-        Ok(None)
-    }
-
-    /// Get account balance by its address.
-    ///
-    /// Returns `None` if the account doesn't exist
-    fn account_balance(&self, addr: &Address) -> ProviderResult<Option<U256>> {
-        // Get basic account information
-        // Returns None if acc doesn't exist
-
-        self.basic_account(addr)?.map_or_else(|| Ok(None), |acc| Ok(Some(acc.balance)))
-    }
-
-    /// Get account nonce by its address.
-    ///
-    /// Returns `None` if the account doesn't exist
-    fn account_nonce(&self, addr: &Address) -> ProviderResult<Option<u64>> {
-        // Get basic account information
-        // Returns None if acc doesn't exist
-        self.basic_account(addr)?.map_or_else(|| Ok(None), |acc| Ok(Some(acc.nonce)))
-    }
 }
 
 /// Minimal requirements to read a full account, for example, to validate its new transactions


### PR DESCRIPTION
📄 Summary
	•	As suggested in the review ([link](https://github.com/paradigmxyz/reth/pull/16886#pullrequestreview-2938915991)), this PR moves the relevant trait methods into AccountReader.
	•	Refactored the dependent components accordingly to resolve the resulting dependency issues.

⸻

🔧 Changes
	•	Moved the following trait methods into AccountReader: `storage`, `account_code`, `account_balance`, `account_nonce`
	•	Updated implementations and usages across the codebase.
	•	Resolved dependency cycles and refactored impacted modules.