### PR TITLE
fix(trie): add lower subtrie root paths to upper subtrie prefix set

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1613,8 +1613,8 @@ impl SparseSubtrieInner {
                 if let Some(hash) = hash.filter(|_| !prefix_set_contains(&path) || value.is_none())
                 {
                     // If the node hash is already computed, and either the node path is not in
-                    // the prefix set or we don't have the value for it, return the pre-computed
-                    // hash
+                    // the prefix set or the leaf doesn't belong to the current trie (its value is
+                    // absent), return the pre-computed hash
                     (RlpNode::word_rlp(&hash), SparseNodeType::Leaf)
                 } else {
                     // Encode the leaf node and update its hash

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1006,13 +1006,10 @@ impl ParallelSparseTrie {
                 }
                 .freeze();
 
-                // If the root node of the subtrie is either a branch or an extension node, we need
-                // to add its full path to the unchanged prefix set, so that when we don't skip it
-                // when calculating hashes for the upper subtrie using lower subtrie root nodes.
-                //
-                // For more information, see how we handle extension and branch nodes in `rlp_node`.
+                // We need the full path of root node of the lower subtrie to the unchanged prefix
+                // set, so that we don't skip it when calculating hashes for the upper subtrie.
                 match subtrie.nodes.get(&subtrie.path) {
-                    Some(SparseNode::Extension { key, .. }) => {
+                    Some(SparseNode::Extension { key, .. } | SparseNode::Leaf { key, .. }) => {
                         unchanged_prefix_set.insert(subtrie.path.join(key));
                     }
                     Some(SparseNode::Branch { .. }) => {
@@ -2882,6 +2879,7 @@ mod tests {
 
         let unchanged_prefix_set = PrefixSetMut::from([
             Nibbles::from_nibbles([0x0]),
+            leaf_2_full_path,
             Nibbles::from_nibbles([0x2, 0x0, 0x0]),
         ]);
         // Create a prefix set with the keys that match only the second subtrie

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1006,6 +1006,21 @@ impl ParallelSparseTrie {
                 }
                 .freeze();
 
+                // If the root node of the subtrie is either a branch or an extension node, we need
+                // to add its full path to the unchanged prefix set, so that when we don't skip it
+                // when calculating hashes for the upper subtrie using lower subtrie root nodes.
+                //
+                // For more information, see how we handle extension and branch nodes in `rlp_node`.
+                match subtrie.nodes.get(&subtrie.path) {
+                    Some(SparseNode::Extension { key, .. }) => {
+                        unchanged_prefix_set.insert(subtrie.path.join(key));
+                    }
+                    Some(SparseNode::Branch { .. }) => {
+                        unchanged_prefix_set.insert(subtrie.path);
+                    }
+                    _ => {}
+                }
+
                 changed_subtries.push(ChangedSubtrie { index, subtrie, prefix_set });
             }
         }

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1609,9 +1609,12 @@ impl SparseSubtrieInner {
             SparseNode::Leaf { key, hash } => {
                 let mut path = path;
                 path.extend(key);
-                if let Some(hash) = hash.filter(|_| !prefix_set_contains(&path)) {
-                    // If the node hash is already computed, and the node path is not in
-                    // the prefix set, return the pre-computed hash
+                let value = self.values.get(&path);
+                if let Some(hash) = hash.filter(|_| !prefix_set_contains(&path) || value.is_none())
+                {
+                    // If the node hash is already computed, and either the node path is not in
+                    // the prefix set or we don't have the value for it, return the pre-computed
+                    // hash
                     (RlpNode::word_rlp(&hash), SparseNodeType::Leaf)
                 } else {
                     // Encode the leaf node and update its hash


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/blob/2614c5a36bdd3183e3aa0ac276a96fc2952342af/crates/trie/sparse-parallel/src/trie.rs#L1009-L1013

If we don't do this, when calculating the upper subtrie hashes, we would skip lower subtrie root extension and branch nodes here https://github.com/paradigmxyz/reth/blob/2614c5a36bdd3183e3aa0ac276a96fc2952342af/crates/trie/sparse-parallel/src/trie.rs#L1631-L1635 https://github.com/paradigmxyz/reth/blob/2614c5a36bdd3183e3aa0ac276a96fc2952342af/crates/trie/sparse-parallel/src/trie.rs#L1684-L1688