### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -489,7 +489,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn find_signer(
         &self,
         account: &Address,
-    ) -> Result<Box<(dyn EthSigner<ProviderTx<Self::Provider>> + 'static)>, Self::Error> {
+    ) -> Result<Box<dyn EthSigner<ProviderTx<Self::Provider>> + 'static>, Self::Error> {
         self.signers()
             .read()
             .iter()


### PR DESCRIPTION
fixes this warning with latest nightly:
```
warning: unnecessary parentheses around type
   --> crates/rpc/rpc-eth-api/src/helpers/transaction.rs:492:21
    |
492 |     ) -> Result<Box<(dyn EthSigner<ProviderTx<Self::Provider>> + 'static)>, Self::Error> {
    |                     ^                                                   ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
492 -     ) -> Result<Box<(dyn EthSigner<ProviderTx<Self::Provider>> + 'static)>, Self::Error> {
492 +     ) -> Result<Box<dyn EthSigner<ProviderTx<Self::Provider>> + 'static>, Self::Error> {
```