### PR TITLE
feat: make CompactEnvelope trait public for external crate usage

### DIFF
--- a/crates/storage/codecs/src/alloy/transaction/ethereum.rs
+++ b/crates/storage/codecs/src/alloy/transaction/ethereum.rs
@@ -112,11 +112,7 @@ impl<Eip4844: Compact + Transaction + RlpEcdsaEncodableTx> Envelope
     }
 }
 
-/// Trait for efficient compact serialization and deserialization of transaction envelopes.
-///
-/// This trait provides a standardized interface for converting transaction envelopes
-/// to and from compact binary format, optimized for database storage with features like
-/// compression and bitfield packing.
+/// Compact serialization for transaction envelopes with compression and bitfield packing.
 pub trait CompactEnvelope: Sized {
     /// Takes a buffer which can be written to. *Ideally*, it returns the length written to.
     fn to_compact<B>(&self, buf: &mut B) -> usize

--- a/crates/storage/codecs/src/alloy/transaction/ethereum.rs
+++ b/crates/storage/codecs/src/alloy/transaction/ethereum.rs
@@ -112,7 +112,12 @@ impl<Eip4844: Compact + Transaction + RlpEcdsaEncodableTx> Envelope
     }
 }
 
-pub(super) trait CompactEnvelope: Sized {
+/// Trait for efficient compact serialization and deserialization of transaction envelopes.
+///
+/// This trait provides a standardized interface for converting transaction envelopes
+/// to and from compact binary format, optimized for database storage with features like
+/// compression and bitfield packing.
+pub trait CompactEnvelope: Sized {
     /// Takes a buffer which can be written to. *Ideally*, it returns the length written to.
     fn to_compact<B>(&self, buf: &mut B) -> usize
     where

--- a/crates/storage/codecs/src/alloy/transaction/mod.rs
+++ b/crates/storage/codecs/src/alloy/transaction/mod.rs
@@ -56,7 +56,7 @@ where
 cond_mod!(eip1559, eip2930, eip4844, eip7702, legacy, txtype);
 
 mod ethereum;
-pub use ethereum::{Envelope, FromTxCompact, ToTxCompact};
+pub use ethereum::{CompactEnvelope, Envelope, FromTxCompact, ToTxCompact};
 
 #[cfg(all(feature = "test-utils", feature = "op"))]
 pub mod optimism;


### PR DESCRIPTION
Makes CompactEnvelope and related traits public to enable external crates to implement efficient transaction serialization following Reth patterns. This change allows chain-specific implementations like Berachain (https://github.com/berachain/bera-reth/pull/50) to leverage the standardized CompactEnvelope system for database storage compatibility while maintaining backwards compatability