### PR TITLE
feat: add generic database support for Receipt<T>

### DIFF
--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -215,7 +215,7 @@ impl_compression_for_compact!(
     Header,
     Account,
     Log,
-    Receipt,
+    Receipt<T>,
     TxType,
     StorageEntry,
     BranchNodeCompact,


### PR DESCRIPTION
Enable Receipt<T> to work with custom transaction types by updating the database compression macro to handle the generic type parameter.

This fixes the extensibility gap from PR #17237 where downstream projects couldn't use Receipt<CustomTxType> due to the macro only supporting concrete Receipt types.

**Change**: Updated impl_compression_for_compact\! macro to use `Receipt<T>` instead of Receipt, enabling automatic database support for any transaction type that implements the required traits.