### PR TITLE
feat: support isthmus in reth-bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7263,6 +7263,7 @@ dependencies = [
  "futures",
  "humantime",
  "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
  "reqwest",
  "reth-cli-runner",
  "reth-cli-util",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -35,6 +35,7 @@ alloy-transport-ipc.workspace = true
 alloy-transport-ws.workspace = true
 alloy-transport.workspace = true
 op-alloy-consensus = { workspace = true, features = ["alloy-compat"] }
+op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # reqwest
 reqwest = { workspace = true, default-features = false, features = ["rustls-tls-native-roots"] }

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -8,10 +8,9 @@ use crate::{
             NEW_PAYLOAD_OUTPUT_SUFFIX,
         },
     },
-    valid_payload::call_new_payload,
+    valid_payload::{block_to_new_payload, call_new_payload},
 };
 use alloy_provider::Provider;
-use alloy_rpc_types_engine::ExecutionPayload;
 use clap::Parser;
 use csv::Writer;
 use reth_cli_runner::CliContext;
@@ -33,29 +32,25 @@ pub struct Command {
 impl Command {
     /// Execute `benchmark new-payload-only` command
     pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
-        let BenchContext { benchmark_mode, block_provider, auth_provider, mut next_block } =
-            BenchContext::new(&self.benchmark, self.rpc_url).await?;
+        let BenchContext {
+            benchmark_mode,
+            block_provider,
+            auth_provider,
+            mut next_block,
+            is_optimism,
+        } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1000);
         tokio::task::spawn(async move {
             while benchmark_mode.contains(next_block) {
                 let block_res = block_provider.get_block_by_number(next_block.into()).full().await;
                 let block = block_res.unwrap().unwrap();
-                let block = block
-                    .into_inner()
-                    .map_header(|header| header.map(|h| h.into_header_with_defaults()))
-                    .try_map_transactions(|tx| {
-                        tx.try_into_either::<op_alloy_consensus::OpTxEnvelope>()
-                    })
-                    .unwrap()
-                    .into_consensus();
+                let header = block.header.clone();
 
-                let blob_versioned_hashes =
-                    block.body.blob_versioned_hashes_iter().copied().collect::<Vec<_>>();
-                let (payload, sidecar) = ExecutionPayload::from_block_slow(&block);
+                let (version, params) = block_to_new_payload(block, is_optimism).unwrap();
 
                 next_block += 1;
-                sender.send((block.header, blob_versioned_hashes, payload, sidecar)).await.unwrap();
+                sender.send((header, version, params)).await.unwrap();
             }
         });
 
@@ -64,7 +59,7 @@ impl Command {
         let total_benchmark_duration = Instant::now();
         let mut total_wait_time = Duration::ZERO;
 
-        while let Some((header, versioned_hashes, payload, sidecar)) = {
+        while let Some((header, version, params)) = {
             let wait_start = Instant::now();
             let result = receiver.recv().await;
             total_wait_time += wait_start.elapsed();
@@ -73,7 +68,7 @@ impl Command {
             // just put gas used here
             let gas_used = header.gas_used;
 
-            let block_number = payload.block_number();
+            let block_number = header.number;
 
             debug!(
                 target: "reth-bench",
@@ -82,14 +77,7 @@ impl Command {
             );
 
             let start = Instant::now();
-            call_new_payload(
-                &auth_provider,
-                payload,
-                sidecar,
-                header.parent_beacon_block_root,
-                versioned_hashes,
-            )
-            .await?;
+            call_new_payload(&auth_provider, version, params).await?;
 
             let new_payload_result = NewPayloadResult { gas_used, latency: start.elapsed() };
             info!(%new_payload_result);

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -2,53 +2,19 @@
 //! response. This is useful for benchmarking, as it allows us to wait for a payload to be valid
 //! before sending additional calls.
 
-use alloy_eips::eip7685::RequestsOrHash;
-use alloy_primitives::B256;
-use alloy_provider::{ext::EngineApi, Network, Provider};
+use alloy_provider::{ext::EngineApi, network::AnyRpcBlock, Network, Provider};
 use alloy_rpc_types_engine::{
-    ExecutionPayload, ExecutionPayloadInputV2, ExecutionPayloadSidecar, ExecutionPayloadV1,
-    ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadStatus,
+    ExecutionPayload, ExecutionPayloadInputV2, ForkchoiceState, ForkchoiceUpdated,
+    PayloadAttributes, PayloadStatus,
 };
 use alloy_transport::TransportResult;
+use op_alloy_rpc_types_engine::OpExecutionPayloadV4;
 use reth_node_api::EngineApiMessageVersion;
 use tracing::error;
 
 /// An extension trait for providers that implement the engine API, to wait for a VALID response.
 #[async_trait::async_trait]
 pub trait EngineApiValidWaitExt<N>: Send + Sync {
-    /// Calls `engine_newPayloadV1` with the given [`ExecutionPayloadV1`], and waits until the
-    /// response is VALID.
-    async fn new_payload_v1_wait(
-        &self,
-        payload: ExecutionPayloadV1,
-    ) -> TransportResult<PayloadStatus>;
-
-    /// Calls `engine_newPayloadV2` with the given [`ExecutionPayloadInputV2`], and waits until the
-    /// response is VALID.
-    async fn new_payload_v2_wait(
-        &self,
-        payload: ExecutionPayloadInputV2,
-    ) -> TransportResult<PayloadStatus>;
-
-    /// Calls `engine_newPayloadV3` with the given [`ExecutionPayloadV3`], parent beacon block root,
-    /// and versioned hashes, and waits until the response is VALID.
-    async fn new_payload_v3_wait(
-        &self,
-        payload: ExecutionPayloadV3,
-        versioned_hashes: Vec<B256>,
-        parent_beacon_block_root: B256,
-    ) -> TransportResult<PayloadStatus>;
-
-    /// Calls `engine_newPayloadV4` with the given [`ExecutionPayloadV3`], parent beacon block root,
-    /// versioned hashes, and requests hash, and waits until the response is VALID.
-    async fn new_payload_v4_wait(
-        &self,
-        payload: ExecutionPayloadV3,
-        versioned_hashes: Vec<B256>,
-        parent_beacon_block_root: B256,
-        requests_hash: B256,
-    ) -> TransportResult<PayloadStatus>;
-
     /// Calls `engine_forkChoiceUpdatedV1` with the given [`ForkchoiceState`] and optional
     /// [`PayloadAttributes`], and waits until the response is VALID.
     async fn fork_choice_updated_v1_wait(
@@ -80,122 +46,6 @@ where
     N: Network,
     P: Provider<N> + EngineApi<N>,
 {
-    async fn new_payload_v1_wait(
-        &self,
-        payload: ExecutionPayloadV1,
-    ) -> TransportResult<PayloadStatus> {
-        let mut status = self.new_payload_v1(payload.clone()).await?;
-        while !status.is_valid() {
-            if status.is_invalid() {
-                error!(?status, ?payload, "Invalid newPayloadV1",);
-                panic!("Invalid newPayloadV1: {status:?}");
-            }
-            status = self.new_payload_v1(payload.clone()).await?;
-        }
-        Ok(status)
-    }
-
-    async fn new_payload_v2_wait(
-        &self,
-        payload: ExecutionPayloadInputV2,
-    ) -> TransportResult<PayloadStatus> {
-        let mut status = self.new_payload_v2(payload.clone()).await?;
-        while !status.is_valid() {
-            if status.is_invalid() {
-                error!(?status, ?payload, "Invalid newPayloadV2",);
-                panic!("Invalid newPayloadV2: {status:?}");
-            }
-            status = self.new_payload_v2(payload.clone()).await?;
-        }
-        Ok(status)
-    }
-
-    async fn new_payload_v3_wait(
-        &self,
-        payload: ExecutionPayloadV3,
-        versioned_hashes: Vec<B256>,
-        parent_beacon_block_root: B256,
-    ) -> TransportResult<PayloadStatus> {
-        let mut status = self
-            .new_payload_v3(payload.clone(), versioned_hashes.clone(), parent_beacon_block_root)
-            .await?;
-        while !status.is_valid() {
-            if status.is_invalid() {
-                error!(
-                    ?status,
-                    ?payload,
-                    ?versioned_hashes,
-                    ?parent_beacon_block_root,
-                    "Invalid newPayloadV3",
-                );
-                panic!("Invalid newPayloadV3: {status:?}");
-            }
-            if status.is_syncing() {
-                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
-                    "invalid range: no canonical state found for parent of requested block",
-                ))
-            }
-            status = self
-                .new_payload_v3(payload.clone(), versioned_hashes.clone(), parent_beacon_block_root)
-                .await?;
-        }
-        Ok(status)
-    }
-
-    async fn new_payload_v4_wait(
-        &self,
-        payload: ExecutionPayloadV3,
-        versioned_hashes: Vec<B256>,
-        parent_beacon_block_root: B256,
-        requests_hash: B256,
-    ) -> TransportResult<PayloadStatus> {
-        // We cannot use `self.new_payload_v4` because it does not support sending
-        // `RequestsOrHash::Hash`
-
-        let mut status: PayloadStatus = self
-            .client()
-            .request(
-                "engine_newPayloadV4",
-                (
-                    payload.clone(),
-                    versioned_hashes.clone(),
-                    parent_beacon_block_root,
-                    RequestsOrHash::Hash(requests_hash),
-                ),
-            )
-            .await?;
-        while !status.is_valid() {
-            if status.is_invalid() {
-                error!(
-                    ?status,
-                    ?payload,
-                    ?versioned_hashes,
-                    ?parent_beacon_block_root,
-                    "Invalid newPayloadV4",
-                );
-                panic!("Invalid newPayloadV4: {status:?}");
-            }
-            if status.is_syncing() {
-                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
-                    "invalid range: no canonical state found for parent of requested block",
-                ))
-            }
-            status = self
-                .client()
-                .request(
-                    "engine_newPayloadV4",
-                    (
-                        payload.clone(),
-                        versioned_hashes.clone(),
-                        parent_beacon_block_root,
-                        RequestsOrHash::Hash(requests_hash),
-                    ),
-                )
-                .await?;
-        }
-        Ok(status)
-    }
-
     async fn fork_choice_updated_v1_wait(
         &self,
         fork_choice_state: ForkchoiceState,
@@ -282,39 +132,60 @@ where
     }
 }
 
-/// Calls the correct `engine_newPayload` method depending on the given [`ExecutionPayload`] and its
-/// versioned variant. Returns the [`EngineApiMessageVersion`] depending on the payload's version.
-///
-/// # Panics
-/// If the given payload is a V3 payload, but a parent beacon block root is provided as `None`.
-pub(crate) async fn call_new_payload<N, P: EngineApiValidWaitExt<N>>(
-    provider: P,
-    payload: ExecutionPayload,
-    sidecar: ExecutionPayloadSidecar,
-    parent_beacon_block_root: Option<B256>,
-    versioned_hashes: Vec<B256>,
-) -> TransportResult<EngineApiMessageVersion> {
-    match payload {
-        ExecutionPayload::V3(payload) => {
-            // We expect the caller to provide `parent_beacon_block_root` for V3 payloads.
-            let parent_beacon_block_root = parent_beacon_block_root
-                .expect("parent_beacon_block_root is required for V3 payloads and higher");
+pub(crate) fn block_to_new_payload(
+    block: AnyRpcBlock,
+    is_optimism: bool,
+) -> eyre::Result<(EngineApiMessageVersion, serde_json::Value)> {
+    let block = block
+        .into_inner()
+        .map_header(|header| header.map(|h| h.into_header_with_defaults()))
+        .try_map_transactions(|tx| {
+            // try to convert unknowns into op type so that we can also support optimism
+            tx.try_into_either::<op_alloy_consensus::OpTxEnvelope>()
+        })?
+        .into_consensus();
 
-            if let Some(requests_hash) = sidecar.requests_hash() {
-                provider
-                    .new_payload_v4_wait(
-                        payload,
-                        versioned_hashes,
-                        parent_beacon_block_root,
-                        requests_hash,
+    // Convert to execution payload
+    let (payload, sidecar) = ExecutionPayload::from_block_slow(&block);
+
+    let (version, params) = match payload {
+        ExecutionPayload::V3(payload) => {
+            let cancun = sidecar.cancun().unwrap();
+
+            if let Some(prague) = sidecar.prague() {
+                if is_optimism {
+                    (
+                        EngineApiMessageVersion::V4,
+                        serde_json::to_value((
+                            OpExecutionPayloadV4 {
+                                payload_inner: payload,
+                                withdrawals_root: block.withdrawals_root.unwrap(),
+                            },
+                            cancun.versioned_hashes.clone(),
+                            cancun.parent_beacon_block_root,
+                            prague.requests.requests_hash(),
+                        ))?,
                     )
-                    .await?;
-                Ok(EngineApiMessageVersion::V4)
+                } else {
+                    (
+                        EngineApiMessageVersion::V4,
+                        serde_json::to_value((
+                            payload,
+                            cancun.versioned_hashes.clone(),
+                            cancun.parent_beacon_block_root,
+                            prague.requests.requests_hash(),
+                        ))?,
+                    )
+                }
             } else {
-                provider
-                    .new_payload_v3_wait(payload, versioned_hashes, parent_beacon_block_root)
-                    .await?;
-                Ok(EngineApiMessageVersion::V3)
+                (
+                    EngineApiMessageVersion::V3,
+                    serde_json::to_value((
+                        payload,
+                        cancun.versioned_hashes.clone(),
+                        cancun.parent_beacon_block_root,
+                    ))?,
+                )
             }
         }
         ExecutionPayload::V2(payload) => {
@@ -323,16 +194,49 @@ pub(crate) async fn call_new_payload<N, P: EngineApiValidWaitExt<N>>(
                 withdrawals: Some(payload.withdrawals),
             };
 
-            provider.new_payload_v2_wait(input).await?;
-
-            Ok(EngineApiMessageVersion::V2)
+            (EngineApiMessageVersion::V2, serde_json::to_value((input,))?)
         }
         ExecutionPayload::V1(payload) => {
-            provider.new_payload_v1_wait(payload).await?;
-
-            Ok(EngineApiMessageVersion::V1)
+            (EngineApiMessageVersion::V1, serde_json::to_value((payload,))?)
         }
+    };
+
+    Ok((version, params))
+}
+
+/// Calls the correct `engine_newPayload` method depending on the given [`ExecutionPayload`] and its
+/// versioned variant. Returns the [`EngineApiMessageVersion`] depending on the payload's version.
+///
+/// # Panics
+/// If the given payload is a V3 payload, but a parent beacon block root is provided as `None`.
+pub(crate) async fn call_new_payload<N: Network, P: Provider<N>>(
+    provider: P,
+    version: EngineApiMessageVersion,
+    params: serde_json::Value,
+) -> TransportResult<()> {
+    let method = match version {
+        EngineApiMessageVersion::V1 => "engine_newPayloadV1",
+        EngineApiMessageVersion::V2 => "engine_newPayloadV2",
+        EngineApiMessageVersion::V3 => "engine_newPayloadV3",
+        EngineApiMessageVersion::V4 => "engine_newPayloadV4",
+        EngineApiMessageVersion::V5 => "engine_newPayloadV5",
+    };
+
+    let mut status: PayloadStatus = provider.client().request(method, &params).await?;
+
+    while !status.is_valid() {
+        if status.is_invalid() {
+            error!(?status, ?params, "Invalid {method}",);
+            panic!("Invalid {method}: {status:?}");
+        }
+        if status.is_syncing() {
+            return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                "invalid range: no canonical state found for parent of requested block",
+            ))
+        }
+        status = provider.client().request(method, &params).await?;
     }
+    Ok(())
 }
 
 /// Calls the correct `engine_forkchoiceUpdated` method depending on the given

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -2,6 +2,7 @@
 //! response. This is useful for benchmarking, as it allows us to wait for a payload to be valid
 //! before sending additional calls.
 
+use alloy_eips::eip7685::Requests;
 use alloy_provider::{ext::EngineApi, network::AnyRpcBlock, Network, Provider};
 use alloy_rpc_types_engine::{
     ExecutionPayload, ExecutionPayloadInputV2, ForkchoiceState, ForkchoiceUpdated,
@@ -163,7 +164,7 @@ pub(crate) fn block_to_new_payload(
                             },
                             cancun.versioned_hashes.clone(),
                             cancun.parent_beacon_block_root,
-                            prague.requests.requests_hash(),
+                            Requests::default(),
                         ))?,
                     )
                 } else {

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -214,13 +214,7 @@ pub(crate) async fn call_new_payload<N: Network, P: Provider<N>>(
     version: EngineApiMessageVersion,
     params: serde_json::Value,
 ) -> TransportResult<()> {
-    let method = match version {
-        EngineApiMessageVersion::V1 => "engine_newPayloadV1",
-        EngineApiMessageVersion::V2 => "engine_newPayloadV2",
-        EngineApiMessageVersion::V3 => "engine_newPayloadV3",
-        EngineApiMessageVersion::V4 => "engine_newPayloadV4",
-        EngineApiMessageVersion::V5 => "engine_newPayloadV5",
-    };
+    let method = version.method_name();
 
     let mut status: PayloadStatus = provider.client().request(method, &params).await?;
 

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -413,6 +413,17 @@ impl EngineApiMessageVersion {
     pub const fn is_v5(&self) -> bool {
         matches!(self, Self::V5)
     }
+
+    /// Returns the method name for the given version.
+    pub const fn method_name(&self) -> &'static str {
+        match self {
+            Self::V1 => "engine_newPayloadV1",
+            Self::V2 => "engine_newPayloadV2",
+            Self::V3 => "engine_newPayloadV3",
+            Self::V4 => "engine_newPayloadV4",
+            Self::V5 => "engine_newPayloadV5",
+        }
+    }
 }
 
 /// Determines how we should choose the payload to return.


### PR DESCRIPTION
Adds support for isthmus `withdrawalsRoot` field to reth-bench by determining whether we're on OP chain and using `OpExecutionPayloadV4` type if relevant

closes https://github.com/paradigmxyz/reth/issues/17087