### PR TITLE
fix: Update Docker Compose Docs Link in etc/README.md

### DIFF
--- a/etc/README.md
+++ b/etc/README.md
@@ -13,7 +13,7 @@ up to date.
 ### Docker Compose
 
 To run Reth, Grafana or Prometheus with Docker Compose, refer to
-the [docker docs](/book/installation/docker.md#using-docker-compose).
+the [docker docs](https://reth.rs/installation/docker#using-docker-compose).
 
 ### Grafana
 


### PR DESCRIPTION





**Description:**  
- Replaced a broken link to the Docker Compose documentation with the correct URL.

