### PR TITLE
fix: Update alloy-evm to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "8.0.3"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -10648,7 +10648,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "27.0.3"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10666,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -10678,7 +10678,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "8.0.3"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "8.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10708,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "either",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "8.0.3"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10751,7 +10751,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "8.0.3"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "either",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "23.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "24.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10835,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4394,7 +4394,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4850,7 +4850,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6056,8 +6056,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9ba9cab294a5ed02afd1a1060220762b3c52911acab635db33822e93f7276d"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -6752,7 +6751,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10649,8 +10648,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a84455f03d3480d4ed2e7271c15f2ec95b758e86d57cb8d258a8ff1c22e9a4"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10668,8 +10666,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a685758a4f375ae9392b571014b9779cfa63f0d8eb91afb4626ddd958b23615"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -10681,8 +10678,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990abf66b47895ca3e915d5f3652bb7c6a4cff6e5351fdf0fc2795171fd411c"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10697,8 +10693,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a303a93102fceccec628265efd550ce49f2817b38ac3a492c53f7d524f18a1ca"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10713,8 +10708,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db360729b61cc347f9c2f12adb9b5e14413aea58778cf9a3b7676c6a4afa115"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10727,8 +10721,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8500194cad0b9b1f0567d72370795fd1a5e0de9ec719b1607fa1566a23f039a"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "auto_impl",
  "either",
@@ -10740,8 +10733,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c35a17a38203976f97109e20eccf6732447ce6c9c42973bae42732b2e957ff"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10759,8 +10751,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abf6a076741bd5cd87b7d6c1b48be2821acc58932f284572323e81a8d4179"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "auto_impl",
  "either",
