### PR TITLE
chore: sanity secp256k1+rayon activations

### DIFF
--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -16,7 +16,8 @@ reth-ethereum-engine-primitives.workspace = true
 reth-ethereum-payload-builder.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-ethereum-primitives.workspace = true
-reth-primitives-traits = { workspace = true, features = ["secp256k1"] }
+## ensure secp256k1 recovery with rayon support is activated
+reth-primitives-traits = { workspace = true, features = ["secp256k1", "rayon"] }
 reth-node-builder.workspace = true
 reth-tracing.workspace = true
 reth-provider.workspace = true

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -16,7 +16,7 @@ reth-ethereum-engine-primitives.workspace = true
 reth-ethereum-payload-builder.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-ethereum-primitives.workspace = true
-reth-primitives-traits.workspace = true
+reth-primitives-traits = { workspace = true, features = ["secp256k1"] }
 reth-node-builder.workspace = true
 reth-tracing.workspace = true
 reth-provider.workspace = true

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-chainspec.workspace = true
-reth-primitives-traits.workspace = true
+reth-primitives-traits = { workspace = true, features = ["secp256k1"] }
 reth-payload-builder.workspace = true
 reth-consensus.workspace = true
 reth-node-api.workspace = true

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -13,7 +13,8 @@ workspace = true
 [dependencies]
 # reth
 reth-chainspec.workspace = true
-reth-primitives-traits = { workspace = true, features = ["secp256k1"] }
+## ensure secp256k1 recovery with rayon support is activated
+reth-primitives-traits = { workspace = true, features = ["secp256k1", "rayon"] }
 reth-payload-builder.workspace = true
 reth-consensus.workspace = true
 reth-node-api.workspace = true


### PR DESCRIPTION
these are already activated, but doesnt hurt to also activate them on the node crates directly, which should serve as the main entrypoint