### PR TITLE
docs: improve NodeAddOns trait documentation

### DIFF
--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -121,11 +121,84 @@ pub struct AddOnsContext<'a, N: FullNodeComponents> {
 }
 
 /// Customizable node add-on types.
+///
+/// This trait defines the interface for extending a node with additional functionality beyond
+/// the core [`FullNodeComponents`]. It provides a way to launch supplementary services such as
+/// RPC servers, monitoring, external integrations, or any custom functionality that builds on
+/// top of the core node components.
+///
+/// ## Purpose
+///
+/// The `NodeAddOns` trait serves as an extension point in the node builder architecture,
+/// allowing developers to:
+/// - Define custom services that run alongside the main node
+/// - Access all node components and configuration during initialization
+/// - Return a handle for managing the launched services (e.g. handle to rpc server)
+///
+/// ## How it fits into NodeBuilder
+///
+/// In the node builder pattern, add-ons are the final layer that gets applied after all core
+/// components are configured and started. The builder flow typically follows:
+///
+/// 1. Configure [`NodeTypes`] (chain spec, database types, etc.)
+/// 2. Build [`FullNodeComponents`] (consensus, networking, transaction pool, etc.)
+/// 3. Launch [`NodeAddOns`] with access to all components via [`AddOnsContext`]
+///
+/// ## Primary Use Case
+///
+/// The primary use of this trait is to launch RPC servers that provide external API access to
+/// the node. For Ethereum nodes, this typically includes two main servers: the regular RPC
+/// server (HTTP/WS/IPC) that handles user requests and the authenticated Engine API server
+/// that communicates with the consensus layer. The returned handle contains the necessary
+/// endpoints and control mechanisms for these servers, allowing the node to serve JSON-RPC
+/// requests and participate in consensus. While RPC is the main use case, the trait is
+/// intentionally flexible to support other kinds of add-ons such as monitoring, indexing, or
+/// custom protocol extensions.
+///
+/// ## Context Access
+///
+/// The [`AddOnsContext`] provides access to:
+/// - All node components via the `node` field
+/// - Node configuration
+/// - Engine API handles for consensus layer communication
+/// - JWT secrets for authenticated endpoints
+///
+/// This ensures add-ons can integrate deeply with the node while maintaining clean separation
+/// of concerns.
 pub trait NodeAddOns<N: FullNodeComponents>: Send {
     /// Handle to add-ons.
+    ///
+    /// This type is returned by [`launch_add_ons`](Self::launch_add_ons) and represents a
+    /// handle to the launched services. It must be `Clone` to allow multiple components to
+    /// hold references and should provide methods to interact with the running services.
+    ///
+    /// For RPC add-ons, this typically includes:
+    /// - Server handles to access local addresses and shutdown methods
+    /// - RPC module registry for runtime inspection of available methods
+    /// - Configured middleware and transport-specific settings
+    /// - For Engine API implementations, this also includes handles for consensus layer
+    ///   communication
     type Handle: Send + Sync + Clone;
 
     /// Configures and launches the add-ons.
+    ///
+    /// This method is called once during node startup after all core components are initialized.
+    /// It receives an [`AddOnsContext`] that provides access to:
+    ///
+    /// - The fully configured node with all its components
+    /// - Node configuration for reading settings
+    /// - Engine API handles for consensus layer communication
+    /// - JWT secrets for setting up authenticated endpoints (if any).
+    ///
+    /// The implementation should:
+    /// 1. Use the context to configure the add-on services
+    /// 2. Launch any background tasks using the node's task executor
+    /// 3. Return a handle that allows interaction with the launched services
+    ///
+    /// # Errors
+    ///
+    /// This method may fail if the add-ons cannot be properly configured or launched,
+    /// for example due to port binding issues or invalid configuration.
     fn launch_add_ons(
         self,
         ctx: AddOnsContext<'_, N>,

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -135,7 +135,7 @@ pub struct AddOnsContext<'a, N: FullNodeComponents> {
 /// - Access all node components and configuration during initialization
 /// - Return a handle for managing the launched services (e.g. handle to rpc server)
 ///
-/// ## How it fits into NodeBuilder
+/// ## How it fits into `NodeBuilder`
 ///
 /// In the node builder pattern, add-ons are the final layer that gets applied after all core
 /// components are configured and started. The builder flow typically follows:


### PR DESCRIPTION
Add comprehensive documentation for the `NodeAddOns` trait explaining:

- Its role as an extension point in the node builder architecture
- How it fits into the NodeBuilder stack as the final layer
- Its primary use case for launching RPC servers (regular RPC and Engine API)
- Details about the Handle type and what it typically contains
- Context access through `AddOnsContext`

The documentation helps developers understand how to use this trait to extend nodes with custom functionality, with a focus on its main purpose of setting up RPC servers.