### PR TITLE
feat: add helper for building pending block env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9244,6 +9244,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-eth-api",
  "revm",
  "thiserror 2.0.12",
 ]

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -20,8 +20,8 @@ use reth_evm::{
 };
 use reth_network::{primitives::BasicNetworkPrimitives, NetworkHandle, PeersInfo};
 use reth_node_api::{
-    AddOnsContext, FullNodeComponents, NodeAddOns, NodePrimitives, PayloadAttributesBuilder,
-    PrimitivesTy, TxTy,
+    AddOnsContext, FullNodeComponents, HeaderTy, NodeAddOns, NodePrimitives,
+    PayloadAttributesBuilder, PrimitivesTy, TxTy,
 };
 use reth_node_builder::{
     components::{
@@ -43,7 +43,7 @@ use reth_rpc::{
 };
 use reth_rpc_api::servers::BlockSubmissionValidationApiServer;
 use reth_rpc_builder::{config::RethRpcServerConfig, middleware::RethRpcMiddleware};
-use reth_rpc_eth_api::RpcConvert;
+use reth_rpc_eth_api::{helpers::pending_block::BuildPendingEnv, RpcConvert};
 use reth_rpc_eth_types::{error::FromEvmError, EthApiError};
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
@@ -144,7 +144,7 @@ impl<N> EthApiBuilder<N> for EthereumEthApiBuilder
 where
     N: FullNodeComponents<
         Types: NodeTypes<ChainSpec: EthereumHardforks, Primitives = EthPrimitives>,
-        Evm: ConfigureEvm<NextBlockEnvCtx: From<NextBlockEnvAttributes>>,
+        Evm: ConfigureEvm<NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>>,
     >,
     EthRpcConverterFor<N>: RpcConvert<
         Primitives = PrimitivesTy<N::Types>,

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -18,6 +18,8 @@ reth-primitives-traits.workspace = true
 reth-execution-errors.workspace = true
 reth-execution-types.workspace = true
 
+reth-rpc-eth-api = { workspace = true, optional = true }
+
 # ethereum
 alloy-eips.workspace = true
 alloy-evm.workspace = true
@@ -71,3 +73,4 @@ std = [
     "reth-evm/std",
 ]
 portable = ["reth-revm/portable"]
+rpc = ["reth-rpc-eth-api"]

--- a/crates/optimism/evm/src/config.rs
+++ b/crates/optimism/evm/src/config.rs
@@ -56,6 +56,22 @@ pub fn revm_spec_by_timestamp_after_bedrock(
     }
 }
 
+#[cfg(feature = "rpc")]
+impl<H: alloy_consensus::BlockHeader> reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv<H>
+    for OpNextBlockEnvAttributes
+{
+    fn build_pending_env(parent: &crate::SealedHeader<H>) -> Self {
+        Self {
+            timestamp: parent.timestamp().saturating_add(12),
+            suggested_fee_recipient: parent.beneficiary(),
+            prev_randao: alloy_primitives::B256::random(),
+            gas_limit: parent.gas_limit(),
+            parent_beacon_block_root: parent.parent_beacon_block_root(),
+            extra_data: parent.extra_data().clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -34,7 +34,7 @@ reth-rpc-api.workspace = true
 
 # op-reth
 reth-optimism-payload-builder.workspace = true
-reth-optimism-evm.workspace = true
+reth-optimism-evm = { workspace = true, features = ["rpc"] }
 reth-optimism-rpc.workspace = true
 reth-optimism-storage.workspace = true
 reth-optimism-txpool.workspace = true

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -3,17 +3,13 @@
 use std::sync::Arc;
 
 use crate::OpEthApi;
-use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::B256;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec};
+use reth_chainspec::ChainSpecProvider;
 use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
-use reth_optimism_evm::OpNextBlockEnvAttributes;
-use reth_optimism_forks::OpHardforks;
-use reth_primitives_traits::{RecoveredBlock, SealedHeader};
+use reth_primitives_traits::RecoveredBlock;
 use reth_rpc_eth_api::{
-    helpers::{LoadPendingBlock, SpawnBlocking},
+    helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock, SpawnBlocking},
     types::RpcTypes,
     EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
@@ -35,14 +31,9 @@ where
             RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
         >,
     N: RpcNodeCore<
-        Provider: BlockReaderIdExt
-                      + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>
-                      + StateProviderFactory,
+        Provider: BlockReaderIdExt + ChainSpecProvider + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<N::Provider>>>,
-        Evm: ConfigureEvm<
-            Primitives = <Self as RpcNodeCore>::Primitives,
-            NextBlockEnvCtx: From<OpNextBlockEnvAttributes>,
-        >,
+        Evm: ConfigureEvm<Primitives = Self::Primitives>,
         Primitives: NodePrimitives<
             BlockHeader = ProviderHeader<Self::Provider>,
             SignedTx = ProviderTx<Self::Provider>,
@@ -61,19 +52,9 @@ where
         self.inner.eth_api.pending_block()
     }
 
-    fn next_env_attributes(
-        &self,
-        parent: &SealedHeader<ProviderHeader<Self::Provider>>,
-    ) -> Result<<Self::Evm as ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
-        Ok(OpNextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12),
-            suggested_fee_recipient: parent.beneficiary(),
-            prev_randao: B256::random(),
-            gas_limit: parent.gas_limit(),
-            parent_beacon_block_root: parent.parent_beacon_block_root(),
-            extra_data: parent.extra_data().clone(),
-        }
-        .into())
+    #[inline]
+    fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<Self::Evm> {
+        self.inner.eth_api.pending_env_builder()
     }
 
     /// Returns the locally built pending block

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -41,7 +41,10 @@ use reth_rpc::{
 };
 use reth_rpc_api::servers::*;
 use reth_rpc_eth_api::{
-    helpers::{Call, EthApiSpec, EthTransactions, LoadPendingBlock, TraceExt},
+    helpers::{
+        pending_block::{BasicPendingEnvBuilder, PendingEnvBuilder},
+        Call, EthApiSpec, EthTransactions, LoadPendingBlock, TraceExt,
+    },
     EthApiServer, EthApiTypes, FullEthApiServer, RpcBlock, RpcConvert, RpcConverter, RpcHeader,
     RpcReceipt, RpcTransaction, RpcTxReq,
 };
