### PR TITLE
fix: correct documentation for block_mut method in RecoveredBlock

### DIFF
--- a/crates/primitives-traits/src/block/recovered.rs
+++ b/crates/primitives-traits/src/block/recovered.rs
@@ -559,7 +559,7 @@ impl<B: crate::test_utils::TestBlock> RecoveredBlock<B> {
         self.block.header_mut()
     }
 
-    /// Returns a mutable reference to the header.
+    /// Returns a mutable reference to the body.
     pub const fn block_mut(&mut self) -> &mut B::Body {
         self.block.body_mut()
     }


### PR DESCRIPTION
Block_mut method in RecoveredBlock was incorrectly documented as returning a mutable reference to the header, while it actually returns a mutable reference to the body