### PR TITLE
refactor(examples): Use `TransactionEnvelope` macro from `alloy` for `CustomPooledTransaction` in the `custom-node` example

### DIFF
--- a/examples/custom-node/src/pool.rs
+++ b/examples/custom-node/src/pool.rs
@@ -1,15 +1,29 @@
 use crate::primitives::{CustomTransaction, CustomTransactionEnvelope};
-use alloy_consensus::error::ValueError;
-use op_alloy_consensus::OpPooledTransaction;
-use reth_ethereum::primitives::Extended;
+use alloy_consensus::{
+    crypto::RecoveryError, error::ValueError, transaction::SignerRecoverable, TransactionEnvelope,
+};
+use alloy_primitives::{Address, Sealed, B256};
+use op_alloy_consensus::{OpPooledTransaction, OpTransaction, TxDeposit};
+use reth_ethereum::primitives::{
+    serde_bincode_compat::RlpBincode, InMemorySize, SignedTransaction,
+};
 
-pub type CustomPooledTransaction = Extended<OpPooledTransaction, CustomTransactionEnvelope>;
+#[derive(Clone, Debug, TransactionEnvelope)]
+#[envelope(tx_type_name = CustomPooledTxType)]
+pub enum CustomPooledTransaction {
+    /// A regular Optimism transaction as defined by [`OpPooledTransaction`].
+    #[envelope(flatten)]
+    Op(OpPooledTransaction),
+    /// A [`CustomTransactionEnvelope`] tagged with type 0x7E.
+    #[envelope(ty = 42)]
+    Payment(CustomTransactionEnvelope),
+}
 
 impl From<CustomPooledTransaction> for CustomTransaction {
     fn from(tx: CustomPooledTransaction) -> Self {
         match tx {
-            CustomPooledTransaction::BuiltIn(tx) => Self::Op(tx.into()),
-            CustomPooledTransaction::Other(tx) => Self::Payment(tx),
+            CustomPooledTransaction::Op(tx) => Self::Op(tx.into()),
+            CustomPooledTransaction::Payment(tx) => Self::Payment(tx),
         }
     }
 }
@@ -19,10 +33,62 @@ impl TryFrom<CustomTransaction> for CustomPooledTransaction {
 
     fn try_from(tx: CustomTransaction) -> Result<Self, Self::Error> {
         match tx {
-            CustomTransaction::Op(op) => Ok(Self::BuiltIn(
+            CustomTransaction::Op(op) => Ok(Self::Op(
                 OpPooledTransaction::try_from(op).map_err(|op| op.map(CustomTransaction::Op))?,
             )),
-            CustomTransaction::Payment(payment) => Ok(Self::Other(payment)),
+            CustomTransaction::Payment(payment) => Ok(Self::Payment(payment)),
+        }
+    }
+}
+
+impl RlpBincode for CustomPooledTransaction {}
+
+impl OpTransaction for CustomPooledTransaction {
+    fn is_deposit(&self) -> bool {
+        match self {
+            CustomPooledTransaction::Op(_) => false,
+            CustomPooledTransaction::Payment(payment) => payment.is_deposit(),
+        }
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        match self {
+            CustomPooledTransaction::Op(_) => None,
+            CustomPooledTransaction::Payment(payment) => payment.as_deposit(),
+        }
+    }
+}
+
+impl SignerRecoverable for CustomPooledTransaction {
+    fn recover_signer(&self) -> Result<Address, RecoveryError> {
+        match self {
+            CustomPooledTransaction::Op(tx) => SignerRecoverable::recover_signer(tx),
+            CustomPooledTransaction::Payment(tx) => SignerRecoverable::recover_signer(tx),
+        }
+    }
+
+    fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
+        match self {
+            CustomPooledTransaction::Op(tx) => SignerRecoverable::recover_signer_unchecked(tx),
+            CustomPooledTransaction::Payment(tx) => SignerRecoverable::recover_signer_unchecked(tx),
+        }
+    }
+}
+
+impl SignedTransaction for CustomPooledTransaction {
+    fn tx_hash(&self) -> &B256 {
+        match self {
+            CustomPooledTransaction::Op(tx) => SignedTransaction::tx_hash(tx),
+            CustomPooledTransaction::Payment(tx) => SignedTransaction::tx_hash(tx),
+        }
+    }
+}
+
+impl InMemorySize for CustomPooledTransaction {
+    fn size(&self) -> usize {
+        match self {
+            CustomPooledTransaction::Op(tx) => InMemorySize::size(tx),
+            CustomPooledTransaction::Payment(tx) => InMemorySize::size(tx),
         }
     }
 }


### PR DESCRIPTION
Closes #17281

Replaces the `Extended` transaction envelope foreign type with a new local type for the `custom-node` example.

It uses the `TransactionEnvelope` macro from `alloy` to accomplish this and a few trivial trait implementations that are outside its scope (from reth).
