### PR TITLE
refactor(consensus): add Consensus methods for fork fields and tx root

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -140,7 +140,7 @@ where
     B: Block,
     ChainSpec: EthereumHardforks,
 {
-    post_merge_hardfork_fields(block, chain_spec)?;
+    validate_post_merge_fork_fields(block, chain_spec)?;
 
     // Check transaction root
     if let Err(error) = block.ensure_transaction_root_valid() {
@@ -157,7 +157,7 @@ where
 ///   information about the specific checks in [`validate_shanghai_withdrawals`].
 /// * EIP-4844 blob gas validation, if cancun is active based on the given chainspec. See more
 ///   information about the specific checks in [`validate_cancun_gas`].
-pub fn post_merge_hardfork_fields<B, ChainSpec>(
+pub fn validate_post_merge_fork_fields<B, ChainSpec>(
     block: &SealedBlock<B>,
     chain_spec: &ChainSpec,
 ) -> Result<(), ConsensusError>

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -69,6 +69,17 @@ pub trait Consensus<B: Block>: HeaderValidator<B::Header> {
     ///
     /// Note: validating blocks does not include other validations of the Consensus
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), Self::Error>;
+
+    /// This performs the same validations as [`Self::validate_block_pre_execution`], besides the
+    /// transactions root validation check.
+    ///
+    /// This primarily validates the post-merge fork specific fields in the block.
+    fn validate_post_merge_fork_fields(&self, block: &SealedBlock<B>) -> Result<(), Self::Error>;
+
+    /// This performs transaction validation. Typically this would perform transactions root
+    /// validation, by calculating the root and comparing the computed root to the field in the
+    /// header.
+    fn validate_transactions(&self, block: &SealedBlock<B>) -> Result<(), Self::Error>;
 }
 
 /// `HeaderValidator` is a protocol that validates headers and their relationships.

--- a/crates/consensus/consensus/src/noop.rs
+++ b/crates/consensus/consensus/src/noop.rs
@@ -43,6 +43,14 @@ impl<B: Block> Consensus<B> for NoopConsensus {
     fn validate_block_pre_execution(&self, _block: &SealedBlock<B>) -> Result<(), Self::Error> {
         Ok(())
     }
+
+    fn validate_post_merge_fork_fields(&self, _block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn validate_transactions(&self, _block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 impl<N: NodePrimitives> FullConsensus<N> for NoopConsensus {

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -82,6 +82,22 @@ impl<B: Block> Consensus<B> for TestConsensus {
             Ok(())
         }
     }
+
+    fn validate_post_merge_fork_fields(&self, _block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        if self.fail_validation() {
+            Err(ConsensusError::BaseFeeMissing)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate_transactions(&self, _block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        if self.fail_validation() {
+            Err(ConsensusError::BaseFeeMissing)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<H> HeaderValidator<H> for TestConsensus {

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -21,6 +21,7 @@ use reth_consensus_common::validation::{
     validate_against_parent_eip1559_base_fee, validate_against_parent_hash_number,
     validate_against_parent_timestamp, validate_block_pre_execution, validate_body_against_header,
     validate_header_base_fee, validate_header_extra_data, validate_header_gas,
+    validate_post_merge_fork_fields,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
@@ -127,6 +128,19 @@ where
 
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), Self::Error> {
         validate_block_pre_execution(block, &self.chain_spec)
+    }
+
+    fn validate_transactions(&self, block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        // Check transaction root
+        if let Err(error) = block.ensure_transaction_root_valid() {
+            return Err(ConsensusError::BodyTransactionRootDiff(error.into()))
+        }
+
+        Ok(())
+    }
+
+    fn validate_post_merge_fork_fields(&self, block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        validate_post_merge_fork_fields(block, &self.chain_spec)
     }
 }
 

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -21,6 +21,7 @@ use reth_consensus_common::validation::{
     validate_against_parent_4844, validate_against_parent_eip1559_base_fee,
     validate_against_parent_hash_number, validate_against_parent_timestamp, validate_cancun_gas,
     validate_header_base_fee, validate_header_extra_data, validate_header_gas,
+    validate_post_merge_fork_fields,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_optimism_forks::OpHardforks;
@@ -129,6 +130,19 @@ where
         }
 
         Ok(())
+    }
+
+    fn validate_transactions(&self, block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        // Check transaction root
+        if let Err(error) = block.ensure_transaction_root_valid() {
+            return Err(ConsensusError::BodyTransactionRootDiff(error.into()))
+        }
+
+        Ok(())
+    }
+
+    fn validate_post_merge_fork_fields(&self, block: &SealedBlock<B>) -> Result<(), Self::Error> {
+        validate_post_merge_fork_fields(block, &self.chain_spec)
     }
 }
 


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/pull/17406 and https://github.com/paradigmxyz/reth/issues/17293

This would allow us to omit the transactions root check in the engine, since we do that on payload conversion.

Need naming advice for the pre-execution validation method that does not have tx root checks.