### PR TITLE
fix: Typographical Errors in Comments

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -33,7 +33,7 @@ where
         let blob_params = self.provider().chain_spec().blob_params_at_timestamp(meta.timestamp);
 
         Ok(EthReceiptBuilder::new(
-            // Note: we assume this transaction is valid, because it's mined and therefor valid
+            // Note: we assume this transaction is valid, because it's mined and therefore valid
             tx.try_into_recovered_unchecked()?.as_recovered_ref(),
             meta,
             &receipt,

--- a/crates/trie/sparse-parallel/src/lower.rs
+++ b/crates/trie/sparse-parallel/src/lower.rs
@@ -5,7 +5,7 @@ use reth_trie_common::Nibbles;
 ///
 /// When a [`crate::ParallelSparseTrie`] is initialized/cleared then its `LowerSparseSubtrie`s are
 /// all blinded, meaning they have no nodes. A blinded `LowerSparseSubtrie` may hold onto a cleared
-/// [`SparseSubtrie`] in order to reuse allocations.
+/// [`SparseSubtrie`] in order to re-use allocations.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum LowerSparseSubtrie {
     Blind(Option<Box<SparseSubtrie>>),

--- a/crates/trie/sparse-parallel/src/lower.rs
+++ b/crates/trie/sparse-parallel/src/lower.rs
@@ -5,7 +5,7 @@ use reth_trie_common::Nibbles;
 ///
 /// When a [`crate::ParallelSparseTrie`] is initialized/cleared then its `LowerSparseSubtrie`s are
 /// all blinded, meaning they have no nodes. A blinded `LowerSparseSubtrie` may hold onto a cleared
-/// [`SparseSubtrie`] in order to re-use allocations.
+/// [`SparseSubtrie`] in order to reuse allocations.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum LowerSparseSubtrie {
     Blind(Option<Box<SparseSubtrie>>),


### PR DESCRIPTION


**Description:**  
This pull request corrects minor typographical errors in code comments for improved clarity and consistency.  
- Fixed "therefor" to "therefore" in `eth/helpers/receipt.rs`
- Changed "re-use" to "reuse" in `sparse-parallel/src/lower.rs`