@@ -301,6 +304,7 @@ impl<N, Provider, Pool, Network, EvmConfig, Consensus>
         EvmConfig: ConfigureEvm,
         Network: Clone,
         RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<Provider::ChainSpec>>: RpcConvert,
+        BasicPendingEnvBuilder: PendingEnvBuilder<EvmConfig>,
     {
         self.eth_api_builder().build()
     }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -6,7 +6,7 @@ use reth_primitives_traits::NodePrimitives;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, SpawnBlocking},
-    RpcNodeCore, RpcNodeCoreExt,
+    RpcNodeCoreExt,
 };
 use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::{BlockReader, ProviderTx};
@@ -27,6 +27,7 @@ where
         >,
     >,
     Provider: BlockReader + ChainSpecProvider,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }
@@ -44,7 +45,7 @@ where
             Evm = EvmConfig,
         >,
     Provider: BlockReader,
-    EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -48,6 +48,7 @@ where
                        + From<ProviderError>,
         > + SpawnBlocking,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
     #[inline]
@@ -66,6 +67,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> EstimateCall
 where
     Self: Call<NetworkTypes = Rpc::Network>,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,6 +1,7 @@
 //! Contains RPC handler implementations for fee history.
 
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
 use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
@@ -17,6 +18,7 @@ where
         >,
     >,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }
@@ -28,6 +30,7 @@ where
     Provider: BlockReaderIdExt
         + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
         + StateProviderFactory,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
     #[inline]

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -3,6 +3,7 @@
 use crate::EthApi;
 use alloy_consensus::crypto::RecoveryError;
 use reth_chainspec::ChainSpecProvider;
+use reth_evm::ConfigureEvm;
 use reth_node_api::NodePrimitives;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{helpers::LoadReceipt, EthApiTypes, RpcNodeCoreExt};
@@ -26,6 +27,7 @@ where
             Error: From<RecoveryError>,
         >,
     Provider: BlockReader + ChainSpecProvider,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -8,6 +8,7 @@ use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::{eip191_hash_message, Address, Signature, B256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
+use reth_evm::ConfigureEvm;
 use reth_rpc_convert::{RpcConvert, RpcTypes, SignableTxRequest};
 use reth_rpc_eth_api::helpers::{signer::Result, AddDevSigners, EthSigner};
 use reth_rpc_eth_types::SignError;
@@ -17,6 +18,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> AddDevSigners
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert<Network: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<Provider>>>>,
 {
     fn with_dev_accounts(&self) {

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,5 +1,6 @@
 use alloy_primitives::U256;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
@@ -20,6 +21,7 @@ where
         Network: NetworkInfo,
     >,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
     type Transaction = ProviderTx<Provider>;

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,6 +1,7 @@
 //! Contains RPC handler implementations specific to state.
 
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_storage_api::{BlockReader, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
@@ -17,6 +18,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> EthState
 where
     Self: LoadState + SpawnBlocking,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
     fn max_proof_window(&self) -> u64 {
@@ -34,6 +36,7 @@ where
             Pool: TransactionPool,
         > + EthApiTypes<NetworkTypes = Rpc::Network>,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -25,6 +25,7 @@ where
         Error: FromEvmError<Self::Evm>,
     >,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -2,6 +2,7 @@
 
 use crate::EthApi;
 use alloy_primitives::{Bytes, B256};
+use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction, SpawnBlocking},
@@ -16,6 +17,7 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> EthTransactions
 where
     Self: LoadTransaction<Provider: BlockReaderIdExt> + EthApiTypes<NetworkTypes = Rpc::Network>,
     Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
     #[inline]
@@ -53,6 +55,7 @@ where
         + RpcNodeCoreExt<Provider: TransactionsProvider, Pool: TransactionPool>
         + EthApiTypes<NetworkTypes = Rpc::Network>,
     Provider: BlockReader,
+    EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,
 {
 }


### PR DESCRIPTION
Introduces `PendingEnvBuilder` trait that encapsulates building of the EVM environment for the pending block. It defaults to `BasicPendingEnvBuilder` which relies on the `NextBlockEnvAttributes` providing implementation directly via `BuildPendingEnv`: 
https://github.com/paradigmxyz/reth/blob/69d0bd49773c6c50f3df79772b741d5c9ddeedc5/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs#L357-L384

More complex implementations can be provided via `EthApiBuilder::with_pending_env_builder`:
https://github.com/paradigmxyz/reth/blob/69d0bd49773c6c50f3df79772b741d5c9ddeedc5/crates/rpc/rpc/src/eth/builder.rs#L146-L150