### PR TITLE
fix: logical error in pruning test for storage_history PruneMode::Full

### DIFF
--- a/crates/stages/stages/benches/README.md
+++ b/crates/stages/stages/benches/README.md
@@ -13,7 +13,7 @@ It will generate a flamegraph report without running any criterion analysis.
 ```
 cargo bench --package reth-stages --bench criterion --features test-utils -- --profile-time=2
 ```
-Flamegraph reports can be find at `target/criterion/Stages/$STAGE_LABEL/profile/flamegraph.svg` 
+Flamegraph reports can be found at `target/criterion/Stages/$STAGE_LABEL/profile/flamegraph.svg` 
 
 
 ## External DB support

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -213,7 +213,7 @@ mod tests {
 
             if prune_modes.storage_history == Some(PruneMode::Full) {
                 // Full is not supported
-                assert!(acc_indexing_stage.execute(&provider, input).is_err());
+                assert!(storage_indexing_stage.execute(&provider, input).is_err());
             } else {
                 storage_indexing_stage.execute(&provider, input).unwrap();
 


### PR DESCRIPTION
Corrected a logical error in the pruning test: when checking for PruneMode::Full on storage_history, the test now correctly asserts that storage_indexing_stage.execute returns an error, instead of incorrectly calling acc_indexing_stage.execute. This ensures the test accurately verifies unsupported full pruning for storage history. No other logic or functionality was changed.