### PR TITLE
fix(rpc): Remove unnecessary parentheses around `dyn EthSigner` return type

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -489,7 +489,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn find_signer(
         &self,
         account: &Address,
-    ) -> Result<Box<(dyn EthSigner<ProviderTx<Self::Provider>> + 'static)>, Self::Error> {
+    ) -> Result<Box<dyn EthSigner<ProviderTx<Self::Provider>> + 'static>, Self::Error> {
         self.signers()
             .read()
             .iter()


### PR DESCRIPTION
Fixes a lint error with the latest `clippy`.