### PR TITLE
fix: optimize iterator chain by removing unnecessary Vec creation

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1182,7 +1182,7 @@ impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ConsistentProvider<N> {
                 stored_indices.tx_count = 0;
 
                 // Iterate from the lowest block in memory until our target block
-                for state in block_state.chain().collect::<Vec<_>>().into_iter().rev() {
+                for state in block_state.chain().rev() {
                     let block_tx_count =
                         state.block_ref().recovered_block().body().transactions().len() as u64;
                     if state.block_ref().recovered_block().number() == number {


### PR DESCRIPTION
Replace inefficient pattern of collecting an iterator into a Vec just to convert it back to an iterator for reverse traversal. This change directly calls .rev() on the iterator, avoiding temporary memory allocation and improving performance.