### PR TITLE
fix: typo in Cargo.toml

### DIFF
--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -47,7 +47,7 @@ alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 # revm with required ethereum features
-# Note: this must be kept to ensure all features are poperly enabled/forwarded
+# Note: this must be kept to ensure all features are properly enabled/forwarded
 revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg"] }
 
 # misc

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -46,7 +46,7 @@ reth-optimism-forks.workspace = true
 reth-optimism-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"] }
 
 # revm with required optimism features
-# Note: this must be kept to ensure all features are poperly enabled/forwarded
+# Note: this must be kept to ensure all features are properly enabled/forwarded
 revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg"] }
 op-revm.workspace = true
 


### PR DESCRIPTION


**Description:**  
Corrected a minor typo in the comment of `crates/ethereum/node/Cargo.toml`, changing `poperly` to `properly`