### PR TITLE
fix: minor typo fixes in comments and documentation

### DIFF
--- a/crates/rpc/rpc-e2e-tests/testdata/rpc-compat/eth_getLogs/topic-exact-match.io
+++ b/crates/rpc/rpc-e2e-tests/testdata/rpc-compat/eth_getLogs/topic-exact-match.io
@@ -1,3 +1,3 @@
-// queries for logs with two topics, with both topics set explictly
+// queries for logs with two topics, with both topics set explicitly
 >> {"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"address":null,"fromBlock":"0x3","toBlock":"0x6","topics":[["0x00000000000000000000000000000000000000000000000000000000656d6974"],["0x4238ace0bf7e66fd40fea01bdf43f4f30423f48432efd0da3af5fcb17a977fd4"]]}]}
 << {"jsonrpc":"2.0","id":1,"result":[{"address":"0x7dcd17433742f4c0ca53122ab541d0ba67fc27df","topics":["0x00000000000000000000000000000000000000000000000000000000656d6974","0x4238ace0bf7e66fd40fea01bdf43f4f30423f48432efd0da3af5fcb17a977fd4"],"data":"0x0000000000000000000000000000000000000000000000000000000000000001","blockNumber":"0x4","transactionHash":"0xf047c5133c96c405a79d01038b4ccf8208c03e296dd9f6bea083727c9513f805","transactionIndex":"0x0","blockHash":"0x94540b21748e45497c41518ed68b2a0c16d728e917b665ae50d51f6895242e53","logIndex":"0x0","removed":false}]}

--- a/crates/trie/sparse-parallel/src/lower.rs
+++ b/crates/trie/sparse-parallel/src/lower.rs
@@ -5,7 +5,7 @@ use reth_trie_common::Nibbles;
 ///
 /// When a [`crate::ParallelSparseTrie`] is initialized/cleared then its `LowerSparseSubtrie`s are
 /// all blinded, meaning they have no nodes. A blinded `LowerSparseSubtrie` may hold onto a cleared
-/// [`SparseSubtrie`] in order to re-use allocations.
+/// [`SparseSubtrie`] in order to reuse allocations.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum LowerSparseSubtrie {
     Blind(Option<Box<SparseSubtrie>>),


### PR DESCRIPTION


---

**Description:**  
This PR corrects minor typos in comments and documentation:
- Fixes "explictly" to "explicitly" in test data.
- Updates "re-use" to "reuse" in code comments for clarity.

---