### PR TITLE
feat: include chain-id query param for etherscan v2 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7548,6 +7548,7 @@ dependencies = [
  "reth-tracing",
  "ringbuffer",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9cc9d81ace3da457883b0bdf76776e55f1b84219a9e9d55c27ad308548d3f"
+checksum = "5674914c2cfdb866c21cb0c09d82374ee39a1395cf512e7515f4c014083b3fff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,7 +464,7 @@ op-revm = { version = "7.0.1", default-features = false }
 revm-inspectors = "0.25.0"
 
 # eth
-alloy-chains = { version = "0.2.0", default-features = false }
+alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.2.0"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-evm = { version = "0.12", default-features = false }

--- a/crates/consensus/debug-client/Cargo.toml
+++ b/crates/consensus/debug-client/Cargo.toml
@@ -28,8 +28,9 @@ auto_impl.workspace = true
 derive_more.workspace = true
 futures.workspace = true
 eyre.workspace = true
-reqwest = { workspace = true, features = ["rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["time"] }
+serde_json.workspace = true
 
 ringbuffer.workspace = true

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -14,6 +14,7 @@ pub struct EtherscanBlockProvider<RpcBlock, PrimitiveBlock> {
     http_client: Client,
     base_url: String,
     api_key: String,
+    chain_id: u64,
     interval: Duration,
     #[debug(skip)]
     convert: Arc<dyn Fn(RpcBlock) -> PrimitiveBlock + Send + Sync>,
@@ -27,12 +28,14 @@ where
     pub fn new(
         base_url: String,
         api_key: String,
+        chain_id: u64,
         convert: impl Fn(RpcBlock) -> PrimitiveBlock + Send + Sync + 'static,
     ) -> Self {
         Self {
             http_client: Client::new(),
             base_url,
             api_key,
+            chain_id,
             interval: Duration::from_secs(3),
             convert: Arc::new(convert),
         }
@@ -65,6 +68,7 @@ where
                 ("tag", &tag),
                 ("boolean", "true"),
                 ("apikey", &self.api_key),
+                ("chainid", &self.chain_id.to_string()),
             ])
             .send()
             .await?

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -68,7 +68,7 @@ where
         ]);
 
         if !self.base_url.contains("chainid=") {
-            // only append chainid of not part of the base
+            // only append chainid if not part of the base url already
             req = req.query(&[("chainid", &self.chain_id.to_string())]);
         }
 

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -145,6 +145,7 @@ where
                         "etherscan api key not found for rpc consensus client for chain: {chain}"
                     )
                 })?,
+                chain.id(),
                 N::Types::rpc_to_primitive_block,
             );
             let rpc_consensus_client = DebugConsensusClient::new(


### PR DESCRIPTION
resolves https://github.com/paradigmxyz/reth/issues/17142

We'll need to update the default api urls to V2 in the [alloy-chains](https://github.com/alloy-rs/chains/blob/09cafe326bd9b9a43124de6087a93803158088c5/src/named.rs#L1290-L1673) crate. I've opened a [PR](https://github.com/alloy-rs/chains/pull/174) to alloy-chains that does this.

Is this an ideal approach? @mattsse 