### PR TITLE
chore(trie): factor out SparseTrieState

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -68,7 +68,7 @@ where
     precompile_cache_disabled: bool,
     /// Precompile cache map.
     precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
-    /// A reset sparse trie, kept around to be re-used for the state root computation so that
+    /// A cleared sparse trie, kept around to be re-used for the state root computation so that
     /// allocations can be minimized.
     sparse_trie: Option<SparseTrie>,
     _marker: std::marker::PhantomData<N>,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -28,7 +28,7 @@ use reth_trie_parallel::{
     proof_task::{ProofTaskCtx, ProofTaskManager},
     root::ParallelStateRootError,
 };
-use reth_trie_sparse::SparseTrieState;
+use reth_trie_sparse::SparseTrie;
 use std::{
     collections::VecDeque,
     sync::{
@@ -68,9 +68,9 @@ where
     precompile_cache_disabled: bool,
     /// Precompile cache map.
     precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
-    /// A sparse trie, kept around to be used for the state root computation so that allocations
-    /// can be minimized.
-    sparse_trie: Option<SparseTrieState>,
+    /// A reset sparse trie, kept around to be re-used for the state root computation so that
+    /// allocations can be minimized.
+    sparse_trie: Option<SparseTrie>,
     _marker: std::marker::PhantomData<N>,
 }
 
@@ -251,7 +251,7 @@ where
     }
 
     /// Sets the sparse trie to be kept around for the state root computation.
