### PR TITLE
chore(trie): remove Default bound from SparseTrieInterface 

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -73,8 +73,8 @@ impl SparseStateTrie {
 
 impl<A, S> SparseStateTrie<A, S>
 where
-    A: SparseTrieInterface,
-    S: SparseTrieInterface,
+    A: SparseTrieInterface + Default,
+    S: SparseTrieInterface + Default,
 {
     /// Create new [`SparseStateTrie`]
     pub fn new() -> Self {

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -18,7 +18,7 @@ use crate::blinded::BlindedProvider;
 /// This trait abstracts over different sparse trie implementations (serial vs parallel)
 /// while providing a unified interface for the core trie operations needed by the
 /// [`crate::SparseTrie`] enum.
-pub trait SparseTrieInterface: Default + Debug + Send + Sync {
+pub trait SparseTrieInterface: Sized + Debug + Send + Sync {
     /// Configures the trie to have the given root node revealed.
     ///
     /// # Arguments

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -65,7 +65,7 @@ impl<T: Default> Default for SparseTrie<T> {
     }
 }
 
-impl<T: SparseTrieInterface> SparseTrie<T> {
+impl<T: SparseTrieInterface + Default> SparseTrie<T> {
     /// Creates a new blind sparse trie.
     ///
     /// # Examples


### PR DESCRIPTION
stacked on https://github.com/paradigmxyz/reth/pull/17266

removes the default bound from `SparseTrieInterface`, instead moving it up to bounds in `SparseStateTrie` and `SparseTrie`