### PR TITLE
feat: abstraction for attributes -> NextBlockEnv conversion

### DIFF
--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -3,14 +3,13 @@
 use crate::{
     config::{OpBuilderConfig, OpDAConfig},
     error::OpPayloadBuilderError,
-    payload::{OpBuiltPayload, OpPayloadBuilderAttributes},
-    OpPayloadPrimitives,
+    payload::OpBuiltPayload,
+    OpAttributes, OpPayloadBuilderAttributes, OpPayloadPrimitives,
 };
 use alloy_consensus::{BlockHeader, Transaction, Typed2718};
-use alloy_primitives::{Bytes, B256, U256};
+use alloy_primitives::{B256, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
-use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_basic_payload_builder::*;
 use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
@@ -21,7 +20,6 @@ use reth_evm::{
     ConfigureEvm, Database, Evm,
 };
 use reth_execution_types::ExecutionOutcome;
-use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{transaction::OpTransaction, ADDRESS_L2_TO_L1_MESSAGE_PASSER};
 use reth_optimism_txpool::{
@@ -30,7 +28,7 @@ use reth_optimism_txpool::{
     OpPooledTx,
 };
 use reth_payload_builder_primitives::PayloadBuilderError;
-use reth_payload_primitives::PayloadBuilderAttributes;
+use reth_payload_primitives::{BuildNextEnv, PayloadBuilderAttributes};
 use reth_payload_util::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
 use reth_primitives_traits::{
     HeaderTy, NodePrimitives, SealedHeader, SealedHeaderFor, SignedTransaction, TxTy,
@@ -42,12 +40,18 @@ use reth_revm::{
 use reth_storage_api::{errors::ProviderError, StateProvider, StateProviderFactory};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
 use revm::context::{Block, BlockEnv};
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 use tracing::{debug, trace, warn};
 
 /// Optimism's payload builder
-#[derive(Debug, Clone)]
-pub struct OpPayloadBuilder<Pool, Client, Evm, Txs = ()> {
+#[derive(Debug)]
+pub struct OpPayloadBuilder<
+    Pool,
+    Client,
+    Evm,
+    Txs = (),
+    Attrs = OpPayloadBuilderAttributes<TxTy<<Evm as ConfigureEvm>::Primitives>>,
+> {
     /// The rollup's compute pending block configuration option.
     // TODO(clabby): Implement this feature.
     pub compute_pending_block: bool,
@@ -62,9 +66,31 @@ pub struct OpPayloadBuilder<Pool, Client, Evm, Txs = ()> {
     /// The type responsible for yielding the best transactions for the payload if mempool
     /// transactions are allowed.
     pub best_transactions: Txs,
+    /// Marker for the payload attributes type.
+    _pd: PhantomData<Attrs>,
 }
 
-impl<Pool, Client, Evm> OpPayloadBuilder<Pool, Client, Evm> {
+impl<Pool, Client, Evm, Txs, Attrs> Clone for OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
+where
+    Pool: Clone,
+    Client: Clone,
+    Evm: ConfigureEvm,
+    Txs: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            evm_config: self.evm_config.clone(),
+            pool: self.pool.clone(),
+            client: self.client.clone(),
+            config: self.config.clone(),
+            best_transactions: self.best_transactions.clone(),
+            compute_pending_block: self.compute_pending_block,
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<Pool, Client, Evm, Attrs> OpPayloadBuilder<Pool, Client, Evm, (), Attrs> {
     /// `OpPayloadBuilder` constructor.
     ///
     /// Configures the builder with the default settings.
@@ -86,11 +112,12 @@ impl<Pool, Client, Evm> OpPayloadBuilder<Pool, Client, Evm> {
             evm_config,
             config,
             best_transactions: (),
+            _pd: PhantomData,
         }
     }
 }
 
-impl<Pool, Client, Evm, Txs> OpPayloadBuilder<Pool, Client, Evm, Txs> {
+impl<Pool, Client, Evm, Txs, Attrs> OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs> {
     /// Sets the rollup's compute pending block configuration option.
     pub const fn set_compute_pending_block(mut self, compute_pending_block: bool) -> Self {
         self.compute_pending_block = compute_pending_block;
@@ -102,7 +129,7 @@ impl<Pool, Client, Evm, Txs> OpPayloadBuilder<Pool, Client, Evm, Txs> {
     pub fn with_transactions<T>(
         self,
         best_transactions: T,
-    ) -> OpPayloadBuilder<Pool, Client, Evm, T> {
+    ) -> OpPayloadBuilder<Pool, Client, Evm, T, Attrs> {
         let Self { pool, client, compute_pending_block, evm_config, config, .. } = self;
         OpPayloadBuilder {
             pool,
@@ -111,6 +138,7 @@ impl<Pool, Client, Evm, Txs> OpPayloadBuilder<Pool, Client, Evm, Txs> {
             evm_config,
             best_transactions,
             config,
+            _pd: PhantomData,
         }
     }
 
@@ -125,12 +153,16 @@ impl<Pool, Client, Evm, Txs> OpPayloadBuilder<Pool, Client, Evm, Txs> {
     }
 }
 
-impl<Pool, Client, Evm, N, T> OpPayloadBuilder<Pool, Client, Evm, T>
+impl<Pool, Client, Evm, N, T, Attrs> OpPayloadBuilder<Pool, Client, Evm, T, Attrs>
 where
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: OpHardforks>,
     N: OpPayloadPrimitives,
-    Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm: ConfigureEvm<
+        Primitives = N,
+        NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
+    >,
+    Attrs: OpAttributes<Transaction = TxTy<Evm::Primitives>>,
 {
     /// Constructs an Optimism payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
@@ -142,7 +174,7 @@ where
     /// a result indicating success with the payload or an error in case of failure.
     fn build_payload<'a, Txs>(
         &self,
-        args: BuildArguments<OpPayloadBuilderAttributes<N::SignedTx>, OpBuiltPayload<N>>,
+        args: BuildArguments<Attrs, OpBuiltPayload<N>>,
         best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
     ) -> Result<BuildOutcome<OpBuiltPayload<N>>, PayloadBuilderError>
     where
@@ -165,7 +197,7 @@ where
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let state = StateProviderDatabase::new(&state_provider);
 
-        if ctx.attributes().no_tx_pool {
+        if ctx.attributes().no_tx_pool() {
             builder.build(state, &state_provider, ctx)
         } else {
             // sequencer mode we can reuse cachedreads from previous runs
@@ -178,10 +210,13 @@ where
     pub fn payload_witness(
         &self,
         parent: SealedHeader<N::BlockHeader>,
-        attributes: OpPayloadAttributes,
-    ) -> Result<ExecutionWitness, PayloadBuilderError> {
-        let attributes = OpPayloadBuilderAttributes::try_new(parent.hash(), attributes, 3)
-            .map_err(PayloadBuilderError::other)?;
+        attributes: Attrs::RpcPayloadAttributes,
+    ) -> Result<ExecutionWitness, PayloadBuilderError>
+    where
+        Attrs: PayloadBuilderAttributes,
+    {
+        let attributes =
+            Attrs::try_new(parent.hash(), attributes, 3).map_err(PayloadBuilderError::other)?;
 
         let config = PayloadConfig { parent_header: Arc::new(parent), attributes };
         let ctx = OpPayloadBuilderCtx {
@@ -201,15 +236,20 @@ where
 }
 
 /// Implementation of the [`PayloadBuilder`] trait for [`OpPayloadBuilder`].
-impl<Pool, Client, Evm, N, Txs> PayloadBuilder for OpPayloadBuilder<Pool, Client, Evm, Txs>
+impl<Pool, Client, Evm, N, Txs, Attrs> PayloadBuilder
+    for OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
 where
     N: OpPayloadPrimitives,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: OpHardforks> + Clone,
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
-    Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm: ConfigureEvm<
+        Primitives = N,
+        NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
+    >,
     Txs: OpPayloadTransactions<Pool::Transaction>,
+    Attrs: OpAttributes<Transaction = N::SignedTx>,
 {
-    type Attributes = OpPayloadBuilderAttributes<N::SignedTx>;
+    type Attributes = Attrs;
     type BuiltPayload = OpBuiltPayload<N>;
 
     fn try_build(
@@ -278,18 +318,22 @@ impl<'a, Txs> OpBuilder<'a, Txs> {
 
 impl<Txs> OpBuilder<'_, Txs> {
     /// Builds the payload on top of the state.
-    pub fn build<EvmConfig, ChainSpec, N>(
+    pub fn build<Evm, ChainSpec, N, Attrs>(
         self,
         db: impl Database<Error = ProviderError>,
         state_provider: impl StateProvider,
-        ctx: OpPayloadBuilderCtx<EvmConfig, ChainSpec>,
+        ctx: OpPayloadBuilderCtx<Evm, ChainSpec, Attrs>,
     ) -> Result<BuildOutcomeKind<OpBuiltPayload<N>>, PayloadBuilderError>
     where
-        EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+        Evm: ConfigureEvm<
+            Primitives = N,
+            NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, ChainSpec>,
+        >,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs:
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
+        Attrs: OpAttributes<Transaction = N::SignedTx>,
     {
         let Self { best } = self;
         debug!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number(), "building new payload");
@@ -308,7 +352,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
 
         // 3. if mem pool transactions are requested we execute them
-        if !ctx.attributes().no_tx_pool {
+        if !ctx.attributes().no_tx_pool() {
             let best_txs = best(ctx.best_transaction_attributes(builder.evm_mut().block()));
             if ctx.execute_best_transactions(&mut info, &mut builder, best_txs)?.is_some() {
                 return Ok(BuildOutcomeKind::Cancelled)
@@ -344,7 +388,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             trie: ExecutedTrieUpdates::Present(Arc::new(trie_updates)),
         };
 
-        let no_tx_pool = ctx.attributes().no_tx_pool;
+        let no_tx_pool = ctx.attributes().no_tx_pool();
 
         let payload =
             OpBuiltPayload::new(ctx.payload_id(), sealed_block, info.total_fees, Some(executed));
@@ -360,16 +404,20 @@ impl<Txs> OpBuilder<'_, Txs> {
     }
 
     /// Builds the payload and returns its [`ExecutionWitness`] based on the state after execution.
-    pub fn witness<Evm, ChainSpec, N>(
+    pub fn witness<Evm, ChainSpec, N, Attrs>(
         self,
         state_provider: impl StateProvider,
-        ctx: &OpPayloadBuilderCtx<Evm, ChainSpec>,
+        ctx: &OpPayloadBuilderCtx<Evm, ChainSpec, Attrs>,
     ) -> Result<ExecutionWitness, PayloadBuilderError>
     where
-        Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+        Evm: ConfigureEvm<
+            Primitives = N,
+            NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, ChainSpec>,
+        >,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
+        Attrs: OpAttributes<Transaction = N::SignedTx>,
     {
         let mut db = State::builder()
             .with_database(StateProviderDatabase::new(&state_provider))
@@ -480,7 +528,11 @@ impl ExecutionInfo {
 
 /// Container type that holds all necessities to build a new payload.
 #[derive(derive_more::Debug)]
-pub struct OpPayloadBuilderCtx<Evm: ConfigureEvm, ChainSpec> {
+pub struct OpPayloadBuilderCtx<
+    Evm: ConfigureEvm,
+    ChainSpec,
+    Attrs = OpPayloadBuilderAttributes<TxTy<<Evm as ConfigureEvm>::Primitives>>,
+> {
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: Evm,
     /// The DA config for the payload builder
@@ -488,18 +540,21 @@ pub struct OpPayloadBuilderCtx<Evm: ConfigureEvm, ChainSpec> {
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
     /// How to build the payload.
-    pub config:
-        PayloadConfig<OpPayloadBuilderAttributes<TxTy<Evm::Primitives>>, HeaderTy<Evm::Primitives>>,
+    pub config: PayloadConfig<Attrs, HeaderTy<Evm::Primitives>>,
     /// Marker to check whether the job has been cancelled.
     pub cancel: CancelOnDrop,
     /// The currently best payload.
     pub best_payload: Option<OpBuiltPayload<Evm::Primitives>>,
 }
 
-impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
+impl<Evm, ChainSpec, Attrs> OpPayloadBuilderCtx<Evm, ChainSpec, Attrs>
 where
-    Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm: ConfigureEvm<
+        Primitives: OpPayloadPrimitives,
+        NextBlockEnvCtx: BuildNextEnv<Attrs, HeaderTy<Evm::Primitives>, ChainSpec>,
+    >,
     ChainSpec: EthChainSpec + OpHardforks,
+    Attrs: OpAttributes<Transaction = TxTy<Evm::Primitives>>,
 {
     /// Returns the parent block the payload will be build on.
     pub fn parent(&self) -> &SealedHeaderFor<Evm::Primitives> {
@@ -507,25 +562,8 @@ where
     }
 
     /// Returns the builder attributes.
-    pub const fn attributes(&self) -> &OpPayloadBuilderAttributes<TxTy<Evm::Primitives>> {
+    pub const fn attributes(&self) -> &Attrs {
         &self.config.attributes
-    }
-
-    /// Returns the extra data for the block.
-    ///
-    /// After holocene this extracts the extra data from the payload
-    pub fn extra_data(&self) -> Result<Bytes, PayloadBuilderError> {
-        if self.is_holocene_active() {
-            self.attributes()
-                .get_holocene_extra_data(
-                    self.chain_spec.base_fee_params_at_timestamp(
-                        self.attributes().payload_attributes.timestamp,
-                    ),
-                )
-                .map_err(PayloadBuilderError::other)
-        } else {
-            Ok(Default::default())
-        }
     }
 
     /// Returns the current fee settings for transactions from the mempool
@@ -539,11 +577,6 @@ where
     /// Returns the unique id for this payload job.
     pub fn payload_id(&self) -> PayloadId {
         self.attributes().payload_id()
-    }
-
-    /// Returns true if holocene is active for the payload.
-    pub fn is_holocene_active(&self) -> bool {
-        self.chain_spec.is_holocene_active_at_timestamp(self.attributes().timestamp())
     }
 
     /// Returns true if the fees are higher than the previous payload.
@@ -560,27 +593,16 @@ where
             .builder_for_next_block(
                 db,
                 self.parent(),
-                OpNextBlockEnvAttributes {
-                    timestamp: self.attributes().timestamp(),
-                    suggested_fee_recipient: self.attributes().suggested_fee_recipient(),
-                    prev_randao: self.attributes().prev_randao(),
-                    gas_limit: self
-                        .attributes()
-                        .gas_limit
-                        .unwrap_or_else(|| self.parent().gas_limit()),
-                    parent_beacon_block_root: self.attributes().parent_beacon_block_root(),
-                    extra_data: self.extra_data()?,
-                },
+                Evm::NextBlockEnvCtx::build_next_env(
+                    self.attributes(),
+                    self.parent(),
+                    self.chain_spec.as_ref(),
+                )
+                .map_err(PayloadBuilderError::other)?,
             )
             .map_err(PayloadBuilderError::other)
     }
-}
 
-impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
-where
-    Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
-    ChainSpec: EthChainSpec + OpHardforks,
-{
     /// Executes all sequencer transactions that are included in the payload attributes.
     pub fn execute_sequencer_transactions(
         &self,
@@ -588,7 +610,7 @@ where
     ) -> Result<ExecutionInfo, PayloadBuilderError> {
         let mut info = ExecutionInfo::new();
 
-        for sequencer_tx in &self.attributes().transactions {
+        for sequencer_tx in self.attributes().sequencer_transactions() {
             // A sequencer's block should never contain blob transactions.
             if sequencer_tx.value().is_eip4844() {
                 return Err(PayloadBuilderError::other(

--- a/crates/optimism/payload/src/traits.rs
+++ b/crates/optimism/payload/src/traits.rs
@@ -1,6 +1,9 @@
 use alloy_consensus::BlockBody;
 use reth_optimism_primitives::{transaction::OpTransaction, DepositReceipt};
-use reth_primitives_traits::{FullBlockHeader, NodePrimitives, SignedTransaction};
+use reth_payload_primitives::PayloadBuilderAttributes;
+use reth_primitives_traits::{FullBlockHeader, NodePrimitives, SignedTransaction, WithEncoded};
+
+use crate::OpPayloadBuilderAttributes;
 
 /// Helper trait to encapsulate common bounds on [`NodePrimitives`] for OP payload builder.
 pub trait OpPayloadPrimitives:
@@ -30,4 +33,28 @@ where
 {
     type _TX = Tx;
     type _Header = Header;
+}
+
+/// Attributes for the OP payload builder.
+pub trait OpAttributes: PayloadBuilderAttributes {
+    /// Primitive transaction type.
+    type Transaction: SignedTransaction;
+
+    /// Whether to use the transaction pool for the payload.
+    fn no_tx_pool(&self) -> bool;
+
+    /// Sequencer transactions to include in the payload.
+    fn sequencer_transactions(&self) -> &[WithEncoded<Self::Transaction>];
+}
+
+impl<T: SignedTransaction> OpAttributes for OpPayloadBuilderAttributes<T> {
+    type Transaction = T;
+
+    fn no_tx_pool(&self) -> bool {
+        self.no_tx_pool
+    }
+
+    fn sequencer_transactions(&self) -> &[WithEncoded<Self::Transaction>] {
+        &self.transactions
+    }
 }

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -26,7 +26,8 @@ pub use error::{
 
 mod traits;
 pub use traits::{
-    BuiltPayload, PayloadAttributes, PayloadAttributesBuilder, PayloadBuilderAttributes,
+    BuildNextEnv, BuiltPayload, PayloadAttributes, PayloadAttributesBuilder,
+    PayloadBuilderAttributes,
 };
 
 mod payload;


### PR DESCRIPTION
towards #17565 

Introduces `BuildNextEnv` trait that should be implemented on `NextBlockEnvCtx` and defines how to construct it from payload attributes, parent header and arbitrary ctx.

Integrates it into `OpPayloadBuilder` in a non-breaking way