### PR TITLE
Fix typo in EVM component documentation

### DIFF
--- a/docs/vocs/docs/pages/sdk/node-components/evm.mdx
+++ b/docs/vocs/docs/pages/sdk/node-components/evm.mdx
@@ -1,6 +1,6 @@
 # EVM Component
 
-The EVM (Ethereum Virtual Machine) component handles transaction execution and state transitionss. It's responsible for processing transactions and updating the blockchain state.
+The EVM (Ethereum Virtual Machine) component handles transaction execution and state transitions. It's responsible for processing transactions and updating the blockchain state.
 
 ## Overview
 


### PR DESCRIPTION
Corrected a minor typo in the EVM component docs:

- transitionss → transitions

This improves the accuracy and readability of the SDK documentation.