### PR TITLE
fix: broken link to system requirements in troubleshooting guide

### DIFF
--- a/docs/vocs/docs/pages/run/faq/troubleshooting.mdx
+++ b/docs/vocs/docs/pages/run/faq/troubleshooting.mdx
@@ -58,7 +58,7 @@ Currently, there are two main ways to fix this issue.
 #### Compact the database
 
 It will take around 5-6 hours and require **additional** disk space located on the same or different drive
-equal to the [freshly synced node](/installation/overview#hardware-requirements).
+equal to the [freshly synced node](/run/system-requirements).
 
 1. Clone Reth
     ```bash


### PR DESCRIPTION


**Problem**: The troubleshooting guide contained a broken anchor link `#hardware-requirements` that led to a non-existent section.

**Solution**: Updated the link to properly reference the system requirements page (`/run/system-requirements`) where users can find actual disk space requirements for freshly synced nodes.

**Impact**: Users seeking disk space information for database compaction will now be directed to the correct documentation.

---

**Changed Files:**
- `docs/vocs/docs/pages/run/faq/troubleshooting.mdx`

**Link Updated:**
- `/installation/overview#hardware-requirements` → `/run/system-requirements`