### PR TITLE
docs: fix typos across documentation

### DIFF
--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -350,7 +350,7 @@ where
 
     /// Compares the node head against the ExEx head, and backfills if needed.
     ///
-    /// CAUTON: This method assumes that the ExEx head is <= the node head, and that it's on the
+    /// CAUTION: This method assumes that the ExEx head is <= the node head, and that it's on the
     /// canonical chain.
     ///
     /// Possible situations are:

--- a/crates/net/discv5/src/filter.rs
+++ b/crates/net/discv5/src/filter.rs
@@ -1,4 +1,4 @@
-//! Predicates to constraint peer lookups.
+//! Predicates to constrain peer lookups.
 
 use std::collections::HashSet;
 


### PR DESCRIPTION
crates/exex/exex/src/notifications.rs
CAUTON --> CAUTION -- fix typo

crates/net/discv5/src/filter.rs
constraint ---> constrain -- The word "constraint" is a noun (restriction), but in this context the verb "constrain" (to restrict) should be used.