### PR TITLE
docs: update metrics link in ethereum.mdx

### DIFF
--- a/docs/vocs/docs/pages/run/ethereum.mdx
+++ b/docs/vocs/docs/pages/run/ethereum.mdx
@@ -90,7 +90,7 @@ In the meantime, consider setting up [observability](/run/monitoring) to monitor
 
 [installation]: ./../installation/installation
 [docs]: https://github.com/paradigmxyz/reth/tree/main/docs
-[metrics]: https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics#current-metrics
+[metrics]: https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics.md#metrics
 
 ## Running without a Consensus Layer
 


### PR DESCRIPTION
Fix broken metrics documentation link 

Old (broken) link:
https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics#current-metrics
New (working) link:
https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics.md#metrics