### PR TITLE
docs: fix typo in NetworkManager diagram

### DIFF
--- a/crates/net/network/docs/mermaid/network-manager.mmd
+++ b/crates/net/network/docs/mermaid/network-manager.mmd
@@ -9,7 +9,7 @@ graph TB
     subgraph Swarm
         direction TB
         B1[(Session Manager)]
-        B2[(Connection Lister)]
+        B2[(Connection Listener)]
         B3[(Network State)]
     end
  end

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -89,7 +89,7 @@ use tracing::{debug, error, trace, warn};
 ///     subgraph Swarm
 ///         direction TB
 ///         B1[(Session Manager)]
-///         B2[(Connection Lister)]
+///         B2[(Connection Listener)]
 ///         B3[(Network State)]
 ///     end
 ///  end


### PR DESCRIPTION
Corrected a typo in the mermaid diagram documentation where "Connection Lister" was incorrectly used instead of "Connection Listener" to match the actual class name and standard networking terminology