### PR TITLE
docs: Consistent Spelling for "Reuse" in Documentation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -149,7 +149,7 @@ where
         self.metrics.sparse_trie_final_update_duration_histogram.record(start.elapsed());
         self.metrics.sparse_trie_total_duration_histogram.record(now.elapsed());
 
-        // take the account trie so that we can re-use its already allocated data structures.
+        // take the account trie so that we can reuse its already allocated data structures.
         let trie = self.trie.take_cleared_accounts_trie();
 
         Ok(StateRootComputeOutcome { state_root, trie_updates, trie })

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -49,7 +49,7 @@ pub enum SparseTrie<T = RevealedSparseTrie> {
     /// until nodes are revealed.
     ///
     /// In this state the `SparseTrie` can optionally carry with it a cleared `RevealedSparseTrie`.
-    /// This allows for re-using the trie's allocations between payload executions.
+    /// This allows for reusing the trie's allocations between payload executions.
     Blind(Option<Box<T>>),
     /// Some nodes in the Trie have been revealed.
     ///


### PR DESCRIPTION


**Description:**  
This pull request updates comments and documentation to use the correct spelling "reuse" instead of "re-use" or "re-using" in the sparse trie modules. 