### PR TITLE
docs: fix typo mod.rs

### DIFF
--- a/crates/optimism/primitives/src/transaction/mod.rs
+++ b/crates/optimism/primitives/src/transaction/mod.rs
@@ -2,7 +2,7 @@
 
 mod tx_type;
 
-/// Kept for concistency tests
+/// Kept for consistency tests
 #[cfg(test)]
 mod signed;
 


### PR DESCRIPTION
`concistency` - `consistency` --> fixed