### PR TITLE
refactor: use alloy `Log::collect_for_receipt` instead of macro to collect logs

### DIFF
--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -33,27 +33,11 @@ where
     let cumulative_gas_used = receipt.cumulative_gas_used();
     let logs_bloom = receipt.bloom();
 
-    macro_rules! build_rpc_logs {
-        ($logs:expr) => {
-            $logs
-                .enumerate()
-                .map(|(tx_log_idx, log)| Log {
-                    inner: log,
-                    block_hash: Some(meta.block_hash),
-                    block_number: Some(meta.block_number),
-                    block_timestamp: Some(meta.timestamp),
-                    transaction_hash: Some(meta.tx_hash),
-                    transaction_index: Some(meta.index),
-                    log_index: Some((next_log_index + tx_log_idx) as u64),
-                    removed: false,
-                })
-                .collect()
-        };
-    }
-
     let logs = match receipt {
-        Cow::Borrowed(r) => build_rpc_logs!(r.logs().iter().cloned()),
-        Cow::Owned(r) => build_rpc_logs!(r.into_logs().into_iter()),
+        Cow::Borrowed(r) => {
+            Log::collect_for_receipt(*next_log_index, *meta, r.logs().iter().cloned())
+        }
+        Cow::Owned(r) => Log::collect_for_receipt(*next_log_index, *meta, r.into_logs()),
     };
 
     let rpc_receipt = alloy_rpc_types_eth::Receipt { status, cumulative_gas_used, logs };


### PR DESCRIPTION
Addresses https://github.com/paradigmxyz/reth/pull/17382/files#r2205416742.