### PR TITLE
perf(trie): reuse allocated trie input in payload processor

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1400,6 +1400,7 @@ where
                 self.persisting_kind_for(block.recovered_block().header()),
                 self.provider.database_provider_ro()?,
                 block.recovered_block().parent_hash(),
+                None,
             )?;
             // Extend with block we are generating trie updates for.
             trie_input.append_ref(block.hashed_state());
@@ -2174,8 +2175,10 @@ where
         persisting_kind: PersistingKind,
         provider: TP,
         parent_hash: B256,
+        allocated_trie_input: Option<TrieInput>,
     ) -> ProviderResult<TrieInput> {
-        let mut input = TrieInput::default();
+        // get allocated trie input or use a default trie input
+        let mut input = allocated_trie_input.unwrap_or_default();
 
         let best_block_number = provider.best_block_number()?;
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -304,8 +304,8 @@ where
     }
 
     /// Takes the trie input from the inner payload processor, if it exists.
-    pub const fn take_trie_input(&mut self) -> Option<TrieInput> {
-        self.trie_input.take()
+    pub fn take_trie_input(&mut self) -> Option<TrieInput> {
+        self.trie_input.take().map(|input| input.cleared())
     }
 
     /// Returns the cache for the given parent hash.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -304,8 +304,8 @@ where
     }
 
     /// Takes the trie input from the inner payload processor, if it exists.
-    pub fn take_trie_input(&mut self) -> Option<TrieInput> {
-        self.trie_input.take().map(|input| input.cleared())
+    pub const fn take_trie_input(&mut self) -> Option<TrieInput> {
+        self.trie_input.take()
     }
 
     /// Returns the cache for the given parent hash.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -80,6 +80,8 @@ where
     >,
     /// Whether to use the parallel sparse trie.
     use_parallel_sparse_trie: bool,
+    /// A cleared trie input, kept around to be reused so allocations can be minimized.
+    trie_input: Option<TrieInput>,
 }
 
 impl<N, Evm> PayloadProcessor<Evm>
@@ -104,6 +106,7 @@ where
             precompile_cache_disabled: config.precompile_cache_disabled(),
             precompile_cache_map,
             sparse_state_trie: Arc::default(),
+            trie_input: None,
             use_parallel_sparse_trie: config.enable_parallel_sparse_trie(),
         }
     }
@@ -165,8 +168,10 @@ where
             + 'static,
     {
         let (to_sparse_trie, sparse_trie_rx) = channel();
-        // spawn multiproof task
-        let state_root_config = MultiProofConfig::new_from_input(consistent_view, trie_input);
+        // spawn multiproof task, save the trie input
+        let (trie_input, state_root_config) =
+            MultiProofConfig::new_from_input(consistent_view, trie_input);
+        self.trie_input = Some(trie_input);
 
         // Create and spawn the storage proof task
         let task_ctx = ProofTaskCtx::new(
@@ -296,6 +301,11 @@ where
             prewarm_task.run();
         });
         CacheTaskHandle { cache, to_prewarm_task: Some(to_prewarm_task), cache_metrics }
+    }
+
+    /// Takes the trie input from the inner payload processor, if it exists.
+    pub const fn take_trie_input(&mut self) -> Option<TrieInput> {
+        self.trie_input.take()
     }
 
     /// Returns the cache for the given parent hash.

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -82,16 +82,20 @@ pub(super) struct MultiProofConfig<Factory> {
 
 impl<Factory> MultiProofConfig<Factory> {
     /// Creates a new state root config from the consistent view and the trie input.
+    ///
+    /// This returns a cleared [`TrieInput`] so that we can reuse any allocated space in the
+    /// [`TrieInput`].
     pub(super) fn new_from_input(
         consistent_view: ConsistentDbView<Factory>,
-        input: TrieInput,
-    ) -> Self {
-        Self {
+        mut input: TrieInput,
+    ) -> (TrieInput, Self) {
+        let config = Self {
             consistent_view,
-            nodes_sorted: Arc::new(input.nodes.into_sorted()),
-            state_sorted: Arc::new(input.state.into_sorted()),
-            prefix_sets: Arc::new(input.prefix_sets),
-        }
+            nodes_sorted: Arc::new(input.nodes.drain_into_sorted()),
+            state_sorted: Arc::new(input.state.drain_into_sorted()),
+            prefix_sets: Arc::new(input.prefix_sets.clone()),
+        };
+        (input, config)
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -95,7 +95,7 @@ impl<Factory> MultiProofConfig<Factory> {
             state_sorted: Arc::new(input.state.drain_into_sorted()),
             prefix_sets: Arc::new(input.prefix_sets.clone()),
         };
-        (input, config)
+        (input.cleared(), config)
     }
 }
 

--- a/crates/trie/common/src/input.rs
+++ b/crates/trie/common/src/input.rs
@@ -109,4 +109,17 @@ impl TrieInput {
         self.nodes.extend_ref(nodes);
         self.state.extend_ref(state);
     }
+
+    /// This method clears the trie input nodes, state, and prefix sets.
+    pub fn clear(&mut self) {
+        self.nodes.clear();
+        self.state.clear();
+        self.prefix_sets.clear();
+    }
+
+    /// This method returns a cleared version of this trie input.
+    pub fn cleared(mut self) -> Self {
+        self.clear();
+        self
+    }
 }

--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -45,6 +45,13 @@ impl TriePrefixSetsMut {
             destroyed_accounts: self.destroyed_accounts,
         }
     }
+
+    /// Clears the prefix sets and destroyed accounts map.
+    pub fn clear(&mut self) {
+        self.destroyed_accounts.clear();
+        self.storage_prefix_sets.clear();
+        self.account_prefix_set.clear();
+    }
 }
 
 /// Collection of trie prefix sets.


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/17292

Puts a `TrieInput` in the payload processor, letting us reuse it. Changes `new_from_input` to use the `drain_into_sorted` methods.