### PR TITLE
fix: dont double serialize resp

### DIFF
--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -182,7 +182,7 @@ where
                             .await
                         {
                             let payload =
-                                jsonrpsee_types::ResponsePayload::success(raw.to_string()).into();
+                                jsonrpsee_types::ResponsePayload::success(raw).into();
                             return MethodResponse::response(req.id, payload, usize::MAX);
                         }
                     }

--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -181,8 +181,7 @@ where
                             .request::<_, serde_json::Value>(req.method_name(), params)
                             .await
                         {
-                            let payload =
-                                jsonrpsee_types::ResponsePayload::success(raw).into();
+                            let payload = jsonrpsee_types::ResponsePayload::success(raw).into();
                             return MethodResponse::response(req.id, payload, usize::MAX);
                         }
                     }


### PR DESCRIPTION
closes #17202

`::success` actually serializes...