### PR TITLE
fix(trie): track branch node updates only in ParallelSparseTrie, not subtries

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -46,7 +46,7 @@ pub mod prewarm;
 pub mod sparse_trie;
 
 /// Entrypoint for executing the payload.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PayloadProcessor<N, Evm>
 where
     N: NodePrimitives,

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -76,7 +76,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
     }
 
     fn with_updates(mut self, retain_updates: bool) -> Self {
-        self.updates = retain_updates.then(|| Default::default());
+        self.updates = retain_updates.then(Default::default);
         self
     }
 
@@ -539,7 +539,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
             subtries
                 .into_par_iter()
                 .map(|ChangedSubtrie { index, mut subtrie, mut prefix_set }| {
-                    let mut update_actions = self.updates_enabled().then(|| Vec::new());
+                    let mut update_actions = self.updates_enabled().then(Vec::new);
                     subtrie.update_hashes(&mut prefix_set, &mut update_actions);
                     (index, subtrie, update_actions)
                 })
@@ -917,7 +917,7 @@ impl ParallelSparseTrie {
             is_in_prefix_set: None,
         });
 
-        let mut update_actions = self.updates_enabled().then(|| Vec::new());
+        let mut update_actions = self.updates_enabled().then(Vec::new);
         while let Some(stack_item) = self.upper_subtrie.inner.buffers.path_stack.pop() {
             let path = stack_item.path;
             let node = if path.len() < UPPER_TRIE_MAX_DEPTH {


### PR DESCRIPTION
This commit contains 3 bug fixes related to branch node update retention.

**Fix 1**

The ParallelSparseTrie previously kept the `Option<SparseTrieUpdates>` field, used to both enable and collect branch node updates, in multiple places:

* 1 on the ParallelSparseTrie
* 1 on the upper SparseSubtrie
* 1 on each of the 256 lower SparseSubtries.

This caused issues in `remove_leaf`, which needs to fully remove a lower subtrie if it no longer has any nodes, and would therefore lose any accumulated branch node updates.

The fix is to only track branch node updates on the ParallelSparseTrie. This introduces a new wrinkle, which is that `update_hashes` runs in parallel on each lower subtrie and needs to make changes to the global update set. To get around this we track these changes using a `Vec<SparseTrieUpdatesAction>` on each lower subtrie, and then apply those actions in `update_subtrie_hashes`.

**Fix 2**

`with_updates` wasn't properly propagating the setting to the lower subtries. Existing lower subtries wouldn't receive the setting, and any created afterwards wouldn't either. This has been fixed, in that the lower subtries don't track the setting at all anymore, and have it passed to their methods when needed.

**Fix 3**

Fixing the above revealed that `update_leaf` had a bug which went unnoticed before because update retention wasn't actually active. When turning an extension into a branch, it's possible `update_leaf` would need to reveal the previous child of the extension. This was failing in cases where the extension was on the upper trie and the child on a lower one. This has been fixed and a test case added.

Fixes #17172 