@@ -10797,8 +10788,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "23.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95c4a9a1662d10b689b66b536ddc2eb1e89f5debfcabc1a2d7b8417a2fa47cd"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10809,8 +10799,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68d54a4733ac36bd29ee645c3c2e5e782fb63f199088d49e2c48c64a9fedc15"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10836,8 +10825,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cdf897b3418f2ee05bcade64985e5faed2dbaa349b2b5f27d3d6bfd10fff2a"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10847,8 +10835,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106fec5c634420118c7d07a6c37110186ae7f23025ceac3a5dbe182eea548363"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#7e98625d1391b11b0f5fb2fa88dae2735959994b"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -11092,7 +11079,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11105,7 +11092,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11163,7 +11150,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11953,7 +11940,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3b746060277f3d7f9c36903bb39b593a741cb7afcb0044164c28f0e9b673f0"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -139,8 +138,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf98679329fa708fa809ea596db6d974da892b068ad45e48ac1956f582edf946"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -154,8 +152,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10e47f5305ea08c37b1772086c1573e9a0a257227143996841172d37d3831bb"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -193,8 +190,7 @@ dependencies = [
 [[package]]
 name = "alloy-eip2124"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+source = "git+https://github.com/alloy-rs/eips?branch=rkrasiuk%2Ffork-hash-from-bytes-arr#1cc63cb63366e5641927369b130cd43de9623a48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -237,8 +233,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f562a81278a3ed83290e68361f2d1c75d018ae3b8589a314faf9303883e18ec9"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -280,8 +275,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc41384e9ab8c9b2fb387c52774d9d432656a28edcda1c2d4083e96051524518"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -320,8 +314,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c454fcfcd5d26ed3b8cae5933cbee9da5f0b05df19b46d4bd4446d1f082565"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -335,8 +328,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d6d39eabe5c7b3d8f23ac47b0b683b99faa4359797114636c66e0743103d05"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -361,8 +353,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3704fa8b7ba9ba3f378d99b3d628c8bc8c2fc431b709947930f154e22a8368b6"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -434,8 +425,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08800e8cbe70c19e2eb7cf3d7ff4b28bdd9b3933f8e1c8136c7d910617ba03bf"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -480,8 +470,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae68457a2c2ead6bd7d7acb5bf5f1623324b1962d4f8e7b0250657a3c3ab0a0b"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -523,8 +512,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162301b5a57d4d8f000bf30f4dcb82f9f468f3e5e846eeb8598dd39e7886932c"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -549,8 +537,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd8ca94ae7e2b32cc3895d9981f3772aab0b4756aa60e9ed0bcfee50f0e1328"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -562,8 +549,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bff682e76f3f72e9ddc75e54a1bd1db5ce53cbdf2cce2d63a3a981437f78f5"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -574,8 +560,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3ff6a778ebda3deaed9af17930d678611afe1effa895c4260b61009c314f82"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -586,8 +571,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076b47e834b367d8618c52dd0a0d6a711ddf66154636df394805300af4923b8a"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -597,8 +581,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f39da9b760e78fc3f347fba4da257aa6328fb33f73682b26cc0a6874798f7d"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -615,8 +598,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a2a86ad7b7d718c15e79d0779bd255561b6b22968dc5ed2e7c0fbc43bb55fe"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -625,8 +607,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba838417c42e8f1fe5eb4f4bbfacb7b5d4b9e615b8d2e831b921e04bf0bed62"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -646,8 +627,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2f847e635ec0be819d06e2ada4bcc4e4204026a83c4bfd78ae8d550e027ae7"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -668,8 +648,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1c9b23cedf70aeb99ea9f16b78cdf902f524e227922fb340e3eb899ebe96dc"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -683,8 +662,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc58180302a94c934d455eeedb3ecb99cdc93da1dbddcdbbdb79dd6fe618b2a"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -697,8 +675,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9f089d78bb94148e0fcfda087d4ce5fd35a7002847b5e90610c0fcb140f7b4"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -709,8 +686,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae699248d02ade9db493bbdae61822277dc14ae0f82a5a4153203b60e34422a6"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -721,8 +697,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf7d793c813515e2b627b19a15693960b3ed06670f9f66759396d06ebe5747b"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -736,8 +711,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a424bc5a11df0d898ce0fd15906b88ebe2a6e4f17a514b51bc93946bb756bd"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -824,8 +798,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f317d20f047b3de4d9728c556e2e9a92c9a507702d2016424cd8be13a74ca5e"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -847,8 +820,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff084ac7b1f318c87b579d221f11b748341d68b9ddaa4ffca5e62ed2b8cfefb4"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -862,8 +834,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb099cdad8ed2e6a80811cdf9bbf715ebf4e34c981b4a6e2d1f9daacbf8b218"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -882,8 +853,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e915e1250dc129ad48d264573ccd08e4716fdda564a772fd217875b8459aff9"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -920,8 +890,7 @@ dependencies = [
 [[package]]
 name = "alloy-tx-macros"
 version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154c8187a5ff985c95a8b2daa2fedcf778b17d7668e5e50e556c4ff9c881154"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -2297,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3167,7 +3136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4425,7 +4394,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4881,7 +4850,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5237,7 +5206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6783,7 +6752,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8306,9 +8275,11 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-chainspec",
+ "reth-consensus-common",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
@@ -11121,7 +11092,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11134,7 +11105,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11192,7 +11163,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11982,7 +11953,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12629,7 +12600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -13175,7 +13146,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b95b3deca680efc7e9cba781f1a1db352fa1ea50e6384a514944dcf4419e652"
+checksum = "d9e8a436f0aad7df8bb47f144095fba61202265d9f5f09a70b0e3227881a668e"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -273,6 +273,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-evm"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28de0dd1bbb0634ef7c3715e8e60176b77b82f8b6b15b2e35fe64cf6640f6550"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "op-alloy-consensus",
+ "op-revm",
+ "revm",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "alloy-genesis"
 version = "1.0.22"
 source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
