### PR TITLE
chore: add capabilities to NetworkStatus

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -35,7 +35,8 @@ pub use events::{
 };
 
 use reth_eth_wire_types::{
-    capability::Capabilities, DisconnectReason, EthVersion, NetworkPrimitives, UnifiedStatus,
+    capability::Capabilities, Capability, DisconnectReason, EthVersion, NetworkPrimitives,
+    UnifiedStatus,
 };
 use reth_network_p2p::sync::NetworkSyncUpdater;
 use reth_network_peers::NodeRecord;
@@ -285,4 +286,6 @@ pub struct NetworkStatus {
     pub protocol_version: u64,
     /// Information about the Ethereum Wire Protocol.
     pub eth_protocol_info: EthProtocolInfo,
+    /// The list of supported capabilities and their versions.
+    pub capabilities: Vec<Capability>,
 }

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -73,6 +73,7 @@ where
                 config: Default::default(),
                 head: Default::default(),
             },
+            capabilities: vec![],
         })
     }
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -457,6 +457,11 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                 genesis: status.genesis,
                 config: Default::default(),
             },
+            capabilities: hello_message
+                .protocols
+                .into_iter()
+                .map(|protocol| protocol.cap)
+                .collect(),
         }
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/sync_listener.rs
+++ b/crates/rpc/rpc/src/eth/helpers/sync_listener.rs
@@ -91,6 +91,7 @@ mod tests {
                     config: Default::default(),
                     head: Default::default(),
                 },
+                capabilities: vec![],
             })
         }
 


### PR DESCRIPTION
It's useful to have `capabilities` in `NetworkStatus`. This refactor streamlines the collection of protocol capabilities for the network status.