### PR TITLE
refactor: stronger bounds on `RpcNodeCore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9412,7 +9412,6 @@ dependencies = [
  "reth-chainspec",
  "reth-evm",
  "reth-metrics",
- "reth-network-api",
  "reth-node-api",
  "reth-node-builder",
  "reth-optimism-chainspec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10076,7 +10076,6 @@ dependencies = [
  "reth-evm",
  "reth-network-api",
  "reth-node-api",
- "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8964,7 +8964,6 @@ dependencies = [
  "futures",
  "rand 0.9.1",
  "reth-chainspec",
- "reth-consensus",
  "reth-db",
  "reth-e2e-test-utils",
  "reth-engine-local",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -24,7 +24,6 @@ reth-transaction-pool.workspace = true
 reth-network.workspace = true
 reth-evm.workspace = true
 reth-evm-ethereum.workspace = true
-reth-consensus.workspace = true
 reth-rpc.workspace = true
 reth-rpc-api.workspace = true
 reth-rpc-eth-api.workspace = true
@@ -83,7 +82,6 @@ js-tracer = ["reth-node-builder/js-tracer"]
 test-utils = [
     "reth-node-builder/test-utils",
     "reth-chainspec/test-utils",
-    "reth-consensus/test-utils",
     "reth-network/test-utils",
     "reth-ethereum-primitives/test-utils",
     "reth-revm/test-utils",

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -6,7 +6,6 @@ use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use alloy_network::Ethereum;
 use alloy_rpc_types_engine::ExecutionData;
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, Hardforks};
-use reth_consensus::{ConsensusError, FullConsensus};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_engine_primitives::EngineTypes;
 use reth_ethereum_consensus::EthBeaconConsensus;
@@ -511,7 +510,7 @@ where
         Types: NodeTypes<ChainSpec: EthChainSpec + EthereumHardforks, Primitives = EthPrimitives>,
     >,
 {
-    type Consensus = Arc<dyn FullConsensus<EthPrimitives, Error = ConsensusError>>;
+    type Consensus = Arc<EthBeaconConsensus<<Node::Types as NodeTypes>::ChainSpec>>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
         Ok(Arc::new(EthBeaconConsensus::new(ctx.chain_spec())))

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -157,21 +157,16 @@ where
     type EthApi = EthApiFor<N>;
 
     async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
-        let api = reth_rpc::EthApiBuilder::new(
-            ctx.components.provider().clone(),
-            ctx.components.pool().clone(),
-            ctx.components.network().clone(),
-            ctx.components.evm_config().clone(),
-        )
-        .eth_cache(ctx.cache)
-        .task_spawner(ctx.components.task_executor().clone())
-        .gas_cap(ctx.config.rpc_gas_cap.into())
-        .max_simulate_blocks(ctx.config.rpc_max_simulate_blocks)
-        .eth_proof_window(ctx.config.eth_proof_window)
-        .fee_history_cache_config(ctx.config.fee_history_cache)
-        .proof_permits(ctx.config.proof_permits)
-        .gas_oracle_config(ctx.config.gas_oracle)
-        .build();
+        let api = reth_rpc::EthApiBuilder::new_with_components(ctx.components.clone())
+            .eth_cache(ctx.cache)
+            .task_spawner(ctx.components.task_executor().clone())
+            .gas_cap(ctx.config.rpc_gas_cap.into())
+            .max_simulate_blocks(ctx.config.rpc_max_simulate_blocks)
+            .eth_proof_window(ctx.config.eth_proof_window)
+            .fee_history_cache_config(ctx.config.fee_history_cache)
+            .proof_permits(ctx.config.proof_permits)
+            .gas_oracle_config(ctx.config.gas_oracle)
+            .build();
         Ok(api)
     }
 }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -11,7 +11,7 @@ use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineTypes, EngineValidator, FullNodeComponents, FullNodeTypes,
-    NodeAddOns, NodeTypes, PayloadTypes, ReceiptTy,
+    NodeAddOns, NodeTypes, PayloadTypes, PrimitivesTy,
 };
 use reth_node_core::{
     node_config::NodeConfig,
@@ -953,7 +953,7 @@ pub struct EthApiCtx<'a, N: FullNodeTypes> {
     /// Eth API configuration
     pub config: EthConfig,
     /// Cache for eth state
-    pub cache: EthStateCache<BlockTy<N::Types>, ReceiptTy<N::Types>>,
+    pub cache: EthStateCache<PrimitivesTy<N::Types>>,
 }
 
 /// A `EthApi` that knows how to build `eth` namespace API from [`FullNodeComponents`].

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -24,7 +24,6 @@ reth-transaction-pool.workspace = true
 reth-rpc.workspace = true
 reth-rpc-api.workspace = true
 reth-node-api.workspace = true
-reth-network-api.workspace = true
 reth-node-builder.workspace = true
 reth-chainspec.workspace = true
 reth-rpc-engine-api.workspace = true

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -1,35 +1,23 @@
 //! Loads and formats OP block RPC response.
 
-use reth_chainspec::ChainSpecProvider;
-use reth_optimism_forks::OpHardforks;
+use crate::{eth::RpcNodeCore, OpEthApi, OpEthApiError};
 use reth_rpc_eth_api::{
-    helpers::{EthBlocks, LoadBlock, LoadPendingBlock, SpawnBlocking},
-    RpcConvert,
+    helpers::{EthBlocks, LoadBlock},
+    FromEvmError, RpcConvert,
 };
-use reth_storage_api::{HeaderProvider, ProviderTx};
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
-
-use crate::{eth::OpNodeCore, OpEthApi, OpEthApiError};
 
 impl<N, Rpc> EthBlocks for OpEthApi<N, Rpc>
 where
-    Self: LoadBlock<
-        Error = OpEthApiError,
-        RpcConvert: RpcConvert<Error = OpEthApiError, Primitives = Self::Primitives>,
-    >,
-    N: OpNodeCore<Provider: ChainSpecProvider<ChainSpec: OpHardforks> + HeaderProvider>,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
 }
 
 impl<N, Rpc> LoadBlock for OpEthApi<N, Rpc>
 where
-    Self: LoadPendingBlock<
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
-        > + SpawnBlocking,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
 }

--- a/crates/optimism/rpc/src/eth/call.rs
+++ b/crates/optimism/rpc/src/eth/call.rs
@@ -1,51 +1,31 @@
-use super::OpNodeCore;
-use crate::{OpEthApi, OpEthApiError};
-use op_revm::OpTransaction;
-use reth_evm::{execute::BlockExecutorFactory, ConfigureEvm, EvmFactory, TxEnvFor};
-use reth_node_api::NodePrimitives;
+use crate::{eth::RpcNodeCore, OpEthApi, OpEthApiError};
+use reth_evm::TxEnvFor;
 use reth_rpc_eth_api::{
-    helpers::{estimate::EstimateCall, Call, EthCall, LoadBlock, LoadState, SpawnBlocking},
-    FromEvmError, FullEthApiTypes, RpcConvert,
+    helpers::{estimate::EstimateCall, Call, EthCall},
+    FromEvmError, RpcConvert,
 };
-use reth_storage_api::{errors::ProviderError, ProviderHeader, ProviderTx};
-use revm::context::TxEnv;
 
 impl<N, Rpc> EthCall for OpEthApi<N, Rpc>
 where
-    Self: EstimateCall + LoadBlock + FullEthApiTypes,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
 }
 
 impl<N, Rpc> EstimateCall for OpEthApi<N, Rpc>
 where
-    Self: Call<Error: From<OpEthApiError>>,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
 }
 
 impl<N, Rpc> Call for OpEthApi<N, Rpc>
 where
-    Self: LoadState<
-            Evm: ConfigureEvm<
-                Primitives: NodePrimitives<
-                    BlockHeader = ProviderHeader<Self::Provider>,
-                    SignedTx = ProviderTx<Self::Provider>,
-                >,
-                BlockExecutorFactory: BlockExecutorFactory<
-                    EvmFactory: EvmFactory<Tx = OpTransaction<TxEnv>>,
-                >,
-            >,
-            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Self::NetworkTypes>,
-            Error: FromEvmError<Self::Evm>
-                       + From<<Self::RpcConvert as RpcConvert>::Error>
-                       + From<ProviderError>,
-        > + SpawnBlocking,
-    Self::Error: From<OpEthApiError>,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -16,44 +16,28 @@ use alloy_primitives::U256;
 use eyre::WrapErr;
 use op_alloy_network::Optimism;
 pub use receipt::{OpReceiptBuilder, OpReceiptFieldsBuilder};
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
-use reth_network_api::NetworkInfo;
-use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy, NodePrimitives};
+use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy};
 use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
 use reth_rpc::eth::{core::EthApiInner, DevSigner};
 use reth_rpc_eth_api::{
     helpers::{
         pending_block::BuildPendingEnv, spec::SignersForApi, AddDevSigners, EthApiSpec, EthFees,
-        EthState, LoadBlock, LoadFee, LoadState, SpawnBlocking, Trace,
+        EthState, LoadFee, LoadState, SpawnBlocking, Trace,
     },
     EthApiTypes, FromEvmError, FullEthApiServer, RpcConvert, RpcConverter, RpcNodeCore,
     RpcNodeCoreExt, RpcTypes, SignableTxRequest,
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
-use reth_storage_api::{
-    BlockNumReader, BlockReader, BlockReaderIdExt, ProviderBlock, ProviderHeader, ProviderReceipt,
-    ProviderTx, StageCheckpointReader, StateProviderFactory,
-};
+use reth_storage_api::{ProviderHeader, ProviderTx};
 use reth_tasks::{
     pool::{BlockingTaskGuard, BlockingTaskPool},
     TaskSpawner,
 };
-use reth_transaction_pool::TransactionPool;
 use std::{fmt, fmt::Formatter, marker::PhantomData, sync::Arc};
 
 /// Adapter for [`EthApiInner`], which holds all the data required to serve core `eth_` API.
-pub type EthApiNodeBackend<N, Rpc> = EthApiInner<
-    <N as RpcNodeCore>::Provider,
-    <N as RpcNodeCore>::Pool,
-    <N as RpcNodeCore>::Network,
-    <N as RpcNodeCore>::Evm,
-    Rpc,
->;
-
-/// A helper trait with requirements for [`RpcNodeCore`] to be used in [`OpEthApi`].
-pub trait OpNodeCore: RpcNodeCore<Provider: BlockReader, Evm: ConfigureEvm> {}
-impl<T> OpNodeCore for T where T: RpcNodeCore<Provider: BlockReader, Evm: ConfigureEvm> {}
+pub type EthApiNodeBackend<N, Rpc> = EthApiInner<N, Rpc>;
 
 /// OP-Reth `Eth` API implementation.
 ///
@@ -65,18 +49,18 @@ impl<T> OpNodeCore for T where T: RpcNodeCore<Provider: BlockReader, Evm: Config
 ///
 /// This type implements the [`FullEthApi`](reth_rpc_eth_api::helpers::FullEthApi) by implemented
 /// all the `Eth` helper traits and prerequisite traits.
-pub struct OpEthApi<N: OpNodeCore, Rpc: RpcConvert> {
+pub struct OpEthApi<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Gateway to node's core components.
     inner: Arc<OpEthApiInner<N, Rpc>>,
 }
 
-impl<N: OpNodeCore, Rpc: RpcConvert> Clone for OpEthApi<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> Clone for OpEthApi<N, Rpc> {
     fn clone(&self) -> Self {
         Self { inner: self.inner.clone() }
     }
 }
 
-impl<N: OpNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
     /// Creates a new `OpEthApi`.
     pub fn new(
         eth_api: EthApiNodeBackend<N, Rpc>,
@@ -105,11 +89,8 @@ impl<N: OpNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
 
 impl<N, Rpc> EthApiTypes for OpEthApi<N, Rpc>
 where
-    Self: Send + Sync + fmt::Debug,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
-    <N as RpcNodeCore>::Evm: fmt::Debug,
-    <N as RpcNodeCore>::Primitives: fmt::Debug,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     type Error = OpEthApiError;
     type NetworkTypes = Rpc::Network;
@@ -122,15 +103,14 @@ where
 
 impl<N, Rpc> RpcNodeCore for OpEthApi<N, Rpc>
 where
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     type Primitives = N::Primitives;
     type Provider = N::Provider;
     type Pool = N::Pool;
-    type Evm = <N as RpcNodeCore>::Evm;
-    type Network = <N as RpcNodeCore>::Network;
-    type PayloadBuilder = ();
+    type Evm = N::Evm;
+    type Network = N::Network;
 
     #[inline]
     fn pool(&self) -> &Self::Pool {
@@ -148,11 +128,6 @@ where
     }
 
     #[inline]
-    fn payload_builder(&self) -> &Self::PayloadBuilder {
-        &()
-    }
-
-    #[inline]
     fn provider(&self) -> &Self::Provider {
         self.inner.eth_api.provider()
     }
@@ -160,24 +135,19 @@ where
 
 impl<N, Rpc> RpcNodeCoreExt for OpEthApi<N, Rpc>
 where
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
-    fn cache(&self) -> &EthStateCache<ProviderBlock<N::Provider>, ProviderReceipt<N::Provider>> {
+    fn cache(&self) -> &EthStateCache<N::Primitives> {
         self.inner.eth_api.cache()
     }
 }
 
 impl<N, Rpc> EthApiSpec for OpEthApi<N, Rpc>
 where
-    N: OpNodeCore<
-        Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
-                      + BlockNumReader
-                      + StageCheckpointReader,
-        Network: NetworkInfo,
-    >,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     type Transaction = ProviderTx<Self::Provider>;
     type Rpc = Rpc::Network;
@@ -195,11 +165,8 @@ where
 
 impl<N, Rpc> SpawnBlocking for OpEthApi<N, Rpc>
 where
-    Self: Send + Sync + Clone + 'static,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
-    <N as RpcNodeCore>::Evm: fmt::Debug,
-    <N as RpcNodeCore>::Primitives: fmt::Debug,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {
@@ -219,13 +186,9 @@ where
 
 impl<N, Rpc> LoadFee for OpEthApi<N, Rpc>
 where
-    Self: LoadBlock<Provider = N::Provider>,
-    N: OpNodeCore<
-        Provider: BlockReaderIdExt
-                      + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
-                      + StateProviderFactory,
-    >,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {
@@ -245,21 +208,15 @@ where
 
 impl<N, Rpc> LoadState for OpEthApi<N, Rpc>
 where
-    N: OpNodeCore<
-        Provider: StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks>,
-        Pool: TransactionPool,
-    >,
-    Rpc: RpcConvert,
-    <N as RpcNodeCore>::Evm: fmt::Debug,
-    <N as RpcNodeCore>::Primitives: fmt::Debug,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 
 impl<N, Rpc> EthState for OpEthApi<N, Rpc>
 where
-    Self: LoadState + SpawnBlocking,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
     fn max_proof_window(&self) -> u64 {
@@ -269,36 +226,23 @@ where
 
 impl<N, Rpc> EthFees for OpEthApi<N, Rpc>
 where
-    Self: LoadFee<
-        Provider: ChainSpecProvider<
-            ChainSpec: EthChainSpec<Header = ProviderHeader<Self::Provider>>,
-        >,
-    >,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
 }
 
 impl<N, Rpc> Trace for OpEthApi<N, Rpc>
 where
-    Self: RpcNodeCore<Provider: BlockReader>
-        + LoadState<
-            Evm: ConfigureEvm<
-                Primitives: NodePrimitives<
-                    BlockHeader = ProviderHeader<Self::Provider>,
-                    SignedTx = ProviderTx<Self::Provider>,
-                >,
-            >,
-            Error: FromEvmError<Self::Evm>,
-        >,
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 
 impl<N, Rpc> AddDevSigners for OpEthApi<N, Rpc>
 where
-    N: OpNodeCore,
+    N: RpcNodeCore,
     Rpc: RpcConvert<
         Network: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<N::Provider>>>,
     >,
@@ -308,14 +252,14 @@ where
     }
 }
 
-impl<N: OpNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApi<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApi<N, Rpc> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpEthApi").finish_non_exhaustive()
     }
 }
 
 /// Container type `OpEthApi`
-pub struct OpEthApiInner<N: OpNodeCore, Rpc: RpcConvert> {
+pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Gateway to node's core components.
     eth_api: EthApiNodeBackend<N, Rpc>,
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
@@ -327,13 +271,13 @@ pub struct OpEthApiInner<N: OpNodeCore, Rpc: RpcConvert> {
     min_suggested_priority_fee: U256,
 }
 
-impl<N: OpNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApiInner<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApiInner<N, Rpc> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpEthApiInner").finish()
     }
 }
 
-impl<N: OpNodeCore, Rpc: RpcConvert> OpEthApiInner<N, Rpc> {
+impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApiInner<N, Rpc> {
     /// Returns a reference to the [`EthApiNodeBackend`].
     const fn eth_api(&self) -> &EthApiNodeBackend<N, Rpc> {
         &self.eth_api
@@ -424,22 +368,17 @@ where
         let rpc_converter =
             RpcConverter::new(OpReceiptConverter::new(ctx.components.provider().clone()))
                 .with_mapper(OpTxInfoMapper::new(ctx.components.provider().clone()));
-        let eth_api = reth_rpc::EthApiBuilder::new(
-            ctx.components.provider().clone(),
-            ctx.components.pool().clone(),
-            ctx.components.network().clone(),
-            ctx.components.evm_config().clone(),
-        )
-        .with_rpc_converter(rpc_converter)
-        .eth_cache(ctx.cache)
-        .task_spawner(ctx.components.task_executor().clone())
-        .gas_cap(ctx.config.rpc_gas_cap.into())
-        .max_simulate_blocks(ctx.config.rpc_max_simulate_blocks)
-        .eth_proof_window(ctx.config.eth_proof_window)
-        .fee_history_cache_config(ctx.config.fee_history_cache)
-        .proof_permits(ctx.config.proof_permits)
-        .gas_oracle_config(ctx.config.gas_oracle)
-        .build_inner();
+        let eth_api = reth_rpc::EthApiBuilder::new_with_components(ctx.components.clone())
+            .with_rpc_converter(rpc_converter)
+            .eth_cache(ctx.cache)
+            .task_spawner(ctx.components.task_executor().clone())
+            .gas_cap(ctx.config.rpc_gas_cap.into())
+            .max_simulate_blocks(ctx.config.rpc_max_simulate_blocks)
+            .eth_proof_window(ctx.config.eth_proof_window)
+            .fee_history_cache_config(ctx.config.fee_history_cache)
+            .proof_permits(ctx.config.proof_permits)
+            .gas_oracle_config(ctx.config.gas_oracle)
+            .build_inner();
 
         let sequencer_client = if let Some(url) = sequencer_url {
             Some(

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -2,49 +2,26 @@
 
 use std::sync::Arc;
 
-use crate::OpEthApi;
+use crate::{OpEthApi, OpEthApiError};
 use alloy_eips::BlockNumberOrTag;
-use reth_chainspec::ChainSpecProvider;
-use reth_evm::ConfigureEvm;
-use reth_node_api::NodePrimitives;
 use reth_primitives_traits::RecoveredBlock;
 use reth_rpc_eth_api::{
-    helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock, SpawnBlocking},
-    EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
+    helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock},
+    FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, PendingBlock};
 use reth_storage_api::{
-    BlockReader, BlockReaderIdExt, ProviderBlock, ProviderHeader, ProviderReceipt, ProviderTx,
-    ReceiptProvider, StateProviderFactory,
+    BlockReader, BlockReaderIdExt, ProviderBlock, ProviderReceipt, ReceiptProvider,
 };
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 impl<N, Rpc> LoadPendingBlock for OpEthApi<N, Rpc>
 where
-    Self: SpawnBlocking
-        + EthApiTypes<
-            Error: FromEvmError<Self::Evm>,
-            RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
-        >,
-    N: RpcNodeCore<
-        Provider: BlockReaderIdExt + ChainSpecProvider + StateProviderFactory,
-        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<N::Provider>>>,
-        Evm: ConfigureEvm<Primitives = Self::Primitives>,
-        Primitives: NodePrimitives<
-            BlockHeader = ProviderHeader<Self::Provider>,
-            SignedTx = ProviderTx<Self::Provider>,
-            Receipt = ProviderReceipt<Self::Provider>,
-            Block = ProviderBlock<Self::Provider>,
-        >,
-    >,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    OpEthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
-    fn pending_block(
-        &self,
-    ) -> &tokio::sync::Mutex<
-        Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>,
-    > {
+    fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<N::Primitives>>> {
         self.inner.eth_api.pending_block()
     }
 
@@ -66,20 +43,17 @@ where
         // See: <https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/miner/worker.go#L367-L375>
         let latest = self
             .provider()
-            .latest_header()
-            .map_err(Self::Error::from_eth_err)?
+            .latest_header()?
             .ok_or(EthApiError::HeaderNotFound(BlockNumberOrTag::Latest.into()))?;
         let block_id = latest.hash().into();
         let block = self
             .provider()
-            .recovered_block(block_id, Default::default())
-            .map_err(Self::Error::from_eth_err)?
+            .recovered_block(block_id, Default::default())?
             .ok_or(EthApiError::HeaderNotFound(block_id.into()))?;
 
         let receipts = self
             .provider()
-            .receipts_by_block(block_id)
-            .map_err(Self::Error::from_eth_err)?
+            .receipts_by_block(block_id)?
             .ok_or(EthApiError::ReceiptsNotFound(block_id.into()))?;
 
         Ok(Some((Arc::new(block), Arc::new(receipts))))

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -1,29 +1,23 @@
 //! Loads and formats OP transaction RPC response.
 
-use crate::{eth::OpNodeCore, OpEthApi, OpEthApiError, SequencerClient};
+use crate::{OpEthApi, OpEthApiError, SequencerClient};
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_eth::TransactionInfo;
 use op_alloy_consensus::{transaction::OpTransactionInfo, OpTxEnvelope};
 use reth_optimism_primitives::DepositReceipt;
 use reth_rpc_eth_api::{
-    helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction, SpawnBlocking},
-    try_into_op_tx_info, EthApiTypes, FromEthApiError, FullEthApiTypes, RpcConvert, RpcNodeCore,
-    RpcNodeCoreExt, TxInfoMapper,
+    helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction},
+    try_into_op_tx_info, FromEthApiError, RpcConvert, RpcNodeCore, TxInfoMapper,
 };
 use reth_rpc_eth_types::utils::recover_raw_transaction;
-use reth_storage_api::{
-    errors::ProviderError, BlockReader, BlockReaderIdExt, ProviderTx, ReceiptProvider,
-    TransactionsProvider,
-};
+use reth_storage_api::{errors::ProviderError, ReceiptProvider};
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 use std::fmt::{Debug, Formatter};
 
 impl<N, Rpc> EthTransactions for OpEthApi<N, Rpc>
 where
-    Self: LoadTransaction<Provider: BlockReaderIdExt>
-        + EthApiTypes<Error = OpEthApiError, NetworkTypes = Rpc::Network>,
-    N: OpNodeCore<Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>>,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.eth_api.signers()
@@ -72,17 +66,15 @@ where
 
 impl<N, Rpc> LoadTransaction for OpEthApi<N, Rpc>
 where
-    Self: SpawnBlocking + FullEthApiTypes + RpcNodeCoreExt,
-    N: OpNodeCore<Provider: TransactionsProvider, Pool: TransactionPool>,
-    Self::Pool: TransactionPool,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
 }
 
 impl<N, Rpc> OpEthApi<N, Rpc>
 where
-    N: OpNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     /// Returns the [`SequencerClient`] if one is set.
     pub fn raw_tx_forwarder(&self) -> Option<SequencerClient> {

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -45,13 +45,14 @@ use reth_rpc_eth_api::{
         pending_block::PendingEnvBuilder, Call, EthApiSpec, EthTransactions, LoadPendingBlock,
         TraceExt,
     },
+    node::RpcNodeCoreAdapter,
     EthApiServer, EthApiTypes, FullEthApiServer, RpcBlock, RpcConvert, RpcConverter, RpcHeader,
-    RpcReceipt, RpcTransaction, RpcTxReq,
+    RpcNodeCore, RpcReceipt, RpcTransaction, RpcTxReq,
 };
 use reth_rpc_eth_types::{receipt::EthReceiptConverter, EthConfig, EthSubscriptionIdProvider};
 use reth_rpc_layer::{AuthLayer, Claims, CompressionLayer, JwtAuthValidator, JwtSecret};
 use reth_storage_api::{
-    AccountReader, BlockReader, BlockReaderIdExt, ChangeSetReader, FullRpcProvider, ProviderBlock,
+    AccountReader, BlockReader, ChangeSetReader, FullRpcProvider, ProviderBlock,
     StateProviderFactory,
 };
 use reth_tasks::{pool::BlockingTaskGuard, TaskSpawner, TokioTaskExecutor};
@@ -253,20 +254,19 @@ impl<N, Provider, Pool, Network, EvmConfig, Consensus>
 
     /// Instantiates a new [`EthApiBuilder`] from the configured components.
     #[expect(clippy::type_complexity)]
-    pub fn eth_api_builder(
+    pub fn eth_api_builder<ChainSpec>(
         &self,
     ) -> EthApiBuilder<
-        Provider,
-        Pool,
-        Network,
-        EvmConfig,
-        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<Provider::ChainSpec>>,
+        RpcNodeCoreAdapter<Provider, Pool, Network, EvmConfig>,
+        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<ChainSpec>>,
     >
     where
-        Provider: BlockReaderIdExt + ChainSpecProvider + Clone,
+        Provider: Clone,
         Pool: Clone,
         Network: Clone,
         EvmConfig: Clone,
+        RpcNodeCoreAdapter<Provider, Pool, Network, EvmConfig>:
+            RpcNodeCore<Provider: ChainSpecProvider<ChainSpec = ChainSpec>, Evm = EvmConfig>,
     {
         EthApiBuilder::new(
             self.provider.clone(),
@@ -282,28 +282,20 @@ impl<N, Provider, Pool, Network, EvmConfig, Consensus>
     ///
     /// See also [`EthApiBuilder`].
     #[expect(clippy::type_complexity)]
-    pub fn bootstrap_eth_api(
+    pub fn bootstrap_eth_api<ChainSpec>(
         &self,
     ) -> EthApi<
-        Provider,
-        Pool,
-        Network,
-        EvmConfig,
-        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<Provider::ChainSpec>>,
+        RpcNodeCoreAdapter<Provider, Pool, Network, EvmConfig>,
+        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<ChainSpec>>,
     >
     where
-        N: NodePrimitives,
-        Provider: BlockReaderIdExt<Block = N::Block, Header = N::BlockHeader, Receipt = N::Receipt>
-            + StateProviderFactory
-            + CanonStateSubscriptions<Primitives = N>
-            + ChainSpecProvider
-            + Clone
-            + Unpin
-            + 'static,
+        Provider: Clone,
         Pool: Clone,
-        EvmConfig: ConfigureEvm,
         Network: Clone,
-        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<Provider::ChainSpec>>: RpcConvert,
+        EvmConfig: ConfigureEvm + Clone,
+        RpcNodeCoreAdapter<Provider, Pool, Network, EvmConfig>:
+            RpcNodeCore<Provider: ChainSpecProvider<ChainSpec = ChainSpec>, Evm = EvmConfig>,
+        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<ChainSpec>>: RpcConvert,
         (): PendingEnvBuilder<EvmConfig>,
     {
         self.eth_api_builder().build()
@@ -818,16 +810,11 @@ where
     /// # Panics
     ///
     /// If called outside of the tokio runtime. See also [`Self::eth_api`]
-    pub fn debug_api(&self) -> DebugApi<EthApi, EvmConfig>
+    pub fn debug_api(&self) -> DebugApi<EthApi>
     where
         EthApi: EthApiSpec + EthTransactions + TraceExt,
-        EvmConfig::Primitives: NodePrimitives<Block = ProviderBlock<EthApi::Provider>>,
     {
-        DebugApi::new(
-            self.eth_api().clone(),
-            self.blocking_pool_guard.clone(),
-            self.evm_config.clone(),
-        )
+        DebugApi::new(self.eth_api().clone(), self.blocking_pool_guard.clone())
     }
 
     /// Instantiates `NetApi`
@@ -859,7 +846,7 @@ where
         + ChangeSetReader,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
-    EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
+    EthApi: FullEthApiServer,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
     Consensus: FullConsensus<N, Error = ConsensusError> + Clone + 'static,
 {
@@ -944,13 +931,11 @@ where
                                 .into_rpc()
                                 .into()
                         }
-                        RethRpcModule::Debug => DebugApi::new(
-                            eth_api.clone(),
-                            self.blocking_pool_guard.clone(),
-                            self.evm_config.clone(),
-                        )
-                        .into_rpc()
-                        .into(),
+                        RethRpcModule::Debug => {
+                            DebugApi::new(eth_api.clone(), self.blocking_pool_guard.clone())
+                                .into_rpc()
+                                .into()
+                        }
                         RethRpcModule::Eth => {
                             // merge all eth handlers
                             let mut module = eth_api.clone().into_rpc();

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -3,7 +3,6 @@
 use crate::{
     fees::{CallFees, CallFeesError},
     RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes,
-};
 use alloy_consensus::{
     error::ValueError, transaction::Recovered, EthereumTxEnvelope, Sealable, TxEip4844,
 };

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -3,6 +3,7 @@
 use crate::{
     fees::{CallFees, CallFeesError},
     RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes,
+};
 use alloy_consensus::{
     error::ValueError, transaction::Recovered, EthereumTxEnvelope, Sealable, TxEip4844,
 };

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -40,7 +40,7 @@ pub struct ConvertReceiptInput<'a, N: NodePrimitives> {
 }
 
 /// A type that knows how to convert primitive receipts to RPC representations.
-pub trait ReceiptConverter<N: NodePrimitives>: Debug {
+pub trait ReceiptConverter<N: NodePrimitives>: Debug + 'static {
     /// RPC representation.
     type RpcReceipt;
 
@@ -56,7 +56,7 @@ pub trait ReceiptConverter<N: NodePrimitives>: Debug {
 }
 
 /// A type that knows how to convert a consensus header into an RPC header.
-pub trait HeaderConverter<Consensus, Rpc>: Debug + Send + Sync + Unpin + Clone {
+pub trait HeaderConverter<Consensus, Rpc>: Debug + Send + Sync + Unpin + Clone + 'static {
     /// Converts a consensus header into an RPC header.
     fn convert_header(&self, header: SealedHeader<Consensus>, block_size: usize) -> Rpc;
 }
@@ -92,7 +92,7 @@ impl<T: Sealable> FromConsensusHeader<T> for alloy_rpc_types_eth::Header<T> {
 /// A generic implementation [`RpcConverter`] should be preferred over a manual implementation. As
 /// long as its trait bound requirements are met, the implementation is created automatically and
 /// can be used in RPC method handlers for all the conversions.
-pub trait RpcConvert: Send + Sync + Unpin + Clone + Debug {
+pub trait RpcConvert: Send + Sync + Unpin + Clone + Debug + 'static {
     /// Associated lower layer consensus types to convert from and into types of [`Self::Network`].
     type Primitives: NodePrimitives;
 
@@ -468,7 +468,7 @@ impl<N, E, Evm, Receipt, Header, Map> RpcConvert for RpcConverter<E, Evm, Receip
 where
     N: NodePrimitives,
     E: RpcTypes + Send + Sync + Unpin + Clone + Debug,
-    Evm: ConfigureEvm<Primitives = N>,
+    Evm: ConfigureEvm<Primitives = N> + 'static,
     TxTy<N>: IntoRpcTx<E::TransactionResponse> + Clone + Debug,
     RpcTxReq<E>: TryIntoSimTx<TxTy<N>> + TryIntoTxEnv<TxEnvFor<Evm>>,
     Receipt: ReceiptConverter<
@@ -495,7 +495,8 @@ where
         + Debug
         + Unpin
         + Send
-        + Sync,
+        + Sync
+        + 'static,
 {
     type Primitives = N;
     type Network = E;

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -30,7 +30,6 @@ reth-rpc-server-types.workspace = true
 reth-network-api.workspace = true
 reth-node-api.workspace = true
 reth-trie-common = { workspace = true, features = ["eip1186"] }
-reth-payload-builder.workspace = true
 
 # ethereum
 alloy-evm = { workspace = true, features = ["overrides", "call-util"] }

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -10,11 +10,9 @@ use alloy_eips::BlockId;
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{Block, BlockTransactions, Index};
 use futures::Future;
-use reth_evm::ConfigureEvm;
 use reth_node_api::BlockBody;
 use reth_primitives_traits::{
-    AlloyBlockHeader, NodePrimitives, RecoveredBlock, SealedHeader, SignedTransaction,
-    TransactionMeta,
+    AlloyBlockHeader, RecoveredBlock, SealedHeader, SignedTransaction, TransactionMeta,
 };
 use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert, RpcHeader};
 use reth_storage_api::{BlockIdReader, BlockReader, ProviderHeader, ProviderReceipt, ProviderTx};
@@ -275,15 +273,7 @@ pub trait EthBlocks:
 /// Loads a block from database.
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` blocks RPC methods.
-pub trait LoadBlock:
-    LoadPendingBlock
-    + SpawnBlocking
-    + RpcNodeCoreExt<
-        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>>,
-        Primitives: NodePrimitives<SignedTx = ProviderTx<Self::Provider>>,
-        Evm: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
-    >
-{
+pub trait LoadBlock: LoadPendingBlock + SpawnBlocking + RpcNodeCoreExt {
     /// Returns the block object for the given block id.
     #[expect(clippy::type_complexity)]
     fn recovered_block(

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -26,7 +26,7 @@ use reth_evm::{
     ConfigureEvm, Evm, EvmEnv, EvmEnvFor, HaltReasonFor, InspectorFor, SpecFor, TransactionEnv,
     TxEnvFor,
 };
-use reth_node_api::{BlockBody, NodePrimitives};
+use reth_node_api::BlockBody;
 use reth_primitives_traits::{Recovered, SignedTransaction};
 use reth_revm::{
     database::StateProviderDatabase,
@@ -39,7 +39,7 @@ use reth_rpc_eth_types::{
     simulate::{self, EthSimulateError},
     EthApiError, RevertError, RpcInvalidTransactionError, StateCacheDb,
 };
-use reth_storage_api::{BlockIdReader, ProviderHeader, ProviderTx};
+use reth_storage_api::{BlockIdReader, ProviderTx};
 use revm::{
     context_interface::{
         result::{ExecutionResult, ResultAndState},
@@ -453,12 +453,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 /// Executes code on state.
 pub trait Call:
     LoadState<
-        Evm: ConfigureEvm<
-            Primitives: NodePrimitives<
-                BlockHeader = ProviderHeader<Self::Provider>,
-                SignedTx = ProviderTx<Self::Provider>,
-            >,
-        >,
         RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>>,
         Error: FromEvmError<Self::Evm>
                    + From<<Self::RpcConvert as RpcConvert>::Error>

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -14,9 +14,8 @@ use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
     ConfigureEvm, Evm, NextBlockEnvAttributes, SpecFor,
 };
-use reth_node_api::NodePrimitives;
 use reth_primitives_traits::{
-    transaction::error::InvalidTransactionError, HeaderTy, Receipt, RecoveredBlock, SealedHeader,
+    transaction::error::InvalidTransactionError, HeaderTy, RecoveredBlock, SealedHeader,
 };
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_rpc_convert::RpcConvert;
@@ -44,24 +43,12 @@ pub trait LoadPendingBlock:
     EthApiTypes<
         Error: FromEvmError<Self::Evm>,
         RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
-    > + RpcNodeCore<
-        Provider: BlockReaderIdExt<Receipt: Receipt> + ChainSpecProvider + StateProviderFactory,
-        Evm: ConfigureEvm<Primitives = Self::Primitives> + 'static,
-        Primitives: NodePrimitives<
-            BlockHeader = ProviderHeader<Self::Provider>,
-            SignedTx = ProviderTx<Self::Provider>,
-            Receipt = ProviderReceipt<Self::Provider>,
-            Block = ProviderBlock<Self::Provider>,
-        >,
-    >
+    > + RpcNodeCore
 {
     /// Returns a handle to the pending block.
     ///
     /// Data access in default (L1) trait method implementations.
-    #[expect(clippy::type_complexity)]
-    fn pending_block(
-        &self,
-    ) -> &Mutex<Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>>;
+    fn pending_block(&self) -> &Mutex<Option<PendingBlock<Self::Primitives>>>;
 
     /// Returns a [`PendingEnvBuilder`] for the pending block.
     fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<Self::Evm>;

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -4,11 +4,10 @@
 use crate::{EthApiTypes, RpcNodeCoreExt, RpcReceipt};
 use alloy_consensus::{transaction::TransactionMeta, TxReceipt};
 use futures::Future;
-use reth_node_api::NodePrimitives;
 use reth_primitives_traits::SignerRecoverable;
 use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert};
 use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
-use reth_storage_api::{ProviderReceipt, ProviderTx, ReceiptProvider, TransactionsProvider};
+use reth_storage_api::{ProviderReceipt, ProviderTx};
 use std::borrow::Cow;
 
 /// Assembles transaction receipt data w.r.t to network.
@@ -22,13 +21,8 @@ pub trait LoadReceipt:
             Network = Self::NetworkTypes,
         >,
         Error: FromEthApiError,
-    > + RpcNodeCoreExt<
-        Provider: TransactionsProvider + ReceiptProvider,
-        Primitives: NodePrimitives<
-            Receipt = ProviderReceipt<Self::Provider>,
-            SignedTx = ProviderTx<Self::Provider>,
-        >,
-    > + Send
+    > + RpcNodeCoreExt
+    + Send
     + Sync
 {
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -192,14 +192,7 @@ pub trait EthState: LoadState + SpawnBlocking {
 /// Loads state from database.
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` state RPC methods.
-pub trait LoadState:
-    EthApiTypes
-    + RpcNodeCoreExt<
-        Provider: StateProviderFactory
-                      + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>,
-        Pool: TransactionPool,
-    >
-{
+pub trait LoadState: EthApiTypes + RpcNodeCoreExt {
     /// Returns the state at the given block number
     fn state_at_hash(&self, block_hash: B256) -> Result<StateProviderBox, Self::Error> {
         self.provider().history_by_block_hash(block_hash).map_err(Self::Error::from_eth_err)

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -8,7 +8,6 @@ use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_eth::{Account, AccountInfo, EIP1186AccountProofResponse};
 use alloy_serde::JsonStorageKey;
 use futures::Future;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
 use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_rpc_eth_types::{EthApiError, PendingBlockEnv, RpcInvalidTransactionError};

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -12,31 +12,19 @@ use reth_evm::{
     evm::EvmFactoryExt, system_calls::SystemCaller, tracing::TracingCtx, ConfigureEvm, Database,
     Evm, EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TxEnvFor,
 };
-use reth_node_api::NodePrimitives;
 use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock, SignedTransaction};
 use reth_revm::{database::StateProviderDatabase, db::CacheDB};
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDb, StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},
     EthApiError,
 };
-use reth_storage_api::{BlockReader, ProviderBlock, ProviderHeader, ProviderTx};
+use reth_storage_api::{ProviderBlock, ProviderTx};
 use revm::{context_interface::result::ResultAndState, DatabaseCommit};
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use std::sync::Arc;
 
 /// Executes CPU heavy tasks.
-pub trait Trace:
-    LoadState<
-    Provider: BlockReader,
-    Evm: ConfigureEvm<
-        Primitives: NodePrimitives<
-            BlockHeader = ProviderHeader<Self::Provider>,
-            SignedTx = ProviderTx<Self::Provider>,
-        >,
-    >,
-    Error: FromEvmError<Self::Evm>,
->
-{
+pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
     /// Executes the [`reth_evm::EvmEnv`] against the given [Database] without committing state
     /// changes.
     #[expect(clippy::type_complexity)]

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -223,8 +223,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     where
         Self: 'static,
     {
-        let provider = self.provider().clone();
-        self.spawn_blocking_io(move |_| {
+        self.spawn_blocking_io(move |this| {
+            let provider = this.provider();
             let (tx, meta) = match provider
                 .transaction_by_hash_with_meta(hash)
                 .map_err(Self::Error::from_eth_err)?

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -1,6 +1,6 @@
 //! Helper trait for interfacing with [`FullNodeComponents`].
 
-use reth_chainspec::ChainSpecProvider;
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{FullNodeComponents, NodePrimitives, PrimitivesTy};
 use reth_primitives_traits::{BlockTy, HeaderTy, ReceiptTy, TxTy};
@@ -19,7 +19,7 @@ use reth_transaction_pool::{PoolTransaction, TransactionPool};
 /// where the full trait bounds of the components are not necessary.
 ///
 /// Every type that is a [`FullNodeComponents`] also implements this trait.
-pub trait RpcNodeCore: Clone + Send + Sync {
+pub trait RpcNodeCore: Clone + Send + Sync + Unpin + 'static {
     /// Blockchain data primitives.
     type Primitives: NodePrimitives;
     /// The provider type used to interact with the node.
@@ -29,7 +29,7 @@ pub trait RpcNodeCore: Clone + Send + Sync {
             Header = HeaderTy<Self::Primitives>,
             Transaction = TxTy<Self::Primitives>,
         > + NodePrimitivesProvider<Primitives = Self::Primitives>
-        + ChainSpecProvider
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + Send
         + Sync
@@ -56,7 +56,7 @@ pub trait RpcNodeCore: Clone + Send + Sync {
 
 impl<T> RpcNodeCore for T
 where
-    T: FullNodeComponents,
+    T: FullNodeComponents<Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>>,
 {
     type Primitives = PrimitivesTy<T::Types>;
     type Provider = T::Provider;

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -1,9 +1,14 @@
 //! Helper trait for interfacing with [`FullNodeComponents`].
 
-use reth_node_api::{FullNodeComponents, NodeTypes, PrimitivesTy};
-use reth_payload_builder::PayloadBuilderHandle;
+use reth_chainspec::ChainSpecProvider;
+use reth_evm::ConfigureEvm;
+use reth_node_api::{FullNodeComponents, NodePrimitives, PrimitivesTy};
+use reth_primitives_traits::{BlockTy, HeaderTy, ReceiptTy, TxTy};
 use reth_rpc_eth_types::EthStateCache;
-use reth_storage_api::{BlockReader, ProviderBlock, ProviderReceipt};
+use reth_storage_api::{
+    BlockReader, BlockReaderIdExt, NodePrimitivesProvider, StateProviderFactory,
+};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 /// Helper trait that provides the same interface as [`FullNodeComponents`] but without requiring
 /// implementation of trait bounds.
@@ -16,18 +21,25 @@ use reth_storage_api::{BlockReader, ProviderBlock, ProviderReceipt};
 /// Every type that is a [`FullNodeComponents`] also implements this trait.
 pub trait RpcNodeCore: Clone + Send + Sync {
     /// Blockchain data primitives.
-    type Primitives: Send + Sync + Clone + Unpin;
+    type Primitives: NodePrimitives;
     /// The provider type used to interact with the node.
-    type Provider: Send + Sync + Clone + Unpin;
+    type Provider: BlockReaderIdExt<
+            Block = BlockTy<Self::Primitives>,
+            Receipt = ReceiptTy<Self::Primitives>,
+            Header = HeaderTy<Self::Primitives>,
+            Transaction = TxTy<Self::Primitives>,
+        > + NodePrimitivesProvider<Primitives = Self::Primitives>
+        + ChainSpecProvider
+        + StateProviderFactory
+        + Send
+        + Sync
+        + 'static;
     /// The transaction pool of the node.
-    type Pool: Send + Sync + Clone + Unpin;
+    type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Primitives>>>;
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
-    type Evm: Send + Sync + Clone + Unpin;
+    type Evm: ConfigureEvm<Primitives = Self::Primitives> + Send + Sync + 'static;
     /// Network API.
     type Network: Send + Sync + Clone;
-
-    /// Builds new blocks.
-    type PayloadBuilder: Send + Sync + Clone;
 
     /// Returns the transaction pool of the node.
     fn pool(&self) -> &Self::Pool;
@@ -37,9 +49,6 @@ pub trait RpcNodeCore: Clone + Send + Sync {
 
     /// Returns the handle to the network
     fn network(&self) -> &Self::Network;
-
-    /// Returns the handle to the payload builder service.
-    fn payload_builder(&self) -> &Self::PayloadBuilder;
 
     /// Returns the provider of the node.
     fn provider(&self) -> &Self::Provider;
@@ -54,7 +63,6 @@ where
     type Pool = T::Pool;
     type Evm = T::Evm;
     type Network = T::Network;
-    type PayloadBuilder = PayloadBuilderHandle<<T::Types as NodeTypes>::Payload>;
 
     #[inline]
     fn pool(&self) -> &Self::Pool {
@@ -72,11 +80,6 @@ where
     }
 
     #[inline]
-    fn payload_builder(&self) -> &Self::PayloadBuilder {
-        FullNodeComponents::payload_builder_handle(self)
-    }
-
-    #[inline]
     fn provider(&self) -> &Self::Provider {
         FullNodeComponents::provider(self)
     }
@@ -86,7 +89,5 @@ where
 /// server.
 pub trait RpcNodeCoreExt: RpcNodeCore<Provider: BlockReader> {
     /// Returns handle to RPC cache service.
-    fn cache(
-        &self,
-    ) -> &EthStateCache<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>;
+    fn cache(&self) -> &EthStateCache<Self::Primitives>;
 }

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -1,12 +1,14 @@
 //! Helper trait for interfacing with [`FullNodeComponents`].
 
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_chain_state::CanonStateSubscriptions;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
+use reth_network_api::NetworkInfo;
 use reth_node_api::{FullNodeComponents, NodePrimitives, PrimitivesTy};
 use reth_primitives_traits::{BlockTy, HeaderTy, ReceiptTy, TxTy};
 use reth_rpc_eth_types::EthStateCache;
 use reth_storage_api::{
-    BlockReader, BlockReaderIdExt, NodePrimitivesProvider, StateProviderFactory,
+    BlockReader, BlockReaderIdExt, StageCheckpointReader, StateProviderFactory,
 };
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
@@ -28,18 +30,22 @@ pub trait RpcNodeCore: Clone + Send + Sync + Unpin + 'static {
             Receipt = ReceiptTy<Self::Primitives>,
             Header = HeaderTy<Self::Primitives>,
             Transaction = TxTy<Self::Primitives>,
-        > + NodePrimitivesProvider<Primitives = Self::Primitives>
-        + ChainSpecProvider<ChainSpec: EthereumHardforks>
-        + StateProviderFactory
+        > + ChainSpecProvider<
+            ChainSpec: EthChainSpec<Header = HeaderTy<Self::Primitives>> + EthereumHardforks,
+        > + StateProviderFactory
+        + CanonStateSubscriptions<Primitives = Self::Primitives>
+        + StageCheckpointReader
         + Send
         + Sync
+        + Clone
+        + Unpin
         + 'static;
     /// The transaction pool of the node.
     type Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Self::Primitives>>>;
     /// The node's EVM configuration, defining settings for the Ethereum Virtual Machine.
     type Evm: ConfigureEvm<Primitives = Self::Primitives> + Send + Sync + 'static;
     /// Network API.
-    type Network: Send + Sync + Clone;
+    type Network: NetworkInfo + Clone;
 
     /// Returns the transaction pool of the node.
     fn pool(&self) -> &Self::Pool;
@@ -90,4 +96,66 @@ where
 pub trait RpcNodeCoreExt: RpcNodeCore<Provider: BlockReader> {
     /// Returns handle to RPC cache service.
     fn cache(&self) -> &EthStateCache<Self::Primitives>;
+}
+
+/// An adapter that allows to construct [`RpcNodeCore`] from components.
+#[derive(Debug, Clone)]
+pub struct RpcNodeCoreAdapter<Provider, Pool, Network, Evm> {
+    provider: Provider,
+    pool: Pool,
+    network: Network,
+    evm_config: Evm,
+}
+
+impl<Provider, Pool, Network, Evm> RpcNodeCoreAdapter<Provider, Pool, Network, Evm> {
+    /// Creates a new `RpcNodeCoreAdapter` instance.
+    pub const fn new(provider: Provider, pool: Pool, network: Network, evm_config: Evm) -> Self {
+        Self { provider, pool, network, evm_config }
+    }
+}
+
+impl<Provider, Pool, Network, Evm> RpcNodeCore for RpcNodeCoreAdapter<Provider, Pool, Network, Evm>
+where
+    Provider: BlockReaderIdExt<
+            Block = BlockTy<Evm::Primitives>,
+            Receipt = ReceiptTy<Evm::Primitives>,
+            Header = HeaderTy<Evm::Primitives>,
+            Transaction = TxTy<Evm::Primitives>,
+        > + ChainSpecProvider<
+            ChainSpec: EthChainSpec<Header = HeaderTy<Evm::Primitives>> + EthereumHardforks,
+        > + StateProviderFactory
+        + CanonStateSubscriptions<Primitives = Evm::Primitives>
+        + StageCheckpointReader
+        + Send
+        + Sync
+        + Unpin
+        + Clone
+        + 'static,
+    Evm: ConfigureEvm + Clone + 'static,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Evm::Primitives>>>
+        + Unpin
+        + 'static,
+    Network: NetworkInfo + Clone + Unpin + 'static,
+{
+    type Primitives = Evm::Primitives;
+    type Provider = Provider;
+    type Pool = Pool;
+    type Evm = Evm;
+    type Network = Network;
+
+    fn pool(&self) -> &Self::Pool {
+        &self.pool
+    }
+
+    fn evm_config(&self) -> &Self::Evm {
+        &self.evm_config
+    }
+
+    fn network(&self) -> &Self::Network {
+        &self.network
+    }
+
+    fn provider(&self) -> &Self::Provider {
+        &self.provider
+    }
 }

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -218,7 +218,7 @@ pub async fn fee_history_cache_new_blocks_task<St, Provider, N>(
     fee_history_cache: FeeHistoryCache<N::BlockHeader>,
     mut events: St,
     provider: Provider,
-    cache: EthStateCache<N::Block, N::Receipt>,
+    cache: EthStateCache<N>,
 ) where
     St: Stream<Item = CanonStateNotification<N>> + Unpin + 'static,
     Provider:

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -15,7 +15,7 @@ use reth_rpc_server_types::{
         DEFAULT_MAX_GAS_PRICE, MAX_HEADER_HISTORY, MAX_REWARD_PERCENTILE_COUNT, SAMPLE_NUMBER,
     },
 };
-use reth_storage_api::{BlockReader, BlockReaderIdExt};
+use reth_storage_api::{BlockReaderIdExt, NodePrimitivesProvider};
 use schnellru::{ByLength, LruMap};
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
@@ -77,12 +77,12 @@ impl Default for GasPriceOracleConfig {
 #[derive(Debug)]
 pub struct GasPriceOracle<Provider>
 where
-    Provider: BlockReader,
+    Provider: NodePrimitivesProvider,
 {
     /// The type used to subscribe to block events and get block info
     provider: Provider,
     /// The cache for blocks
-    cache: EthStateCache<Provider::Block, Provider::Receipt>,
+    cache: EthStateCache<Provider::Primitives>,
     /// The config for the oracle
     oracle_config: GasPriceOracleConfig,
     /// The price under which the sample will be ignored.
@@ -94,13 +94,13 @@ where
 
 impl<Provider> GasPriceOracle<Provider>
 where
-    Provider: BlockReaderIdExt,
+    Provider: BlockReaderIdExt + NodePrimitivesProvider,
 {
     /// Creates and returns the [`GasPriceOracle`].
     pub fn new(
         provider: Provider,
         mut oracle_config: GasPriceOracleConfig,
-        cache: EthStateCache<Provider::Block, Provider::Receipt>,
+        cache: EthStateCache<Provider::Primitives>,
     ) -> Self {
         // sanitize the percentile to be less than 100
         if oracle_config.percentile > 100 {

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -10,7 +10,7 @@ use alloy_primitives::B256;
 use derive_more::Constructor;
 use reth_ethereum_primitives::Receipt;
 use reth_evm::EvmEnv;
-use reth_primitives_traits::{Block, RecoveredBlock, SealedHeader};
+use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock, SealedHeader};
 
 /// Configured [`EvmEnv`] for a pending block.
 #[derive(Debug, Clone, Constructor)]
@@ -75,11 +75,11 @@ impl<B: Block, R> PendingBlockEnvOrigin<B, R> {
 
 /// Locally built pending block for `pending` tag.
 #[derive(Debug, Constructor)]
-pub struct PendingBlock<B: Block, R> {
+pub struct PendingBlock<N: NodePrimitives> {
     /// Timestamp when the pending block is considered outdated.
     pub expires_at: Instant,
     /// The locally built pending block.
-    pub block: Arc<RecoveredBlock<B>>,
+    pub block: Arc<RecoveredBlock<N::Block>>,
     /// The receipts for the pending block
-    pub receipts: Arc<Vec<R>>,
+    pub receipts: Arc<Vec<N::Receipt>>,
 }

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -102,7 +102,7 @@ impl<ChainSpec> EthReceiptConverter<ChainSpec> {
 impl<N, ChainSpec> ReceiptConverter<N> for EthReceiptConverter<ChainSpec>
 where
     N: NodePrimitives<Receipt = Receipt>,
-    ChainSpec: EthChainSpec,
+    ChainSpec: EthChainSpec + 'static,
 {
     type Error = EthApiError;
     type RpcReceipt = TransactionReceipt;

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -4,10 +4,11 @@ use crate::{eth::core::EthApiInner, EthApi};
 use alloy_network::Ethereum;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::ChainSpecProvider;
-use reth_evm::ConfigureEvm;
-use reth_node_api::NodePrimitives;
+use reth_primitives_traits::HeaderTy;
 use reth_rpc_convert::{RpcConvert, RpcConverter};
-use reth_rpc_eth_api::helpers::pending_block::PendingEnvBuilder;
+use reth_rpc_eth_api::{
+    helpers::pending_block::PendingEnvBuilder, node::RpcNodeCoreAdapter, RpcNodeCore,
+};
 use reth_rpc_eth_types::{
     fee_history::fee_history_cache_new_blocks_task, receipt::EthReceiptConverter, EthStateCache,
     EthStateCacheConfig, FeeHistoryCache, FeeHistoryCacheConfig, GasCap, GasPriceOracle,
@@ -16,7 +17,6 @@ use reth_rpc_eth_types::{
 use reth_rpc_server_types::constants::{
     DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_SIMULATE_BLOCKS, DEFAULT_PROOF_PERMITS,
 };
-use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::{pool::BlockingTaskPool, TaskSpawner, TokioTaskExecutor};
 use std::sync::Arc;
 
@@ -25,14 +25,8 @@ use std::sync::Arc;
 /// This builder type contains all settings to create an [`EthApiInner`] or an [`EthApi`] instance
 /// directly.
 #[derive(Debug)]
-pub struct EthApiBuilder<Provider, Pool, Network, EvmConfig, Rpc, NextEnv = ()>
-where
-    Provider: BlockReaderIdExt,
-{
-    provider: Provider,
-    pool: Pool,
-    network: Network,
-    evm_config: EvmConfig,
+pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
+    components: N,
     rpc_converter: Rpc,
     gas_cap: GasCap,
     max_simulate_blocks: u64,
@@ -40,36 +34,39 @@ where
     fee_history_cache_config: FeeHistoryCacheConfig,
     proof_permits: usize,
     eth_state_cache_config: EthStateCacheConfig,
-    eth_cache: Option<EthStateCache<Provider::Block, Provider::Receipt>>,
+    eth_cache: Option<EthStateCache<N::Primitives>>,
     gas_oracle_config: GasPriceOracleConfig,
-    gas_oracle: Option<GasPriceOracle<Provider>>,
+    gas_oracle: Option<GasPriceOracle<N::Provider>>,
     blocking_task_pool: Option<BlockingTaskPool>,
     task_spawner: Box<dyn TaskSpawner + 'static>,
     next_env: NextEnv,
 }
 
-impl<Provider, Pool, Network, EvmConfig>
+impl<Provider, Pool, Network, EvmConfig, ChainSpec>
     EthApiBuilder<
-        Provider,
-        Pool,
-        Network,
-        EvmConfig,
-        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<Provider::ChainSpec>>,
+        RpcNodeCoreAdapter<Provider, Pool, Network, EvmConfig>,
+        RpcConverter<Ethereum, EvmConfig, EthReceiptConverter<ChainSpec>>,
     >
 where
-    Provider: BlockReaderIdExt + ChainSpecProvider,
+    RpcNodeCoreAdapter<Provider, Pool, Network, EvmConfig>:
+        RpcNodeCore<Provider: ChainSpecProvider<ChainSpec = ChainSpec>, Evm = EvmConfig>,
 {
     /// Creates a new `EthApiBuilder` instance.
-    pub fn new(provider: Provider, pool: Pool, network: Network, evm_config: EvmConfig) -> Self
-    where
-        Provider: BlockReaderIdExt,
-    {
-        let rpc_converter = RpcConverter::new(EthReceiptConverter::new(provider.chain_spec()));
+    pub fn new(provider: Provider, pool: Pool, network: Network, evm_config: EvmConfig) -> Self {
+        Self::new_with_components(RpcNodeCoreAdapter::new(provider, pool, network, evm_config))
+    }
+}
+
+impl<N, ChainSpec> EthApiBuilder<N, RpcConverter<Ethereum, N::Evm, EthReceiptConverter<ChainSpec>>>
+where
+    N: RpcNodeCore<Provider: ChainSpecProvider<ChainSpec = ChainSpec>>,
+{
+    /// Creates a new `EthApiBuilder` instance with the provided components.
+    pub fn new_with_components(components: N) -> Self {
+        let rpc_converter =
+            RpcConverter::new(EthReceiptConverter::new(components.provider().chain_spec()));
         Self {
-            provider,
-            pool,
-            network,
-            evm_config,
+            components,
             rpc_converter,
             eth_cache: None,
             gas_oracle: None,
@@ -87,10 +84,9 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc, NextEnv>
-    EthApiBuilder<Provider, Pool, Network, EvmConfig, Rpc, NextEnv>
+impl<N, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv>
 where
-    Provider: BlockReaderIdExt + ChainSpecProvider,
+    N: RpcNodeCore,
 {
     /// Configures the task spawner used to spawn additional tasks.
     pub fn task_spawner(mut self, spawner: impl TaskSpawner + 'static) -> Self {
@@ -102,12 +98,9 @@ where
     pub fn with_rpc_converter<RpcNew>(
         self,
         rpc_converter: RpcNew,
-    ) -> EthApiBuilder<Provider, Pool, Network, EvmConfig, RpcNew, NextEnv> {
+    ) -> EthApiBuilder<N, RpcNew, NextEnv> {
         let Self {
-            provider,
-            pool,
-            network,
-            evm_config,
+            components,
             rpc_converter: _,
             gas_cap,
             max_simulate_blocks,
@@ -123,10 +116,7 @@ where
             next_env,
         } = self;
         EthApiBuilder {
-            provider,
-            pool,
-            network,
-            evm_config,
+            components,
             rpc_converter,
             gas_cap,
             max_simulate_blocks,
@@ -147,12 +137,9 @@ where
     pub fn with_pending_env_builder<NextEnvNew>(
         self,
         next_env: NextEnvNew,
-    ) -> EthApiBuilder<Provider, Pool, Network, EvmConfig, Rpc, NextEnvNew> {
+    ) -> EthApiBuilder<N, Rpc, NextEnvNew> {
         let Self {
-            provider,
-            pool,
-            network,
-            evm_config,
+            components,
             rpc_converter,
             gas_cap,
             max_simulate_blocks,
@@ -168,10 +155,7 @@ where
             next_env: _,
         } = self;
         EthApiBuilder {
-            provider,
-            pool,
-            network,
-            evm_config,
+            components,
             rpc_converter,
             gas_cap,
             max_simulate_blocks,
@@ -199,10 +183,7 @@ where
     }
 
     /// Sets `eth_cache` instance
-    pub fn eth_cache(
-        mut self,
-        eth_cache: EthStateCache<Provider::Block, Provider::Receipt>,
-    ) -> Self {
+    pub fn eth_cache(mut self, eth_cache: EthStateCache<N::Primitives>) -> Self {
         self.eth_cache = Some(eth_cache);
         self
     }
@@ -215,7 +196,7 @@ where
     }
 
     /// Sets `gas_oracle` instance
-    pub fn gas_oracle(mut self, gas_oracle: GasPriceOracle<Provider>) -> Self {
+    pub fn gas_oracle(mut self, gas_oracle: GasPriceOracle<N::Provider>) -> Self {
         self.gas_oracle = Some(gas_oracle);
         self
     }
@@ -267,29 +248,13 @@ where
     ///
     /// This function panics if the blocking task pool cannot be built.
     /// This will panic if called outside the context of a Tokio runtime.
-    pub fn build_inner(self) -> EthApiInner<Provider, Pool, Network, EvmConfig, Rpc>
+    pub fn build_inner(self) -> EthApiInner<N, Rpc>
     where
-        Provider: BlockReaderIdExt
-            + StateProviderFactory
-            + ChainSpecProvider
-            + CanonStateSubscriptions<
-                Primitives: NodePrimitives<
-                    Block = Provider::Block,
-                    Receipt = Provider::Receipt,
-                    BlockHeader = Provider::Header,
-                >,
-            > + Clone
-            + Unpin
-            + 'static,
-        EvmConfig: ConfigureEvm,
         Rpc: RpcConvert,
-        NextEnv: PendingEnvBuilder<EvmConfig>,
+        NextEnv: PendingEnvBuilder<N::Evm>,
     {
         let Self {
-            provider,
-            pool,
-            network,
-            evm_config,
+            components,
             rpc_converter,
             eth_state_cache_config,
             gas_oracle_config,
@@ -305,27 +270,27 @@ where
             next_env,
         } = self;
 
+        let provider = components.provider().clone();
+
         let eth_cache = eth_cache
             .unwrap_or_else(|| EthStateCache::spawn(provider.clone(), eth_state_cache_config));
         let gas_oracle = gas_oracle.unwrap_or_else(|| {
             GasPriceOracle::new(provider.clone(), gas_oracle_config, eth_cache.clone())
         });
-        let fee_history_cache = FeeHistoryCache::<Provider::Header>::new(fee_history_cache_config);
+        let fee_history_cache =
+            FeeHistoryCache::<HeaderTy<N::Primitives>>::new(fee_history_cache_config);
         let new_canonical_blocks = provider.canonical_state_stream();
         let fhc = fee_history_cache.clone();
         let cache = eth_cache.clone();
-        let prov = provider.clone();
         task_spawner.spawn_critical(
             "cache canonical blocks for fee history task",
             Box::pin(async move {
-                fee_history_cache_new_blocks_task(fhc, new_canonical_blocks, prov, cache).await;
+                fee_history_cache_new_blocks_task(fhc, new_canonical_blocks, provider, cache).await;
             }),
         );
 
         EthApiInner::new(
-            provider,
-            pool,
-            network,
+            components,
             eth_cache,
             gas_oracle,
             gas_cap,
@@ -335,7 +300,6 @@ where
                 BlockingTaskPool::build().expect("failed to build blocking task pool")
             }),
             fee_history_cache,
-            evm_config,
             task_spawner,
             proof_permits,
             rpc_converter,
@@ -351,23 +315,10 @@ where
     ///
     /// This function panics if the blocking task pool cannot be built.
     /// This will panic if called outside the context of a Tokio runtime.
-    pub fn build(self) -> EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+    pub fn build(self) -> EthApi<N, Rpc>
     where
-        Provider: BlockReaderIdExt
-            + StateProviderFactory
-            + CanonStateSubscriptions<
-                Primitives: NodePrimitives<
-                    Block = Provider::Block,
-                    Receipt = Provider::Receipt,
-                    BlockHeader = Provider::Header,
-                >,
-            > + ChainSpecProvider
-            + Clone
-            + Unpin
-            + 'static,
         Rpc: RpcConvert,
-        EvmConfig: ConfigureEvm,
-        NextEnv: PendingEnvBuilder<EvmConfig>,
+        NextEnv: PendingEnvBuilder<N::Evm>,
     {
         EthApi { inner: Arc::new(self.build_inner()) }
     }

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -456,7 +456,7 @@ where
 
     /// Returns the inner `Network`
     #[inline]
-    pub const fn network(&self) -> &N::Network {
+    pub fn network(&self) -> &N::Network {
         self.components.network()
     }
 

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -376,8 +376,8 @@ where
         &self.pending_block
     }
 
-    /// Returns a type that knows how to build a [`ConfigureEvm::NextBlockEnvCtx`] for a pending
-    /// block.
+    /// Returns a type that knows how to build a [`reth_evm::ConfigureEvm::NextBlockEnvCtx`] for a
+    /// pending block.
     #[inline]
     pub const fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<N::Evm> {
         &*self.next_env_builder

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -13,7 +13,7 @@ use reth_errors::ProviderError;
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
 use reth_rpc_eth_api::{
     EngineEthFilter, EthApiTypes, EthFilterApiServer, FullEthApiTypes, QueryLimits, RpcConvert,
-    RpcNodeCore, RpcNodeCoreExt, RpcTransaction,
+    RpcNodeCoreExt, RpcTransaction,
 };
 use reth_rpc_eth_types::{
     logs_utils::{self, append_matching_block_logs, ProviderOrBlock},
@@ -22,7 +22,7 @@ use reth_rpc_eth_types::{
 use reth_rpc_server_types::{result::rpc_error_with_code, ToRpcResult};
 use reth_storage_api::{
     BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, HeaderProvider, ProviderBlock,
-    ProviderReceipt, ReceiptProvider, TransactionsProvider,
+    ProviderReceipt, ReceiptProvider,
 };
 use reth_tasks::TaskSpawner;
 use reth_transaction_pool::{NewSubpoolTransactionStream, PoolTransaction, TransactionPool};
@@ -1085,6 +1085,7 @@ mod tests {
     use reth_network_api::noop::NoopNetwork;
     use reth_provider::test_utils::MockEthProvider;
     use reth_rpc_convert::RpcConverter;
+    use reth_rpc_eth_api::node::RpcNodeCoreAdapter;
     use reth_rpc_eth_types::receipt::EthReceiptConverter;
     use reth_tasks::TokioTaskExecutor;
     use reth_testing_utils::generators;
@@ -1114,13 +1115,11 @@ mod tests {
     }
 
     // Helper function to create a test EthApi instance
+    #[expect(clippy::type_complexity)]
     fn build_test_eth_api(
         provider: MockEthProvider,
     ) -> EthApi<
-        MockEthProvider,
-        TestPool,
-        NoopNetwork,
-        EthEvmConfig,
+        RpcNodeCoreAdapter<MockEthProvider, TestPool, NoopNetwork, EthEvmConfig>,
         RpcConverter<Ethereum, EthEvmConfig, EthReceiptConverter<ChainSpec>>,
     > {
         EthApiBuilder::new(

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -304,13 +304,7 @@ where
 #[async_trait]
 impl<Eth> EthFilterApiServer<RpcTransaction<Eth::NetworkTypes>> for EthFilter<Eth>
 where
-    Eth: FullEthApiTypes
-        + RpcNodeCoreExt<
-            Provider: BlockIdReader,
-            Primitives: NodePrimitives<
-                SignedTx = <<Eth as RpcNodeCore>::Provider as TransactionsProvider>::Transaction,
-            >,
-        > + 'static,
+    Eth: FullEthApiTypes + RpcNodeCoreExt + 'static,
 {
     /// Handler for `eth_newFilter`
     async fn new_filter(&self, filter: Filter) -> RpcResult<FilterId> {
@@ -437,9 +431,7 @@ where
     }
 
     /// Access the underlying [`EthStateCache`].
-    fn eth_cache(
-        &self,
-    ) -> &EthStateCache<ProviderBlock<Eth::Provider>, ProviderReceipt<Eth::Provider>> {
+    fn eth_cache(&self) -> &EthStateCache<Eth::Primitives> {
         self.eth_api.cache()
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -2,50 +2,27 @@
 
 use reth_chainspec::ChainSpecProvider;
 use reth_evm::ConfigureEvm;
-use reth_primitives_traits::NodePrimitives;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, SpawnBlocking},
-    RpcNodeCoreExt,
+    RpcNodeCore, RpcNodeCoreExt,
 };
 use reth_rpc_eth_types::EthApiError;
-use reth_storage_api::{BlockReader, ProviderTx};
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use reth_storage_api::BlockReader;
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthBlocks
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthBlocks for EthApi<N, Rpc>
 where
-    Self: LoadBlock<
-        Error = EthApiError,
-        NetworkTypes = Rpc::Network,
-        RpcConvert: RpcConvert<
-            Primitives = Self::Primitives,
-            Error = Self::Error,
-            Network = Rpc::Network,
-        >,
-    >,
-    Provider: BlockReader + ChainSpecProvider,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadBlock
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadBlock for EthApi<N, Rpc>
 where
-    Self: LoadPendingBlock
-        + SpawnBlocking
-        + RpcNodeCoreExt<
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
-            Primitives: NodePrimitives<SignedTx = ProviderTx<Self::Provider>>,
-            Evm = EvmConfig,
-        >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
+    Self: LoadPendingBlock,
+    N: RpcNodeCore,
     Rpc: RpcConvert,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -1,14 +1,11 @@
 //! Contains RPC handler implementations specific to blocks.
 
-use reth_chainspec::ChainSpecProvider;
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
-    helpers::{EthBlocks, LoadBlock, LoadPendingBlock, SpawnBlocking},
-    FromEvmError, RpcNodeCore, RpcNodeCoreExt,
+    helpers::{EthBlocks, LoadBlock, LoadPendingBlock},
+    FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::EthApiError;
-use reth_storage_api::BlockReader;
 
 use crate::EthApi;
 
@@ -16,7 +13,7 @@ impl<N, Rpc> EthBlocks for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
@@ -24,6 +21,6 @@ impl<N, Rpc> LoadBlock for EthApi<N, Rpc>
 where
     Self: LoadPendingBlock,
     N: RpcNodeCore,
-    Rpc: RpcConvert,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -5,7 +5,7 @@ use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock, LoadPendingBlock, SpawnBlocking},
-    RpcNodeCore, RpcNodeCoreExt,
+    FromEvmError, RpcNodeCore, RpcNodeCoreExt,
 };
 use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::BlockReader;
@@ -15,6 +15,7 @@ use crate::EthApi;
 impl<N, Rpc> EthBlocks for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -8,34 +8,22 @@ use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEvmError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
 };
+use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::BlockReader;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthCall
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthCall for EthApi<N, Rpc>
 where
-    Self: EstimateCall<NetworkTypes = Rpc::Network>
-        + LoadPendingBlock<NetworkTypes = Rpc::Network>
-        + FullEthApiTypes<NetworkTypes = Rpc::Network>
-        + RpcNodeCoreExt<Evm = EvmConfig>,
-    EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
-    Provider: BlockReader,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> Call
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> Call for EthApi<N, Rpc>
 where
-    Self: LoadState<
-            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Rpc::Network>,
-            NetworkTypes = Rpc::Network,
-            Error: FromEvmError<Self::Evm>
-                       + From<<Self::RpcConvert as RpcConvert>::Error>
-                       + From<ProviderError>,
-        > + SpawnBlocking,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -48,12 +36,10 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EstimateCall
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EstimateCall for EthApi<N, Rpc>
 where
-    Self: Call<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -1,21 +1,19 @@
 //! Contains RPC handler implementations specific to endpoints that call/execute within evm.
 
 use crate::EthApi;
-use reth_errors::ProviderError;
-use reth_evm::{ConfigureEvm, TxEnvFor};
+use reth_evm::TxEnvFor;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
-    helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
-    FromEvmError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
+    helpers::{estimate::EstimateCall, Call, EthCall},
+    FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::EthApiError;
-use reth_storage_api::BlockReader;
 
 impl<N, Rpc> EthCall for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
 }
 
@@ -23,7 +21,7 @@ impl<N, Rpc> Call for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -40,6 +38,6 @@ impl<N, Rpc> EstimateCall for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -3,14 +3,12 @@
 use crate::EthApi;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, TxEnvFor};
-use reth_node_api::NodePrimitives;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall, LoadPendingBlock, LoadState, SpawnBlocking},
     FromEvmError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
 };
-use reth_storage_api::{BlockReader, ProviderHeader, ProviderTx};
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use reth_storage_api::BlockReader;
 
 impl<Provider, Pool, Network, EvmConfig, Rpc> EthCall
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
@@ -18,13 +16,7 @@ where
     Self: EstimateCall<NetworkTypes = Rpc::Network>
         + LoadPendingBlock<NetworkTypes = Rpc::Network>
         + FullEthApiTypes<NetworkTypes = Rpc::Network>
-        + RpcNodeCoreExt<
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
-            Primitives: NodePrimitives<SignedTx = ProviderTx<Self::Provider>>,
-            Evm = EvmConfig,
-        >,
+        + RpcNodeCoreExt<Evm = EvmConfig>,
     EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
     Provider: BlockReader,
     Rpc: RpcConvert,
@@ -35,12 +27,6 @@ impl<Provider, Pool, Network, EvmConfig, Rpc> Call
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
     Self: LoadState<
-            Evm: ConfigureEvm<
-                Primitives: NodePrimitives<
-                    BlockHeader = ProviderHeader<Self::Provider>,
-                    SignedTx = ProviderTx<Self::Provider>,
-                >,
-            >,
             RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Rpc::Network>,
             NetworkTypes = Rpc::Network,
             Error: FromEvmError<Self::Evm>

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -1,14 +1,12 @@
 //! Contains RPC handler implementations for fee history.
 
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
-    helpers::{EthFees, LoadBlock, LoadFee},
-    RpcNodeCore,
+    helpers::{EthFees, LoadFee},
+    FromEvmError, RpcNodeCore,
 };
-use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
-use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderHeader, StateProviderFactory};
+use reth_rpc_eth_types::{EthApiError, FeeHistoryCache, GasPriceOracle};
+use reth_storage_api::ProviderHeader;
 
 use crate::EthApi;
 
@@ -16,7 +14,7 @@ impl<N, Rpc> EthFees for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
@@ -24,7 +22,7 @@ impl<N, Rpc> LoadFee for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {
@@ -32,7 +30,7 @@ where
     }
 
     #[inline]
-    fn fee_history_cache(&self) -> &FeeHistoryCache<ProviderHeader<Provider>> {
+    fn fee_history_cache(&self) -> &FeeHistoryCache<ProviderHeader<N::Provider>> {
         self.inner.fee_history_cache()
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/fees.rs
+++ b/crates/rpc/rpc/src/eth/helpers/fees.rs
@@ -3,35 +3,28 @@
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
-use reth_rpc_eth_api::helpers::{EthFees, LoadBlock, LoadFee};
+use reth_rpc_eth_api::{
+    helpers::{EthFees, LoadBlock, LoadFee},
+    RpcNodeCore,
+};
 use reth_rpc_eth_types::{FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderHeader, StateProviderFactory};
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthFees
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthFees for EthApi<N, Rpc>
 where
-    Self: LoadFee<
-        Provider: ChainSpecProvider<
-            ChainSpec: EthChainSpec<Header = ProviderHeader<Self::Provider>>,
-        >,
-    >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadFee
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadFee for EthApi<N, Rpc>
 where
-    Self: LoadBlock<Provider = Provider>,
-    Provider: BlockReaderIdExt
-        + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
-        + StateProviderFactory,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -12,12 +12,9 @@ use reth_storage_api::{BlockReader, ProviderBlock, ProviderReceipt};
 
 impl<N, Rpc> LoadPendingBlock for EthApi<N, Rpc>
 where
-    Self: SpawnBlocking<
-            NetworkTypes = Rpc::Network,
-            Error: FromEvmError<Self::Evm>,
-            RpcConvert: RpcConvert<Network = Rpc::Network>,
-        > + RpcNodeCore,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
     fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<Self::Primitives>>> {

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -1,14 +1,12 @@
 //! Support for building a pending block with transactions from local view of mempool.
 
 use crate::EthApi;
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
-    helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock, SpawnBlocking},
+    helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock},
     FromEvmError, RpcNodeCore,
 };
-use reth_rpc_eth_types::PendingBlock;
-use reth_storage_api::{BlockReader, ProviderBlock, ProviderReceipt};
+use reth_rpc_eth_types::{EthApiError, PendingBlock};
 
 impl<N, Rpc> LoadPendingBlock for EthApi<N, Rpc>
 where

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -1,53 +1,26 @@
 //! Support for building a pending block with transactions from local view of mempool.
 
 use crate::EthApi;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
-use reth_node_api::NodePrimitives;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock, SpawnBlocking},
     FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::PendingBlock;
-use reth_storage_api::{
-    BlockReader, BlockReaderIdExt, ProviderBlock, ProviderHeader, ProviderReceipt, ProviderTx,
-    StateProviderFactory,
-};
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use reth_storage_api::{BlockReader, ProviderBlock, ProviderReceipt};
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadPendingBlock
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadPendingBlock for EthApi<N, Rpc>
 where
     Self: SpawnBlocking<
             NetworkTypes = Rpc::Network,
             Error: FromEvmError<Self::Evm>,
             RpcConvert: RpcConvert<Network = Rpc::Network>,
-        > + RpcNodeCore<
-            Provider: BlockReaderIdExt<Receipt = Provider::Receipt, Block = Provider::Block>
-                          + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
-                          + StateProviderFactory,
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
-            Evm = EvmConfig,
-            Primitives: NodePrimitives<
-                BlockHeader = ProviderHeader<Self::Provider>,
-                SignedTx = ProviderTx<Self::Provider>,
-                Receipt = ProviderReceipt<Self::Provider>,
-                Block = ProviderBlock<Self::Provider>,
-            >,
-        >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm<Primitives = Self::Primitives>,
+        > + RpcNodeCore,
     Rpc: RpcConvert,
 {
     #[inline]
-    fn pending_block(
-        &self,
-    ) -> &tokio::sync::Mutex<
-        Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>,
-    > {
+    fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<Self::Primitives>>> {
         self.inner.pending_block()
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -4,20 +4,15 @@ use crate::EthApi;
 use alloy_consensus::crypto::RecoveryError;
 use reth_chainspec::ChainSpecProvider;
 use reth_evm::ConfigureEvm;
-use reth_node_api::NodePrimitives;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{helpers::LoadReceipt, EthApiTypes, RpcNodeCoreExt};
-use reth_storage_api::{BlockReader, ProviderReceipt, ProviderTx};
+use reth_storage_api::BlockReader;
 
 impl<Provider, Pool, Network, EvmConfig, Rpc> LoadReceipt
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
-    Self: RpcNodeCoreExt<
-            Primitives: NodePrimitives<
-                SignedTx = ProviderTx<Self::Provider>,
-                Receipt = ProviderReceipt<Self::Provider>,
-            >,
-        > + EthApiTypes<
+    Self: RpcNodeCoreExt
+        + EthApiTypes<
             NetworkTypes = Rpc::Network,
             RpcConvert: RpcConvert<
                 Network = Rpc::Network,

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -1,28 +1,14 @@
 //! Builds an RPC receipt response w.r.t. data layout of network.
 
 use crate::EthApi;
-use alloy_consensus::crypto::RecoveryError;
-use reth_chainspec::ChainSpecProvider;
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
-use reth_rpc_eth_api::{helpers::LoadReceipt, EthApiTypes, RpcNodeCoreExt};
-use reth_storage_api::BlockReader;
+use reth_rpc_eth_api::{helpers::LoadReceipt, FromEvmError, RpcNodeCore};
+use reth_rpc_eth_types::EthApiError;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadReceipt
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadReceipt for EthApi<N, Rpc>
 where
-    Self: RpcNodeCoreExt
-        + EthApiTypes<
-            NetworkTypes = Rpc::Network,
-            RpcConvert: RpcConvert<
-                Network = Rpc::Network,
-                Primitives = Self::Primitives,
-                Error = Self::Error,
-            >,
-            Error: From<RecoveryError>,
-        >,
-    Provider: BlockReader + ChainSpecProvider,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -8,18 +8,21 @@ use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::{eip191_hash_message, Address, Signature, B256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::{RpcConvert, RpcTypes, SignableTxRequest};
-use reth_rpc_eth_api::helpers::{signer::Result, AddDevSigners, EthSigner};
-use reth_rpc_eth_types::SignError;
-use reth_storage_api::{BlockReader, ProviderTx};
+use reth_rpc_eth_api::{
+    helpers::{signer::Result, AddDevSigners, EthSigner},
+    FromEvmError, RpcNodeCore,
+};
+use reth_rpc_eth_types::{EthApiError, SignError};
+use reth_storage_api::ProviderTx;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> AddDevSigners
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> AddDevSigners for EthApi<N, Rpc>
 where
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert<Network: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<Provider>>>>,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<
+        Network: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<N::Provider>>>,
+    >,
 {
     fn with_dev_accounts(&self) {
         *self.inner.signers().write() = DevSigner::random_signers(20)

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,30 +1,19 @@
 use alloy_primitives::U256;
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_evm::ConfigureEvm;
-use reth_network_api::NetworkInfo;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForApi, EthApiSpec},
     RpcNodeCore,
 };
-use reth_storage_api::{BlockNumReader, BlockReader, ProviderTx, StageCheckpointReader};
+use reth_storage_api::ProviderTx;
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthApiSpec
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthApiSpec for EthApi<N, Rpc>
 where
-    Self: RpcNodeCore<
-        Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
-                      + BlockNumReader
-                      + StageCheckpointReader,
-        Network: NetworkInfo,
-    >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
-    type Transaction = ProviderTx<Provider>;
+    type Transaction = ProviderTx<N::Provider>;
     type Rpc = Rpc::Network;
 
     fn starting_block(&self) -> U256 {

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -1,14 +1,9 @@
 //! Contains RPC handler implementations specific to state.
 
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
-use reth_storage_api::{BlockReader, StateProviderFactory};
-use reth_transaction_pool::TransactionPool;
-
 use reth_rpc_eth_api::{
-    helpers::{EthState, LoadState, SpawnBlocking},
-    EthApiTypes, RpcNodeCore, RpcNodeCoreExt,
+    helpers::{EthState, LoadState},
+    RpcNodeCore,
 };
 
 use crate::EthApi;
@@ -35,77 +30,42 @@ mod tests {
     use crate::eth::helpers::types::EthRpcConverter;
 
     use super::*;
-    use alloy_consensus::Header;
-    use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use alloy_primitives::{Address, StorageKey, StorageValue, U256};
     use reth_chainspec::ChainSpec;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
-    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider, NoopProvider};
-    use reth_rpc_eth_api::helpers::EthState;
-    use reth_rpc_eth_types::{
-        receipt::EthReceiptConverter, EthStateCache, FeeHistoryCache, FeeHistoryCacheConfig,
-        GasPriceOracle,
+    use reth_provider::{
+        test_utils::{ExtendedAccount, MockEthProvider, NoopProvider},
+        ChainSpecProvider,
     };
-    use reth_rpc_server_types::constants::{
-        DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_SIMULATE_BLOCKS, DEFAULT_PROOF_PERMITS,
-    };
-    use reth_tasks::pool::BlockingTaskPool;
+    use reth_rpc_eth_api::{helpers::EthState, node::RpcNodeCoreAdapter};
     use reth_transaction_pool::test_utils::{testing_pool, TestPool};
     use std::collections::HashMap;
 
-    fn noop_eth_api(
-    ) -> EthApi<NoopProvider, TestPool, NoopNetwork, EthEvmConfig, EthRpcConverter<ChainSpec>> {
+    fn noop_eth_api() -> EthApi<
+        RpcNodeCoreAdapter<NoopProvider, TestPool, NoopNetwork, EthEvmConfig>,
+        EthRpcConverter<ChainSpec>,
+    > {
         let provider = NoopProvider::default();
         let pool = testing_pool();
         let evm_config = EthEvmConfig::mainnet();
 
-        let cache = EthStateCache::spawn(NoopProvider::default(), Default::default());
-        let rpc_converter = EthRpcConverter::new(EthReceiptConverter::new(provider.chain_spec()));
-        EthApi::new(
-            provider,
-            pool,
-            NoopNetwork::default(),
-            cache.clone(),
-            GasPriceOracle::new(NoopProvider::default(), Default::default(), cache),
-            ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            DEFAULT_MAX_SIMULATE_BLOCKS,
-            DEFAULT_ETH_PROOF_WINDOW,
-            BlockingTaskPool::build().expect("failed to build tracing pool"),
-            FeeHistoryCache::<Header>::new(FeeHistoryCacheConfig::default()),
-            evm_config,
-            DEFAULT_PROOF_PERMITS,
-            rpc_converter,
-        )
+        EthApi::builder(provider, pool, NoopNetwork::default(), evm_config).build()
     }
 
     fn mock_eth_api(
         accounts: HashMap<Address, ExtendedAccount>,
-    ) -> EthApi<MockEthProvider, TestPool, (), EthEvmConfig, EthRpcConverter<ChainSpec>> {
+    ) -> EthApi<
+        RpcNodeCoreAdapter<MockEthProvider, TestPool, NoopNetwork, EthEvmConfig>,
+        EthRpcConverter<ChainSpec>,
+    > {
         let pool = testing_pool();
         let mock_provider = MockEthProvider::default();
 
         let evm_config = EthEvmConfig::new(mock_provider.chain_spec());
         mock_provider.extend_accounts(accounts);
 
-        let cache = EthStateCache::spawn(mock_provider.clone(), Default::default());
-        let rpc_converter =
-            EthRpcConverter::new(EthReceiptConverter::new(mock_provider.chain_spec()));
-        EthApi::new(
-            mock_provider.clone(),
-            pool,
-            (),
-            cache.clone(),
-            GasPriceOracle::new(mock_provider, Default::default(), cache),
-            ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            DEFAULT_MAX_SIMULATE_BLOCKS,
-            DEFAULT_ETH_PROOF_WINDOW + 1,
-            BlockingTaskPool::build().expect("failed to build tracing pool"),
-            FeeHistoryCache::<Header>::new(FeeHistoryCacheConfig::default()),
-            evm_config,
-            DEFAULT_PROOF_PERMITS,
-            rpc_converter,
-        )
+        EthApi::builder(mock_provider, pool, NoopNetwork::default(), evm_config).build()
     }
 
     #[tokio::test]

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -8,36 +8,25 @@ use reth_transaction_pool::TransactionPool;
 
 use reth_rpc_eth_api::{
     helpers::{EthState, LoadState, SpawnBlocking},
-    EthApiTypes, RpcNodeCoreExt,
+    EthApiTypes, RpcNodeCore, RpcNodeCoreExt,
 };
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthState
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthState for EthApi<N, Rpc>
 where
-    Self: LoadState + SpawnBlocking,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_proof_window()
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadState
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadState for EthApi<N, Rpc>
 where
-    Self: RpcNodeCoreExt<
-            Provider: BlockReader
-                          + StateProviderFactory
-                          + ChainSpecProvider<ChainSpec: EthereumHardforks>,
-            Pool: TransactionPool,
-        > + EthApiTypes<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -1,12 +1,8 @@
 //! Contains RPC handler implementations specific to tracing.
 
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
-use reth_rpc_eth_api::{
-    helpers::{LoadState, Trace},
-    FromEvmError,
-};
-use reth_storage_api::BlockReader;
+use reth_rpc_eth_api::{helpers::Trace, FromEvmError, RpcNodeCore};
+use reth_rpc_eth_types::EthApiError;
 
 use crate::EthApi;
 
@@ -14,6 +10,6 @@ impl<N, Rpc> Trace for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    RpcConvert: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -1,29 +1,19 @@
 //! Contains RPC handler implementations specific to tracing.
 
 use reth_evm::ConfigureEvm;
-use reth_node_api::NodePrimitives;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{LoadState, Trace},
     FromEvmError,
 };
-use reth_storage_api::{BlockReader, ProviderHeader, ProviderTx};
+use reth_storage_api::BlockReader;
 
 use crate::EthApi;
 
 impl<Provider, Pool, Network, EvmConfig, Rpc> Trace
     for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
 where
-    Self: LoadState<
-        Provider: BlockReader,
-        Evm: ConfigureEvm<
-            Primitives: NodePrimitives<
-                BlockHeader = ProviderHeader<Self::Provider>,
-                SignedTx = ProviderTx<Self::Provider>,
-            >,
-        >,
-        Error: FromEvmError<Self::Evm>,
-    >,
+    Self: LoadState<Error: FromEvmError<Self::Evm>>,
     Provider: BlockReader,
     EvmConfig: ConfigureEvm,
     Rpc: RpcConvert,

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -10,12 +10,10 @@ use reth_storage_api::BlockReader;
 
 use crate::EthApi;
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> Trace
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> Trace for EthApi<N, Rpc>
 where
-    Self: LoadState<Error: FromEvmError<Self::Evm>>,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    RpcConvert: RpcConvert<Primitives = N::Primitives>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -2,23 +2,19 @@
 
 use crate::EthApi;
 use alloy_primitives::{Bytes, B256};
-use reth_evm::ConfigureEvm;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
-    helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction, SpawnBlocking},
-    EthApiTypes, FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
+    helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction},
+    FromEvmError, RpcNodeCore,
 };
-use reth_rpc_eth_types::utils::recover_raw_transaction;
-use reth_storage_api::{BlockReader, BlockReaderIdExt, ProviderTx, TransactionsProvider};
+use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError};
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthTransactions
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthTransactions for EthApi<N, Rpc>
 where
-    Self: LoadTransaction<Provider: BlockReaderIdExt> + EthApiTypes<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
     #[inline]
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
@@ -37,49 +33,29 @@ where
         let pool_transaction = <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
 
         // submit the transaction to the pool with a `Local` origin
-        let hash = self
-            .pool()
-            .add_transaction(TransactionOrigin::Local, pool_transaction)
-            .await
-            .map_err(Self::Error::from_eth_err)?;
+        let hash = self.pool().add_transaction(TransactionOrigin::Local, pool_transaction).await?;
 
         Ok(hash)
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadTransaction
-    for EthApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadTransaction for EthApi<N, Rpc>
 where
-    Self: SpawnBlocking
-        + FullEthApiTypes
-        + RpcNodeCoreExt<Provider: TransactionsProvider, Pool: TransactionPool>
-        + EthApiTypes<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::eth::helpers::types::EthRpcConverter;
-
     use super::*;
-    use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
     use alloy_primitives::{hex_literal::hex, Bytes};
     use reth_chainspec::ChainSpecProvider;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_provider::test_utils::NoopProvider;
     use reth_rpc_eth_api::helpers::EthTransactions;
-    use reth_rpc_eth_types::{
-        receipt::EthReceiptConverter, EthStateCache, FeeHistoryCache, FeeHistoryCacheConfig,
-        GasPriceOracle,
-    };
-    use reth_rpc_server_types::constants::{
-        DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_SIMULATE_BLOCKS, DEFAULT_PROOF_PERMITS,
-    };
-    use reth_tasks::pool::BlockingTaskPool;
     use reth_transaction_pool::{test_utils::testing_pool, TransactionPool};
 
     #[tokio::test]
@@ -90,25 +66,9 @@ mod tests {
         let pool = testing_pool();
 
         let evm_config = EthEvmConfig::new(noop_provider.chain_spec());
-        let cache = EthStateCache::spawn(noop_provider.clone(), Default::default());
-        let fee_history_cache = FeeHistoryCache::new(FeeHistoryCacheConfig::default());
-        let rpc_converter =
-            EthRpcConverter::new(EthReceiptConverter::new(noop_provider.chain_spec()));
-        let eth_api = EthApi::new(
-            noop_provider.clone(),
-            pool.clone(),
-            noop_network_provider,
-            cache.clone(),
-            GasPriceOracle::new(noop_provider, Default::default(), cache.clone()),
-            ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            DEFAULT_MAX_SIMULATE_BLOCKS,
-            DEFAULT_ETH_PROOF_WINDOW,
-            BlockingTaskPool::build().expect("failed to build tracing pool"),
-            fee_history_cache,
-            evm_config,
-            DEFAULT_PROOF_PERMITS,
-            rpc_converter,
-        );
+        let eth_api =
+            EthApi::builder(noop_provider.clone(), pool.clone(), noop_network_provider, evm_config)
+                .build();
 
         // https://etherscan.io/tx/0xa694b71e6c128a2ed8e2e0f6770bddbe52e3bb8f10e8472f9a79ab81497a8b5d
         let tx_1 = Bytes::from(hex!(


### PR DESCRIPTION
Based on #17490 

This flattens `EthApi` component generics into a single `N: RpcNodeCore` generic and enforces harder bounds on `RpcNodeCore` to make it similar to `FullNodeComponents`.

This allows to substantially simplify some of the RPC bounds, making most of them look like:
https://github.com/paradigmxyz/reth/blob/029ffadd3b59b268b176fd70d4e31c0dbd3df747/crates/rpc/rpc/src/eth/helpers/trace.rs#L9-L15

Which is still not perfect but feels much easier to deal with