### PR TITLE
docs(trie): update ParallelSparseTrie documentation

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -64,15 +64,17 @@ pub const NUM_LOWER_SUBTRIES: usize = 16usize.pow(UPPER_TRIE_MAX_DEPTH as u32);
 ///
 /// ## Leaf Operations
 ///
-/// **Update**: When updating a leaf, the `prefix_set` is marked to track the change. The value is
-/// stored in the appropriate subtrie's values map. If the leaf is new, the trie structure is
-/// updated by walking to the leaf from the root, creating necessary intermediate branch nodes.
+/// **Update**: When updating a leaf, the new value is stored in the appropriate subtrie's values
+/// map. If the leaf is new, the trie structure is updated by walking to the leaf from the root,
+/// creating necessary intermediate branch nodes.
 ///
 /// **Removal**: Leaf removal may require parent node modifications. The algorithm walks up the
 /// trie, removing nodes that become empty and converting single-child branches to extensions.
 ///
 /// During leaf operations the overall structure of the trie may change, causing nodes to be moved
 /// from the upper to lower trie or vice-versa.
+///
+/// The `prefix_set` is modified during both leaf updates and removals to track changed leaf paths.
 ///
 /// ## Root Hash Calculation
 ///

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -64,10 +64,9 @@ pub const NUM_LOWER_SUBTRIES: usize = 16usize.pow(UPPER_TRIE_MAX_DEPTH as u32);
 ///
 /// ## Leaf Operations
 ///
-/// **Update**: When updating a leaf, the [`prefix_set`](Self::prefix_set) is marked to track the
-/// change. The value is stored in the appropriate subtrie's values map. If the leaf is new, the
-/// trie structure is updated by walking to the leaf from the root, creating necessary intermediate
-/// branch nodes.
+/// **Update**: When updating a leaf, the `prefix_set` is marked to track the change. The value is
+/// stored in the appropriate subtrie's values map. If the leaf is new, the trie structure is
+/// updated by walking to the leaf from the root, creating necessary intermediate branch nodes.
 ///
 /// **Removal**: Leaf removal may require parent node modifications. The algorithm walks up the
 /// trie, removing nodes that become empty and converting single-child branches to extensions.
@@ -82,8 +81,8 @@ pub const NUM_LOWER_SUBTRIES: usize = 16usize.pow(UPPER_TRIE_MAX_DEPTH as u32);
 /// 2. Update hashes for the upper subtrie (which may reference lower subtrie hashes)
 /// 3. Calculate the final root hash from the upper subtrie's root node
 ///
-/// The [`prefix_set`](Self::prefix_set) tracks which paths have been modified, enabling incremental
-/// updates instead of recalculating the entire trie.
+/// The `prefix_set` tracks which paths have been modified, enabling incremental updates instead of
+/// recalculating the entire trie.
 ///
 /// ## Invariants
 ///

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -37,7 +37,7 @@ pub const NUM_LOWER_SUBTRIES: usize = 16usize.pow(UPPER_TRIE_MAX_DEPTH as u32);
 /// The trie is divided into two tiers for efficient parallel processing:
 /// - **Upper subtrie**: Contains nodes with paths shorter than [`UPPER_TRIE_MAX_DEPTH`]
 /// - **Lower subtries**: An array of [`NUM_LOWER_SUBTRIES`] subtries, each handling nodes with
-///   paths of [`UPPER_TRIE_MAX_DEPTH`]+ nibbles
+///   paths of at least [`UPPER_TRIE_MAX_DEPTH`] nibbles
 ///
 /// Node placement is determined by path depth:
 /// - Paths with < [`UPPER_TRIE_MAX_DEPTH`] nibbles go to the upper subtrie

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -35,17 +35,25 @@ pub const NUM_LOWER_SUBTRIES: usize = 16usize.pow(UPPER_TRIE_MAX_DEPTH as u32);
 /// ## Structure
 ///
 /// The trie is divided into two tiers for efficient parallel processing:
