### PR TITLE
chore: fix reth-engine-tree dev-dependencies import

### DIFF
--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -37,7 +37,7 @@ thiserror.workspace = true
 reth-engine-tree = { workspace = true, features = ["test-utils"] }
 reth-ethereum-consensus.workspace = true
 reth-ethereum-engine-primitives.workspace = true
-reth-evm-ethereum.workspace = true
+reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 reth-exex-types.workspace = true
 reth-chainspec.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -25,6 +25,7 @@ reth-tasks.workspace = true
 reth-node-types.workspace = true
 reth-chainspec.workspace = true
 reth-engine-primitives.workspace = true
+reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 
 # async
 futures.workspace = true
@@ -37,7 +38,6 @@ thiserror.workspace = true
 reth-engine-tree = { workspace = true, features = ["test-utils"] }
 reth-ethereum-consensus.workspace = true
 reth-ethereum-engine-primitives.workspace = true
-reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 reth-exex-types.workspace = true
 reth-chainspec.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -25,7 +25,6 @@ reth-tasks.workspace = true
 reth-node-types.workspace = true
 reth-chainspec.workspace = true
 reth-engine-primitives.workspace = true
-reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 
 # async
 futures.workspace = true
@@ -38,6 +37,7 @@ thiserror.workspace = true
 reth-engine-tree = { workspace = true, features = ["test-utils"] }
 reth-ethereum-consensus.workspace = true
 reth-ethereum-engine-primitives.workspace = true
+reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 reth-exex-types.workspace = true
 reth-chainspec.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -32,7 +32,7 @@ reth-rpc-convert.workspace = true
 revm-inspectors.workspace = true
 reth-network-peers = { workspace = true, features = ["secp256k1"] }
 reth-evm.workspace = true
-reth-evm-ethereum.workspace = true
+reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-types.workspace = true


### PR DESCRIPTION

Updates `reth-evm-ethereum` dependency in `crates/engine/service/Cargo.toml` to include the `test-utils` feature for development dependencies.


