### PR TITLE
feat(alloy-provider): implement `sealed_header` method

### DIFF
--- a/crates/alloy-provider/src/lib.rs
+++ b/crates/alloy-provider/src/lib.rs
@@ -301,12 +301,12 @@ where
     }
 
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::Header>> {
-        let Some(header) = self.sealed_header(num)? else {
+        let Some(sealed_header) = self.sealed_header(num)? else {
             // If the block was not found, return None
             return Ok(None);
         };
 
-        Ok(Some(header.into_header()))
+        Ok(Some(sealed_header.into_header()))
     }
 
     fn header_td(&self, _hash: &BlockHash) -> ProviderResult<Option<U256>> {

--- a/crates/alloy-provider/src/lib.rs
+++ b/crates/alloy-provider/src/lib.rs
@@ -301,20 +301,12 @@ where
     }
 
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::Header>> {
-        let block_response = self.block_on_async(async {
-            self.provider.get_block_by_number(num.into()).await.map_err(ProviderError::other)
-        })?;
-
-        let Some(block_response) = block_response else {
+        let Some(header) = self.sealed_header(num)? else {
             // If the block was not found, return None
             return Ok(None);
         };
 
-        // Convert the network block response to primitive block
-        let block = <BlockTy<Node> as TryFromBlockResponse<N>>::from_block_response(block_response)
-            .map_err(ProviderError::other)?;
-
-        Ok(Some(block.into_header()))
+        Ok(Some(header.into_header()))
     }
 
     fn header_td(&self, _hash: &BlockHash) -> ProviderResult<Option<U256>> {
@@ -334,9 +326,23 @@ where
 
     fn sealed_header(
         &self,
-        _number: BlockNumber,
+        number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
-        Err(ProviderError::UnsupportedProvider)
+        let block_response = self.block_on_async(async {
+            self.provider.get_block_by_number(number.into()).await.map_err(ProviderError::other)
+        })?;
+
+        let Some(block_response) = block_response else {
+            // If the block was not found, return None
+            return Ok(None);
+        };
+        let block_hash = block_response.header().hash();
+
+        // Convert the network block response to primitive block
+        let block = <BlockTy<Node> as TryFromBlockResponse<N>>::from_block_response(block_response)
+            .map_err(ProviderError::other)?;
+
+        Ok(Some(SealedHeader::new(block.into_header(), block_hash)))
     }
 
     fn sealed_headers_while(


### PR DESCRIPTION
Since the block hash is provided in the RPC response, we can use it to populate the `SealedHeader`. As the method is very similar to `header_by_number`, we can reduce duplication by reusing the `sealed_header` method.