### PR TITLE
docs: fix error in RawCapabilityMessage comment

### DIFF
--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -534,7 +534,7 @@ mod tests {
         let mut encoded = Vec::new();
         msg.encode(&mut encoded);
 
-        // Decode the bytes back into RawCapbailitMessage
+        // Decode the bytes back into RawCapabilityMessage
         let decoded = RawCapabilityMessage::decode(&mut &encoded[..]).unwrap();
 
         // Verify that the decoded message matches the original


### PR DESCRIPTION
Corrected a error in the test_raw_capability_rlp test function comment:
Changed `RawCapbailitMessage` to `RawCapabilityMessage` for consistency and accuracy