### PR TITLE
docs: fix Sepolia URL description

### DIFF
--- a/crates/era/tests/it/main.rs
+++ b/crates/era/tests/it/main.rs
@@ -49,7 +49,7 @@ const ERA1_MAINNET_FILES_NAMES: [&str; 6] = [
 /// Sepolia network name
 const SEPOLIA: &str = "sepolia";
 
-/// Default sepolia mainnet url
+/// Default sepolia url
 /// for downloading sepolia `.era1` files
 const SEPOLIA_URL: &str = "https://era.ithaca.xyz/sepolia-era1/";
 


### PR DESCRIPTION
Remove redundant `mainnet` word in the `SEPOLIA_URL` constant comment