### PR TITLE
chore: simplify blob count extraction using new blob_count() method

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -493,8 +493,7 @@ where
                 ))
             }
 
-            let blob_count =
-                transaction.blob_versioned_hashes().map(|b| b.len() as u64).unwrap_or(0);
+            let blob_count = transaction.blob_count().unwrap_or(0);
             if blob_count == 0 {
                 // no blobs
                 return Err(TransactionValidationOutcome::Invalid(

--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -103,7 +103,7 @@ where
             .body()
             .transactions()
             .filter(|tx| tx.is_eip4844())
-            .map(|tx| (tx.clone(), tx.blob_versioned_hashes().unwrap().len()))
+            .map(|tx| (tx.clone(), tx.blob_count().unwrap_or(0) as usize))
             .collect();
 
         let mut all_blobs_available = true;


### PR DESCRIPTION
Make use of the new `blob_count()`, improve readability and remove unwrap.