### PR TITLE
feat(bench): add start block to Continuous mode

### DIFF
--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -79,9 +79,15 @@ impl BenchContext {
         let auth_provider = RootProvider::<AnyNetwork>::new(client);
 
         let first_block = match benchmark_mode {
-            BenchMode::Continuous => {
-                // fetch Latest block
-                block_provider.get_block_by_number(BlockNumberOrTag::Latest).full().await?.unwrap()
+            BenchMode::Continuous { start } => {
+                let block_number = if start == 0 && bench_args.from.is_none() {
+                    BlockNumberOrTag::Latest
+                } else {
+                    BlockNumberOrTag::Number(start)
+                };
+
+                // fetch block
+                block_provider.get_block_by_number(block_number).full().await?.unwrap()
             }
             BenchMode::Range(ref mut range) => {
                 match range.next() {

--- a/bin/reth-bench/src/bench_mode.rs
+++ b/bin/reth-bench/src/bench_mode.rs
@@ -1,3 +1,5 @@
+// bin/reth-bench/src/bench_mode.rs
+
 //! The benchmark mode defines whether the benchmark should run for a closed or open range of
 //! blocks.
 use std::ops::RangeInclusive;
@@ -5,9 +7,11 @@ use std::ops::RangeInclusive;
 /// Whether or not the benchmark should run as a continuous stream of payloads.
 #[derive(Debug, PartialEq, Eq)]
 pub enum BenchMode {
-    // TODO: just include the start block in `Continuous`
-    /// Run the benchmark as a continuous stream of payloads, until the benchmark is interrupted.
-    Continuous,
+    /// Run the benchmark as a continuous stream of payloads, starting from a specific block.
+    Continuous {
+        /// The block to start from.
+        start: u64,
+    },
     /// Run the benchmark for a specific range of blocks.
     Range(RangeInclusive<u64>),
 }
@@ -16,21 +20,22 @@ impl BenchMode {
     /// Check if the block number is in the range
     pub fn contains(&self, block_number: u64) -> bool {
         match self {
-            Self::Continuous => true,
+            Self::Continuous { start } => block_number >= *start,
             Self::Range(range) => range.contains(&block_number),
         }
     }
 
     /// Create a [`BenchMode`] from optional `from` and `to` fields.
     pub fn new(from: Option<u64>, to: Option<u64>) -> Result<Self, eyre::Error> {
-        // If neither `--from` nor `--to` are provided, we will run the benchmark continuously,
-        // starting at the latest block.
         match (from, to) {
             (Some(from), Some(to)) => Ok(Self::Range(from..=to)),
-            (None, None) => Ok(Self::Continuous),
-            _ => {
-                // both or neither are allowed, everything else is ambiguous
-                Err(eyre::eyre!("`from` and `to` must be provided together, or not at all."))
+            (Some(from), None) => Ok(Self::Continuous { start: from }),
+            // If neither --from nor --to are provided, we run the benchmark continuously,
+            // starting from block 0 as a default. This preserves the old behavior.
+            (None, None) => Ok(Self::Continuous { start: 0 }),
+            (None, Some(_)) => {
+                // `to` without `from` is ambiguous.
+                Err(eyre::eyre!("--to cannot be specified without --from."))
             }
         }
     }


### PR DESCRIPTION
Extends BenchMode::Continuous to include a starting block.

This keeps the existing CLI behavior (`reth bench` with no flags still works),
and uses block 0 as the default start when `--from` is not provided.

Also updates BenchContext to fetch the correct starting block, respecting the new start value in Continuous mode.