### PR TITLE
chore: make receipt root mismatch log more useful

### DIFF
--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_consensus::{proofs::calculate_receipt_root, BlockHeader, TxReceipt};
-use alloy_eips::eip7685::Requests;
-use alloy_primitives::{Bloom, B256};
+use alloy_eips::{eip7685::Requests, Encodable2718};
+use alloy_primitives::{Bloom, Bytes, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{
@@ -41,6 +41,10 @@ where
         if let Err(error) =
             verify_receipts(block.header().receipts_root(), block.header().logs_bloom(), receipts)
         {
+            let receipts = receipts
+                .iter()
+                .map(|r| Bytes::from(r.with_bloom_ref().encoded_2718()))
+                .collect::<Vec<_>>();
             tracing::debug!(%error, ?receipts, "receipts verification failed");
             return Err(error)
         }

--- a/crates/optimism/consensus/src/validation/mod.rs
+++ b/crates/optimism/consensus/src/validation/mod.rs
@@ -6,7 +6,8 @@ pub mod isthmus;
 use crate::proof::calculate_receipt_root_optimism;
 use alloc::vec::Vec;
 use alloy_consensus::{BlockHeader, TxReceipt, EMPTY_OMMER_ROOT_HASH};
-use alloy_primitives::{Bloom, B256};
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Bloom, Bytes, B256};
 use alloy_trie::EMPTY_ROOT_HASH;
 use op_alloy_consensus::{decode_holocene_extra_data, EIP1559ParamError};
 use reth_chainspec::{BaseFeeParams, EthChainSpec};
@@ -99,6 +100,10 @@ pub fn validate_block_post_execution<R: DepositReceipt>(
             chain_spec,
             header.timestamp(),
         ) {
+            let receipts = receipts
+                .iter()
+                .map(|r| Bytes::from(r.with_bloom_ref().encoded_2718()))
+                .collect::<Vec<_>>();
             tracing::debug!(%error, ?receipts, "receipts verification failed");
             return Err(error)
         }


### PR DESCRIPTION
this currently logs just a debug impl of a vec which is pretty much unusable if you want to programatically compare it with actual receipts

this PR changes this to vec of rlp encodings which can then be directly compared against valid rlp or decoded into e.g alloy type