### PR TITLE
fix: refactor typo in comment `RawCapbailitMessage` → `RawCapabilityMessage`

### DIFF
--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -534,7 +534,7 @@ mod tests {
         let mut encoded = Vec::new();
         msg.encode(&mut encoded);
 
-        // Decode the bytes back into RawCapbailitMessage
+        // Decode the bytes back into RawCapabilityMessage
         let decoded = RawCapabilityMessage::decode(&mut &encoded[..]).unwrap();
 
         // Verify that the decoded message matches the original


### PR DESCRIPTION


**Description:**  
This pull request refactors a comment in `capability.rs` by correcting a typo:  
- `RawCapbailitMessage` is now `RawCapabilityMessage`

