### PR TITLE
chore: add helpers for disabling read-tx timeout

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -147,11 +147,19 @@ impl DatabaseArguments {
     }
 
     /// Set the maximum duration of a read transaction.
+    pub const fn max_read_transaction_duration(
+        &mut self,
+        max_read_transaction_duration: Option<MaxReadTransactionDuration>,
+    ) {
+        self.max_read_transaction_duration = max_read_transaction_duration;
+    }
+
+    /// Set the maximum duration of a read transaction.
     pub const fn with_max_read_transaction_duration(
         mut self,
         max_read_transaction_duration: Option<MaxReadTransactionDuration>,
     ) -> Self {
-        self.max_read_transaction_duration = max_read_transaction_duration;
+        self.max_read_transaction_duration(max_read_transaction_duration);
         self
     }
 

--- a/crates/storage/provider/src/providers/database/builder.rs
+++ b/crates/storage/provider/src/providers/database/builder.rs
@@ -160,7 +160,7 @@ impl ReadOnlyConfig {
     ///
     /// Caution: Keeping database transaction open indefinitely can cause the free list to grow if
     /// changes to the database are made.
-    pub fn disable_long_read_transaction_safety(mut self) -> Self {
+    pub const fn disable_long_read_transaction_safety(mut self) -> Self {
         self.db_args.max_read_transaction_duration(Some(MaxReadTransactionDuration::Unbounded));
         self
     }

--- a/crates/storage/provider/src/providers/database/builder.rs
+++ b/crates/storage/provider/src/providers/database/builder.rs
@@ -4,7 +4,10 @@
 //! up to the intended build target.
 
 use crate::{providers::StaticFileProvider, ProviderFactory};
-use reth_db::{mdbx::DatabaseArguments, open_db_read_only, DatabaseEnv};
+use reth_db::{
+    mdbx::{DatabaseArguments, MaxReadTransactionDuration},
+    open_db_read_only, DatabaseEnv,
+};
 use reth_db_api::{database_metrics::DatabaseMetrics, Database};
 use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter};
 use std::{
@@ -62,12 +65,35 @@ impl<N> ProviderFactoryBuilder<N> {
     /// ```no_run
     /// use reth_chainspec::MAINNET;
     /// use reth_node_types::NodeTypes;
-    /// ///
+    ///
     /// use reth_provider::providers::{ProviderFactoryBuilder, ReadOnlyConfig};
     ///
     /// fn demo<N: NodeTypes<ChainSpec = reth_chainspec::ChainSpec>>() {
     ///     let provider_factory = ProviderFactoryBuilder::<N>::default()
     ///         .open_read_only(MAINNET.clone(), ReadOnlyConfig::from_datadir("datadir").no_watch())
+    ///         .unwrap();
+    /// }
+    /// ```
+    ///
+    /// # Open an instance with disabled read-transaction timeout
+    ///
+    /// By default, read transactions are automatically terminated after a timeout to prevent
+    /// database free list growth, which can degrade performance when the database is actively
+    /// being modified. However, if the database is static (no writes occurring), this safety
+    /// mechanism can be disabled using [`ReadOnlyConfig::disable_long_read_transaction_safety`].
+    ///
+    /// ```no_run
+    /// use reth_chainspec::MAINNET;
+    /// use reth_node_types::NodeTypes;
+    ///
+    /// use reth_provider::providers::{ProviderFactoryBuilder, ReadOnlyConfig};
+    ///
+    /// fn demo<N: NodeTypes<ChainSpec = reth_chainspec::ChainSpec>>() {
+    ///     let provider_factory = ProviderFactoryBuilder::<N>::default()
+    ///         .open_read_only(
+    ///             MAINNET.clone(),
+    ///             ReadOnlyConfig::from_datadir("datadir").disable_long_read_transaction_safety(),
+    ///         )
     ///         .unwrap();
     /// }
     /// ```
@@ -127,6 +153,16 @@ impl ReadOnlyConfig {
     pub fn from_datadir(datadir: impl AsRef<Path>) -> Self {
         let datadir = datadir.as_ref();
         Self::from_dirs(datadir.join("db"), datadir.join("static_files"))
+    }
+
+    /// Disables long-lived read transaction safety guarantees, such as backtrace recording and
+    /// timeout.
+    ///
+    /// Caution: Keeping database transaction open indefinitely can cause the free list to grow if
+    /// changes to the database are made.
+    pub fn disable_long_read_transaction_safety(mut self) -> Self {
+        self.db_args.max_read_transaction_duration(Some(MaxReadTransactionDuration::Unbounded));
+        self
     }
 
     /// Derives the [`ReadOnlyConfig`] from the database dir.

--- a/crates/storage/provider/src/providers/database/builder.rs
+++ b/crates/storage/provider/src/providers/database/builder.rs
@@ -78,9 +78,9 @@ impl<N> ProviderFactoryBuilder<N> {
     /// # Open an instance with disabled read-transaction timeout
     ///
     /// By default, read transactions are automatically terminated after a timeout to prevent
-    /// database free list growth, which can degrade performance when the database is actively
-    /// being modified. However, if the database is static (no writes occurring), this safety
-    /// mechanism can be disabled using [`ReadOnlyConfig::disable_long_read_transaction_safety`].
+    /// database free list growth. However, if the database is static (no writes occurring), this
+    /// safety mechanism can be disabled using
+    /// [`ReadOnlyConfig::disable_long_read_transaction_safety`].
     ///
     /// ```no_run
     /// use reth_chainspec::MAINNET;
@@ -155,8 +155,7 @@ impl ReadOnlyConfig {
         Self::from_dirs(datadir.join("db"), datadir.join("static_files"))
     }
 
-    /// Disables long-lived read transaction safety guarantees, such as backtrace recording and
-    /// timeout.
+    /// Disables long-lived read transaction safety guarantees.
     ///
     /// Caution: Keeping database transaction open indefinitely can cause the free list to grow if
     /// changes to the database are made.


### PR DESCRIPTION
Improves the documentation for disabling read transaction timeouts to make it clearer when and why users might want to disable this safety mechanism.

The updated documentation:
- Clarifies that timeouts are automatic by default
- Explains that free list growth occurs when the database is actively being modified
- Makes it clear when it's safe to disable timeouts (static databases with no writes)
- Uses more concise and direct language

Also adds a mutable setter method `max_read_transaction_duration()` to match the existing builder pattern in `DatabaseArguments`.

Closes #17328