### PR TITLE
chore: removed link for book `repo/layout.md`

### DIFF
--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -29,7 +29,7 @@ The supporting crates are split into two categories: [primitives](#primitives) a
 
 ### Documentation
 
-Contributor documentation is in [`docs`](../../docs) and end-user documentation is in [`book`](../../book).
+Contributor documentation is in [`docs`](../../docs).
 
 ### Binaries
 


### PR DESCRIPTION
I found dead link in docs and removed their.
ref: https://github.com/paradigmxyz/reth/pull/17096