### PR TITLE
test(trie): copy serial sparse trie tests to parallel sparse trie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10618,6 +10618,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "itertools 0.14.0",
+ "pretty_assertions",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10626,6 +10626,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-primitives-traits",
+ "reth-tracing",
  "reth-trie",
  "reth-trie-common",
  "reth-trie-sparse",

--- a/crates/trie/sparse-parallel/Cargo.toml
+++ b/crates/trie/sparse-parallel/Cargo.toml
@@ -33,6 +33,7 @@ reth-primitives-traits.workspace = true
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie.workspace = true
 reth-trie-sparse = { workspace = true, features = ["test-utils"] }
+reth-tracing.workspace = true
 
 # misc
 arbitrary.workspace = true

--- a/crates/trie/sparse-parallel/Cargo.toml
+++ b/crates/trie/sparse-parallel/Cargo.toml
@@ -42,6 +42,7 @@ proptest-arbitrary-interop.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true
+pretty_assertions.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1944,7 +1944,6 @@ mod tests {
         map::{foldhash::fast::RandomState, B256Set, DefaultHashBuilder, HashMap},
         B256, U256,
     };
-    use std::collections::BTreeMap;
     use alloy_rlp::{Decodable, Encodable};
     use alloy_trie::{BranchNodeCompact, Nibbles};
     use assert_matches::assert_matches;
@@ -1969,6 +1968,7 @@ mod tests {
         blinded::{BlindedProvider, DefaultBlindedProvider, RevealedNode},
         SparseNode, SparseTrieInterface, TrieMasks,
     };
+    use std::collections::BTreeMap;
 
     /// Mock blinded provider for testing that allows pre-setting nodes at specific paths.
     ///
@@ -4554,7 +4554,10 @@ mod tests {
         let sparse_updates = sparse.updates.as_ref().unwrap();
 
         pretty_assertions::assert_eq!(sparse_root, hash_builder_root);
-        pretty_assertions::assert_eq!(sparse_updates.updated_nodes, hash_builder_updates.account_nodes);
+        pretty_assertions::assert_eq!(
+            sparse_updates.updated_nodes,
+            hash_builder_updates.account_nodes
+        );
         assert_eq_parallel_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
 
         let (hash_builder_root, hash_builder_updates, hash_builder_proof_nodes, _, _) =
@@ -4585,34 +4588,60 @@ mod tests {
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
 
         sparse
-            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), value.clone(), DefaultBlindedProvider)
+            .update_leaf(
+                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
+                value.clone(),
+                DefaultBlindedProvider,
+            )
             .unwrap();
         sparse
-            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]), value.clone(), DefaultBlindedProvider)
+            .update_leaf(
+                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
+                value.clone(),
+                DefaultBlindedProvider,
+            )
             .unwrap();
         sparse
-            .update_leaf(Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), value.clone(), DefaultBlindedProvider)
+            .update_leaf(
+                Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]),
+                value.clone(),
+                DefaultBlindedProvider,
+            )
             .unwrap();
         sparse
-            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]), value.clone(), DefaultBlindedProvider)
+            .update_leaf(
+                Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]),
+                value.clone(),
+                DefaultBlindedProvider,
+            )
             .unwrap();
         sparse
-            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]), value.clone(), DefaultBlindedProvider)
+            .update_leaf(
+                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]),
+                value.clone(),
+                DefaultBlindedProvider,
+            )
             .unwrap();
-        sparse.update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]), value, DefaultBlindedProvider).unwrap();
+        sparse
+            .update_leaf(
+                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]),
+                value,
+                DefaultBlindedProvider,
+            )
+            .unwrap();
 
         // For ParallelSparseTrie, we need to collect nodes from both upper and lower subtries
         let mut all_nodes = std::collections::BTreeMap::new();
-        
+
         // Add upper subtrie nodes
-        for (path, node) in sparse.upper_subtrie.nodes.iter() {
-            all_nodes.insert(path.clone(), node.clone());
+        for (path, node) in &sparse.upper_subtrie.nodes {
+            all_nodes.insert(*path, node.clone());
         }
-        
+
         // Add lower subtrie nodes
         for subtrie in sparse.lower_subtries.iter().flatten() {
-            for (path, node) in subtrie.nodes.iter() {
-                all_nodes.insert(path.clone(), node.clone());
+            for (path, node) in &subtrie.nodes {
+                all_nodes.insert(*path, node.clone());
             }
         }
 
@@ -4670,20 +4699,22 @@ mod tests {
             ])
         );
 
