### PR TITLE
fix: correct documentation for block_mut method in SealedBlock

### DIFF
--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -349,7 +349,7 @@ impl<B: crate::test_utils::TestBlock> SealedBlock<B> {
         self.header.set_hash(hash)
     }
 
-    /// Returns a mutable reference to the header.
+    /// Returns a mutable reference to the body.
     pub const fn body_mut(&mut self) -> &mut B::Body {
         &mut self.body
     }


### PR DESCRIPTION
Block_mut method in SealedBlock was incorrectly documented as returning a mutable reference to the header, while it actually returns a mutable reference to the body