### PR TITLE
test: allow empty response

### DIFF
--- a/crates/stages/stages/src/stages/s3/downloader/fetch.rs
+++ b/crates/stages/stages/src/stages/s3/downloader/fetch.rs
@@ -174,11 +174,18 @@ mod tests {
         reth_tracing::init_test_tracing();
 
         let b3sum = b256!("0xe9908f4992ae39c4d1fe9984dd743ae3f8e9a84a4a5af768128833605ff72723");
-        let url = "https://link.testfile.org/15MB";
+        let url = "https://link.testfile.org/5MB";
 
         let file = tempfile::NamedTempFile::new().unwrap();
         let filename = file.path().file_name().unwrap().to_str().unwrap();
         let target_dir = file.path().parent().unwrap();
-        fetch(filename, target_dir, url, 4, Some(b3sum)).await.unwrap();
+        match fetch(filename, target_dir, url, 4, Some(b3sum)).await {
+            Ok(_) | Err(DownloaderError::EmptyContentLength) => {
+                // the testfil API can be flaky, so we ignore this error
+            }
+            Err(error) => {
+                panic!("Unexpected download error: {error:?}");
+            }
+        }
     }
 }


### PR DESCRIPTION
this test does some basic download test, the service can be down leading to failing CI, we can ignore this error.