### PR TITLE
fix: correct typos 

### DIFF
--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -209,7 +209,7 @@ mod tests {
         let request2 = codec
             .decode(&mut buf)
             .expect("There should be no error in first 2nd test")
-            .expect("There should be aa request in 2nd whitespace test");
+            .expect("There should be a request in 2nd whitespace test");
         // TODO: maybe actually trim it out
         assert_eq!(request2, "\n\n\n\n{ test: 2 }");
 

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -48,7 +48,7 @@ pub struct NippyJarWriter<H: NippyJarHeader = ()> {
 impl<H: NippyJarHeader> NippyJarWriter<H> {
     /// Creates a [`NippyJarWriter`] from [`NippyJar`].
     ///
-    /// If will  **always** attempt to heal any inconsistent state when called.
+    /// If will **always** attempt to heal any inconsistent state when called.
     pub fn new(jar: NippyJar<H>) -> Result<Self, NippyJarError> {
         let (data_file, offsets_file, is_created) =
             Self::create_or_open_files(jar.data_path(), &jar.offsets_path())?;


### PR DESCRIPTION
in crates/rpc/ipc/src/stream_codec.rs
be aa request - **deleted extra** `a`

in crates/storage/nippy-jar/src/writer.rs
 If will __**always** - **deleted extra space**