### PR TITLE
feat: add generic type parameter support to Compact derive macro

### DIFF
--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -22,6 +22,30 @@ use reth_primitives_traits::{proofs::ordered_trie_root_with_encoder, InMemorySiz
     compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
     decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
 ))]
+pub struct Receipt2<T = TxType> {
+    /// Receipt type.
+    pub tx_type: T,
+    /// If transaction is executed successfully.
+    ///
+    /// This is the `statusCode`
+    pub success: bool,
+    /// Gas used
+    pub cumulative_gas_used: u64,
+    /// Log send from contracts.
+    pub logs: Vec<Log>,
+}
+
+/// Typed ethereum transaction receipt.
+/// Receipt containing result of transaction execution.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "reth-codec", derive(reth_codecs::CompactZstd))]
+#[cfg_attr(feature = "reth-codec", reth_codecs::add_arbitrary_tests(compact, rlp))]
+#[cfg_attr(feature = "reth-codec", reth_zstd(
+    compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
+    decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
+))]
 pub struct Receipt {
     /// Receipt type.
     pub tx_type: TxType,

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -22,30 +22,6 @@ use reth_primitives_traits::{proofs::ordered_trie_root_with_encoder, InMemorySiz
     compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
     decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
 ))]
-pub struct Receipt2<T = TxType> {
-    /// Receipt type.
-    pub tx_type: T,
-    /// If transaction is executed successfully.
-    ///
-    /// This is the `statusCode`
-    pub success: bool,
-    /// Gas used
-    pub cumulative_gas_used: u64,
-    /// Log send from contracts.
-    pub logs: Vec<Log>,
-}
-
-/// Typed ethereum transaction receipt.
-/// Receipt containing result of transaction execution.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "reth-codec", derive(reth_codecs::CompactZstd))]
-#[cfg_attr(feature = "reth-codec", reth_codecs::add_arbitrary_tests(compact, rlp))]
-#[cfg_attr(feature = "reth-codec", reth_zstd(
-    compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
-    decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
-))]
 pub struct Receipt {
     /// Receipt type.
     pub tx_type: TxType,

--- a/crates/storage/codecs/derive/src/compact/flags.rs
+++ b/crates/storage/codecs/derive/src/compact/flags.rs
@@ -60,7 +60,7 @@ pub(crate) fn generate_flag_struct(
     let bitflag_encoded_bytes = format!("Used bytes by [`{flags_ident}`]");
     let bitflag_unused_bits = format!("Unused bits for new fields by [`{flags_ident}`]");
     let (impl_generics, type_generics, _where_clause) = generics.split_for_impl();
-    
+
     let impl_bitflag_encoded_bytes = quote! {
         impl #impl_generics #ident #type_generics {
             #[doc = #bitflag_encoded_bytes]
@@ -176,7 +176,7 @@ fn placeholder_flag_struct(ident: &Ident, flags: &Ident, generics: &syn::Generic
     let bitflag_encoded_bytes = format!("Used bytes by [`{flags}`]");
     let bitflag_unused_bits = format!("Unused bits for new fields by [`{flags}`]");
     let (impl_generics, type_generics, _where_clause) = generics.split_for_impl();
-    
+
     quote! {
         impl #impl_generics #ident #type_generics {
             #[doc = #bitflag_encoded_bytes]

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -27,7 +27,7 @@ pub fn generate_from_to(
 
     // Extract type parameters and add Compact bounds
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
-    
+
     // Create where clause with Compact bounds for type parameters
     let mut where_clause = where_clause.cloned().unwrap_or_else(|| syn::parse_quote! { where });
     for param in &generics.params {
@@ -36,7 +36,7 @@ pub fn generate_from_to(
             where_clause.predicates.push(syn::parse_quote! { #ident: #reth_codecs::Compact });
         }
     }
-    
+
     let impl_compact = quote! {
         impl #impl_generics #reth_codecs::Compact for #ident #type_generics #where_clause
     };
@@ -60,7 +60,7 @@ pub fn generate_from_to(
 
     let has_lifetime = generics.lifetimes().next().is_some();
     let has_type_params = generics.type_params().next().is_some();
-    
+
     // Skip fuzz tests if there are lifetimes or type parameters
     let fuzz_tests = if has_lifetime || has_type_params {
         quote! {}

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -56,7 +56,6 @@ pub fn derive(input: DeriveInput, zstd: Option<ZstdConfig>) -> TokenStream {
     output.into()
 }
 
-
 /// Given a list of fields on a struct, extract their fields and types.
 pub fn get_fields(data: &Data) -> FieldList {
     let mut fields = vec![];

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, Generics};
+use syn::{Data, DeriveInput};
 
 mod generator;
 use generator::*;
@@ -50,17 +50,12 @@ pub fn derive(input: DeriveInput, zstd: Option<ZstdConfig>) -> TokenStream {
 
     let DeriveInput { ident, data, generics, attrs, .. } = input;
 
-    let has_lifetime = has_lifetime(&generics);
-
     let fields = get_fields(&data);
-    output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, zstd.is_some()));
+    output.extend(generate_flag_struct(&ident, &attrs, &generics, &fields, zstd.is_some()));
     output.extend(generate_from_to(&ident, &attrs, &generics, &fields, zstd));
     output.into()
 }
 
-pub fn has_lifetime(generics: &Generics) -> bool {
-    generics.lifetimes().next().is_some()
-}
 
 /// Given a list of fields on a struct, extract their fields and types.
 pub fn get_fields(data: &Data) -> FieldList {
@@ -246,8 +241,7 @@ mod tests {
         let mut output = quote! {};
         let DeriveInput { ident, data, attrs, generics, .. } = parse2(f_struct).unwrap();
         let fields = get_fields(&data);
-        let has_lifetime = has_lifetime(&generics);
-        output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+        output.extend(generate_flag_struct(&ident, &attrs, &generics, &fields, false));
         output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
 
         // Expected output in a TokenStream format. Commas matter!

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -54,7 +54,7 @@ pub fn derive(input: DeriveInput, zstd: Option<ZstdConfig>) -> TokenStream {
 
     let fields = get_fields(&data);
     output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, zstd.is_some()));
-    output.extend(generate_from_to(&ident, &attrs, has_lifetime, &fields, zstd));
+    output.extend(generate_from_to(&ident, &attrs, &generics, &fields, zstd));
     output.into()
 }
 
@@ -217,6 +217,9 @@ pub fn is_flag_type(ftype: &str) -> bool {
 }
 
 #[cfg(test)]
+mod test_generics;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use similar_asserts::assert_eq;
@@ -241,10 +244,11 @@ mod tests {
 
         // Generate code that will impl the `Compact` trait.
         let mut output = quote! {};
-        let DeriveInput { ident, data, attrs, .. } = parse2(f_struct).unwrap();
+        let DeriveInput { ident, data, attrs, generics, .. } = parse2(f_struct).unwrap();
         let fields = get_fields(&data);
-        output.extend(generate_flag_struct(&ident, &attrs, false, &fields, false));
-        output.extend(generate_from_to(&ident, &attrs, false, &fields, None));
+        let has_lifetime = has_lifetime(&generics);
+        output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+        output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
 
         // Expected output in a TokenStream format. Commas matter!
         let should_output = quote! {

--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -132,7 +132,7 @@ impl<'a> StructHandler<'a> {
         // "T::from_compact(buf, len)" since the length of "u64" is known internally (bitpacked).
         // Check if this is a single uppercase letter (likely a generic type parameter)
         let is_generic_param = ftype.len() == 1 && ftype.chars().next().unwrap().is_uppercase();
-        
+
         assert!(
             known_types.contains(&ftype.as_str()) ||
                 is_flag_type(ftype) ||

--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -130,9 +130,13 @@ impl<'a> StructHandler<'a> {
         // relying on the length provided by the higher-level deserializer. For example, a
         // type "T" with two "u64" fields doesn't need the length parameter from
         // "T::from_compact(buf, len)" since the length of "u64" is known internally (bitpacked).
+        // Check if this is a single uppercase letter (likely a generic type parameter)
+        let is_generic_param = ftype.len() == 1 && ftype.chars().next().unwrap().is_uppercase();
+        
         assert!(
             known_types.contains(&ftype.as_str()) ||
                 is_flag_type(ftype) ||
+                is_generic_param ||
                 self.fields_iterator.peek().is_none(),
             "`{ftype}` field should be placed as the last one since it's not known.
             If it's an alias type (which are not supported by proc_macro), be sure to add it to either `known_types` or `get_bit_size` lists in the derive crate."

--- a/crates/storage/codecs/derive/src/compact/test_generics.rs
+++ b/crates/storage/codecs/derive/src/compact/test_generics.rs
@@ -4,7 +4,7 @@ use syn::parse2;
 
 #[test]
 fn test_compact_with_generics() {
-        let input = quote! {
+    let input = quote! {
             #[derive(Debug, PartialEq, Clone)]
             pub struct GenericStruct<T> {
                 value: T,
@@ -12,24 +12,24 @@ fn test_compact_with_generics() {
         }
     };
 
-        // Parse the input
-        let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
-        let fields = get_fields(&data);
-        let has_lifetime = has_lifetime(&generics);
-        
-        // Generate the code
-        let mut output = quote! {};
-        output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
-        output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
+    // Parse the input
+    let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
+    let fields = get_fields(&data);
+    let has_lifetime = has_lifetime(&generics);
 
-        // The generated impl should include the generic parameter with Compact bound
-        let output_str = output.to_string();
-        assert!(output_str.contains("impl < T > reth_codecs :: Compact for GenericStruct < T > where T : reth_codecs :: Compact"));
+    // Generate the code
+    let mut output = quote! {};
+    output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+    output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
+
+    // The generated impl should include the generic parameter with Compact bound
+    let output_str = output.to_string();
+    assert!(output_str.contains("impl < T > reth_codecs :: Compact for GenericStruct < T > where T : reth_codecs :: Compact"));
 }
 
-#[test] 
+#[test]
 fn test_compact_with_multiple_generics() {
-        let input = quote! {
+    let input = quote! {
             #[derive(Debug, PartialEq, Clone)]
             pub struct MultiGenericStruct<T, U> {
                 first: T,
@@ -38,19 +38,18 @@ fn test_compact_with_multiple_generics() {
         }
     };
 
-        // Parse the input
-        let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
-        let fields = get_fields(&data);
-        let has_lifetime = has_lifetime(&generics);
-        
-        // Generate the code
-        let mut output = quote! {};
-        output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
-        output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
+    // Parse the input
+    let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
+    let fields = get_fields(&data);
+    let has_lifetime = has_lifetime(&generics);
 
-        // The generated impl should include both generic parameters with Compact bounds
-        let output_str = output.to_string();
-        assert!(output_str.contains("T : reth_codecs :: Compact"));
-        assert!(output_str.contains("U : reth_codecs :: Compact"));
+    // Generate the code
+    let mut output = quote! {};
+    output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+    output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
+
+    // The generated impl should include both generic parameters with Compact bounds
+    let output_str = output.to_string();
+    assert!(output_str.contains("T : reth_codecs :: Compact"));
+    assert!(output_str.contains("U : reth_codecs :: Compact"));
 }
-

--- a/crates/storage/codecs/derive/src/compact/test_generics.rs
+++ b/crates/storage/codecs/derive/src/compact/test_generics.rs
@@ -15,11 +15,10 @@ fn test_compact_with_generics() {
     // Parse the input
     let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
     let fields = get_fields(&data);
-    let has_lifetime = has_lifetime(&generics);
 
     // Generate the code
     let mut output = quote! {};
-    output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+    output.extend(generate_flag_struct(&ident, &attrs, &generics, &fields, false));
     output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
 
     // The generated impl should include the generic parameter with Compact bound
@@ -41,15 +40,38 @@ fn test_compact_with_multiple_generics() {
     // Parse the input
     let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
     let fields = get_fields(&data);
-    let has_lifetime = has_lifetime(&generics);
 
     // Generate the code
     let mut output = quote! {};
-    output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+    output.extend(generate_flag_struct(&ident, &attrs, &generics, &fields, false));
     output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
 
     // The generated impl should include both generic parameters with Compact bounds
     let output_str = output.to_string();
     assert!(output_str.contains("T : reth_codecs :: Compact"));
     assert!(output_str.contains("U : reth_codecs :: Compact"));
+}
+
+#[test]
+fn test_bitflag_functions_with_generics() {
+    let input = quote! {
+        #[derive(Debug, PartialEq, Clone)]
+        pub struct GenericStruct<T> {
+            value: T,
+            count: u64,
+        }
+    };
+
+    // Parse the input
+    let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
+    let fields = get_fields(&data);
+
+    // Generate the flag struct
+    let output = generate_flag_struct(&ident, &attrs, &generics, &fields, false);
+
+    // The generated impl should include the generic parameter in bitflag functions
+    let output_str = output.to_string();
+    assert!(output_str.contains("impl < T > GenericStruct < T >"));
+    assert!(output_str.contains("pub const fn bitflag_encoded_bytes"));
+    assert!(output_str.contains("pub const fn bitflag_unused_bits"));
 }

--- a/crates/storage/codecs/derive/src/compact/test_generics.rs
+++ b/crates/storage/codecs/derive/src/compact/test_generics.rs
@@ -1,0 +1,56 @@
+use super::*;
+use quote::quote;
+use syn::parse2;
+
+#[test]
+fn test_compact_with_generics() {
+        let input = quote! {
+            #[derive(Debug, PartialEq, Clone)]
+            pub struct GenericStruct<T> {
+                value: T,
+                count: u64,
+        }
+    };
+
+        // Parse the input
+        let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
+        let fields = get_fields(&data);
+        let has_lifetime = has_lifetime(&generics);
+        
+        // Generate the code
+        let mut output = quote! {};
+        output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+        output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
+
+        // The generated impl should include the generic parameter with Compact bound
+        let output_str = output.to_string();
+        assert!(output_str.contains("impl < T > reth_codecs :: Compact for GenericStruct < T > where T : reth_codecs :: Compact"));
+}
+
+#[test] 
+fn test_compact_with_multiple_generics() {
+        let input = quote! {
+            #[derive(Debug, PartialEq, Clone)]
+            pub struct MultiGenericStruct<T, U> {
+                first: T,
+                second: U,
+                count: u64,
+        }
+    };
+
+        // Parse the input
+        let DeriveInput { ident, data, attrs, generics, .. } = parse2(input).unwrap();
+        let fields = get_fields(&data);
+        let has_lifetime = has_lifetime(&generics);
+        
+        // Generate the code
+        let mut output = quote! {};
+        output.extend(generate_flag_struct(&ident, &attrs, has_lifetime, &fields, false));
+        output.extend(generate_from_to(&ident, &attrs, &generics, &fields, None));
+
+        // The generated impl should include both generic parameters with Compact bounds
+        let output_str = output.to_string();
+        assert!(output_str.contains("T : reth_codecs :: Compact"));
+        assert!(output_str.contains("U : reth_codecs :: Compact"));
+}
+


### PR DESCRIPTION
Adds support for generic type parameters to the `Compact` derive macro. This is a prerequisite for #17081, which aims to make the receipt type generic over TxType.

## Changes

The Compact derive macro now supports generic type parameters. When deriving Compact for a generic struct, the macro automatically adds the necessary `T: Compact` trait bounds to the implementation.

### Example

```rust
#[derive(Compact)]
struct GenericWrapper<T> {
    inner: T,
    count: u64,
}
```

This generates:
```rust
impl<T> Compact for GenericWrapper<T> where T: Compact { ... }
```

### Implementation Details

1. Modified the `derive` function to pass the full generics information instead of just a lifetime flag
2. Updated `generate_from_to` to properly handle generic parameters and add trait bounds
3. Fixed field type checking to recognize single uppercase letters as generic type parameters
4. Added tests to verify the macro works with single and multiple generic parameters

This enables types like `Receipt` to be made generic over transaction types while still deriving the `Compact` trait.

## Blocker: Generic Type Flag Size Limitation

There is a fundamental limitation with the current implementation regarding generic types and the flag struct generation:

### The Issue

The `Compact` derive macro generates a bitfield flag struct at compile time to store field lengths. This requires knowing the exact bit size needed for each field type:
- `u64` needs 4 bits to store its length
- `U256` needs 6 bits 
- `bool` needs 1 bit
- etc.

For generic type parameters like `T`, we cannot know at compile time what bit size is needed because it depends on the concrete type that will be substituted for `T`. The current implementation treats unknown types (including generics) as requiring 1 bit for presence tracking only.

### Impact

This means that generic fields may not compress as efficiently as their non-generic counterparts. For example:
- A field of type `u64` normally uses 4 bits in the flag struct for optimal compression
- A field of type `T` where `T = u64` will only use 1 bit, potentially resulting in less efficient encoding

### Current Behavior

The macro currently:
1. Treats generic type parameters as unknown types that get 1 bit for presence tracking
2. Relies on the `T: Compact` bound to ensure the type can be serialized/deserialized
3. Works correctly but may not achieve optimal compression for generic fields

This limitation is inherent to the design where flag struct layout must be determined at compile time, while generic type information is only available at instantiation time.

Related to #17081