### PR TITLE
fix: Make the code_size field in AccountInfo an enum from an Option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce138b29a2f8e7ed97c064af8359dfa6559c12cba5e821ae4eb93081a56557e"
+checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9a510692bef4871797062ca09ec7873c45dc68c7f3f72291165320f53606a3"
+checksum = "2090f21bb6df43e147d976e754bc9a007ca851badbfc6685377aa679b5f151d9"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -1329,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "brotli",
  "flate2",
@@ -1990,9 +1990,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2110,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2122,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2439,9 +2439,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -2582,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "373b7c5dbd637569a2cca66e8d66b8c446a1e7bf064ea321d265d7b3dfe7c97e"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2976,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -3680,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -4359,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5469,9 +5469,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -5897,12 +5897,13 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
+checksum = "675b3a54e5b12af997abc8b6638b0aee51a28caedab70d4967e0d5db3a3f1d06"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
+ "cfg-if",
  "proptest",
  "ruint",
  "serde",
@@ -6053,8 +6054,8 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "8.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -7047,9 +7048,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "regress"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
+checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
 dependencies = [
  "hashbrown 0.15.4",
  "memchr",
@@ -10611,8 +10612,8 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "27.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "27.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10629,8 +10630,8 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "6.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "6.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -10641,8 +10642,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "8.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10656,8 +10657,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "8.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "8.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10671,8 +10672,8 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "7.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10684,8 +10685,8 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "7.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
  "either",
@@ -10696,8 +10697,8 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "8.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10714,8 +10715,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "8.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
  "either",
@@ -10731,9 +10732,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.26.0"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c42441fb05ac958e69262bd86841f8a91220e6794f9a0b99db1e1af51d8013e"
+checksum = "c7b99a2332cf8eed9e9a22fffbf76dfadc99d2c45de6ae6431a1eb9f657dd97a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10751,8 +10752,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "23.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "23.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10763,7 +10764,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "24.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10789,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10798,8 +10799,8 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "7.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#a7ad86728a8ddbfe6c3ad456d7a2ccfb4ed876ac"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -11048,22 +11049,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
@@ -11125,9 +11126,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -11196,9 +11197,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -11433,7 +11434,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.10.0",
  "schemars 0.9.0",
- "schemars 1.0.3",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11904,7 +11905,7 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -12178,9 +12179,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
@@ -13625,9 +13626,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -13704,7 +13705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7184,6 +7184,7 @@ dependencies = [
  "reth-trie",
  "revm",
  "revm-primitives",
+ "revm-state",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -750,16 +750,16 @@ alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "fusaka/devnet2"
 # jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 # jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 
-revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-database = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-state = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-handler = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-context = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
-op-revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-database = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-state = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-handler = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-context = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+op-revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }

--- a/crates/alloy-provider/Cargo.toml
+++ b/crates/alloy-provider/Cargo.toml
@@ -44,6 +44,7 @@ tracing.workspace = true
 # revm
 revm.workspace = true
 revm-primitives.workspace = true
+revm-state.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/alloy-provider/src/lib.rs
+++ b/crates/alloy-provider/src/lib.rs
@@ -53,6 +53,7 @@ use reth_storage_api::{
     ReceiptProviderIdExt, StatsReader,
 };
 use reth_trie::{updates::TrieUpdates, AccountProof, HashedPostState, MultiProof, TrieInput};
+use revm::state::CodeSize;
 use std::{
     collections::BTreeMap,
     future::Future,
@@ -1732,7 +1733,7 @@ where
                     } else {
                         Some(revm::bytecode::Bytecode::new_raw(account_info.code))
                     },
-                    code_size: None,
+                    code_size: CodeSize::Known(0),
                 }))
             }
         })

--- a/crates/engine/tree/benches/channel_perf.rs
+++ b/crates/engine/tree/benches/channel_perf.rs
@@ -7,7 +7,9 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 use proptest::test_runner::TestRunner;
 use rand::Rng;
 use revm_primitives::{Address, HashMap};
-use revm_state::{Account, AccountInfo, AccountStatus, EvmState, EvmStorage, EvmStorageSlot};
+use revm_state::{
+    Account, AccountInfo, AccountStatus, CodeSize, EvmState, EvmStorage, EvmStorageSlot,
+};
 use std::{hint::black_box, thread};
 
 /// Creates a mock state with the specified number of accounts for benchmarking
