### PR TITLE
docs: fix typo in OpReceiptBuilder comment

### DIFF
--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -295,7 +295,7 @@ impl OpReceiptBuilder {
         Ok(Self { core_receipt, op_receipt_fields })
     }
 
-    /// Builds [`OpTransactionReceipt`] by combing core (l1) receipt fields and additional OP
+    /// Builds [`OpTransactionReceipt`] by combining core (l1) receipt fields and additional OP
     /// receipt fields.
     pub fn build(self) -> OpTransactionReceipt {
         let Self { core_receipt: inner, op_receipt_fields } = self;


### PR DESCRIPTION
Change "combing" to "combining" in the comment for the build method to correct a typo in the description of how the receipt fields are processed