### PR TITLE
ci: fix Hive EEST fixtures branch

### DIFF
--- a/.github/assets/hive/build_simulators.sh
+++ b/.github/assets/hive/build_simulators.sh
@@ -11,7 +11,8 @@ go build .
 
 # Run each hive command in the background for each simulator and wait
 echo "Building images"
-./hive -client reth --sim "ethereum/eest" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_develop.tar.gz --sim.buildarg branch=v4.4.0 -sim.timelimit 1s || true &
+# We're not using `branch=v4.4.0` here, because `uv pip install` is broken for it. It's not an issue, because we're still pinning the fixtures to v4.4.0.
+./hive -client reth --sim "ethereum/eest" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_develop.tar.gz --sim.buildarg branch=6cf5107cee0eae1c2d4dd6a5ef5bc729aea6c379 -sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/engine" -sim.timelimit 1s || true &
 ./hive -client reth --sim "devp2p" -sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/rpc-compat" -sim.timelimit 1s || true &

--- a/.github/assets/hive/build_simulators.sh
+++ b/.github/assets/hive/build_simulators.sh
@@ -11,8 +11,7 @@ go build .
 
 # Run each hive command in the background for each simulator and wait
 echo "Building images"
-# We're not using `branch=v4.4.0` here, because `uv pip install` is broken for it. It's not an issue, because we're still pinning the fixtures to v4.4.0.
-./hive -client reth --sim "ethereum/eest" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_develop.tar.gz --sim.buildarg branch=6cf5107cee0eae1c2d4dd6a5ef5bc729aea6c379 -sim.timelimit 1s || true &
+./hive -client reth --sim "ethereum/eest" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_develop.tar.gz --sim.buildarg branch=v4.4.0 -sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/engine" -sim.timelimit 1s || true &
 ./hive -client reth --sim "devp2p" -sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/rpc-compat" -sim.timelimit 1s || true &

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ethereum/hive
+          ref: 1e662fbbe3e44915a042da872793ed5786df8fb2
           path: hivetests
 
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Pins the EEST branch to latest commit, because tag `v4.4.0` is broken now https://github.com/paradigmxyz/reth/blob/c020fd5a039b442f6ba3308d8e4e3c6d64d1778e/.github/assets/hive/build_simulators.sh#L14

CI succeeds now: https://github.com/paradigmxyz/reth/actions/runs/16346231258/job/46180539226

Can be bumped to `v4.6.0` once it's released.