### PR TITLE
fix: use primitives headers for pruner

### DIFF
--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -82,7 +82,7 @@ impl PrunerBuilder {
                 ProviderRW: PruneCheckpointWriter
                                 + BlockReader<Transaction: Encodable2718>
                                 + StaticFileProviderFactory<
-                    Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>,
+                    Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
                 >,
             > + StaticFileProviderFactory<
                 Primitives = <PF::ProviderRW as NodePrimitivesProvider>::Primitives,
@@ -107,8 +107,9 @@ impl PrunerBuilder {
         static_file_provider: StaticFileProvider<Provider::Primitives>,
     ) -> Pruner<Provider, ()>
     where
-        Provider: StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>>
-            + DBProvider<Tx: DbTxMut>
+        Provider: StaticFileProviderFactory<
+                Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
+            > + DBProvider<Tx: DbTxMut>
             + BlockReader<Transaction: Encodable2718>
             + PruneCheckpointWriter,
     {

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -47,8 +47,9 @@ impl<Provider> SegmentSet<Provider> {
 
 impl<Provider> SegmentSet<Provider>
 where
-    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>>
-        + DBProvider<Tx: DbTxMut>
+    Provider: StaticFileProviderFactory<
+            Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
+        > + DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter
         + BlockReader<Transaction: Encodable2718>,
 {

--- a/crates/prune/prune/src/segments/static_file/headers.rs
+++ b/crates/prune/prune/src/segments/static_file/headers.rs
@@ -7,9 +7,11 @@ use alloy_primitives::BlockNumber;
 use itertools::Itertools;
 use reth_db_api::{
     cursor::{DbCursorRO, RangeWalker},
+    table::Value,
     tables,
     transaction::DbTxMut,
 };
+use reth_primitives_traits::NodePrimitives;
 use reth_provider::{providers::StaticFileProvider, DBProvider, StaticFileProviderFactory};
 use reth_prune_types::{
     PruneMode, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
@@ -32,8 +34,10 @@ impl<N> Headers<N> {
     }
 }
 
-impl<Provider: StaticFileProviderFactory + DBProvider<Tx: DbTxMut>> Segment<Provider>
-    for Headers<Provider::Primitives>
+impl<Provider> Segment<Provider> for Headers<Provider::Primitives>
+where
+    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Value>>
+        + DBProvider<Tx: DbTxMut>,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::Headers
@@ -63,7 +67,11 @@ impl<Provider: StaticFileProviderFactory + DBProvider<Tx: DbTxMut>> Segment<Prov
 
         let range = last_pruned_block.map_or(0, |block| block + 1)..=block_range_end;
 
-        let mut headers_cursor = provider.tx_ref().cursor_write::<tables::Headers>()?;
+        // let mut headers_cursor = provider.tx_ref().cursor_write::<tables::Headers>()?;
+        let mut headers_cursor = provider
+            .tx_ref()
+            .cursor_write::<tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>>()?;
+
         let mut header_tds_cursor =
             provider.tx_ref().cursor_write::<tables::HeaderTerminalDifficulties>()?;
         let mut canonical_headers_cursor =
@@ -108,11 +116,12 @@ type Walker<'a, Provider, T> =
 #[allow(missing_debug_implementations)]
 struct HeaderTablesIter<'a, Provider>
 where
-    Provider: DBProvider<Tx: DbTxMut>,
+    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Value>>
+    + DBProvider<Tx: DbTxMut>,
 {
     provider: &'a Provider,
     limiter: &'a mut PruneLimiter,
-    headers_walker: Walker<'a, Provider, tables::Headers>,
+    headers_walker: Walker<'a, Provider,  tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>>,
     header_tds_walker: Walker<'a, Provider, tables::HeaderTerminalDifficulties>,
     canonical_headers_walker: Walker<'a, Provider, tables::CanonicalHeaders>,
 }
@@ -124,12 +133,13 @@ struct HeaderTablesIterItem {
 
 impl<'a, Provider> HeaderTablesIter<'a, Provider>
 where
-    Provider: DBProvider<Tx: DbTxMut>,
+    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Value>>
+    + DBProvider<Tx: DbTxMut>,
 {
     const fn new(
         provider: &'a Provider,
         limiter: &'a mut PruneLimiter,
-        headers_walker: Walker<'a, Provider, tables::Headers>,
+        headers_walker: Walker<'a, Provider, tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>>,
         header_tds_walker: Walker<'a, Provider, tables::HeaderTerminalDifficulties>,
         canonical_headers_walker: Walker<'a, Provider, tables::CanonicalHeaders>,
     ) -> Self {
@@ -139,7 +149,8 @@ where
 
 impl<Provider> Iterator for HeaderTablesIter<'_, Provider>
 where
-    Provider: DBProvider<Tx: DbTxMut>,
+    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Value>>
+    + DBProvider<Tx: DbTxMut>,
 {
     type Item = Result<HeaderTablesIterItem, PrunerError>;
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/prune/prune/src/segments/static_file/headers.rs
+++ b/crates/prune/prune/src/segments/static_file/headers.rs
@@ -70,7 +70,8 @@ where
         // let mut headers_cursor = provider.tx_ref().cursor_write::<tables::Headers>()?;
         let mut headers_cursor = provider
             .tx_ref()
-            .cursor_write::<tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>>()?;
+            .cursor_write::<tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>>(
+            )?;
 
         let mut header_tds_cursor =
             provider.tx_ref().cursor_write::<tables::HeaderTerminalDifficulties>()?;
@@ -117,11 +118,15 @@ type Walker<'a, Provider, T> =
 struct HeaderTablesIter<'a, Provider>
 where
     Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Value>>
-    + DBProvider<Tx: DbTxMut>,
+        + DBProvider<Tx: DbTxMut>,
 {
     provider: &'a Provider,
     limiter: &'a mut PruneLimiter,
-    headers_walker: Walker<'a, Provider,  tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>>,
+    headers_walker: Walker<
+        'a,
+        Provider,
+        tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>,
+    >,
     header_tds_walker: Walker<'a, Provider, tables::HeaderTerminalDifficulties>,
     canonical_headers_walker: Walker<'a, Provider, tables::CanonicalHeaders>,
 }
@@ -134,12 +139,16 @@ struct HeaderTablesIterItem {
 impl<'a, Provider> HeaderTablesIter<'a, Provider>
 where
     Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Value>>
-    + DBProvider<Tx: DbTxMut>,
+        + DBProvider<Tx: DbTxMut>,
 {
     const fn new(
         provider: &'a Provider,
         limiter: &'a mut PruneLimiter,
-        headers_walker: Walker<'a, Provider, tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>>,
+        headers_walker: Walker<
+            'a,
+            Provider,
+            tables::Headers<<Provider::Primitives as NodePrimitives>::BlockHeader>,
+        >,
         header_tds_walker: Walker<'a, Provider, tables::HeaderTerminalDifficulties>,
         canonical_headers_walker: Walker<'a, Provider, tables::CanonicalHeaders>,
     ) -> Self {
@@ -150,7 +159,7 @@ where
 impl<Provider> Iterator for HeaderTablesIter<'_, Provider>
 where
     Provider: StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Value>>
-    + DBProvider<Tx: DbTxMut>,
+        + DBProvider<Tx: DbTxMut>,
 {
     type Item = Result<HeaderTablesIterItem, PrunerError>;
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -42,7 +42,7 @@ where
         + PruneCheckpointReader
         + PruneCheckpointWriter
         + BlockReader
-        + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>>,
+        + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>>,
 {
     fn id(&self) -> StageId {
         StageId::Prune
@@ -131,7 +131,7 @@ where
         + PruneCheckpointReader
         + PruneCheckpointWriter
         + BlockReader
-        + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value>>,
+        + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>>,
 {
     fn id(&self) -> StageId {
         StageId::PruneSenderRecovery

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -42,7 +42,9 @@ where
         + PruneCheckpointReader
         + PruneCheckpointWriter
         + BlockReader
-        + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>>,
+        + StaticFileProviderFactory<
+            Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
+        >,
 {
     fn id(&self) -> StageId {
         StageId::Prune
@@ -131,7 +133,9 @@ where
         + PruneCheckpointReader
         + PruneCheckpointWriter
         + BlockReader
-        + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>>,
+        + StaticFileProviderFactory<
+            Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
+        >,
 {
     fn id(&self) -> StageId {
         StageId::PruneSenderRecovery


### PR DESCRIPTION
this was using the eth header type when opening the cursor, but we need to use the header type from primitives here