@@ -26,7 +28,7 @@ fn create_bench_state(num_accounts: usize) -> EvmState {
                 nonce: 10,
                 code_hash: B256::from_slice(&rng.random::<[u8; 32]>()),
                 code: Default::default(),
-                code_size: None,
+                code_size: CodeSize::Known(0),
             },
             storage,
             status: AccountStatus::empty(),

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -26,7 +26,9 @@ use reth_provider::{
 };
 use reth_trie::TrieInput;
 use revm_primitives::{HashMap, U256};
-use revm_state::{Account as RevmAccount, AccountInfo, AccountStatus, EvmState, EvmStorageSlot};
+use revm_state::{
+    Account as RevmAccount, AccountInfo, AccountStatus, CodeSize, EvmState, EvmStorageSlot,
+};
 use std::{hint::black_box, sync::Arc};
 
 #[derive(Debug, Clone)]
@@ -75,7 +77,7 @@ fn create_bench_state_updates(params: &BenchParams) -> Vec<EvmState> {
                         nonce: rng.random::<u64>(),
                         code_hash: KECCAK_EMPTY,
                         code: Some(Default::default()),
-                        code_size: None,
+                        code_size: CodeSize::Known(0),
                     },
                     storage: (0..rng.random_range(0..=params.storage_slots_per_account))
                         .map(|_| {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -479,7 +479,7 @@ mod tests {
     use reth_testing_utils::generators;
     use reth_trie::{test_utils::state_root, HashedPostState, TrieInput};
     use revm_primitives::{Address, HashMap, B256, KECCAK_EMPTY, U256};
-    use revm_state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot};
+    use revm_state::{AccountInfo, AccountStatus, CodeSize, EvmState, EvmStorageSlot};
     use std::sync::Arc;
 
     fn create_mock_state_updates(num_accounts: usize, updates_per_account: usize) -> Vec<EvmState> {
@@ -515,7 +515,7 @@ mod tests {
                         nonce: rng.random::<u64>(),
                         code_hash: KECCAK_EMPTY,
                         code: Some(Default::default()),
-                        code_size: None,
+                        code_size: CodeSize::Known(0),
                     },
                     storage,
                     status: AccountStatus::Touched,

--- a/crates/ethereum/evm/tests/execute.rs
+++ b/crates/ethereum/evm/tests/execute.rs
@@ -25,7 +25,7 @@ use reth_testing_utils::generators::{self, sign_tx_with_key_pair};
 use revm::{
     database::{CacheDB, EmptyDB, TransitionState},
     primitives::address,
-    state::{AccountInfo, Bytecode, EvmState},
+    state::{AccountInfo, Bytecode, CodeSize, EvmState},
     Database,
 };
 use std::sync::{mpsc, Arc};
@@ -38,7 +38,7 @@ fn create_database_with_beacon_root_contract() -> CacheDB<EmptyDB> {
         code_hash: keccak256(BEACON_ROOTS_CODE.clone()),
         nonce: 1,
         code: Some(Bytecode::new_raw(BEACON_ROOTS_CODE.clone())),
-        code_size: None,
+        code_size: CodeSize::Known(0),
     };
 
     db.insert_account_info(BEACON_ROOTS_ADDRESS, beacon_root_contract_account);
@@ -54,7 +54,7 @@ fn create_database_with_withdrawal_requests_contract() -> CacheDB<EmptyDB> {
         balance: U256::ZERO,
         code_hash: keccak256(WITHDRAWAL_REQUEST_PREDEPLOY_CODE.clone()),
         code: Some(Bytecode::new_raw(WITHDRAWAL_REQUEST_PREDEPLOY_CODE.clone())),
-        code_size: None,
+        code_size: CodeSize::Known(0),
     };
 
     db.insert_account_info(
@@ -341,7 +341,7 @@ fn create_database_with_block_hashes(latest_block: u64) -> CacheDB<EmptyDB> {
         code_hash: keccak256(HISTORY_STORAGE_CODE.clone()),
         code: Some(Bytecode::new_raw(HISTORY_STORAGE_CODE.clone())),
         nonce: 1,
-        code_size: None,
+        code_size: CodeSize::Known(0),
     };
 
     db.insert_account_info(HISTORY_STORAGE_ADDRESS, blockhashes_contract_account);

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -556,7 +556,7 @@ mod tests {
     use reth_ethereum_primitives::EthPrimitives;
     use revm::{
         database::{CacheDB, EmptyDB},
-        state::AccountInfo,
+        state::{AccountInfo, CodeSize},
     };
 
     #[derive(Clone, Debug, Default)]
@@ -626,7 +626,7 @@ mod tests {
             nonce,
             code_hash: KECCAK_EMPTY,
             code: None,
-            code_size: None,
+            code_size: CodeSize::Known(0),
         };
         state.insert_account(addr, account_info);
         state
@@ -668,7 +668,7 @@ mod tests {
             nonce: 1,
             code_hash: KECCAK_EMPTY,
             code: None,
-            code_size: None,
+            code_size: CodeSize::Known(0),
         };
         state.insert_account(addr2, account2);
 
@@ -695,7 +695,7 @@ mod tests {
             nonce: 1,
             code_hash: KECCAK_EMPTY,
             code: None,
-            code_size: None,
+            code_size: CodeSize::Known(0),
         };
         state.insert_account(addr2, account2);
 

--- a/crates/evm/evm/src/metrics.rs
+++ b/crates/evm/evm/src/metrics.rs
@@ -169,7 +169,7 @@ mod tests {
         database::State,
         database_interface::EmptyDB,
         inspector::NoOpInspector,
-        state::{Account, AccountInfo, AccountStatus, EvmStorage, EvmStorageSlot},
+        state::{Account, AccountInfo, AccountStatus, CodeSize, EvmStorage, EvmStorageSlot},
         Context, MainBuilder, MainContext,
     };
     use std::sync::mpsc;
@@ -286,7 +286,7 @@ mod tests {
                         nonce: 10,
                         code_hash: B256::random(),
                         code: Default::default(),
-                        code_size: None,
+                        code_size: CodeSize::Known(0),
                     },
                     storage,
                     status: AccountStatus::default(),

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -556,6 +556,7 @@ mod tests {
     use super::*;
     use alloy_consensus::TxType;
     use alloy_primitives::{bytes, Address, LogData, B256};
+    use revm::state::CodeSize;
 
     #[test]
     fn test_initialisation() {
@@ -929,14 +930,14 @@ mod tests {
             balance: U256::from(100),
             code_hash: B256::ZERO,
             code: None,
-            code_size: None,
+            code_size: CodeSize::Known(0),
         };
         let account_info2 = AccountInfo {
             nonce: 2,
             balance: U256::from(200),
             code_hash: B256::ZERO,
             code: None,
-            code_size: None,
+            code_size: CodeSize::Known(0),
         };
 
         // Set up the bundle state with these accounts

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{keccak256, Bytes, B256, U256};
 use alloy_trie::TrieAccount;
 use derive_more::Deref;
 use revm_bytecode::{Bytecode as RevmBytecode, BytecodeDecodeError};
-use revm_state::AccountInfo;
+use revm_state::{AccountInfo, CodeSize};
 
 #[cfg(any(test, feature = "reth-codec"))]
 /// Identifiers used in [`Compact`](reth_codecs::Compact) encoding of [`Bytecode`].
@@ -231,7 +231,7 @@ impl From<Account> for AccountInfo {
             nonce: reth_acc.nonce,
             code_hash: reth_acc.bytecode_hash.unwrap_or(KECCAK_EMPTY),
             code: None,
-            code_size: None,
+            code_size: CodeSize::Known(0),
         }
     }
 }

--- a/crates/rpc/rpc-eth-api/src/bundle.rs
+++ b/crates/rpc/rpc-eth-api/src/bundle.rs
@@ -4,8 +4,8 @@
 
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_mev::{
-    CancelBundleRequest, CancelPrivateTransactionRequest, EthBundleHash, EthCallBundle,
-    EthCallBundleResponse, EthSendBundle, PrivateTransactionRequest,
+    CancelPrivateTransactionRequest, EthBundleHash, EthCallBundle, EthCallBundleResponse,
+    EthCancelBundle, EthSendBundle, PrivateTransactionRequest,
 };
 use jsonrpsee::proc_macros::rpc;
 
@@ -43,7 +43,7 @@ pub trait EthBundleApi {
 
     /// `eth_cancelBundle` is used to prevent a submitted bundle from being included on-chain. See [bundle cancellations](https://docs.flashbots.net/flashbots-auction/advanced/bundle-cancellations) for more information.
     #[method(name = "cancelBundle")]
-    async fn cancel_bundle(&self, request: CancelBundleRequest) -> jsonrpsee::core::RpcResult<()>;
+    async fn cancel_bundle(&self, request: EthCancelBundle) -> jsonrpsee::core::RpcResult<()>;
 
     /// `eth_sendPrivateTransaction` is used to send a single transaction to Flashbots. Flashbots will attempt to build a block including the transaction for the next 25 blocks. See [Private Transactions](https://docs.flashbots.net/flashbots-protect/additional-documentation/eth-sendPrivateTransaction) for more info.
     #[method(name = "sendPrivateTransaction")]

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -489,7 +489,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn find_signer(
         &self,
         account: &Address,
-    ) -> Result<Box<(dyn EthSigner<ProviderTx<Self::Provider>> + 'static)>, Self::Error> {
+    ) -> Result<Box<dyn EthSigner<ProviderTx<Self::Provider>> + 'static>, Self::Error> {
         self.signers()
             .read()
             .iter()

--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -5,7 +5,11 @@ use crate::trie::StatelessTrie;
 use alloc::{collections::btree_map::BTreeMap, format};
 use alloy_primitives::{map::B256Map, Address, B256, U256};
 use reth_errors::ProviderError;
-use reth_revm::{bytecode::Bytecode, state::AccountInfo, Database};
+use reth_revm::{
+    bytecode::Bytecode,
+    state::{AccountInfo, CodeSize},
+    Database,
+};
 
 /// An EVM database implementation backed by witness data.
 ///
@@ -82,7 +86,7 @@ where
                 nonce: account.nonce,
                 code_hash: account.code_hash,
                 code: None,
-                code_size: None,
+                code_size: CodeSize::Known(0),
             })
         })
     }

--- a/crates/storage/db-models/src/accounts.rs
+++ b/crates/storage/db-models/src/accounts.rs
@@ -27,10 +27,11 @@ impl reth_codecs::Compact for AccountBeforeTx {
         // for now put full bytes and later compress it.
         buf.put_slice(self.address.as_slice());
 
-        let mut acc_len = 0;
-        if let Some(account) = self.info {
-            acc_len = account.to_compact(buf);
-        }
+        let acc_len = if let Some(account) = self.info {
+            account.to_compact(buf)
+        } else {
+            0
+        };
         acc_len + 20
     }
 

--- a/crates/storage/db-models/src/accounts.rs
+++ b/crates/storage/db-models/src/accounts.rs
@@ -27,11 +27,7 @@ impl reth_codecs::Compact for AccountBeforeTx {
         // for now put full bytes and later compress it.
         buf.put_slice(self.address.as_slice());
 
-        let acc_len = if let Some(account) = self.info {
-            account.to_compact(buf)
-        } else {
-            0
-        };
+        let acc_len = if let Some(account) = self.info { account.to_compact(buf) } else { 0 };
         acc_len + 20
     }
 

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -582,7 +582,7 @@ mod tests {
     use crate::KeccakKeyHasher;
     use alloy_primitives::Bytes;
     use revm_database::{states::StorageSlot, StorageWithOriginalValues};
-    use revm_state::{AccountInfo, Bytecode};
+    use revm_state::{AccountInfo, Bytecode, CodeSize};
 
     #[test]
     fn hashed_state_wiped_extension() {
@@ -669,7 +669,7 @@ mod tests {
             nonce: 42,
             code_hash: B256::random(),
             code: Some(Bytecode::new_raw(Bytes::from(vec![1, 2]))),
-            code_size: None,
+            code_size: CodeSize::Known(0),
         };
 
         let mut storage = StorageWithOriginalValues::default();
@@ -714,7 +714,7 @@ mod tests {
             nonce: 1,
             code_hash: B256::random(),
             code: None,
-            code_size: None,
+            code_size: CodeSize::Known(0),
         };
 
         // Create hashed accounts with addresses.


### PR DESCRIPTION
This PR does the following:
1. Uses an enum for the `code_size` field in the `AccountInfo` struct which has been changed with eip7907. The changes for eip7907 in revm can be tracked at: https://github.com/bluealloy/revm/tree/rakita/eip7907
2. Uses `rakita/eip7907` branch for revm to refer to the latest eip7907 changes