### PR TITLE
docs: fix doc comments: clarify downloaded bytes and builder return condition

### DIFF
--- a/crates/stages/stages/src/stages/s3/downloader/meta.rs
+++ b/crates/stages/stages/src/stages/s3/downloader/meta.rs
@@ -12,7 +12,7 @@ use tracing::info;
 pub struct Metadata {
     /// Total file size
     pub total_size: usize,
-    /// Total file size
+    /// Total downloaded bytes
     pub downloaded: usize,
     /// Download chunk size. Default 150MB.
     pub chunk_size: usize,
@@ -141,7 +141,7 @@ impl MetadataBuilder {
         self
     }
 
-    /// Returns a [Metadata] if
+    /// Returns a [Metadata] if total size is valid
     pub fn build(&self) -> Result<Metadata, DownloaderError> {
         match &self.total_size {
             Some(total_size) if *total_size > 0 => {
@@ -173,7 +173,7 @@ impl MetadataBuilder {
 struct MetadataFile {
     /// Total file size
     total_size: usize,
-    /// Total file size
+    /// Total downloaded bytes
     downloaded: usize,
     /// Download chunk size. Default 150MB.
     chunk_size: usize,

--- a/crates/storage/errors/src/writer.rs
+++ b/crates/storage/errors/src/writer.rs
@@ -2,7 +2,6 @@ use crate::db::DatabaseError;
 use reth_static_file_types::StaticFileSegment;
 
 /// `UnifiedStorageWriter` related errors
-/// `StorageWriter` related errors
 #[derive(Clone, Debug, derive_more::Display, PartialEq, Eq, derive_more::Error)]
 pub enum UnifiedStorageWriterError {
     /// Database writer is missing


### PR DESCRIPTION
Description:  
- Corrects the doc comment for the `downloaded` field in `Metadata` to "Total downloaded bytes" instead of "Total file size"
- Expands the doc comment for `MetadataBuilder::build` to clarify it returns `Metadata` only if total size is valid
