### PR TITLE
docs: update Grafana repository URL in monitoring documentation

### DIFF
--- a/docs/vocs/docs/pages/run/monitoring.mdx
+++ b/docs/vocs/docs/pages/run/monitoring.mdx
@@ -57,7 +57,7 @@ cd prometheus-*
 # Install Grafana
 sudo apt-get install -y apt-transport-https software-properties-common
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
-echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+echo "deb https://packages.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 sudo apt-get update
 sudo apt-get install grafana
 ```


### PR DESCRIPTION


The old Grafana repository URL (packages.grafana.com/oss/deb) is no longer working correctly for Debian/Ubuntu installations. This PR updates it to use the current working repository URL (packages.grafana.com).

Changes made:
- Updated the repository URL in the apt sources configuration from:
  `deb https://packages.grafana.com/oss/deb stable main`
  to:
  `deb https://packages.grafana.com stable main`

This change ensures that users can successfully install Grafana when following the monitoring setup instructions.