### PR TITLE
chore(doc): update exclude list for doc/cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ members = [
     "crates/tracing-otlp",
 ]
 default-members = ["bin/reth"]
-exclude = ["doc/cli"]
+exclude = ["docs/cli"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ members = [
     "crates/tracing-otlp",
 ]
 default-members = ["bin/reth"]
-exclude = ["book/sources", "book/cli"]
+exclude = ["doc/cli"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html


### PR DESCRIPTION
This updates the `exclude` list in `Cargo.toml` to include proper path for `doc/cli`. Also removes old paths. 