-        sparse.remove_leaf(&Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), DefaultBlindedProvider).unwrap();
+        sparse
+            .remove_leaf(&Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), DefaultBlindedProvider)
+            .unwrap();
 
         // Collect nodes again after removal
         let mut all_nodes_after = BTreeMap::new();
-        
+
         // Add upper subtrie nodes
-        for (path, node) in sparse.upper_subtrie.nodes.iter() {
-            all_nodes_after.insert(path.clone(), node.clone());
+        for (path, node) in &sparse.upper_subtrie.nodes {
+            all_nodes_after.insert(*path, node.clone());
         }
-        
+
         // Add lower subtrie nodes
         for subtrie in sparse.lower_subtries.iter().flatten() {
-            for (path, node) in subtrie.nodes.iter() {
-                all_nodes_after.insert(path.clone(), node.clone());
+            for (path, node) in &subtrie.nodes {
+                all_nodes_after.insert(*path, node.clone());
             }
         }
 
@@ -4736,20 +4767,22 @@ mod tests {
             ])
         );
 
-        sparse.remove_leaf(&Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), DefaultBlindedProvider).unwrap();
+        sparse
+            .remove_leaf(&Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), DefaultBlindedProvider)
+            .unwrap();
 
         // Collect nodes again after second removal
         let mut all_nodes_final = BTreeMap::new();
-        
+
         // Add upper subtrie nodes
