### PR TITLE
feat(merkle): add IntermediateRootState for storage root progress

### DIFF
--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -250,7 +250,7 @@ where
 
                     let checkpoint = MerkleCheckpoint::new(
                         to_block,
-                        state.account_root_state.last_account_key,
+                        state.account_root_state.last_hashed_key,
                         state
                             .account_root_state
                             .walker_stack

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{constants::KECCAK_EMPTY, BlockHeader};
 use alloy_primitives::{BlockNumber, Sealable, B256};
 use reth_codecs::Compact;
 use reth_consensus::ConsensusError;
@@ -13,7 +13,7 @@ use reth_provider::{
 };
 use reth_stages_api::{
     BlockErrorKind, EntitiesCheckpoint, ExecInput, ExecOutput, MerkleCheckpoint, Stage,
-    StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
+    StageCheckpoint, StageError, StageId, StorageRootMerkleCheckpoint, UnwindInput, UnwindOutput,
 };
 use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress, StoredSubNode};
 use reth_trie_db::DatabaseStateRoot;
@@ -248,7 +248,7 @@ where
                 StateRootProgress::Progress(state, hashed_entries_walked, updates) => {
                     provider.write_trie_updates(&updates)?;
 
-                    let checkpoint = MerkleCheckpoint::new(
+                    let mut checkpoint = MerkleCheckpoint::new(
                         to_block,
                         state.account_root_state.last_hashed_key,
                         state
@@ -259,6 +259,24 @@ where
                             .collect(),
                         state.account_root_state.hash_builder.into(),
                     );
+
+                    // Save storage root state if present
+                    if let Some(storage_state) = state.storage_root_state {
+                        checkpoint.storage_root_checkpoint =
+                            Some(StorageRootMerkleCheckpoint::new(
+                                storage_state.state.last_hashed_key,
+                                storage_state
+                                    .state
+                                    .walker_stack
+                                    .into_iter()
+                                    .map(StoredSubNode::from)
+                                    .collect(),
+                                storage_state.state.hash_builder.into(),
+                                storage_state.account.nonce,
+                                storage_state.account.balance,
+                                storage_state.account.bytecode_hash.unwrap_or(KECCAK_EMPTY),
+                            ));
+                    }
                     self.save_execution_checkpoint(provider, Some(checkpoint))?;
 
                     entities_checkpoint.processed += hashed_entries_walked as u64;

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -250,9 +250,14 @@ where
 
                     let checkpoint = MerkleCheckpoint::new(
                         to_block,
-                        state.last_account_key,
-                        state.walker_stack.into_iter().map(StoredSubNode::from).collect(),
-                        state.hash_builder.into(),
+                        state.account_root_state.last_account_key,
+                        state
+                            .account_root_state
+                            .walker_stack
+                            .into_iter()
+                            .map(StoredSubNode::from)
+                            .collect(),
+                        state.account_root_state.hash_builder.into(),
                     );
                     self.save_execution_checkpoint(provider, Some(checkpoint))?;
 

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -580,6 +580,9 @@ mod tests {
                 node: None,
             }],
             state: HashBuilderState::default(),
+            account_nonce: 0,
+            account_balance: U256::ZERO,
+            account_bytecode_hash: B256::ZERO,
         };
 
         let mut buf = Vec::new();
@@ -601,6 +604,9 @@ mod tests {
                 node: None,
             }],
             state: HashBuilderState::default(),
