### PR TITLE
feat: add `into_logs()` to `TxReceipt` for `Receipt`/`OpReceipt`

### DIFF
--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -286,7 +286,6 @@ impl<T: TxTy> TxReceipt for Receipt<T> {
     fn into_logs(self) -> Vec<Log> {
         self.logs
     }
-
 }
 
 impl<T: TxTy> Typed2718 for Receipt<T> {

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -282,6 +282,11 @@ impl<T: TxTy> TxReceipt for Receipt<T> {
     fn logs(&self) -> &[Log] {
         &self.logs
     }
+
+    fn into_logs(self) -> Vec<Log> {
+        self.logs
+    }
+
 }
 
 impl<T: TxTy> Typed2718 for Receipt<T> {

--- a/crates/optimism/primitives/src/receipt.rs
+++ b/crates/optimism/primitives/src/receipt.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use alloy_consensus::{
     Eip2718EncodableReceipt, Eip658Value, Receipt, ReceiptWithBloom, RlpDecodableReceipt,
     RlpEncodableReceipt, TxReceipt, Typed2718,

--- a/crates/optimism/primitives/src/receipt.rs
+++ b/crates/optimism/primitives/src/receipt.rs
@@ -357,6 +357,17 @@ impl TxReceipt for OpReceipt {
     fn logs(&self) -> &[Log] {
         self.as_receipt().logs()
     }
+
+    fn into_logs(self) -> Vec<Self::Log>
+    {
+        match self {
+            Self::Legacy(receipt) |
+            Self::Eip2930(receipt) |
+            Self::Eip1559(receipt) |
+            Self::Eip7702(receipt) => receipt.logs,
+            Self::Deposit(receipt) => receipt.inner.logs,
+        }
+    }
 }
 
 impl Typed2718 for OpReceipt {

--- a/crates/optimism/primitives/src/receipt.rs
+++ b/crates/optimism/primitives/src/receipt.rs
@@ -358,8 +358,7 @@ impl TxReceipt for OpReceipt {
         self.as_receipt().logs()
     }
 
-    fn into_logs(self) -> Vec<Self::Log>
-    {
+    fn into_logs(self) -> Vec<Self::Log> {
         match self {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |


### PR DESCRIPTION
Override default [`into_logs()`](https://github.com/alloy-rs/alloy/blob/1f157f03af5d9472044d6972ad84056f89db7d4c/crates/consensus/src/receipt/mod.rs#L94) to avoid cloning, necessary for `to_vec()`