### PR TITLE
refactor: rename `AlloyRethProvider` to `RpcBlockchainProvider` and move to storage

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -60,7 +60,7 @@ exclude_crates=(
   reth-ress-provider
   # The following are not supposed to be working
   reth # all of the crates below
-  reth-alloy-provider
+  reth-storage-rpc-provider
   reth-invalid-block-hooks # reth-provider
   reth-libmdbx # mdbx
   reth-mdbx-sys # mdbx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7192,36 +7192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-alloy-provider"
-version = "1.5.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-rpc-types-engine",
- "parking_lot",
- "reth-chainspec",
- "reth-db-api",
- "reth-errors",
- "reth-execution-types",
- "reth-node-types",
- "reth-primitives",
- "reth-provider",
- "reth-prune-types",
- "reth-rpc-convert",
- "reth-stages-types",
- "reth-storage-api",
- "reth-trie",
- "revm",
- "revm-primitives",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "reth-basic-payload-builder"
 version = "1.5.1"
 dependencies = [
@@ -10374,6 +10344,35 @@ dependencies = [
  "reth-static-file-types",
  "revm-database-interface",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reth-storage-rpc-provider"
+version = "1.5.1"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types",
+ "alloy-rpc-types-engine",
+ "parking_lot",
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-errors",
+ "reth-execution-types",
+ "reth-node-types",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-rpc-convert",
+ "reth-stages-types",
+ "reth-storage-api",
+ "reth-trie",
+ "revm",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [".github/"]
 members = [
     "bin/reth-bench/",
     "bin/reth/",
-    "crates/alloy-provider/",
+    "crates/storage/rpc-provider/",
     "crates/chain-state/",
     "crates/chainspec/",
     "crates/cli/cli/",
@@ -323,7 +323,7 @@ codegen-units = 1
 # reth
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
-reth-alloy-provider = { path = "crates/alloy-provider" }
+reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }
 reth-basic-payload-builder = { path = "crates/payload/basic" }
 reth-bench = { path = "bin/reth-bench" }
 reth-chain-state = { path = "crates/chain-state" }

--- a/crates/storage/rpc-provider/Cargo.toml
+++ b/crates/storage/rpc-provider/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "reth-alloy-provider"
+name = "reth-storage-rpc-provider"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Alloy provider implementation for reth that fetches state via RPC"
+description = "RPC-based blockchain provider for reth that fetches data via RPC calls"
 
 [lints]
 workspace = true
@@ -44,7 +44,6 @@ parking_lot.workspace = true
 
 # revm
 revm.workspace = true
-revm-primitives.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/storage/rpc-provider/README.md
+++ b/crates/storage/rpc-provider/README.md
@@ -1,11 +1,12 @@
-# Alloy Provider for Reth
+# RPC Blockchain Provider for Reth
 
-This crate provides an implementation of reth's `StateProviderFactory` and related traits that fetches state data via RPC instead of from a local database.
+This crate provides an RPC-based implementation of reth's [`BlockchainProvider`](../provider/src/providers/blockchain_provider.rs) which provides access to local blockchain data, this crate offers the same functionality but for remote blockchain access via RPC.
 
 Originally created by [cakevm](https://github.com/cakevm/alloy-reth-provider).
 
 ## Features
 
+- Provides the same interface as `BlockchainProvider` but for remote nodes
 - Implements `StateProviderFactory` for remote RPC state access
 - Supports Ethereum networks
 - Useful for testing without requiring a full database
@@ -15,8 +16,7 @@ Originally created by [cakevm](https://github.com/cakevm/alloy-reth-provider).
 
 ```rust
 use alloy_provider::ProviderBuilder;
-use reth_alloy_provider::AlloyRethProvider;
-use reth_ethereum_node::EthereumNode;
+use reth_storage_rpc_provider::RpcBlockchainProvider;
 
 // Initialize provider
 let provider = ProviderBuilder::new()
@@ -24,11 +24,11 @@ let provider = ProviderBuilder::new()
     .await
     .unwrap();
 
-// Create database provider with NodeTypes
-let db_provider = AlloyRethProvider::new(provider, EthereumNode);
+// Create RPC blockchain provider with NodeTypes
+let rpc_provider = RpcBlockchainProvider::new(provider);
 
-// Get state at specific block
-let state = db_provider.state_by_block_id(BlockId::number(16148323)).unwrap();
+// Get state at specific block - same interface as BlockchainProvider
+let state = rpc_provider.state_by_block_id(BlockId::number(16148323)).unwrap();
 ```
 
 ## Configuration
@@ -36,15 +36,14 @@ let state = db_provider.state_by_block_id(BlockId::number(16148323)).unwrap();
 The provider can be configured with custom settings:
 
 ```rust
-use reth_alloy_provider::{AlloyRethProvider, AlloyRethProviderConfig};
-use reth_ethereum_node::EthereumNode;
+use reth_storage_rpc_provider::{RpcBlockchainProvider, RpcBlockchainProviderConfig};
 
-let config = AlloyRethProviderConfig {
+let config = RpcBlockchainProviderConfig {
     compute_state_root: true,  // Enable state root computation
     reth_rpc_support: true,    // Use Reth-specific RPC methods (default: true)
 };
 
-let db_provider = AlloyRethProvider::new_with_config(provider, EthereumNode, config);
+let rpc_provider = RpcBlockchainProvider::new_with_config(provider, config);
 ```
 
 ## Configuration Options
@@ -58,7 +57,9 @@ let db_provider = AlloyRethProvider::new_with_config(provider, EthereumNode, con
 
 ## Technical Details
 
-The provider uses `alloy_network::AnyNetwork` for network operations, providing compatibility with various Ethereum-based networks while maintaining the expected block structure with headers.
+The `RpcBlockchainProvider` uses `alloy_network::AnyNetwork` for network operations, providing compatibility with various Ethereum-based networks while maintaining the expected block structure with headers.
+
+This provider implements the same traits as the local `BlockchainProvider`, making it a drop-in replacement for scenarios where remote RPC access is preferred over local database access.
 
 ## License
 


### PR DESCRIPTION
To make the purpose of the implementation clearer, it has been renamed to `RpcBlockchainProvider`, as it functions like `BlockchainProvider` but is based on RPC. Since it is closely related to `reth-provider`, it has also been moved to the storage folder and renamed to `reth-storage-rpc-provider`. Remove the `AsyncDbWrapper` since it is not required for this scenario.