### PR TITLE
fix: correct prune mode assignments in HistoryIndexingStages

### DIFF
--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -444,12 +444,12 @@ where
             .add_stage(IndexStorageHistoryStage::new(
                 self.stages_config.index_storage_history,
                 self.stages_config.etl.clone(),
-                self.prune_modes.account_history,
+                self.prune_modes.storage_history,
             ))
             .add_stage(IndexAccountHistoryStage::new(
                 self.stages_config.index_account_history,
                 self.stages_config.etl.clone(),
-                self.prune_modes.storage_history,
+                self.prune_modes.account_history,
             ))
     }
 }


### PR DESCRIPTION
Fix incorrect prune mode assignments in the HistoryIndexingStages implementation. The IndexStorageHistoryStage was incorrectly receiving account_history prune mode, and IndexAccountHistoryStage was incorrectly receiving storage_history prune mode. This change ensures each stage receives its corresponding prune mode configuration