### PR TITLE
chore: remove Beacon from type names

### DIFF
--- a/bin/reth/src/ress.rs
+++ b/bin/reth/src/ress.rs
@@ -2,7 +2,7 @@ use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::ConfigureEvm;
 use reth_network::{protocol::IntoRlpxSubProtocol, NetworkProtocols};
 use reth_network_api::FullNetwork;
-use reth_node_api::BeaconConsensusEngineEvent;
+use reth_node_api::ConsensusEngineEvent as BeaconConsensusEngineEvent;
 use reth_node_core::args::RessArgs;
 use reth_provider::providers::{BlockchainProvider, ProviderNodeTypes};
 use reth_ress_protocol::{NodeType, ProtocolState, RessProtocolHandler};

--- a/crates/consensus/debug-client/src/client.rs
+++ b/crates/consensus/debug-client/src/client.rs
@@ -1,8 +1,8 @@
 use alloy_consensus::Sealable;
 use alloy_primitives::B256;
 use reth_node_api::{
-    BeaconConsensusEngineHandle, BuiltPayload, EngineApiMessageVersion, ExecutionPayload,
-    NodePrimitives, PayloadTypes,
+    BuiltPayload, ConsensusEngineHandle as BeaconConsensusEngineHandle, EngineApiMessageVersion,
+    ExecutionPayload, NodePrimitives, PayloadTypes,
 };
 use reth_primitives_traits::{Block, SealedBlock};
 use reth_tracing::tracing::warn;

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{TxHash, B256};
 use alloy_rpc_types_engine::ForkchoiceState;
 use eyre::OptionExt;
 use futures_util::{stream::Fuse, StreamExt};
-use reth_engine_primitives::BeaconConsensusEngineHandle;
+use reth_engine_primitives::ConsensusEngineHandle as BeaconConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, PayloadAttributesBuilder, PayloadKind, PayloadTypes,

--- a/crates/engine/primitives/src/event.rs
+++ b/crates/engine/primitives/src/event.rs
@@ -14,9 +14,11 @@ use reth_chain_state::ExecutedBlockWithTrieUpdates;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader};
 
+type BeaconConsensusEngineEvent<N> = ConsensusEngineEvent<N>;
+
 /// Events emitted by the consensus engine.
 #[derive(Clone, Debug)]
