### PR TITLE
fix: typo in documentation comments

### DIFF
--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -340,7 +340,7 @@ impl HashedPostState {
     ///
     /// This effectively clears all the fields in the [`HashedPostStateSorted`].
     ///
-    /// This allows us to re-use the allocated space. This allocates new space for the sorted hashed
+    /// This allows us to reuse the allocated space. This allocates new space for the sorted hashed
     /// post state, like `into_sorted`.
     pub fn drain_into_sorted(&mut self) -> HashedPostStateSorted {
         let mut updated_accounts = Vec::new();

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -123,7 +123,7 @@ impl TrieUpdates {
     ///
     /// This effectively clears all the fields in the [`TrieUpdatesSorted`].
     ///
-    /// This allows us to re-use the allocated space. This allocates new space for the sorted
+    /// This allows us to reuse the allocated space. This allocates new space for the sorted
     /// updates, like `into_sorted`.
     pub fn drain_into_sorted(&mut self) -> TrieUpdatesSorted {
         let mut account_nodes = self.account_nodes.drain().collect::<Vec<_>>();


### PR DESCRIPTION


---



## Description
This pull request corrects a minor typo in documentation comments by replacing `re-use` with `reuse` for consistency and clarity.

- Updated in `hashed_state.rs` and `updates.rs`


