### PR TITLE
docs: Fix broken internal links in history-expiry guide

### DIFF
--- a/docs/vocs/docs/pages/guides/history-expiry.mdx
+++ b/docs/vocs/docs/pages/guides/history-expiry.mdx
@@ -34,7 +34,7 @@ If enabled, importing blocks from ERA1 files can be done automatically with no m
 
 #### Enabling the ERA stage
 
-The import from ERA1 files within the pre-merge block range is included in the [reth node](../cli/reth/node.mdx) synchronization pipeline. It is disabled by default. To enable it, pass the `--era.enable` flag when running the [`node`](../cli/reth/node.mdx) command.
+The import from ERA1 files within the pre-merge block range is included in the [reth node](../cli/reth/node.mdx) synchronization pipeline. It is disabled by default. To enable it, pass the `--era.enable` flag when running the [`node`](/cli/reth/node) command.
 
 The benefit of using this option is significant increase in the synchronization speed for the headers and mainly bodies stage of the pipeline within the ERA1 block range. We encourage you to use it! Eventually, it will become enabled by default.
 

--- a/docs/vocs/docs/pages/guides/history-expiry.mdx
+++ b/docs/vocs/docs/pages/guides/history-expiry.mdx
@@ -34,7 +34,7 @@ If enabled, importing blocks from ERA1 files can be done automatically with no m
 
 #### Enabling the ERA stage
 
-The import from ERA1 files within the pre-merge block range is included in the [reth node](../cli/reth/node) synchronization pipeline. It is disabled by default. To enable it, pass the `--era.enable` flag when running the [`node`](../cli/reth/node) command.
+The import from ERA1 files within the pre-merge block range is included in the [reth node](../cli/reth/node.mdx) synchronization pipeline. It is disabled by default. To enable it, pass the `--era.enable` flag when running the [`node`](../cli/reth/node.mdx) command.
 
 The benefit of using this option is significant increase in the synchronization speed for the headers and mainly bodies stage of the pipeline within the ERA1 block range. We encourage you to use it! Eventually, it will become enabled by default.
 

--- a/docs/vocs/docs/pages/guides/history-expiry.mdx
+++ b/docs/vocs/docs/pages/guides/history-expiry.mdx
@@ -34,7 +34,7 @@ If enabled, importing blocks from ERA1 files can be done automatically with no m
 
 #### Enabling the ERA stage
 
-The import from ERA1 files within the pre-merge block range is included in the [reth node](../cli/reth/node.mdx) synchronization pipeline. It is disabled by default. To enable it, pass the `--era.enable` flag when running the [`node`](/cli/reth/node) command.
+The import from ERA1 files within the pre-merge block range is included in the [reth node](/cli/reth/node) synchronization pipeline. It is disabled by default. To enable it, pass the `--era.enable` flag when running the [`node`](/cli/reth/node) command.
 
 The benefit of using this option is significant increase in the synchronization speed for the headers and mainly bodies stage of the pipeline within the ERA1 block range. We encourage you to use it! Eventually, it will become enabled by default.
 


### PR DESCRIPTION
Replaced the internal link to node in history-expiry.mdx with a site-relative path (/cli/reth/node). This ensures the link works correctly on the synchronized documentation website and directs users to the appropriate node synchronization pipeline section.