### PR TITLE
fix: call state_root() method instead of field in state root mismatch error

### DIFF
--- a/crates/ethereum/cli/src/debug_cmd/build_block.rs
+++ b/crates/ethereum/cli/src/debug_cmd/build_block.rs
@@ -244,7 +244,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
                 if state_root != block_with_senders.state_root() {
                     eyre::bail!(
                         "state root mismatch. expected: {}. got: {}",
-                        block_with_senders.state_root,
+                        block_with_senders.state_root(),
                         state_root
                     );
                 }


### PR DESCRIPTION
Corrects a typo in the error message for state root mismatch by calling the state_root() method instead of referencing it as a field. This ensures the actual state root value is displayed in the error output, improving debugging accuracy.