-        for (path, node) in sparse.upper_subtrie.nodes.iter() {
-            all_nodes_final.insert(path.clone(), node.clone());
+        for (path, node) in &sparse.upper_subtrie.nodes {
+            all_nodes_final.insert(*path, node.clone());
         }
-        
+
         // Add lower subtrie nodes
         for subtrie in sparse.lower_subtries.iter().flatten() {
-            for (path, node) in subtrie.nodes.iter() {
-                all_nodes_final.insert(path.clone(), node.clone());
+            for (path, node) in &subtrie.nodes {
+                all_nodes_final.insert(*path, node.clone());
             }
         }
 
@@ -4871,7 +4904,10 @@ mod tests {
 
         // Removing a non-existent leaf should be a noop
         let sparse_old = sparse.clone();
-        assert_matches!(sparse.remove_leaf(&Nibbles::from_nibbles([0x2]), DefaultBlindedProvider), Ok(()));
+        assert_matches!(
+            sparse.remove_leaf(&Nibbles::from_nibbles([0x2]), DefaultBlindedProvider),
+            Ok(())
+        );
         assert_eq!(sparse, sparse_old);
     }
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -3898,8 +3898,10 @@ mod tests {
         let (leaf1_path, value1) = ctx.create_test_leaf([0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0], 1);
         let (leaf2_path, value2) = ctx.create_test_leaf([0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1], 2);
 
-        trie.update_leaf(leaf1_path, value1.clone(), DefaultBlindedProvider).unwrap();
-        trie.update_leaf(leaf2_path, value2.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[
+            (leaf1_path, value1.clone()),
+            (leaf2_path, value2.clone()),
+        ]);
 
         // Verify upper trie has extension with the full common prefix
         ctx.assert_upper_subtrie(&trie).has_extension(
@@ -3951,9 +3953,7 @@ mod tests {
         }
 
         // Insert all leaves
-        for (path, value) in &leaves {
-            trie.update_leaf(*path, value.clone(), DefaultBlindedProvider).unwrap();
-        }
+        ctx.insert_leaves(&mut trie, &leaves);
 
         // Verify upper trie structure
         ctx.assert_upper_subtrie(&trie)
@@ -4003,9 +4003,7 @@ mod tests {
         ];
 
         // Insert all leaves
-        for (path, value) in &leaves {
-            trie.update_leaf(*path, value.clone(), DefaultBlindedProvider).unwrap();
-        }
+        ctx.insert_leaves(&mut trie, &leaves);
 
         // Verify upper trie has extension then branch
         ctx.assert_upper_subtrie(&trie)

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1,9 +1,8 @@
 use alloy_primitives::{
     map::{Entry, HashMap},
-    B256, U256,
+    B256,
 };
 use alloy_rlp::Decodable;
-use std::collections::BTreeMap;
 use alloy_trie::{BranchNodeCompact, TrieMask, EMPTY_ROOT_HASH};
 use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
 use reth_trie_common::{
@@ -2282,6 +2281,15 @@ mod tests {
             subtrie.nodes.insert(path, node);
         }
         trie
+    }
+
+    /// Helper function to pad nibbles to the right with zeros to make them full B256 paths
+    fn pad_nibbles_right(mut nibbles: Nibbles) -> Nibbles {
+        nibbles.extend(&Nibbles::from_nibbles_unchecked(vec![
+            0;
+            B256::len_bytes() * 2 - nibbles.len()
+        ]));
+        nibbles
     }
 
     /// Assert that the parallel sparse trie nodes and the proof nodes from the hash builder are
@@ -4865,5 +4873,268 @@ mod tests {
         let sparse_old = sparse.clone();
         assert_matches!(sparse.remove_leaf(&Nibbles::from_nibbles([0x2]), DefaultBlindedProvider), Ok(()));
         assert_eq!(sparse, sparse_old);
+    }
+
+    #[test]
+    fn parallel_sparse_trie_reveal_node_1() {
+        let key1 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00]));
+        let key2 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01]));
+        let key3 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x02]));
+        let value = || Account::default();
+        let value_encoded = || {
+            let mut account_rlp = Vec::new();
+            value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
+            account_rlp
+        };
+
+        // Generate the proof for the root node and initialize the sparse trie with it
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key3(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [Nibbles::default()],
+            );
+        let mut sparse = ParallelSparseTrie::from_root(
+            TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
+            TrieMasks {
+                hash_mask: branch_node_hash_masks.get(&Nibbles::default()).copied(),
+                tree_mask: branch_node_tree_masks.get(&Nibbles::default()).copied(),
+            },
+            false,
+        )
+        .unwrap();
+
+        // Generate the proof for the first key and reveal it in the sparse trie
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key3(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [key1()],
+            );
+        for (path, node) in hash_builder_proof_nodes.nodes_sorted() {
+            let hash_mask = branch_node_hash_masks.get(&path).copied();
+            let tree_mask = branch_node_tree_masks.get(&path).copied();
+            sparse
+                .reveal_node(
+                    path,
+                    TrieNode::decode(&mut &node[..]).unwrap(),
+                    TrieMasks { hash_mask, tree_mask },
+                )
+                .unwrap();
+        }
+
+        // Check that the branch node exists with only two nibbles set
+        assert_eq!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(&SparseNode::new_branch(0b101.into()))
+        );
+
+        // Insert the leaf for the second key
+        sparse.update_leaf(key2(), value_encoded(), DefaultBlindedProvider).unwrap();
+
+        // Check that the branch node was updated and another nibble was set
+        assert_eq!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(&SparseNode::new_branch(0b111.into()))
+        );
+
+        // Generate the proof for the third key and reveal it in the sparse trie
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key3(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [key3()],
+            );
+        for (path, node) in hash_builder_proof_nodes.nodes_sorted() {
+            let hash_mask = branch_node_hash_masks.get(&path).copied();
+            let tree_mask = branch_node_tree_masks.get(&path).copied();
+            sparse
+                .reveal_node(
+                    path,
+                    TrieNode::decode(&mut &node[..]).unwrap(),
+                    TrieMasks { hash_mask, tree_mask },
+                )
+                .unwrap();
+        }
+
+        // Check that nothing changed in the branch node
+        assert_eq!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(&SparseNode::new_branch(0b111.into()))
+        );
+
+        // Generate the nodes for the full trie with all three key using the hash builder, and
+        // compare them to the sparse trie
+        let (_, _, hash_builder_proof_nodes, _, _) = run_hash_builder(
+            [(key1(), value()), (key2(), value()), (key3(), value())],
+            NoopAccountTrieCursor::default(),
+            Default::default(),
+            [key1(), key2(), key3()],
+        );
+
+        assert_eq_parallel_sparse_trie_proof_nodes(&sparse, hash_builder_proof_nodes);
+    }
+
+    #[test]
+    fn parallel_sparse_trie_reveal_node_2() {
+        let key1 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00, 0x00]));
+        let key2 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01, 0x01]));
+        let key3 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01, 0x02]));
+        let value = || Account::default();
+
+        // Generate the proof for the root node and initialize the sparse trie with it
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key2(), value()), (key3(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [Nibbles::default()],
+            );
+        let mut sparse = ParallelSparseTrie::from_root(
+            TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
+            TrieMasks {
+                hash_mask: branch_node_hash_masks.get(&Nibbles::default()).copied(),
+                tree_mask: branch_node_tree_masks.get(&Nibbles::default()).copied(),
+            },
+            false,
+        )
+        .unwrap();
+
+        // Generate the proof for the children of the root branch node and reveal it in the sparse
+        // trie
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key2(), value()), (key3(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [key1(), Nibbles::from_nibbles_unchecked([0x01])],
+            );
+        for (path, node) in hash_builder_proof_nodes.nodes_sorted() {
+            let hash_mask = branch_node_hash_masks.get(&path).copied();
+            let tree_mask = branch_node_tree_masks.get(&path).copied();
+            sparse
+                .reveal_node(
+                    path,
+                    TrieNode::decode(&mut &node[..]).unwrap(),
+                    TrieMasks { hash_mask, tree_mask },
+                )
+                .unwrap();
+        }
+
+        // Check that the branch node exists
+        assert_eq!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(&SparseNode::new_branch(0b11.into()))
+        );
+
+        // Remove the leaf for the first key
+        sparse.remove_leaf(&key1(), DefaultBlindedProvider).unwrap();
+
+        // Check that the branch node was turned into an extension node
+        assert_eq!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(&SparseNode::new_ext(Nibbles::from_nibbles_unchecked([0x01])))
+        );
+
+        // Generate the proof for the third key and reveal it in the sparse trie
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key2(), value()), (key3(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [key2()],
+            );
+        for (path, node) in hash_builder_proof_nodes.nodes_sorted() {
+            let hash_mask = branch_node_hash_masks.get(&path).copied();
+            let tree_mask = branch_node_tree_masks.get(&path).copied();
+            sparse
+                .reveal_node(
+                    path,
+                    TrieNode::decode(&mut &node[..]).unwrap(),
+                    TrieMasks { hash_mask, tree_mask },
+                )
+                .unwrap();
+        }
+
+        // Check that nothing changed in the extension node
+        assert_eq!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(&SparseNode::new_ext(Nibbles::from_nibbles_unchecked([0x01])))
+        );
+    }
+
+    #[test]
+    fn parallel_sparse_trie_reveal_node_3() {
+        let key1 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00, 0x01]));
+        let key2 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00, 0x02]));
+        let key3 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01, 0x00]));
+        let value = || Account::default();
+        let value_encoded = || {
+            let mut account_rlp = Vec::new();
+            value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
+            account_rlp
+        };
+
+        // Generate the proof for the root node and initialize the sparse trie with it
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key2(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [Nibbles::default()],
+            );
+        let mut sparse = ParallelSparseTrie::from_root(
+            TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
+            TrieMasks {
+                hash_mask: branch_node_hash_masks.get(&Nibbles::default()).copied(),
+                tree_mask: branch_node_tree_masks.get(&Nibbles::default()).copied(),
+            },
+            false,
+        )
+        .unwrap();
+
+        // Check that the root extension node exists
+        assert_matches!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(SparseNode::Extension { key, hash: None, store_in_db_trie: None }) if *key == Nibbles::from_nibbles([0x00])
+        );
+
+        // Insert the leaf with a different prefix
+        sparse.update_leaf(key3(), value_encoded(), DefaultBlindedProvider).unwrap();
+
+        // Check that the extension node was turned into a branch node
+        assert_matches!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(SparseNode::Branch { state_mask, hash: None, store_in_db_trie: None }) if *state_mask == TrieMask::new(0b11)
+        );
+
+        // Generate the proof for the first key and reveal it in the sparse trie
+        let (_, _, hash_builder_proof_nodes, branch_node_hash_masks, branch_node_tree_masks) =
+            run_hash_builder(
+                [(key1(), value()), (key2(), value())],
+                NoopAccountTrieCursor::default(),
+                Default::default(),
+                [key1()],
+            );
+        for (path, node) in hash_builder_proof_nodes.nodes_sorted() {
+            let hash_mask = branch_node_hash_masks.get(&path).copied();
+            let tree_mask = branch_node_tree_masks.get(&path).copied();
+            sparse
+                .reveal_node(
+                    path,
+                    TrieNode::decode(&mut &node[..]).unwrap(),
+                    TrieMasks { hash_mask, tree_mask },
+                )
+                .unwrap();
+        }
+
+        // Check that the branch node wasn't overwritten by the extension node in the proof
+        assert_matches!(
+            sparse.upper_subtrie.nodes.get(&Nibbles::default()),
+            Some(SparseNode::Branch { state_mask, hash: None, store_in_db_trie: None }) if *state_mask == TrieMask::new(0b11)
+        );
     }
 }

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -3614,7 +3614,7 @@ mod tests {
 
         // First add leaf 0x1345 - this should create a leaf in upper trie at 0x
         let (leaf1_path, value1) = ctx.create_test_leaf([0x1, 0x3, 0x4, 0x5], 1);
-        trie.update_leaf(leaf1_path, value1.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(leaf1_path, value1.clone())]);
 
         // Verify upper trie has a leaf at the root with key 1345
         ctx.assert_upper_subtrie(&trie)
