### PR TITLE
chore(trie): add Send and Sync to SparseTrieInterface

### DIFF
--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -18,7 +18,7 @@ use crate::blinded::BlindedProvider;
 /// This trait abstracts over different sparse trie implementations (serial vs parallel)
 /// while providing a unified interface for the core trie operations needed by the
 /// [`crate::SparseTrie`] enum.
-pub trait SparseTrieInterface: Default + Debug {
+pub trait SparseTrieInterface: Default + Debug + Send + Sync {
     /// Creates a new revealed sparse trie from the given root node.
     ///
     /// This function initializes the internal structures and then reveals the root.


### PR DESCRIPTION
We will need `Send` + `Sync` anyways because we'll be sending these around in threads, for example when we update storage tries in parallel in `update_sparse_trie`