### PR TITLE
refactor(txpool): Remove txhash from PoolUpdate

### DIFF
--- a/crates/transaction-pool/src/pool/update.rs
+++ b/crates/transaction-pool/src/pool/update.rs
@@ -3,7 +3,6 @@
 use crate::{
     identifier::TransactionId, pool::state::SubPool, PoolTransaction, ValidPoolTransaction,
 };
-use alloy_primitives::TxHash;
 use std::sync::Arc;
 
 /// A change of the transaction's location
@@ -13,8 +12,6 @@ use std::sync::Arc;
 pub(crate) struct PoolUpdate {
     /// Internal tx id.
     pub(crate) id: TransactionId,
-    /// Hash of the transaction.
-    pub(crate) hash: TxHash,
     /// Where the transaction is currently held.
     pub(crate) current: SubPool,
     /// Where to move the transaction to.


### PR DESCRIPTION
- introduce `prune_transaction_by_id` and  `remove_transaction_by_id` functions that operate on `tx_id` but equivalent to `prune_transaction_by_hash` and remove_transaction_by_hash`

- remove txhash field from poolupdate to keep mem print low


closes #17226 