### PR TITLE
fix: `logIndex` in `getBlockReceipts`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -150,7 +150,7 @@ pub trait EthBlocks:
                         };
 
                         gas_used = receipt.cumulative_gas_used();
-                        next_log_index = receipt.logs().len();
+                        next_log_index += receipt.logs().len();
 
                         input
                     })


### PR DESCRIPTION
Small bug from #17450 