### PR TITLE
feat(alloy-provider): compatibility for non-reth nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7202,6 +7202,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
+ "parking_lot",
  "reth-chainspec",
  "reth-db-api",
  "reth-errors",

--- a/crates/alloy-provider/Cargo.toml
+++ b/crates/alloy-provider/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 # other
 tracing.workspace = true
+parking_lot.workspace = true
 
 # revm
 revm.workspace = true

--- a/crates/alloy-provider/README.md
+++ b/crates/alloy-provider/README.md
@@ -40,11 +40,21 @@ use reth_alloy_provider::{AlloyRethProvider, AlloyRethProviderConfig};
 use reth_ethereum_node::EthereumNode;
 
 let config = AlloyRethProviderConfig {
-    compute_state_root: true, // Enable state root computation
+    compute_state_root: true,  // Enable state root computation
+    reth_rpc_support: true,    // Use Reth-specific RPC methods (default: true)
 };
 
 let db_provider = AlloyRethProvider::new_with_config(provider, EthereumNode, config);
 ```
+
+## Configuration Options
+
+- `compute_state_root`: When enabled, computes state root and trie updates (requires Reth-specific RPC methods)
+- `reth_rpc_support`: When enabled (default), uses Reth-specific RPC methods for better performance:
+  - `eth_getAccountInfo`: Fetches account balance, nonce, and code in a single call
+  - `debug_codeByHash`: Retrieves bytecode by hash without needing the address
+  
+  When disabled, falls back to standard RPC methods and caches bytecode locally for compatibility with non-Reth nodes.
 
 ## Technical Details
 


### PR DESCRIPTION
This introduces a config option `reth_rpc_support`. This is by default `true`, if `false` only standard RPC methods are used.  Second a option is added to set the chain spec with `with_chain_spec`.


PS: Foundry anvil currently does not work well with `eth_getAccountInfo`. Until this is fixed `reth_rpc_support=false` can be used as workaround.