@@ -3622,14 +3622,14 @@ mod tests {
 
         // Add leaf 0x1234 - this should go first in the upper subtrie
         let (leaf2_path, value2) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4], 2);
-        trie.update_leaf(leaf2_path, value2.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(leaf2_path, value2.clone())]);
 
         // Upper trie should now have a branch at 0x1
         ctx.assert_upper_subtrie(&trie).has_branch(&Nibbles::from_nibbles([0x1]), &[0x2, 0x3]);
 
         // Add leaf 0x1245 - this should cause a branch and create the 0x12 subtrie
         let (leaf3_path, value3) = ctx.create_test_leaf([0x1, 0x2, 0x4, 0x5], 3);
-        trie.update_leaf(leaf3_path, value3.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(leaf3_path, value3.clone())]);
 
         // Verify lower subtrie at 0x12 exists with correct structure
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x2]))
@@ -3641,7 +3641,7 @@ mod tests {
 
         // Add leaf 0x1334 - this should create another lower subtrie
         let (leaf4_path, value4) = ctx.create_test_leaf([0x1, 0x3, 0x3, 0x4], 4);
-        trie.update_leaf(leaf4_path, value4.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(leaf4_path, value4.clone())]);
 
         // Verify lower subtrie at 0x13 exists with correct values
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x3]))
@@ -3676,7 +3676,7 @@ mod tests {
         // First insert a leaf that ends exactly at the boundary (2 nibbles)
         let (first_leaf_path, first_value) = ctx.create_test_leaf([0x1, 0x2, 0x2, 0x4], 1);
 
-        trie.update_leaf(first_leaf_path, first_value.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(first_leaf_path, first_value.clone())]);
 
         // In an empty trie, the first leaf becomes the root, regardless of path length
         ctx.assert_upper_subtrie(&trie)
