### PR TITLE
feat(trie): add HashedPostState::clear

### DIFF
--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -334,6 +334,12 @@ impl HashedPostState {
 
         HashedPostStateSorted { accounts, storages }
     }
+
+    /// Clears the account and storage maps of this `HashedPostState`.
+    pub fn clear(&mut self) {
+        self.accounts.clear();
+        self.storages.clear();
+    }
 }
 
 /// Representation of in-memory hashed storage.


### PR DESCRIPTION
Adds a method that clears the maps in the `HashedPostState`