### PR TITLE
fix: convert latency to milliseconds in reth-bench script

### DIFF
--- a/bin/reth-bench/scripts/compare_newpayload_latency.py
+++ b/bin/reth-bench/scripts/compare_newpayload_latency.py
@@ -68,8 +68,9 @@ def main():
         df1 = df1.head(min_len)
         df2 = df2.head(min_len)
 
-    latency1 = df1['total_latency'].values
-    latency2 = df2['total_latency'].values
+    # Convert from microseconds to milliseconds for better readability
+    latency1 = df1['total_latency'].values / 1000.0
+    latency2 = df2['total_latency'].values / 1000.0
 
     # Handle division by zero
     with np.errstate(divide='ignore', invalid='ignore'):


### PR DESCRIPTION
The CSV data contains latency values in microseconds, but the Y-axis was incorrectly displaying them as raw values while labeling them as milliseconds. This fix converts the values by dividing by 1000 to properly display milliseconds on the charts.

🤖 Generated with [Claude Code](https://claude.ai/code)