### PR TITLE
chore(txpool): use alloy-primitives HashMap for SenderIdentifiers

### DIFF
--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -1,7 +1,6 @@
 //! Identifier types for transactions and senders.
-use alloy_primitives::Address;
+use alloy_primitives::{map::HashMap, Address};
 use rustc_hash::FxHashMap;
-use std::collections::HashMap;
 
 /// An internal mapping of addresses.
 ///


### PR DESCRIPTION
noticed that this was using the `std::collections` hashmap, thought `alloy_primitives` was preferred usually