### PR TITLE
docs: normalize dynamic CLI defaults in help generation

### DIFF
--- a/docs/cli/help.rs
+++ b/docs/cli/help.rs
@@ -274,6 +274,16 @@ fn preprocess_help(s: &str) -> Cow<'_, str> {
                 r"(rpc.max-tracing-requests <COUNT>\n.*\n.*\n.*\n.*\n.*)\[default: \d+\]",
                 r"$1[default: <NUM CPU CORES-2>]",
             ),
+            // Handle engine.max-proof-task-concurrency dynamic default
+            (
+                r"(engine\.max-proof-task-concurrency.*)\[default: \d+\]",
+                r"$1[default: <DYNAMIC: CPU cores * 8>]",
+            ),
+            // Handle engine.reserved-cpu-cores dynamic default
+            (
+                r"(engine\.reserved-cpu-cores.*)\[default: \d+\]",
+                r"$1[default: <DYNAMIC: min(2, CPU cores)>]",
+            ),
         ];
         patterns
             .iter()


### PR DESCRIPTION
Fixes inconsistent CLI documentation caused by dynamic default values.

Two CLI args have defaults calculated from CPU cores:
- `--engine.max-proof-task-concurrency` (CPU cores * 8)  
- `--engine.reserved-cpu-cores` (min(2, CPU cores))

These showed different values on different machines, making docs inconsistent.

Now replaces actual numbers with descriptive text like existing `--rpc.max-tracing-requests` handling.

**Before:** `[default: 16]`  
**After:** `[default: <DYNAMIC: CPU cores * 8>]`