### PR TITLE
some changes and tweaks

### DIFF
--- a/book/run/config.md
+++ b/book/run/config.md
@@ -125,7 +125,7 @@ max_blocks = 500000
 # The maximum number of state changes to keep in memory before the execution stage commits.
 max_changes = 5000000
 # The maximum cumulative amount of gas to process before the execution stage commits.
-max_cumulative_gas = 1500000000000 # 30_000_000 * 50_000_000
+max_cumulative_gas = 1500000000000 # 300_000_000 * 50_000_000
 # The maximum time spent on blocks processing before the execution stage commits.
 max_duration = '10m'
 ```

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -7,10 +7,7 @@ use crate::{
 use alloy_consensus::{
     Header, SignableTransaction, Transaction as _, TxEip1559, TxReceipt, EMPTY_ROOT_HASH,
 };
-use alloy_eips::{
-    eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, INITIAL_BASE_FEE},
-    eip7685::Requests,
-};
+use alloy_eips::{eip1559::INITIAL_BASE_FEE, eip7685::Requests};
 use alloy_primitives::{Address, BlockNumber, B256, U256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
@@ -146,7 +143,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
             parent_hash,
             gas_used: transactions.len() as u64 * MIN_TRANSACTION_GAS,
             mix_hash: B256::random(),
-            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            gas_limit: 300_000_000,
             base_fee_per_gas: Some(INITIAL_BASE_FEE),
             transactions_root: calculate_transaction_root(
                 &transactions.clone().into_iter().map(|tx| tx.into_tx()).collect::<Vec<_>>(),

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -247,7 +247,7 @@ impl Default for ExecutionConfig {
             max_blocks: Some(500_000),
             max_changes: Some(5_000_000),
             // 50k full blocks of 30M gas
-            max_cumulative_gas: Some(30_000_000 * 50_000),
+            max_cumulative_gas: Some(300_000_000 * 50_000),
             // 10 minutes
             max_duration: Some(Duration::from_secs(10 * 60)),
         }

--- a/crates/engine/tree/src/backfill.rs
+++ b/crates/engine/tree/src/backfill.rs
@@ -231,7 +231,6 @@ mod tests {
     use super::*;
     use crate::test_utils::{insert_headers_into_client, TestPipelineBuilder};
     use alloy_consensus::Header;
-    use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use alloy_primitives::{BlockNumber, B256};
     use assert_matches::assert_matches;
     use futures::poll;
@@ -269,11 +268,8 @@ mod tests {
 
             let pipeline_sync = PipelineSync::new(pipeline, Box::<TokioTaskExecutor>::default());
             let client = TestFullBlockClient::default();
-            let header = Header {
-                base_fee_per_gas: Some(7),
-                gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-                ..Default::default()
-            };
+            let header =
+                Header { base_fee_per_gas: Some(7), gas_limit: 300_000_000, ..Default::default() };
             let header = SealedHeader::seal_slow(header);
             insert_headers_into_client(&client, header, 0..total_blocks);
 

--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -313,7 +313,6 @@ mod tests {
     use super::*;
     use crate::test_utils::insert_headers_into_client;
     use alloy_consensus::Header;
-    use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use assert_matches::assert_matches;
     use reth_chainspec::{ChainSpecBuilder, MAINNET};
     use reth_ethereum_consensus::EthBeaconConsensus;
@@ -338,11 +337,8 @@ mod tests {
             );
 
             let client = TestFullBlockClient::default();
-            let header = Header {
-                base_fee_per_gas: Some(7),
-                gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-                ..Default::default()
-            };
+            let header =
+                Header { base_fee_per_gas: Some(7), gas_limit: 300_000_000, ..Default::default() };
             let header = SealedHeader::seal_slow(header);
 
             insert_headers_into_client(&client, header, 0..total_blocks);

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -76,7 +76,7 @@ impl<EXT, DB: Database> Evm for EthEvm<'_, EXT, DB> {
             transact_to: TxKind::Call(contract),
             // Explicitly set nonce to None so revm does not do any nonce checks
             nonce: None,
-            gas_limit: 30_000_000,
+            gas_limit: 300_000_000,
             value: U256::ZERO,
             data,
             // Setting the gas price to zero enforces that no value is transferred as part of the

--- a/crates/ethereum/payload/src/config.rs
+++ b/crates/ethereum/payload/src/config.rs
@@ -1,4 +1,3 @@
-use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_primitives::Bytes;
 use reth_primitives_traits::constants::GAS_LIMIT_BOUND_DIVISOR;
 
@@ -14,7 +13,7 @@ pub struct EthereumBuilderConfig {
 impl EthereumBuilderConfig {
     /// Create new payload builder config.
     pub const fn new(extra_data: Bytes) -> Self {
-        Self { extra_data, desired_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M }
+        Self { extra_data, desired_gas_limit: 300_000_000 }
     }
 
     /// Set desired gas limit.

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -6,7 +6,7 @@
 /// Spec'd at 4096 hashes.
 ///
 /// <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08>
-pub const SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE: usize = 4096;
+pub const SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE: usize = 8192;
 
 /// Default soft limit for the byte size of a [`Transactions`](reth_eth_wire::Transactions)
 /// broadcast message.
@@ -40,7 +40,7 @@ pub mod tx_manager {
     /// Default limit for number of transactions to keep track of for a single peer.
     ///
     /// Default is 320 transaction hashes.
-    pub const DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER: u32 = 10 * 1024 / 32;
+    pub const DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER: u32 = 100 * 1024 / 32;
 
     /// Default maximum pending pool imports to tolerate.
     ///

--- a/crates/node/core/src/args/payload_builder.rs
+++ b/crates/node/core/src/args/payload_builder.rs
@@ -1,6 +1,6 @@
 use crate::{cli::config::PayloadBuilderConfig, version::default_extra_data};
 use alloy_consensus::constants::MAXIMUM_EXTRA_DATA_SIZE;
-use alloy_eips::{eip1559::ETHEREUM_BLOCK_GAS_LIMIT_36M, merge::SLOT_DURATION};
+use alloy_eips::merge::SLOT_DURATION;
 use clap::{
     builder::{RangedU64ValueParser, TypedValueParser},
     Arg, Args, Command,
@@ -17,7 +17,7 @@ pub struct PayloadBuilderArgs {
     pub extra_data: String,
 
     /// Target gas limit for built blocks.
-    #[arg(long = "builder.gaslimit", default_value_t = ETHEREUM_BLOCK_GAS_LIMIT_36M, value_name = "GAS_LIMIT")]
+    #[arg(long = "builder.gaslimit", default_value_t = 300_000_000, value_name = "GAS_LIMIT")]
     pub gas_limit: u64,
 
     /// The interval at which the job should build a new payload after the last.
@@ -41,7 +41,7 @@ impl Default for PayloadBuilderArgs {
     fn default() -> Self {
         Self {
             extra_data: default_extra_data(),
-            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_36M,
+            gas_limit: 300_000_000,
             interval: Duration::from_secs(1),
             deadline: SLOT_DURATION,
             max_payload_tasks: 3,

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -1,7 +1,7 @@
 //! Transaction pool arguments
 
 use crate::cli::config::RethTransactionPoolConfig;
-use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
+use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
 use alloy_primitives::Address;
 use clap::Args;
 use reth_cli_util::parse_duration_from_secs_or_ms;
@@ -62,7 +62,7 @@ pub struct TxPoolArgs {
     pub minimal_protocol_basefee: u64,
 
     /// The default enforced gas limit for transactions entering the pool
-    #[arg(long = "txpool.gas-limit", default_value_t = ETHEREUM_BLOCK_GAS_LIMIT_30M)]
+    #[arg(long = "txpool.gas-limit", default_value_t = 300_000_000)]
     pub enforced_gas_limit: u64,
 
     /// Price bump percentage to replace an already existing blob transaction
@@ -122,7 +122,7 @@ impl Default for TxPoolArgs {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
-            enforced_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            enforced_gas_limit: 300_000_000,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
             max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             max_cached_entries: DEFAULT_MAX_CACHED_BLOBS,

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -78,7 +78,7 @@ impl<EXT, DB: Database> Evm for OpEvm<'_, EXT, DB> {
             transact_to: TxKind::Call(contract),
             // Explicitly set nonce to None so revm does not do any nonce checks
             nonce: None,
-            gas_limit: 30_000_000,
+            gas_limit: 300_000_000,
             value: U256::ZERO,
             data,
             // Setting the gas price to zero enforces that no value is transferred as part of the

--- a/crates/optimism/node/src/utils.rs
+++ b/crates/optimism/node/src/utils.rs
@@ -67,7 +67,7 @@ pub fn optimism_payload_attributes<T>(timestamp: u64) -> OpPayloadBuilderAttribu
         payload_attributes: EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
         transactions: vec![],
         no_tx_pool: false,
-        gas_limit: Some(30_000_000),
+        gas_limit: Some(300_000_000),
         eip_1559_params: None,
     }
 }

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -81,7 +81,7 @@ pub mod gas_oracle {
     /// The default gas limit for `eth_call` and adjacent calls.
     ///
     /// This is different from the default to regular 30M block gas limit
-    /// `ETHEREUM_BLOCK_GAS_LIMIT_30M` to allow for more complex calls.
+    /// `300_000_000` to allow for more complex calls.
     pub const RPC_DEFAULT_GAS_CAP: u64 = 50_000_000;
 
     /// Allowed error ratio for gas estimation

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -36,7 +36,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use alloy_primitives::{Address, StorageKey, StorageValue, U256};
     use reth_chainspec::MAINNET;
     use reth_evm_ethereum::EthEvmConfig;
@@ -64,7 +63,7 @@ mod tests {
             NoopNetwork::default(),
             cache.clone(),
             GasPriceOracle::new(NoopProvider::default(), Default::default(), cache),
-            ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            300_000_000,
             DEFAULT_MAX_SIMULATE_BLOCKS,
             DEFAULT_ETH_PROOF_WINDOW,
             BlockingTaskPool::build().expect("failed to build tracing pool"),
@@ -90,7 +89,7 @@ mod tests {
             (),
             cache.clone(),
             GasPriceOracle::new(mock_provider, Default::default(), cache),
-            ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            300_000_000,
             DEFAULT_MAX_SIMULATE_BLOCKS,
             DEFAULT_ETH_PROOF_WINDOW + 1,
             BlockingTaskPool::build().expect("failed to build tracing pool"),

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -56,7 +56,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use alloy_primitives::{hex_literal::hex, Bytes};
     use reth_chainspec::ChainSpecProvider;
     use reth_evm_ethereum::EthEvmConfig;
@@ -88,7 +87,7 @@ mod tests {
             noop_network_provider,
             cache.clone(),
             GasPriceOracle::new(noop_provider, Default::default(), cache.clone()),
-            ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            300_000_000,
             DEFAULT_MAX_SIMULATE_BLOCKS,
             DEFAULT_ETH_PROOF_WINDOW,
             BlockingTaskPool::build().expect("failed to build tracing pool"),

--- a/crates/stages/types/src/execution.rs
+++ b/crates/stages/types/src/execution.rs
@@ -25,7 +25,7 @@ impl Default for ExecutionStageThresholds {
             max_blocks: Some(500_000),
             max_changes: Some(5_000_000),
             // 50k full blocks of 30M gas
-            max_cumulative_gas: Some(30_000_000 * 50_000),
+            max_cumulative_gas: Some(300_000_000 * 50_000),
             // 10 minutes
             max_duration: Some(Duration::from_secs(10 * 60)),
         }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -4,18 +4,18 @@ use crate::{
     PoolSize, TransactionOrigin,
 };
 use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
-use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
+use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
 use alloy_primitives::Address;
 use std::{collections::HashSet, ops::Mul, time::Duration};
 
 /// Guarantees max transactions for one sender, compatible with geth/erigon
-pub const TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;
+pub const TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 160;
 
 /// The default maximum allowed number of transactions in the given subpool.
-pub const TXPOOL_SUBPOOL_MAX_TXS_DEFAULT: usize = 10_000;
+pub const TXPOOL_SUBPOOL_MAX_TXS_DEFAULT: usize = 50_000;
 
 /// The default maximum allowed size of the given subpool.
-pub const TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT: usize = 20;
+pub const TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT: usize = 200;
 
 /// The default additional validation tasks size.
 pub const DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS: usize = 1;
@@ -29,7 +29,7 @@ pub const DEFAULT_PRICE_BUMP: u128 = 10;
 pub const REPLACE_BLOB_PRICE_BUMP: u128 = 100;
 
 /// Default maximum new transactions for broadcasting.
-pub const MAX_NEW_PENDING_TXS_NOTIFICATIONS: usize = 200;
+pub const MAX_NEW_PENDING_TXS_NOTIFICATIONS: usize = 2000;
 
 /// Configuration options for the Transaction pool.
 #[derive(Debug, Clone)]
@@ -84,7 +84,7 @@ impl Default for PoolConfig {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
-            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            gas_limit: 300_000_000,
             local_transactions_config: Default::default(),
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -16,10 +16,7 @@ use crate::{
     PropagatedTransactions, TransactionEvents, TransactionOrigin, TransactionPool,
     TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
 };
-use alloy_eips::{
-    eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M,
-    eip4844::{BlobAndProofV1, BlobTransactionSidecar},
-};
+use alloy_eips::eip4844::{BlobAndProofV1, BlobTransactionSidecar};
 use alloy_primitives::{Address, TxHash, B256, U256};
 use reth_eth_wire_types::HandleMempoolData;
 use reth_primitives::Recovered;
@@ -43,7 +40,7 @@ impl TransactionPool for NoopTransactionPool {
 
     fn block_info(&self) -> BlockInfo {
         BlockInfo {
-            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            block_gas_limit: 300_000_000,
             last_seen_block_hash: Default::default(),
             last_seen_block_number: 0,
             pending_basefee: 0,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -120,9 +120,9 @@ pub mod txpool;
 mod update;
 
 /// Bound on number of pending transactions from `reth_network::TransactionsManager` to buffer.
-pub const PENDING_TX_LISTENER_BUFFER_SIZE: usize = 2048;
+pub const PENDING_TX_LISTENER_BUFFER_SIZE: usize = 20000;
 /// Bound on number of new transactions from `reth_network::TransactionsManager` to buffer.
-pub const NEW_TX_LISTENER_BUFFER_SIZE: usize = 1024;
+pub const NEW_TX_LISTENER_BUFFER_SIZE: usize = 20000;
 
 const BLOB_SIDECAR_LISTENER_BUFFER_SIZE: usize = 512;
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -22,11 +22,7 @@ use alloy_consensus::constants::{
     EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
     LEGACY_TX_TYPE_ID,
 };
-use alloy_eips::{
-    eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE},
-    eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
-    Typed2718,
-};
+use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip4844::BLOB_TX_MIN_BLOB_GASPRICE, Typed2718};
 use alloy_primitives::{Address, TxHash, B256};
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -1832,7 +1828,7 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
         Self {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
-            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            block_gas_limit: 300_000_000,
             by_hash: Default::default(),
             txs: Default::default(),
             tx_counter: Default::default(),
@@ -2730,7 +2726,7 @@ mod tests {
         let mut f = MockTransactionFactory::default();
         let mut pool = AllTransactions::default();
 
-        let tx = MockTransaction::eip1559().with_gas_limit(30_000_000);
+        let tx = MockTransaction::eip1559().with_gas_limit(300_000_000);
 
         let InsertOk { state, .. } =
             pool.insert_tx(f.validated(tx), on_chain_balance, on_chain_nonce).unwrap();

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -18,10 +18,7 @@ use alloy_consensus::{
     },
     BlockHeader,
 };
-use alloy_eips::{
-    eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M, eip4844::env_settings::EnvKzgSettings,
-    eip7840::BlobParams,
-};
+use alloy_eips::{eip4844::env_settings::EnvKzgSettings, eip7840::BlobParams};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_primitives::{InvalidTransactionError, SealedBlock};
 use reth_primitives_traits::{Block, GotExpected};
@@ -592,7 +589,7 @@ impl<Client> EthTransactionValidatorBuilder<Client> {
     ///  - EIP-4844
     pub fn new(client: Client) -> Self {
         Self {
-            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M.into(),
+            block_gas_limit: 300_000_000.into(),
             client,
             minimum_priority_fee: None,
             additional_tasks: 1,

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -1,7 +1,7 @@
 //! Transaction pool eviction tests.
 
 use alloy_consensus::Transaction;
-use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
+use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
 use alloy_primitives::{Address, B256};
 use rand::distributions::Uniform;
 use reth_transaction_pool::{
@@ -28,7 +28,7 @@ async fn only_blobs_eviction() {
 
     let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
     let block_info = BlockInfo {
-        block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+        block_gas_limit: 300_000_000,
         last_seen_block_hash: B256::ZERO,
         last_seen_block_number: 0,
         pending_basefee: 10,
@@ -141,7 +141,7 @@ async fn mixed_eviction() {
 
     let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
     let block_info = BlockInfo {
-        block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+        block_gas_limit: 300_000_000,
         last_seen_block_hash: B256::ZERO,
         last_seen_block_number: 0,
         pending_basefee: 10,
@@ -243,7 +243,7 @@ async fn nonce_gaps_eviction() {
 
     let pool: TestPool = TestPoolBuilder::default().with_config(pool_config.clone()).into();
     let block_info = BlockInfo {
-        block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+        block_gas_limit: 300_000_000,
         last_seen_block_hash: B256::ZERO,
         last_seen_block_number: 0,
         pending_basefee: 10,


### PR DESCRIPTION
1)
vanilla 
```
     Running `target/debug/malachitebft-eth-utils spam --time=60 --rate=10000`
