### PR TITLE
feat(trie): add Trie generic to PayloadProcessor

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -25,6 +25,7 @@ use reth_provider::{
     AccountReader, ChainSpecProvider, HashingWriter, ProviderFactory,
 };
 use reth_trie::TrieInput;
+use reth_trie_sparse::RevealedSparseTrie;
 use revm_primitives::{HashMap, U256};
 use revm_state::{Account as RevmAccount, AccountInfo, AccountStatus, EvmState, EvmStorageSlot};
 use std::{hint::black_box, sync::Arc};
@@ -220,12 +221,13 @@ fn bench_state_root(c: &mut Criterion) {
                         let state_updates = create_bench_state_updates(params);
                         setup_provider(&factory, &state_updates).expect("failed to setup provider");
 
-                        let payload_processor = PayloadProcessor::<EthPrimitives, _>::new(
-                            WorkloadExecutor::default(),
-                            EthEvmConfig::new(factory.chain_spec()),
-                            &TreeConfig::default(),
-                            PrecompileCacheMap::default(),
-                        );
+                        let payload_processor =
+                            PayloadProcessor::<EthPrimitives, _, RevealedSparseTrie>::new(
+                                WorkloadExecutor::default(),
+                                EthEvmConfig::new(factory.chain_spec()),
+                                &TreeConfig::default(),
+                                PrecompileCacheMap::default(),
+                            );
                         let provider = BlockchainProvider::new(factory).unwrap();
 
                         (genesis_hash, payload_processor, provider, state_updates)

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -47,6 +47,7 @@ use reth_stages_api::ControlFlow;
 use reth_trie::{updates::TrieUpdates, HashedPostState, TrieInput};
 use reth_trie_db::{DatabaseHashedPostState, StateCommitment};
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
+use reth_trie_sparse::RevealedSparseTrie;
 use state::TreeState;
 use std::{
     borrow::Cow,
@@ -272,7 +273,7 @@ where
     /// The engine API variant of this handler
     engine_kind: EngineApiKind,
     /// The type responsible for processing new payloads
-    payload_processor: PayloadProcessor<N, C>,
+    payload_processor: PayloadProcessor<N, C, RevealedSparseTrie>,
     /// The EVM configuration.
     evm_config: C,
     /// Precompile cache map.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -11,7 +11,7 @@ use reth_trie_parallel::root::ParallelStateRootError;
 use reth_trie_sparse::{
     blinded::{BlindedProvider, BlindedProviderFactory},
     errors::{SparseStateTrieResult, SparseTrieErrorKind},
-    SparseStateTrie, SparseTrie,
+    RevealedSparseTrie, SparseStateTrie, SparseTrie, SparseTrieInterface,
 };
 use std::{
     sync::mpsc,
@@ -20,7 +20,7 @@ use std::{
 use tracing::{debug, trace, trace_span};
 
 /// A task responsible for populating the sparse trie.
-pub(super) struct SparseTrieTask<BPF>
+pub(super) struct SparseTrieTask<BPF, A = RevealedSparseTrie, S = RevealedSparseTrie>
 where
     BPF: BlindedProviderFactory + Send + Sync,
     BPF::AccountNodeProvider: BlindedProvider + Send + Sync,
@@ -34,17 +34,19 @@ where
     /// Sparse Trie initialized with the blinded provider factory.
     ///
     /// It's kept as a field on the struct to prevent blocking on de-allocation in [`Self::run`].
-    pub(super) trie: SparseStateTrie,
+    pub(super) trie: SparseStateTrie<A, S>,
     pub(super) metrics: MultiProofTaskMetrics,
     /// Blinded node provider factory.
     blinded_provider_factory: BPF,
 }
 
-impl<BPF> SparseTrieTask<BPF>
+impl<BPF, A, S> SparseTrieTask<BPF, A, S>
 where
     BPF: BlindedProviderFactory + Send + Sync + Clone,
     BPF::AccountNodeProvider: BlindedProvider + Send + Sync,
     BPF::StorageNodeProvider: BlindedProvider + Send + Sync,
+    A: SparseTrieInterface + Send + Sync,
+    S: SparseTrieInterface + Send + Sync,
 {
     /// Creates a new sparse trie task.
     pub(super) fn new(
@@ -69,7 +71,7 @@ where
         updates: mpsc::Receiver<SparseTrieUpdate>,
         blinded_provider_factory: BPF,
         trie_metrics: MultiProofTaskMetrics,
-        sparse_trie: Option<SparseTrie>,
+        sparse_trie: Option<SparseTrie<A>>,
     ) -> Self {
         if let Some(sparse_trie) = sparse_trie {
             Self::with_accounts_trie(
@@ -91,7 +93,7 @@ where
         updates: mpsc::Receiver<SparseTrieUpdate>,
         blinded_provider_factory: BPF,
         metrics: MultiProofTaskMetrics,
-        sparse_trie: SparseTrie,
+        sparse_trie: SparseTrie<A>,
     ) -> Self {
         debug_assert!(sparse_trie.is_blind());
         let trie = SparseStateTrie::new().with_updates(true).with_accounts_trie(sparse_trie);
@@ -106,7 +108,7 @@ where
     ///
     /// NOTE: This function does not take `self` by value to prevent blocking on [`SparseStateTrie`]
     /// drop.
-    pub(super) fn run(&mut self) -> Result<StateRootComputeOutcome, ParallelStateRootError> {
+    pub(super) fn run(&mut self) -> Result<StateRootComputeOutcome<A>, ParallelStateRootError> {
         let now = Instant::now();
 
         let mut num_iterations = 0;
@@ -159,18 +161,18 @@ where
 /// Outcome of the state root computation, including the state root itself with
 /// the trie updates.
 #[derive(Debug)]
-pub struct StateRootComputeOutcome {
+pub struct StateRootComputeOutcome<T = RevealedSparseTrie> {
     /// The state root.
     pub state_root: B256,
     /// The trie updates.
     pub trie_updates: TrieUpdates,
     /// The account state trie.
-    pub trie: SparseTrie,
+    pub trie: SparseTrie<T>,
 }
 
 /// Updates the sparse trie with the given proofs and state, and returns the elapsed time.
-pub(crate) fn update_sparse_trie<BPF>(
-    trie: &mut SparseStateTrie,
+pub(crate) fn update_sparse_trie<BPF, A, S>(
+    trie: &mut SparseStateTrie<A, S>,
     SparseTrieUpdate { mut state, multiproof }: SparseTrieUpdate,
     blinded_provider_factory: &BPF,
 ) -> SparseStateTrieResult<Duration>
@@ -178,6 +180,8 @@ where
     BPF: BlindedProviderFactory + Send + Sync,
     BPF::AccountNodeProvider: BlindedProvider + Send + Sync,
     BPF::StorageNodeProvider: BlindedProvider + Send + Sync,
+    A: SparseTrieInterface + Send + Sync,
+    S: SparseTrieInterface + Send + Sync,
 {
     trace!(target: "engine::root::sparse", "Updating sparse trie");
     let started_at = Instant::now();


### PR DESCRIPTION
Adds a trie generic to the payload processor and propagates it, so that we can set it in the engine.