### PR TITLE
ci: add https:// to image URLs in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ env:
   OP_IMAGE_NAME: ${{ github.repository_owner }}/op-reth
   REPRODUCIBLE_IMAGE_NAME: ${{ github.repository_owner }}/reth-reproducible
   CARGO_TERM_COLOR: always
-  DOCKER_IMAGE_NAME_URL: ghcr.io/${{ github.repository_owner }}/reth
-  DOCKER_OP_IMAGE_NAME_URL: ghcr.io/${{ github.repository_owner }}/op-reth
+  DOCKER_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/reth
+  DOCKER_OP_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/op-reth
 
 jobs:
   dry-run:


### PR DESCRIPTION
Otherwise it looks like a path for GH CLI, and it creates a link like https://github.com/paradigmxyz/reth/blob/v1.5.0/ghcr.io/paradigmxyz/reth