### PR TITLE
refactor(rpc): Arc PendingBlock internals

### DIFF
--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -1,5 +1,7 @@
 //! Loads OP pending block for a RPC response.
 
+use std::sync::Arc;
+
 use crate::OpEthApi;
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
@@ -78,8 +80,8 @@ where
         &self,
     ) -> Result<
         Option<(
-            RecoveredBlock<ProviderBlock<Self::Provider>>,
-            Vec<ProviderReceipt<Self::Provider>>,
+            Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>,
+            Arc<Vec<ProviderReceipt<Self::Provider>>>,
         )>,
         Self::Error,
     > {
@@ -102,6 +104,6 @@ where
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::ReceiptsNotFound(block_id.into()))?;
 
-        Ok(Some((block, receipts)))
+        Ok(Some((Arc::new(block), Arc::new(receipts))))
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -135,7 +135,7 @@ pub trait EthBlocks: LoadBlock {
 
                 // If no pending block from provider, build the pending block locally.
                 if let Some((block, receipts)) = self.local_pending_block().await? {
-                    return Ok(Some((Arc::new(block), Arc::new(receipts))));
+                    return Ok(Some((block, receipts)));
                 }
             }
 
@@ -245,7 +245,7 @@ pub trait LoadBlock:
 
                 // If no pending block from provider, try to get local pending block
                 return match self.local_pending_block().await? {
-                    Some((block, _)) => Ok(Some(Arc::new(block))),
+                    Some((block, _)) => Ok(Some(block)),
                     None => Ok(None),
                 };
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -181,14 +181,17 @@ pub trait LoadPendingBlock:
                 }
             };
 
+            let sealed_block = Arc::new(sealed_block);
+            let receipts = Arc::new(receipts);
+
             let now = Instant::now();
             *lock = Some(PendingBlock::new(
                 now + Duration::from_secs(1),
-                Arc::new(sealed_block.clone()),
-                Arc::new(receipts.clone()),
+                sealed_block.clone(),
+                receipts.clone()
             ));
 
-            Ok(Some((Arc::new(sealed_block), Arc::new(receipts))))
+            Ok(Some((sealed_block, receipts)))
         }
     }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -188,7 +188,7 @@ pub trait LoadPendingBlock:
             *lock = Some(PendingBlock::new(
                 now + Duration::from_secs(1),
                 sealed_block.clone(),
-                receipts.clone()
+                receipts.clone(),
             ));
 
             Ok(Some((sealed_block, receipts)))

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -30,7 +30,10 @@ use reth_transaction_pool::{
     TransactionPool,
 };
 use revm::context_interface::Block;
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -92,7 +95,7 @@ pub trait LoadPendingBlock:
 
                 return Ok(PendingBlockEnv::new(
                     evm_env,
-                    PendingBlockEnvOrigin::ActualPending(block, receipts),
+                    PendingBlockEnvOrigin::ActualPending(Arc::new(block), Arc::new(receipts)),
                 ));
             }
         }
@@ -127,8 +130,8 @@ pub trait LoadPendingBlock:
     ) -> impl Future<
         Output = Result<
             Option<(
-                RecoveredBlock<<Self::Provider as BlockReader>::Block>,
-                Vec<ProviderReceipt<Self::Provider>>,
+                Arc<RecoveredBlock<<Self::Provider as BlockReader>::Block>>,
+                Arc<Vec<ProviderReceipt<Self::Provider>>>,
             )>,
             Self::Error,
         >,
@@ -181,11 +184,11 @@ pub trait LoadPendingBlock:
             let now = Instant::now();
             *lock = Some(PendingBlock::new(
                 now + Duration::from_secs(1),
-                sealed_block.clone(),
-                receipts.clone(),
+                Arc::new(sealed_block.clone()),
+                Arc::new(receipts.clone()),
             ));
 
-            Ok(Some((sealed_block, receipts)))
+            Ok(Some((Arc::new(sealed_block), Arc::new(receipts))))
         }
     }
 

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -2,7 +2,7 @@
 //!
 //! Types used in block building.
 
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
@@ -25,7 +25,7 @@ pub struct PendingBlockEnv<B: Block, R, Spec> {
 #[derive(Clone, Debug)]
 pub enum PendingBlockEnvOrigin<B: Block = reth_ethereum_primitives::Block, R = Receipt> {
     /// The pending block as received from the CL.
-    ActualPending(RecoveredBlock<B>, Vec<R>),
+    ActualPending(Arc<RecoveredBlock<B>>, Arc<Vec<R>>),
     /// The _modified_ header of the latest block.
     ///
     /// This derives the pending state based on the latest header by modifying:
@@ -42,7 +42,7 @@ impl<B: Block, R> PendingBlockEnvOrigin<B, R> {
     }
 
     /// Consumes the type and returns the actual pending block.
-    pub fn into_actual_pending(self) -> Option<RecoveredBlock<B>> {
+    pub fn into_actual_pending(self) -> Option<Arc<RecoveredBlock<B>>> {
         match self {
             Self::ActualPending(block, _) => Some(block),
             _ => None,
@@ -79,7 +79,7 @@ pub struct PendingBlock<B: Block, R> {
     /// Timestamp when the pending block is considered outdated.
     pub expires_at: Instant,
     /// The locally built pending block.
-    pub block: RecoveredBlock<B>,
+    pub block: Arc<RecoveredBlock<B>>,
     /// The receipts for the pending block
-    pub receipts: Vec<R>,
+    pub receipts: Arc<Vec<R>>,
 }


### PR DESCRIPTION
refactor: use Arc for pending block and receipts to improve memory management as they're often cloned

closes #17229 