### PR TITLE
fix: remove Temporary ETL Files on Write Error

### DIFF
--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -131,30 +131,29 @@ where
     }
 
     fn flush(&mut self) -> io::Result<()> {
-    self.buffer_size_bytes = 0;
-    self.buffer.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
-    let mut buf = Vec::with_capacity(self.buffer.len());
-    std::mem::swap(&mut buf, &mut self.buffer);
+        self.buffer_size_bytes = 0;
+        self.buffer.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut buf = Vec::with_capacity(self.buffer.len());
+        std::mem::swap(&mut buf, &mut self.buffer);
 
-    let path = self.dir()?.path().to_path_buf();
+        let path = self.dir()?.path().to_path_buf();
 
-    // Try to create a new temporary ETL file and handle errors properly
-    match EtlFile::new(path.as_path(), buf) {
-        Ok(file) => {
-            // Success: add the file to the list of ETL files
-            self.files.push(file);
+        // Try to create a new temporary ETL file and handle errors properly
+        match EtlFile::new(path.as_path(), buf) {
+            Ok(file) => {
+                // Success: add the file to the list of ETL files
+                self.files.push(file);
+            }
+            Err(e) => {
+                // If an error occurs, try to remove the temporary file to avoid leaving garbage on disk
+                // (This is especially important if EtlFile::new created the file but failed to write)
+                let _ = std::fs::remove_file(&path);
+                // Return the original error to the caller
+                return Err(e);
+            }
         }
-        Err(e) => {
-            // If an error occurs, try to remove the temporary file to avoid leaving garbage on disk
-            // (This is especially important if EtlFile::new created the file but failed to write)
-            let _ = std::fs::remove_file(&path);
-            // Return the original error to the caller
-            return Err(e);
-        }
-    }
 
-    Ok(())
-}
+        Ok(())
     }
 
     /// Returns an iterator over the collector data.

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -145,8 +145,8 @@ where
                 self.files.push(file);
             }
             Err(e) => {
-                // If an error occurs, try to remove the temporary file to avoid leaving garbage on disk
-                // (This is especially important if EtlFile::new created the file but failed to write)
+                // If an error occurs, try to remove the temporary file to avoid leaving garbage on
+                // disk. This is especially important if EtlFile::new created the file but failed to write
                 let _ = std::fs::remove_file(&path);
                 // Return the original error to the caller
                 return Err(e);

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -146,7 +146,8 @@ where
             }
             Err(e) => {
                 // If an error occurs, try to remove the temporary file to avoid leaving garbage on
-                // disk. This is especially important if EtlFile::new created the file but failed to write
+                // disk. This is especially important if EtlFile::new created the file but failed to
+                // write
                 let _ = std::fs::remove_file(&path);
                 // Return the original error to the caller
                 return Err(e);


### PR DESCRIPTION


## Description

This PR improves the reliability of the ETL collector by ensuring that temporary files are properly removed if an error occurs during file creation or writing.  
Now, if writing to a temp ETL file fails, the code attempts to delete the file to avoid leaving garbage on disk.

- Prevents orphaned temp files on disk
- Adds clear inline comments for maintainability
- No changes to public API

