### PR TITLE
chore: Fix typo in block number reader comment

### DIFF
--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -347,7 +347,7 @@ impl<N: ProviderNodeTypes> BlockNumReader for ProviderFactory<N> {
 
     fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
         // earliest history height tracks the lowest block number that has __not__ been expired, in
-        // other words, the first/earlierst available block.
+        // other words, the first/earliest available block.
         Ok(self.static_file_provider.earliest_history_height())
     }
 


### PR DESCRIPTION
Corrected a spelling mistake in a comment within ProviderFactory implementation:

- earlierst → earliest

This small fix improves the clarity and professionalism of the documentation for the earliest_block_number method.