### PR TITLE
fix: rename `highest_static_fileted_block` to `highest_static_file_block`

### DIFF
--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -110,11 +110,11 @@ impl StaticFileTargets {
             (self.block_meta.as_ref(), static_files.block_meta),
         ]
         .iter()
-        .all(|(target_block_range, highest_static_fileted_block)| {
+        .all(|(target_block_range, highest_static_file_block)| {
             target_block_range.is_none_or(|target_block_range| {
                 *target_block_range.start() ==
-                    highest_static_fileted_block.map_or(0, |highest_static_fileted_block| {
-                        highest_static_fileted_block + 1
+                    highest_static_file_block.map_or(0, |highest_static_file_block| {
+                        highest_static_file_block + 1
                     })
             })
         })

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -112,8 +112,8 @@ impl StaticFileTargets {
         .iter()
         .all(|(target_block_range, highest_static_file_block)| {
             target_block_range.is_none_or(|target_block_range| {
-                *target_block_range.start() 
-                    == highest_static_file_block
+                *target_block_range.start() ==
+                    highest_static_file_block
                         .map_or(0, |highest_static_file_block| highest_static_file_block + 1)
             })
         })

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -112,10 +112,9 @@ impl StaticFileTargets {
         .iter()
         .all(|(target_block_range, highest_static_file_block)| {
             target_block_range.is_none_or(|target_block_range| {
-                *target_block_range.start() ==
-                    highest_static_file_block.map_or(0, |highest_static_file_block| {
-                        highest_static_file_block + 1
-                    })
+                *target_block_range.start() 
+                    == highest_static_file_block
+                        .map_or(0, |highest_static_file_block| highest_static_file_block + 1)
             })
         })
     }


### PR DESCRIPTION
## Description
This pull request fixes a typo in the variable name `highest_static_fileted_block`, renaming it to the correct and more descriptive `highest_static_file_block` in `crates/static-file/types/src/lib.rs`.

**Why:**  
- Improves code readability and consistency.