### PR TITLE
fix: remove duplicate comment in capabilities.rs

### DIFF
--- a/crates/rpc/rpc-engine-api/src/capabilities.rs
+++ b/crates/rpc/rpc-engine-api/src/capabilities.rs
@@ -21,8 +21,6 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getBlobsV2",
 ];
 
-// The list of all supported Engine capabilities available over the engine endpoint.
-///
 /// Latest spec: Prague
 #[derive(Debug, Clone)]
 pub struct EngineCapabilities {


### PR DESCRIPTION
Remove duplicate comment "The list of all supported Engine capabilities available over the engine endpoint" that was repeated on line 20. The comment was already present on line 3 and was redundant between the struct definition and its implementation

<img width="1129" height="89" alt="image" src="https://github.com/user-attachments/assets/d9d2fb9b-c17c-4ab9-b087-62bf0031cf89" />
