### PR TITLE
docs: fix typo in trie test comment

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -3761,7 +3761,7 @@ mod tests {
             ParallelSparseTrie::from_root(TrieNode::EmptyRoot, TrieMasks::none(), true).unwrap();
 
         // First, add multiple leaves that will create a subtrie structure
-        // All leaves share the prefix [0x1, 0x2] to ensure they create a branch ndoe and subtrie
+        // All leaves share the prefix [0x1, 0x2] to ensure they create a branch node and subtrie
         //
         // This should result in a trie with the following structure
         // 0x: Extension { key: 0x12 }


### PR DESCRIPTION


**Description:**  
This pull request corrects a minor typo in a comment within the `trie.rs` test module. The word "ndoe" has been updated to "node" for improved clarity and accuracy in documentation. 