@@ -301,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
+checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -370,7 +390,7 @@ checksum = "98354b9c3d50de701a63693d5b6a37e468a93b970b2224f934dd745c727ef998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.14.0",
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
@@ -393,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
+checksum = "3cfebde8c581a5d37b678d0a48a32decb51efd7a63a08ce2517ddec26db705c8"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -414,7 +434,7 @@ dependencies = [
  "paste",
  "proptest",
  "proptest-derive",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -727,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f21d053aea4c6630687c2f4ad614bed4c81e14737a9b904798b24f30ea849"
+checksum = "aedac07a10d4c2027817a43cc1f038313fc53c7ac866f7363239971fd01f9f18"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -741,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d99282e7c9ef14eb62727981a985a01869e586d1dec729d3bb33679094c100"
+checksum = "24f9a598f010f048d8b8226492b6401104f5a5c1273c2869b72af29b48bb4ba9"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -759,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda029f955b78e493360ee1d7bd11e1ab9f2a220a5715449babc79d6d0a01105"
+checksum = "f494adf9d60e49aa6ce26dfd42c7417aa6d4343cf2ae621f20e4d92a5ad07d85"
 dependencies = [
  "const-hex",
  "dunce",
@@ -775,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
+checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
 dependencies = [
  "serde",
  "winnow",
@@ -785,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58377025a47d8b8426b3e4846a251f2c1991033b27f517aade368146f6ab1dfe"
+checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -893,7 +913,7 @@ version = "1.0.22"
 source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#a32aa227de3aa9b5591e82150e3046fd233d427f"
 dependencies = [
  "alloy-primitives",
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -2266,7 +2286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2613,8 +2633,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+dependencies = [
+ "darling_core 0.21.0",
+ "darling_macro 0.21.0",
 ]
 
 [[package]]
@@ -2632,12 +2662,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+dependencies = [
+ "darling_core 0.21.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -2780,7 +2835,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3193,7 +3248,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd55d08012b4e0dfcc92b8d6081234df65f2986ad34cc76eeed69c5e2ce7506"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3275,7 +3330,7 @@ name = "example-custom-beacon-withdrawals"
 version = "0.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-sol-macro",
  "alloy-sol-types",
  "eyre",
@@ -3319,7 +3374,7 @@ dependencies = [
 name = "example-custom-evm"
 version = "0.0.0"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -3333,7 +3388,7 @@ name = "example-custom-inspector"
 version = "0.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "clap",
@@ -3347,7 +3402,7 @@ version = "0.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-genesis",
  "alloy-op-evm",
  "alloy-primitives",
@@ -3555,7 +3610,7 @@ dependencies = [
 name = "example-precompile-cache"
 version = "0.0.0"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -4174,7 +4229,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "serde",
  "thiserror 2.0.12",
@@ -4197,7 +4252,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -4394,7 +4449,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4763,7 +4818,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -4805,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -4993,7 +5048,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -5206,7 +5261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5551,7 +5606,7 @@ dependencies = [
  "metrics",
  "ordered-float",
  "quanta",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -5944,9 +5999,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.11"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18986c5cf19a790b8b9e8c856a950b48ed6dd6a0259d0efd5f5c9bebbba1fc3a"
+checksum = "d3c719b26da6d9cac18c3a35634d6ab27a74a304ed9b403b43749c22e57a389f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5970,9 +6025,9 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.18.11"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac69810db9294e1de90b2cc6688b213399d8a5c96b283220caddd98a65dcbc39"
+checksum = "66be312d3446099f1c46b3bb4bbaccdd4b3d6fb3668921158e3d47dff0a8d4a0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5986,9 +6041,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.18.11"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490c08acf608a3fd039728dc5b77a2ff903793db223509f4d94e43c22717a8f7"
+checksum = "3833995acfc568fdac3684f037c4ed3f1f2bd2ef5deeb3f46ecee32aafa34c8e"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -5996,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.18.11"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dd487b283473591919ba95829f7a8d27d511488948d2ee6b24b283dd83008f"
+checksum = "99911fa02e717a96ba24de59874b20cf31c9d116ce79ed4e0253267260b6922f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6015,9 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.11"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814d2b82a6d0b973afc78e797a74818165f257041b9173016dccbe3647f8b1da"
+checksum = "50cf45d43a3d548fdc39d9bfab6ba13cc06b3214ef4b9c36d3efbf3faea1b9f1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6152,7 +6207,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
@@ -6605,7 +6660,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -6728,7 +6783,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -6802,9 +6857,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -6954,9 +7009,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -7264,7 +7319,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -7289,7 +7344,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -7414,7 +7469,7 @@ dependencies = [
  "eyre",
  "libc",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
@@ -7495,7 +7550,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-primitives",
@@ -7574,7 +7629,7 @@ dependencies = [
  "parity-scale-codec",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
@@ -7675,7 +7730,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
@@ -7699,7 +7754,7 @@ dependencies = [
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -7729,7 +7784,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chainspec",
  "reth-config",
@@ -7928,7 +7983,7 @@ version = "1.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -7944,7 +7999,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -8029,7 +8084,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "eyre",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest",
  "reth-era-downloader",
  "reth-ethereum-primitives",
@@ -8114,7 +8169,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
@@ -8150,7 +8205,7 @@ dependencies = [
  "derive_more",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
@@ -8310,7 +8365,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
@@ -8335,7 +8390,7 @@ version = "1.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -8360,7 +8415,7 @@ version = "1.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-genesis",
  "alloy-primitives",
  "derive_more",
@@ -8380,7 +8435,7 @@ dependencies = [
 name = "reth-execution-errors"
 version = "1.5.1"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -8394,12 +8449,12 @@ version = "1.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-primitives",
  "arbitrary",
  "bincode 1.3.3",
  "derive_more",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
@@ -8421,7 +8476,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-config",
@@ -8492,7 +8547,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bincode 1.3.3",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-ethereum-primitives",
  "reth-execution-types",
@@ -8547,7 +8602,7 @@ dependencies = [
  "interprocess",
  "jsonrpsee",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-tracing",
  "serde",
  "serde_json",
@@ -8570,7 +8625,7 @@ dependencies = [
  "derive_more",
  "indexmap 2.10.0",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-mdbx-sys",
  "smallvec",
  "tempfile",
@@ -8639,7 +8694,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -8733,7 +8788,7 @@ dependencies = [
  "alloy-rlp",
  "enr",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "secp256k1 0.30.0",
  "serde_json",
  "serde_with",
@@ -8764,7 +8819,7 @@ dependencies = [
  "derive_more",
  "lz4_flex",
  "memmap2",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-fs-util",
  "serde",
  "tempfile",
@@ -8877,7 +8932,7 @@ dependencies = [
  "futures",
  "humantime",
  "proptest",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
@@ -8933,7 +8988,7 @@ dependencies = [
  "alloy-sol-types",
  "eyre",
  "futures",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",
@@ -9202,7 +9257,7 @@ version = "1.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-genesis",
  "alloy-op-evm",
  "alloy-primitives",
@@ -9342,7 +9397,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
@@ -9579,7 +9634,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chainspec",
  "reth-codecs",
@@ -9609,7 +9664,7 @@ dependencies = [
  "metrics",
  "notify",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9767,7 +9822,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9795,7 +9850,7 @@ dependencies = [
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
@@ -10027,7 +10082,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10070,7 +10125,7 @@ version = "1.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.15.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10081,7 +10136,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -10157,7 +10212,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "paste",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reqwest",
  "reth-chainspec",
@@ -10240,7 +10295,7 @@ dependencies = [
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-trie-common",
  "serde",
@@ -10372,7 +10427,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "secp256k1 0.30.0",
@@ -10433,7 +10488,7 @@ dependencies = [
  "paste",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -10562,7 +10617,7 @@ dependencies = [
  "metrics",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-db-api",
  "reth-execution-errors",
@@ -10596,7 +10651,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -10625,7 +10680,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-execution-errors",
  "reth-primitives-traits",
@@ -11010,7 +11065,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rlp",
  "ruint-macro",
  "serde",
@@ -11299,7 +11354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.1",
+ "rand 0.9.2",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -11483,7 +11538,7 @@ version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -11852,9 +11907,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ac494e7266fcdd2ad80bf4375d55d27a117ea5c866c26d0e97fe5b3caeeb75"
+checksum = "a7a985ff4ffd7373e10e0fb048110fb11a162e5a4c47f92ddb8787a6f766b769"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -11978,9 +12033,9 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2f06b1ae65cbf4dc1f4975279cee7dbf70fcca269bdbdd8aabd20a79e6785c"
+checksum = "bb4eb3ad07d6df1b12c23bc2d034e35a80c25d2e1232d083b42c081fd01c1c63"
 dependencies = [
  "serde",
  "serde_combinators",
@@ -11991,9 +12046,9 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-internal"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6a1dc2074c20c6410ac75687be17808a22abfd449e28301a95d72974b91768"
+checksum = "53b853a8b27e0c335dd114f182fc808b917ced20dbc1bcdab79cc3e023b38762"
 dependencies = [
  "bincode 2.0.1",
  "cargo_metadata 0.19.2",
@@ -12002,11 +12057,11 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-macro"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190423aabaca6cec8392cf45e471777e036d424a14d979db8033f25cc417f1ad"
+checksum = "eb25760cf823885b202e5cc8ef8dc385e80ef913537656129ea8b34470280601"
 dependencies = [
- "darling",
+ "darling 0.21.0",
  "heck",
  "itertools 0.14.0",
  "prettyplease",
@@ -12017,9 +12072,9 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-runtime"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05723662ca81651b49dd87b50cae65a0a38523aa1c0cb6b049a8c4f5c2c7836"
+checksum = "c9b807e6d99cb6157a3f591ccf9f02187730a5774b9b1f066ff7dffba329495e"
 dependencies = [
  "hex",
  "num-traits",
@@ -12587,7 +12642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12609,7 +12664,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -12648,7 +12703,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -13133,7 +13188,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -712,34 +712,36 @@ visibility = "0.1.1"
 walkdir = "2.3.3"
 vergen-git2 = "1.0.5"
 
-# [patch.crates-io]
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+[patch.crates-io]
+alloy-eip2124 = { git = "https://github.com/alloy-rs/eips", branch = "rkrasiuk/fork-hash-from-bytes-arr" }
+
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
 
 # op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
 # op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -743,6 +743,18 @@ alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fu
 alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
 alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
 
+revm = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-database = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-state = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-context = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+op-revm = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+
 # op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
 # op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
 # op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,7 +471,7 @@ revm-inspectors = "0.26.5"
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.2.0"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-evm = { version = "0.14", default-features = false }
+alloy-evm = { version = "0.15", default-features = false }
 alloy-primitives = { version = "1.2.0", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-macro = "1.2.0"

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -11,6 +11,9 @@ use reth_primitives_traits::{
     SealedHeader,
 };
 
+/// The maximum RLP length of a block, defined in [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934).
+pub const MAX_RLP_BLOCK_SIZE: usize = 8_388_608;
+
 /// Gas used needs to be less than gas limit. Gas used is going to be checked after execution.
 #[inline]
 pub fn validate_header_gas<H: BlockHeader>(header: &H) -> Result<(), ConsensusError> {
@@ -157,6 +160,7 @@ where
 ///   information about the specific checks in [`validate_shanghai_withdrawals`].
 /// * EIP-4844 blob gas validation, if cancun is active based on the given chainspec. See more
 ///   information about the specific checks in [`validate_cancun_gas`].
+/// * EIP-7934 block size limit validation, if osaka is active based on the given chainspec.
 pub fn post_merge_hardfork_fields<B, ChainSpec>(
     block: &SealedBlock<B>,
     chain_spec: &ChainSpec,
@@ -184,6 +188,15 @@ where
 
     if chain_spec.is_cancun_active_at_timestamp(block.timestamp()) {
         validate_cancun_gas(block)?;
+    }
+
+    if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) &&
+        block.rlp_length() > MAX_RLP_BLOCK_SIZE
+    {
+        return Err(ConsensusError::BlockTooLarge {
+            rlp_length: block.rlp_length(),
+            max_rlp_length: MAX_RLP_BLOCK_SIZE,
+        })
     }
 
     Ok(())
@@ -335,8 +348,12 @@ pub fn validate_against_parent_4844<H: BlockHeader>(
     }
     let excess_blob_gas = header.excess_blob_gas().ok_or(ConsensusError::ExcessBlobGasMissing)?;
 
-    let expected_excess_blob_gas =
-        blob_params.next_block_excess_blob_gas(parent_excess_blob_gas, parent_blob_gas_used);
+    let parent_base_fee_per_gas = parent.base_fee_per_gas().unwrap_or(0);
+    let expected_excess_blob_gas = blob_params.next_block_excess_blob_gas(
+        parent_excess_blob_gas,
+        parent_blob_gas_used,
+        parent_base_fee_per_gas,
+    );
     if expected_excess_blob_gas != excess_blob_gas {
         return Err(ConsensusError::ExcessBlobGasDiff {
             diff: GotExpected { got: excess_blob_gas, expected: expected_excess_blob_gas },

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -395,6 +395,14 @@ pub enum ConsensusError {
         /// The block's timestamp.
         timestamp: u64,
     },
+    /// Error when the block is too large.
+    #[error("block is too large: {rlp_length} > {max_rlp_length}")]
+    BlockTooLarge {
+        /// The actual RLP length of the block.
+        rlp_length: usize,
+        /// The maximum allowed RLP length.
+        max_rlp_length: usize,
+    },
     /// Other, likely an injected L2 error.
     #[error("{0}")]
     Other(String),

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -84,7 +84,7 @@ where
             } else {
                 // for the first post-fork block, both parent.blob_gas_used and
                 // parent.excess_blob_gas are evaluated as 0
-                Some(alloy_eips::eip7840::BlobParams::cancun().next_block_excess_blob_gas(0, 0))
+                Some(alloy_eips::eip7840::BlobParams::cancun().next_block_excess_blob_gas(0, 0, 0))
             };
         }
 

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -26,13 +26,13 @@ use alloy_evm::{
 };
 use alloy_primitives::{Bytes, U256};
 use core::{convert::Infallible, fmt::Debug};
-use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
+use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, MAINNET};
 use reth_ethereum_primitives::{Block, EthPrimitives, TransactionSigned};
 use reth_evm::{
     precompiles::PrecompilesMap, ConfigureEvm, EvmEnv, EvmFactory, NextBlockEnvAttributes,
     TransactionEnv,
 };
-use reth_primitives_traits::{SealedBlock, SealedHeader};
+use reth_primitives_traits::{constants::MAX_TX_GAS_LIMIT_OSAKA, SealedBlock, SealedHeader};
 use revm::{
     context::{BlockEnv, CfgEnv},
     context_interface::block::BlobExcessGasAndPrice,
@@ -161,6 +161,10 @@ where
             cfg_env.set_max_blobs_per_tx(blob_params.max_blobs_per_tx);
         }
 
+        if self.chain_spec().is_osaka_active_at_timestamp(header.timestamp) {
+            cfg_env.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
+        }
+
         // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current
         // blobparams
         let blob_excess_gas_and_price =
@@ -203,6 +207,10 @@ where
 
         if let Some(blob_params) = &blob_params {
             cfg.set_max_blobs_per_tx(blob_params.max_blobs_per_tx);
+        }
+
+        if self.chain_spec().is_osaka_active_at_timestamp(attributes.timestamp) {
+            cfg.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
         }
 
         // if the parent block did not have excess blob gas (i.e. it was pre-cancun), but it is

--- a/crates/ethereum/payload/Cargo.toml
+++ b/crates/ethereum/payload/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-consensus-common.workspace = true
 reth-ethereum-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-revm.workspace = true
@@ -29,6 +30,7 @@ reth-chainspec.workspace = true
 reth-payload-validator.workspace = true
 
 # ethereum
+alloy-rlp.workspace = true
 revm.workspace = true
 alloy-rpc-types-engine.workspace = true
 

--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -18,7 +18,7 @@ pub const MAXIMUM_GAS_LIMIT_BLOCK: u64 = 2u64.pow(63) - 1;
 pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 
 /// Maximum transaction gas limit as defined by [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) activated in `Osaka` hardfork.
-pub const MAX_TX_GAS_LIMIT_OSAKA: u64 = 30_000_000;
+pub const MAX_TX_GAS_LIMIT_OSAKA: u64 = 2u64.pow(24);
 
 /// The number of blocks to unwind during a reorg that already became a part of canonical chain.
 ///

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -60,19 +60,19 @@ pub trait EstimateCall: Call {
         let tx_request_gas_limit = request.as_ref().gas_limit();
         let tx_request_gas_price = request.as_ref().gas_price();
         // the gas limit of the corresponding block
-        let block_env_gas_limit = evm_env.block_env.gas_limit;
+        let max_gas_limit = evm_env.cfg_env.tx_gas_limit_cap.unwrap_or(evm_env.block_env.gas_limit);
 
         // Determine the highest possible gas limit, considering both the request's specified limit
         // and the block's limit.
         let mut highest_gas_limit = tx_request_gas_limit
             .map(|mut tx_gas_limit| {
-                if block_env_gas_limit < tx_gas_limit {
+                if max_gas_limit < tx_gas_limit {
                     // requested gas limit is higher than the allowed gas limit, capping
-                    tx_gas_limit = block_env_gas_limit;
+                    tx_gas_limit = max_gas_limit;
                 }
                 tx_gas_limit
             })
-            .unwrap_or(block_env_gas_limit);
+            .unwrap_or(max_gas_limit);
 
         // Configure the evm env
         let mut db = CacheDB::new(StateProviderDatabase::new(state));
@@ -138,7 +138,7 @@ pub trait EstimateCall: Call {
                 if err.is_gas_too_high() &&
                     (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
             {
-                return Self::map_out_of_gas_err(&mut evm, tx_env, block_env_gas_limit);
+                return Self::map_out_of_gas_err(&mut evm, tx_env, max_gas_limit);
             }
             Err(err) if err.is_gas_too_low() => {
                 // This failed because the configured gas cost of the tx was lower than what
@@ -165,7 +165,7 @@ pub trait EstimateCall: Call {
                 // if price or limit was included in the request then we can execute the request
                 // again with the block's gas limit to check if revert is gas related or not
                 return if tx_request_gas_limit.is_some() || tx_request_gas_price.is_some() {
-                    Self::map_out_of_gas_err(&mut evm, tx_env, block_env_gas_limit)
+                    Self::map_out_of_gas_err(&mut evm, tx_env, max_gas_limit)
                 } else {
                     // the transaction did revert
                     Err(RpcInvalidTransactionError::Revert(RevertError::new(output)).into_eth_err())
@@ -294,14 +294,14 @@ pub trait EstimateCall: Call {
     fn map_out_of_gas_err<DB>(
         evm: &mut EvmFor<Self::Evm, DB>,
         mut tx_env: TxEnvFor<Self::Evm>,
-        higher_gas_limit: u64,
+        max_gas_limit: u64,
     ) -> Result<U256, Self::Error>
     where
         DB: Database<Error = ProviderError>,
         EthApiError: From<DB::Error>,
     {
         let req_gas_limit = tx_env.gas_limit();
-        tx_env.set_gas_limit(higher_gas_limit);
+        tx_env.set_gas_limit(max_gas_limit);
 
         let retry_res = evm.transact(tx_env).map_err(Self::Error::from_evm_err)?;
 

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -179,7 +179,13 @@ impl EthApiError {
 
     /// Returns `true` if error is [`RpcInvalidTransactionError::GasTooHigh`]
     pub const fn is_gas_too_high(&self) -> bool {
-        matches!(self, Self::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh))
+        matches!(
+            self,
+            Self::InvalidTransaction(
+                RpcInvalidTransactionError::GasTooHigh |
+                    RpcInvalidTransactionError::GasLimitTooHigh
+            )
+        )
     }
 
     /// Returns `true` if error is [`RpcInvalidTransactionError::GasTooLow`]

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -402,10 +402,11 @@ where
     /// Returns a `None` if no excess blob gas is set, no EIP-4844 support
     pub fn next_block_excess_blob_gas(&self) -> Option<u64> {
         self.header.excess_blob_gas().and_then(|excess_blob_gas| {
-            Some(
-                self.blob_params?
-                    .next_block_excess_blob_gas(excess_blob_gas, self.header.blob_gas_used()?),
-            )
+            Some(self.blob_params?.next_block_excess_blob_gas(
+                excess_blob_gas,
+                self.header.blob_gas_used()?,
+                self.header.base_fee_per_gas()?,
+            ))
         })
     }
 }

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -342,7 +342,7 @@ where
                 TracingInspectorConfig::default_parity(),
                 |tx_info, ctx| {
                     Ok(ctx
-                        .inspector
+                        .inspector.clone()
                         .into_parity_builder()
                         .into_localized_transaction_traces(tx_info))
                 },

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -342,7 +342,8 @@ where
                 TracingInspectorConfig::default_parity(),
                 |tx_info, ctx| {
                     Ok(ctx
-                        .inspector.clone()
+                        .inspector
+                        .clone()
                         .into_parity_builder()
                         .into_localized_transaction_traces(tx_info))
                 },

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -404,7 +404,8 @@ where
                 TracingInspectorConfig::default_parity(),
                 move |tx_info, ctx| {
                     let mut traces = ctx
-                        .inspector.clone()
+                        .inspector
+                        .clone()
                         .into_parity_builder()
                         .into_localized_transaction_traces(tx_info);
                     traces.retain(|trace| matcher.matches(&trace.trace));
@@ -472,8 +473,11 @@ where
             None,
             TracingInspectorConfig::default_parity(),
             |tx_info, ctx| {
-                let traces =
-                    ctx.inspector.clone().into_parity_builder().into_localized_transaction_traces(tx_info);
+                let traces = ctx
+                    .inspector
+                    .clone()
+                    .into_parity_builder()
+                    .into_localized_transaction_traces(tx_info);
                 Ok(traces)
             },
         );
@@ -510,7 +514,8 @@ where
                 TracingInspectorConfig::from_parity_config(&trace_types),
                 move |tx_info, ctx| {
                     let mut full_trace = ctx
-                        .inspector.clone()
+                        .inspector
+                        .clone()
                         .into_parity_builder()
                         .into_trace_results(&ctx.result, &trace_types);
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -404,7 +404,7 @@ where
                 TracingInspectorConfig::default_parity(),
                 move |tx_info, ctx| {
                     let mut traces = ctx
-                        .inspector
+                        .inspector.clone()
                         .into_parity_builder()
                         .into_localized_transaction_traces(tx_info);
                     traces.retain(|trace| matcher.matches(&trace.trace));
@@ -473,7 +473,7 @@ where
             TracingInspectorConfig::default_parity(),
             |tx_info, ctx| {
                 let traces =
-                    ctx.inspector.into_parity_builder().into_localized_transaction_traces(tx_info);
+                    ctx.inspector.clone().into_parity_builder().into_localized_transaction_traces(tx_info);
                 Ok(traces)
             },
         );
@@ -510,7 +510,7 @@ where
                 TracingInspectorConfig::from_parity_config(&trace_types),
                 move |tx_info, ctx| {
                     let mut full_trace = ctx
-                        .inspector
+                        .inspector.clone()
                         .into_parity_builder()
                         .into_trace_results(&ctx.result, &trace_types);
 


### PR DESCRIPTION
The EIP-2395 blockhashes contract system calls fail in the `fusaka-devnet-3` branch as the calls have a gas limit of 30M. 

https://github.com/paradigmxyz/reth/commit/5b45d7bfe6c0947af1c2ce1147645e4ee1ef7789 updated the fusaka-devnet-3 to use the latest revm fusaka-devnet-3 branch. But it didn't update `alloy-evm` to 0.15 which includes the updates done in the latest fusaka-devnet-3 revm branch.

Some clones are introduced since `TracingCtx` struct lost the Copy trait https://github.com/alloy-rs/evm/blob/main/crates/evm/src/tracing.rs#L20