### PR TITLE
fix(stages): correct "testfil" typo in downloader comment

### DIFF
--- a/crates/stages/stages/src/stages/s3/downloader/fetch.rs
+++ b/crates/stages/stages/src/stages/s3/downloader/fetch.rs
@@ -181,7 +181,7 @@ mod tests {
         let target_dir = file.path().parent().unwrap();
         match fetch(filename, target_dir, url, 4, Some(b3sum)).await {
             Ok(_) | Err(DownloaderError::EmptyContentLength) => {
-                // the testfil API can be flaky, so we ignore this error
+                // the testfile API can be flaky, so we ignore this error
             }
             Err(error) => {
                 panic!("Unexpected download error: {error:?}");


### PR DESCRIPTION
Fixes spelling error in the test function comment where "testfil" was incorrectly used instead of "testfile" when referring to the testfile.org API