### PR TITLE
refactor(docs): improve regex pattern robustness in CLI help parser

### DIFF
--- a/docs/cli/help.rs
+++ b/docs/cli/help.rs
@@ -184,7 +184,7 @@ fn get_entry(cmd: &Cmd) -> io::Result<(Vec<String>, String)> {
 /// Returns a list of subcommands from the help output of a command.
 fn parse_sub_commands(s: &str) -> Vec<String> {
     // This regex matches lines starting with two spaces, followed by the subcommand name.
-    let re = regex!(r"^  (\S+)");
+    let re = regex!(r"^\s{2}(\S+)");
 
     s.split("Commands:")
         .nth(1) // Get the part after "Commands:"


### PR DESCRIPTION
Replace hardcoded spaces with whitespace metacharacter in regex pattern to enhance parsing reliability and follow regex best practices. This change ensures the parser can handle various CLI output formats while maintaining backward compatibility.