-    pub(super) fn set_sparse_trie(&mut self, sparse_trie: SparseTrieState) {
+    pub(super) fn set_sparse_trie(&mut self, sparse_trie: SparseTrie) {
         self.sparse_trie = Some(sparse_trie);
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -11,7 +11,7 @@ use reth_trie_parallel::root::ParallelStateRootError;
 use reth_trie_sparse::{
     blinded::{BlindedProvider, BlindedProviderFactory},
     errors::{SparseStateTrieResult, SparseTrieErrorKind},
-    SparseStateTrie, SparseTrieState,
+    SparseStateTrie, SparseTrie,
 };
 use std::{
     sync::mpsc,
@@ -66,40 +66,39 @@ where
         }
     }
 
-    /// Creates a new sparse trie, populating the accounts trie with the given cleared
-    /// `SparseTrieState` if it exists.
+    /// Creates a new sparse trie, populating the accounts trie with the given `SparseTrie`, if it
+    /// exists.
     pub(super) fn new_with_stored_trie(
         executor: WorkloadExecutor,
         updates: mpsc::Receiver<SparseTrieUpdate>,
         blinded_provider_factory: BPF,
         trie_metrics: MultiProofTaskMetrics,
-        sparse_trie_state: Option<SparseTrieState>,
+        sparse_trie: Option<SparseTrie>,
     ) -> Self {
-        if let Some(sparse_trie_state) = sparse_trie_state {
+        if let Some(sparse_trie) = sparse_trie {
             Self::with_accounts_trie(
                 executor,
                 updates,
                 blinded_provider_factory,
                 trie_metrics,
-                sparse_trie_state,
+                sparse_trie,
             )
         } else {
             Self::new(executor, updates, blinded_provider_factory, trie_metrics)
         }
     }
 
-    /// Creates a new sparse trie task, using the given cleared `SparseTrieState` for the accounts
+    /// Creates a new sparse trie task, using the given [`SparseTrie::Blind`] for the accounts
     /// trie.
     pub(super) fn with_accounts_trie(
         executor: WorkloadExecutor,
         updates: mpsc::Receiver<SparseTrieUpdate>,
         blinded_provider_factory: BPF,
         metrics: MultiProofTaskMetrics,
-        sparse_trie_state: SparseTrieState,
+        sparse_trie: SparseTrie,
     ) -> Self {
-        let mut trie = SparseStateTrie::new().with_updates(true);
-        trie.populate_from(sparse_trie_state);
-
+        debug_assert!(sparse_trie.is_blind());
+        let trie = SparseStateTrie::new().with_updates(true).with_accounts_trie(sparse_trie);
         Self { executor, updates, metrics, trie, blinded_provider_factory }
     }
 
@@ -154,8 +153,8 @@ where
         self.metrics.sparse_trie_final_update_duration_histogram.record(start.elapsed());
         self.metrics.sparse_trie_total_duration_histogram.record(now.elapsed());
 
-        // take the account trie
-        let trie = self.trie.take_cleared_account_trie_state();
+        // take the account trie so that we can re-use its already allocated datastructures.
+        let trie = self.trie.take_reset_accounts_trie();
 
         Ok(StateRootComputeOutcome { state_root, trie_updates, trie })
     }
@@ -170,7 +169,7 @@ pub struct StateRootComputeOutcome {
     /// The trie updates.
     pub trie_updates: TrieUpdates,
     /// The account state trie.
-    pub trie: SparseTrieState,
+    pub trie: SparseTrie,
 }
 
 /// Updates the sparse trie with the given proofs and state, and returns the elapsed time.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -154,7 +154,7 @@ where
         self.metrics.sparse_trie_total_duration_histogram.record(now.elapsed());
 
         // take the account trie so that we can re-use its already allocated data structures.
-        let trie = self.trie.take_reset_accounts_trie();
+        let trie = self.trie.take_cleared_accounts_trie();
 
         Ok(StateRootComputeOutcome { state_root, trie_updates, trie })
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -153,7 +153,7 @@ where
         self.metrics.sparse_trie_final_update_duration_histogram.record(start.elapsed());
         self.metrics.sparse_trie_total_duration_histogram.record(now.elapsed());
 
-        // take the account trie so that we can re-use its already allocated datastructures.
+        // take the account trie so that we can re-use its already allocated data structures.
         let trie = self.trie.take_reset_accounts_trie();
 
         Ok(StateRootComputeOutcome { state_root, trie_updates, trie })

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -75,7 +75,7 @@ impl SparseStateTrie {
         self
     }
 
-    /// Set the state root to the given `SparseTrie`.
+    /// Set the accounts trie to the given `SparseTrie`.
     pub fn with_accounts_trie(mut self, trie: SparseTrie) -> Self {
         self.state = trie;
         self

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -81,9 +81,9 @@ impl SparseStateTrie {
         self
     }
 
-    /// Takes the `SparseTrie` from within the state root and resets it if it is not blinded.
-    pub fn take_reset_accounts_trie(&mut self) -> SparseTrie {
-        core::mem::take(&mut self.state).blinded()
+    /// Takes the `SparseTrie` from within the state root and clears it if it is not blinded.
+    pub fn take_cleared_accounts_trie(&mut self) -> SparseTrie {
+        core::mem::take(&mut self.state).clear()
     }
 
     /// Returns `true` if account was already revealed.
@@ -575,7 +575,6 @@ impl SparseStateTrie {
         Ok(Some(root_node))
     }
 
-    #[cfg(test)]
     /// Wipe the storage trie at the provided address.
     pub fn wipe_storage(&mut self, address: B256) -> SparseStateTrieResult<()> {
         if let Some(trie) = self.storages.get_mut(&address) {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2058,6 +2058,8 @@ impl SparseTrieUpdates {
     }
 
     /// Clears the updates, but keeps the backing data structures allocated.
+    ///
+    /// Sets `wiped` to `false`.
     pub fn clear(&mut self) {
         self.updated_nodes.clear();
         self.removed_nodes.clear();


### PR DESCRIPTION
This change removes the need for the SparseTrieState type, and the associated `SparseTrie::AllocatedEmpty` variant, by instead passing around the reset RevealedSparseTrie itself in order to re-use allocations across payloads.

The `SparseTrie::Blind` variant is modified to now optionally carry a `RevealedSparseTrie`, and the SparseTrieTask will take that out of the SparseStateTrie to re-use.

The `RevealedSparseTrie::from_root` method is transformed into `RevealedSparseTrie::with_root`, which performs essentially the same function but allows us to re-use the RevealedSparseTrie while maintaining correct semantics around the empty root node.