### PR TITLE
chore: fix reth-engine-tree dev-dependencies import

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -72,7 +72,7 @@ reth-tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 # reth
-reth-evm-ethereum.workspace = true
+reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 reth-chain-state = { workspace = true, features = ["test-utils"] }
 reth-chainspec.workspace = true
 reth-db-common.workspace = true


### PR DESCRIPTION
One-liner to add the `test-utils` feature to the `reth-evm-ethereum` dependency; without this it's not possible to run tests on `reth-engine-tree` without manually passing in `-F test-utils`.