### PR TITLE
docs: fix correction in storage reverts iterator test comment

### DIFF
--- a/crates/storage/provider/src/bundle_state/state_reverts.rs
+++ b/crates/storage/provider/src/bundle_state/state_reverts.rs
@@ -173,7 +173,7 @@ mod tests {
                 (B256::from_slice(&[8; 32]), U256::from(70)), // Revert takes priority.
                 (B256::from_slice(&[9; 32]), U256::from(80)), // Only revert present.
                 (B256::from_slice(&[10; 32]), U256::from(85)), // Wiped entry.
-                (B256::from_slice(&[15; 32]), U256::from(90)), // WGreater revert entry
+                (B256::from_slice(&[15; 32]), U256::from(90)), // Greater revert entry
             ]
         );
     }


### PR DESCRIPTION
Corrected a typo in the test comment where "WGreater revert entry" was changed to "Greater revert entry" to accurately describe the test case.