### PR TITLE
docs: fix typo from `optstack` to `opstack`

### DIFF
--- a/crates/primitives-traits/src/extended.rs
+++ b/crates/primitives-traits/src/extended.rs
@@ -25,7 +25,7 @@ macro_rules! delegate {
 
 /// An enum that combines two different transaction types.
 ///
-/// This is intended to be used to extend existing presets, for example the ethereum or optstack
+/// This is intended to be used to extend existing presets, for example the ethereum or opstack
 /// transaction types and receipts
 ///
 /// Note: The [`Extended::Other`] variants must not overlap with the builtin one, transaction


### PR DESCRIPTION
`OpStack` is the official name of the Optimism technology. The typo `optstack` in documentation could cause confusion, break search functionality