### PR TITLE
fix: remove extra space in PostStateRootMismatch error message

### DIFF
--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -71,7 +71,7 @@ pub enum StatelessValidationError {
     HeaderDeserializationFailed,
 
     /// Error when the computed state root does not match the one in the block header.
-    #[error("mismatched post- state root: {got}\n {expected}")]
+    #[error("mismatched post-state root: {got}\n {expected}")]
     PostStateRootMismatch {
         /// The computed post-state root
         got: B256,


### PR DESCRIPTION
remove the unnecessary space between "post-" and "state" in the error message for PostStateRootMismatch