### PR TITLE
refactor: improve storage error messages

### DIFF
--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -46,7 +46,7 @@ pub enum DatabaseError {
     #[error("log level {_0:?} is not available")]
     LogLevelUnavailable(LogLevel),
     /// Other unspecified error.
-    #[error("{_0}")]
+    #[error("database error: {_0}")]
     Other(String),
 }
 

--- a/crates/storage/errors/src/lockfile.rs
+++ b/crates/storage/errors/src/lockfile.rs
@@ -7,7 +7,7 @@ pub enum StorageLockError {
     #[error("storage directory is currently in use as read-write by another process: PID {_0}")]
     Taken(usize),
     /// Indicates other unspecified errors.
-    #[error("{_0}")]
+    #[error("storage lock error: {_0}")]
     Other(String),
 }
 

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -21,7 +21,7 @@ pub enum ProviderError {
     #[error(transparent)]
     Pruning(#[from] PruneSegmentError),
     /// RLP error.
-    #[error("{_0}")]
+    #[error("failed to decode RLP data: {_0}")]
     Rlp(alloy_rlp::Error),
     /// Trie witness error.
     #[error("trie witness error: {_0}")]


### PR DESCRIPTION
Improve error message specificity in storage layer components:

- Replace generic "{_0}" with "failed to decode RLP data: {_0}" in provider errors
- Add context "storage lock error: {_0}" for lockfile operations
- Specify "database error: {_0}" for database-related failures