### PR TITLE
refactor: rename `RevealedSparseTrie` to `SerialSparseTrie`

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -2170,7 +2170,7 @@ mod tests {
     use reth_trie_db::DatabaseTrieCursorFactory;
     use reth_trie_sparse::{
         blinded::{BlindedProvider, DefaultBlindedProvider, RevealedNode},
-        RevealedSparseTrie, SparseNode, SparseTrieInterface, SparseTrieUpdates, TrieMasks,
+        SerialSparseTrie, SparseNode, SparseTrieInterface, SparseTrieUpdates, TrieMasks,
     };
     use std::collections::{BTreeMap, BTreeSet};
 
@@ -4451,7 +4451,7 @@ mod tests {
 
         fn test(updates: Vec<(BTreeMap<Nibbles, Account>, BTreeSet<Nibbles>)>) {
             let default_provider = DefaultBlindedProvider;
-            let mut serial = RevealedSparseTrie::default().with_updates(true);
+            let mut serial = SerialSparseTrie::default().with_updates(true);
             let mut parallel = ParallelSparseTrie::default().with_updates(true);
 
             for (update, keys_to_delete) in updates {

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -7,7 +7,7 @@ use proptest::{prelude::*, test_runner::TestRunner};
 use rand::{seq::IteratorRandom, Rng};
 use reth_testing_utils::generators;
 use reth_trie::Nibbles;
-use reth_trie_sparse::{blinded::DefaultBlindedProvider, RevealedSparseTrie, SparseTrieInterface};
+use reth_trie_sparse::{blinded::DefaultBlindedProvider, SerialSparseTrie, SparseTrieInterface};
 
 fn update_rlp_node_level(c: &mut Criterion) {
     let mut rng = generators::rng();
@@ -23,7 +23,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
 
         // Create a sparse trie with `size` leaves
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         for (key, value) in &state {
             sparse
                 .update_leaf(

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -13,7 +13,7 @@ use reth_trie::{
     HashedStorage,
 };
 use reth_trie_common::{HashBuilder, Nibbles};
-use reth_trie_sparse::{blinded::DefaultBlindedProvider, RevealedSparseTrie, SparseTrie};
+use reth_trie_sparse::{blinded::DefaultBlindedProvider, SerialSparseTrie, SparseTrie};
 
 fn calculate_root_from_leaves(c: &mut Criterion) {
     let mut group = c.benchmark_group("calculate root from leaves");
@@ -42,7 +42,7 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
         // sparse trie
         let provider = DefaultBlindedProvider;
         group.bench_function(BenchmarkId::new("sparse trie", size), |b| {
-            b.iter_with_setup(SparseTrie::<RevealedSparseTrie>::revealed_empty, |mut sparse| {
+            b.iter_with_setup(SparseTrie::<SerialSparseTrie>::revealed_empty, |mut sparse| {
                 for (key, value) in &state {
                     sparse
                         .update_leaf(
@@ -189,7 +189,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                 group.bench_function(benchmark_id, |b| {
                     b.iter_with_setup(
                         || {
-                            let mut sparse = SparseTrie::<RevealedSparseTrie>::revealed_empty();
+                            let mut sparse = SparseTrie::<SerialSparseTrie>::revealed_empty();
                             for (key, value) in &init_state {
                                 sparse
                                     .update_leaf(

--- a/crates/trie/sparse/benches/update.rs
+++ b/crates/trie/sparse/benches/update.rs
@@ -5,7 +5,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 use proptest::{prelude::*, strategy::ValueTree};
 use rand::seq::IteratorRandom;
 use reth_trie_common::Nibbles;
-use reth_trie_sparse::{blinded::DefaultBlindedProvider, RevealedSparseTrie, SparseTrie};
+use reth_trie_sparse::{blinded::DefaultBlindedProvider, SerialSparseTrie, SparseTrie};
 
 const LEAF_COUNTS: [usize; 2] = [1_000, 5_000];
 
@@ -20,7 +20,7 @@ fn update_leaf(c: &mut Criterion) {
 
             b.iter_batched(
                 || {
-                    let mut trie = SparseTrie::<RevealedSparseTrie>::revealed_empty();
+                    let mut trie = SparseTrie::<SerialSparseTrie>::revealed_empty();
                     // Pre-populate with data
                     for (path, value) in leaves.iter().cloned() {
                         trie.update_leaf(path, value, &provider).unwrap();
@@ -64,7 +64,7 @@ fn remove_leaf(c: &mut Criterion) {
 
             b.iter_batched(
                 || {
-                    let mut trie = SparseTrie::<RevealedSparseTrie>::revealed_empty();
+                    let mut trie = SparseTrie::<SerialSparseTrie>::revealed_empty();
                     // Pre-populate with data
                     for (path, value) in leaves.iter().cloned() {
                         trie.update_leaf(path, value, &provider).unwrap();

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1,7 +1,7 @@
 use crate::{
     blinded::{BlindedProvider, BlindedProviderFactory},
     traits::SparseTrieInterface,
-    LeafLookup, RevealedSparseTrie, SparseTrie, TrieMasks,
+    LeafLookup, SerialSparseTrie, SparseTrie, TrieMasks,
 };
 use alloc::{collections::VecDeque, vec::Vec};
 use alloy_primitives::{
@@ -24,8 +24,8 @@ use tracing::trace;
 #[derive(Debug)]
 /// Sparse state trie representing lazy-loaded Ethereum state trie.
 pub struct SparseStateTrie<
-    A = RevealedSparseTrie, // Account trie implementation
-    S = RevealedSparseTrie, // Storage trie implementation
+    A = SerialSparseTrie, // Account trie implementation
+    S = SerialSparseTrie, // Storage trie implementation
 > {
     /// Sparse account trie.
     state: SparseTrie<A>,
@@ -930,7 +930,7 @@ mod tests {
 
     #[test]
     fn validate_root_node_first_node_not_root() {
-        let sparse = SparseStateTrie::<RevealedSparseTrie>::default();
+        let sparse = SparseStateTrie::<SerialSparseTrie>::default();
         let proof = [(Nibbles::from_nibbles([0x1]), Bytes::from([EMPTY_STRING_CODE]))];
         assert_matches!(
             sparse.validate_root_node(&mut proof.into_iter().peekable()).map_err(|e| e.into_kind()),
@@ -940,7 +940,7 @@ mod tests {
 
     #[test]
     fn validate_root_node_invalid_proof_with_empty_root() {
-        let sparse = SparseStateTrie::<RevealedSparseTrie>::default();
+        let sparse = SparseStateTrie::<SerialSparseTrie>::default();
         let proof = [
             (Nibbles::default(), Bytes::from([EMPTY_STRING_CODE])),
             (Nibbles::from_nibbles([0x1]), Bytes::new()),
@@ -959,7 +959,7 @@ mod tests {
         let proofs = hash_builder.take_proof_nodes();
         assert_eq!(proofs.len(), 1);
 
-        let mut sparse = SparseStateTrie::<RevealedSparseTrie>::default();
+        let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
         assert_eq!(sparse.state, SparseTrie::Blind(None));
 
         sparse.reveal_account(Default::default(), proofs.into_inner()).unwrap();
@@ -974,7 +974,7 @@ mod tests {
         let proofs = hash_builder.take_proof_nodes();
         assert_eq!(proofs.len(), 1);
 
-        let mut sparse = SparseStateTrie::<RevealedSparseTrie>::default();
+        let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
         assert!(sparse.storages.is_empty());
 
         sparse
@@ -989,7 +989,7 @@ mod tests {
     #[test]
     fn reveal_account_path_twice() {
         let provider_factory = DefaultBlindedProviderFactory;
-        let mut sparse = SparseStateTrie::<RevealedSparseTrie>::default();
+        let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
 
         let leaf_value = alloy_rlp::encode(TrieAccount::default());
         let leaf_1 = alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(
@@ -1061,7 +1061,7 @@ mod tests {
     #[test]
     fn reveal_storage_path_twice() {
         let provider_factory = DefaultBlindedProviderFactory;
-        let mut sparse = SparseStateTrie::<RevealedSparseTrie>::default();
+        let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
 
         let leaf_value = alloy_rlp::encode(TrieAccount::default());
         let leaf_1 = alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(
@@ -1193,7 +1193,7 @@ mod tests {
         let proof_nodes = hash_builder.take_proof_nodes();
 
         let provider_factory = DefaultBlindedProviderFactory;
-        let mut sparse = SparseStateTrie::<RevealedSparseTrie>::default().with_updates(true);
+        let mut sparse = SparseStateTrie::<SerialSparseTrie>::default().with_updates(true);
         sparse
             .reveal_decoded_multiproof(
                 MultiProof {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -26,7 +26,7 @@ use smallvec::SmallVec;
 use tracing::trace;
 
 /// The level below which the sparse trie hashes are calculated in
-/// [`RevealedSparseTrie::update_subtrie_hashes`].
+/// [`SerialSparseTrie::update_subtrie_hashes`].
 const SPARSE_TRIE_SUBTRIE_HASHES_LEVEL: usize = 2;
 
 /// A sparse trie that is either in a "blind" state (no nodes are revealed, root node hash is
@@ -42,13 +42,13 @@ const SPARSE_TRIE_SUBTRIE_HASHES_LEVEL: usize = 2;
 /// 3. Incremental operations - nodes can be revealed as needed without loading the entire trie.
 ///    This is what gives rise to the notion of a "sparse" trie.
 #[derive(PartialEq, Eq, Debug)]
-pub enum SparseTrie<T = RevealedSparseTrie> {
+pub enum SparseTrie<T = SerialSparseTrie> {
     /// The trie is blind -- no nodes have been revealed
     ///
     /// This is the default state. In this state, the trie cannot be directly queried or modified
     /// until nodes are revealed.
     ///
-    /// In this state the `SparseTrie` can optionally carry with it a cleared `RevealedSparseTrie`.
+    /// In this state the `SparseTrie` can optionally carry with it a cleared `SerialSparseTrie`.
     /// This allows for reusing the trie's allocations between payload executions.
     Blind(Option<Box<T>>),
     /// Some nodes in the Trie have been revealed.
@@ -71,11 +71,11 @@ impl<T: SparseTrieInterface + Default> SparseTrie<T> {
     /// # Examples
     ///
     /// ```
-    /// use reth_trie_sparse::{blinded::DefaultBlindedProvider, RevealedSparseTrie, SparseTrie};
+    /// use reth_trie_sparse::{blinded::DefaultBlindedProvider, SerialSparseTrie, SparseTrie};
     ///
-    /// let trie = SparseTrie::<RevealedSparseTrie>::blind();
+    /// let trie = SparseTrie::<SerialSparseTrie>::blind();
     /// assert!(trie.is_blind());
-    /// let trie = SparseTrie::<RevealedSparseTrie>::default();
+    /// let trie = SparseTrie::<SerialSparseTrie>::default();
     /// assert!(trie.is_blind());
     /// ```
     pub const fn blind() -> Self {
@@ -87,9 +87,9 @@ impl<T: SparseTrieInterface + Default> SparseTrie<T> {
     /// # Examples
     ///
     /// ```
-    /// use reth_trie_sparse::{blinded::DefaultBlindedProvider, RevealedSparseTrie, SparseTrie};
+    /// use reth_trie_sparse::{blinded::DefaultBlindedProvider, SerialSparseTrie, SparseTrie};
     ///
-    /// let trie = SparseTrie::<RevealedSparseTrie>::revealed_empty();
+    /// let trie = SparseTrie::<SerialSparseTrie>::revealed_empty();
     /// assert!(!trie.is_blind());
     /// ```
     pub fn revealed_empty() -> Self {
@@ -256,7 +256,7 @@ impl<T: SparseTrieInterface + Default> SparseTrie<T> {
 ///   The opposite is also true.
 /// - All keys in `values` collection are full leaf paths.
 #[derive(Clone, PartialEq, Eq)]
-pub struct RevealedSparseTrie {
+pub struct SerialSparseTrie {
     /// Map from a path (nibbles) to its corresponding sparse trie node.
     /// This contains all of the revealed nodes in trie.
     nodes: HashMap<Nibbles, SparseNode>,
@@ -276,9 +276,9 @@ pub struct RevealedSparseTrie {
     rlp_buf: Vec<u8>,
 }
 
-impl fmt::Debug for RevealedSparseTrie {
+impl fmt::Debug for SerialSparseTrie {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RevealedSparseTrie")
+        f.debug_struct("SerialSparseTrie")
             .field("nodes", &self.nodes)
             .field("branch_tree_masks", &self.branch_node_tree_masks)
             .field("branch_hash_masks", &self.branch_node_hash_masks)
@@ -296,7 +296,7 @@ fn encode_nibbles(nibbles: &Nibbles) -> String {
     encoded[..nibbles.len()].to_string()
 }
 
-impl fmt::Display for RevealedSparseTrie {
+impl fmt::Display for SerialSparseTrie {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // This prints the trie in preorder traversal, using a stack
         let mut stack = Vec::new();
@@ -362,7 +362,7 @@ impl fmt::Display for RevealedSparseTrie {
     }
 }
 
-impl Default for RevealedSparseTrie {
+impl Default for SerialSparseTrie {
     fn default() -> Self {
         Self {
             nodes: HashMap::from_iter([(Nibbles::default(), SparseNode::Empty)]),
@@ -376,7 +376,7 @@ impl Default for RevealedSparseTrie {
     }
 }
 
-impl SparseTrieInterface for RevealedSparseTrie {
+impl SparseTrieInterface for SerialSparseTrie {
     fn with_root(
         mut self,
         root: TrieNode,
@@ -385,7 +385,7 @@ impl SparseTrieInterface for RevealedSparseTrie {
     ) -> SparseTrieResult<Self> {
         self = self.with_updates(retain_updates);
 
-        // A fresh/cleared `RevealedSparseTrie` has a `SparseNode::Empty` at its root. Delete that
+        // A fresh/cleared `SerialSparseTrie` has a `SparseNode::Empty` at its root. Delete that
         // so we can reveal the new root node.
         let path = Nibbles::default();
         let _removed_root = self.nodes.remove(&path).expect("root node should exist");
@@ -1055,7 +1055,7 @@ impl SparseTrieInterface for RevealedSparseTrie {
     }
 }
 
-impl RevealedSparseTrie {
+impl SerialSparseTrie {
     /// Creates a new revealed sparse trie from the given root node.
     ///
     /// This function initializes the internal structures and then reveals the root.
@@ -1838,7 +1838,7 @@ struct RemovedSparseNode {
     unset_branch_nibble: Option<u8>,
 }
 
-/// Collection of reusable buffers for [`RevealedSparseTrie::rlp_node`] calculations.
+/// Collection of reusable buffers for [`SerialSparseTrie::rlp_node`] calculations.
 ///
 /// These buffers reduce allocations when computing RLP representations during trie updates.
 #[derive(Debug, Default)]
@@ -1941,7 +1941,7 @@ mod find_leaf_tests {
     fn find_leaf_existing_leaf() {
         // Create a simple trie with one leaf
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
         let value = b"test_value".to_vec();
 
@@ -1960,7 +1960,7 @@ mod find_leaf_tests {
     fn find_leaf_value_mismatch() {
         // Create a simple trie with one leaf
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
         let value = b"test_value".to_vec();
         let wrong_value = b"wrong_value".to_vec();
@@ -1978,7 +1978,7 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_not_found_empty_trie() {
         // Empty trie
-        let sparse = RevealedSparseTrie::default();
+        let sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
 
         // Leaf should not exist
@@ -1991,7 +1991,7 @@ mod find_leaf_tests {
 
     #[test]
     fn find_leaf_empty_trie() {
-        let sparse = RevealedSparseTrie::default();
+        let sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
 
         let result = sparse.find_leaf(&path, None);
@@ -2003,7 +2003,7 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_exists_no_value_check() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
         sparse.update_leaf(path, VALUE_A(), &provider).unwrap();
 
@@ -2014,7 +2014,7 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_exists_with_value_check_ok() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
         let value = VALUE_A();
         sparse.update_leaf(path, value.clone(), &provider).unwrap();
@@ -2026,7 +2026,7 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_exclusion_branch_divergence() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let path1 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]); // Creates branch at 0x12
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]); // Belongs to same branch
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]); // Diverges at nibble 7
@@ -2044,7 +2044,7 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_exclusion_extension_divergence() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         // This will create an extension node at root with key 0x12
         let path1 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4, 0x5, 0x6]);
         // This path diverges from the extension key
@@ -2062,7 +2062,7 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_exclusion_leaf_divergence() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let existing_leaf_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4, 0x5, 0x6]);
 
@@ -2080,7 +2080,7 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_exclusion_path_ends_at_branch() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let path1 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]); // Creates branch at 0x12
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2]); // Path of the branch itself
@@ -2118,7 +2118,7 @@ mod find_leaf_tests {
         ); // Branch at 0x123, child 4
         nodes.insert(leaf_path, SparseNode::Hash(blinded_hash)); // Blinded node at 0x1234
 
-        let sparse = RevealedSparseTrie {
+        let sparse = SerialSparseTrie {
             nodes,
             branch_node_tree_masks: Default::default(),
             branch_node_hash_masks: Default::default(),
@@ -2161,7 +2161,7 @@ mod find_leaf_tests {
         let mut values = HashMap::with_hasher(RandomState::default());
         values.insert(path_revealed_leaf, VALUE_A());
 
-        let sparse = RevealedSparseTrie {
+        let sparse = SerialSparseTrie {
             nodes,
             branch_node_tree_masks: Default::default(),
             branch_node_hash_masks: Default::default(),
@@ -2208,7 +2208,7 @@ mod find_leaf_tests {
 
         // 3. Initialize the sparse trie using from_root
         // This will internally create Hash nodes for paths "1" and "5" initially.
-        let mut sparse = RevealedSparseTrie::from_root(root_trie_node, TrieMasks::none(), false)
+        let mut sparse = SerialSparseTrie::from_root(root_trie_node, TrieMasks::none(), false)
             .expect("Failed to create trie from root");
 
         // Assertions before we reveal child5
@@ -2357,10 +2357,7 @@ mod tests {
     }
 
     /// Assert that the sparse trie nodes and the proof nodes from the hash builder are equal.
-    fn assert_eq_sparse_trie_proof_nodes(
-        sparse_trie: &RevealedSparseTrie,
-        proof_nodes: ProofNodes,
-    ) {
+    fn assert_eq_sparse_trie_proof_nodes(sparse_trie: &SerialSparseTrie, proof_nodes: ProofNodes) {
         let proof_nodes = proof_nodes
             .into_nodes_sorted()
             .into_iter()
@@ -2404,8 +2401,8 @@ mod tests {
 
     #[test]
     fn sparse_trie_is_blind() {
-        assert!(SparseTrie::<RevealedSparseTrie>::blind().is_blind());
-        assert!(!SparseTrie::<RevealedSparseTrie>::revealed_empty().is_blind());
+        assert!(SparseTrie::<SerialSparseTrie>::blind().is_blind());
+        assert!(!SparseTrie::<SerialSparseTrie>::revealed_empty().is_blind());
     }
 
     #[test]
@@ -2427,7 +2424,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default().with_updates(true);
+        let mut sparse = SerialSparseTrie::default().with_updates(true);
         sparse.update_leaf(key, value_encoded(), &provider).unwrap();
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -2458,7 +2455,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default().with_updates(true);
+        let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
             sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
@@ -2489,7 +2486,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default().with_updates(true);
+        let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
             sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
@@ -2528,7 +2525,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default().with_updates(true);
+        let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
             sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
@@ -2568,7 +2565,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default().with_updates(true);
+        let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
             sparse.update_leaf(*path, old_value_encoded.clone(), &provider).unwrap();
         }
@@ -2603,7 +2600,7 @@ mod tests {
         reth_tracing::init_test_tracing();
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
 
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
 
@@ -2857,7 +2854,7 @@ mod tests {
         ));
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::from_root(
+        let mut sparse = SerialSparseTrie::from_root(
             branch.clone(),
             TrieMasks { hash_mask: Some(TrieMask::new(0b01)), tree_mask: None },
             false,
@@ -2902,7 +2899,7 @@ mod tests {
         ));
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::from_root(
+        let mut sparse = SerialSparseTrie::from_root(
             branch.clone(),
             TrieMasks { hash_mask: Some(TrieMask::new(0b01)), tree_mask: None },
             false,
@@ -2943,7 +2940,7 @@ mod tests {
                 let mut state = BTreeMap::default();
                 let default_provider = DefaultBlindedProvider;
                 let provider_factory = create_test_provider_factory();
-                let mut sparse = RevealedSparseTrie::default().with_updates(true);
+                let mut sparse = SerialSparseTrie::default().with_updates(true);
 
                 for (update, keys_to_delete) in updates {
                     // Insert state updates into the sparse trie and calculate the root
@@ -3103,7 +3100,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::from_root(
+        let mut sparse = SerialSparseTrie::from_root(
             TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
             TrieMasks {
                 hash_mask: branch_node_hash_masks.get(&Nibbles::default()).copied(),
@@ -3213,7 +3210,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::from_root(
+        let mut sparse = SerialSparseTrie::from_root(
             TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
             TrieMasks {
                 hash_mask: branch_node_hash_masks.get(&Nibbles::default()).copied(),
@@ -3316,7 +3313,7 @@ mod tests {
             );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::from_root(
+        let mut sparse = SerialSparseTrie::from_root(
             TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
             TrieMasks {
                 hash_mask: branch_node_hash_masks.get(&Nibbles::default()).copied(),
@@ -3371,7 +3368,7 @@ mod tests {
     #[test]
     fn sparse_trie_get_changed_nodes_at_depth() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
 
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
 
@@ -3486,7 +3483,7 @@ mod tests {
         );
 
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         sparse.update_leaf(key1(), value_encoded(), &provider).unwrap();
         sparse.update_leaf(key2(), value_encoded(), &provider).unwrap();
         let sparse_root = sparse.root();
@@ -3499,7 +3496,7 @@ mod tests {
     #[test]
     fn sparse_trie_wipe() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default().with_updates(true);
+        let mut sparse = SerialSparseTrie::default().with_updates(true);
 
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
 
@@ -3549,7 +3546,7 @@ mod tests {
         // tests that if we fill a sparse trie with some nodes and then clear it, it has the same
         // contents as an empty sparse trie
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
         sparse
             .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), value.clone(), &provider)
@@ -3566,14 +3563,14 @@ mod tests {
 
         sparse.clear();
 
-        let empty_trie = RevealedSparseTrie::default();
+        let empty_trie = SerialSparseTrie::default();
         assert_eq!(empty_trie, sparse);
     }
 
     #[test]
     fn sparse_trie_display() {
         let provider = DefaultBlindedProvider;
-        let mut sparse = RevealedSparseTrie::default();
+        let mut sparse = SerialSparseTrie::default();
 
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
 

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -22,7 +22,7 @@ use reth_execution_errors::{
 use reth_trie_common::{MultiProofTargets, Nibbles};
 use reth_trie_sparse::{
     blinded::{BlindedProvider, BlindedProviderFactory, RevealedNode},
-    RevealedSparseTrie, SparseStateTrie,
+    SerialSparseTrie, SparseStateTrie,
 };
 use std::sync::{mpsc, Arc};
 
@@ -154,7 +154,7 @@ where
             ),
             tx,
         );
-        let mut sparse_trie = SparseStateTrie::<RevealedSparseTrie>::new();
+        let mut sparse_trie = SparseStateTrie::<SerialSparseTrie>::new();
         sparse_trie.reveal_multiproof(multiproof)?;
 
         // Attempt to update state trie to gather additional information for the witness.


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/17289

Renamed `RevealedSparseTrie` to `SerialSparseTrie` across the codebase, so that we have `SerialSparseTrie` and `ParallelSparseTrie` that both get used through a generic `SparseTrie`.