### PR TITLE
feat: Add IPC socket permission configuration

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -94,6 +94,12 @@ pub struct RpcServerArgs {
     #[arg(long, default_value_t = constants::DEFAULT_IPC_ENDPOINT.to_string())]
     pub ipcpath: String,
 
+    /// Set the permissions for the IPC socket file, in octal format.
+    ///
+    /// If not specified, the permissions will be set by the system's umask.
+    #[arg(long = "ipc.permissions")]
+    pub ipc_socket_permissions: Option<String>,
+
     /// Auth server address to listen on
     #[arg(long = "authrpc.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub auth_addr: IpAddr,
@@ -337,6 +343,7 @@ impl Default for RpcServerArgs {
             ws_api: None,
             ipcdisable: false,
             ipcpath: constants::DEFAULT_IPC_ENDPOINT.to_string(),
+            ipc_socket_permissions: None,
             auth_addr: Ipv4Addr::LOCALHOST.into(),
             auth_port: constants::DEFAULT_AUTH_PORT,
             auth_jwtsecret: None,

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -19,6 +19,7 @@ use jsonrpsee::{
 use std::{
     future::Future,
     io,
+    os::unix::fs::PermissionsExt,
     pin::{pin, Pin},
     sync::Arc,
     task::{Context, Poll},
@@ -139,7 +140,15 @@ where
             .to_fs_name::<GenericFilePath>()
             .and_then(|name| ListenerOptions::new().name(name).create_tokio())
         {
-            Ok(listener) => listener,
+            Ok(listener) => {
+                if let Some(perms_str) = &self.cfg.ipc_socket_permissions {
+                    if let Ok(mode) = u32::from_str_radix(&perms_str.replace("0o", ""), 8) {
+                        let perms = std::fs::Permissions::from_mode(mode);
+                        let _ = std::fs::set_permissions(&self.endpoint, perms);
+                    }
+                }
+                listener
+            }
             Err(err) => {
                 on_ready
                     .send(Err(IpcServerStartError { endpoint: self.endpoint.clone(), source: err }))
@@ -550,6 +559,8 @@ pub struct Settings {
     message_buffer_capacity: u32,
     /// Custom tokio runtime to run the server on.
     tokio_runtime: Option<tokio::runtime::Handle>,
+    /// The permissions to create the IPC socket with.
+    ipc_socket_permissions: Option<String>,
 }
 
 impl Default for Settings {
@@ -562,6 +573,7 @@ impl Default for Settings {
             max_subscriptions_per_connection: 1024,
             message_buffer_capacity: 1024,
             tokio_runtime: None,
+            ipc_socket_permissions: None,
         }
     }
 }
@@ -645,6 +657,12 @@ impl<HttpMiddleware, RpcMiddleware> Builder<HttpMiddleware, RpcMiddleware> {
     /// Default: [`tokio::spawn`]
     pub fn custom_tokio_runtime(mut self, rt: tokio::runtime::Handle) -> Self {
         self.settings.tokio_runtime = Some(rt);
+        self
+    }
+
+    /// Sets the permissions for the IPC socket file.
+    pub fn set_ipc_socket_permissions(mut self, permissions: Option<String>) -> Self {
+        self.settings.ipc_socket_permissions = permissions;
         self
     }
 
@@ -767,6 +785,22 @@ mod tests {
     use std::pin::pin;
     use tokio::sync::broadcast;
     use tokio_stream::wrappers::BroadcastStream;
+
+    #[tokio::test]
+    async fn test_ipc_socket_permissions() {
+        let endpoint = &dummy_name();
+        let perms = "0777";
+        let server = Builder::default()
+            .set_ipc_socket_permissions(Some(perms.to_string()))
+            .build(endpoint.clone());
+        let module = RpcModule::new(());
+        let handle = server.start(module).await.unwrap();
+        tokio::spawn(handle.stopped());
+
+        let meta = std::fs::metadata(endpoint).unwrap();
+        let perms = meta.permissions();
+        assert_eq!(perms.mode() & 0o777, 0o777);
+    }
 
     async fn pipe_from_stream_with_bounded_buffer(
         pending: PendingSubscriptionSink,

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -174,6 +174,7 @@ impl RethRpcServerConfig for RpcServerArgs {
             .max_request_body_size(self.rpc_max_request_size_bytes())
             .max_response_body_size(self.rpc_max_response_size_bytes())
             .max_connections(self.rpc_max_connections.get())
+            .set_ipc_socket_permissions(self.ipc_socket_permissions.clone())
     }
 
     fn rpc_server_config(&self) -> RpcServerConfig {

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -287,6 +287,11 @@ RPC:
 
           [default: <CACHE_DIR>.ipc]
 
+      --ipc.permissions <IPC_SOCKET_PERMISSIONS>
+          Set the permissions for the IPC socket file, in octal format.
+
+          If not specified, the permissions will be set by the system's umask.
+
       --authrpc.addr <AUTH_ADDR>
           Auth server address to listen on
 


### PR DESCRIPTION
## Issue Addressed

Fixes #15806 

## Proposed Changes

- Add `ipc.permissions` setting to `node`.
- Handle the transmission of this setting down to the IPC server builder.
- Use `os::unix::fs::PermissionsExt` to write the provided permissions to the file/socket.