### PR TITLE
replace reference monitoring.mdx

### DIFF
--- a/docs/vocs/docs/pages/run/monitoring.mdx
+++ b/docs/vocs/docs/pages/run/monitoring.mdx
@@ -141,4 +141,4 @@ This will all be very useful to you, whether you're simply running a home node a
 [installation]: ../installation/installation
 [release-profile]: https://doc.rust-lang.org/cargo/reference/profiles.html#release
 [docs]: https://github.com/paradigmxyz/reth/tree/main/docs
-[metrics]: https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics#current-metrics
+[metrics]: https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics.md


### PR DESCRIPTION
Updated the [metrics] link in `monitoring.mdx` to point to a new documentation location:
- Removed: `https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics#current-metrics`
- Added: `https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics.md`