-/// - **Upper subtrie**: Contains nodes with paths shorter than `UPPER_TRIE_MAX_DEPTH` (2 nibbles)
-/// - **Lower subtries**: An array of 256 subtries, each handling nodes with paths of 2+ nibbles
+/// - **Upper subtrie**: Contains nodes with paths shorter than [`UPPER_TRIE_MAX_DEPTH`]
+/// - **Lower subtries**: An array of [`NUM_LOWER_SUBTRIES`] subtries, each handling nodes with
+///   paths of [`UPPER_TRIE_MAX_DEPTH`]+ nibbles
 ///
 /// Node placement is determined by path depth:
-/// - Paths with < 2 nibbles go to the upper subtrie
-/// - Paths with >= 2 nibbles go to lower subtries, indexed by their first 2 nibbles
+/// - Paths with < [`UPPER_TRIE_MAX_DEPTH`] nibbles go to the upper subtrie
+/// - Paths with >= [`UPPER_TRIE_MAX_DEPTH`] nibbles go to lower subtries, indexed by their first
+///   [`UPPER_TRIE_MAX_DEPTH`] nibbles.
+///
+/// Each lower subtrie tracks its root via the `path` field, which represents the shortest path
+/// in that subtrie. This path will have at least [`UPPER_TRIE_MAX_DEPTH`] nibbles, but may be
+/// longer when an extension node in the upper trie "reaches into" the lower subtrie. For example,
+/// if the upper trie has an extension from `0x1` to `0x12345`, then the lower subtrie for prefix
+/// `0x12` will have its root at path `0x12345` rather than at `0x12`.
 ///
 /// ## Node Revealing
 ///
 /// The trie uses lazy loading to efficiently handle large state tries. Nodes can be:
-/// - **Blind nodes**: Stored as hashes (`SparseNode::Hash`), representing unloaded trie parts
+/// - **Blind nodes**: Stored as hashes ([`SparseNode::Hash`]), representing unloaded trie parts
 /// - **Revealed nodes**: Fully loaded nodes (Branch, Extension, Leaf) with complete structure
 ///
 /// Note: An empty trie contains an `EmptyRoot` node at the root path, rather than no nodes at all.
@@ -56,12 +64,16 @@ pub const NUM_LOWER_SUBTRIES: usize = 16usize.pow(UPPER_TRIE_MAX_DEPTH as u32);
 ///
 /// ## Leaf Operations
 ///
-/// **Update**: When updating a leaf, the `prefix_set` is marked to track the change. The value
-/// is stored in the appropriate subtrie's values map. If the leaf is new, the trie structure
-/// is updated by walking to the leaf from the root, creating necessary intermediate branch nodes.
+/// **Update**: When updating a leaf, the [`prefix_set`](Self::prefix_set) is marked to track the
+/// change. The value is stored in the appropriate subtrie's values map. If the leaf is new, the
+/// trie structure is updated by walking to the leaf from the root, creating necessary intermediate
+/// branch nodes.
 ///
 /// **Removal**: Leaf removal may require parent node modifications. The algorithm walks up the
 /// trie, removing nodes that become empty and converting single-child branches to extensions.
+///
+/// During leaf operations the overall structure of the trie may change, causing nodes to be moved
+/// from the upper to lower trie or vice-versa.
 ///
 /// ## Root Hash Calculation
 ///
@@ -70,8 +82,8 @@ pub const NUM_LOWER_SUBTRIES: usize = 16usize.pow(UPPER_TRIE_MAX_DEPTH as u32);
 /// 2. Update hashes for the upper subtrie (which may reference lower subtrie hashes)
 /// 3. Calculate the final root hash from the upper subtrie's root node
 ///
-/// The `prefix_set` tracks which paths have been modified, enabling incremental updates
-/// instead of recalculating the entire trie.
+/// The [`prefix_set`](Self::prefix_set) tracks which paths have been modified, enabling incremental
+/// updates instead of recalculating the entire trie.
 ///
 /// ## Invariants
 ///


### PR DESCRIPTION
Now that PST is more stable we can fill out its documentation a bit.

Fixes #17042