### PR TITLE
docs(guides): Add history expiry

### DIFF
--- a/docs/vocs/docs/pages/guides/history-expiry.mdx
+++ b/docs/vocs/docs/pages/guides/history-expiry.mdx
@@ -1,0 +1,49 @@
+---
+description: Usage of tools for importing, exporting and pruning historical blocks
+---
+
+# History Expiry
+
+In this chapter, we will learn how to use tools for dealing with historical data, it's import, export and removal.
+
+We will use [reth cli](../cli/cli) to import and export historical data.
+
+## File format
+
+The historical data is packaged and distributed in files of special formats with different names, all of which are based on [e2store](https://github.com/status-im/nimbus-eth2/blob/613f4a9a50c9c4bd8568844eaffb3ac15d067e56/docs/e2store.md#introduction). The most important ones are the **ERA1**, which deals with block range from genesis until the last pre-merge block, and **ERA**, which deals with block range from the merge onwards. See their [specification](https://github.com/eth-clients/e2store-format-specs) for more details.
+
+The contents of these archives is an ordered sequence of blocks. We're mostly concerned with headers and transactions. For ERA1, there is 8192 blocks per file except for the last one, i.e. the one containing pre-merge block, which can be less than that.
+
+## Import
+
+In this section we discuss how to get blocks from ERA1 files.
+
+### Automatic sync
+
+If enabled, importing blocks from ERA1 files can be done automatically with no manual steps required.
+
+#### Enabling the ERA stage
+
+The import from ERA1 files within the pre-merge block range is included in the [reth node](../cli/reth/node) synchronization pipeline. It is disabled by default. To enable it, pass the `--era.enable` flag when running the [`node`](../cli/reth/node) command.
+
+The benefit of using this option is significant increase in the synchronization speed for the headers and mainly bodies stage of the pipeline within the ERA1 block range. We encourage you to use it! Eventually, it will become enabled by default.
+
+#### Using the ERA stage
+
+When enabled, the import from ERA1 files runs as its own separate stage before all others. It is an optional stage that is doing the work of headers and bodies stage at a significantly higher speed. The checkpoints of these stages are shifted by the ERA stage.
+
+### Manual import
+
+If you want to import block headers and transactions from ERA1 files without running the synchronization pipeline, you may use the [`import-era`](../cli/reth/import-era) command.
+
+### Options
+
+Both ways of importing the ERA1 files have the same options because they use the same underlying subsystems. No options are mandatory.
+
+#### Sources
+
+There are two kinds of data sources for the ERA1 import.
+* Remote from an HTTP URL. Use the option `--era.url` with an ERA1 hosting provider URL.
+* Local from a file-system directory. Use the option `--era.path` with a directory containing ERA1 files.
+
+Both options cannot be used at the same time. If no option is specified, the remote source is used with a URL derived from the chain ID. Only Mainnet and Sepolia have ERA1 files. If the node is running on a different chain, no source is provided and nothing is imported.


### PR DESCRIPTION
Closes #16547

Adds a documentation chapter on history expiry serving as a guide.

Notes:
* `export-era` is not yet implemented #17132 , maybe that section should be added later?
* Pruning: maybe add a section on pruning expired historical data? Matt could help here.
* I couldn't find a proper section for this so I added directory `guides/`. Should it be put somewhere else?
* I came up with the format, should it be any different?