-pub enum BeaconConsensusEngineEvent<N: NodePrimitives = EthPrimitives> {
+pub enum ConsensusEngineEvent<N: NodePrimitives = EthPrimitives> {
     /// The fork choice state was updated, and the current fork choice status
     ForkchoiceUpdated(ForkchoiceState, ForkchoiceStatus),
     /// A block was added to the fork chain.

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -18,6 +18,8 @@ use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadTypes;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
+type BeaconConsensusEngineHandle<Payload> = ConsensusEngineHandle<Payload>;
+
 /// Represents the outcome of forkchoice update.
 ///
 /// This is a future that resolves to [`ForkChoiceUpdateResult`]
@@ -192,7 +194,7 @@ impl<Payload: PayloadTypes> Display for BeaconEngineMessage<Payload> {
 ///
 /// This type mirrors consensus related functions of the engine API.
 #[derive(Debug, Clone)]
-pub struct BeaconConsensusEngineHandle<Payload>
+pub struct ConsensusEngineHandle<Payload>
 where
     Payload: PayloadTypes,
 {

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -2,7 +2,9 @@ use futures::{Stream, StreamExt};
 use pin_project::pin_project;
 use reth_chainspec::EthChainSpec;
 use reth_consensus::{ConsensusError, FullConsensus};
-use reth_engine_primitives::{BeaconConsensusEngineEvent, BeaconEngineMessage, EngineValidator};
+use reth_engine_primitives::{
+    BeaconEngineMessage, ConsensusEngineEvent as BeaconConsensusEngineEvent, EngineValidator,
+};
 use reth_engine_tree::{
     backfill::PipelineSync,
     download::BasicBlockDownloader,

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -8,7 +8,9 @@ use crate::{
 use alloy_primitives::B256;
 use futures::{Stream, StreamExt};
 use reth_chain_state::ExecutedBlockWithTrieUpdates;
-use reth_engine_primitives::{BeaconConsensusEngineEvent, BeaconEngineMessage};
+use reth_engine_primitives::{
+    BeaconEngineMessage, ConsensusEngineEvent as BeaconConsensusEngineEvent,
+};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_payload_primitives::PayloadTypes;
 use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock};

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -26,8 +26,9 @@ use reth_chain_state::{
 use reth_consensus::{Consensus, FullConsensus};
 pub use reth_engine_primitives::InvalidBlockHook;
 use reth_engine_primitives::{
-    BeaconConsensusEngineEvent, BeaconEngineMessage, BeaconOnNewPayloadError, EngineValidator,
-    ExecutionPayload, ForkchoiceStateTracker, OnForkChoiceUpdated,
+    BeaconEngineMessage, BeaconOnNewPayloadError,
+    ConsensusEngineEvent as BeaconConsensusEngineEvent, EngineValidator, ExecutionPayload,
+    ForkchoiceStateTracker, OnForkChoiceUpdated,
 };
 use reth_errors::{ConsensusError, ProviderResult};
 use reth_evm::{ConfigureEvm, Evm, SpecFor};

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -5,7 +5,10 @@ use alloy_rpc_types_engine::JwtSecret;
 use reth_basic_payload_builder::PayloadBuilder;
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
-use reth_engine_primitives::{BeaconConsensusEngineEvent, BeaconConsensusEngineHandle};
+use reth_engine_primitives::{
+    ConsensusEngineEvent as BeaconConsensusEngineEvent,
+    ConsensusEngineHandle as BeaconConsensusEngineHandle,
+};
 use reth_evm::ConfigureEvm;
 use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -23,8 +23,8 @@ use reth_exex::ExExManagerHandle;
 use reth_network::{types::BlockRangeUpdate, NetworkSyncUpdater, SyncState};
 use reth_network_api::BlockDownloaderProvider;
 use reth_node_api::{
-    BeaconConsensusEngineHandle, BuiltPayload, FullNodeTypes, NodeTypes, NodeTypesWithDBAdapter,
-    PayloadAttributesBuilder, PayloadTypes,
+    BuiltPayload, ConsensusEngineHandle as BeaconConsensusEngineHandle, FullNodeTypes, NodeTypes,
+    NodeTypesWithDBAdapter, PayloadAttributesBuilder, PayloadTypes,
 };
 use reth_node_core::{
     dirs::{ChainPath, DataDirPath},

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -3,7 +3,10 @@
 pub use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceBuilder};
 pub use reth_rpc_builder::{middleware::RethRpcMiddleware, Identity};
 
-use crate::{BeaconConsensusEngineEvent, BeaconConsensusEngineHandle};
+use crate::{
+    ConsensusEngineEvent as BeaconConsensusEngineEvent,
+    ConsensusEngineHandle as BeaconConsensusEngineHandle,
+};
 use alloy_rpc_types::engine::ClientVersionV1;
 use alloy_rpc_types_engine::ExecutionData;
 use jsonrpsee::{core::middleware::layer::Either, RpcModule};

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -6,7 +6,8 @@ use alloy_primitives::{BlockNumber, B256};
 use alloy_rpc_types_engine::ForkchoiceState;
 use futures::Stream;
 use reth_engine_primitives::{
-    BeaconConsensusEngineEvent, ConsensusEngineLiveSyncProgress, ForkchoiceStatus,
+    ConsensusEngineEvent as BeaconConsensusEngineEvent, ConsensusEngineLiveSyncProgress,
+    ForkchoiceStatus,
 };
 use reth_network_api::PeersInfo;
 use reth_primitives_traits::{format_gas, format_gas_throughput, BlockBody, NodePrimitives};

--- a/crates/ress/provider/src/pending_state.rs
+++ b/crates/ress/provider/src/pending_state.rs
@@ -7,7 +7,7 @@ use futures::StreamExt;
 use parking_lot::RwLock;
 use reth_chain_state::ExecutedBlockWithTrieUpdates;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_node_api::{BeaconConsensusEngineEvent, NodePrimitives};
+use reth_node_api::{ConsensusEngineEvent as BeaconConsensusEngineEvent, NodePrimitives};
 use reth_primitives_traits::{Bytecode, RecoveredBlock};
 use reth_storage_api::BlockNumReader;
 use reth_tokio_util::EventStream;

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -3,7 +3,7 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use alloy_rpc_types_engine::{ClientCode, ClientVersionV1};
 use reth_chainspec::MAINNET;
 use reth_consensus::noop::NoopConsensus;
-use reth_engine_primitives::BeaconConsensusEngineHandle;
+use reth_engine_primitives::ConsensusEngineHandle as BeaconConsensusEngineHandle;
 use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_ethereum_primitives::EthPrimitives;
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -18,7 +18,9 @@ use async_trait::async_trait;
 use jsonrpsee_core::{server::RpcModule, RpcResult};
 use parking_lot::Mutex;
 use reth_chainspec::EthereumHardforks;
-use reth_engine_primitives::{BeaconConsensusEngineHandle, EngineTypes, EngineValidator};
+use reth_engine_primitives::{
+    ConsensusEngineHandle as BeaconConsensusEngineHandle, EngineTypes, EngineValidator,
+};
 use reth_payload_builder::PayloadStore;
 use reth_payload_primitives::{
     validate_payload_timestamp, EngineApiMessageVersion, ExecutionPayload,

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -2,7 +2,7 @@ use super::handle::ImportHandle;
 use crate::block_import::parlia::{ParliaConsensus, ParliaConsensusErr};
 use alloy_rpc_types::engine::{ForkchoiceState, PayloadStatusEnum};
 use futures::{future::Either, stream::FuturesUnordered, StreamExt};
-use reth_engine_primitives::{BeaconConsensusEngineHandle, EngineTypes};
+use reth_engine_primitives::{ConsensusEngineHandle as BeaconConsensusEngineHandle, EngineTypes};
 use reth_eth_wire::NewBlock;
 use reth_network::{
     import::{BlockImportError, BlockImportEvent, BlockImportOutcome, BlockValidation},

--- a/examples/custom-node/src/engine_api.rs
+++ b/examples/custom-node/src/engine_api.rs
@@ -11,8 +11,8 @@ use alloy_rpc_types_engine::{
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
 use reth_ethereum::node::api::{
-    AddOnsContext, BeaconConsensusEngineHandle, EngineApiMessageVersion, FullNodeComponents,
-    NodeTypes,
+    AddOnsContext, ConsensusEngineHandle as BeaconConsensusEngineHandle, EngineApiMessageVersion,
+    FullNodeComponents, NodeTypes,
 };
 use reth_node_builder::rpc::EngineApiBuilder;
 use reth_op::node::OpStorage;


### PR DESCRIPTION
Fixes #17176 

Renamed `BeaconConsensusEngineHandle` and `BeaconConsensusEngineEvent` to `ConsensusEngineHandle` and `ConsensusEngineEvent`

Added type aliases where needed