### PR TITLE
ethereum: Fix hardcoded error type in Ethereum payload builder

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -286,9 +286,7 @@ where
                     trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
                     best_txs.mark_invalid(
                         &pool_tx,
-                        InvalidPoolTransactionError::Consensus(
-                            InvalidTransactionError::TxTypeNotSupported,
-                        ),
+                        InvalidPoolTransactionError::Consensus(error),
                     );
                 }
                 continue


### PR DESCRIPTION
When marking invalid transactions, the code was always returning `TxTypeNotSupported` instead of the actual error from validation.

This meant users would see "transaction type not supported" for any invalid tx - insufficient funds, bad nonce, etc. Makes debugging really confusing.

Now it properly forwards the real error type.