@@ -3686,7 +3686,7 @@ mod tests {
         // Now insert another leaf that shares the same 2-nibble prefix
         let (second_leaf_path, second_value) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4], 2);
 
-        trie.update_leaf(second_leaf_path, second_value.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(second_leaf_path, second_value.clone())]);
 
         // Now both leaves should be in a lower subtrie at index [0x1, 0x2]
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x2]))
@@ -3749,7 +3749,7 @@ mod tests {
         let updated_path = Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4]);
         let (_, updated_value) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4], 100);
 
-        trie.update_leaf(updated_path, updated_value.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(updated_path, updated_value.clone())]);
 
         // Verify the subtrie structure is maintained and value is updated
         // The branch structure should remain the same and all values should be present
@@ -3763,7 +3763,7 @@ mod tests {
         // Add a new leaf that extends an existing branch
         let (new_leaf_path, new_leaf_value) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x6], 200);
 
-        trie.update_leaf(new_leaf_path, new_leaf_value.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[(new_leaf_path, new_leaf_value.clone())]);
 
         // Verify the branch at [0x1, 0x2, 0x3] now has an additional child
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x2]))
@@ -3856,10 +3856,12 @@ mod tests {
         let (leaf3_path, value3) = ctx.create_test_leaf([0x2], 3);
         let (leaf4_path, value4) = ctx.create_test_leaf([0x3], 4);
 
-        trie.update_leaf(leaf1_path, value1.clone(), DefaultBlindedProvider).unwrap();
-        trie.update_leaf(leaf2_path, value2.clone(), DefaultBlindedProvider).unwrap();
-        trie.update_leaf(leaf3_path, value3.clone(), DefaultBlindedProvider).unwrap();
-        trie.update_leaf(leaf4_path, value4.clone(), DefaultBlindedProvider).unwrap();
+        ctx.insert_leaves(&mut trie, &[
+            (leaf1_path, value1.clone()),
+            (leaf2_path, value2.clone()),
+            (leaf3_path, value3.clone()),
+            (leaf4_path, value4.clone()),
+        ]);
 
         // Verify upper trie has a branch at root with 4 children
         ctx.assert_upper_subtrie(&trie)


### PR DESCRIPTION
Towards https://github.com/paradigmxyz/reth/issues/16946

The only change needed was in the `parallel_sparse_trie_remove_leaf` test, because currently, ParallelSparseTrie can't be integrated into the SparseTrie enum to initialize a blind trie.

Additionally, we can't yet add all the update tests, as they also rely on the sparse trie being blind at the beginning of the test.