Spamming 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 starting from nonce=0
[0] elapsed 13.680s: Sent 10000 txs (1179503 bytes); TxpoolStatus { pending: 1316, queued: 0 }
[0] elapsed 24.162s: Sent 10000 txs (1179882 bytes); TxpoolStatus { pending: 690, queued: 0 }
[0] elapsed 35.575s: Sent 10000 txs (1179879 bytes); TxpoolStatus { pending: 894, queued: 0 }
[0] elapsed 48.660s: Sent 9999 txs (1179747 bytes); 1 failed with {"error sending request for url (http://127.0.0.1:8545/)": 1}; TxpoolStatus { pending: 0, queued: 1002 }
[0] elapsed 59.303s: Sent 8999 txs (1061765 bytes); 1001 failed with {"Server Error -32003: txpool is full": 1001}; TxpoolStatus { pending: 0, queued: 10000 }
[0] elapsed 60.301s: Sent 0 txs (0 bytes); 652 failed with {"Server Error -32003: txpool is full": 652}; TxpoolStatus { pending: 0, queued: 10000 }
Total: [0] elapsed 60.301s: Sent 48998 txs (5780776 bytes); 1654 failed with {"error sending request for url (http://127.0.0.1:8545/)": 1, "Server Error -32003: txpool is full": 1653}

```


2)
hacked
```
➜  malaketh-layered git:(main) ✗ cargo run --bin malachitebft-eth-utils spam --time=60 --rate=10000


    Finished `dev` profile [optimized + debuginfo] target(s) in 1.30s
     Running `target/debug/malachitebft-eth-utils spam --time=60 --rate=10000`
Spamming 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 starting from nonce=0
[0] elapsed 9.910s: Sent 10000 txs (1179503 bytes); TxpoolStatus { pending: 610, queued: 0 }
[0] elapsed 21.839s: Sent 10000 txs (1179882 bytes); TxpoolStatus { pending: 510, queued: 0 }
[0] elapsed 33.364s: Sent 10000 txs (1179879 bytes); TxpoolStatus { pending: 776, queued: 0 }
[0] elapsed 43.209s: Sent 10000 txs (1179865 bytes); TxpoolStatus { pending: 621, queued: 0 }
[0] elapsed 53.840s: Sent 10000 txs (1179871 bytes); TxpoolStatus { pending: 222, queued: 0 }
[0] elapsed 60.035s: Sent 6429 txs (758550 bytes); TxpoolStatus { pending: 250, queued: 0 }
Total: [0] elapsed 60.035s: Sent 56429 txs (6657550 bytes)
```