### PR TITLE
docs: fix typo `fileted` to `filtered`

### DIFF
--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -91,7 +91,7 @@ pub struct BestTransactions<T: TransactionOrdering> {
     /// There might be the case where a yielded transactions is invalid, this will track it.
     pub(crate) invalid: HashSet<SenderId>,
     /// Used to receive any new pending transactions that have been added to the pool after this
-    /// iterator was static fileted
+    /// iterator was static filtered
     ///
     /// These new pending transactions are inserted into this iterator's pool before yielding the
     /// next value


### PR DESCRIPTION
fixes a typographical error in the comment for the new_transaction_receiver field in the BestTransactions struct. The word "fileted" is incorrect and has been changed to "filtered" to accurately describe that the iterator filters transactions from the pool.
