### PR TITLE
feat: make payload validation functions generic over block header type

### DIFF
--- a/crates/payload/validator/src/cancun.rs
+++ b/crates/payload/validator/src/cancun.rs
@@ -11,14 +11,15 @@ use reth_primitives_traits::{AlloyBlockHeader, Block, SealedBlock};
 /// - doesn't contain EIP-4844 transactions unless Cancun is active
 /// - checks blob versioned hashes in block and sidecar match
 #[inline]
-pub fn ensure_well_formed_fields<T, B>(
+pub fn ensure_well_formed_fields<T, B, H>(
     block: &SealedBlock<B>,
     cancun_sidecar_fields: Option<&CancunPayloadFields>,
     is_cancun_active: bool,
 ) -> Result<(), PayloadError>
 where
     T: Transaction + Typed2718,
-    B: Block<Body = BlockBody<T>>,
+    H: AlloyBlockHeader,
+    B: Block<Header = H, Body = BlockBody<T, H>>,
 {
     ensure_well_formed_header_and_sidecar_fields(block, cancun_sidecar_fields, is_cancun_active)?;
     ensure_well_formed_transactions_field_with_sidecar(
@@ -72,8 +73,8 @@ pub fn ensure_well_formed_header_and_sidecar_fields<T: Block>(
 /// - doesn't contain EIP-4844 transactions unless Cancun is active
 /// - checks blob versioned hashes in block and sidecar match
 #[inline]
-pub fn ensure_well_formed_transactions_field_with_sidecar<T: Transaction + Typed2718>(
-    block_body: &BlockBody<T>,
+pub fn ensure_well_formed_transactions_field_with_sidecar<T: Transaction + Typed2718, H>(
+    block_body: &BlockBody<T, H>,
     cancun_sidecar_fields: Option<&CancunPayloadFields>,
     is_cancun_active: bool,
 ) -> Result<(), PayloadError> {
@@ -89,8 +90,8 @@ pub fn ensure_well_formed_transactions_field_with_sidecar<T: Transaction + Typed
 /// Ensures that the number of blob versioned hashes of a EIP-4844 transactions in block, matches
 /// the number hashes included in the _separate_ `block_versioned_hashes` of the cancun payload
 /// fields on the sidecar.
-pub fn ensure_matching_blob_versioned_hashes<T: Transaction + Typed2718>(
-    block_body: &BlockBody<T>,
+pub fn ensure_matching_blob_versioned_hashes<T: Transaction + Typed2718, H>(
+    block_body: &BlockBody<T, H>,
     cancun_sidecar_fields: Option<&CancunPayloadFields>,
 ) -> Result<(), PayloadError> {
     let num_blob_versioned_hashes = block_body.blob_versioned_hashes_iter().count();

--- a/crates/payload/validator/src/prague.rs
+++ b/crates/payload/validator/src/prague.rs
@@ -10,8 +10,8 @@ use alloy_rpc_types_engine::{PayloadError, PraguePayloadFields};
 /// - Prague fields are not present unless Prague is active
 /// - does not contain EIP-7702 transactions if Prague is not active
 #[inline]
-pub fn ensure_well_formed_fields<T: Typed2718>(
-    block_body: &BlockBody<T>,
+pub fn ensure_well_formed_fields<T: Typed2718, H>(
+    block_body: &BlockBody<T, H>,
     prague_fields: Option<&PraguePayloadFields>,
     is_prague_active: bool,
 ) -> Result<(), PayloadError> {
@@ -36,8 +36,8 @@ pub const fn ensure_well_formed_sidecar_fields(
 /// Checks that transactions field doesn't contain EIP-7702 transactions if Prague is not
 /// active.
 #[inline]
-pub fn ensure_well_formed_transactions_field<T: Typed2718>(
-    block_body: &BlockBody<T>,
+pub fn ensure_well_formed_transactions_field<T: Typed2718, H>(
+    block_body: &BlockBody<T, H>,
     is_prague_active: bool,
 ) -> Result<(), PayloadError> {
     if !is_prague_active && block_body.has_eip7702_transactions() {


### PR DESCRIPTION
## Summary

Updates payload validation functions to be generic over block header types instead of being hardcoded to specific block implementations. This change enables chains with custom block headers to utilize the existing validation logic.

## Changes

- Added generic header type parameter `H` to payload validation functions in `cancun.rs` and `prague.rs`
- Updated `BlockBody<T>` usage to `BlockBody<T, H>` for type consistency
- Maintains identical validation behavior while improving flexibility for downstream chains


This change is particularly beneficial for chains like Optimism, Berachain, and other custom implementations that extend Ethereum's block structure with additional header fields.