### PR TITLE
docs: add code example to extend_rpc_modules method

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -547,6 +547,39 @@ where
     }
 
     /// Sets the hook that is run to configure the rpc modules.
+    ///
+    /// This hook can obtain the node's components (txpool, provider, etc.) and can modify the
+    /// modules that the RPC server installs.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+    ///
+    /// #[derive(Clone)]
+    /// struct CustomApi<Pool> { pool: Pool }
+    ///
+    /// #[rpc(server, namespace = "custom")]
+    /// impl CustomApi {
+    ///     #[method(name = "hello")]
+    ///     async fn hello(&self) -> RpcResult<String> {
+    ///         Ok("World".to_string())
+    ///     }
+    /// }
+    ///
+    /// let node = NodeBuilder::new(config)
+    ///     .node(EthereumNode::default())
+    ///     .extend_rpc_modules(|ctx| {
+    ///         // Access node components, so they can used by the CustomApi
+    ///         let pool = ctx.pool().clone();
+    ///         
+    ///         // Add custom RPC namespace
+    ///         ctx.modules.merge_configured(CustomApi { pool }.into_rpc())?;
+    ///         
+    ///         Ok(())
+    ///     })
+    ///     .build()?;
+    /// ```
     pub fn extend_rpc_modules<F>(self, hook: F) -> Self
     where
         F: FnOnce(RpcContext<'_, NodeAdapter<T, CB::Components>, AO::EthApi>) -> eyre::Result<()>

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -283,6 +283,8 @@ where
     }
 
     /// Returns a reference to the configured node.
+    ///
+    /// This gives access to the node's components.
     pub const fn node(&self) -> &Node {
         &self.node
     }

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -32,7 +32,9 @@ fn main() {
     Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
         .run(|builder, args| async move {
             let handle = builder
+                // configure default ethereum node
                 .node(EthereumNode::default())
+                // extend the rpc modules with our custom `TxpoolExt` endpoints
                 .extend_rpc_modules(move |ctx| {
                     if !args.enable_ext {
                         return Ok(())
@@ -50,6 +52,7 @@ fn main() {
 
                     Ok(())
                 })
+                // launch the
                 .launch()
                 .await?;
 

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
 
                     Ok(())
                 })
-                // launch the
+                // launch the node with custom rpc
                 .launch()
                 .await?;
 


### PR DESCRIPTION
## Summary

Adds a comprehensive code example to the `extend_rpc_modules` method documentation in the node builder.

## Changes

- Added a practical example showing how to:
  - Create a custom RPC API with the `custom` namespace
  - Access node components (pool) within the RPC module
  - Configure and merge custom RPC modules into the node

The example demonstrates the most common use case while being concise and easy to understand.

## Motivation

The `extend_rpc_modules` method is a key customization point for node builders, but lacked concrete examples showing how to use it properly. This documentation helps developers understand how to extend their node's RPC functionality.