+            account_nonce: 0,
+            account_balance: U256::ZERO,
+            account_bytecode_hash: B256::ZERO,
         };
 
         // Create a merkle checkpoint with the storage root checkpoint

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -56,12 +56,14 @@ impl reth_codecs::Compact for MerkleCheckpoint {
         // Serialize the optional storage root checkpoint
         match &self.storage_root_checkpoint {
             Some(checkpoint) => {
-                buf.put_u8(1); // Indicate Some
+                // one means Some
+                buf.put_u8(1);
                 len += 1;
                 len += checkpoint.to_compact(buf);
             }
             None => {
-                buf.put_u8(0); // Indicate None
+                // zero means None
+                buf.put_u8(0);
                 len += 1;
             }
         }

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{Address, BlockNumber, B256};
 use core::ops::RangeInclusive;
 use reth_trie_common::{hash_builder::HashBuilderState, StoredSubNode};
 
+// TODO: add storage root progress
 /// Saves the progress of Merkle stage.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct MerkleCheckpoint {

--- a/crates/stages/types/src/lib.rs
+++ b/crates/stages/types/src/lib.rs
@@ -19,7 +19,7 @@ mod checkpoints;
 pub use checkpoints::{
     AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint,
     HeadersCheckpoint, IndexHistoryCheckpoint, MerkleCheckpoint, StageCheckpoint,
-    StageUnitCheckpoint, StorageHashingCheckpoint,
+    StageUnitCheckpoint, StorageHashingCheckpoint, StorageRootMerkleCheckpoint,
 };
 
 mod execution;

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -572,7 +572,7 @@ where
                 total_flushed_updates += updated_len;
 
                 trace!(target: "reth::cli",
-                    last_account_key = %state.last_account_key,
+                    last_account_key = %state.account_root_state.last_account_key,
                     updated_len,
                     total_flushed_updates,
                     "Flushing trie updates"

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -572,7 +572,7 @@ where
                 total_flushed_updates += updated_len;
 
                 trace!(target: "reth::cli",
-                    last_account_key = %state.account_root_state.last_account_key,
+                    last_account_key = %state.account_root_state.last_hashed_key,
                     updated_len,
                     total_flushed_updates,
                     "Flushing trie updates"

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -41,7 +41,10 @@ pub use trie::{StateRoot, StorageRoot, TrieType};
 
 /// Utilities for state root checkpoint progress.
 mod progress;
-pub use progress::{IntermediateStateRootState, StateRootProgress, StorageRootProgress};
+pub use progress::{
+    IntermediateStateRootState, IntermediateStorageRootState, StateRootProgress,
+    StorageRootProgress,
+};
 
 /// Trie calculation stats.
 pub mod stats;

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -41,7 +41,7 @@ pub use trie::{StateRoot, StorageRoot, TrieType};
 
 /// Utilities for state root checkpoint progress.
 mod progress;
-pub use progress::{IntermediateStateRootState, StateRootProgress};
+pub use progress::{IntermediateStateRootState, StateRootProgress, StorageRootProgress};
 
 /// Trie calculation stats.
 pub mod stats;

--- a/crates/trie/trie/src/progress.rs
+++ b/crates/trie/trie/src/progress.rs
@@ -9,7 +9,8 @@ use reth_stages_types::MerkleCheckpoint;
 /// The progress of the state root computation.
 #[derive(Debug)]
 pub enum StateRootProgress {
-    /// The complete state root computation with updates and computed root.
+    /// The complete state root computation with updates, the total number of entries walked, and
+    /// the computed root.
     Complete(B256, usize, TrieUpdates),
     /// The intermediate progress of state root computation.
     /// Contains the walker stack, the hash builder, and the trie updates.

--- a/crates/trie/trie/src/progress.rs
+++ b/crates/trie/trie/src/progress.rs
@@ -15,20 +15,33 @@ pub enum StateRootProgress {
 /// The intermediate state of the state root computation.
 #[derive(Debug)]
 pub struct IntermediateStateRootState {
+    /// The intermediate account root state.
+    pub account_root_state: IntermediateRootState,
+    /// The intermediate storage root state.
+    pub storage_root_state: Option<IntermediateRootState>,
+}
+
+impl From<MerkleCheckpoint> for IntermediateStateRootState {
+    fn from(value: MerkleCheckpoint) -> Self {
+        Self {
+            account_root_state: IntermediateRootState {
+                hash_builder: HashBuilder::from(value.state),
+                walker_stack: value.walker_stack.into_iter().map(CursorSubNode::from).collect(),
+                last_account_key: value.last_account_key,
+            },
+            // TODO: update with intermediate storage state from checkpoint
+            storage_root_state: None,
+        }
+    }
+}
+
+/// The intermediate state of a state root computation, whether account or storage root.
+#[derive(Debug)]
+pub struct IntermediateRootState {
     /// Previously constructed hash builder.
     pub hash_builder: HashBuilder,
     /// Previously recorded walker stack.
     pub walker_stack: Vec<CursorSubNode>,
     /// The last hashed account key processed.
     pub last_account_key: B256,
-}
-
-impl From<MerkleCheckpoint> for IntermediateStateRootState {
-    fn from(value: MerkleCheckpoint) -> Self {
-        Self {
-            hash_builder: HashBuilder::from(value.state),
-            walker_stack: value.walker_stack.into_iter().map(CursorSubNode::from).collect(),
-            last_account_key: value.last_account_key,
-        }
-    }
 }

--- a/crates/trie/trie/src/progress.rs
+++ b/crates/trie/trie/src/progress.rs
@@ -1,4 +1,8 @@
-use crate::{hash_builder::HashBuilder, trie_cursor::CursorSubNode, updates::TrieUpdates};
+use crate::{
+    hash_builder::HashBuilder,
+    trie_cursor::CursorSubNode,
+    updates::{StorageTrieUpdates, TrieUpdates},
+};
 use alloy_primitives::B256;
 use reth_stages_types::MerkleCheckpoint;
 
@@ -8,7 +12,9 @@ pub enum StateRootProgress {
     /// The complete state root computation with updates and computed root.
     Complete(B256, usize, TrieUpdates),
     /// The intermediate progress of state root computation.
-    /// Contains the walker stack, the hash builder and the trie updates.
+    /// Contains the walker stack, the hash builder, and the trie updates.
+    ///
+    /// Also contains any progress in an inner storage root computation.
     Progress(Box<IntermediateStateRootState>, usize, TrieUpdates),
 }
 
@@ -44,4 +50,14 @@ pub struct IntermediateRootState {
     pub walker_stack: Vec<CursorSubNode>,
     /// The last hashed account key processed.
     pub last_account_key: B256,
+}
+
+/// The progress of a storage root calculation.
+#[derive(Debug)]
+pub enum StorageRootProgress {
+    /// The complete storage root computation with updates and computed root.
+    Complete(B256, usize, StorageTrieUpdates),
+    /// The intermediate progress of state root computation.
+    /// Contains the walker stack, the hash builder, and the trie updates.
+    Progress(Box<IntermediateRootState>, usize, StorageTrieUpdates),
 }

--- a/crates/trie/trie/src/progress.rs
+++ b/crates/trie/trie/src/progress.rs
@@ -33,10 +33,19 @@ impl From<MerkleCheckpoint> for IntermediateStateRootState {
             account_root_state: IntermediateRootState {
                 hash_builder: HashBuilder::from(value.state),
                 walker_stack: value.walker_stack.into_iter().map(CursorSubNode::from).collect(),
-                last_account_key: value.last_account_key,
+                last_hashed_key: value.last_account_key,
             },
-            // TODO: update with intermediate storage state from checkpoint
-            storage_root_state: None,
+            storage_root_state: value.storage_root_checkpoint.map(|checkpoint| {
+                IntermediateRootState {
+                    hash_builder: HashBuilder::from(checkpoint.state),
+                    walker_stack: checkpoint
+                        .walker_stack
+                        .into_iter()
+                        .map(CursorSubNode::from)
+                        .collect(),
+                    last_hashed_key: checkpoint.last_storage_key,
+                }
+            }),
         }
     }
 }
@@ -48,8 +57,8 @@ pub struct IntermediateRootState {
     pub hash_builder: HashBuilder,
     /// Previously recorded walker stack.
     pub walker_stack: Vec<CursorSubNode>,
-    /// The last hashed account key processed.
-    pub last_account_key: B256,
+    /// The last hashed key processed.
+    pub last_hashed_key: B256,
 }
 
 /// The progress of a storage root calculation.

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -302,6 +302,8 @@ pub struct StorageRoot<T, H> {
     pub hashed_address: B256,
     /// The set of storage slot prefixes that have changed.
     pub prefix_set: PrefixSet,
+    /// Previous intermediate state.
+    previous_state: Option<IntermediateRootState>,
     /// The number of updates after which the intermediate progress should be returned.
     threshold: u64,
     /// Storage root metrics.
@@ -341,6 +343,7 @@ impl<T, H> StorageRoot<T, H> {
             hashed_cursor_factory,
             hashed_address,
             prefix_set,
+            previous_state: None,
             // TODO: should we have a constructor that accepts the threshold, so the higher level
             // state root can share its remaining threshold with storage root computation? For
             // example, if we want to stop after 100k, we could run to 99k in the state root part,
@@ -369,6 +372,12 @@ impl<T, H> StorageRoot<T, H> {
         self
     }
 
+    /// Set the previously recorded intermediate state.
+    pub fn with_intermediate_state(mut self, state: Option<IntermediateRootState>) -> Self {
+        self.previous_state = state;
+        self
+    }
+
     /// Set the hashed cursor factory.
     pub fn with_hashed_cursor_factory<HF>(self, hashed_cursor_factory: HF) -> StorageRoot<T, HF> {
         StorageRoot {
@@ -376,6 +385,7 @@ impl<T, H> StorageRoot<T, H> {
             hashed_cursor_factory,
             hashed_address: self.hashed_address,
             prefix_set: self.prefix_set,
+            previous_state: self.previous_state,
             threshold: self.threshold,
             #[cfg(feature = "metrics")]
             metrics: self.metrics,
@@ -389,6 +399,7 @@ impl<T, H> StorageRoot<T, H> {
             hashed_cursor_factory: self.hashed_cursor_factory,
             hashed_address: self.hashed_address,
             prefix_set: self.prefix_set,
+            previous_state: self.previous_state,
             threshold: self.threshold,
             #[cfg(feature = "metrics")]
             metrics: self.metrics,

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -173,7 +173,7 @@ where
                 )
                 .with_deletions_retained(retain_updates);
                 let node_iter = TrieNodeIter::state_trie(walker, hashed_account_cursor)
-                    .with_last_hashed_key(state.last_account_key);
+                    .with_last_hashed_key(state.last_hashed_key);
                 (hash_builder, node_iter)
             }
             None => {
@@ -249,7 +249,7 @@ where
                         let state = IntermediateRootState {
                             hash_builder,
                             walker_stack,
-                            last_account_key: hashed_address,
+                            last_hashed_key: hashed_address,
                         };
 
                         let state = IntermediateStateRootState {


### PR DESCRIPTION
fixes https://github.com/paradigmxyz/reth/issues/17547

This introduces intermediate storage root state, to keep track of storage root progress. This is included in the `MerkleCheckpoint` so that we can save / reload this progress when we have many buffered storage trie updates. This allows us to limit memory usage in the merkle stage for arbitrarily large contracts while continuing to make progress calculating the storage root.