### PR TITLE
docs: fix typo in documentation comments

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -68,7 +68,7 @@ where
     precompile_cache_disabled: bool,
     /// Precompile cache map.
     precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
-    /// A cleared sparse trie, kept around to be re-used for the state root computation so that
+    /// A cleared sparse trie, kept around to be reused for the state root computation so that
     /// allocations can be minimized.
     sparse_trie: Option<SparseTrie>,
     _marker: std::marker::PhantomData<N>,

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -214,7 +214,7 @@ pub trait SparseTrieInterface: Default + Debug {
     /// Removes all nodes and values from the trie, resetting it to a blank state
     /// with only an empty root node. This is used when a storage root is deleted.
     ///
-    /// This should not be used when intending to re-use the trie for a fresh account/storage root;
+    /// This should not be used when intending to reuse the trie for a fresh account/storage root;
     /// use `clear` for that.
     ///
     /// Note: All previously tracked changes to the trie are also removed.


### PR DESCRIPTION

This pull request standardizes the spelling of "reuse" in documentation comments, replacing inconsistent forms like "re-use" with "reuse" for improved readability and professionalism.  
- Updated comments in `payload_processor/mod.rs` and `sparse/src/traits.rs`
