### PR TITLE
chore(trie): add Either type for SparseTrieInterface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10625,6 +10625,7 @@ dependencies = [
  "assert_matches",
  "auto_impl",
  "codspeed-criterion-compat",
+ "either",
  "itertools 0.14.0",
  "metrics",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -517,6 +517,7 @@ op-alloy-rpc-jsonrpsee = { version = "0.18.7", default-features = false }
 op-alloy-flz = { version = "0.13.1", default-features = false }
 
 # misc
+either = { version = "1.15.0", default-features = false }
 aquamarine = "0.6"
 auto_impl = "1"
 backon = { version = "1.2", default-features = false, features = ["std-blocking-sleep", "tokio-sleep"] }

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -26,6 +26,7 @@ alloy-rlp.workspace = true
 # misc
 auto_impl.workspace = true
 smallvec = { workspace = true, features = ["const_new"] }
+either.workspace = true
 
 # metrics
 reth-metrics = { workspace = true, optional = true }
@@ -62,6 +63,7 @@ std = [
     "reth-storage-api/std",
     "reth-trie-common/std",
     "tracing/std",
+    "either/std",
 ]
 metrics = ["dep:reth-metrics", "dep:metrics", "std"]
 test-utils = [

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -16,6 +16,9 @@ pub use traits::*;
 
 pub mod blinded;
 
+// Re-export `Either` because it implements `SparseTrieInterface`.
+pub use either::Either;
+
 #[cfg(feature = "metrics")]
 mod metrics;
 


### PR DESCRIPTION
Adds an `Either<A, B>` type which we could use for the sparse trie in the payload processor. The idea is to switch on the cli flag in the payload processor, to build either a `ParallelSparseTrie` or a `RevealedSparseTrie` as the accounts trie. The idea is that we would use this as the account trie type.

ref https://github.com/paradigmxyz/reth/pull/17266 for `from_root`
based on https://github.com/paradigmxyz/reth/pull/17268