### PR TITLE
fix(trie): duplicate hash mask check in sparse trie implementations

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1868,7 +1868,7 @@ impl SparseSubtrieInner {
                         // removed nodes.
                         update_actions.push(SparseTrieUpdatesAction::InsertRemoved(path));
                     } else if self
-                        .branch_node_hash_masks
+                        .branch_node_tree_masks
                         .get(&path)
                         .is_none_or(|mask| mask.is_empty()) &&
                         self.branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty())

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1618,7 +1618,7 @@ impl RevealedSparseTrie {
                             updates.updated_nodes.remove(&path);
                             updates.removed_nodes.insert(path);
                         } else if self
-                            .branch_node_hash_masks
+                            .branch_node_tree_masks
                             .get(&path)
                             .is_none_or(|mask| mask.is_empty()) &&
                             self.branch_node_hash_masks


### PR DESCRIPTION
Both serial sparse and parallel sparse trie implementations had a bug where `branch_node_hash_masks` was checked twice instead of checking both `branch_node_tree_masks` and `branch_node_hash_masks` when determining if masks were previously empty.

Thanks Claude.