### PR TITLE
test(era1): add more `Receipt` tests to verify decoding

### DIFF
--- a/crates/era/src/era1_types.rs
+++ b/crates/era/src/era1_types.rs
@@ -163,11 +163,11 @@ mod tests {
         test_utils::{create_sample_block, create_test_block_with_compressed_data},
         DecodeCompressed,
     };
+    use alloy_consensus::ReceiptWithBloom;
     use alloy_primitives::{B256, U256};
-    use reth_ethereum_primitives::Receipt;
 
     #[test]
-    fn test_alloy_components_decode() {
+    fn test_alloy_components_decode_and_receipt_in_bloom() {
         // Create a block tuple from compressed data
         let block: BlockTuple = create_test_block_with_compressed_data(30);
 
@@ -188,7 +188,7 @@ mod tests {
         assert_eq!(body.ommers.len(), 0, "Should have no ommers");
         assert!(body.withdrawals.is_some(), "Should have withdrawals field");
 
-        let receipts: alloy_consensus::Receipts<Receipt> = block.receipts.decode().unwrap();
+        let receipts: Vec<ReceiptWithBloom> = block.receipts.decode().unwrap();
         assert_eq!(receipts.len(), 1, "Should have exactly 1 receipt");
     }
 

--- a/crates/era/src/era1_types.rs
+++ b/crates/era/src/era1_types.rs
@@ -159,29 +159,37 @@ impl Era1Id {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::execution_types::{
-        CompressedBody, CompressedHeader, CompressedReceipts, TotalDifficulty,
+    use crate::{
+        test_utils::{create_sample_block, create_test_block_with_compressed_data},
+        DecodeCompressed,
     };
     use alloy_primitives::{B256, U256};
+    use reth_ethereum_primitives::Receipt;
 
-    /// Helper function to create a sample block tuple
-    fn create_sample_block(data_size: usize) -> BlockTuple {
-        // Create a compressed header with very sample data
-        let header_data = vec![0xAA; data_size];
-        let header = CompressedHeader::new(header_data);
+    #[test]
+    fn test_alloy_components_decode() {
+        // Create a block tuple from compressed data
+        let block: BlockTuple = create_test_block_with_compressed_data(30);
 
-        // Create a compressed body
-        let body_data = vec![0xBB; data_size * 2];
-        let body = CompressedBody::new(body_data);
+        // Decode and decompress the block header
+        let header: alloy_consensus::Header = block.header.decode().unwrap();
+        assert_eq!(header.number, 30, "Header block number should match");
+        assert_eq!(header.difficulty, U256::from(30 * 1000), "Header difficulty should match");
+        assert_eq!(header.gas_limit, 5000000, "Gas limit should match");
+        assert_eq!(header.gas_used, 21000, "Gas used should match");
+        assert_eq!(header.timestamp, 1609459200 + 30, "Timestamp should match");
+        assert_eq!(header.base_fee_per_gas, Some(10), "Base fee per gas should match");
+        assert!(header.withdrawals_root.is_some(), "Should have withdrawals root");
+        assert!(header.blob_gas_used.is_none(), "Should not have blob gas used");
+        assert!(header.excess_blob_gas.is_none(), "Should not have excess blob gas");
 
-        // Create compressed receipts
-        let receipts_data = vec![0xCC; data_size];
-        let receipts = CompressedReceipts::new(receipts_data);
+        let body: alloy_consensus::BlockBody<alloy_primitives::Bytes> =
+            block.body.decode().unwrap();
+        assert_eq!(body.ommers.len(), 0, "Should have no ommers");
+        assert!(body.withdrawals.is_some(), "Should have withdrawals field");
 
-        let difficulty = TotalDifficulty::new(U256::from(data_size));
-
-        // Create and return the block tuple
-        BlockTuple::new(header, body, receipts, difficulty)
+        let receipts: alloy_consensus::Receipts<Receipt> = block.receipts.decode().unwrap();
+        assert_eq!(receipts.len(), 1, "Should have exactly 1 receipt");
     }
 
     #[test]

--- a/crates/era/src/era_types.rs
+++ b/crates/era/src/era_types.rs
@@ -126,21 +126,9 @@ impl IndexEntry for SlotIndex {
 mod tests {
     use super::*;
     use crate::{
-        consensus_types::{CompressedBeaconState, CompressedSignedBeaconBlock},
         e2s_types::{Entry, IndexEntry},
+        test_utils::{create_beacon_block, create_beacon_state},
     };
-
-    /// Helper function to create a simple beacon block
-    fn create_beacon_block(data_size: usize) -> CompressedSignedBeaconBlock {
-        let block_data = vec![0xAA; data_size];
-        CompressedSignedBeaconBlock::new(block_data)
-    }
-
-    /// Helper function to create a simple beacon state
-    fn create_beacon_state(data_size: usize) -> CompressedBeaconState {
-        let state_data = vec![0xBB; data_size];
-        CompressedBeaconState::new(state_data)
-    }
 
     #[test]
     fn test_slot_index_roundtrip() {
@@ -208,6 +196,7 @@ mod tests {
         assert_eq!(era_group.state_slot_index.starting_slot, 1000);
         assert_eq!(era_group.state_slot_index.offsets, vec![100, 200, 300]);
     }
+
     #[test]
     fn test_era_group_with_block_index() {
         let blocks = vec![create_beacon_block(10), create_beacon_block(15)];

--- a/crates/era/src/execution_types.rs
+++ b/crates/era/src/execution_types.rs
@@ -1,4 +1,4 @@
-//! Execution layer specific types for era1 files
+//! Execution layer specific types for `.era1` files
 //!
 //! Contains implementations for compressed execution layer data structures:
 //! - [`CompressedHeader`] - Block header
@@ -15,12 +15,11 @@
 //! ## [`CompressedHeader`]
 //!
 //! ```rust
-//! use crate::reth_era::DecodeCompressed;
 //! use alloy_consensus::Header;
-//! use reth_era::execution_types::CompressedHeader;
+//! use reth_era::{execution_types::CompressedHeader, DecodeCompressed};
 //!
 //! let header = Header { number: 100, ..Default::default() };
-//! // Compress the header : rlp encoding and Snappy compression
+//! // Compress the header: rlp encoding and Snappy compression
 //! let compressed = CompressedHeader::from_header(&header)?;
 //! // Decompressed and decode typed compressed header
 //! let decoded_header: Header = compressed.decode_header()?;
@@ -31,10 +30,9 @@
 //! ## [`CompressedBody`]
 //!
 //! ```rust
-//! use crate::reth_era::DecodeCompressed;
 //! use alloy_consensus::{BlockBody, Header};
 //! use alloy_primitives::Bytes;
-//! use reth_era::execution_types::CompressedBody;
+//! use reth_era::{execution_types::CompressedBody, DecodeCompressed};
 //! use reth_ethereum_primitives::TransactionSigned;
 //!
 //! let body: BlockBody<Bytes> = BlockBody {
@@ -54,9 +52,8 @@
 //! ## [`CompressedReceipts`]
 //!
 //! ```rust
-//! use crate::reth_era::DecodeCompressed;
 //! use alloy_consensus::ReceiptWithBloom;
-//! use reth_era::execution_types::CompressedReceipts;
+//! use reth_era::{execution_types::CompressedReceipts, DecodeCompressed};
 //! use reth_ethereum_primitives::{Receipt, TxType};
 //!
 //! let receipt = Receipt {
@@ -66,7 +63,7 @@
 //!     logs: vec![],
 //! };
 //! let receipt_with_bloom = ReceiptWithBloom { receipt, logs_bloom: Default::default() };
-//! // Compress the receipts : rlp encoding and Snappy compression
+//! // Compress the receipt: rlp encoding and snappy compression
 //! let compressed_receipt_data = CompressedReceipts::from_encodable(&receipt_with_bloom)?;
 //! // Get raw receipt by decoding and decompressing compressed and encoded receipt
 //! let decompressed_receipt = compressed_receipt_data.decode::<ReceiptWithBloom>()?;

--- a/crates/era/src/execution_types.rs
+++ b/crates/era/src/execution_types.rs
@@ -9,6 +9,67 @@
 //! These types use Snappy compression to match the specification.
 //!
 //! See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
+//!
+//! # Examples
+//!
+//! ## [`CompressedHeader`]
+//!
+//! ```rust
+//! use alloy_consensus::Header;
+//! use reth_era::execution_types::CompressedHeader;
+//!
+//! let header = Header { number: 100, ..Default::default() };
+//! // Compress the header : rlp encoding and Snappy compression
+//! let compressed = CompressedHeader::from_header(&header)?;
+//! // Get raw decompressed rlp data
+//! let decompressed = compressed.decompress()?;
+//! // Decode back to typed header
+//! let decoded: Header = compressed.decode()?;
+//! assert_eq!(decoded.number, 100);
+//! # Ok::<(), reth_era::e2s_types::E2sError>(())
+//! ```
+//!
+//! ## [`CompressedBody`]
+//!
+//! ```rust
+//! use alloy_consensus::BlockBody;
+//! use alloy_primitives::Bytes;
+//! use reth_era::execution_types::CompressedBody;
+//!
+//! let body = BlockBody { transactions: vec![Bytes::from(vec![1, 2, 3])], ..Default::default() };
+//! // Compress the body : rlp encoding and Snappy compression
+//! let compressed = CompressedBody::from_body(&body)?;
+//! // Get raw decompressed rlp data
+//! let decompressed = compressed.decompress()?;
+//! // Decode back to typed body
+//! let decoded: BlockBody<Bytes> = compressed.decode()?;
+//! assert_eq!(decoded.transactions.len(), 1);
+//! # Ok::<(), reth_era::e2s_types::E2sError>(())
+//! ```
+//!
+//! ## [`CompressedReceipts`]
+//!
+//! ```rust
+//! use alloy_consensus::ReceiptWithBloom;
+//! use reth_era::execution_types::CompressedReceipts;
+//! use reth_ethereum_primitives::{Receipt, TxType};
+//!
+//! let receipt = Receipt {
+//!     tx_type: TxType::Legacy,
+//!     success: true,
+//!     cumulative_gas_used: 21000,
+//!     logs: vec![],
+//! };
+//! let receipt_with_bloom = ReceiptWithBloom { receipt, logs_bloom: Default::default() };
+//! // Compress the receipts : rlp encoding and Snappy compression
+//! let compressed = CompressedReceipts::from_encodable(&receipt_with_bloom)?;
+//! // Get raw decompressed rlp data
+//! let decompressed = compressed.decompress()?;
+//! // Decode back to typed receipts
+//! let decoded: ReceiptWithBloom = compressed.decode()?;
+//! assert_eq!(decoded.receipt.cumulative_gas_used, 21000);
+//! # Ok::<(), reth_era::e2s_types::E2sError>(())
+//! ``````
 
 use crate::{
     e2s_types::{E2sError, Entry},
@@ -158,7 +219,7 @@ impl CompressedHeader {
         self.decode()
     }
 
-    /// Create a [`CompressedHeader`] from a header.
+    /// Create a [`CompressedHeader`] from a header
     pub fn from_header<H: Encodable>(header: &H) -> Result<Self, E2sError> {
         let encoder = SnappyRlpCodec::new();
         let compressed = encoder.encode(header)?;

--- a/crates/era/src/lib.rs
+++ b/crates/era/src/lib.rs
@@ -19,6 +19,8 @@ pub mod era1_file;
 pub mod era1_types;
 pub mod era_types;
 pub mod execution_types;
+#[cfg(test)]
+pub(crate) mod test_utils;
 
 use crate::e2s_types::E2sError;
 use alloy_rlp::Decodable;

--- a/crates/era/src/lib.rs
+++ b/crates/era/src/lib.rs
@@ -12,10 +12,6 @@
 //! - Era format: <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md>
 //! - Era1 format: <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
 
-//! # Examples
-//! ```
-//! ```
-
 pub mod consensus_types;
 pub mod e2s_file;
 pub mod e2s_types;

--- a/crates/era/src/lib.rs
+++ b/crates/era/src/lib.rs
@@ -12,6 +12,10 @@
 //! - Era format: <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md>
 //! - Era1 format: <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
 
+//! # Examples
+//! ```
+//! ```
+
 pub mod consensus_types;
 pub mod e2s_file;
 pub mod e2s_types;

--- a/crates/era/src/test_utils.rs
+++ b/crates/era/src/test_utils.rs
@@ -1,0 +1,165 @@
+//! Utilities helpers to create era data structures for testing purposes.
+use crate::{
+    consensus_types::{CompressedBeaconState, CompressedSignedBeaconBlock},
+    execution_types::{
+        BlockTuple, CompressedBody, CompressedHeader, CompressedReceipts, TotalDifficulty,
+    },
+};
+use alloy_consensus::Header;
+use alloy_primitives::{Address, BlockNumber, Bytes, Log, LogData, B256, B64, U256};
+use reth_ethereum_primitives::{Receipt, TxType};
+
+// Helper function to create a test header
+pub(crate) fn create_header() -> Header {
+    Header {
+        parent_hash: B256::default(),
+        ommers_hash: B256::default(),
+        beneficiary: Address::default(),
+        state_root: B256::default(),
+        transactions_root: B256::default(),
+        receipts_root: B256::default(),
+        logs_bloom: Default::default(),
+        difficulty: U256::from(123456u64),
+        number: 100,
+        gas_limit: 5000000,
+        gas_used: 21000,
+        timestamp: 1609459200,
+        extra_data: Bytes::default(),
+        mix_hash: B256::default(),
+        nonce: B64::default(),
+        base_fee_per_gas: Some(10),
+        withdrawals_root: Some(B256::default()),
+        blob_gas_used: None,
+        excess_blob_gas: None,
+        parent_beacon_block_root: None,
+        requests_hash: None,
+    }
+}
+
+// Helper function to create a test receipt with customizable parameters
+pub(crate) fn create_test_receipt(
+    tx_type: TxType,
+    success: bool,
+    cumulative_gas_used: u64,
+    log_count: usize,
+) -> Receipt {
+    let mut logs = Vec::new();
+
+    for i in 0..log_count {
+        let address_byte = (i + 1) as u8;
+        let topic_byte = (i + 10) as u8;
+        let data_byte = (i + 100) as u8;
+
+        logs.push(Log {
+            address: Address::from([address_byte; 20]),
+            data: LogData::new_unchecked(
+                vec![B256::from([topic_byte; 32]), B256::from([topic_byte + 1; 32])],
+                alloy_primitives::Bytes::from(vec![data_byte, data_byte + 1, data_byte + 2]),
+            ),
+        });
+    }
+
+    Receipt { tx_type, success, cumulative_gas_used, logs }
+}
+
+// Helper function to create a list of test receipts with different characteristics
+pub(crate) fn create_test_receipts() -> Vec<Receipt> {
+    vec![
+        // Legacy transaction, successful, no logs
+        create_test_receipt(TxType::Legacy, true, 21000, 0),
+        // EIP-2930 transaction, failed, one log
+        create_test_receipt(TxType::Eip2930, false, 42000, 1),
+        // EIP-1559 transaction, successful, multiple logs
+        create_test_receipt(TxType::Eip1559, true, 63000, 3),
+        // EIP-4844 transaction, successful, two logs
+        create_test_receipt(TxType::Eip4844, true, 84000, 2),
+        // EIP-7702 transaction, failed, no logs
+        create_test_receipt(TxType::Eip7702, false, 105000, 0),
+    ]
+}
+
+// Helper function to create a sample block tuple
+pub(crate) fn create_sample_block(data_size: usize) -> BlockTuple {
+    // Create a compressed header with very sample data - not compressed for simplicity
+    let header_data = vec![0xAA; data_size];
+    let header = CompressedHeader::new(header_data);
+
+    // Create a compressed body with very sample data - not compressed for simplicity
+    let body_data = vec![0xBB; data_size * 2];
+    let body = CompressedBody::new(body_data);
+
+    // Create compressed receipts with very sample data - not compressed for simplicity
+    let receipts_data = vec![0xCC; data_size];
+    let receipts = CompressedReceipts::new(receipts_data);
+
+    let difficulty = TotalDifficulty::new(U256::from(data_size));
+
+    // Create and return the block tuple
+    BlockTuple::new(header, body, receipts, difficulty)
+}
+
+// Helper function to create a test block with compressed data
+pub(crate) fn create_test_block_with_compressed_data(number: BlockNumber) -> BlockTuple {
+    use alloy_consensus::{BlockBody, Header};
+    use alloy_eips::eip4895::Withdrawals;
+    use alloy_primitives::{Address, Bytes, B256, B64, U256};
+
+    // Create a proper test header
+    let header = Header {
+        parent_hash: B256::default(),
+        ommers_hash: B256::default(),
+        beneficiary: Address::default(),
+        state_root: B256::default(),
+        transactions_root: B256::default(),
+        receipts_root: B256::default(),
+        logs_bloom: Default::default(),
+        difficulty: U256::from(number * 1000),
+        number,
+        gas_limit: 5000000,
+        gas_used: 21000,
+        timestamp: 1609459200 + number,
+        extra_data: Bytes::default(),
+        mix_hash: B256::default(),
+        nonce: B64::default(),
+        base_fee_per_gas: Some(10),
+        withdrawals_root: Some(B256::default()),
+        blob_gas_used: None,
+        excess_blob_gas: None,
+        parent_beacon_block_root: None,
+        requests_hash: None,
+    };
+
+    // Create a proper test body
+    let body: BlockBody<Bytes> = BlockBody {
+        transactions: vec![Bytes::from(vec![(number % 256) as u8; 10])],
+        ommers: vec![],
+        withdrawals: Some(Withdrawals(vec![])),
+    };
+
+    // Create test receipts
+    let receipts_list: Vec<reth_ethereum_primitives::Receipt> =
+        vec![create_test_receipt(reth_ethereum_primitives::TxType::Legacy, true, 21000, 0)];
+
+    let receipts: alloy_consensus::Receipts<reth_ethereum_primitives::Receipt> =
+        alloy_consensus::Receipts::from(receipts_list);
+
+    // Create properly compressed components using the correct methods
+    let compressed_header = CompressedHeader::from_header(&header).unwrap();
+    let compressed_body = CompressedBody::from_body(&body).unwrap();
+    let compressed_receipts = CompressedReceipts::from_encodable_list(&receipts).unwrap();
+    let total_difficulty = TotalDifficulty::new(U256::from(number * 1000));
+
+    BlockTuple::new(compressed_header, compressed_body, compressed_receipts, total_difficulty)
+}
+
+/// Helper function to create a simple beacon block
+pub(crate) fn create_beacon_block(data_size: usize) -> CompressedSignedBeaconBlock {
+    let block_data = vec![0xAA; data_size];
+    CompressedSignedBeaconBlock::new(block_data)
+}
+
+/// Helper function to create a simple beacon state
+pub(crate) fn create_beacon_state(data_size: usize) -> CompressedBeaconState {
+    let state_data = vec![0xBB; data_size];
+    CompressedBeaconState::new(state_data)
+}

--- a/crates/era/src/test_utils.rs
+++ b/crates/era/src/test_utils.rs
@@ -148,8 +148,12 @@ pub(crate) fn create_test_block_with_compressed_data(number: BlockNumber) -> Blo
     };
 
     // Create test receipt list with bloom
-    let receipts_list: Vec<ReceiptWithBloom> =
-        vec![create_test_receipt_with_bloom(reth_ethereum_primitives::TxType::Legacy, true, 21000, 0)];
+    let receipts_list: Vec<ReceiptWithBloom> = vec![create_test_receipt_with_bloom(
+        reth_ethereum_primitives::TxType::Legacy,
+        true,
+        21000,
+        0,
+    )];
 
     // Compressed test compressed
     let compressed_header = CompressedHeader::from_header(&header).unwrap();

--- a/crates/era/tests/it/roundtrip.rs
+++ b/crates/era/tests/it/roundtrip.rs
@@ -252,6 +252,7 @@ async fn test_file_roundtrip(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "download intensive"]
 async fn test_roundtrip_compression_encoding_mainnet() -> eyre::Result<()> {
     let downloader = Era1TestDownloader::new().await?;
 

--- a/crates/era/tests/it/roundtrip.rs
+++ b/crates/era/tests/it/roundtrip.rs
@@ -7,13 +7,15 @@
 //! - Writing the data back to a new file
 //! - Confirming that all original data is preserved throughout the process
 
-use alloy_consensus::{BlockBody, BlockHeader, Header};
+use alloy_consensus::{BlockBody, BlockHeader, Header, ReceiptWithBloom};
 use rand::{prelude::IndexedRandom, rng};
 use reth_era::{
     e2s_types::IndexEntry,
     era1_file::{Era1File, Era1Reader, Era1Writer},
     era1_types::{Era1Group, Era1Id},
-    execution_types::{BlockTuple, CompressedBody, CompressedHeader, TotalDifficulty},
+    execution_types::{
+        BlockTuple, CompressedBody, CompressedHeader, CompressedReceipts, TotalDifficulty,
+    },
 };
 use reth_ethereum_primitives::TransactionSigned;
 use std::io::Cursor;
@@ -144,6 +146,21 @@ async fn test_file_roundtrip(
             "Ommers count should match after roundtrip"
         );
 
+        // Decode receipts
+        let original_receipts_decoded =
+            original_block.receipts.decode::<Vec<ReceiptWithBloom>>()?;
+        let roundtrip_receipts_decoded =
+            roundtrip_block.receipts.decode::<Vec<ReceiptWithBloom>>()?;
+
+        assert_eq!(
+            original_receipts_decoded, roundtrip_receipts_decoded,
+            "Block {block_number} decoded receipts should be identical after roundtrip"
+        );
+        assert_eq!(
+            original_receipts_data, roundtrip_receipts_data,
+            "Block {block_number} receipts data should be identical after roundtrip"
+        );
+
         // Check withdrawals presence/absence matches
         assert_eq!(
             original_decoded_body.withdrawals.is_some(),
@@ -179,11 +196,20 @@ async fn test_file_roundtrip(
             "Transaction count should match after re-compression"
         );
 
+        // Re-encore and re-compress the receipts
+        let recompressed_receipts = CompressedReceipts::from_encodable(&roundtrip_receipts_decoded)?;
+        let recompressed_receipts_data = recompressed_receipts.decompress()?;
+
+        assert_eq!(
+            original_receipts_data.len(),
+            recompressed_receipts_data.len(),
+            "Receipts length should match after re-compression"
+        );
+
         let recompressed_block = BlockTuple::new(
             recompressed_header,
             recompressed_body,
-            original_block.receipts.clone(), /* reuse original receipts directly as it not
-                                              * possible to decode them */
+            recompressed_receipts,
             TotalDifficulty::new(original_block.total_difficulty.value),
         );
 
@@ -225,7 +251,6 @@ async fn test_file_roundtrip(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "download intensive"]
 async fn test_roundtrip_compression_encoding_mainnet() -> eyre::Result<()> {
     let downloader = Era1TestDownloader::new().await?;
 

--- a/crates/era/tests/it/roundtrip.rs
+++ b/crates/era/tests/it/roundtrip.rs
@@ -197,7 +197,8 @@ async fn test_file_roundtrip(
         );
 
         // Re-encore and re-compress the receipts
-        let recompressed_receipts = CompressedReceipts::from_encodable(&roundtrip_receipts_decoded)?;
+        let recompressed_receipts =
+            CompressedReceipts::from_encodable(&roundtrip_receipts_decoded)?;
         let recompressed_receipts_data = recompressed_receipts.decompress()?;
 
         assert_eq!(


### PR DESCRIPTION
- Add more era1 tests for for receipts (reth-ethereum-primitives and alloy's one), with the decode part in `Vec<RecordWithBloom>`
- Add examples in `execution_types` code docs