### PR TITLE
fix: Refine Transaction Abstraction Link

### DIFF
--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -3,7 +3,7 @@
 ## Abstractions
 
 - We created a [Database trait abstraction](https://github.com/paradigmxyz/reth/blob/main/crates/cli/commands/src/db/mod.rs) using Rust Stable GATs which frees us from being bound to a single database implementation. We currently use MDBX, but are exploring [redb](https://github.com/cberner/redb) as an alternative.
-- We then iterated on [`Transaction`](https://github.com/paradigmxyz/reth/blob/0d9b9a392d4196793736522f3fc2ac804991b45d/crates/stages/src/db.rs#L14-L19) as a non-leaky abstraction with helpers for strictly-typed and unit-tested higher-level database abstractions.
+- We then iterated on [`Transaction`](https://github.com/paradigmxyz/reth/blob/main/crates/storage/errors/src/db.rs) as a non-leaky abstraction with helpers for strictly-typed and unit-tested higher-level database abstractions.
 
 ## Codecs
 


### PR DESCRIPTION
**Description:**
- Updated the reference link for the `Transaction` abstraction to point to the correct file and location.