### PR TITLE
fix(txpool): enforce encoded length check

### DIFF
--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -391,6 +391,11 @@ impl InvalidPoolTransactionError {
         }
     }
 
+    /// Returns `true` if an import failed due to an oversized transaction
+    pub const fn is_oversized(&self) -> bool {
+        matches!(self, Self::OversizedData(_, _))
+    }
+
     /// Returns `true` if an import failed due to nonce gap.
     pub const fn is_nonce_gap(&self) -> bool {
         matches!(self, Self::Consensus(InvalidTransactionError::NonceNotConsistent { .. })) ||

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -66,6 +66,14 @@ impl<T: PoolTransaction> TransactionValidationOutcome<T> {
         }
     }
 
+    /// Returns the [`InvalidPoolTransactionError`] if this is an invalid variant.
+    pub const fn as_invalid(&self) -> Option<&InvalidPoolTransactionError> {
+        match self {
+            Self::Invalid(_, err) => Some(err),
+            _ => None,
+        }
+    }
+
     /// Returns true if the transaction is valid.
     pub const fn is_valid(&self) -> bool {
         matches!(self, Self::Valid { .. })


### PR DESCRIPTION
this rule must be applied to the encoded size of the txs, for non blob txs, blobs we can basically ignore here.

ref https://github.com/ethereum/go-ethereum/blob/16117eb7cddc4584865af106d2332aa89f387d3d/core/txpool/blobpool/blobpool.go#L57-L61

