### PR TITLE
chore: migrate from codespell to typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,0 @@
-[codespell]
-skip = .git,target,./crates/storage/libmdbx-rs/mdbx-sys/libmdbx,Cargo.toml,Cargo.lock
-ignore-words-list = crate,ser,ratatui

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -276,7 +276,7 @@ jobs:
       - fmt
       - udeps
       - book
-      - codespell
+      - typos
       - grafana
       - no-test-deps
       - features

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -188,14 +188,12 @@ jobs:
       - name: Check docs changes
         run: git diff --exit-code
 
-  codespell:
+  typos:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
-        with:
-          skip: "*.json"
+      - uses: crate-ci/typos@v1
 
   check-toml:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -415,12 +415,12 @@ clippy-op-dev:
 	--locked \
 	--all-features
 
-lint-codespell: ensure-codespell
-	codespell --skip "*.json" --skip "./testing/ef-tests/ethereum-tests"
+lint-typos: ensure-typos
+	typos
 
-ensure-codespell:
-	@if ! command -v codespell &> /dev/null; then \
-		echo "codespell not found. Please install it by running the command `pip install codespell` or refer to the following link for more information: https://github.com/codespell-project/codespell" \
+ensure-typos:
+	@if ! command -v typos &> /dev/null; then \
+		echo "typos not found. Please install it by running the command `cargo install typos-cli` or refer to the following link for more information: https://github.com/crate-ci/typos" \
 		exit 1; \
     fi
 
@@ -446,7 +446,7 @@ ensure-dprint:
 lint:
 	make fmt && \
 	make clippy && \
-	make lint-codespell && \
+	make lint-typos && \
 	make lint-toml
 
 clippy-fix:

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -364,7 +364,7 @@ pub trait Trace:
     ///
     /// This
     /// 1. fetches all transactions of the block
-    /// 2. configures the EVM evn
+    /// 2. configures the EVM env
     /// 3. loops over all transactions and executes them
     /// 4. calls the callback with the transaction info, the execution result, the changed state
     ///    _after_ the transaction [`StateProviderDatabase`] and the database that points to the
@@ -400,7 +400,7 @@ pub trait Trace:
     ///
     /// This
     /// 1. fetches all transactions of the block
-    /// 2. configures the EVM evn
+    /// 2. configures the EVM env
     /// 3. loops over all transactions and executes them
     /// 4. calls the callback with the transaction info, the execution result, the changed state
     ///    _after_ the transaction `EvmState` and the database that points to the state right

--- a/typos.toml
+++ b/typos.toml
@@ -11,12 +11,12 @@ extend-exclude = [
 [default]
 extend-ignore-re = [
     # Hex strings of various lengths
-    "(?i)0x[0-9a-f]{8}",     # 8 hex chars
-    "(?i)0x[0-9a-f]{40}",    # 40 hex chars
-    "(?i)0x[0-9a-f]{64}",    # 64 hex chars
-    "(?i)[0-9a-f]{8}",       # 8 hex chars without 0x
-    "(?i)[0-9a-f]{40}",      # 40 hex chars without 0x
-    "(?i)[0-9a-f]{64}",      # 64 hex chars without 0x
+    "(?i)0x[0-9a-f]{8}", # 8 hex chars
+    "(?i)0x[0-9a-f]{40}", # 40 hex chars
+    "(?i)0x[0-9a-f]{64}", # 64 hex chars
+    "(?i)[0-9a-f]{8}", # 8 hex chars without 0x
+    "(?i)[0-9a-f]{40}", # 40 hex chars without 0x
+    "(?i)[0-9a-f]{64}", # 64 hex chars without 0x
     # Ordinals in identifiers
     "[0-9]+nd",
     "[0-9]+th",
@@ -29,11 +29,11 @@ extend-ignore-re = [
 crate = "crate"
 ser = "ser"
 ratatui = "ratatui"
-seeked = "seeked"  # Past tense of seek, used in trie iterator
-Seeked = "Seeked"  # Type name in trie iterator
-Whe = "Whe"  # Part of base64 encoded signature
-hel = "hel"  # Part of hostname bootnode-hetzner-hel
-ONL = "ONL"  # Part of base64 encoded ENR
-Iy = "Iy"  # Part of base64 encoded ENR
-flate = "flate"  # zlib-flate is a valid tool name
-Pn = "Pn"  # Part of UPnP (Universal Plug and Play)
+seeked = "seeked" # Past tense of seek, used in trie iterator
+Seeked = "Seeked" # Type name in trie iterator
+Whe = "Whe" # Part of base64 encoded signature
+hel = "hel" # Part of hostname bootnode-hetzner-hel
+ONL = "ONL" # Part of base64 encoded ENR
+Iy = "Iy" # Part of base64 encoded ENR
+flate = "flate" # zlib-flate is a valid tool name
+Pn = "Pn" # Part of UPnP (Universal Plug and Play)

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,39 @@
+[files]
+extend-exclude = [
+    ".git",
+    "target",
+    "crates/storage/libmdbx-rs/mdbx-sys/libmdbx",
+    "Cargo.toml",
+    "Cargo.lock",
+    "testing/ef-tests",
+]
+
+[default]
+extend-ignore-re = [
+    # Hex strings of various lengths
+    "(?i)0x[0-9a-f]{8}",     # 8 hex chars
+    "(?i)0x[0-9a-f]{40}",    # 40 hex chars
+    "(?i)0x[0-9a-f]{64}",    # 64 hex chars
+    "(?i)[0-9a-f]{8}",       # 8 hex chars without 0x
+    "(?i)[0-9a-f]{40}",      # 40 hex chars without 0x
+    "(?i)[0-9a-f]{64}",      # 64 hex chars without 0x
+    # Ordinals in identifiers
+    "[0-9]+nd",
+    "[0-9]+th",
+    "[0-9]+st",
+    "[0-9]+rd",
+]
+
+[default.extend-words]
+# These are valid identifiers/terms that should be allowed
+crate = "crate"
+ser = "ser"
+ratatui = "ratatui"
+seeked = "seeked"  # Past tense of seek, used in trie iterator
+Seeked = "Seeked"  # Type name in trie iterator
+Whe = "Whe"  # Part of base64 encoded signature
+hel = "hel"  # Part of hostname bootnode-hetzner-hel
+ONL = "ONL"  # Part of base64 encoded ENR
+Iy = "Iy"  # Part of base64 encoded ENR
+flate = "flate"  # zlib-flate is a valid tool name
+Pn = "Pn"  # Part of UPnP (Universal Plug and Play)


### PR DESCRIPTION
Migrates the spellcheck tooling from codespell to typos, following the same approach as https://github.com/foundry-rs/foundry/pull/11045.

## Summary

This PR replaces codespell with typos for improved performance and more flexible configuration. The typos tool is written in Rust and provides faster execution times along with better support for ignoring false positives through regex patterns.

## Changes

- Replace codespell GitHub Action with `crate-ci/typos@v1` in the lint workflow
- Create `typos.toml` configuration with:
  - Equivalent file exclusions from `.codespellrc`
  - Regex patterns to ignore hex strings and ordinals
  - Allowed words for project-specific terms and false positives
- Update Makefile to use `lint-typos` target instead of `lint-codespell`
- Remove obsolete `.codespellrc` configuration
- Fix actual typo found during migration: `evn` → `env` in trace.rs documentation

The configuration maintains all existing exclusions and adds patterns to handle common false positives in the codebase.

cc @DaniPopes 