### PR TITLE
chore: fix typo in documentation comment in environment.rs

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -511,7 +511,7 @@ impl<R> Default for Geometry<R> {
 /// Read transactions prevent reuse of pages freed by newer write transactions, thus the database
 /// can grow quickly. This callback will be called when there is not enough space in the database
 /// (i.e. before increasing the database size or before `MDBX_MAP_FULL` error) and thus can be
-/// used to resolve issues with a "long-lived" read transacttions.
+/// used to resolve issues with a "long-lived" read transactions.
 ///
 /// Depending on the arguments and needs, your implementation may wait,
 /// terminate a process or thread that is performing a long read, or perform


### PR DESCRIPTION
Corrected a typo in the docstring:

- transacttions → transactions

This improves the clarity and correctness of documentation related to read transaction behavior in the LMDBX environment configuration.