### PR TITLE
fix: refactor trace log key and comment formatting

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -956,7 +956,7 @@ impl PeersManager {
 
             if peer.addr != new_addr {
                 peer.addr = new_addr;
-                trace!(target: "net::peers", ?peer_id, addre=?peer.addr, "Updated resolved trusted peer address");
+                trace!(target: "net::peers", ?peer_id, addr=?peer.addr, "Updated resolved trusted peer address");
             }
         }
     }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -497,7 +497,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 self.on_peer_action(action);
             }
 
-            // We need to poll again tn case we have received any responses because they may have
+            // We need to poll again in case we have received any responses because they may have
             // triggered follow-up requests.
             if self.queued_messages.is_empty() {
                 return Poll::Pending


### PR DESCRIPTION


### **Description**

* Renamed `addre` to `addr` in trace log to maintain consistency across logs.
* Minor comment formatting fix in `state.rs` for improved readability.

---

