### PR TITLE
Update metrics documentation link to new official Reth docs

### DIFF
--- a/docs/vocs/docs/pages/run/monitoring.mdx
+++ b/docs/vocs/docs/pages/run/monitoring.mdx
@@ -141,4 +141,4 @@ This will all be very useful to you, whether you're simply running a home node a
 [installation]: ../installation/installation
 [release-profile]: https://doc.rust-lang.org/cargo/reference/profiles.html#release
 [docs]: https://github.com/paradigmxyz/reth/tree/main/docs
-[metrics]: https://github.com/paradigmxyz/reth/blob/main/docs/design/metrics#current-metrics
+[metrics]: https://reth.rs/run/observability.html


### PR DESCRIPTION
Replaced the outdated GitHub link to the Reth metrics documentation with the current official page at https://reth.rs/run/observability.html. This ensures users are directed to the latest and most accurate information about Reth metrics and observability.