### PR TITLE
fix: Update Base Sequencer URL to mainnet.base.org

### DIFF
--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -174,7 +174,7 @@ mod test {
             "--http.api",
             "admin,debug,eth,net,trace,txpool,web3,rpc,reth,ots",
             "--rollup.sequencer-http",
-            "https://mainnet-sequencer.base.org",
+            "https://mainnet.base.org",
             "--rpc-max-tracing-requests",
             "1000000",
             "--rpc.gascap",


### PR DESCRIPTION


**Description:**  
Replaces the outdated Base Sequencer endpoint (mainnet-sequencer.base.org) with the correct and working mainnet.base.org URL.  
