### PR TITLE
docs: update snapshot URL from downloads.merkle.io to snapshots.merkle.io

### DIFF
--- a/crates/cli/commands/src/download.rs
+++ b/crates/cli/commands/src/download.rs
@@ -17,7 +17,7 @@ use tokio::task;
 use tracing::info;
 
 const BYTE_UNITS: [&str; 4] = ["B", "KB", "MB", "GB"];
-const MERKLE_BASE_URL: &str = "https://downloads.merkle.io";
+const MERKLE_BASE_URL: &str = "https://snapshots.merkle.io";
 const EXTENSION_TAR_FILE: &str = ".tar.lz4";
 
 #[derive(Debug, Parser)]
@@ -32,7 +32,7 @@ pub struct DownloadCommand<C: ChainSpecParser> {
         long_help = "Specify a snapshot URL or let the command propose a default one.\n\
         \n\
         Available snapshot sources:\n\
-        - https://downloads.merkle.io (default, mainnet archive)\n\
+        - https://snapshots.merkle.io (default, mainnet archive)\n\
         - https://publicnode.com/snapshots (full nodes & testnets)\n\
         \n\
         If no URL is provided, the latest mainnet archive snapshot\n\

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -71,7 +71,7 @@ Database:
           Specify a snapshot URL or let the command propose a default one.
 
           Available snapshot sources:
-          - https://downloads.merkle.io (default, mainnet archive)
+          - https://snapshots.merkle.io (default, mainnet archive)
           - https://publicnode.com/snapshots (full nodes & testnets)
 
           If no URL is provided, the latest mainnet archive snapshot


### PR DESCRIPTION
https://downloads.merkle.io → https://snapshots.merkle.io

Updates the documentation to reflect Merkle's new snapshot URL. The old URL (downloads.merkle.io) has been replaced with snapshots.merkle.io, which is the current active endpoint for downloading mainnet archive snapshots.

