### PR TITLE
feat: make engine API metered methods and utilities public

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -147,7 +147,7 @@ where
     }
 
     /// Metered version of `new_payload_v1`.
-    async fn new_payload_v1_metered(
+    pub async fn new_payload_v1_metered(
         &self,
         payload: PayloadT::ExecutionData,
     ) -> EngineApiResult<PayloadStatus> {
@@ -270,6 +270,10 @@ where
         self.inner.metrics.latency.new_payload_v4.record(elapsed);
         self.inner.metrics.new_payload_response.update_response_metrics(&res, gas_used, elapsed);
         Ok(res?)
+    }
+
+    pub fn accept_execution_requests_hash(&self) -> bool {
+        self.inner.accept_execution_requests_hash
     }
 }
 
@@ -754,7 +758,7 @@ where
             .map_err(|err| EngineApiError::Internal(Box::new(err)))
     }
 
-    fn get_blobs_v1_metered(
+    pub fn get_blobs_v1_metered(
         &self,
         versioned_hashes: Vec<B256>,
     ) -> EngineApiResult<Vec<Option<BlobAndProofV1>>> {
@@ -788,7 +792,7 @@ where
             .map_err(|err| EngineApiError::Internal(Box::new(err)))
     }
 
-    fn get_blobs_v2_metered(
+    pub fn get_blobs_v2_metered(
         &self,
         versioned_hashes: Vec<B256>,
     ) -> EngineApiResult<Option<Vec<BlobAndProofV2>>> {

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -272,6 +272,7 @@ where
         Ok(res?)
     }
 
+    /// Returns whether the engine accepts execution requests hash.
     pub fn accept_execution_requests_hash(&self) -> bool {
         self.inner.accept_execution_requests_hash
     }
@@ -758,6 +759,7 @@ where
             .map_err(|err| EngineApiError::Internal(Box::new(err)))
     }
 
+    /// Metered version of `get_blobs_v1`.
     pub fn get_blobs_v1_metered(
         &self,
         versioned_hashes: Vec<B256>,
@@ -792,6 +794,7 @@ where
             .map_err(|err| EngineApiError::Internal(Box::new(err)))
     }
 
+    /// Metered version of `get_blobs_v2`.
     pub fn get_blobs_v2_metered(
         &self,
         versioned_hashes: Vec<B256>,


### PR DESCRIPTION
## Summary

Makes metered methods and utility functions in the Engine API public to enable external implementations that wrap and delegate to the underlying engine API.

### Changes Made
- `new_payload_v1_metered` → public 
- `get_blobs_v1_metered` → public
- `get_blobs_v2_metered` → public  
- `accept_execution_requests_hash` → public (new utility method)

### Usage Example: BerachainEngineApi

External implementations like `BerachainEngineApi` wrap the standard engine API while adding chain-specific validation:

```rust
pub struct BerachainEngineApi<Provider, PayloadT, Pool, Validator, ChainSpec> {
    inner: EngineApi<Provider, PayloadT, Pool, Validator, ChainSpec>,
    chain_spec: Arc<ChainSpec>,
}

    async fn new_payload_v4(
        &self,
        payload: ExecutionPayloadV3,
        versioned_hashes: Vec<B256>,
        parent_beacon_block_root: B256,
        execution_requests: RequestsOrHash,
        parent_proposer_pub_key: Option<BlsPublicKey>, /// New field
    ) -> RpcResult<PayloadStatus> {
       ...

        // Accept requests as a hash only if it is explicitly allowed
        if execution_requests.is_hash() && !self.inner.accept_execution_requests_hash() {
            return Err(EngineApiError::UnexpectedRequestsHash.into());
        }

        let berachain_payload = BerachainExecutionData::new(
            payload.into(),
            BerachainExecutionPayloadSidecar::v4(
                CancunPayloadFields { versioned_hashes, parent_beacon_block_root },
                execution_requests,
                parent_proposer_pub_key,
            ),
        );

        Ok(self.inner.new_payload_v4_metered(berachain_payload).await?) /// Delegate to inner
    }
```

### API Consistency

Follows the existing pattern where most metered methods in the Engine API are already public (e.g., `new_payload_v2_metered`, `fork_choice_updated_v1_metered`, `get_payload_v1_metered`, etc.). This change makes the remaining few methods consistent with the established pattern, enabling wrapper implementations to maintain uniform delegation patterns across all engine API methods.